### PR TITLE
fix: set device exists when created + non negative number

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
@@ -58,7 +58,7 @@
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <input type="hidden" th:name="factorId" th:value="${factor.id}"/>
                     <div class="mfa-challenge-form-actions">
-                        <div th:if="${rememberDeviceIsActive && rememberDeviceConsentTimeSeconds != null && !deviceAlreadyExists}" style="align-content:flex-start;margin-top:10px;margin-right:40px">
+                        <div th:if="${rememberDeviceIsActive && rememberDeviceConsentTimeSeconds != null && deviceId != null && !deviceAlreadyExists}" style="align-content:flex-start;margin-top:10px;margin-right:40px">
                             <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect mdl-typography--text-center">
                                 <input class="mdl-checkbox__input" type="checkbox" id="rememberDeviceConsent" name="rememberDeviceConsent">
                                 <span id="#label" class="mdl-checkboxm__label">Remember my device for [[${rememberDeviceConsentTimeSeconds >= 2629746 ? (rememberDeviceConsentTimeSeconds / 2629746) + " month(s)" : (rememberDeviceConsentTimeSeconds >= 86400 ? (rememberDeviceConsentTimeSeconds / 86400) + " day(s)" : (rememberDeviceConsentTimeSeconds >= 3600 ? (rememberDeviceConsentTimeSeconds / 3600) + " hours(s)" : (rememberDeviceConsentTimeSeconds >= 60 ? (rememberDeviceConsentTimeSeconds / 60) + " minute(s)" : (rememberDeviceConsentTimeSeconds + " second(s)"))))}]]</span>

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchRememberDeviceSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchRememberDeviceSettings.java
@@ -18,6 +18,7 @@ package io.gravitee.am.service.model;
 import io.gravitee.am.model.RememberDeviceSettings;
 import io.gravitee.am.service.utils.SetterUtils;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -67,7 +68,7 @@ public class PatchRememberDeviceSettings {
         RememberDeviceSettings toPatch = _toPatch == null ? new RememberDeviceSettings() : new RememberDeviceSettings(_toPatch);
         SetterUtils.safeSet(toPatch::setDeviceIdentifierId, this.getDeviceIdentifierId());
         SetterUtils.safeSet(toPatch::setActive, this.getActive());
-        SetterUtils.safeSet(toPatch::setExpirationTimeSeconds, this.getExpirationTimeSeconds());
+        SetterUtils.safeSet(toPatch::setExpirationTimeSeconds, this.getExpirationTimeSeconds().filter(Objects::nonNull).map(Math::abs));
         return toPatch;
     }
 }

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/factors/factors.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/factors/factors.component.ts
@@ -82,6 +82,7 @@ export class ApplicationFactorsComponent implements OnInit {
     data.factors = this.application.factors;
     data.settings = {};
     if (this.rememberDevice.active && this.rememberDeviceTime.expirationTime) {
+      this.rememberDeviceTime.expirationTime = Math.abs(this.rememberDeviceTime.expirationTime);
       this.rememberDevice.expirationTimeSeconds =
         moment.duration(this.rememberDeviceTime.expirationTime, this.rememberDeviceTime.expirationTimeUnit).asSeconds();
     }


### PR DESCRIPTION
This PR takes into account QA's remarks:

- Negative time when creating remember device
- Setting device to known after MFA challenge succeeded  and created device
- Not showing the checkbox when we don't know the device