### PR TITLE
feat(management): Identifier-first login

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/AuthenticationFlowHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/AuthenticationFlowHandlerImpl.java
@@ -43,6 +43,7 @@ public class AuthenticationFlowHandlerImpl implements AuthenticationFlowHandler 
     public Handler<RoutingContext> create() {
         List<AuthenticationFlowStep> steps = new LinkedList<>();
         steps.add(new SPNEGOStep(RedirectHandler.create("/login/SSO/SPNEGO"), identityProviderManager));
+        steps.add(new FormIdentifierFirstLoginStep(RedirectHandler.create("/login/identifier"), domain));
         steps.add(new FormLoginStep(RedirectHandler.create("/login")));
         steps.add(new WebAuthnRegisterStep(domain, RedirectHandler.create("/webauthn/register")));
         steps.add(new MFAEnrollStep(RedirectHandler.create("/mfa/enroll")));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/FormIdentifierFirstLoginStep.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/FormIdentifierFirstLoginStep.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.vertx.core.Handler;
+import io.vertx.reactivex.ext.auth.User;
+import io.vertx.reactivex.ext.web.RoutingContext;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
+import static java.util.Optional.ofNullable;
+import static java.util.function.Predicate.not;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class FormIdentifierFirstLoginStep extends AuthenticationFlowStep {
+
+    private final Domain domain;
+
+    public FormIdentifierFirstLoginStep(Handler<RoutingContext> wrapper, Domain domain) {
+        super(wrapper);
+        this.domain = domain;
+    }
+
+    @Override
+    public void execute(RoutingContext routingContext, AuthenticationFlowChain flow) {
+        Optional<User> user = ofNullable(routingContext.user());
+        Optional<Client> client = ofNullable(routingContext.<Client>get(CLIENT_CONTEXT_KEY)).filter(Objects::nonNull);
+        boolean identifierFirstLoginEnabled = isIdentifierFirstLoginEnabled(client);
+        Optional<String> username = getOptionalUsername(routingContext);
+        if (user.isEmpty() && identifierFirstLoginEnabled && username.isEmpty()) {
+            flow.exit(this);
+        } else {
+            flow.doNext(routingContext);
+        }
+    }
+
+    private Boolean isIdentifierFirstLoginEnabled(Optional<Client> optionalClient) {
+        return optionalClient.map(client -> LoginSettings.getInstance(domain, client))
+                .map(LoginSettings::isIdentifierFirstEnabled)
+                .orElse(false);
+    }
+
+    private Optional<String> getOptionalUsername(RoutingContext routingContext) {
+        return ofNullable(routingContext.request().getParam(USERNAME_PARAM_KEY))
+                .filter(Objects::nonNull)
+                .filter(not(String::isEmpty));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/FormIdentifierFirstLoginStepTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/FormIdentifierFirstLoginStepTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.common.vertx.web.handler;
+
+import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.AuthenticationFlowChain;
+import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.FormIdentifierFirstLoginStep;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+import io.vertx.reactivex.ext.auth.User;
+import io.vertx.reactivex.ext.web.RoutingContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FormIdentifierFirstLoginStepTest {
+
+    private static final Handler<RoutingContext> redirectHandler = RedirectHandler.create("/login/identifier");
+
+    @Mock
+    private RoutingContext routingContext;
+
+    @Mock
+    private HttpServerRequest httpServerRequest;
+
+    private AuthenticationFlowChain authenticationFlowChain;
+
+    private FormIdentifierFirstLoginStep formIdentifierFirstLoginStep;
+    private Client client;
+    private Domain domain;
+
+    @Before
+    public void setUp() {
+        domain = new Domain();
+        domain.setLoginSettings(new LoginSettings());
+        formIdentifierFirstLoginStep = new FormIdentifierFirstLoginStep(redirectHandler, domain);
+        authenticationFlowChain = spy(new AuthenticationFlowChain(List.of(formIdentifierFirstLoginStep)));
+        client = new Client();
+        client.setLoginSettings(new LoginSettings());
+
+        when(routingContext.get(CLIENT_CONTEXT_KEY)).thenReturn(client);
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        doNothing().when(authenticationFlowChain).exit(Mockito.any());
+        doNothing().when(authenticationFlowChain).doNext(Mockito.any());
+    }
+
+    @Test
+    public void mustExitFlow_identifierFirstLoginEnabledAndEmptyUsernameAndEmptyUser() {
+        client.getLoginSettings().setInherited(false);
+        client.getLoginSettings().setIdentifierFirstEnabled(true);
+
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        when(routingContext.user()).thenReturn(null);
+        when(httpServerRequest.getParam(USERNAME_PARAM_KEY)).thenReturn(null);
+
+        formIdentifierFirstLoginStep.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(1)).exit(formIdentifierFirstLoginStep);
+        verify(authenticationFlowChain, times(0)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustExitFlow_identifierFirstLoginEnabledAndEmptyUsernameAndEmptyUserWithDomain() {
+        client.getLoginSettings().setInherited(true);
+        domain.getLoginSettings().setIdentifierFirstEnabled(true);
+
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        when(routingContext.user()).thenReturn(null);
+        when(httpServerRequest.getParam(USERNAME_PARAM_KEY)).thenReturn(null);
+
+        formIdentifierFirstLoginStep.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(1)).exit(formIdentifierFirstLoginStep);
+        verify(authenticationFlowChain, times(0)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustNotExitFlow_identifierFirstLoginDisabledAtDomain() {
+        client.getLoginSettings().setInherited(true);
+        domain.getLoginSettings().setIdentifierFirstEnabled(false);
+
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        when(routingContext.user()).thenReturn(null);
+        when(httpServerRequest.getParam(USERNAME_PARAM_KEY)).thenReturn(null);
+
+        formIdentifierFirstLoginStep.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(0)).exit(formIdentifierFirstLoginStep);
+        verify(authenticationFlowChain, times(1)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustDoNext_identifierFirstLoginDisabled() {
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        when(routingContext.user()).thenReturn(User.create(new JsonObject()));
+        when(httpServerRequest.getParam(USERNAME_PARAM_KEY)).thenReturn("a username");
+
+        formIdentifierFirstLoginStep.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(0)).exit(formIdentifierFirstLoginStep);
+        verify(authenticationFlowChain, times(1)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustDoNext_userNotEmpty() {
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        when(routingContext.user()).thenReturn(User.create(new JsonObject()));
+        when(httpServerRequest.getParam(USERNAME_PARAM_KEY)).thenReturn(null);
+
+        formIdentifierFirstLoginStep.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(0)).exit(formIdentifierFirstLoginStep);
+        verify(authenticationFlowChain, times(1)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustDoNext_usernameNotEmpty() {
+        client.getLoginSettings().setIdentifierFirstEnabled(true);
+
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        when(routingContext.user()).thenReturn(null);
+        when(httpServerRequest.getParam(USERNAME_PARAM_KEY)).thenReturn("a username");
+
+        formIdentifierFirstLoginStep.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(0)).exit(formIdentifierFirstLoginStep);
+        verify(authenticationFlowChain, times(1)).doNext(routingContext);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/AbstractEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/AbstractEndpoint.java
@@ -17,9 +17,17 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint;
 
 import io.gravitee.am.gateway.handler.manager.form.FormManager;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.MediaType;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import io.vertx.reactivex.ext.web.RoutingContext;
+import io.vertx.reactivex.ext.web.common.template.TemplateEngine;
+import org.slf4j.Logger;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -27,6 +35,12 @@ import java.util.Optional;
  * @author GraviteeSource Team
  */
 public abstract class AbstractEndpoint {
+
+    private final TemplateEngine templateEngine;
+
+    protected AbstractEndpoint(TemplateEngine templateEngine) {
+        this.templateEngine = templateEngine;
+    }
 
     public abstract String getTemplateSuffix();
 
@@ -39,5 +53,19 @@ public abstract class AbstractEndpoint {
         routingContext.put(paramKey, request.getParam(paramKey));
     }
 
+    protected void renderPage(RoutingContext routingContext, Map<String, Object> data, Client client, Logger logger, String errorMessage) {
+        this.renderPage(data, client, res -> {
+            if (res.succeeded()) {
+                routingContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML);
+                routingContext.response().end(res.result());
+            } else {
+                logger.error(errorMessage, res.cause());
+                routingContext.fail(res.cause());
+            }
+        });
+    }
 
+    protected void renderPage(Map<String, Object> data, Client client, Handler<AsyncResult<Buffer>> handler) {
+        templateEngine.render(data, getTemplateFileName(client), handler);
+    }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpoint.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.resources.endpoint.identifierfirst;
+
+import io.gravitee.am.gateway.handler.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
+import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
+import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
+import io.gravitee.am.gateway.handler.context.EvaluableRequest;
+import io.gravitee.am.gateway.handler.context.provider.ClientProperties;
+import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
+import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.vertx.core.Handler;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+import io.vertx.reactivex.ext.web.RoutingContext;
+import io.vertx.reactivex.ext.web.common.template.TemplateEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.ACTION_KEY;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.resolveProxyRequest;
+import static io.gravitee.am.model.Template.IDENTIFIER_FIRST_LOGIN;
+import static java.util.Optional.ofNullable;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class IdentifierFirstLoginEndpoint extends AbstractEndpoint implements Handler<RoutingContext> {
+
+    private static final Logger logger = LoggerFactory.getLogger(IdentifierFirstLoginEndpoint.class);
+    private static final String REQUEST_CONTEXT_KEY = "request";
+    private static final String ALLOW_REGISTER_CONTEXT_KEY = "allowRegister";
+    private static final String ALLOW_PASSWORDLESS_CONTEXT_KEY = "allowPasswordless";
+    private static final String REGISTER_ACTION_KEY = "registerAction";
+    private static final String WEBAUTHN_ACTION_KEY = "passwordlessAction";
+
+    private final Domain domain;
+    private final BotDetectionManager botDetectionManager;
+
+    public IdentifierFirstLoginEndpoint(TemplateEngine templateEngine, Domain domain, BotDetectionManager botDetectionManager) {
+        super(templateEngine);
+        this.domain = domain;
+        this.botDetectionManager = botDetectionManager;
+    }
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+        final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
+        prepareContext(routingContext, client);
+        renderLoginPage(routingContext, client);
+    }
+
+    private void prepareContext(RoutingContext routingContext, Client client) {
+        final HttpServerRequest request = routingContext.request();
+        // remove sensible client data
+        routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, new ClientProperties(client));
+        // put domain in context data
+        routingContext.put(ConstantKeys.DOMAIN_CONTEXT_KEY, domain);
+        // put request in context
+        EvaluableRequest evaluableRequest = new EvaluableRequest(new VertxHttpServerRequest(request.getDelegate(), true));
+        routingContext.put(REQUEST_CONTEXT_KEY, evaluableRequest);
+
+        LoginSettings loginSettings = LoginSettings.getInstance(domain, client);
+        var optionalSettings = ofNullable(loginSettings).filter(Objects::nonNull);
+        routingContext.put(ALLOW_REGISTER_CONTEXT_KEY, optionalSettings.map(LoginSettings::isRegisterEnabled).orElse(false));
+        routingContext.put(ALLOW_PASSWORDLESS_CONTEXT_KEY, optionalSettings.map(LoginSettings::isPasswordlessEnabled).orElse(false));
+
+        // put error in context
+        final String error = request.getParam(ConstantKeys.ERROR_PARAM_KEY);
+        final String errorDescription = request.getParam(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY);
+        routingContext.put(ConstantKeys.ERROR_PARAM_KEY, error);
+        routingContext.put(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, errorDescription);
+
+        // put parameters in context (backward compatibility)
+        Map<String, String> params = new HashMap<>(evaluableRequest.getParams().toSingleValueMap());
+        params.put(ConstantKeys.ERROR_PARAM_KEY, error);
+        params.put(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, errorDescription);
+        routingContext.put(ConstantKeys.PARAM_CONTEXT_KEY, params);
+
+        final MultiMap queryParams = RequestUtils.getCleanedQueryParams(request);
+        routingContext.put(ACTION_KEY, resolveProxyRequest(request, routingContext.get(CONTEXT_PATH) + "/login", queryParams, true));
+        routingContext.put(REGISTER_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true));
+        routingContext.put(WEBAUTHN_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true));
+    }
+
+    private void renderLoginPage(RoutingContext routingContext, Client client) {
+        final Map<String, Object> data = new HashMap<>(routingContext.data());
+        data.putAll(botDetectionManager.getTemplateVariables(domain, client));
+        this.renderPage(routingContext, data, client, logger, "Unable to render Identifier-first login page");
+    }
+
+    @Override
+    public String getTemplateSuffix() {
+        return IDENTIFIER_FIRST_LOGIN.template();
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpoint.java
@@ -18,54 +18,59 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.login;
 import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
 import io.gravitee.am.gateway.handler.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
-import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
-import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.context.EvaluableRequest;
 import io.gravitee.am.gateway.handler.context.provider.ClientProperties;
-import io.gravitee.am.gateway.handler.manager.form.FormManager;
-import io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler;
+import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.Template;
 import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.oidc.Client;
-import io.gravitee.common.http.HttpHeaders;
-import io.gravitee.common.http.MediaType;
 import io.vertx.core.Handler;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.ext.web.RoutingContext;
-import io.vertx.reactivex.ext.web.templ.thymeleaf.ThymeleafTemplateEngine;
+import io.vertx.reactivex.ext.web.common.template.TemplateEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.*;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.ACTION_KEY;
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils.getCleanedQueryParams;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.resolveProxyRequest;
+import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler.SOCIAL_PROVIDER_CONTEXT_KEY;
+import static java.lang.Boolean.TRUE;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class LoginEndpoint implements Handler<RoutingContext> {
+public class LoginEndpoint extends AbstractEndpoint implements Handler<RoutingContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(LoginEndpoint.class);
     private static final String ALLOW_FORGOT_PASSWORD_CONTEXT_KEY = "allowForgotPassword";
     private static final String ALLOW_REGISTER_CONTEXT_KEY = "allowRegister";
     private static final String ALLOW_PASSWORDLESS_CONTEXT_KEY = "allowPasswordless";
     private static final String HIDE_FORM_CONTEXT_KEY = "hideLoginForm";
+    private static final String IDENTIFIER_FIRST_LOGIN_CONTEXT_KEY = "identifierFirstLoginEnabled";
     private static final String REQUEST_CONTEXT_KEY = "request";
     private static final String FORGOT_ACTION_KEY = "forgotPasswordAction";
     private static final String REGISTER_ACTION_KEY = "registerAction";
     private static final String WEBAUTHN_ACTION_KEY = "passwordlessAction";
+    private static final String BACK_TO_LOGIN_IDENTIFIER_ACTION_KEY = "backToLoginIdentifierAction";
+    private static final String REDIRECT_TO_LOGIN_IDENTIFIER = "redirectToLoginIdentifier";
 
-    private final ThymeleafTemplateEngine engine;
     private final Domain domain;
     private final BotDetectionManager botDetectionManager;
 
-    public LoginEndpoint(ThymeleafTemplateEngine thymeleafTemplateEngine, Domain domain, BotDetectionManager botDetectionManager) {
-        this.engine = thymeleafTemplateEngine;
+    public LoginEndpoint(TemplateEngine templateEngine, Domain domain, BotDetectionManager botDetectionManager) {
+        super(templateEngine);
         this.domain = domain;
         this.botDetectionManager = botDetectionManager;
     }
@@ -73,25 +78,31 @@ public class LoginEndpoint implements Handler<RoutingContext> {
     @Override
     public void handle(RoutingContext routingContext) {
         final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
-
-        // prepare context
         prepareContext(routingContext, client);
-
-        // render login page
         renderLoginPage(routingContext, client);
     }
 
     private void prepareContext(RoutingContext routingContext, Client client) {
+        // create query params
+        final MultiMap queryParams = getCleanedQueryParams(routingContext.request());
         // remove sensible client data
         routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, new ClientProperties(client));
         // put domain in context data
         routingContext.put(ConstantKeys.DOMAIN_CONTEXT_KEY, domain);
         // put login settings in context data
         LoginSettings loginSettings = LoginSettings.getInstance(domain, client);
-        routingContext.put(ALLOW_FORGOT_PASSWORD_CONTEXT_KEY, loginSettings != null && loginSettings.isForgotPasswordEnabled());
-        routingContext.put(ALLOW_REGISTER_CONTEXT_KEY, loginSettings != null && loginSettings.isRegisterEnabled());
-        routingContext.put(ALLOW_PASSWORDLESS_CONTEXT_KEY, loginSettings != null && loginSettings.isPasswordlessEnabled());
-        routingContext.put(HIDE_FORM_CONTEXT_KEY, loginSettings != null && loginSettings.isHideForm());
+        var optionalSettings = ofNullable(loginSettings).filter(Objects::nonNull);
+        boolean isIdentifierFirstLoginEnabled = optionalSettings.map(LoginSettings::isIdentifierFirstEnabled).orElse(false);
+
+        routingContext.put(ALLOW_FORGOT_PASSWORD_CONTEXT_KEY, optionalSettings.map(LoginSettings::isForgotPasswordEnabled).orElse(false));
+        routingContext.put(ALLOW_REGISTER_CONTEXT_KEY, optionalSettings.map(LoginSettings::isRegisterEnabled).orElse(false));
+        routingContext.put(ALLOW_PASSWORDLESS_CONTEXT_KEY, optionalSettings.map(LoginSettings::isPasswordlessEnabled).orElse(false));
+        routingContext.put(HIDE_FORM_CONTEXT_KEY, optionalSettings.map(LoginSettings::isHideForm).orElse(false));
+        routingContext.put(IDENTIFIER_FIRST_LOGIN_CONTEXT_KEY, isIdentifierFirstLoginEnabled);
+
+        if (isIdentifierFirstLoginEnabled) {
+            routingContext.put(USERNAME_PARAM_KEY, routingContext.request().getParam(USERNAME_PARAM_KEY));
+        }
 
         // put request in context
         EvaluableRequest evaluableRequest = new EvaluableRequest(new VertxHttpServerRequest(routingContext.request().getDelegate(), true));
@@ -107,48 +118,85 @@ public class LoginEndpoint implements Handler<RoutingContext> {
         Map<String, String> params = new HashMap<>(evaluableRequest.getParams().toSingleValueMap());
         params.put(ConstantKeys.ERROR_PARAM_KEY, error);
         params.put(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, errorDescription);
+        if (!isIdentifierFirstLoginEnabled) {
+            params.remove(USERNAME_PARAM_KEY);
+        }
         routingContext.put(ConstantKeys.PARAM_CONTEXT_KEY, params);
 
         // create post action url.
-        final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-        routingContext.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true));
-        routingContext.put(FORGOT_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true));
-        routingContext.put(REGISTER_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true));
-        routingContext.put(WEBAUTHN_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true));
+        if (isIdentifierFirstLoginEnabled && isNullOrEmpty(routingContext.get(USERNAME_PARAM_KEY))) {
+            routingContext.put(REDIRECT_TO_LOGIN_IDENTIFIER, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParams, true));
+        } else {
+            routingContext.put(ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true));
+            routingContext.put(FORGOT_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true));
+            routingContext.put(REGISTER_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true));
+            routingContext.put(WEBAUTHN_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true));
+
+            var queryParamsNoUsername = MultiMap.caseInsensitiveMultiMap();
+            queryParamsNoUsername.addAll(queryParams);
+            queryParamsNoUsername.remove(USERNAME_PARAM_KEY);
+            routingContext.put(BACK_TO_LOGIN_IDENTIFIER_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParamsNoUsername, true));
+        }
     }
 
     private void renderLoginPage(RoutingContext routingContext, Client client) {
-        // render the login page
-        final Map<String, Object> data = new HashMap<>();
-        data.putAll(routingContext.data());
-        data.putAll(botDetectionManager.getTemplateVariables(domain, client));
+        // we redirect if we don't have the username while being on first login identifier enabled
+        final String urlIdentifierFirstRedirect = routingContext.get(REDIRECT_TO_LOGIN_IDENTIFIER);
+        if (!isNullOrEmpty(urlIdentifierFirstRedirect)) {
+            routingContext.response()
+                    .putHeader(io.vertx.core.http.HttpHeaders.LOCATION, urlIdentifierFirstRedirect)
+                    .setStatusCode(302)
+                    .end();
+        } else {
+            var data = new HashMap<>(routingContext.data());
+            data.putAll(botDetectionManager.getTemplateVariables(domain, client));
 
-        final List<IdentityProvider> providers = (List<IdentityProvider>)data.get(LoginSocialAuthenticationHandler.SOCIAL_PROVIDER_CONTEXT_KEY);
-        if (providers != null && Boolean.TRUE.equals(data.get(HIDE_FORM_CONTEXT_KEY))) {
-            if (providers.size() == 1) {
-                // hide login form enabled and only one IdP configured, redirect to the IdP login page
-                Map<String, String> urls = (Map<String, String>)data.get(LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY);
-                String redirectUrl = urls.get(providers.get(0).getId());
-                routingContext.response()
-                        .putHeader(io.vertx.core.http.HttpHeaders.LOCATION, redirectUrl)
-                        .setStatusCode(302)
-                        .end();
-                return;
+            //we render the page if no redirect is set
+            final boolean identifierFirstLoginEnabled = TRUE.equals(routingContext.get(IDENTIFIER_FIRST_LOGIN_CONTEXT_KEY));
+            boolean render = identifierFirstLoginEnabled ?
+                    redirectAutomaticallyFirstIdentifierLogin(routingContext, data) :
+                    redirectAutomaticallySingle(routingContext, data);
+            if (render) {
+                this.renderPage(routingContext, data, client, logger, "Unable to render login page");
             }
         }
+    }
 
-        engine.render(data, getTemplateFileName(client), res -> {
-            if (res.succeeded()) {
-                routingContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML);
-                routingContext.response().end(res.result());
-            } else {
-                logger.error("Unable to render login page", res.cause());
-                routingContext.fail(res.cause());
+    private boolean redirectAutomaticallyFirstIdentifierLogin(RoutingContext routingContext, Map<String, Object> data) {
+        var optionalProviders = ofNullable((List<IdentityProvider>) data.get(SOCIAL_PROVIDER_CONTEXT_KEY));
+        final String userName = String.valueOf(data.get(USERNAME_PARAM_KEY));
+        String[] usernameDomain = userName.split("@");
+        return usernameDomain.length == 1 || optionalProviders.orElse(List.of()).stream().noneMatch(provider -> {
+            boolean domainMatches = provider.getDomainWhitelist().stream().anyMatch(usernameDomain[1]::equals);
+            if (domainMatches) {
+                redirectToExternalProvider(routingContext, data, provider.getId(), "google".equals(provider.getType()));
             }
+            return domainMatches;
         });
     }
 
-    private String getTemplateFileName(Client client) {
-        return "login" + (client != null ? FormManager.TEMPLATE_NAME_SEPARATOR + client.getId() : "");
+    private boolean redirectAutomaticallySingle(RoutingContext routingContext, Map<String, Object> data) {
+        final List<IdentityProvider> providers = (List<IdentityProvider>) data.get(SOCIAL_PROVIDER_CONTEXT_KEY);
+        if (providers != null && TRUE.equals(data.get(HIDE_FORM_CONTEXT_KEY))) {
+            if (providers.size() == 1) {
+                redirectToExternalProvider(routingContext, data, providers.get(0).getId(), false);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void redirectToExternalProvider(RoutingContext routingContext, Map<String, Object> data, String providerId, boolean forceChoose) {
+        Map<String, String> urls = (Map<String, String>) data.get(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY);
+        String redirectUrl = urls.get(providerId);
+        routingContext.response()
+                .putHeader(io.vertx.core.http.HttpHeaders.LOCATION, redirectUrl + (forceChoose ? "&prompt=select_account+consent" : ""))
+                .setStatusCode(302)
+                .end();
+    }
+
+    @Override
+    public String getTemplateSuffix() {
+        return Template.LOGIN.template();
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnEndpoint.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.webauthn;
 
 import io.gravitee.am.common.exception.authentication.UsernameNotFoundException;
 import io.gravitee.am.gateway.handler.common.auth.user.UserAuthenticationManager;
+import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.gateway.api.Request;
@@ -25,16 +26,23 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.ext.web.RoutingContext;
+import io.vertx.reactivex.ext.web.common.template.TemplateEngine;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public abstract class WebAuthnEndpoint implements Handler<RoutingContext> {
+public abstract class WebAuthnEndpoint extends AbstractEndpoint implements Handler<RoutingContext> {
 
     protected final UserAuthenticationManager userAuthenticationManager;
 
+    WebAuthnEndpoint(TemplateEngine templateEngine, UserAuthenticationManager userAuthenticationManager) {
+        super(templateEngine);
+        this.userAuthenticationManager = userAuthenticationManager;
+    }
+
     WebAuthnEndpoint(UserAuthenticationManager userAuthenticationManager) {
+        super(null);
         this.userAuthenticationManager = userAuthenticationManager;
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnResponseEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnResponseEndpoint.java
@@ -30,6 +30,7 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.CredentialService;
+import io.gravitee.am.service.exception.NotImplementedException;
 import io.gravitee.common.http.HttpHeaders;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -197,5 +198,10 @@ public class WebAuthnResponseEndpoint extends WebAuthnEndpoint {
                         () -> handler.handle(Future.succeededFuture()),
                         error -> handler.handle(Future.failedFuture(error))
                 );
+    }
+
+    @Override
+    public String getTemplateSuffix() {
+        throw new NotImplementedException("No need to render a template");
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFormHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFormHandler.java
@@ -21,6 +21,9 @@ import io.gravitee.am.gateway.handler.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.UserAuthProvider;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.service.exception.NotImplementedException;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
@@ -32,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.PASSWORD_PARAM_KEY;
 import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
+import static java.util.Objects.isNull;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/login.css
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/login.css
@@ -45,6 +45,10 @@
     justify-content: flex-end;
 }
 
+.login-form-actions > .no-margin-left {
+    margin-left: 0px;
+}
+
 .login-form-additional-actions {
     display:flex;
     flex-direction: column;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Identifier-first Login</title>
+
+    <!-- CSS -->
+    <link rel="stylesheet" th:href="@{../assets/material/material.blue_grey-blue.min.css}">
+    <link rel="stylesheet" th:href="@{../assets/material/material.icons.css}">
+    <link rel="stylesheet" th:href="@{../assets/font-awesome/css/font-awesome.min.css}">
+    <link rel="stylesheet" th:href="@{../assets/css/login.css}">
+
+    <!-- Favicon and touch icons -->
+    <link rel="shortcut icon" th:href="@{../assets/ico/favicon.ico}">
+
+    <script th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}" th:src="${'https://www.google.com/recaptcha/api.js?render=' + bot_detection_configuration.siteKey}"></script>
+
+</head>
+
+<body>
+<div class="mdl-layout mdl-js-layout">
+    <div class="login-container">
+        <div class="login-form">
+            <div class="login-form-title">
+                <label>Sign in</label>
+                <span>to continue to <span th:text="${domain.name}"></span></span>
+            </div>
+            <form id="form" role="form" th:action="${action}" method="get">
+                <div class="login-form-content">
+                    <div class="input-textfield">
+                        <label for="username">Username</label>
+                        <input type="text" id="username" name="username" autofocus="autofocus" required />
+                    </div>
+                    <div th:if="${error}" class="login-error-info">
+                            <span>
+                                <span class="error" th:text="${error}"></span>
+                                <small class="error_description" th:text="*{error_description}?: 'Wrong user or password'"></small>
+                            </span>
+                    </div>
+                </div>
+
+                <input type="hidden" th:name="response_type" th:value="${param.response_type}"/>
+                <input type="hidden" th:name="redirect_uri" th:value="${param.redirect_uri}"/>
+                <input type="hidden" th:name="client_id" th:value="${param.client_id}"/>
+
+                <input type="hidden" th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}"
+                       th:id="${bot_detection_configuration.get('tokenParameterName')}"
+                       th:name="${bot_detection_configuration.get('tokenParameterName')}" />
+
+                <div class="login-form-actions">
+                    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Sign in</button>
+                </div>
+                <div class="login-form-additional-actions">
+                    <div th:if="${allowRegister}">
+                        <a th:href="${registerAction}">No account ? Register</a>
+                    </div>
+                    <div  th:if="${allowPasswordless}">
+                        <a th:href="${passwordlessAction}">Sign in with fingerprint, device or security key</a>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!--[if lt IE 10]>
+<script th:src="@{../assets/js/placeholder.js}"></script>
+<![endif]-->
+<script th:src="@{../assets/material/material.min.js}"></script>
+<script th:src="@{../assets/js/jquery-3.5.1.min.js}"></script>
+<script th:inline="javascript">
+    $(".mdl-textfield__input").focus(function (){
+        if( !this.value ){
+            $(this).prop('required', true);
+            $(this).parent().addClass('is-invalid');
+        }
+    });
+
+    $(".mdl-button").filter(":button").click(function (event){
+        /*[# th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}"]*/
+        event.preventDefault();
+        grecaptcha.ready(function() {
+            grecaptcha.execute(/*[[${bot_detection_configuration.siteKey}]]*/, {action: 'submit'}).then(function(token) {
+                $("#"+ /*[[${bot_detection_configuration.get('tokenParameterName')}]]*/ "no-name").val(token);
+                $("#form").unbind('submit').submit();
+            });
+        });
+        /*[/]*/
+
+        $(this).siblings(".mdl-textfield").addClass('is-invalid');
+        $(this).siblings(".mdl-textfield").children(".mdl-textfield__input").prop('required', true);
+    });
+</script>
+</body>
+</html>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
@@ -32,7 +32,10 @@
                     <div class="login-form-content">
                         <div class="input-textfield">
                             <label for="username">Username</label>
-                            <input type="text" id="username" name="username" autofocus="autofocus" required />
+                            <input type="text" id="username" name="username"
+                                   th:value="${identifierFirstLoginEnabled ? param.username : ''}" autofocus="autofocus" required
+                                   th:readonly="${identifierFirstLoginEnabled}"
+                            />
                         </div>
                         <div class="input-textfield">
                             <label for="password">Password</label>
@@ -57,13 +60,16 @@
                         <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Sign in</button>
                     </div>
                     <div class="login-form-additional-actions">
+                        <div th:if="${identifierFirstLoginEnabled}">
+                            <a th:href="${backToLoginIdentifierAction}">Switch account</a>
+                        </div>
                         <div th:if="${allowForgotPassword}">
                             <a th:href="${forgotPasswordAction}">Forgot Password ?</a>
                         </div>
-                        <div th:if="${allowRegister}">
+                        <div th:if="${allowRegister && !identifierFirstLoginEnabled}">
                             <a th:href="${registerAction}">No account ? Register</a>
                         </div>
-                        <div  th:if="${allowPasswordless}">
+                        <div  th:if="${allowPasswordless && !identifierFirstLoginEnabled}">
                             <a th:href="${passwordlessAction}">Sign in with fingerprint, device or security key</a>
                         </div>
                     </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpointTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.root.resources.endpoint.identifierfirst;
+
+import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
+import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
+import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
+import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
+import io.gravitee.am.gateway.handler.root.resources.handler.client.ClientRequestParseHandler;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.Maybe;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.ext.web.RoutingContext;
+import io.vertx.reactivex.ext.web.common.template.TemplateEngine;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.ACTION_KEY;
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.DOMAIN_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.resolveProxyRequest;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
+
+    @Mock
+    private ClientSyncService clientSyncService;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private BotDetectionManager botDetectionManager;
+
+    private Client appClient;
+    private io.gravitee.am.gateway.handler.root.resources.endpoint.identifierfirst.IdentifierFirstLoginEndpoint identifierFirstLoginEndpoint;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        ClientRequestParseHandler clientRequestParseHandler = new ClientRequestParseHandler(clientSyncService);
+        clientRequestParseHandler.setRequired(true);
+
+        final LoginSettings loginSettings = new LoginSettings();
+        loginSettings.setIdentifierFirstEnabled(true);
+
+        appClient = new Client();
+        appClient.setClientId(UUID.randomUUID().toString());
+
+        domain = new Domain();
+        domain.setId(UUID.randomUUID().toString());
+        domain.setPath("/id-first-domain");
+        domain.setLoginSettings(loginSettings);
+
+        appClient.setDomain(domain.getId());
+
+        identifierFirstLoginEndpoint = new IdentifierFirstLoginEndpoint(templateEngine, domain, botDetectionManager);
+        router.route(HttpMethod.GET, "/login/identifier")
+                .handler(clientRequestParseHandler)
+                .failureHandler(new ErrorHandler());
+    }
+
+    @Test
+    public void mustInvokeIdentifierFirstLoginEndpoint() throws Exception {
+        router.route(HttpMethod.GET, "/login/identifier").handler(get200AssertMockRoutingContextHandler(identifierFirstLoginEndpoint));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login/identifier?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.OK_200, "OK");
+    }
+
+    @Test
+    public void mustNotInvokeIdentifierFirstLoginEndpoint_noClientId() throws Exception {
+        testRequest(
+                HttpMethod.GET, "/login/identifier",
+                HttpStatusCode.BAD_REQUEST_400, "Bad Request");
+    }
+
+    @Test
+    public void mustNotInvokeIdentifierFirstLoginEndpoint_wrongClientId() throws Exception {
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.empty());
+        testRequest(
+                HttpMethod.GET, "/login/identifier?client_id=" + appClient.getClientId(),
+                HttpStatusCode.BAD_REQUEST_400, "Bad Request");
+    }
+
+    private Handler<RoutingContext> get200AssertMockRoutingContextHandler(IdentifierFirstLoginEndpoint identifierFirstLoginEndpoint) {
+        return routingContext -> {
+            doAnswer(answer -> {
+                try {
+                    assertNotNull(routingContext.get(CLIENT_CONTEXT_KEY));
+                    assertEquals(routingContext.get(DOMAIN_CONTEXT_KEY), domain);
+                    assertNotNull(routingContext.get(PARAM_CONTEXT_KEY));
+                    final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
+                    assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(),
+                            routingContext.get(CONTEXT_PATH) + "/login", queryParams, true));
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    routingContext.end();
+                }
+                return answer;
+            }).when(templateEngine).render(Mockito.<Map<String, Object>>any(), Mockito.any(), Mockito.any());
+            identifierFirstLoginEndpoint.handle(routingContext);
+        };
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpointHandlerTest.java
@@ -17,16 +17,40 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.login;
 
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
 import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
+import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
 import io.gravitee.am.gateway.handler.root.resources.handler.client.ClientRequestParseHandler;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
 import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.Maybe;
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.ext.web.RoutingContext;
+import io.vertx.reactivex.ext.web.common.template.TemplateEngine;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.*;
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.ACTION_KEY;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.resolveProxyRequest;
+import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler.SOCIAL_PROVIDER_CONTEXT_KEY;
+import static java.lang.Boolean.TRUE;
+import static java.util.stream.Collectors.toMap;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -36,8 +60,26 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class LoginEndpointHandlerTest extends RxWebTestBase {
 
+    private static final String FORGOT_ACTION_KEY = "forgotPasswordAction";
+    private static final String REGISTER_ACTION_KEY = "registerAction";
+    private static final String WEBAUTHN_ACTION_KEY = "passwordlessAction";
+    private static final String ALLOW_FORGOT_PASSWORD_CONTEXT_KEY = "allowForgotPassword";
+    private static final String ALLOW_REGISTER_CONTEXT_KEY = "allowRegister";
+    private static final String ALLOW_PASSWORDLESS_CONTEXT_KEY = "allowPasswordless";
+    private static final String HIDE_FORM_CONTEXT_KEY = "hideLoginForm";
+    private static final String IDENTIFIER_FIRST_LOGIN_ENABLED = "identifierFirstLoginEnabled";
+    private static final String BACK_TO_LOGIN_IDENTIFIER_ACTION_KEY = "backToLoginIdentifierAction";
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private BotDetectionManager botDetectionManager;
+
     @Mock
     private ClientSyncService clientSyncService;
+    private Client appClient;
+    private LoginEndpoint loginEndpoint;
 
     @Override
     public void setUp() throws Exception {
@@ -46,9 +88,188 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
         ClientRequestParseHandler clientRequestParseHandler = new ClientRequestParseHandler(clientSyncService);
         clientRequestParseHandler.setRequired(true);
 
+        final LoginSettings loginSettings = new LoginSettings();
+
+        appClient = new Client();
+        appClient.setClientId(UUID.randomUUID().toString());
+
+        domain = new Domain();
+        domain.setId(UUID.randomUUID().toString());
+        domain.setPath("/login-domain");
+        domain.setLoginSettings(loginSettings);
+        appClient.setDomain(domain.getId());
+        loginEndpoint = new LoginEndpoint(templateEngine, domain, botDetectionManager);
+        appClient.setLoginSettings(loginSettings);
+
         router.route(HttpMethod.GET, "/login")
+                .handler(routingContext -> {
+                    routingContext.put(CONTEXT_PATH, "");
+                    routingContext.next();
+                })
                 .handler(clientRequestParseHandler)
                 .failureHandler(new ErrorHandler());
+    }
+
+    @Test
+    public void shouldInvokeLoginEndpoint_buildTemplate() throws Exception {
+        appClient.getLoginSettings().setIdentifierFirstEnabled(false);
+        appClient.getLoginSettings().setHideForm(false);
+        router.route(HttpMethod.GET, "/login").handler(get200AssertMockRoutingContextHandler(loginEndpoint, false, false));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.OK_200, "OK");
+    }
+
+    @Test
+    public void shouldInvokeLoginEndpoint_redirectProvider() throws Exception {
+        appClient.getLoginSettings().setIdentifierFirstEnabled(false);
+        appClient.getLoginSettings().setHideForm(TRUE);
+        router.route(HttpMethod.GET, "/login").handler(routingContext -> {
+            final IdentityProvider idp = new IdentityProvider();
+            idp.setId("provider-id");
+            routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+            routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
+            routingContext.next();
+        }).handler(get302AssertMockRoutingContextHandler(loginEndpoint, true, false));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.FOUND_302, "Found");
+    }
+
+    @Test
+    public void shouldInvokeLoginEndpoint_noRedirect() throws Exception {
+        appClient.getLoginSettings().setHideForm(false);
+        router.route(HttpMethod.GET, "/login").handler(routingContext -> {
+            final IdentityProvider idp = new IdentityProvider();
+            idp.setId("provider-id");
+            routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+            routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
+            routingContext.next();
+        }).handler(get200AssertMockRoutingContextHandler(loginEndpoint, false, false));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.OK_200, "OK");
+    }
+
+    @Test
+    public void shouldInvokeLoginEndpoint_noRedirectNoMatchingProviders() throws Exception {
+        appClient.getLoginSettings().setHideForm(false);
+        appClient.getLoginSettings().setIdentifierFirstEnabled(true);
+        router.route(HttpMethod.GET, "/login").handler(routingContext -> {
+            final IdentityProvider idp = new IdentityProvider();
+            idp.setId("provider-id");
+            idp.setDomainWhitelist(List.of("other-domain.com"));
+            routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+            routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
+            routingContext.next();
+        }).handler(get200AssertMockRoutingContextHandler(loginEndpoint, false, true));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?username=username@domain.com&client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.OK_200, "OK");
+    }
+
+    @Test
+    public void shouldInvokeLoginEndpoint_noRedirectUsernameIsNotAnEmail() throws Exception {
+        appClient.getLoginSettings().setHideForm(false);
+        appClient.getLoginSettings().setIdentifierFirstEnabled(true);
+        router.route(HttpMethod.GET, "/login").handler(routingContext -> {
+            final IdentityProvider idp = new IdentityProvider();
+            idp.setId("provider-id");
+            idp.setDomainWhitelist(List.of("other-domain.com"));
+            routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+            routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
+            routingContext.next();
+        }).handler(get200AssertMockRoutingContextHandler(loginEndpoint, false, true));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?username=username&client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.OK_200, "OK");
+    }
+
+    @Test
+    public void shouldInvokeLoginEndpoint_redirectUsernameMatchesDomain() throws Exception {
+        appClient.getLoginSettings().setHideForm(false);
+        appClient.getLoginSettings().setIdentifierFirstEnabled(true);
+        router.route(HttpMethod.GET, "/login").handler(routingContext -> {
+            final IdentityProvider idp = new IdentityProvider();
+            idp.setId("provider-id");
+            idp.setDomainWhitelist(List.of("domain.com"));
+            routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+            routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
+            routingContext.next();
+        }).handler(get302AssertMockRoutingContextHandler(loginEndpoint, false, true));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?username=username@domain.com&client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.FOUND_302, "Found");
+    }
+
+    @Test
+    public void shouldInvokeLoginEndpoint_redirectUsernameMatchesDomainAndSpecificIdp() throws Exception {
+        appClient.getLoginSettings().setHideForm(false);
+        appClient.getLoginSettings().setIdentifierFirstEnabled(true);
+        router.route(HttpMethod.GET, "/login").handler(routingContext -> {
+            final IdentityProvider idp = new IdentityProvider();
+            idp.setId("provider-id");
+            idp.setDomainWhitelist(List.of("domain.com"));
+            idp.setType("google");
+            routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+            routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
+            routingContext.next();
+        }).handler(get302AssertMockRoutingContextHandler(loginEndpoint, false, true));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?username=username@domain.com&client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.FOUND_302, "Found");
+    }
+
+    @Test
+    public void shouldInvokeLoginEndpoint_noRedirectMultipleProviders() throws Exception {
+        appClient.getLoginSettings().setIdentifierFirstEnabled(false);
+        appClient.getLoginSettings().setHideForm(TRUE);
+        router.route(HttpMethod.GET, "/login").handler(routingContext -> {
+            final IdentityProvider idp1 = new IdentityProvider();
+            idp1.setId("provider-id-1");
+            final IdentityProvider idp2 = new IdentityProvider();
+            idp2.setId("provider-id-2");
+            routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp1, idp2));
+            routingContext.next();
+        }).handler(get200AssertMockRoutingContextHandler(loginEndpoint, true, false));
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.OK_200, "OK");
+    }
+
+    @Test
+    public void shouldNotInvokeLoginEndpoint_emptyUsernameWhenIdentifierFirstEnabled() throws Exception {
+        appClient.getLoginSettings().setIdentifierFirstEnabled(true);
+        router.route(HttpMethod.GET, "/login").handler(context -> {
+            loginEndpoint.handle(context);
+            context.next();
+        });
+        ;
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com&username=",
+                HttpStatusCode.FOUND_302, "Found");
+    }
+
+    @Test
+    public void shouldNotInvokeLoginEndpoint_nullUsernameWhenIdentifierFirstEnabled() throws Exception {
+        appClient.getLoginSettings().setIdentifierFirstEnabled(true);
+        router.route(HttpMethod.GET, "/login").handler(context -> {
+            loginEndpoint.handle(context);
+            context.next();
+        });
+        when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
+        testRequest(
+                HttpMethod.GET, "/login?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com",
+                HttpStatusCode.FOUND_302, "Found");
     }
 
     @Test
@@ -67,4 +288,70 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
                 HttpStatusCode.BAD_REQUEST_400, "Bad Request");
     }
 
+    private Handler<RoutingContext> get200AssertMockRoutingContextHandler(LoginEndpoint loginEndpoint, boolean expectedHide, boolean expectedFirstIdentifier) {
+        return routingContext -> {
+            doAnswer(answer -> {
+                try {
+                    assertNotNull(routingContext.get(CLIENT_CONTEXT_KEY));
+                    assertEquals(routingContext.get(DOMAIN_CONTEXT_KEY), domain);
+                    assertNotNull(routingContext.get(PARAM_CONTEXT_KEY));
+
+                    final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
+                    var queryParamsNoUsername = MultiMap.caseInsensitiveMultiMap();
+                    queryParamsNoUsername.addAll(queryParams);
+                    queryParamsNoUsername.remove(USERNAME_PARAM_KEY);
+                    assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login", queryParams, true));
+                    assertEquals(routingContext.get(FORGOT_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true));
+                    assertEquals(routingContext.get(REGISTER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true));
+                    assertEquals(routingContext.get(WEBAUTHN_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true));
+                    assertEquals(routingContext.get(BACK_TO_LOGIN_IDENTIFIER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParamsNoUsername, true));
+
+                    assertFalse(TRUE.equals(routingContext.get(ALLOW_FORGOT_PASSWORD_CONTEXT_KEY)));
+                    assertFalse(TRUE.equals(routingContext.get(ALLOW_REGISTER_CONTEXT_KEY)));
+                    assertFalse(TRUE.equals(routingContext.get(ALLOW_PASSWORDLESS_CONTEXT_KEY)));
+                    assertEquals(TRUE.equals(routingContext.get(HIDE_FORM_CONTEXT_KEY)), expectedHide);
+                    assertEquals(TRUE.equals(routingContext.get(IDENTIFIER_FIRST_LOGIN_ENABLED)), expectedFirstIdentifier);
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    routingContext.end();
+                }
+                return answer;
+            }).when(templateEngine).render(Mockito.<Map<String, Object>>any(), Mockito.any(), Mockito.any());
+            loginEndpoint.handle(routingContext);
+        };
+    }
+
+    private Handler<RoutingContext> get302AssertMockRoutingContextHandler(LoginEndpoint loginEndpoint, boolean expectedHide, boolean expectedFirstIdentifier) {
+        return routingContext -> {
+            loginEndpoint.handle(routingContext);
+            try {
+                assertNotNull(routingContext.get(CLIENT_CONTEXT_KEY));
+                assertEquals(routingContext.get(DOMAIN_CONTEXT_KEY), domain);
+                assertNotNull(routingContext.get(PARAM_CONTEXT_KEY));
+
+                final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
+                var queryParamsNoUsername = MultiMap.caseInsensitiveMultiMap();
+                queryParamsNoUsername.addAll(queryParams);
+                queryParamsNoUsername.remove(USERNAME_PARAM_KEY);
+
+                assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login", queryParams, true));
+                assertEquals(routingContext.get(FORGOT_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true));
+                assertEquals(routingContext.get(REGISTER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true));
+                assertEquals(routingContext.get(WEBAUTHN_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true));
+                assertEquals(routingContext.get(BACK_TO_LOGIN_IDENTIFIER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParamsNoUsername, true));
+
+                assertFalse(TRUE.equals(routingContext.get(ALLOW_FORGOT_PASSWORD_CONTEXT_KEY)));
+                assertFalse(TRUE.equals(routingContext.get(ALLOW_REGISTER_CONTEXT_KEY)));
+                assertFalse(TRUE.equals(routingContext.get(ALLOW_PASSWORDLESS_CONTEXT_KEY)));
+                assertEquals(TRUE.equals(routingContext.get(HIDE_FORM_CONTEXT_KEY)), expectedHide);
+                assertEquals(TRUE.equals(routingContext.get(IDENTIFIER_FIRST_LOGIN_ENABLED)), expectedFirstIdentifier);
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                routingContext.end();
+            }
+        };
+    }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
@@ -20,6 +20,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <gravitee-service-geoip.version>1.0.0-SNAPSHOT</gravitee-service-geoip.version>
+    </properties>
 
     <parent>
         <artifactId>gravitee-am-gateway-standalone</artifactId>

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/ManagementApplication.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/ManagementApplication.java
@@ -16,7 +16,16 @@
 package io.gravitee.am.management.handlers.management.api;
 
 import io.gravitee.am.management.handlers.management.api.mapper.ObjectMapperResolver;
-import io.gravitee.am.management.handlers.management.api.provider.*;
+import io.gravitee.am.management.handlers.management.api.provider.ByteArrayOutputStreamWriter;
+import io.gravitee.am.management.handlers.management.api.provider.ClientErrorExceptionMapper;
+import io.gravitee.am.management.handlers.management.api.provider.JsonMappingExceptionMapper;
+import io.gravitee.am.management.handlers.management.api.provider.ManagementExceptionMapper;
+import io.gravitee.am.management.handlers.management.api.provider.Oauth2ExceptionMapper;
+import io.gravitee.am.management.handlers.management.api.provider.ThrowableMapper;
+import io.gravitee.am.management.handlers.management.api.provider.UnrecognizedPropertyExceptionMapper;
+import io.gravitee.am.management.handlers.management.api.provider.UriBuilderRequestFilter;
+import io.gravitee.am.management.handlers.management.api.provider.ValidationExceptionMapper;
+import io.gravitee.am.management.handlers.management.api.provider.WebApplicationExceptionMapper;
 import io.gravitee.am.management.handlers.management.api.resources.organizations.OrganizationsResource;
 import io.gravitee.am.management.handlers.management.api.resources.organizations.CurrentUserResource;
 import io.gravitee.am.management.handlers.management.api.resources.platform.PlatformResource;

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationFormsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationFormsResource.java
@@ -28,10 +28,13 @@ import io.gravitee.am.service.FormService;
 import io.gravitee.am.service.exception.ApplicationNotFoundException;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.model.NewForm;
-import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.reactivex.Maybe;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.validation.Valid;
@@ -44,8 +47,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 
-import static io.gravitee.am.management.service.permissions.Permissions.of;
-import static io.gravitee.am.management.service.permissions.Permissions.or;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
@@ -34,10 +34,21 @@ import org.junit.Test;
 
 import javax.ws.rs.core.Response;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 
 /**

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/IdentityProvidersResourceTest.java
@@ -91,10 +91,12 @@ public class IdentityProvidersResourceTest extends JerseySpringTest {
         newIdentityProvider.setName("extensionGrant-name");
         newIdentityProvider.setType("extensionGrant-type");
         newIdentityProvider.setConfiguration("extensionGrant-configuration");
+        newIdentityProvider.setDomainWhitelist(List.of());
 
         IdentityProvider identityProvider = new IdentityProvider();
         identityProvider.setId("identityProvider-id");
         identityProvider.setName("identityProvider-name");
+        identityProvider.setDomainWhitelist(List.of());
 
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
         doReturn(Single.just(identityProvider)).when(identityProviderService).create(eq(domainId), any(), any());

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/IdentityProvider.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/IdentityProvider.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.model;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -42,6 +43,8 @@ public class IdentityProvider {
 
     private boolean external;
 
+    private List<String> domainWhitelist;
+
     private Date createdAt;
 
     private Date updatedAt;
@@ -59,6 +62,7 @@ public class IdentityProvider {
         this.referenceType = other.referenceType;
         this.referenceId = other.referenceId;
         this.external = other.external;
+        this.domainWhitelist = other.domainWhitelist;
         this.createdAt = other.createdAt;
         this.updatedAt = other.updatedAt;
     }
@@ -137,6 +141,14 @@ public class IdentityProvider {
 
     public Date getCreatedAt() {
         return createdAt;
+    }
+
+    public List<String> getDomainWhitelist() {
+        return domainWhitelist;
+    }
+
+    public void setDomainWhitelist(List<String> domainWhitelist) {
+        this.domainWhitelist = domainWhitelist;
     }
 
     public void setCreatedAt(Date createdAt) {

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Template.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Template.java
@@ -37,6 +37,7 @@ public enum Template {
     COMPLETE_PROFILE("complete_profile", "/completeProfile"),
     WEBAUTHN_REGISTER("webauthn_register", "/webauthn/register"),
     WEBAUTHN_LOGIN("webauthn_login", "/webauthn/login"),
+    IDENTIFIER_FIRST_LOGIN("identifier_first_login", "/login/identifier"),
     ERROR("error", "/error");
 
     private final String template;
@@ -56,14 +57,14 @@ public enum Template {
     }
 
     public static Template parse(String toParse) {
-        if(toParse==null || toParse.trim().isEmpty()) {
+        if (toParse == null || toParse.trim().isEmpty()) {
             throw new IllegalArgumentException("template must not be null");
         }
         List<Template> matchingTemplate = Arrays.stream(Template.values())
                 .filter(template -> template.template().equals(toParse))
                 .collect(Collectors.toList());
 
-        if(matchingTemplate.size()==1) {
+        if (matchingTemplate.size() == 1) {
             return matchingTemplate.get(0);
         }
 

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/login/LoginSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/login/LoginSettings.java
@@ -48,6 +48,10 @@ public class LoginSettings {
      * Enable/Disable hide login form
      */
     private boolean hideForm;
+    /**
+     * Enable/Disable Identifier-first Login
+     */
+    private boolean identifierFirstEnabled;
 
     public LoginSettings() {
     }
@@ -58,7 +62,8 @@ public class LoginSettings {
         this.registerEnabled = other.registerEnabled;
         this.rememberMeEnabled = other.rememberMeEnabled;
         this.passwordlessEnabled = other.passwordlessEnabled;
-        this.hideForm = other.hideForm;
+        this.hideForm = !other.identifierFirstEnabled && other.hideForm;
+        this.identifierFirstEnabled = other.identifierFirstEnabled;
     }
 
     public boolean isInherited() {
@@ -107,6 +112,14 @@ public class LoginSettings {
 
     public void setHideForm(boolean hideForm) {
         this.hideForm = hideForm;
+    }
+
+    public boolean isIdentifierFirstEnabled() {
+        return identifierFirstEnabled;
+    }
+
+    public void setIdentifierFirstEnabled(boolean identifierFirstEnabled) {
+        this.identifierFirstEnabled = identifierFirstEnabled;
     }
 
     public static LoginSettings getInstance(Domain domain, Client client) {

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/login/LoginSettingsTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/login/LoginSettingsTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.model.login;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LoginSettingsTest {
+
+    @Test
+    public void mustInstantiateLoginSettingsWithoutHideFormWithoutSecondSteps() {
+        var loginSettings = new LoginSettings();
+        loginSettings.setHideForm(false);
+        loginSettings.setIdentifierFirstEnabled(false);
+
+        assertResult(loginSettings, false, false);
+    }
+
+    @Test
+    public void mustInstantiateLoginSettingsWithHideFormWithoutSecondSteps() {
+        var loginSettings = new LoginSettings();
+        loginSettings.setHideForm(true);
+        loginSettings.setIdentifierFirstEnabled(false);
+
+        assertResult(loginSettings, true, false);
+    }
+
+    @Test
+    public void mustInstantiateLoginSettingsWithoutHideFormWithSecondSteps() {
+        var loginSettings = new LoginSettings();
+        loginSettings.setHideForm(false);
+        loginSettings.setIdentifierFirstEnabled(true);
+
+        assertResult(loginSettings, false, true);
+    }
+
+    @Test
+    public void mustInstantiateLoginSettingsWithHideFormWithSecondSteps() {
+        var loginSettings = new LoginSettings();
+        loginSettings.setHideForm(true);
+        loginSettings.setIdentifierFirstEnabled(true);
+        // We cannot have both set to true
+        assertResult(loginSettings, false, true);
+
+    }
+
+    private void assertResult(LoginSettings loginSettings, boolean isHideForm, boolean isIdentifierFirstEnabled) {
+        var expectedSetting = new LoginSettings(loginSettings);
+        assertEquals(expectedSetting.isHideForm(), isHideForm);
+        assertEquals(expectedSetting.isIdentifierFirstEnabled(), isIdentifierFirstEnabled);
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/JdbcRepositoryProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/JdbcRepositoryProvider.java
@@ -37,14 +37,12 @@ public class JdbcRepositoryProvider implements RepositoryProvider {
 
     @Override
     public Class<?> configuration(Scope scope) {
-
         switch (scope) {
             case MANAGEMENT:
                 return ManagementRepositoryConfiguration.class;
             case OAUTH2:
                 return OAuth2RepositoryConfiguration.class;
         }
-
         return null;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/PostgresqlHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/PostgresqlHelper.java
@@ -53,7 +53,7 @@ public class PostgresqlHelper extends AbstractDialectHelper {
     @Override
     public Map<SqlIdentifier, Object> addJsonField(Map<SqlIdentifier, Object> spec, String name, Object value) {
         if (value == null) {
-            spec.put(SqlIdentifier.quoted(name), (Json)null);
+            spec.put(SqlIdentifier.quoted(name), (Json) null);
         } else {
             spec.put(SqlIdentifier.quoted(name), Json.of(JSONMapper.toJson(value)));
         }
@@ -66,22 +66,22 @@ public class PostgresqlHelper extends AbstractDialectHelper {
         final String value = criteria.getFilterValue();
         switch (operator) {
             case "eq":
-                queryBuilder.append(path[0]+" ->> '"+path[1] + "' = '" + value + "' ");
+                queryBuilder.append(path[0] + " ->> '" + path[1] + "' = '" + value + "' ");
                 break;
             case "ne":
-                queryBuilder.append(path[0]+" ->> '"+path[1] + "' != '" + value + "' ");
+                queryBuilder.append(path[0] + " ->> '" + path[1] + "' != '" + value + "' ");
                 break;
             case "pr":
-                queryBuilder.append(path[0]+" ? '"+path[1] + "'");
+                queryBuilder.append(path[0] + " ? '" + path[1] + "'");
                 break;
             case "co":
-                queryBuilder.append(path[0]+" ->> '"+path[1] + "' like '%" + value + "%' ");
+                queryBuilder.append(path[0] + " ->> '" + path[1] + "' like '%" + value + "%' ");
                 break;
             case "sw":
-                queryBuilder.append(path[0]+" ->> '"+path[1] + "' like '" + value + "%' ");
+                queryBuilder.append(path[0] + " ->> '" + path[1] + "' like '" + value + "%' ");
                 break;
             case "ew":
-                queryBuilder.append(path[0]+" ->> '"+path[1] + "' like '%" + value + "' ");
+                queryBuilder.append(path[0] + " ->> '" + path[1] + "' like '%" + value + "' ");
                 break;
             default:
                 // TODO gt, ge, lt, le not managed yet... we have to know the json field type in order to adapt the clause
@@ -127,13 +127,13 @@ public class PostgresqlHelper extends AbstractDialectHelper {
     }
 
     protected String buildPagingClause(String field, int page, int size) {
-        return " ORDER BY "+field+" LIMIT " + size + " OFFSET " + (page * size);
+        return " ORDER BY " + field + " LIMIT " + size + " OFFSET " + (page * size);
     }
 
     @Override
     public String buildFindUserByReferenceAndEmail(ReferenceType referenceType, String referenceId, String email, boolean strict) {
         boolean organizationUser = (ReferenceType.ORGANIZATION == referenceType);
-        return new StringBuilder("SELECT * FROM " + (organizationUser ? "organization_users" : "users") +" u WHERE ")
+        return new StringBuilder("SELECT * FROM " + (organizationUser ? "organization_users" : "users") + " u WHERE ")
                 .append(" u.reference_type = :refType")
                 .append(" AND u.reference_id = :refId AND (")
                 .append(strict ? "u.email" : "UPPER(u.email)")

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcInstallationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcInstallationRepository.java
@@ -16,12 +16,9 @@
 package io.gravitee.am.repository.jdbc.management.api;
 
 import io.gravitee.am.common.utils.RandomString;
-import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.Installation;
 import io.gravitee.am.repository.jdbc.management.AbstractJdbcRepository;
-import io.gravitee.am.repository.jdbc.management.api.model.JdbcIdentityProvider;
 import io.gravitee.am.repository.jdbc.management.api.model.JdbcInstallation;
-import io.gravitee.am.repository.jdbc.management.api.spring.SpringIdentityProviderRepository;
 import io.gravitee.am.repository.jdbc.management.api.spring.SpringInstallationRepository;
 import io.gravitee.am.repository.management.api.InstallationRepository;
 import io.reactivex.Completable;
@@ -32,7 +29,6 @@ import org.springframework.data.r2dbc.core.DatabaseClient;
 import org.springframework.data.relational.core.query.Update;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcIdentityProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcIdentityProvider.java
@@ -22,6 +22,7 @@ import org.springframework.data.relational.core.mapping.Table;
 
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,6 +39,8 @@ public class JdbcIdentityProvider {
     private String mappers;
     @Column("role_mapper")
     private String roleMapper;
+    @Column("domain_whitelist")
+    private String domainWhitelist;
     @Column("reference_type")
     private String referenceType;
     @Column("reference_id")
@@ -134,5 +137,13 @@ public class JdbcIdentityProvider {
 
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public String getDomainWhitelist() {
+        return domainWhitelist;
+    }
+
+    public void setDomainWhitelist(String domainWhitelist) {
+        this.domainWhitelist = domainWhitelist;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/mapper/ListToStringConverter.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/mapper/ListToStringConverter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.management.api.model.mapper;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.dozermapper.core.DozerConverter;
+import io.gravitee.am.repository.jdbc.common.JSONMapper;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ListToStringConverter extends DozerConverter<List, String> {
+
+    public ListToStringConverter() {
+        super(List.class, String.class);
+    }
+
+    @Override
+    public String convertTo(List bean, String s) {
+        return JSONMapper.toJson(bean);
+    }
+
+    @Override
+    public List convertFrom(String s, List bean) {
+        return JSONMapper.toCollectionOfBean(s, new TypeReference<List<String>>() { });
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/dozer.xml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/dozer.xml
@@ -82,6 +82,12 @@
             <!-- hint required otherwise generic Collection interface can't be mapped -->
             <a-hint>java.util.Map</a-hint>
         </field>
+        <field custom-converter="io.gravitee.am.repository.jdbc.management.api.model.mapper.ListToStringConverter">
+            <a>domainWhitelist</a>
+            <b>domainWhitelist</b>
+            <!-- hint required otherwise generic Collection interface can't be mapped -->
+            <a-hint>java.util.List</a-hint>
+        </field>
     </mapping>
 
     <mapping map-null="false">

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_12_0/schema.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_12_0/schema.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.12.0
+      author: GraviteeSource Team
+      changes:
+        ## domain_whitelist column
+        ###################
+        - addColumn:
+            tableName: identities
+            columns:
+              - column: { name: domain_whitelist, type: clob, constraints: { nullable: true }}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -27,4 +27,6 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_10_0/schema-add-self-service-account-settings.yml
   - include:
       - file: liquibase/changelogs/v3_11_0/schema-par.yml
+  - include:
+      - file: liquibase/changelogs/v3_12_0/schema.yml
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/JdbcRepositoriesTestInitializer.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/JdbcRepositoriesTestInitializer.java
@@ -22,7 +22,6 @@ import io.reactivex.Flowable;
 import io.reactivex.schedulers.Schedulers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/IdentityProviderMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/IdentityProviderMongo.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.am.repository.mongodb.management.internal.model;
 
+import com.mongodb.BasicDBList;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.repository.mongodb.common.model.Auditable;
+import org.bson.BsonArray;
 import org.bson.Document;
 import org.bson.codecs.pojo.annotations.BsonId;
 
@@ -44,6 +46,8 @@ public class IdentityProviderMongo extends Auditable {
      * Map codec support is planned for version 3.7 jira.mongodb.org issue: JAVA-2695
      */
     private Document roleMapper;
+
+    private BsonArray domainWhitelist;
 
     private ReferenceType referenceType;
 
@@ -121,6 +125,14 @@ public class IdentityProviderMongo extends Auditable {
 
     public void setExternal(boolean external) {
         this.external = external;
+    }
+
+    public BsonArray getDomainWhitelist() {
+        return domainWhitelist;
+    }
+
+    public void setDomainWhitelist(BsonArray domainWhitelist) {
+        this.domainWhitelist = domainWhitelist;
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/LoginSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/LoginSettingsMongo.java
@@ -29,6 +29,7 @@ public class LoginSettingsMongo {
     private boolean rememberMeEnabled;
     private boolean passwordlessEnabled;
     private boolean hideForm;
+    private boolean identifierFirstLoginEnabled;
 
     public boolean isInherited() {
         return inherited;
@@ -78,15 +79,23 @@ public class LoginSettingsMongo {
         this.hideForm = hideForm;
     }
 
-    public LoginSettings convert() {
+    public boolean isIdentifierFirstLoginEnabled() {
+        return identifierFirstLoginEnabled;
+    }
 
+    public void setIdentifierFirstLoginEnabled(boolean identifierFirstLoginEnabled) {
+        this.identifierFirstLoginEnabled = identifierFirstLoginEnabled;
+    }
+
+    public LoginSettings convert() {
         LoginSettings loginSettings = new LoginSettings();
         loginSettings.setInherited(isInherited());
         loginSettings.setForgotPasswordEnabled(isForgotPasswordEnabled());
         loginSettings.setRegisterEnabled(isRegisterEnabled());
         loginSettings.setRememberMeEnabled(isRememberMeEnabled());
         loginSettings.setPasswordlessEnabled(isPasswordlessEnabled());
-        loginSettings.setHideForm(isHideForm());
+        loginSettings.setHideForm(!isIdentifierFirstLoginEnabled() && isHideForm());
+        loginSettings.setIdentifierFirstEnabled(isIdentifierFirstLoginEnabled());
 
         return loginSettings;
     }
@@ -102,7 +111,8 @@ public class LoginSettingsMongo {
         loginSettingsMongo.setRegisterEnabled(loginSettings.isRegisterEnabled());
         loginSettingsMongo.setRememberMeEnabled(loginSettings.isRememberMeEnabled());
         loginSettingsMongo.setPasswordlessEnabled(loginSettings.isPasswordlessEnabled());
-        loginSettingsMongo.setHideForm(loginSettings.isHideForm());
+        loginSettingsMongo.setHideForm(!loginSettings.isIdentifierFirstEnabled() && loginSettings.isHideForm());
+        loginSettingsMongo.setIdentifierFirstLoginEnabled(loginSettings.isIdentifierFirstEnabled());
 
         return loginSettingsMongo;
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/MongodbProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/MongodbProvider.java
@@ -22,6 +22,8 @@ import com.mongodb.connection.ClusterSettings;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
+import org.bson.codecs.BsonArrayCodec;
+import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.springframework.beans.factory.DisposableBean;
@@ -59,8 +61,10 @@ public class MongodbProvider implements InitializingBean, DisposableBean {
         // cluster configuration
         ClusterSettings clusterSettings = ClusterSettings.builder().hosts(Collections.singletonList(new ServerAddress(mongoDBContainer.getHost(), mongoDBContainer.getFirstMappedPort()))).build();
         // codec configuration
-        CodecRegistry pojoCodecRegistry = fromRegistries(MongoClients.getDefaultCodecRegistry(),
-                fromProviders(PojoCodecProvider.builder().automatic(true).build()));
+        CodecRegistry pojoCodecRegistry = fromRegistries(
+                MongoClients.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().automatic(true).build())
+        );
 
         MongoClientSettings settings = MongoClientSettings.builder()
                 .applyToClusterSettings(builder1 -> builder1.applySettings(clusterSettings))

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/management/internal/model/LoginSettingsMongoTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/management/internal/model/LoginSettingsMongoTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.repository.mongodb.management.internal.model;
+
+import io.gravitee.am.model.login.LoginSettings;
+import org.junit.Test;
+
+import static io.gravitee.am.repository.mongodb.management.internal.model.LoginSettingsMongo.convert;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LoginSettingsMongoTest {
+
+    @Test
+    public void mustInstantiateLoginSettingsWithoutHideFormWithoutSecondSteps() {
+        var loginSettings = new LoginSettingsMongo();
+        loginSettings.setHideForm(false);
+        loginSettings.setIdentifierFirstLoginEnabled(false);
+
+        assertResult(loginSettings.convert(), false, false);
+    }
+
+    @Test
+    public void mustInstantiateLoginSettingsMongoWithoutHideFormWithoutSecondSteps() {
+        var loginSettings = new LoginSettings();
+        loginSettings.setHideForm(false);
+        loginSettings.setIdentifierFirstEnabled(false);
+
+        assertMongoResult(convert(loginSettings), false, false);
+    }
+
+    @Test
+    public void mustInstantiateLoginSettingsWithHideFormWithoutSecondSteps() {
+        var loginSettings = new LoginSettingsMongo();
+        loginSettings.setHideForm(true);
+        loginSettings.setIdentifierFirstLoginEnabled(false);
+
+        assertResult(loginSettings.convert(), true, false);
+    }
+
+    @Test
+    public void mustInstantiateLoginMongoSettingsWithHideFormWithoutSecondSteps() {
+        var loginSettings = new LoginSettings();
+        loginSettings.setHideForm(true);
+        loginSettings.setIdentifierFirstEnabled(false);
+
+        assertMongoResult(convert(loginSettings), true, false);
+    }
+
+    @Test
+    public void mustInstantiateLoginSettingsWithoutHideFormWithSecondSteps() {
+        var loginSettings = new LoginSettingsMongo();
+        loginSettings.setHideForm(false);
+        loginSettings.setIdentifierFirstLoginEnabled(true);
+
+        assertResult(loginSettings.convert(), false, true);
+    }
+
+    @Test
+    public void mustInstantiateLoginMongoSettingsWithoutHideFormWithSecondSteps() {
+        var loginSettings = new LoginSettings();
+        loginSettings.setHideForm(false);
+        loginSettings.setIdentifierFirstEnabled(true);
+
+        assertMongoResult(convert(loginSettings), false, true);
+    }
+
+    @Test
+    public void mustInstantiateLoginSettingsWithHideFormWithSecondSteps() {
+        var loginSettings = new LoginSettingsMongo();
+        loginSettings.setHideForm(true);
+        loginSettings.setIdentifierFirstLoginEnabled(true);
+        // We cannot have both set to true
+        assertResult(loginSettings.convert(), false, true);
+
+    }
+
+    @Test
+    public void mustInstantiateLoginMongoSettingsWithHideFormWithSecondSteps() {
+        var loginSettings = new LoginSettings();
+        loginSettings.setHideForm(true);
+        loginSettings.setIdentifierFirstEnabled(true);
+
+        assertMongoResult(convert(loginSettings), false, true);
+    }
+
+    @Test
+    public void mustReturnNullWithNullLocalSettings() {
+        assertNull(convert(null));
+    }
+
+    private void assertResult(LoginSettings expectedSetting, boolean isHideForm, boolean isIdentifierFirstLoginEnabled) {
+        assertEquals(expectedSetting.isHideForm(), isHideForm);
+        assertEquals(expectedSetting.isIdentifierFirstEnabled(), isIdentifierFirstLoginEnabled);
+    }
+
+    private void assertMongoResult(LoginSettingsMongo expectedSetting, boolean isHideForm, boolean isIdentifierFirstLoginEnabled) {
+        assertEquals(expectedSetting.isHideForm(), isHideForm);
+        assertEquals(expectedSetting.isIdentifierFirstLoginEnabled(), isIdentifierFirstLoginEnabled);
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryTest.java
@@ -81,7 +81,7 @@ public class ApplicationRepositoryTest extends AbstractManagementTest {
 
 
     @Test
-    public void testFindByDomainAndClientId() throws TechnicalException {
+    public void testFindByDomainAndClientId() {
         // create application
         Application application = new Application();
         application.setName("testApp");
@@ -141,7 +141,7 @@ public class ApplicationRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
-    public void testFindByIdentity() throws TechnicalException {
+    public void testFindByIdentity() {
         // create app
         Application app = buildApplication();
         Application appCreated = applicationRepository.create(app).blockingGet();

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DomainRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DomainRepositoryTest.java
@@ -102,7 +102,7 @@ public class DomainRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
-    public void testFindAllByEnvironment() throws TechnicalException {
+    public void testFindAllByEnvironment() {
         // create domain
         Domain domain = initDomain();
         domain.setReferenceType(ReferenceType.ENVIRONMENT);
@@ -126,7 +126,7 @@ public class DomainRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
-    public void testFindInIds() throws TechnicalException {
+    public void testFindInIds() {
         // create domain
         Domain domain = initDomain();
         Domain domainCreated = domainRepository.create(domain).blockingGet();

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/IdentityProviderRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/IdentityProviderRepositoryTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 public class IdentityProviderRepositoryTest extends AbstractManagementTest {
 
     public static final String ORGANIZATION_ID = "orga#1";
+
     @Autowired
     private IdentityProviderRepository identityProviderRepository;
 
@@ -65,20 +66,22 @@ public class IdentityProviderRepositoryTest extends AbstractManagementTest {
     private IdentityProvider buildIdentityProvider() {
         String random = UUID.randomUUID().toString();
         IdentityProvider identityProvider = new IdentityProvider();
-        identityProvider.setName("name"+random);
+        identityProvider.setName("name" + random);
         identityProvider.setReferenceType(ReferenceType.DOMAIN);
-        identityProvider.setReferenceId("ref"+random);
-        identityProvider.setConfiguration("{\"field\": \""+random+"\"}");
+        identityProvider.setReferenceId("ref" + random);
+        identityProvider.setConfiguration("{\"field\": \"" + random + "\"}");
         identityProvider.setExternal(true);
-        identityProvider.setType("type"+random);
+        identityProvider.setType("type" + random);
 
         Map<String, String> mappers = new HashMap<>();
-        mappers.put("mapper", "mapper"+random);
+        mappers.put("mapper", "mapper" + random);
         identityProvider.setMappers(mappers);
 
         Map<String, String[]> roleMapper = new HashMap<>();
-        roleMapper.put("mapper", new String[]{"mapper"+random, "mapper2"+random});
+        roleMapper.put("mapper", new String[]{"mapper" + random, "mapper2" + random});
         identityProvider.setRoleMapper(roleMapper);
+
+        identityProvider.setDomainWhitelist(List.of("gmail.com", "hotmail.com", "customdomain.com"));
 
         identityProvider.setCreatedAt(new Date());
         identityProvider.setUpdatedAt(new Date());
@@ -110,7 +113,7 @@ public class IdentityProviderRepositoryTest extends AbstractManagementTest {
         testObserver.assertValue(idp -> idp.getReferenceType().equals(identityProvider.getReferenceType()));
         testObserver.assertValue(idp -> idp.getMappers().entrySet().equals(identityProvider.getMappers().entrySet()));
         testObserver.assertValue(idp -> idp.getRoleMapper().keySet().equals(identityProvider.getRoleMapper().keySet()));
-        testObserver.assertValue(idp -> idp.getRoleMapper().values().stream().filter(v -> v instanceof String[]).count()>0);
+        testObserver.assertValue(idp -> idp.getRoleMapper().values().stream().filter(v -> v instanceof String[]).count() > 0);
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
@@ -135,7 +135,7 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
     public Single<IdentityProvider> create(ReferenceType referenceType, String referenceId, NewIdentityProvider newIdentityProvider, User principal) {
         LOGGER.debug("Create a new identity provider {} for {} {}", newIdentityProvider, referenceType, referenceId);
 
-        IdentityProvider identityProvider = new IdentityProvider();
+        var identityProvider = new IdentityProvider();
         identityProvider.setId(newIdentityProvider.getId() == null ? RandomString.generate() : newIdentityProvider.getId());
         identityProvider.setReferenceType(referenceType);
         identityProvider.setReferenceId(referenceId);
@@ -143,6 +143,7 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
         identityProvider.setType(newIdentityProvider.getType());
         identityProvider.setConfiguration(newIdentityProvider.getConfiguration());
         identityProvider.setExternal(newIdentityProvider.isExternal());
+        identityProvider.setDomainWhitelist(newIdentityProvider.getDomainWhitelist());
         identityProvider.setCreatedAt(new Date());
         identityProvider.setUpdatedAt(identityProvider.getCreatedAt());
 
@@ -178,6 +179,7 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
                     identityToUpdate.setConfiguration(updateIdentityProvider.getConfiguration());
                     identityToUpdate.setMappers(updateIdentityProvider.getMappers());
                     identityToUpdate.setRoleMapper(updateIdentityProvider.getRoleMapper());
+                    identityToUpdate.setDomainWhitelist(updateIdentityProvider.getDomainWhitelist());
                     identityToUpdate.setUpdatedAt(new Date());
 
                     return identityProviderRepository.update(identityToUpdate)

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewIdentityProvider.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewIdentityProvider.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.service.model;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -33,6 +34,9 @@ public class NewIdentityProvider {
 
     @NotNull
     private String configuration;
+
+    @NotNull
+    private List<String> domainWhitelist;
 
     private boolean external;
 
@@ -74,6 +78,14 @@ public class NewIdentityProvider {
 
     public void setExternal(boolean external) {
         this.external = external;
+    }
+
+    public List<String> getDomainWhitelist() {
+        return domainWhitelist;
+    }
+
+    public void setDomainWhitelist(List<String> domainWhitelist) {
+        this.domainWhitelist = domainWhitelist;
     }
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateIdentityProvider.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateIdentityProvider.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.service.model;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,6 +34,9 @@ public class UpdateIdentityProvider {
     private Map<String, String> mappers;
 
     private Map<String, String[]> roleMapper;
+
+    @NotNull
+    private List<String> domainWhitelist;
 
     public String getName() {
         return name;
@@ -64,6 +68,14 @@ public class UpdateIdentityProvider {
 
     public void setRoleMapper(Map<String, String[]> roleMapper) {
         this.roleMapper = roleMapper;
+    }
+
+    public List<String> getDomainWhitelist() {
+        return domainWhitelist;
+    }
+
+    public void setDomainWhitelist(List<String> domainWhitelist) {
+        this.domainWhitelist = domainWhitelist;
     }
 
     @Override

--- a/gravitee-am-ui/build.json
+++ b/gravitee-am-ui/build.json
@@ -1,3 +1,3 @@
 {
-    "version": "3.11.0"
+    "version": "3.12.0-SNAPSHOT"
 }

--- a/gravitee-am-ui/package-lock.json
+++ b/gravitee-am-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-am-webui",
-  "version": "3.11.0",
+  "version": "3.12.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/gravitee-am-ui/package.json
+++ b/gravitee-am-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-am-webui",
-  "version": "3.11.0",
+  "version": "3.12.0-SNAPSHOT",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/gravitee-am-ui/src/app/domain/applications/application/design/forms/forms.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/design/forms/forms.component.ts
@@ -45,6 +45,13 @@ export class ApplicationFormsComponent implements OnInit {
         'enabled': this.applicationSettingsValid()
       },
       {
+        'name': 'Identifier-first Login',
+        'description': 'Identifier-first login page to authenticate users',
+        'template': 'IDENTIFIER_FIRST_LOGIN',
+        'icon': 'account_box',
+        'enabled': this.applicationSettingsValid()
+      },
+      {
         'name': 'WebAuthn Register',
         'description': 'Passwordless page to register authenticators (devices)',
         'template': 'WEBAUTHN_REGISTER',

--- a/gravitee-am-ui/src/app/domain/components/login/login-settings.component.html
+++ b/gravitee-am-ui/src/app/domain/components/login/login-settings.component.html
@@ -56,10 +56,18 @@
       <div fxLayout="column" style="margin-top: 10px;">
         <mat-slide-toggle
           (change)="enableHideForm($event)"
-          [checked]="isHideFormEnabled()" [disabled]="readonly">
+          [checked]="isHideFormEnabled()" [disabled]="readonly || isIdentifierFirstLoginEnabled()">
           Hide login form
         </mat-slide-toggle>
         <mat-hint style="font-size: 75%;">Hide the login form to only display external Identity Providers (if only one provider is enabled, the login page is skipped to redirect to the login page of the identity provider).</mat-hint>
+      </div>
+      <div fxLayout="column" style="margin-top: 10px;">
+        <mat-slide-toggle
+          (change)="enableIdentifierFirstLogin($event)"
+          [checked]="isIdentifierFirstLoginEnabled()" [disabled]="readonly">
+          Identifier-first login
+        </mat-slide-toggle>
+        <mat-hint style="font-size: 75%;">Enables Identifier-first login (after entering the login, the user will be either asked to sign-in to an internal identity provider or will be redirected to an external provider regarding its domain whitelist).</mat-hint>
       </div>
     </div>
   </div>

--- a/gravitee-am-ui/src/app/domain/components/login/login-settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/login/login-settings.component.ts
@@ -96,4 +96,16 @@ export class LoginSettingsComponent implements OnInit, OnChanges {
   isHideFormEnabled() {
     return this.loginSettings && this.loginSettings.hideForm;
   }
+
+  enableIdentifierFirstLogin(event) {
+    this.loginSettings.identifierFirstEnabled = event.checked;
+    if (event.checked) {
+      this.loginSettings.hideForm = !event.checked;
+    }
+    this.formChanged = true;
+  }
+
+  isIdentifierFirstLoginEnabled() {
+    return this.loginSettings && this.loginSettings.identifierFirstEnabled;
+  }
 }

--- a/gravitee-am-ui/src/app/domain/settings/forms/forms.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/forms/forms.component.ts
@@ -47,6 +47,13 @@ export class DomainSettingsFormsComponent implements OnInit {
         'enabled': true
       },
       {
+        'name': 'Identifier-first login',
+        'description': 'Identifier-first login page to authenticate users',
+        'template': 'IDENTIFIER_FIRST_LOGIN',
+        'icon': 'account_box',
+        'enabled': true
+      },
+      {
         'name': 'WebAuthn Login',
         'description': 'Passwordless page to authenticate users',
         'template': 'WEBAUTHN_LOGIN',

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.ts
@@ -35,9 +35,20 @@ export class ProviderCreationStep1Component implements OnInit {
     this.identities = this.route.snapshot.data['identities'];
   }
 
+  private initDomainWhitelist(idpType:string) {
+    this.provider.domainWhitelist = [];
+    if(idpType === 'google-am-idp'){
+      this.provider.domainWhitelist.push("gmail.com");
+    }
+    if(idpType === 'azure-ad-am-idp'){
+      this.provider.domainWhitelist.push("microsoft.com");
+    }
+  }
+
   selectProviderType({id, external}) {
     this.provider.external = external === true;
     this.provider.type = id;
+    this.initDomainWhitelist(id);
   }
 
   displayName(identityProvider) {

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step2/step2.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step2/step2.component.html
@@ -27,6 +27,29 @@
           <input matInput type="text" placeholder="Name" name="name" [(ngModel)]="provider.name" required>
           <mat-hint>Identity provider name</mat-hint>
         </mat-form-field>
+        <div *ngIf="provider.external">
+          <div fxLayout="row" fxLayoutGap="10px">
+            <mat-form-field appearance="outline" floatLabel="always">
+              <mat-label>Domain Whitelist</mat-label>
+              <mat-chip-list #chipList aria-label="domainWhitelist">
+                <mat-chip
+                  *ngFor="let dwPattern of provider.domainWhitelist"
+                  [removable]="true"
+                  (removed)="removeDomainWhitelistPattern(dwPattern)">
+                  {{dwPattern}}
+                  <mat-icon matChipRemove >cancel</mat-icon>
+                </mat-chip>
+                <input matInput
+                       type="text" placeholder="Enter a domain whitelist pattern" name="domainWhitelist"
+                       [matChipInputFor]="chipList"
+                       (keydown.enter)="addDomainWhitelistPattern($event)"
+                       [value]="domainWhitelistPattern || ''" (input)='domainWhitelistPattern = $event.target.value'
+                />
+              </mat-chip-list>
+              <mat-hint>Enables Identifier-first login automatic redirection to the provider when the user email domain matches the list</mat-hint>
+            </mat-form-field>
+          </div>
+        </div>
       </div>
 
       <div class="gv-form-section">

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step2/step2.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step2/step2.component.ts
@@ -17,6 +17,7 @@ import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges
 import {ActivatedRoute} from '@angular/router';
 import {OrganizationService} from '../../../../../../services/organization.service';
 import * as _ from 'lodash';
+import {SnackbarService} from "../../../../../../services/snackbar.service";
 
 @Component({
   selector: 'provider-creation-step2',
@@ -29,9 +30,11 @@ export class ProviderCreationStep2Component implements OnInit, OnChanges {
   @Output('configurationIsValidChange') configurationIsValidChange: EventEmitter<boolean> = new EventEmitter<boolean>();
   configuration: any;
   providerSchema: any = {};
+  domainWhitelistPattern:string = ''
   private certificates: any[];
 
   constructor(private organizationService: OrganizationService,
+              private snackbarService: SnackbarService,
               private route: ActivatedRoute) { }
 
   ngOnInit() {
@@ -60,4 +63,25 @@ export class ProviderCreationStep2Component implements OnInit, OnChanges {
     this.configurationIsValidChange.emit(this.configurationIsValid);
     this.provider.configuration = configurationWrapper.configuration;
   }
+
+  addDomainWhitelistPattern(event){
+    event.preventDefault();
+    if (this.domainWhitelistPattern) {
+      if (!this.provider.domainWhitelist.some(el => el === this.domainWhitelistPattern)) {
+        this.provider.domainWhitelist.push(this.domainWhitelistPattern);
+        this.provider.domainWhitelist = [...this.provider.domainWhitelist]
+        this.domainWhitelistPattern = '';
+      } else {
+        this.snackbarService.open(`Error : domain whitelist pattern "${this.domainWhitelistPattern}" already exists`);
+      }
+    }
+  }
+
+  removeDomainWhitelistPattern(dwPattern){
+    const index = this.provider.domainWhitelist.indexOf(dwPattern);
+    if (index > -1){
+      this.provider.domainWhitelist.splice(index, 1);
+    }
+  }
+
 }

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
@@ -28,6 +28,29 @@
             <input matInput type="text" placeholder="Name" name="name" [(ngModel)]="provider.name" required>
             <mat-hint>Identity provider name</mat-hint>
           </mat-form-field>
+          <div *ngIf="provider.external">
+              <div fxLayout="row" fxLayoutGap="10px">
+                  <mat-form-field appearance="outline" floatLabel="always">
+                    <mat-label>Domain Whitelist</mat-label>
+                    <mat-chip-list #chipList aria-label="domainWhitelist">
+                      <mat-chip
+                        *ngFor="let dwPattern of provider.domainWhitelist"
+                        [removable]="true"
+                        (removed)="removeDomainWhitelistPattern(dwPattern)">
+                        {{dwPattern}}
+                        <mat-icon matChipRemove >cancel</mat-icon>
+                      </mat-chip>
+                      <input matInput
+                             type="text" placeholder="Enter a domain whitelist pattern" name="domainWhitelist"
+                             [matChipInputFor]="chipList"
+                             (keydown.enter)="addDomainWhitelistPattern($event)"
+                             [value]="domainWhitelistPattern || ''" (input)='domainWhitelistPattern = $event.target.value'
+                      />
+                    </mat-chip-list>
+                    <mat-hint>Enables Identifier-first login automatic redirection to the provider when the user email domain matches the list</mat-hint>
+                  </mat-form-field>
+              </div>
+          </div>
         </div>
 
         <div class="gv-form-section">

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
@@ -45,6 +45,7 @@ export class ProviderSettingsComponent implements OnInit {
   updateProviderConfiguration: any;
   redirectUri: string;
   customCode: string;
+  domainWhitelistPattern:string;
 
   constructor(private providerService: ProviderService,
               private organizationService: OrganizationService,
@@ -124,6 +125,28 @@ export class ProviderSettingsComponent implements OnInit {
       this.configurationIsValid = configurationWrapper.isValid;
       this.updateProviderConfiguration = configurationWrapper.configuration;
     });
+  }
+
+  addDomainWhitelistPattern(event){
+    event.preventDefault();
+    if (this.domainWhitelistPattern) {
+      if (!this.provider.domainWhitelist.some(el => el === this.domainWhitelistPattern)) {
+        this.provider.domainWhitelist.push(this.domainWhitelistPattern);
+        this.provider.domainWhitelist = [...this.provider.domainWhitelist]
+        this.form.form.markAsDirty();
+        this.domainWhitelistPattern = '';
+      } else {
+        this.snackbarService.open(`Error : domain whitelist pattern "${this.domainWhitelistPattern}" already exists`);
+      }
+    }
+  }
+
+  removeDomainWhitelistPattern(dwPattern){
+    const index = this.provider.domainWhitelist.indexOf(dwPattern);
+    if (index > -1){
+      this.provider.domainWhitelist.splice(index, 1);
+      this.form.form.markAsDirty();
+    }
   }
 
   valueCopied(message: string) {

--- a/gravitee-am-ui/src/app/services/provider.service.ts
+++ b/gravitee-am-ui/src/app/services/provider.service.ts
@@ -34,7 +34,7 @@ export class ProviderService {
   findUserProvidersByDomain(domainId): Observable<any> {
     return this.http.get<any>(this.providersURL + domainId + '/identities?userProvider=true');
   }
-  
+
   findOrganizationUserProviders(): Observable<any> {
     return this.organizationService.identityProviders(true);
   }
@@ -59,6 +59,7 @@ export class ProviderService {
     return this.http.put<any>(this.providersURL + domainId + '/identities/' + id, {
       'name' : provider.name,
       'configuration' : provider.configuration,
+      'domainWhitelist' : provider.domainWhitelist,
       'mappers' : provider.mappers,
       'roleMapper' : provider.roleMapper
     });

--- a/postman/collections/graviteeio-am-api-management-collection.json
+++ b/postman/collections/graviteeio-am-api-management-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "58d46c7f-da8d-4372-b7b4-ada62d0871da",
+		"_postman_id": "2551b100-c026-48be-a008-a36974b3f9e1",
 		"name": "Gravitee.io - AM - API Management",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -165,7 +165,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"external\":false,\n\t\"type\":\"inline-am-idp\",\n\t\"configuration\":\"{\\\"users\\\":[{\\\"firstname\\\":\\\"test\\\",\\\"lastname\\\":\\\"test\\\",\\\"username\\\":\\\"{{username}}\\\",\\\"email\\\":\\\"test@test.com\\\",\\\"password\\\":\\\"test\\\"}]}\",\n\t\"name\":\"Inline Users 2\"\n}",
+									"raw": "{\n\t\"external\":false,\n\t\"type\":\"inline-am-idp\",\n    \"domainWhitelist\" : [],\n\t\"configuration\":\"{\\\"users\\\":[{\\\"firstname\\\":\\\"test\\\",\\\"lastname\\\":\\\"test\\\",\\\"username\\\":\\\"{{username}}\\\",\\\"email\\\":\\\"test@test.com\\\",\\\"password\\\":\\\"test\\\"}]}\",\n\t\"name\":\"Inline Users 2\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -815,7 +815,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"{{username}}\\\",\\\"password\\\":\\\"test\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+									"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"{{username}}\\\",\\\"password\\\":\\\"test\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 								},
 								"url": {
 									"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",
@@ -1076,7 +1076,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"external\": true,\n\t\"type\": \"oauth2-generic-am-idp\",\n\t\"configuration\": \"{\\\"clientId\\\":\\\"my-client\\\",\\\"clientSecret\\\":\\\"my-client-secret\\\",\\\"wellKnownUri\\\":\\\"{{gateway_url}}/social/oidc/.well-known/openid-configuration\\\",\\\"responseType\\\":\\\"code\\\",\\\"encodeRedirectUri\\\":false,\\\"useIdTokenForUserInfo\\\":false,\\\"signature\\\":\\\"RSA_RS256\\\",\\\"publicKeyResolver\\\":\\\"GIVEN_KEY\\\",\\\"connectTimeout\\\":10000,\\\"maxPoolSize\\\":200}\",\n\t\"name\": \"Social\"\n}",
+									"raw": "{\n\t\"external\": true,\n\t\"type\": \"oauth2-generic-am-idp\",\n    \"domainWhitelist\" : [],\n\t\"configuration\": \"{\\\"clientId\\\":\\\"my-client\\\",\\\"clientSecret\\\":\\\"my-client-secret\\\",\\\"wellKnownUri\\\":\\\"{{gateway_url}}/social/oidc/.well-known/openid-configuration\\\",\\\"responseType\\\":\\\"code\\\",\\\"encodeRedirectUri\\\":false,\\\"useIdTokenForUserInfo\\\":false,\\\"signature\\\":\\\"RSA_RS256\\\",\\\"publicKeyResolver\\\":\\\"GIVEN_KEY\\\",\\\"connectTimeout\\\":10000,\\\"maxPoolSize\\\":200}\",\n\t\"name\": \"Social\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/postman/collections/graviteeio-am-client-management-collection-app-version.json
+++ b/postman/collections/graviteeio-am-client-management-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b5ab30a3-6091-4101-ae5b-9a8676901983",
+		"_postman_id": "db24733c-1b80-4a57-81a8-648229f3eff0",
 		"name": "Gravitee.io - AM - Application Management",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},

--- a/postman/collections/graviteeio-am-environment-collection.json
+++ b/postman/collections/graviteeio-am-environment-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ce56e9d4-da51-48a3-a417-0a69bdcc9c73",
+		"_postman_id": "404fc017-384e-47e9-863e-d4b01ea200f4",
 		"name": "Gravitee.io - AM - Environment Management",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},

--- a/postman/collections/graviteeio-am-flows-collection-app-version.json
+++ b/postman/collections/graviteeio-am-flows-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b2734358-1ea3-425f-a14b-fc452ada8f80",
+		"_postman_id": "0cdb0387-134e-43c1-8752-6b8e2ec4bdb9",
 		"name": "Gravitee.io - AM - Flows - app version",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -154,7 +154,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"},{\\\"firstname\\\":\\\"Jensen\\\",\\\"lastname\\\":\\\"Barbara\\\",\\\"username\\\":\\\"jensen.barbara\\\",\\\"email\\\":\\\"jensen.barbara@mail.com\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"},{\\\"firstname\\\":\\\"Jensen\\\",\\\"lastname\\\":\\\"Barbara\\\",\\\"username\\\":\\\"jensen.barbara\\\",\\\"email\\\":\\\"jensen.barbara@mail.com\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",

--- a/postman/collections/graviteeio-am-login-collection-app-version.json
+++ b/postman/collections/graviteeio-am-login-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f0e09d75-0b09-4a0f-8cd6-e28b895785b9",
+		"_postman_id": "b3895ed0-4b5b-4262-8e85-9b1906a726b3",
 		"name": "Gravitee.io - AM - Login - app version",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -154,7 +154,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",
@@ -286,6 +286,61 @@
 					"response": []
 				},
 				{
+					"name": "Create application 3",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"var body = JSON.parse(responseBody);",
+									"pm.environment.set('app3', body.id);",
+									"pm.environment.set('clientId3', body.settings.oauth.clientId);",
+									"pm.environment.set('clientSecret3', body.settings.oauth.clientSecret);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"my-client\",\n  \"type\": \"WEB\"\n}"
+						},
+						"url": {
+							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/applications",
+							"host": [
+								"{{management_url}}"
+							],
+							"path": [
+								"management",
+								"organizations",
+								"{{defaultOrganizationId}}",
+								"environments",
+								"{{defaultEnvironmentId}}",
+								"domains",
+								"{{domain}}",
+								"applications"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Configure application",
 					"event": [
 						{
@@ -393,6 +448,57 @@
 								"{{domain}}",
 								"applications",
 								"{{app2}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Configure application 3",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"identities\": [\n    \"{{idp.inmemory}}\"\n  ],\n  \"settings\": {\n    \"login\": {\n        \"identifierFirstEnabled\" : true,\n        \"inherited\" : false\n    },\n  \t\"oauth\": {\n  \t\t\"redirectUris\": [],\n\t\t\"grantTypes\": [\n\t\t    \"authorization_code\",\n\t\t    \"client_credentials\",\n\t\t    \"password\",\n\t\t    \"refresh_token\"\n\t\t  ],\n\t\t\"scopes\": [\"openid\"]\n\t}\n  }\n}"
+						},
+						"url": {
+							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/applications/{{app3}}",
+							"host": [
+								"{{management_url}}"
+							],
+							"path": [
+								"management",
+								"organizations",
+								"{{defaultOrganizationId}}",
+								"environments",
+								"{{defaultEnvironmentId}}",
+								"domains",
+								"{{domain}}",
+								"applications",
+								"{{app3}}"
 							]
 						}
 					},
@@ -773,6 +879,466 @@
 								}
 							]
 						}
+					},
+					"response": []
+				},
+				{
+					"name": "Logout user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 302\", function () {",
+									"    pm.response.to.have.status(302);",
+									"});",
+									"",
+									"pm.test(\"Should be redirected\", function () {",
+									"    pm.response.to.be.redirection;",
+									"    pm.response.to.have.header('Location');",
+									"    ",
+									"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{logoutEndpoint}}",
+							"host": [
+								"{{logoutEndpoint}}"
+							]
+						},
+						"description": "The client does not have a redirect_uri define"
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Case - Identifier First login",
+			"item": [
+				{
+					"name": "Initiate Login Flow",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 302\", function () {",
+									"    pm.response.to.have.status(302);",
+									"});",
+									"",
+									"pm.test(\"Should be redirected\", function () {",
+									"    pm.response.to.be.redirection;",
+									"    pm.response.to.have.header('Location');",
+									"});",
+									"",
+									"pm.test(\"Should be a redirection to login page\", function() {",
+									"    var location = postman.getResponseHeader('Location');",
+									"    let domain = pm.environment.get(\"domainHrid\");",
+									"    ",
+									"    tests['Redirect to login page with client_id'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/login/identifier') && location.includes('client_id=' + pm.environment.get('clientId3'));",
+									"    ",
+									"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{gateway_url}}/{{domainHrid}}/oauth/authorize/?response_type=code&client_id={{clientId3}}&redirect_uri=http://localhost:4000/&state=1234-5678-9876",
+							"host": [
+								"{{gateway_url}}"
+							],
+							"path": [
+								"{{domainHrid}}",
+								"oauth",
+								"authorize",
+								""
+							],
+							"query": [
+								{
+									"key": "response_type",
+									"value": "code"
+								},
+								{
+									"key": "client_id",
+									"value": "{{clientId3}}"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "http://localhost:4000/"
+								},
+								{
+									"key": "state",
+									"value": "1234-5678-9876"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Redirect to login form",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Should be ok\", function () {",
+									"    pm.response.to.be.ok;",
+									"    ",
+									"    var responseHTML = cheerio.load(pm.response.text());",
+									"    const action = responseHTML('form').attr('action');",
+									"    ",
+									"    var response_type = responseHTML('response_type').val();",
+									"    var redirect_uri = responseHTML('redirect_uri').val();",
+									"    var clientId3 = responseHTML('client_id').val();",
+									"",
+									"    pm.environment.set('action', action);",
+									"    pm.environment.set('clientId3', clientId3);",
+									"    pm.environment.set('response_type', response_type);",
+									"    pm.environment.set('redirect_uri', redirect_uri);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{redirection}}",
+							"host": [
+								"{{redirection}}"
+							]
+						},
+						"description": "The client does not have a redirect_uri define"
+					},
+					"response": []
+				},
+				{
+					"name": "302 empty username",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 302\", function () {",
+									"    pm.response.to.have.status(302);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": []
+						},
+						"url": {
+							"raw": "{{action}}?client_id={{clientId3}}&username=&response_type={{response_type}}&redirect_uri={{redirect_uri}}&state=1234-5678-9876",
+							"host": [
+								"{{action}}"
+							],
+							"query": [
+								{
+									"key": "client_id",
+									"value": "{{clientId3}}"
+								},
+								{
+									"key": "username",
+									"value": ""
+								},
+								{
+									"key": "response_type",
+									"value": "{{response_type}}"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "{{redirect_uri}}"
+								},
+								{
+									"key": "state",
+									"value": "1234-5678-9876"
+								}
+							]
+						},
+						"description": "The client does not have a redirect_uri define"
+					},
+					"response": []
+				},
+				{
+					"name": "302 null username",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 302\", function () {",
+									"    pm.response.to.have.status(302);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": []
+						},
+						"url": {
+							"raw": "{{action}}?client_id={{clientId3}}&response_type={{response_type}}&redirect_uri={{redirect_uri}}&state=1234-5678-9876",
+							"host": [
+								"{{action}}"
+							],
+							"query": [
+								{
+									"key": "client_id",
+									"value": "{{clientId3}}"
+								},
+								{
+									"key": "response_type",
+									"value": "{{response_type}}"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "{{redirect_uri}}"
+								},
+								{
+									"key": "state",
+									"value": "1234-5678-9876"
+								}
+							]
+						},
+						"description": "The client does not have a redirect_uri define"
+					},
+					"response": []
+				},
+				{
+					"name": "Get to second login form",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Should be ok\", function () {",
+									"    pm.response.to.be.ok;",
+									"    ",
+									"    // Extract the XSRF token to send it with the next request.",
+									"    var responseHTML = cheerio.load(pm.response.text());",
+									"    var xsrfToken = responseHTML('[name=\"X-XSRF-TOKEN\"]').val();",
+									"    var username = responseHTML('[name=\"username\"]').val();",
+									"    const action = responseHTML('form').attr('action');",
+									"    pm.environment.set('xsrf', xsrfToken);",
+									"    pm.environment.set('action', action);",
+									"    pm.environment.set('username', username);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": []
+						},
+						"url": {
+							"raw": "{{action}}?client_id={{clientId3}}&username=user&response_type={{response_type}}&redirect_uri={{redirect_uri}}&state=1234-5678-9876",
+							"host": [
+								"{{action}}"
+							],
+							"query": [
+								{
+									"key": "client_id",
+									"value": "{{clientId3}}"
+								},
+								{
+									"key": "username",
+									"value": "user"
+								},
+								{
+									"key": "response_type",
+									"value": "{{response_type}}"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "{{redirect_uri}}"
+								},
+								{
+									"key": "state",
+									"value": "1234-5678-9876"
+								}
+							]
+						},
+						"description": "The client does not have a redirect_uri define"
+					},
+					"response": []
+				},
+				{
+					"name": "Post login form",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 302\", function () {",
+									"    pm.response.to.have.status(302);",
+									"});",
+									"",
+									"pm.test(\"Should be redirected to login with invalid account\", function () {",
+									"    pm.response.to.be.redirection;",
+									"    pm.response.to.have.header('Location');",
+									"",
+									"    var location = postman.getResponseHeader(\"Location\");",
+									"    pm.environment.set('redirection', location);",
+									"    // if login was ok, we replay the authorize flow",
+									"    tests['Redirect to consent page'] = location.includes('/oauth/authorize');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "X-XSRF-TOKEN",
+									"value": "{{xsrf}}",
+									"type": "text"
+								},
+								{
+									"key": "client_id",
+									"value": "{{clientId}}",
+									"type": "text"
+								},
+								{
+									"key": "username",
+									"value": "{{username}}",
+									"type": "text"
+								},
+								{
+									"key": "password",
+									"value": "#CoMpL3X-P@SsW0Rd",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{action}}",
+							"host": [
+								"{{action}}"
+							]
+						},
+						"description": "The client does not have a redirect_uri define"
 					},
 					"response": []
 				},

--- a/postman/collections/graviteeio-am-logout-collection-app-version.json
+++ b/postman/collections/graviteeio-am-logout-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "2137543b-7973-47ee-b812-3a6e2338550e",
+		"_postman_id": "952ba507-1696-4cc3-8e7b-952481081f5d",
 		"name": "Gravitee.io - AM - Logout - app version",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -215,7 +215,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"},{\\\"firstname\\\":\\\"Jensen\\\",\\\"lastname\\\":\\\"Barbara\\\",\\\"username\\\":\\\"jensen.barbara\\\",\\\"email\\\":\\\"jensen.barbara@mail.com\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"},{\\\"firstname\\\":\\\"Jensen\\\",\\\"lastname\\\":\\\"Barbara\\\",\\\"username\\\":\\\"jensen.barbara\\\",\\\"email\\\":\\\"jensen.barbara@mail.com\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",

--- a/postman/collections/graviteeio-am-oauth2-collection-app-version.json
+++ b/postman/collections/graviteeio-am-oauth2-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f294fde1-1f85-4dca-be6d-6e448a170187",
+		"_postman_id": "af8d388e-b6d6-48da-a070-ee107dac0ee9",
 		"name": "Gravitee.io - AM - Oauth2 - app version",
 		"description": "Test Oauth2 (RFC 6749) specifications",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -319,7 +319,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"},{\\\"firstname\\\":\\\"Jensen\\\",\\\"lastname\\\":\\\"Barbara\\\",\\\"username\\\":\\\"jensen.barbara\\\",\\\"email\\\":\\\"jensen.barbara@mail.com\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"},{\\\"firstname\\\":\\\"Jensen\\\",\\\"lastname\\\":\\\"Barbara\\\",\\\"username\\\":\\\"jensen.barbara\\\",\\\"email\\\":\\\"jensen.barbara@mail.com\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",

--- a/postman/collections/graviteeio-am-openid-core-collection-app-version.json
+++ b/postman/collections/graviteeio-am-openid-core-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b8413fe9-f1bf-4d60-8f1e-c42e6be747b7",
+		"_postman_id": "7aa50445-ee4c-4dea-ba24-6c14e7ef5403",
 		"name": "Gravitee.io - AM - Openid Core - app version",
 		"description": "Test Openid core specifications: https://openid.net/specs/openid-connect-core-1_0.html",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -267,7 +267,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",

--- a/postman/collections/graviteeio-am-openid-core-request-object-collection.json
+++ b/postman/collections/graviteeio-am-openid-core-request-object-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "bfa6f7e7-60a3-4172-9860-7fffe62c9083",
+		"_postman_id": "55f738b9-91d2-4958-80b0-02caee15dbbd",
 		"name": "Gravitee.io - AM - Openid Core - Request Object",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -270,7 +270,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",

--- a/postman/collections/graviteeio-am-openid-dcr-collection-app-version.json
+++ b/postman/collections/graviteeio-am-openid-dcr-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b905b5ea-a02b-41f0-a6a5-240e7e1c7060",
+		"_postman_id": "a71fb0bc-c2a9-447a-91ee-6444d68197f6",
 		"name": "Gravitee.io - AM - Openid DCR - app version",
 		"description": "Test openid connect dynamc client registration specifications: https://openid.net/specs/openid-connect-registration-1_0.html",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -214,7 +214,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"#CoMpL3X-P@SsW0Rd\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",
@@ -16749,9 +16749,9 @@
 													"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
 													"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
 													"});",
-                                                  "",
-                                                  "// wait for sync process",
-                                                  "setTimeout(function(){}, 5000);"
+													"",
+													"// wait for sync process",
+													"setTimeout(function(){}, 5000);"
 												],
 												"type": "text/javascript"
 											}

--- a/postman/collections/graviteeio-am-openid-discovery-collection.json
+++ b/postman/collections/graviteeio-am-openid-discovery-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c1ada774-658d-4329-912a-1ea9e35b5441",
+		"_postman_id": "163296ee-b1c2-4bb9-b2cc-fb3e05f5d593",
 		"name": "Gravitee.io - AM - Openid Discovery",
 		"description": "Test openid connect discovery specifications: https://openid.net/specs/openid-connect-discovery-1_0.html",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"

--- a/postman/collections/graviteeio-am-openid-fapi-collection.json
+++ b/postman/collections/graviteeio-am-openid-fapi-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b3876695-3da7-4116-8989-e73d275cc16e",
+		"_postman_id": "0cf1e7b4-0529-49b3-98e7-ecfc256634c5",
 		"name": "Gravitee.io - AM - OpenID FAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -270,7 +270,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"password\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"password\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",

--- a/postman/collections/graviteeio-am-openid-jarm-collection.json
+++ b/postman/collections/graviteeio-am-openid-jarm-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "88b10f5e-24db-40d4-804c-ac986219ac73",
+		"_postman_id": "c44f03a8-bd4d-4cc8-86c3-f67937c2a722",
 		"name": "Gravitee.io - AM - Openid JARM",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -273,7 +273,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"password\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"my-user\\\",\\\"lastname\\\":\\\"my-user-lastname\\\",\\\"username\\\":\\\"user\\\",\\\"password\\\":\\\"password\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",

--- a/postman/collections/graviteeio-am-scim-collection-app-version.json
+++ b/postman/collections/graviteeio-am-scim-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cf4c74bf-c3b4-43c4-b1a9-20e1f2418853",
+		"_postman_id": "d67013ac-2b9f-444c-834b-999201fc709b",
 		"name": "Gravitee.io - AM - SCIM - app version",
 		"description": "Test System for Cross-domain Identity Management\nSCIM 2.0 is released as RFC7642, RFC7643 and RFC7644",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"

--- a/postman/collections/graviteeio-am-scope-management-collection.json
+++ b/postman/collections/graviteeio-am-scope-management-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0fc3660f-63d3-4323-b540-f110254e37d3",
+		"_postman_id": "d8f231cd-0462-4728-8ffa-80a03a353bfb",
 		"name": "Gravitee.io - AM - Scope Management",
 		"description": "Test openid connect discovery specifications: https://openid.net/specs/openid-connect-discovery-1_0.html",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"

--- a/postman/collections/graviteeio-am-self-account-management-collection-app-version.json
+++ b/postman/collections/graviteeio-am-self-account-management-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cf17867d-bd28-4005-a32d-3ba8cec13cb5",
+		"_postman_id": "ebddc50d-e391-4277-b81c-87f8761dbd9c",
 		"name": "Gravitee.io - AM - Self Account Management - app version",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},

--- a/postman/collections/graviteeio-am-uma2-app-version-collection.json
+++ b/postman/collections/graviteeio-am-uma2-app-version-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c8334b83-058d-46ed-925c-9818a776be33",
+		"_postman_id": "207bc982-68fc-4c33-9eab-a7c65823593d",
 		"name": "Gravitee.io - AM - UMA 2.0 - app version",
 		"description": "Test openid connect discovery specifications: https://openid.net/specs/openid-connect-discovery-1_0.html",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -206,7 +206,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"Alice\\\",\\\"lastname\\\":\\\"Doe\\\",\\\"username\\\":\\\"alice\\\",\\\"password\\\":\\\"password\\\"},{\\\"firstname\\\":\\\"Bob\\\",\\\"lastname\\\":\\\"Doe\\\",\\\"username\\\":\\\"bob\\\",\\\"email\\\":\\\"bob.doe@mail.com\\\",\\\"password\\\":\\\"password\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
+							"raw": "{\n  \"external\": false,\n  \"type\": \"inline-am-idp\",\n  \"domainWhitelist\" : [],\n  \"configuration\": \"{\\\"users\\\":[{\\\"firstname\\\":\\\"Alice\\\",\\\"lastname\\\":\\\"Doe\\\",\\\"username\\\":\\\"alice\\\",\\\"password\\\":\\\"password\\\"},{\\\"firstname\\\":\\\"Bob\\\",\\\"lastname\\\":\\\"Doe\\\",\\\"username\\\":\\\"bob\\\",\\\"email\\\":\\\"bob.doe@mail.com\\\",\\\"password\\\":\\\"password\\\"}]}\",\n  \"name\": \"inmemory\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/identities",

--- a/postman/collections/graviteeio-am-user-management-collection-app-version.json
+++ b/postman/collections/graviteeio-am-user-management-collection-app-version.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "51a06319-3aff-4486-bad7-3cfd3f28fc58",
+		"_postman_id": "7f2d6889-7a3e-41f0-a261-ffe4e9bb036e",
 		"name": "Gravitee.io - AM - User Management - app version",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},

--- a/postman/collections/graviteeio-am-vhost-collection.json
+++ b/postman/collections/graviteeio-am-vhost-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "af085490-c8e0-4b35-bcc4-4836c01bb36d",
+		"_postman_id": "8239ed3e-f0c6-4ec4-8a7c-4333c57378b3",
 		"name": "Gravitee.io - AM - VirtualHost",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},


### PR DESCRIPTION
fixes gravitee-io/issues#5388

How to test: 
- Create an Access Management domain
- Create an application (make sure that you have the openid scope at least)
- Activate Identifier-first login at application (or settings) level

![localhost_4200_environments_default_domains_social-domains_settings_login (1)](https://user-images.githubusercontent.com/8531515/133396063-fc33b07a-8a5a-4496-a616-0a0e2e07f256.png)

- Create an identity provider with a or several `Domain Whitelist` patterns corresponding to the domain of the external identity provider, this will enable email domain lookup on the username (for example here, if the email domain matches `gmail.com` or `graviteesource.com`)

![localhost_4200_environments_default_domains_social-domains_applications_fbbc76c2-90b2-47a0-bc76-c290b267a039_settings_login (1)](https://user-images.githubusercontent.com/8531515/133268063-86a51cf0-a07f-460d-88cc-a57a35194756.png)

- Initiate the Login Flow, if the username is just a login / is an email not matching the domain whitelist of the configured providers you'll get to the 2nd step with a password to enter and the possible external identity providers

![localhost_8092_social-domains_2step_login_client_id=8dfff187-79ec-4eb0-bff1-8779ec6eb06b response_type=code redirect_uri=https%3A%2F%2Fnowhere com (1)](https://user-images.githubusercontent.com/8531515/133270104-7e2985d7-6a85-4076-be2e-87447e667de5.png)

![localhost_8092_social-domains_login_username=remi sultan%40domain com response_type=code redirect_uri=https%3A%2F%2Fnowhere com client_id=8dfff187-79ec-4eb0-bff1-8779ec6eb06b](https://user-images.githubusercontent.com/8531515/133270505-9b4510e6-a475-4c18-9510-47afa28b0cf0.png)

If the email matches one of the identity providers you'll get redirected to it
![image](https://user-images.githubusercontent.com/8531515/133270695-53145c84-b081-434b-9569-aaa1194951f2.png)

After this you should get the consent page or be logged directly if you are already logged in.

You can also edit the first screen login page at domain level or application level : 
![localhost_4200_environments_default_domains_social-domains_applications_fbbc76c2-90b2-47a0-bc76-c290b267a039_settings_general (1)](https://user-images.githubusercontent.com/8531515/133271306-e9ea480f-d81a-482e-855c-4b1fc0ba070d.png)

![localhost_4200_environments_default_domains_social-domains_applications_fbbc76c2-90b2-47a0-bc76-c290b267a039_settings_general](https://user-images.githubusercontent.com/8531515/133271113-6fbb7acd-8bd2-4d85-a853-e1bd61bd9a6a.png)

![localhost_8092_social-domains_2step_login_client_id=8dfff187-79ec-4eb0-bff1-8779ec6eb06b response_type=code redirect_uri=https%3A%2F%2Fnowhere com (2)](https://user-images.githubusercontent.com/8531515/133271467-528d41bd-70f0-4cee-a69d-2c087aaecc4c.png)


- Note: 
    - Hide Login is disabled since we need to redirect if the password is necessary
    - Works with WebAuthn  if the user already has already logged in with it.
    - User Registration can be activated as well


Tested with:
- MongoDB ✅ 
- Postges 13 ✅ 
- Postgres 9 ✅ 
- MySQL 8 ✅ 
- MySQL 5.7 ✅ 
- MariaDB 10.5 ✅  
- MariaDB 10.3 ✅ 
- MsSQL 2019 ✅ 
- MsSQL 2017 ✅ 
