### PR TITLE
fix(management): application scope scope_approval set to 0 instead null on jdbc

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcApplication.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcApplication.java
@@ -219,7 +219,7 @@ public class JdbcApplication {
         @Column("is_default")
         private boolean defaultScope;
         @Column("scope_approval")
-        private int scopeApproval;
+        private Integer scopeApproval;
 
         public String getApplicationId() {
             return applicationId;
@@ -245,11 +245,11 @@ public class JdbcApplication {
             this.defaultScope = defaultScope;
         }
 
-        public int getScopeApproval() {
+        public Integer getScopeApproval() {
             return scopeApproval;
         }
 
-        public void setScopeApproval(int scopeApproval) {
+        public void setScopeApproval(Integer scopeApproval) {
             this.scopeApproval = scopeApproval;
         }
     }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_12_4/schema-reset-default-scope-approval.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_12_4/schema-reset-default-scope-approval.yml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.12.4-reset-default-scope-approval
+      author: GraviteeSource Team
+      changes:
+        - sql:
+            sql: "UPDATE application_scope_settings SET scope_approval = null where scope_approval <= 0;"

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -33,3 +33,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_12_0/schema-app-scope-settings.yml
   - include:
       - file: liquibase/changelogs/v3_12_0/schema-system-tasks.yml
+  - include:
+      - file: liquibase/changelogs/v3_12_4/schema-reset-default-scope-approval.yml


### PR DESCRIPTION
fixes: https://github.com/gravitee-io/issues/issues/6478
This PR is a backport of : https://github.com/gravitee-io/gravitee-access-management/pull/1435