### PR TITLE
fix: use right source value for OrganizationUser tests

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/OrganizationUserRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/OrganizationUserRepositoryTest.java
@@ -222,7 +222,7 @@ public class OrganizationUserRepositoryTest extends AbstractManagementTest {
         user.setLoginsCount(5l);
         user.setNewsletter(false);
         user.setNickName("nick"+random);
-        user.setSource("test");
+        user.setSource("gravitee");
         user.setPassword("testpassword");
 
         Attribute attribute = new Attribute();


### PR DESCRIPTION
fixes gravitee-io/issues#5908