### PR TITLE
fix: authorize empty as value to updtade the application certificate

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplication.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplication.java
@@ -159,7 +159,7 @@ public class PatchApplication {
             requiredPermissions.add(Permission.APPLICATION_FACTOR);
         }
 
-        if (certificate != null && certificate.isPresent()) {
+        if (certificate != null) {
             requiredPermissions.add(Permission.APPLICATION_CERTIFICATE);
         }
 


### PR DESCRIPTION
fixes gravitee-io/issues#5922