### PR TITLE
feat: user profile pattern password validation

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/services/impl/AccountServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/services/impl/AccountServiceImpl.java
@@ -139,7 +139,7 @@ public class AccountServiceImpl implements AccountService {
     public Single<ResetPasswordResponse> resetPassword(User user, Client client, String password, io.gravitee.am.identityprovider.api.User principal) {
         return Single.defer(() -> {
             PasswordSettings passwordSettings = PasswordSettings.getInstance(client, this.domain).orElse(null);
-            passwordService.validate(password, passwordSettings);
+            passwordService.validate(password, passwordSettings, user);
             user.setPassword(password);
             return gatewayUserService.resetPassword(client, user, principal);
         });

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRequestHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRequestHandler.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.root.resources.handler.user;
 
 import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.gateway.handler.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.identityprovider.api.DefaultUser;
@@ -59,7 +60,7 @@ public abstract class UserRequestHandler implements Handler<RoutingContext> {
     }
 
     protected User getAuthenticatedUser(RoutingContext routingContext) {
-        io.gravitee.am.model.User user = routingContext.get("user");
+        io.gravitee.am.model.User user = routingContext.get(ConstantKeys.USER_CONTEXT_KEY);
         if (user != null) {
             DefaultUser authenticatedUser = new DefaultUser(user.getUsername());
             authenticatedUser.setId(user.getId());
@@ -80,5 +81,16 @@ public abstract class UserRequestHandler implements Handler<RoutingContext> {
 
     private void doRedirect(HttpServerResponse response, String url) {
         response.putHeader(HttpHeaders.LOCATION, url).setStatusCode(302).end();
+    }
+
+    protected io.gravitee.am.model.User convert(MultiMap params) {
+        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setUsername(params.get("username"));
+        user.setFirstName(params.get("firstName"));
+        user.setLastName(params.get("lastName"));
+        user.setEmail(params.get("email"));
+        user.setPassword(params.get("password"));
+        user.setClient(params.get("client_id"));
+        return user;
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterProcessHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterProcessHandler.java
@@ -95,16 +95,4 @@ public class RegisterProcessHandler extends UserRequestHandler {
         principal.setAdditionalInformation(additionalInformation);
         return principal;
     }
-
-    private User convert(MultiMap params) {
-        User user = new User();
-        user.setUsername(params.get("username"));
-        user.setFirstName(params.get("firstName"));
-        user.setLastName(params.get("lastName"));
-        user.setEmail(params.get("email"));
-        user.setPassword(params.get("password"));
-        user.setClient(params.get("client_id"));
-
-        return user;
-    }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/reset_password.css
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/reset_password.css
@@ -68,6 +68,13 @@
     border: 1px solid #e2e5e7;
 }
 
+.reset-password-warning-info {
+    margin-top: 20px;
+    padding: 20px;
+    border-radius: 2px;
+    border: 1px solid #e2e5e7;
+}
+
 .reset-password-error-info .error {
     color: orange;
     font-weight: bold;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/password-validation.js
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/password-validation.js
@@ -1,12 +1,21 @@
 // this script need passwordSettings to be declared before including this script
 
+//Form elements
 const passwordInput = document.getElementById("password");
+const firstNameInput = document.getElementById("firstName");
+const lastNameInput = document.getElementById("lastName");
+const emailInput = document.getElementById("username");
+const submitBtn = document.getElementById("submitBtn");
+
+//Validation elements
 const length = document.getElementById("minLength");
 const number = document.getElementById("includeNumbers");
 const specialChar = document.getElementById("includeSpecialChar");
 const mixedCase = document.getElementById("mixedCase");
 const maxConsecutiveLetters = document.getElementById("maxConsecutiveLetters");
-const submitBtn = document.getElementById("submitBtn");
+const excludeUserProfileInfoInPassword = document.getElementById("excludeUserProfileInfoInPassword");
+
+
 
 /**
  * When the user starts to type something inside the password field
@@ -54,7 +63,19 @@ passwordInput.onkeyup = function () {
         isMaxConsecutiveLettersOk = !isOverMaxConsecutiveLetters(passwordInput.value, passwordSettings.maxConsecutiveLetters);
         validateMessageElement(maxConsecutiveLetters, isMaxConsecutiveLettersOk);
     }
-    submitBtn.disabled = !(isMinLengthOk && isIncludeNumbersOk && isIncludeSpecialCharactersOk && isLettersInMixedCaseOk && isMaxConsecutiveLettersOk);
+
+    //validate user profile in password
+    let isExcludeUserProfileInfoInPasswordOk = true;
+    if (passwordSettings.excludeUserProfileInfoInPassword && firstNameInput && lastNameInput && emailInput) {
+        const lowerPassword = passwordInput.value ? passwordInput.value.toLowerCase() : passwordInput.value;
+        isExcludeUserProfileInfoInPasswordOk = (
+            (!firstNameInput.value || !lowerPassword.includes(firstNameInput.value.toLowerCase())) &&
+            (!lastNameInput.value || !lowerPassword.includes(lastNameInput.value.toLowerCase())) &&
+            (!emailInput.value || !lowerPassword.includes(emailInput.value.toLowerCase()))
+        )
+        validateMessageElement(excludeUserProfileInfoInPassword, isExcludeUserProfileInfoInPasswordOk);
+    }
+    submitBtn.disabled = !(isMinLengthOk && isIncludeNumbersOk && isIncludeSpecialCharactersOk && isLettersInMixedCaseOk && isMaxConsecutiveLettersOk && isExcludeUserProfileInfoInPasswordOk);
 }
 
 /**

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration.html
@@ -76,7 +76,8 @@
                         <p th:if="${passwordSettings.includeSpecialCharacters}" id="includeSpecialChar" class="invalid">Contains a special character</p>
                         <p th:if="${passwordSettings.lettersInMixedCase}" id="mixedCase" class="invalid">Contains letters in mixed case</p>
                         <p th:if="${passwordSettings.maxConsecutiveLetters != null}" id="maxConsecutiveLetters" class="valid">Max <span th:text="${passwordSettings.maxConsecutiveLetters}"/> consecutive letters or numbers</p>
-                        <p th:if="${passwordSettings.excludePasswordsInDictionary}" id="excludePasswordsInDictionary" class="advice">don't use common names or passwords</p>
+                        <p th:if="${passwordSettings.excludePasswordsInDictionary}" id="excludePasswordsInDictionary" class="advice">Don't use common names or passwords</p>
+                        <p th:if="${passwordSettings.excludeUserProfileInfoInPassword}" id="excludeUserProfileInfoInPassword" class="invalid">Don't use your profile information in password</p>
                     </div>
                 </div>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
@@ -26,8 +26,12 @@
                 <label>Sign-up confirmation</label>
                 <span>Thanks for signing up, please complete the form to activate your account</span>
             </div>
-            <div th:if="${warning}" class="registration-confirmation-error-info">
-                <p>Invalid password value. It does not comply with the password policy.</p>
+            <div class="registration-confirmation-error-info" th:switch="${warning}" th:if="${warning}">
+                <p style="margin: 0;" th:case="invalid_password_value">Invalid password value. It does not comply with
+                    the password policy.
+                <p style="margin: 0;" th:case="invalid_user_information">Invalid first name, last name or username.</p>
+                <p style="margin: 0;" th:case="invalid_email">Invalid email address.</p>
+                <p style="margin: 0;" th:case="*">Some information are missing or invalid.</p>
             </div>
             <form role="form" th:action="${action}" method="post" style="display: flex; flex-direction: column; margin-top: 30px;">
                 <div class="registration-confirmation-form-content">
@@ -44,7 +48,8 @@
                         <p th:if="${passwordSettings.includeSpecialCharacters}" id="includeSpecialChar" class="invalid">Contains a special character</p>
                         <p th:if="${passwordSettings.lettersInMixedCase}" id="mixedCase" class="invalid">Contains letters in mixed case</p>
                         <p th:if="${passwordSettings.maxConsecutiveLetters != null}" id="maxConsecutiveLetters" class="valid">Max <span th:text="${passwordSettings.maxConsecutiveLetters}"/> consecutive letters or numbers</p>
-                        <p th:if="${passwordSettings.excludePasswordsInDictionary}" id="excludePasswordsInDictionary" class="advice">don't use common names or passwords</p>
+                        <p th:if="${passwordSettings.excludePasswordsInDictionary}" id="excludePasswordsInDictionary" class="advice">Don't use common names or passwords</p>
+                        <p th:if="${passwordSettings.excludeUserProfileInfoInPassword}" id="excludeUserProfileInfoInPassword" class="advice">Don't use your profile information in password</p>
                     </div>
                 </div>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/reset_password.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/reset_password.html
@@ -27,6 +27,11 @@
                 <span>Please enter a new password for your account</span>
             </div>
 
+            <div class="reset-password-warning-info" th:switch="${warning}" th:if="${warning}">
+                <p style="margin: 0;" th:case="invalid_password_value">Invalid password value. It does not comply with
+                    the password policy.
+                <p style="margin: 0;" th:case="*">Some information are missing or invalid.</p>
+            </div>
 
             <form role="form" th:action="${action}" method="post">
                 <div class="reset-password-form-content">
@@ -43,7 +48,8 @@
                         <p th:if="${passwordSettings.includeSpecialCharacters}" id="includeSpecialChar" class="invalid">Contains a special character</p>
                         <p th:if="${passwordSettings.lettersInMixedCase}" id="mixedCase" class="invalid">Contains letters in mixed case</p>
                         <p th:if="${passwordSettings.maxConsecutiveLetters != null}" id="maxConsecutiveLetters" class="valid">Max <span th:text="${passwordSettings.maxConsecutiveLetters}"/> consecutive letters or numbers</p>
-                        <p th:if="${passwordSettings.excludePasswordsInDictionary}" id="excludePasswordsInDictionary" class="advice">don't use common names or passwords</p>
+                        <p th:if="${passwordSettings.excludePasswordsInDictionary}" id="excludePasswordsInDictionary" class="advice">Don't use common names or passwords</p>
+                        <p th:if="${passwordSettings.excludeUserProfileInfoInPassword}" id="excludeUserProfileInfoInPassword" class="advice">Don't use your profile information in password</p>
                     </div>
                 </div>
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/PasswordPolicyRequestParseHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/PasswordPolicyRequestParseHandlerTest.java
@@ -28,8 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 
@@ -61,7 +60,7 @@ public class PasswordPolicyRequestParseHandlerTest extends RxWebTestBase {
                 .handler(passwordPolicyRequestParseHandler)
                 .handler(rc -> rc.response().end());
 
-        doThrow(InvalidPasswordException.class).when(passwordValidator).validate(anyString(), eq(null));
+        doThrow(InvalidPasswordException.class).when(passwordValidator).validate(anyString(), eq(null), any());
 
         testRequest(HttpMethod.POST, "/", req -> {
             Buffer buffer = Buffer.buffer();
@@ -83,7 +82,7 @@ public class PasswordPolicyRequestParseHandlerTest extends RxWebTestBase {
                 .handler(rc -> rc.response().end());
 
 
-        doNothing().when(passwordValidator).validate(anyString(), eq(null));
+        doNothing().when(passwordValidator).validate(anyString(), eq(null), any());
 
         testRequest(HttpMethod.POST, "/", req -> {
             Buffer buffer = Buffer.buffer();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/UserServiceTest.java
@@ -205,7 +205,7 @@ public class UserServiceTest {
         ArgumentCaptor<io.gravitee.am.model.User> userCaptor = ArgumentCaptor.forClass(io.gravitee.am.model.User.class);
         when(userRepository.update(any())).thenReturn(Single.just(existingUser));
         when(groupService.findByMember(existingUser.getId())).thenReturn(Flowable.empty());
-        when(passwordService.isValid("user-password", null)).thenReturn(true);
+        when(passwordService.isValid(eq("user-password"), any(), any())).thenReturn(true);
 
         TestObserver<User> testObserver = userService.update(existingUser.getId(), scimUser, null, "/", null).test();
         testObserver.assertNoErrors();
@@ -219,7 +219,6 @@ public class UserServiceTest {
     public void shouldNotUpdateUser_unknownIdentityProvider() {
         io.gravitee.am.model.User existingUser = mock(io.gravitee.am.model.User.class);
         when(existingUser.getId()).thenReturn("user-id");
-        when(existingUser.getSource()).thenReturn("user-idp");
         when(existingUser.getUsername()).thenReturn("username");
 
         User scimUser = mock(User.class);
@@ -227,9 +226,7 @@ public class UserServiceTest {
         when(scimUser.isActive()).thenReturn(true);
 
         when(userRepository.findById(existingUser.getId())).thenReturn(Maybe.just(existingUser));
-        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(null);
         ArgumentCaptor<io.gravitee.am.model.User> userCaptor = ArgumentCaptor.forClass(io.gravitee.am.model.User.class);
-        when(passwordService.isValid("user-password", null)).thenReturn(true);
 
         TestObserver<User> testObserver = userService.update(existingUser.getId(), scimUser, null, "/", null).test();
         testObserver.assertError(InvalidValueException.class);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
@@ -426,7 +426,7 @@ public class UserServiceTest {
         when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
         when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
 
-        doReturn(true).when(passwordService).isValid(password, null);
+        doReturn(true).when(passwordService).isValid(eq(password), eq(null), any());
         when(commonUserService.findById(eq(ReferenceType.DOMAIN), eq(domain.getId()), eq("user-id"))).thenReturn(Single.just(user));
         when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
         when(commonUserService.update(any())).thenReturn(Single.just(user));
@@ -455,7 +455,7 @@ public class UserServiceTest {
         when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.empty());
         when(userProvider.create(any())).thenReturn(Single.just(idpUser));
 
-        doReturn(true).when(passwordService).isValid(password, null);
+        when(passwordService.isValid(eq(password), eq(null), any())).thenReturn(true);
         when(commonUserService.findById(eq(ReferenceType.DOMAIN), eq(domain.getId()), eq("user-id"))).thenReturn(Single.just(user));
         when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
         when(commonUserService.update(any())).thenReturn(Single.just(user));
@@ -562,7 +562,6 @@ public class UserServiceTest {
 
     @Test
     public void shouldNotCreate_invalid_password() {
-
         Domain domain = new Domain();
         domain.setId("domainId");
         String password = "myPassword";
@@ -577,7 +576,7 @@ public class UserServiceTest {
                 .test()
                 .assertNotComplete()
                 .assertError(InvalidPasswordException.class);
-        verify(passwordService, times(1)).isValid(password, null);
+        verify(passwordService, times(1)).isValid(eq(password), eq(null), any());
     }
 
     @Test
@@ -596,6 +595,6 @@ public class UserServiceTest {
                 .test()
                 .assertNotComplete()
                 .assertError(InvalidPasswordException.class);
-        verify(passwordService, times(1)).isValid(password, null);
+        verify(passwordService, times(1)).isValid(eq(password), eq(null), any());
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/PasswordSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/PasswordSettings.java
@@ -69,6 +69,11 @@ public class PasswordSettings {
      */
     private Boolean excludePasswordsInDictionary;
 
+    /**
+     * Excludes user profile information from password
+     */
+    private Boolean excludeUserProfileInfoInPassword;
+
     public PasswordSettings() {
 
     }
@@ -81,6 +86,8 @@ public class PasswordSettings {
         this.includeSpecialCharacters = other.includeSpecialCharacters;
         this.lettersInMixedCase = other.lettersInMixedCase;
         this.maxConsecutiveLetters = other.maxConsecutiveLetters;
+        this.excludePasswordsInDictionary = other.excludePasswordsInDictionary;
+        this.excludeUserProfileInfoInPassword = other.excludeUserProfileInfoInPassword;
     }
 
     public Integer getMinLength() {
@@ -145,6 +152,14 @@ public class PasswordSettings {
 
     public void setExcludePasswordsInDictionary(Boolean excludePasswordsInDictionary) {
         this.excludePasswordsInDictionary = excludePasswordsInDictionary;
+    }
+
+    public Boolean isExcludeUserProfileInfoInPassword() {
+        return excludeUserProfileInfoInPassword;
+    }
+
+    public void setExcludeUserProfileInfoInPassword(Boolean excludeUserProfileInfoInPassword) {
+        this.excludeUserProfileInfoInPassword = excludeUserProfileInfoInPassword;
     }
 
     public static Optional<PasswordSettings> getInstance(PasswordSettingsAware passwordSettingsAware, Domain domain) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/PasswordSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/PasswordSettingsMongo.java
@@ -59,9 +59,15 @@ public class PasswordSettingsMongo {
     private Integer maxConsecutiveLetters;
 
     /**
-     * Max consecutive letters
+     *  Excludes passwords contained in dictionary
      */
     private Boolean excludePasswordsInDictionary;
+
+
+    /**
+     * Excludes user profile information from password
+     */
+    private Boolean excludeUserProfileInfoInPassword;
 
     public boolean isInherited() {
         return inherited;
@@ -127,6 +133,14 @@ public class PasswordSettingsMongo {
         this.excludePasswordsInDictionary = excludePasswordsInDictionary;
     }
 
+    public Boolean isExcludeUserProfileInfoInPassword() {
+        return excludeUserProfileInfoInPassword;
+    }
+
+    public void setExcludeUserProfileInfoInPassword(Boolean excludeUserProfileInfoInPassword) {
+        this.excludeUserProfileInfoInPassword = excludeUserProfileInfoInPassword;
+    }
+
     public PasswordSettings convert() {
         PasswordSettings passwordSettings = new PasswordSettings();
         passwordSettings.setInherited(isInherited());
@@ -137,6 +151,7 @@ public class PasswordSettingsMongo {
         passwordSettings.setLettersInMixedCase(getLettersInMixedCase());
         passwordSettings.setMaxConsecutiveLetters(getMaxConsecutiveLetters());
         passwordSettings.setExcludePasswordsInDictionary(isExcludePasswordsInDictionary());
+        passwordSettings.setExcludeUserProfileInfoInPassword(isExcludeUserProfileInfoInPassword());
         return passwordSettings;
     }
 
@@ -153,6 +168,7 @@ public class PasswordSettingsMongo {
         passwordSettings.setLettersInMixedCase(other.getLettersInMixedCase());
         passwordSettings.setMaxConsecutiveLetters(other.getMaxConsecutiveLetters());
         passwordSettings.setExcludePasswordsInDictionary(other.isExcludePasswordsInDictionary());
+        passwordSettings.setExcludeUserProfileInfoInPassword(other.isExcludeUserProfileInfoInPassword());
         return passwordSettings;
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/PasswordService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/PasswordService.java
@@ -17,6 +17,8 @@
 package io.gravitee.am.service;
 
 import io.gravitee.am.model.PasswordSettings;
+import io.gravitee.am.model.User;
+import io.gravitee.am.service.exception.InvalidPasswordException;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
@@ -24,12 +26,19 @@ import io.gravitee.am.model.PasswordSettings;
  */
 public interface PasswordService {
 
-    default boolean isValid(String password){
-        return isValid(password, null);
+    default boolean isValid(String password) {
+        return isValid(password, null, null);
     }
 
-    boolean isValid(String password, PasswordSettings passwordSettings);
+    default boolean isValid(String password, PasswordSettings passwordSettings, User user) {
+        try {
+            validate(password, passwordSettings, user);
+            return true;
+        } catch (InvalidPasswordException e) {
+            return false;
+        }
+    }
 
-    void validate(String password, PasswordSettings passwordSettings);
+    void validate(String password, PasswordSettings passwordSettings, User user);
 
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchPasswordSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchPasswordSettings.java
@@ -35,6 +35,7 @@ public class PatchPasswordSettings {
     private Optional<Boolean> lettersInMixedCase;
     private Optional<Integer> maxConsecutiveLetters;
     private Optional<Boolean> excludePasswordsInDictionary;
+    private Optional<Boolean> excludeUserProfileInfoInPassword;
 
     public Optional<Integer> getMinLength() {
         return minLength;
@@ -100,6 +101,14 @@ public class PatchPasswordSettings {
         this.excludePasswordsInDictionary = excludePasswordsInDictionary;
     }
 
+    public Optional<Boolean> getExcludeUserProfileInfoInPassword() {
+        return excludeUserProfileInfoInPassword;
+    }
+
+    public void setExcludeUserProfileInfoInPassword(Optional<Boolean> excludeUserProfileInfoInPassword) {
+        this.excludeUserProfileInfoInPassword = excludeUserProfileInfoInPassword;
+    }
+
     public PasswordSettings patch(PasswordSettings _toPatch) {
         // create new object for audit purpose (patch json result)
         PasswordSettings toPatch = Optional.ofNullable(_toPatch).map(PasswordSettings::new).orElseGet(PasswordSettings::new);
@@ -111,6 +120,7 @@ public class PatchPasswordSettings {
         SetterUtils.safeSet(toPatch::setLettersInMixedCase, this.lettersInMixedCase);
         SetterUtils.safeSet(toPatch::setMaxConsecutiveLetters, this.maxConsecutiveLetters);
         SetterUtils.safeSet(toPatch::setExcludePasswordsInDictionary, this.excludePasswordsInDictionary);
+        SetterUtils.safeSet(toPatch::setExcludeUserProfileInfoInPassword, this.excludeUserProfileInfoInPassword);
 
         if (toPatch.getMinLength() != null && toPatch.getMaxLength() != null) {
             if (toPatch.getMinLength() > toPatch.getMaxLength()) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/password/impl/UserProfilePasswordValidator.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/password/impl/UserProfilePasswordValidator.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.service.validators.password.impl;
+
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.scim.Attribute;
+import io.gravitee.am.service.exception.InvalidPasswordException;
+import io.gravitee.am.service.validators.password.PasswordValidator;
+
+import java.util.List;
+import java.util.Locale;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.isNull;
+import static java.util.Optional.ofNullable;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UserProfilePasswordValidator implements PasswordValidator {
+
+    private static final String ERROR_MESSAGE = "invalid password user profile";
+    private static final InvalidPasswordException INVALID_PASSWORD_EXCEPTION = InvalidPasswordException.of(ERROR_MESSAGE, ERROR_KEY);
+    private final boolean excludeUserProfileInfo;
+    private final User user;
+
+    public UserProfilePasswordValidator(Boolean excludeUserProfileInfo, User user) {
+        this.excludeUserProfileInfo = Boolean.TRUE.equals(excludeUserProfileInfo);
+        this.user = user;
+    }
+
+    @Override
+    public Boolean validate(String password) {
+        if (!this.excludeUserProfileInfo || isNull(user)) {
+            return true;
+        }
+        final String passwordToLower = password.toLowerCase(Locale.ROOT);
+        return isFieldValid(passwordToLower, user.getUsername()) &&
+                isFieldValid(passwordToLower, user.getNickName()) &&
+                isFieldValid(passwordToLower, user.getFirstName()) &&
+                isFieldValid(passwordToLower, user.getMiddleName()) &&
+                isFieldValid(passwordToLower, user.getLastName()) &&
+                isFieldValid(passwordToLower, user.getEmail()) &&
+                ofNullable(user.getEmails()).orElse(List.of()).stream().map(Attribute::getValue)
+                        .allMatch(phone -> isFieldValid(passwordToLower, phone)) &&
+                isFieldValid(passwordToLower, user.getPhoneNumber()) &&
+                ofNullable(user.getPhoneNumbers()).orElse(List.of()).stream().map(Attribute::getValue)
+                        .allMatch(phone -> isFieldValid(passwordToLower, phone));
+    }
+
+    private boolean isFieldValid(String password, String userProfileInfo) {
+        return isNullOrEmpty(userProfileInfo) || !password.contains(userProfileInfo.toLowerCase(Locale.ROOT));
+    }
+
+    @Override
+    public InvalidPasswordException getCause() {
+        return INVALID_PASSWORD_EXCEPTION;
+    }
+}

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/password-policy/password-policy.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/password-policy/password-policy.component.html
@@ -78,6 +78,12 @@
               </mat-slide-toggle>
               <mat-hint style="font-size: 75%;">Will exclude common unsafe passwords (e.g: <i>123456</i>, <i>qwertyuiop</i>, <i>trustno1</i>, ...).</mat-hint>
             </div>
+            <div fxLayout="column" style="margin-top: 5px;">
+              <mat-slide-toggle [checked]="excludeUserProfileInfoInPassword" (change)="setExcludeUserProfileInfoInPassword($event);formChange()">
+                Exclude user profile information from passwords
+              </mat-slide-toggle>
+              <mat-hint style="font-size: 75%;">Will user profile information from passwords (e.g:username, firstname, lastname, middle-name, nickname, email, phone number)</mat-hint>
+            </div>
           </div>
 
           <div fxLayout="row">

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/password-policy/password-policy.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/password-policy/password-policy.component.ts
@@ -41,6 +41,7 @@ export class PasswordPolicyComponent implements OnInit {
   inherited: boolean;
   maxConsecutiveLetters: number;
   excludePasswordsInDictionary: boolean;
+  excludeUserProfileInfoInPassword: boolean;
 
   constructor(private route: ActivatedRoute,
               private router: Router,
@@ -65,6 +66,7 @@ export class PasswordPolicyComponent implements OnInit {
       this.lettersInMixedCase = this.passwordSettings.lettersInMixedCase;
       this.maxConsecutiveLetters = this.passwordSettings.maxConsecutiveLetters;
       this.excludePasswordsInDictionary = this.passwordSettings.excludePasswordsInDictionary;
+      this.excludeUserProfileInfoInPassword = this.passwordSettings.excludeUserProfileInfoInPassword;
     }
     this.editMode = this.authService.hasPermissions(['application_settings_update']);
   }
@@ -94,6 +96,10 @@ export class PasswordPolicyComponent implements OnInit {
     this.excludePasswordsInDictionary = e.checked;
   }
 
+  setExcludeUserProfileInfoInPassword(e) {
+    this.excludeUserProfileInfoInPassword = e.checked;
+  }
+
   update() {
     const data: any = {};
     data.settings = {};
@@ -105,7 +111,8 @@ export class PasswordPolicyComponent implements OnInit {
       'includeSpecialCharacters': this.includeSpecialCharacters,
       'lettersInMixedCase': this.lettersInMixedCase,
       'maxConsecutiveLetters': this.maxConsecutiveLetters,
-      'excludePasswordsInDictionary': this.excludePasswordsInDictionary
+      'excludePasswordsInDictionary': this.excludePasswordsInDictionary,
+      'excludeUserProfileInfoInPassword': this.excludeUserProfileInfoInPassword
     };
     this.applicationService.patch(this.domainId, this.application.id, data).subscribe(response => {
       this.formChanged = false;

--- a/gravitee-am-ui/src/app/domain/settings/password-policy/domain-password-policy.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/password-policy/domain-password-policy.component.html
@@ -71,6 +71,12 @@
               </mat-slide-toggle>
               <mat-hint style="font-size: 75%;">Will exclude common unsafe passwords (e.g: <i>123456</i>, <i>qwertyuiop</i>, <i>trustno1</i>, ...).</mat-hint>
             </div>
+            <div fxLayout="column" style="margin-top: 5px;">
+              <mat-slide-toggle [checked]="excludeUserProfileInfoInPassword" (change)="setExcludeUserProfileInfoInPassword($event);formChange()">
+                Exclude user profile information from passwords
+              </mat-slide-toggle>
+              <mat-hint style="font-size: 75%;">Will user profile information from passwords (e.g:username, firstname, lastname, middle-name, nickname, email, phone number)</mat-hint>
+            </div>
           </div>
           <div fxLayout="row">
             <button mat-raised-button [disabled]="(!applicationForm.valid || applicationForm.pristine) && !formChanged" type="submit">

--- a/gravitee-am-ui/src/app/domain/settings/password-policy/domain-password-policy.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/password-policy/domain-password-policy.component.ts
@@ -39,6 +39,7 @@ export class DomainPasswordPolicyComponent implements OnInit {
   lettersInMixedCase: boolean;
   maxConsecutiveLetters: number;
   excludePasswordsInDictionary: boolean;
+  excludeUserProfileInfoInPassword: boolean;
 
   constructor(private route: ActivatedRoute,
               private router: Router,
@@ -60,6 +61,7 @@ export class DomainPasswordPolicyComponent implements OnInit {
       this.lettersInMixedCase = this.passwordSettings.lettersInMixedCase;
       this.maxConsecutiveLetters = this.passwordSettings.maxConsecutiveLetters;
       this.excludePasswordsInDictionary = this.passwordSettings.excludePasswordsInDictionary;
+      this.excludeUserProfileInfoInPassword = this.passwordSettings.excludeUserProfileInfoInPassword;
     }
     this.editMode = this.authService.hasPermissions(['application_settings_update']);
   }
@@ -84,6 +86,10 @@ export class DomainPasswordPolicyComponent implements OnInit {
     this.excludePasswordsInDictionary = e.checked;
   }
 
+  setExcludeUserProfileInfoInPassword(e) {
+    this.excludeUserProfileInfoInPassword = e.checked;
+  }
+
   update() {
     const data: any = {};
     data.passwordSettings = {
@@ -93,7 +99,8 @@ export class DomainPasswordPolicyComponent implements OnInit {
       'includeSpecialCharacters': this.includeSpecialCharacters,
       'lettersInMixedCase': this.lettersInMixedCase,
       'maxConsecutiveLetters': this.maxConsecutiveLetters,
-      'excludePasswordsInDictionary': this.excludePasswordsInDictionary
+      'excludePasswordsInDictionary': this.excludePasswordsInDictionary,
+      'excludeUserProfileInfoInPassword': this.excludeUserProfileInfoInPassword
     };
     this.domainService.patchPasswordSettings(this.domainId, data).subscribe(data => {
       this.passwordSettings = data.passwordSettings;


### PR DESCRIPTION
closes: https://github.com/gravitee-io/issues/issues/6521

This feature allows to exclude user profile information within the password (case insensitive)

The testing process is the same as this one: https://github.com/gravitee-io/gravitee-access-management/pull/1456
Instead: Toggle `Exclude user profile information in password` in the Password Policy Settings

~Also do not merge before https://github.com/gravitee-io/gravitee-access-management/pull/1456 is merged !~