### PR TITLE
fixed Dockerfile for APIM 3.5.1 release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, pr_build]
-    default: pr_build
+    enum: [release, publish_rpms, pull_requests]
+    default: pull_requests
   dry_run:
     type: boolean
     default: true
@@ -13,6 +13,26 @@ parameters:
     type: string
     default: "gravitee-dry-run"
     description: "Maven ID of the Maven profile to use for a dry run ?"
+  ee_id_provider_cas_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the CAS identity provider plugin to bundle with Gravitee AM Enterprise Edition"
+  ee_id_provider_kerberos_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the Kerberos identity provider plugin to bundle with Gravitee AM Enterprise Edition"
+  ee_id_provider_saml_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the SAML2 identity provider plugin to bundle with Gravitee AM Enterprise Edition"
+  ee_gravitee_license_version:
+    type: string
+    default: ''
+    description: "The semver version number of the Gravitee License to bundle with Gravitee AM Enterprise Edition"
+  ee_gravitee_ae_connector_version:
+    type: string
+    default: ''
+    description: "The semver version number of the Gravitee Alert Engine connector to bundle with Gravitee AM Enterprise Edition"
   secrethub_org:
     type: string
     default: "gravitee-lab"
@@ -21,43 +41,406 @@ parameters:
     type: string
     default: "cicd"
     description: "SecretHub Repo to use to fetch secrets ?"
+  graviteeio_version:
+    type: string
+    default: "cicd"
+    description: "Release version number to use to publish the Docker nightly images ?"
 
 orbs:
-  gravitee: gravitee-io/gravitee@dev:1.0.4
+  gravitee: gravitee-io/gravitee@1.0
+  secrethub: secrethub/cli@1.1.0
+  slack: circleci/slack@4.2.1
+
+jobs:
+  secrethub:
+    docker:
+      - image: 'cimg/base:stable'
+    environment:
+      DEV_MAVEN_SETTINGS: 'secrethub://graviteeio/cicd/graviteebot/infra/maven/dry-run/artifactory/settings.dev.xml'
+      RELEASE_MAVEN_SETTINGS: 'secrethub://graviteeio/cicd/graviteebot/infra/maven/dry-run/artifactory/settings.non.dry.run.xml'
+      DRY_RELEASE_MAVEN_SETTINGS: 'secrethub://graviteeio/cicd/graviteebot/infra/maven/dry-run/artifactory/settings.xml'
+      GIO_GPG_PUB_KEY: 'secrethub://graviteeio/cicd/graviteebot/gpg/armor_format_pub_key'
+      GIO_GPG_PRV_KEY: 'secrethub://graviteeio/cicd/graviteebot/gpg/armor_format_private_key'
+      GIT_USER_NAME: 'secrethub://graviteeio/cicd/graviteebot/git/user/name'
+      GIT_USER_EMAIL: 'secrethub://graviteeio/cicd/graviteebot/git/user/email'
+      DOCKERHUB_USER_NAME: 'secrethub://graviteeio/cicd/graviteebot/infra/dockerhub-user-name'
+      DOCKERHUB_USER_TOKEN: 'secrethub://graviteeio/cicd/graviteebot/infra/dockerhub-user-token'
+    steps:
+      - secrethub/exec:
+          command: |
+            echo $DEV_MAVEN_SETTINGS > /tmp/.circleci.settings.xml
+            mkdir -p /tmp/gravit33bot/.secrets/.gungpg
+            echo $RELEASE_MAVEN_SETTINGS > /tmp/gravit33bot/.secrets/release.settings.xml
+            echo $DRY_RELEASE_MAVEN_SETTINGS > /tmp/gravit33bot/.secrets/dry.release.settings.xml
+            echo $GIO_GPG_PUB_KEY > /tmp/gravit33bot/.secrets/.gungpg/graviteebot.gpg.pub.key
+            echo $GIO_GPG_PRV_KEY > /tmp/gravit33bot/.secrets/.gungpg/graviteebot.gpg.priv.key
+            echo $GIT_USER_NAME > /tmp/gravit33bot/git_user_name
+            echo $GIT_USER_EMAIL > /tmp/gravit33bot/git_user_email
+            mkdir -p /tmp/gravit33bot/.secrets/dockerhub
+            echo $DOCKERHUB_USER_NAME > /tmp/gravit33bot/.secrets/dockerhub/user_name
+            echo $DOCKERHUB_USER_TOKEN > /tmp/gravit33bot/.secrets/dockerhub/user_token
+      - secrethub/install
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - .circleci.settings.xml
+            - gravit33bot
+  build:
+    docker:
+      - image: circleci/openjdk:11.0.3-jdk-stretch
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - checkout
+      - restore_cache:
+          keys:
+            - gio-gravitee-pull-requests-dependencies-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gio-gravitee-pull-requests-dependencies
+      - run:
+          name: Maven Package
+          command: |
+            mvn -s /tmp/.circleci.settings.xml install -DaltDeploymentRepository=${NEXUS_SNAPSHOTS_SERVER_ID}::default::${NEXUS_SNAPSHOTS_URL}
+            cp ./gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/target/*.zip ~/
+            cp ./gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/target/*.zip ~/
+            cp ./gravitee-am-ui/target/*.zip ~/
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - ./gravitee-am-gateway-standalone-*.zip
+            - ./gravitee-am-management-api-standalone-*.zip
+            - ./gravitee-am-webui-*.zip
+
+  run_postman_tests:
+    docker:
+      - image: cimg/openjdk:11.0.10-node
+      - image: mongo:4.2
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Install Newman
+          command: sudo npm i -g newman
+      - run:
+          name: Wait for Mongo to be up and running
+          command: timeout 15s bash -c 'until nc -vz localhost 27017; do sleep 2; done'
+      - run:
+          name: Run API, GW and Postman tests
+          command: |
+            # Prepare AM
+
+            unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
+            unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
+
+            export AM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+
+            # Start AM Management
+            gravitee-am-management-api-standalone-${AM_VERSION}/bin/gravitee &
+
+            # Start AM Gateway
+            gravitee-am-gateway-standalone-${AM_VERSION}/bin/gravitee &
+
+            sleep 30
+
+            # Wait for AM to be up and running
+            timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
+            timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
+
+            sleep 30
+
+            # Run Postman tests
+            make postman
+      - slack/notify:
+          branch_pattern: ".+"
+          event: fail
+          mentions: "@am_team"
+          template: basic_fail_1
+
+  publish-images-azure-registry:
+    docker:
+      - image: circleci/openjdk:11.0.3-jdk-stretch
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp
+      - setup_remote_docker
+      - run:
+          name: Compute Tag for Docker images
+          command: |
+            # Compute tag with branch name, commmit SHA and timestamp. Then slugify it to be sure it can be handled by Docker
+            export TAG=$(echo "${CIRCLE_BRANCH:0:15}-${CIRCLE_SHA1:0:7}-$(date +%s)" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)
+            # Workaround for sharing this variable to the next steps
+            echo "export TAG=$TAG" >> $BASH_ENV
+            echo "Docker images will be tagged with: ${TAG}"
+            echo $TAG > /tmp/docker-tag.txt
+      - run:
+          name: Build & Publish Management API Docker Image to Azure Registry
+          command: |
+            export AM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            echo "Gravitee AM version: ${AM_VERSION}"
+            export IMAGE_TAG=graviteeio.azurecr.io/am-management-api:${TAG}
+            docker build -f docker/management-api/Dockerfile-dev --build-arg GRAVITEEAM_VERSION=${AM_VERSION} -t ${IMAGE_TAG} /tmp
+            echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+            docker push ${IMAGE_TAG}
+      - run:
+          name: Build & Publish Gateway Docker Image to Azure Registry
+          command: |
+            export AM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            export IMAGE_TAG=graviteeio.azurecr.io/am-gateway:${TAG}
+            docker build -f docker/gateway/Dockerfile-dev --build-arg GRAVITEEAM_VERSION=${AM_VERSION} -t ${IMAGE_TAG} /tmp
+            echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+            docker push ${IMAGE_TAG}
+      - run:
+          name: Build & Publish Web UI Docker Image to Azure Registry
+          command: |
+            cp -fr docker/management-ui/config /tmp/
+            cp -fr docker/management-ui/run.sh /tmp/
+
+            export AM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            export IMAGE_TAG=graviteeio.azurecr.io/am-management-ui:${TAG}
+            docker build -f docker/management-ui/Dockerfile-dev --build-arg GRAVITEEAM_VERSION=${AM_VERSION} -t ${IMAGE_TAG} /tmp
+            echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+            docker push ${IMAGE_TAG}
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - ./docker-tag.txt
+
+  deploy-on-aks:
+    docker:
+      - image: mcr.microsoft.com/azure-cli:latest
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Read tag of Docker images to deploy
+          command: |
+            export TAG=$(cat /tmp/docker-tag.txt)
+            # Workaround for sharing this variable to the next steps
+            echo "export TAG=$TAG" >> $BASH_ENV
+            echo "Will deploy Docker images with tag: ${TAG}"
+      - run:
+          name: Install Helm
+          command: |
+            curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+            helm version
+      - run:
+          name: Install Kubectl
+          command: |
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+            chmod +x ./kubectl
+            mv ./kubectl /usr/local/bin/kubectl
+            kubectl version --client=true
+      - add_ssh_keys:
+          fingerprints:
+            - "ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c"
+      - run:
+          name: Setup Git config and clone cloud-am repo
+          command: |
+            # For details see https://circleci.com/docs/2.0/gh-bb-integration/#establishing-the-authenticity-of-an-ssh-host
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+            # Add SSH Key
+            export LOCAL_SSH_PRVIKEY="${HOME}/.ssh/id_rsa_ac88238fc60f7df0fcdf73203456026c"
+            ssh-add -D
+            ssh-add "${LOCAL_SSH_PRVIKEY}"
+
+            git clone --branch hprod  git@github.com:gravitee-io/cloud-am.git
+      - run:
+          name: Helm upgrade and 🚀 Mongo and JDBC instances
+          command: |
+            az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
+            az aks get-credentials --resource-group am-hprod --name am-hprod
+            helm upgrade --repo https://helm.gravitee.io \
+                        --install am \
+                        -n nightly \
+                        -f ./cloud-am/nightly/values.yaml am \
+                        --set "api.image.repository=graviteeio.azurecr.io/am-management-api" \
+                        --set "api.image.tag=${TAG}" \
+                        --set "gateway.image.repository=graviteeio.azurecr.io/am-gateway" \
+                        --set "gateway.image.tag=${TAG}" \
+                        --set "ui.image.repository=graviteeio.azurecr.io/am-management-ui" \
+                        --set "ui.image.tag=${TAG}"
+            helm upgrade --repo https://helm.gravitee.io \
+                        --install am-psql \
+                        -n nightly-postgres \
+                        -f ./cloud-am/nightly/values-psql.yaml am \
+                        --set "api.image.repository=graviteeio.azurecr.io/am-management-api" \
+                        --set "api.image.tag=${TAG}" \
+                        --set "gateway.image.repository=graviteeio.azurecr.io/am-gateway" \
+                        --set "gateway.image.tag=${TAG}" \
+                        --set "ui.image.repository=graviteeio.azurecr.io/am-management-ui" \
+                        --set "ui.image.tag=${TAG}"
+
+  purge-azure-registry:
+    docker:
+      - image: mcr.microsoft.com/azure-cli:latest
+    resource_class: small
+    steps:
+      - run:
+          name: 🗑 Let's purge all AM images older than 1d
+          command: |
+            az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
+            az acr run --cmd "acr purge --filter 'am-gateway:master-.*' --untagged --ago 1d --keep 3" --registry graviteeio /dev/null
+            az acr run --cmd "acr purge --filter 'am-management-api:master-.*' --untagged --ago 1d --keep 3" --registry graviteeio /dev/null
+            az acr run --cmd "acr purge --filter 'am-management-ui:master-.*' --untagged --ago 1d --keep 3" --registry graviteeio /dev/null
 
 workflows:
   version: 2.1
+  # -- typically this workflow is executed on pull requests events for Community Edition Gravitee Repositories
   pull_requests:
     when:
-      equal: [ pr_build, << pipeline.parameters.gio_action >> ]
+      and:
+        - equal: [ pull_requests, << pipeline.parameters.gio_action >> ]
     jobs:
-      - gravitee/pr-build:
+      - gravitee/d_pull_requests_secrets:
           context: cicd-orchestrator
+          name: pr_secrets_resolution
+      - gravitee/d_pull_requests_ce:
+          name: process_pull_request
+          requires:
+            - pr_secrets_resolution
+          # "What is the maven ID of the maven profile to use to build and deploy SNAPSHOTS to Prviate Artifactory ?"
+          maven_profile_id: 'gio-dev'
+          # nexus_snapshots_url: 'https://oss.sonatype.org/content/repositories/snapshots'
+          # nexus_snapshots_server_id: 'sonatype-nexus-snapshots'
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'xlarge'
+          filters:
+            branches:
+              ignore:
+                - master
+                # - /^[0-999].[0-999].x/ # Ignore support branches, because they are checked with noightly ? Would make sense...
+
+  build_branch:
+    jobs:
+      - secrethub:
+          context:
+            - cicd-orchestrator
+      - build:
+          requires:
+            - secrethub
+          filters:
+            branches:
+              only:
+                - master
+                - /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.x$/
+      - run_postman_tests:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.x$/
+      - publish-images-azure-registry:
+          context: cicd-orchestrator
+          pre-steps:
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
+                var-name: AZURE_DOCKER_REGISTRY_USERNAME
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
+                var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.x$/
+      - deploy-on-aks:
+          context: cicd-orchestrator
+          pre-steps:
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/application-id
+                var-name: AZURE_APPLICATION_ID
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/tenant
+                var-name: AZURE_TENANT
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/application-secret
+                var-name: AZURE_APPLICATION_SECRET
+          requires:
+            - publish-images-azure-registry
+          filters:
+            branches:
+              only: master
+
   release:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
-        - not: << pipeline.parameters.dry_run >>
+        - not : << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
+      - gravitee/d_am_release_secrets:
           context: cicd-orchestrator
+          name: 'am_release_secrets'
+      - gravitee/d_am_release:
+          requires:
+            - am_release_secrets
           dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: 'gio-release'
+          ee_id_provider_cas_version: << pipeline.parameters.ee_id_provider_cas_version >>
+          ee_id_provider_kerberos_version: << pipeline.parameters.ee_id_provider_kerberos_version >>
+          ee_id_provider_saml_version: << pipeline.parameters.ee_id_provider_saml_version >>
+          ee_gravitee_license_version: << pipeline.parameters.ee_gravitee_license_version >>
+          ee_gravitee_ae_connector_version: << pipeline.parameters.ee_gravitee_ae_connector_version >>
+
   release_dry_run:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
+      - gravitee/d_am_release_secrets:
           context: cicd-orchestrator
+          name: 'am_release_secrets'
+      - gravitee/d_am_release:
+          requires:
+            - am_release_secrets
           dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: 'gravitee-dry-run'
+          ee_id_provider_cas_version: << pipeline.parameters.ee_id_provider_cas_version >>
+          ee_id_provider_kerberos_version: << pipeline.parameters.ee_id_provider_kerberos_version >>
+          ee_id_provider_saml_version: << pipeline.parameters.ee_id_provider_saml_version >>
+          ee_gravitee_license_version: << pipeline.parameters.ee_gravitee_license_version >>
+          ee_gravitee_ae_connector_version: << pipeline.parameters.ee_gravitee_ae_connector_version >>
+
+  publish_rpms:
+    when:
+      equal: [ publish_rpms, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/publish_am_rpms:
+          context: cicd-orchestrator
+          secrethub_org: graviteeio
+          secrethub_repo: cicd
+          gio_release_version: << pipeline.parameters.graviteeio_version >>
+
+  daily-purge-azure-registry:
+    triggers:
+      - schedule:
+          cron: "0 1 * * 1"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - purge-azure-registry:
+          context: cicd-orchestrator
+          pre-steps:
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/application-id
+                var-name: AZURE_APPLICATION_ID
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/tenant
+                var-name: AZURE_TENANT
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/azure/application-secret
+                var-name: AZURE_APPLICATION_SECRET

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-man
 .vertx
 
 dependency-reduced-pom.xml
+
+
+## Devops tests
+docker/management-ui/3.9.2

--- a/docker/gateway/Dockerfile
+++ b/docker/gateway/Dockerfile
@@ -18,11 +18,12 @@ FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0
+ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-am/components/gravitee-am-gateway
 ENV GRAVITEEIO_HOME /opt/graviteeio-am-gateway
 
 RUN apk update \
 	&& apk add --update --no-cache zip unzip netcat-openbsd wget \
-	&& wget --no-check-certificate -O /tmp/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION}.zip https://download.gravitee.io/graviteeio-am/components/gravitee-am-gateway/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION}.zip \
+	&& wget --no-check-certificate -O /tmp/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION}.zip $GRAVITEEIO_DOWNLOAD_URL/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION}.zip \
     && unzip /tmp/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION}.zip -d /tmp/ \
 	&& apk del zip unzip netcat-openbsd wget \
     && mv /tmp/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION} ${GRAVITEEIO_HOME} \

--- a/docker/management-api/Dockerfile
+++ b/docker/management-api/Dockerfile
@@ -18,11 +18,12 @@ FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0
+ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-am/components/gravitee-am-management-api
 ENV GRAVITEEIO_HOME /opt/graviteeio-am-management-api
 
 RUN apk update \
 	&& apk add --update --no-cache zip unzip netcat-openbsd wget \
-	&& wget --no-check-certificate  -O /tmp/gravitee-am-management-api-standalone-${GRAVITEEAM_VERSION}.zip https://download.gravitee.io/graviteeio-am/components/gravitee-am-management-api/gravitee-am-management-api-standalone-${GRAVITEEAM_VERSION}.zip \
+	&& wget --no-check-certificate  -O /tmp/gravitee-am-management-api-standalone-${GRAVITEEAM_VERSION}.zip $GRAVITEEIO_DOWNLOAD_URL/gravitee-am-management-api-standalone-${GRAVITEEAM_VERSION}.zip \
     && unzip /tmp/gravitee-am-management-api-standalone-${GRAVITEEAM_VERSION}.zip -d /tmp/ \
 	&& apk del zip unzip netcat-openbsd wget \
     && mv /tmp/gravitee-am-management-api-standalone-${GRAVITEEAM_VERSION} ${GRAVITEEIO_HOME} \

--- a/docker/management-ui/Dockerfile
+++ b/docker/management-ui/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM nginx:1.18-alpine
+FROM nginx:1.19-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0
@@ -33,11 +33,15 @@ RUN wget --no-check-certificate -O /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}.
     && mv /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}/* ${WWW_TARGET} \
     && rm -rf /tmp/* \
     && wget -T 5 ${CONFD_URL}/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 -O /bin/confd \
-    && chmod +x /bin/confd
-
-# support running as arbitrary user which belongs to the root group
-RUN chgrp -R 0 /usr/share/nginx/ /var/log/nginx /var/cache/nginx/ /etc/nginx/ /var/run/ && \
-    chmod -R g=u /usr/share/nginx/ /var/log/nginx /var/cache/nginx/ /etc/nginx/ /var/run/
+    && chmod +x /bin/confd \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+    && sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
+    && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
+    && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \
+    && chown -R 101:0 /usr/share/nginx /var/log/nginx /var/cache/nginx /etc/nginx /var/run \
+    && chmod -R g+w /var/cache/nginx \
+    && chmod -R g+w /etc/nginx
 
 ADD config /etc/confd
 

--- a/docker/management-ui/Dockerfile
+++ b/docker/management-ui/Dockerfile
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 
-FROM nginx:1.19-alpine
+FROM nginx:1.18-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0
+ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-am/components/gravitee-am-webui
 
 ENV CONFD_VERSION="0.16.0"
 ENV CONFD_URL="https://github.com/kelseyhightower/confd/releases/download"
@@ -27,21 +28,17 @@ RUN apk --update add zip unzip bash wget
 
 ENV WWW_TARGET /usr/share/nginx/html
 
-RUN wget --no-check-certificate -O /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip https://download.gravitee.io/graviteeio-am/components/gravitee-am-webui/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip \
+RUN wget --no-check-certificate -O /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip $GRAVITEEIO_DOWNLOAD_URL/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip \
     && unzip /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip -d /tmp/ \
     && mkdir -p ${WWW_TARGET} \
     && mv /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}/* ${WWW_TARGET} \
     && rm -rf /tmp/* \
     && wget -T 5 ${CONFD_URL}/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 -O /bin/confd \
-    && chmod +x /bin/confd \
-    && ln -sf /dev/stdout /var/log/nginx/access.log \
-    && ln -sf /dev/stderr /var/log/nginx/error.log \
-    && sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
-    && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
-    && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \
-    && chown -R 101:0 /usr/share/nginx /var/log/nginx /var/cache/nginx /etc/nginx /var/run \
-    && chmod -R g+w /var/cache/nginx \
-    && chmod -R g+w /etc/nginx
+    && chmod +x /bin/confd
+
+# support running as arbitrary user which belongs to the root group
+RUN chgrp -R 0 /usr/share/nginx/ /var/log/nginx /var/cache/nginx/ /etc/nginx/ /var/run/ && \
+    chmod -R g=u /usr/share/nginx/ /var/log/nginx /var/cache/nginx/ /etc/nginx/ /var/run/
 
 ADD config /etc/confd
 

--- a/gravitee-am-certificate/gravitee-am-certificate-api/pom.xml
+++ b/gravitee-am-certificate/gravitee-am-certificate-api/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <artifactId>gravitee-am-certificate</artifactId>
         <groupId>io.gravitee.am.certificate</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-am-certificate-api</artifactId>
     <packaging>jar</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Certificate - API</name>
 
     <dependencies>

--- a/gravitee-am-certificate/gravitee-am-certificate-javakeystore/pom.xml
+++ b/gravitee-am-certificate/gravitee-am-certificate-javakeystore/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <artifactId>gravitee-am-certificate</artifactId>
         <groupId>io.gravitee.am.certificate</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-am-certificate-javakeystore</artifactId>
     <packaging>jar</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Certificate - JavaKeyStore</name>
 
     <dependencies>

--- a/gravitee-am-certificate/gravitee-am-certificate-pkcs12/pom.xml
+++ b/gravitee-am-certificate/gravitee-am-certificate-pkcs12/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <artifactId>gravitee-am-certificate</artifactId>
         <groupId>io.gravitee.am.certificate</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-am-certificate-pkcs12</artifactId>
     <packaging>jar</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Certificate - PKCS12</name>
 
     <dependencies>

--- a/gravitee-am-certificate/pom.xml
+++ b/gravitee-am-certificate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-parent</artifactId>
         <groupId>io.gravitee.am</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.certificate</groupId>

--- a/gravitee-am-common/pom.xml
+++ b/gravitee-am-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-parent</artifactId>
         <groupId>io.gravitee.am</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.common</groupId>

--- a/gravitee-am-extensiongrant/gravitee-am-extensiongrant-api/pom.xml
+++ b/gravitee-am-extensiongrant/gravitee-am-extensiongrant-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-extensiongrant</artifactId>
         <groupId>io.gravitee.am.extensiongrant</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-extensiongrant-api</artifactId>

--- a/gravitee-am-extensiongrant/gravitee-am-extensiongrant-jwtbearer/pom.xml
+++ b/gravitee-am-extensiongrant/gravitee-am-extensiongrant-jwtbearer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-extensiongrant</artifactId>
         <groupId>io.gravitee.am.extensiongrant</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-extensiongrant-jwtbearer</artifactId>

--- a/gravitee-am-extensiongrant/pom.xml
+++ b/gravitee-am-extensiongrant/pom.xml
@@ -24,14 +24,14 @@
     <parent>
         <groupId>io.gravitee.am</groupId>
         <artifactId>gravitee-am-parent</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.extensiongrant</groupId>
     <artifactId>gravitee-am-extensiongrant</artifactId>
     <packaging>pom</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Extension Grant</name>
 
     <modules>

--- a/gravitee-am-factor/gravitee-am-factor-api/pom.xml
+++ b/gravitee-am-factor/gravitee-am-factor-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-factor</artifactId>
         <groupId>io.gravitee.am.factor</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-factor/gravitee-am-factor-otp/pom.xml
+++ b/gravitee-am-factor/gravitee-am-factor-otp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-factor</artifactId>
         <groupId>io.gravitee.am.factor</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-factor-otp</artifactId>

--- a/gravitee-am-factor/pom.xml
+++ b/gravitee-am-factor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-parent</artifactId>
         <groupId>io.gravitee.am</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-certificate/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-certificate/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-gateway</artifactId>
         <groupId>io.gravitee.am.gateway</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-core/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-gateway</artifactId>
         <groupId>io.gravitee.am.gateway</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-api/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway.handler</groupId>
         <artifactId>gravitee-am-gateway-handler</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-handler-api</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-gateway-handler</artifactId>
         <groupId>io.gravitee.am.gateway.handler</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-handler-common</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-context/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-context/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-gateway-handler</artifactId>
         <groupId>io.gravitee.am.gateway.handler</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway.handler</groupId>
         <artifactId>gravitee-am-gateway-handler</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-handler-core</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-discovery/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-discovery/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-am-gateway-handler</artifactId>
         <groupId>io.gravitee.am.gateway.handler</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-handler-discovery</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-am-gateway-handler</artifactId>
         <groupId>io.gravitee.am.gateway.handler</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-handler-oidc</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway.handler</groupId>
         <artifactId>gravitee-am-gateway-handler</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-users/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-users/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-am-gateway-handler</artifactId>
         <groupId>io.gravitee.am.gateway.handler</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-handler-users</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway</groupId>
         <artifactId>gravitee-am-gateway</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.gateway.handler</groupId>

--- a/gravitee-am-gateway/gravitee-am-gateway-policy/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-policy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-gateway</artifactId>
         <groupId>io.gravitee.am.gateway</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway</groupId>
         <artifactId>gravitee-am-gateway</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-reactor</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-gateway-services</artifactId>
         <groupId>io.gravitee.am.gateway</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-services/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-am-gateway</artifactId>
         <groupId>io.gravitee.am.gateway</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-services</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-bootstrap/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-bootstrap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway.standalone</groupId>
         <artifactId>gravitee-am-gateway-standalone</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-standalone-bootstrap</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway.standalone</groupId>
         <artifactId>gravitee-am-gateway-standalone</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-standalone-container</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway.standalone</groupId>
         <artifactId>gravitee-am-gateway-standalone-distribution</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-standalone-distribution-zip</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-gateway-standalone</artifactId>
         <groupId>io.gravitee.am.gateway.standalone</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-gateway-standalone-distribution</artifactId>

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.am.gateway</groupId>
         <artifactId>gravitee-am-gateway</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.gateway.standalone</groupId>

--- a/gravitee-am-gateway/pom.xml
+++ b/gravitee-am-gateway/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee.am</groupId>
         <artifactId>gravitee-am-parent</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.gateway</groupId>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>io.gravitee.am.identityprovider</groupId>
         <artifactId>gravitee-am-identityprovider</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-identityprovider-api</artifactId>
     <packaging>jar</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - API</name>
 
     <dependencies>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-azure-ad/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-azure-ad/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-identityprovider-azure-ad</artifactId>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-common/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-facebook/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-facebook/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-franceconnect/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-franceconnect/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-am-identityprovider-franceconnect</artifactId>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - FranceConnect</name>
 
     <dependencies>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-github/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-github/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-am-identityprovider-github</artifactId>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - GitHub</name>
 
     <dependencies>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-google/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-google/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-identityprovider-http</artifactId>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - HTTP</name>
 
     <properties>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-inline/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-inline/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>io.gravitee.am.identityprovider</groupId>
         <artifactId>gravitee-am-identityprovider</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-identityprovider-inline</artifactId>
     <packaging>jar</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - Inline</name>
 
     <dependencies>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-identityprovider-jdbc</artifactId>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - JDBC</name>
 
     <properties>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-ldap/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-ldap/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>io.gravitee.am.identityprovider</groupId>
         <artifactId>gravitee-am-identityprovider</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-identityprovider-ldap</artifactId>
     <packaging>jar</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - LDAP</name>
 
     <properties>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-linkedin/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-linkedin/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-am-identityprovider-linkedin</artifactId>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - Linkedin</name>
 
     <dependencies>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>io.gravitee.am.identityprovider</groupId>
         <artifactId>gravitee-am-identityprovider</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-identityprovider-mongo</artifactId>
     <packaging>jar</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - MongoDB</name>
 
     <properties>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-am-identityprovider-oauth2-generic</artifactId>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Identity Provider - OpenID Connect</name>
 
     <properties>

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-twitter/pom.xml
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-twitter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-identityprovider</artifactId>
         <groupId>io.gravitee.am.identityprovider</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-identityprovider/pom.xml
+++ b/gravitee-am-identityprovider/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.am</groupId>
         <artifactId>gravitee-am-parent</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.identityprovider</groupId>

--- a/gravitee-am-jwt/pom.xml
+++ b/gravitee-am-jwt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-parent</artifactId>
         <groupId>io.gravitee.am</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.management</groupId>
         <artifactId>gravitee-am-management-api</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-management-api-rest</artifactId>

--- a/gravitee-am-management-api/gravitee-am-management-api-service/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.management</groupId>
         <artifactId>gravitee-am-management-api</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-management-api-service</artifactId>

--- a/gravitee-am-management-api/gravitee-am-management-api-services/gravitee-am-management-api-services-purge/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-services/gravitee-am-management-api-services-purge/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-management-api-services</artifactId>
         <groupId>io.gravitee.am.management</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-management-api/gravitee-am-management-api-services/gravitee-am-management-api-services-sync/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-services/gravitee-am-management-api-services-sync/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-management-api-services</artifactId>
         <groupId>io.gravitee.am.management</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-management-api-services-sync</artifactId>

--- a/gravitee-am-management-api/gravitee-am-management-api-services/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-services/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>gravitee-am-management-api</artifactId>
         <groupId>io.gravitee.am.management</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-management-api-services</artifactId>

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-bootstrap/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-bootstrap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee.am.management.standalone</groupId>
         <artifactId>gravitee-am-management-api-standalone</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee.am.management.standalone</groupId>
         <artifactId>gravitee-am-management-api-standalone</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee.am.management.standalone</groupId>
         <artifactId>gravitee-am-management-api-standalone-distribution</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee.am.management.standalone</groupId>
         <artifactId>gravitee-am-management-api-standalone</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee.am.management</groupId>
         <artifactId>gravitee-am-management-api</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-management-api/pom.xml
+++ b/gravitee-am-management-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am</groupId>
         <artifactId>gravitee-am-parent</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.management</groupId>

--- a/gravitee-am-model/pom.xml
+++ b/gravitee-am-model/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.am</groupId>
         <artifactId>gravitee-am-parent</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.model</groupId>

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-certificate/pom.xml
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-certificate/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-am-plugins-handlers</artifactId>
         <groupId>io.gravitee.am.plugins.handlers</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-plugins-handlers-certificate</artifactId>

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-extensiongrant/pom.xml
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-extensiongrant/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-plugins-handlers</artifactId>
         <groupId>io.gravitee.am.plugins.handlers</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-plugins-handlers-extensiongrant</artifactId>

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-factor/pom.xml
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-factor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-plugins-handlers</artifactId>
         <groupId>io.gravitee.am.plugins.handlers</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-identityprovider/pom.xml
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-identityprovider/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-am-plugins-handlers</artifactId>
         <groupId>io.gravitee.am.plugins.handlers</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-plugins-handlers-identityprovider</artifactId>

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-policy/pom.xml
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-policy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-plugins-handlers</artifactId>
         <groupId>io.gravitee.am.plugins.handlers</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-protocol/pom.xml
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-protocol/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-plugins-handlers</artifactId>
         <groupId>io.gravitee.am.plugins.handlers</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-plugins-handlers-protocol</artifactId>

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-reporter/pom.xml
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-reporter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-plugins-handlers</artifactId>
         <groupId>io.gravitee.am.plugins.handlers</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-plugins-handlers-reporter</artifactId>

--- a/gravitee-am-plugins-handlers/pom.xml
+++ b/gravitee-am-plugins-handlers/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-am-parent</artifactId>
         <groupId>io.gravitee.am</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.plugins.handlers</groupId>

--- a/gravitee-am-reporter/gravitee-am-reporter-api/pom.xml
+++ b/gravitee-am-reporter/gravitee-am-reporter-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-reporter</artifactId>
         <groupId>io.gravitee.am.reporter</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-reporter-api</artifactId>

--- a/gravitee-am-reporter/gravitee-am-reporter-jdbc/pom.xml
+++ b/gravitee-am-reporter/gravitee-am-reporter-jdbc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-am-reporter</artifactId>
         <groupId>io.gravitee.am.reporter</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/pom.xml
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-am-reporter</artifactId>
         <groupId>io.gravitee.am.reporter</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-reporter-mongodb</artifactId>

--- a/gravitee-am-reporter/pom.xml
+++ b/gravitee-am-reporter/pom.xml
@@ -24,14 +24,14 @@
     <parent>
         <artifactId>gravitee-am-parent</artifactId>
         <groupId>io.gravitee.am</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.reporter</groupId>
     <artifactId>gravitee-am-reporter</artifactId>
     <packaging>pom</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Reporter</name>
 
     <modules>

--- a/gravitee-am-repository/gravitee-am-repository-api/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.repository</groupId>
         <artifactId>gravitee-am-repository</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-repository-api</artifactId>

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-repository</artifactId>
         <groupId>io.gravitee.am.repository</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.am.repository</groupId>
         <artifactId>gravitee-am-repository</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-am-repository-mongodb</artifactId>

--- a/gravitee-am-repository/gravitee-am-repository-tests/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-am-repository</artifactId>
         <groupId>io.gravitee.am.repository</groupId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-repository/pom.xml
+++ b/gravitee-am-repository/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>io.gravitee.am</groupId>
         <artifactId>gravitee-am-parent</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.am.repository</groupId>
     <artifactId>gravitee-am-repository</artifactId>
     <packaging>pom</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management - Repository</name>
 
     <modules>

--- a/gravitee-am-service/pom.xml
+++ b/gravitee-am-service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee.am</groupId>
         <artifactId>gravitee-am-parent</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-am-ui/pom.xml
+++ b/gravitee-am-ui/pom.xml
@@ -28,12 +28,12 @@
   <parent>
     <groupId>io.gravitee.am</groupId>
     <artifactId>gravitee-am-parent</artifactId>
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
   </parent>
 
   <groupId>io.gravitee.am</groupId>
   <artifactId>gravitee-am-webui</artifactId>
-  <version>3.5.1</version>
+  <version>3.5.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Gravitee.io AM - Portal</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19</version>
+        <version>19.2.1</version>
     </parent>
 
     <groupId>io.gravitee.am</groupId>
     <artifactId>gravitee-am-parent</artifactId>
     <packaging>pom</packaging>
 
-    <version>3.5.1</version>
+    <version>3.5.1-SNAPSHOT</version>
     <name>Gravitee IO - Access Management</name>
 
     <scm>


### PR DESCRIPTION
This PR brings a fix to an issue experienced while trying to deploy AM `3.5.1` using Helm Chart Latest version.

It appeared that it was the `Dockerfile` of AM CE Which had to be repaired

This PR's git branch `cicd/fix-351-dock-image` will be used to build and push docker image of AM docker tagged `3.5.1-techopsfix` , and it will not be a latest release, no other docker tags will be docker pushed

```bash
git clone git@github.com:gravitee-io/gravitee-access-management.git
cd ./gravitee-access-management/
git checkout 3.5.1
git checkout -b cicd/fix-351-dock-image && git push -u origin HEAD
git add -A && git commit -m "fixed Dockerfile for APIM 3.5.1 release version" && git push -u origin HEAD
```
