### PR TITLE
chore: bump gravitee-plugin & gravitee-cockpit-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,13 +67,13 @@
     <properties>
         <gravitee-bom.version>1.0</gravitee-bom.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
-        <gravitee-plugin.version>1.17.1</gravitee-plugin.version>
+        <gravitee-plugin.version>1.18.0</gravitee-plugin.version>
         <gravitee-node.version>1.15.1</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>1.26.0</gravitee-gateway-api.version>
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>
         <gravitee-platform-repository-api.version>1.0.0</gravitee-platform-repository-api.version>
-        <gravitee-cockpit-api.version>1.5.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>1.7.0</gravitee-cockpit-api.version>
         <spring-security.version>5.3.9.RELEASE</spring-security.version>
         <spring-integration.version>5.2.6.RELEASE</spring-integration.version>
         <nimbus.version>8.17</nimbus.version>
@@ -108,7 +108,7 @@
         <gravitee-policy-ipfiltering.version>1.8.0</gravitee-policy-ipfiltering.version>
         <gravitee-policy-request-validation.version>1.12.0</gravitee-policy-request-validation.version>
         <gravitee-license-node.version>1.1.0</gravitee-license-node.version>
-        <gravitee-cockpit-connectors.version>2.0.0-SNAPSHOT</gravitee-cockpit-connectors.version>
+        <gravitee-cockpit-connectors.version>2.0.0</gravitee-cockpit-connectors.version>
         <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
         <gravitee-notifier-email.version>1.3.0</gravitee-notifier-email.version>
         <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>


### PR DESCRIPTION
gravitee-cockpit-connectors@2.0.0 needs gravitee-cockpit-api@1.7.0 & gravitee-plugin@1.18.0

Related https://github.com/gravitee-io/issues/issues/5909