### PR TITLE
fix(management): domainWhitelist issue on identity providers

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
@@ -48,6 +48,9 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.List;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -141,7 +144,7 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
         identityProvider.setType(newIdentityProvider.getType());
         identityProvider.setConfiguration(newIdentityProvider.getConfiguration());
         identityProvider.setExternal(newIdentityProvider.isExternal());
-        identityProvider.setDomainWhitelist(newIdentityProvider.getDomainWhitelist());
+        identityProvider.setDomainWhitelist(ofNullable(newIdentityProvider.getDomainWhitelist()).orElse(List.of()));
         identityProvider.setCreatedAt(new Date());
         identityProvider.setUpdatedAt(identityProvider.getCreatedAt());
 
@@ -177,7 +180,7 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
                     identityToUpdate.setConfiguration(updateIdentityProvider.getConfiguration());
                     identityToUpdate.setMappers(updateIdentityProvider.getMappers());
                     identityToUpdate.setRoleMapper(updateIdentityProvider.getRoleMapper());
-                    identityToUpdate.setDomainWhitelist(updateIdentityProvider.getDomainWhitelist());
+                    identityToUpdate.setDomainWhitelist(ofNullable(updateIdentityProvider.getDomainWhitelist()).orElse(List.of()));
                     identityToUpdate.setUpdatedAt(new Date());
 
                     return identityProviderRepository.update(identityToUpdate)

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewIdentityProvider.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewIdentityProvider.java
@@ -35,7 +35,6 @@ public class NewIdentityProvider {
     @NotNull
     private String configuration;
 
-    @NotNull
     private List<String> domainWhitelist;
 
     private boolean external;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateIdentityProvider.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateIdentityProvider.java
@@ -35,7 +35,6 @@ public class UpdateIdentityProvider {
 
     private Map<String, String[]> roleMapper;
 
-    @NotNull
     private List<String> domainWhitelist;
 
     public String getName() {


### PR DESCRIPTION
This PR fixes saving/updating identity providers with null domainWhitelist

The bug happened mainly on historical providers already saved and not returning the field.
Try to save a default saved identity provider and you should be able to see this is saved