### PR TITLE
Updating orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ parameters:
     description: "Release version number to use to publish the Docker nightly images ?"
 
 orbs:
-  gravitee: gravitee-io/gravitee@dev:1.0.40
+  gravitee: gravitee-io/gravitee@1.0
   secrethub: secrethub/cli@1.1.0
   slack: circleci/slack@4.2.1
 


### PR DESCRIPTION
This PR is created in order to reset the orb version to 1.0 after releasing the AM with the new library parameter set,

Orb CircleCI link : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-access-management/3802/workflows/19e761aa-7f1b-447f-9ac0-126b50c0a386

