### PR TITLE
fix: safe setting PatchRememberDevice optional expirationTimeSeconds

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchRememberDeviceSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchRememberDeviceSettings.java
@@ -21,6 +21,8 @@ import io.gravitee.am.service.utils.SetterUtils;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.util.Objects.isNull;
+
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
@@ -68,7 +70,8 @@ public class PatchRememberDeviceSettings {
         RememberDeviceSettings toPatch = _toPatch == null ? new RememberDeviceSettings() : new RememberDeviceSettings(_toPatch);
         SetterUtils.safeSet(toPatch::setDeviceIdentifierId, this.getDeviceIdentifierId());
         SetterUtils.safeSet(toPatch::setActive, this.getActive());
-        SetterUtils.safeSet(toPatch::setExpirationTimeSeconds, this.getExpirationTimeSeconds().filter(Objects::nonNull).map(Math::abs));
+        final Optional<Long> expirationTimeSeconds = isNull(this.getExpirationTimeSeconds()) ? Optional.empty() : this.getExpirationTimeSeconds();
+        SetterUtils.safeSet(toPatch::setExpirationTimeSeconds, expirationTimeSeconds.filter(Objects::nonNull).map(Math::abs));
         return toPatch;
     }
 }


### PR DESCRIPTION
This PR fixes the first time when remember device is created: 
It caused a NPE
```
11:32:42.417 [reactor-tcp-nio-4] [] ERROR i.g.a.s.impl.ApplicationServiceImpl - An error occurs while trying to patch an application
java.lang.NullPointerException: null
	at io.gravitee.am.service.model.PatchRememberDeviceSettings.patch(PatchRememberDeviceSettings.java:71)
	at io.gravitee.am.service.model.PatchMFASettings.patch(PatchMFASettings.java:73)
```