### PR TITLE
feat: separate idp roles from static roles

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
@@ -16,12 +16,10 @@
 package io.gravitee.am.gateway.handler.common.auth;
 
 import io.gravitee.am.common.exception.authentication.AccountDisabledException;
-import io.gravitee.am.gateway.handler.common.auth.user.impl.UserAuthenticationServiceImpl;
 import io.gravitee.am.gateway.handler.common.auth.user.UserAuthenticationService;
+import io.gravitee.am.gateway.handler.common.auth.user.impl.UserAuthenticationServiceImpl;
 import io.gravitee.am.gateway.handler.common.user.UserService;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.Group;
-import io.gravitee.am.model.Role;
 import io.gravitee.am.model.User;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
@@ -34,8 +32,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -148,12 +144,6 @@ public class UserAuthenticationServiceTest {
         String source = "SRC";
         String id = "id";
 
-        Role role1= new Role();
-        role1.setId("idp-role");
-        Role role2 = new Role();
-        role2.setId("idp2-role");
-        Set<Role> roles = new HashSet<>(Arrays.asList(role1, role2));
-
         io.gravitee.am.identityprovider.api.User user = mock(io.gravitee.am.identityprovider.api.User.class);
         when(user.getUsername()).thenReturn(username);
         when(user.getId()).thenReturn(id);
@@ -187,12 +177,6 @@ public class UserAuthenticationServiceTest {
         String source = "SRC";
         String id = "id";
 
-        Role role1= new Role();
-        role1.setId("idp-role");
-        Role role2 = new Role();
-        role2.setId("idp2-role");
-        Set<Role> roles = new HashSet<>(Arrays.asList(role1, role2));
-
         io.gravitee.am.identityprovider.api.User user = mock(io.gravitee.am.identityprovider.api.User.class);
         when(user.getUsername()).thenReturn(username);
         when(user.getId()).thenReturn(id);
@@ -225,13 +209,6 @@ public class UserAuthenticationServiceTest {
         String source = "SRC";
         String id = "id";
 
-        Group group = mock(Group.class);
-
-        Role role1= new Role();
-        role1.setId("idp-role");
-        Role role2 = new Role();
-        role2.setId("idp2-role");
-        Set<Role> roles = new HashSet<>(Arrays.asList(role1, role2));
 
         io.gravitee.am.identityprovider.api.User user = mock(io.gravitee.am.identityprovider.api.User.class);
         when(user.getUsername()).thenReturn(username);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/ExtensionGrantGranter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/ExtensionGrantGranter.java
@@ -32,17 +32,13 @@ import io.gravitee.am.identityprovider.api.Authentication;
 import io.gravitee.am.identityprovider.api.AuthenticationProvider;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.identityprovider.api.SimpleAuthenticationContext;
-import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ExtensionGrant;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
 import io.reactivex.Maybe;
-import io.reactivex.MaybeSource;
 import io.reactivex.Single;
-import io.reactivex.functions.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -146,7 +142,7 @@ public class ExtensionGrantGranter extends AbstractTokenGranter {
                                         user.setAdditionalInformation(extraInformation);
                                         user.setCreatedAt(idpUser.getCreatedAt());
                                         user.setUpdatedAt(idpUser.getUpdatedAt());
-                                        user.setRoles(idpUser.getRoles());
+                                        user.setDynamicRoles(idpUser.getRoles());
                                         return user;
                                     })
                                     .switchIfEmpty(Maybe.error(new InvalidGrantException("Unknown user: " + endUser.getId())));
@@ -168,7 +164,8 @@ public class ExtensionGrantGranter extends AbstractTokenGranter {
     private Maybe<io.gravitee.am.identityprovider.api.User> retrieveUserByUsernameFromIdp(AuthenticationProvider provider, TokenRequest tokenRequest, User user) {
         SimpleAuthenticationContext authenticationContext = new SimpleAuthenticationContext(tokenRequest);
         final Authentication authentication = new EndUserAuthentication(user, null, authenticationContext);
-        return provider.loadPreAuthenticatedUser(authentication);
+        final Maybe<io.gravitee.am.identityprovider.api.User> userMaybe = provider.loadPreAuthenticatedUser(authentication);
+        return userMaybe;
     }
 
     private User convert(io.gravitee.am.identityprovider.api.User idpUser) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -117,7 +117,7 @@ public class TokenServiceImpl implements TokenService {
     @Override
     public Single<Token> introspect(String token) {
         return introspectionTokenService.introspect(token, false)
-                .map(jwt -> convertAccessToken(jwt));
+                .map(this::convertAccessToken);
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/UserServiceImpl.java
@@ -250,6 +250,15 @@ public class UserServiceImpl implements UserService {
                                 userToUpdate.setCreatedAt(existingUser.getCreatedAt());
                                 userToUpdate.setUpdatedAt(new Date());
                                 userToUpdate.setFactors(existingUser.getFactors());
+                                userToUpdate.setDynamicRoles(existingUser.getDynamicRoles());
+
+                                // We remove the dynamic roles from the user roles to be updated in order to preserve
+                                // the roles that were assigned by the RoleMappers so that whenever the rule from the
+                                // said RoleMapper does not apply anymore, user loses the role
+                                if (userToUpdate.getRoles() != null && userToUpdate.getDynamicRoles() != null) {
+                                    userToUpdate.getRoles().removeAll(userToUpdate.getDynamicRoles());
+                                }
+
                                 UserFactorUpdater.updateFactors(existingUser.getFactors(), existingUser, userToUpdate);
 
                                 // set source

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/DefaultIdentityProviderRoleMapper.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/DefaultIdentityProviderRoleMapper.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.am.identityprovider.api;
 
-import io.gravitee.am.identityprovider.api.IdentityProviderRoleMapper;
 import io.gravitee.el.TemplateEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,13 +63,15 @@ public class DefaultIdentityProviderRoleMapper implements IdentityProviderRoleMa
                     } else {
                         // user/group have the following syntax userAttribute=userValue
                         String[] attributes = u.split("=", 2);
-                        String userAttribute = attributes[0];
-                        String userValue = attributes[1];
-                        if (userInfo.containsKey(userAttribute)) {
-                            if (userInfo.get(userAttribute) instanceof Collection && ((Collection<?>) userInfo.get(userAttribute)).contains(userValue)) {
-                                mappedRoles.add(role);
-                            } else if (userValue.equals(String.valueOf(userInfo.get(userAttribute)))) {
-                                mappedRoles.add(role);
+                        if (attributes.length == 2){
+                            String userAttribute = attributes[0];
+                            String userValue = attributes[1];
+                            if (userInfo.containsKey(userAttribute)) {
+                                if (userInfo.get(userAttribute) instanceof Collection && ((Collection<?>) userInfo.get(userAttribute)).contains(userValue)) {
+                                    mappedRoles.add(role);
+                                } else if (userValue.equals(String.valueOf(userInfo.get(userAttribute)))) {
+                                    mappedRoles.add(role);
+                                }
                             }
                         }
                     }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UserEntity.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UserEntity.java
@@ -54,6 +54,7 @@ public class UserEntity extends User {
         setLoginsCount(user.getLoginsCount());
         setLoggedAt(user.getLoggedAt());
         setRoles(user.getRoles());
+        setDynamicRoles(user.getDynamicRoles());
         setRolesPermissions(user.getRolesPermissions());
         setAdditionalInformation(user.getAdditionalInformation());
         setCreatedAt(user.getCreatedAt());

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UserResource.java
@@ -26,7 +26,6 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.IdentityProviderService;
-import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.UserInvalidException;
 import io.gravitee.am.service.model.UpdateUser;
 import io.gravitee.common.http.MediaType;

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
@@ -25,7 +25,6 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
-import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.authentication.crypto.password.bcrypt.BCryptPasswordEncoder;
 import io.gravitee.am.service.exception.*;
 import io.gravitee.am.service.model.NewUser;
@@ -53,9 +52,6 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
 
     @Autowired
     private io.gravitee.am.service.OrganizationUserService userService;
-
-    @Autowired
-    private RoleService roleService;
 
     @Override
     protected io.gravitee.am.service.OrganizationUserService getUserService() {
@@ -147,12 +143,10 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
                                                 userToPersist.setExternalId(userToPersist.getId());
                                                 return userToPersist;
                                             })
-                                            .flatMap(newOrgUser -> {
-                                                return userService.create(newOrgUser)
-                                                        .flatMap(newlyCreatedUser -> userService.setRoles(newlyCreatedUser).andThen(Single.just(newlyCreatedUser)))
-                                                        .doOnSuccess(user1 -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).type(EventType.USER_CREATED).user(user1)))
-                                                        .doOnError(throwable -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).type(EventType.USER_CREATED).throwable(throwable)));
-                                            })
+                                            .flatMap(newOrgUser -> userService.create(newOrgUser)
+                                                    .flatMap(newlyCreatedUser -> userService.setRoles(newlyCreatedUser).andThen(Single.just(newlyCreatedUser)))
+                                                    .doOnSuccess(user1 -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).type(EventType.USER_CREATED).user(user1)))
+                                                    .doOnError(throwable -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).type(EventType.USER_CREATED).throwable(throwable))))
                                             .map(this::setInternalStatus));
                                 });
 

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
@@ -70,6 +70,8 @@ public class User implements IUser {
 
     private List<String> roles;
 
+    private List<String> dynamicRoles;
+
     private Set<Role> rolesPermissions;
 
     private List<String> groups;
@@ -161,6 +163,7 @@ public class User implements IUser {
         this.entitlements = other.entitlements != null ? new ArrayList<>(other.entitlements) : null;
         this.addresses = other.addresses != null ? new ArrayList<>(other.addresses) : null;
         this.roles = other.roles != null ? new ArrayList<>(other.roles) : null;
+        this.dynamicRoles = other.dynamicRoles != null ? new ArrayList<>(other.dynamicRoles) : null;
         this.rolesPermissions = other.rolesPermissions;
         this.x509Certificates = other.x509Certificates != null ? new ArrayList<>(other.x509Certificates) : null;
         this.accountNonExpired = other.accountNonExpired;
@@ -576,6 +579,14 @@ public class User implements IUser {
 
     public void setRoles(List<String> roles) {
         this.roles = roles;
+    }
+
+    public List<String> getDynamicRoles() {
+        return dynamicRoles;
+    }
+
+    public void setDynamicRoles(List<String> roles) {
+        this.dynamicRoles = roles;
     }
 
     public Set<Role> getRolesPermissions() {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcOrganizationUser.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcOrganizationUser.java
@@ -15,11 +15,8 @@
  */
 package io.gravitee.am.repository.jdbc.management.api.model;
 
-import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
-
-import java.time.LocalDateTime;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -62,7 +59,14 @@ public class JdbcOrganizationUser extends AbstractUser {
     }
 
     @Table("organization_user_roles")
-    public static class Role {
+    public static class Role extends AbstractRole {
+    }
+
+    @Table("organization_dynamic_user_roles")
+    public static class DynamicRole extends AbstractRole {
+    }
+
+    public static abstract class AbstractRole {
         @Column("user_id")
         private String userId;
         private String role;

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcUser.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcUser.java
@@ -15,11 +15,8 @@
  */
 package io.gravitee.am.repository.jdbc.management.api.model;
 
-import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
-
-import java.time.LocalDateTime;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -52,7 +49,14 @@ public class JdbcUser extends AbstractUser {
     }
 
     @Table("user_roles")
-    public static class Role {
+    public static class Role extends AbstractRole {
+    }
+
+    @Table("dynamic_user_roles")
+    public static class DynamicRole extends AbstractRole {
+    }
+
+    public static abstract class AbstractRole {
         @Column("user_id")
         private String userId;
         private String role;

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/user/SpringDynamicUserRoleRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/user/SpringDynamicUserRoleRepository.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.management.api.spring.user;
+
+import io.gravitee.am.repository.jdbc.management.api.model.JdbcUser;
+import io.reactivex.Flowable;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.reactive.RxJava2CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Repository
+public interface SpringDynamicUserRoleRepository extends RxJava2CrudRepository<JdbcUser.DynamicRole, String> {
+    @Query("select * from dynamic_user_roles r where r.user_id = :user")
+    Flowable<JdbcUser.DynamicRole> findByUserId(@Param("user") String userId);
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/user/SpringOrganizationUserDynamicRoleRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/user/SpringOrganizationUserDynamicRoleRepository.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.management.api.spring.user;
+
+import io.gravitee.am.repository.jdbc.management.api.model.JdbcOrganizationUser;
+import io.reactivex.Flowable;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.reactive.RxJava2CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Repository
+public interface SpringOrganizationUserDynamicRoleRepository extends RxJava2CrudRepository<JdbcOrganizationUser.DynamicRole, String> {
+    @Query("select * from organization_dynamic_user_roles r where r.user_id = :user")
+    Flowable<JdbcOrganizationUser.DynamicRole> findByUserId(@Param("user") String userId);
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_0/schema.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_0/schema.yml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.15.0
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: dynamic_user_roles
+            columns:
+              - column: { name: user_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: role, type: nvarchar(64), constraints: { nullable: false } }
+
+        - createIndex:
+            tableName: dynamic_user_roles
+            columns:
+              - column:
+                  name: user_id
+            indexName: idx_dynamic_user_roles
+            unique: false
+
+        - createTable:
+            tableName: organization_dynamic_user_roles
+            columns:
+              - column: { name: user_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: role, type: nvarchar(64), constraints: { nullable: false } }
+
+        - createIndex:
+            tableName: organization_dynamic_user_roles
+            columns:
+              - column:
+                  name: user_id
+            indexName: idx_organization_dynamic_user_roles
+            unique: false

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -39,3 +39,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_13_0/schema.yml
   - include:
       - file: liquibase/changelogs/v3_13_0/schema-device.yml
+  - include:
+      - file: liquibase/changelogs/v3_15_0/schema.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractUserRepository.java
@@ -240,6 +240,7 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
         user.setLoggedAt(userMongo.getLoggedAt());
         user.setLastPasswordReset(userMongo.getLastPasswordReset());
         user.setRoles(userMongo.getRoles());
+        user.setDynamicRoles(userMongo.getDynamicRoles());
         user.setEmails(toModelAttributes(userMongo.getEmails()));
         user.setPhoneNumbers(toModelAttributes(userMongo.getPhoneNumbers()));
         user.setIms(toModelAttributes(userMongo.getIms()));
@@ -292,6 +293,7 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
         userMongo.setLoggedAt(user.getLoggedAt());
         userMongo.setLastPasswordReset(user.getLastPasswordReset());
         userMongo.setRoles(user.getRoles());
+        userMongo.setDynamicRoles(user.getDynamicRoles());
         userMongo.setEmails(toMongoAttributes(user.getEmails()));
         userMongo.setPhoneNumbers(toMongoAttributes(user.getPhoneNumbers()));
         userMongo.setIms(toMongoAttributes(user.getIms()));

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoUserRepository.java
@@ -22,14 +22,8 @@ import io.gravitee.am.common.analytics.Field;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.analytics.AnalyticsQuery;
-import io.gravitee.am.model.scim.Address;
-import io.gravitee.am.model.scim.Attribute;
-import io.gravitee.am.model.scim.Certificate;
 import io.gravitee.am.repository.management.api.UserRepository;
 import io.gravitee.am.repository.mongodb.management.internal.model.UserMongo;
-import io.gravitee.am.repository.mongodb.management.internal.model.scim.AddressMongo;
-import io.gravitee.am.repository.mongodb.management.internal.model.scim.AttributeMongo;
-import io.gravitee.am.repository.mongodb.management.internal.model.scim.CertificateMongo;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
@@ -160,102 +154,6 @@ public class MongoUserRepository extends AbstractUserRepository<UserMongo> imple
                     return registrations;
                 })
                 .first(Collections.emptyMap());
-    }
-
-    private List<Attribute> toModelAttributes(List<AttributeMongo> mongoAttributes) {
-        if (mongoAttributes == null) {
-            return null;
-        }
-        return mongoAttributes
-                .stream()
-                .map(mongoAttribute -> {
-                    Attribute modelAttribute = new Attribute();
-                    modelAttribute.setPrimary(mongoAttribute.isPrimary());
-                    modelAttribute.setValue(mongoAttribute.getValue());
-                    modelAttribute.setType(mongoAttribute.getType());
-                    return modelAttribute;
-                }).collect(Collectors.toList());
-    }
-
-    private List<AttributeMongo> toMongoAttributes(List<Attribute> modelAttributes) {
-        if (modelAttributes == null) {
-            return null;
-        }
-        return modelAttributes
-                .stream()
-                .map(modelAttribute -> {
-                    AttributeMongo mongoAttribute = new AttributeMongo();
-                    mongoAttribute.setPrimary(modelAttribute.isPrimary());
-                    mongoAttribute.setValue(modelAttribute.getValue());
-                    mongoAttribute.setType(modelAttribute.getType());
-                    return mongoAttribute;
-                }).collect(Collectors.toList());
-    }
-
-    private List<Address> toModelAddresses(List<AddressMongo> mongoAddresses) {
-        if (mongoAddresses == null) {
-            return null;
-        }
-        return mongoAddresses
-                .stream()
-                .map(mongoAddress -> {
-                    Address modelAddress = new Address();
-                    modelAddress.setType(mongoAddress.getType());
-                    modelAddress.setFormatted(mongoAddress.getFormatted());
-                    modelAddress.setStreetAddress(mongoAddress.getStreetAddress());
-                    modelAddress.setCountry(mongoAddress.getCountry());
-                    modelAddress.setLocality(mongoAddress.getLocality());
-                    modelAddress.setPostalCode(mongoAddress.getPostalCode());
-                    modelAddress.setRegion(mongoAddress.getRegion());
-                    modelAddress.setPrimary(mongoAddress.isPrimary());
-                    return modelAddress;
-                }).collect(Collectors.toList());
-    }
-
-    private List<AddressMongo> toMongoAddresses(List<Address> modelAddresses) {
-        if (modelAddresses == null) {
-            return null;
-        }
-        return modelAddresses
-                .stream()
-                .map(modelAddress -> {
-                    AddressMongo mongoAddress = new AddressMongo();
-                    mongoAddress.setType(modelAddress.getType());
-                    mongoAddress.setFormatted(modelAddress.getFormatted());
-                    mongoAddress.setStreetAddress(modelAddress.getStreetAddress());
-                    mongoAddress.setCountry(modelAddress.getCountry());
-                    mongoAddress.setLocality(modelAddress.getLocality());
-                    mongoAddress.setPostalCode(modelAddress.getPostalCode());
-                    mongoAddress.setRegion(modelAddress.getRegion());
-                    mongoAddress.setPrimary(modelAddress.isPrimary());
-                    return mongoAddress;
-                }).collect(Collectors.toList());
-    }
-
-    private List<Certificate> toModelCertificates(List<CertificateMongo> mongoCertificates) {
-        if (mongoCertificates == null) {
-            return null;
-        }
-        return mongoCertificates
-                .stream()
-                .map(mongoCertificate -> {
-                    Certificate modelCertificate = new Certificate();
-                    modelCertificate.setValue(mongoCertificate.getValue());
-                    return modelCertificate;
-                }).collect(Collectors.toList());
-    }
-
-    private List<CertificateMongo> toMongoCertificates(List<Certificate> modelCertificates) {
-        if (modelCertificates == null) {
-            return null;
-        }
-        return modelCertificates
-                .stream()
-                .map(modelCertificate -> {
-                    CertificateMongo mongoCertificate = new CertificateMongo();
-                    mongoCertificate.setValue(modelCertificate.getValue());
-                    return mongoCertificate;
-                }).collect(Collectors.toList());
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/UserMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/UserMongo.java
@@ -72,6 +72,7 @@ public class UserMongo extends Auditable {
     private List<CertificateMongo> x509Certificates;
     private List<EnrolledFactor> factors;
     private List<String> roles;
+    private List<String> dynamicRoles;
     /**
      * Map codec support is planned for version 3.7 jira.mongodb.org issue: JAVA-2695
      */
@@ -387,6 +388,14 @@ public class UserMongo extends Auditable {
 
     public void setRoles(List<String> roles) {
         this.roles = roles;
+    }
+
+    public List<String> getDynamicRoles() {
+        return dynamicRoles;
+    }
+
+    public void setDynamicRoles(List<String> dynamicRoles) {
+        this.dynamicRoles = dynamicRoles;
     }
 
     public Document getAdditionalInformation() {

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/OrganizationUserRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/OrganizationUserRepositoryTest.java
@@ -125,6 +125,7 @@ public class OrganizationUserRepositoryTest extends AbstractManagementTest {
         testObserver.assertValue(u -> u.getPassword().equals(user.getPassword()));
         testObserver.assertValue(u -> u.getExternalId().equals(user.getExternalId()));
         testObserver.assertValue(u -> u.getRoles().containsAll(user.getRoles()));
+        testObserver.assertValue(u -> u.getDynamicRoles().containsAll(user.getDynamicRoles()));
         testObserver.assertValue(u -> u.getEntitlements().containsAll(user.getEntitlements()));
         testObserver.assertValue(u -> u.getEmails().size() == 1);
         testObserver.assertValue(u -> u.getPhoneNumbers().size() == 1);
@@ -170,6 +171,7 @@ public class OrganizationUserRepositoryTest extends AbstractManagementTest {
         testObserver.assertValue(u -> u.getPassword().equals(user.getPassword()));
         testObserver.assertValue(u -> u.getExternalId().equals(user.getExternalId()));
         testObserver.assertValue(u -> u.getRoles().containsAll(user.getRoles()));
+        testObserver.assertValue(u -> u.getDynamicRoles().containsAll(user.getDynamicRoles()));
         testObserver.assertValue(u -> u.getEntitlements().containsAll(user.getEntitlements()));
         testObserver.assertValue(u -> u.getEmails().size() == 1);
         testObserver.assertValue(u -> u.getPhoneNumbers().size() == 1);
@@ -236,6 +238,7 @@ public class OrganizationUserRepositoryTest extends AbstractManagementTest {
 
         user.setEntitlements(Arrays.asList("ent"+random));
         user.setRoles(Arrays.asList("role"+random));
+        user.setDynamicRoles(Arrays.asList("dynamic_role"+random));
 
         Address addr = new Address();
         addr.setCountry("fr");

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/UserRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/UserRepositoryTest.java
@@ -127,6 +127,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         testObserver.assertValue(u -> u.getEmail().equals(user.getEmail()));
         testObserver.assertValue(u -> u.getExternalId().equals(user.getExternalId()));
         testObserver.assertValue(u -> u.getRoles().containsAll(user.getRoles()));
+        testObserver.assertValue(u -> u.getDynamicRoles().containsAll(user.getDynamicRoles()));
         testObserver.assertValue(u -> u.getEntitlements().containsAll(user.getEntitlements()));
         testObserver.assertValue(u -> u.getEmails().size() == 1);
         testObserver.assertValue(u -> u.getPhoneNumbers().size() == 1);
@@ -171,6 +172,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         testObserver.assertValue(u -> u.getEmail().equals(user.getEmail()));
         testObserver.assertValue(u -> u.getExternalId().equals(user.getExternalId()));
         testObserver.assertValue(u -> u.getRoles().containsAll(user.getRoles()));
+        testObserver.assertValue(u -> u.getDynamicRoles().containsAll(user.getDynamicRoles()));
         testObserver.assertValue(u -> u.getEntitlements().containsAll(user.getEntitlements()));
         testObserver.assertValue(u -> u.getEmails().size() == 1);
         testObserver.assertValue(u -> u.getPhoneNumbers().size() == 1);
@@ -236,6 +238,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
 
         user.setEntitlements(Arrays.asList("ent"+random));
         user.setRoles(Arrays.asList("role"+random));
+        user.setDynamicRoles(Arrays.asList("dynamic_role"+random));
 
         Address addr = new Address();
         addr.setCountry("fr");

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/OrganizationUserService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/OrganizationUserService.java
@@ -15,20 +15,8 @@
  */
 package io.gravitee.am.service;
 
-import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
-import io.gravitee.am.model.analytics.AnalyticsQuery;
-import io.gravitee.am.model.common.Page;
-import io.gravitee.am.repository.management.api.search.FilterCriteria;
-import io.gravitee.am.service.model.NewUser;
-import io.gravitee.am.service.model.UpdateUser;
 import io.reactivex.Completable;
-import io.reactivex.Flowable;
-import io.reactivex.Maybe;
-import io.reactivex.Single;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractUserService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractUserService.java
@@ -304,14 +304,15 @@ public abstract class AbstractUserService<T extends CommonUserRepository> implem
                     if (user.getRoles() != null && !user.getRoles().isEmpty()) {
                         roles.addAll(user.getRoles());
                     }
+                    if (user.getDynamicRoles() != null && !user.getDynamicRoles().isEmpty()) {
+                        roles.addAll(user.getDynamicRoles());
+                    }
                     // fetch roles information and enhance user data
                     if (!roles.isEmpty()) {
-                        return roleService.findByIdIn(new ArrayList<>(roles))
-                                .map(roles1 -> {
-                                    user.setRolesPermissions(roles1);
-                                    return user;
-                                });
-
+                        return roleService.findByIdIn(new ArrayList<>(roles)).map(foundRoles -> {
+                            user.setRolesPermissions(foundRoles);
+                            return user;
+                        });
                     }
                     return Single.just(user);
                 })

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/OrganizationUserServiceImpl.java
@@ -30,12 +30,9 @@ import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.exception.AbstractManagementException;
 import io.gravitee.am.service.exception.RoleNotFoundException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
-import io.gravitee.am.service.exception.UserNotFoundException;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -79,7 +76,7 @@ public class OrganizationUserServiceImpl extends AbstractUserService implements 
 
         if (principal != null && principal.getRoles() != null && !principal.getRoles().isEmpty()) {
             // We allow only one role in AM portal. Get the first (should not append).
-            String roleId = principal.getRoles().get(0);
+            String roleId =  principal.getRoles().get(0);
 
             roleObs = roleService.findById(user.getReferenceType(), user.getReferenceId(), roleId)
                     .toMaybe()

--- a/gravitee-am-ui/src/app/app-routing.module.ts
+++ b/gravitee-am-ui/src/app/app-routing.module.ts
@@ -81,6 +81,7 @@ import {UserApplicationsComponent} from './domain/settings/users/user/applicatio
 import {UserApplicationComponent} from './domain/settings/users/user/applications/application/application.component';
 import {UserRolesComponent} from './domain/settings/users/user/roles/roles.component';
 import {UserRolesResolver} from './resolvers/user-roles.resolver';
+import {DynamicUserRolesResolver} from './resolvers/dynamic-user-roles.resolver';
 import {UserFactorsComponent} from './domain/settings/users/user/factors/factors.component';
 import {UserCredentialsResolver} from './resolvers/user-credentials.resolver';
 import {UserCredentialResolver} from './resolvers/user-credential.resolver';
@@ -202,16 +203,16 @@ import {AlertNotifierResolver} from "./resolvers/alert-notifier.resolver";
 import {DomainAlertNotifierCreationComponent} from "./domain/alerts/notifiers/creation/notifier-creation.component";
 import {DomainAlertNotifierComponent} from "./domain/alerts/notifiers/notifier/notifier.component";
 import {PlatformAlertStatusResolver} from "./resolvers/platform-alert-status.resolver";
-import { FactorPluginsResolver } from './resolvers/factor-plugins.resolver';
-import { ResourcePluginsResolver } from './resolvers/resource-plugins.resolver';
-import { DomainSettingsBotDetectionsComponent } from './domain/settings/botdetections/bot-detections.component';
-import { BotDetectionsResolver } from './resolvers/bot-detections.resolver';
-import { BotDetectionCreationComponent } from './domain/settings/botdetections/creation/bot-detection-creation.component';
-import { BotDetectionPluginsResolver } from './resolvers/bot-detection-plugins.resolver';
-import { BotDetectionComponent } from './domain/settings/botdetections/bot-detection/bot-detection.component';
-import { BotDetectionResolver } from './resolvers/bot-detection.resolver';
-import { ScopesAllResolver } from "./resolvers/scopes-all.resolver";
-import { OIDCProfileComponent } from './domain/settings/openid/oidc-profile/oidc-profile.component';
+import {FactorPluginsResolver} from './resolvers/factor-plugins.resolver';
+import {ResourcePluginsResolver} from './resolvers/resource-plugins.resolver';
+import {DomainSettingsBotDetectionsComponent} from './domain/settings/botdetections/bot-detections.component';
+import {BotDetectionsResolver} from './resolvers/bot-detections.resolver';
+import {BotDetectionCreationComponent} from './domain/settings/botdetections/creation/bot-detection-creation.component';
+import {BotDetectionPluginsResolver} from './resolvers/bot-detection-plugins.resolver';
+import {BotDetectionComponent} from './domain/settings/botdetections/bot-detection/bot-detection.component';
+import {BotDetectionResolver} from './resolvers/bot-detection.resolver';
+import {ScopesAllResolver} from "./resolvers/scopes-all.resolver";
+import {OIDCProfileComponent} from './domain/settings/openid/oidc-profile/oidc-profile.component';
 import {DomainSettingsDeviceIdentifiersComponent} from "./domain/settings/deviceidentifiers/device-identifiers.component";
 import {DeviceIdentifierPluginsResolver} from "./resolvers/device-identifier-plugins.resolver";
 import {DeviceIdentifierCreationComponent} from "./domain/settings/deviceidentifiers/creation/device-identifier-creation.component";
@@ -2011,7 +2012,7 @@ export const routes: Routes = [
                               {
                                 path: 'roles',
                                 component: UserRolesComponent,
-                                resolve: {roles: UserRolesResolver}
+                                resolve: {roles: UserRolesResolver, dynamicRoles: DynamicUserRolesResolver}
                               },
                               {
                                 path: 'devices',
@@ -2438,7 +2439,7 @@ export const routes: Routes = [
   {path: 'login/callback', component: LoginCallbackComponent},
   {path: 'logout', component: LogoutComponent},
   {path: 'logout/callback', component: LogoutCallbackComponent},
-  {path: 'newsletter', component: NewsletterComponent, resolve: { taglines: NewsletterResolver }},
+  {path: 'newsletter', component: NewsletterComponent, resolve: {taglines: NewsletterResolver}},
   {path: 'dummy', component: DummyComponent},
   {path: '404', component: NotFoundComponent},
   {path: '', component: HomeComponent},

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -386,6 +386,7 @@ import {DeviceIdentifierService} from "./services/device-identifier.service";
 import {DeviceIdentifierComponent} from "./domain/settings/deviceidentifiers/device-identifier/device-identifier.component";
 import { UserDevicesComponent } from './domain/settings/users/user/devices/devices.component';
 import {UserDevicesResolver} from "./resolvers/user-devices.resolver";
+import { DynamicUserRolesResolver } from './resolvers/dynamic-user-roles.resolver';
 
 @NgModule({
   declarations: [
@@ -657,6 +658,7 @@ import {UserDevicesResolver} from "./resolvers/user-devices.resolver";
     UsersResolver,
     UserResolver,
     UserRolesResolver,
+    DynamicUserRolesResolver,
     UserCredentialsResolver,
     UserCredentialResolver,
     UserDevicesResolver,

--- a/gravitee-am-ui/src/app/domain/settings/users/user/roles/roles.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/roles/roles.component.html
@@ -19,14 +19,17 @@
     <div fxFlex="70">
       <div fxLayout="row" fxLayoutAlign="center">
         <div fxFlex>
-          <span *ngIf="isEmpty">There are no</span><b *ngIf="!isEmpty">{{userRoles.length}}</b> role(s) assigned to this user.
+          <span *ngIf="isEmpty">There are no</span><b *ngIf="!isEmpty">{{ totalRoles }}</b> role(s) assigned to this user.
         </div>
         <div style="height: 40px;">
           <button *ngIf="editMode" color="primary" mat-stroked-button (click)="add()">Assign roles</button>
         </div>
       </div>
-      <mat-divider *ngIf="isEmpty" style="margin-bottom: 20px;"></mat-divider>
-      <ngx-datatable *ngIf="!isEmpty" class="material"
+      <mat-divider *ngIf="isUserRoleEmpty" style="margin-bottom: 20px;"></mat-divider>
+      <div *ngIf="!isUserRoleEmpty">
+        <span><b>Assigned Roles</b></span>
+      </div>
+      <ngx-datatable *ngIf="!isUserRoleEmpty" class="material"
                      [columnMode]="'flex'"
                      [headerHeight]="40"
                      [footerHeight]="40"
@@ -47,6 +50,26 @@
             <div fxLayout="row" class="gv-table-cell-actions" *ngIf="editMode">
               <button mat-icon-button (click)="revoke($event, row)"><mat-icon matTooltip="Revoke role">highlight_off</mat-icon></button>
             </div>
+          </ng-template>
+        </ngx-datatable-column>
+      </ngx-datatable>
+      <div *ngIf="!isDynamicUserRoleEmpty">
+        <span><b>Dynamic Roles (via role mapper)</b></span>
+      </div>
+      <ngx-datatable *ngIf="!isDynamicUserRoleEmpty" class="material"
+                     [columnMode]="'flex'"
+                     [headerHeight]="40"
+                     [footerHeight]="40"
+                     [rowHeight]="50"
+                     [rows]='dynamicRoles'>
+        <ngx-datatable-column name="Name" [flexGrow]="2">
+          <ng-template let-row="row" ngx-datatable-cell-template>
+            {{row.name}}
+          </ng-template>
+        </ngx-datatable-column>
+        <ngx-datatable-column name="Description" [flexGrow]="4">
+          <ng-template let-row="row" ngx-datatable-cell-template>
+            {{row.description}}
           </ng-template>
         </ngx-datatable-column>
       </ngx-datatable>

--- a/gravitee-am-ui/src/app/domain/settings/users/users.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/users.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Component, ElementRef, OnInit, ViewChild} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UserService} from '../../../services/user.service';
@@ -23,8 +23,6 @@ import { OrganizationService } from '../../../services/organization.service';
 import { AuthService } from '../../../services/auth.service';
 import {ApplicationService} from "../../../services/application.service";
 import {ProviderService} from "../../../services/provider.service";
-import * as _ from "lodash";
-import {FormControl} from "@angular/forms";
 
 @Component({
   selector: 'app-users',

--- a/gravitee-am-ui/src/app/resolvers/dynamic-user-roles.resolver.spec.ts
+++ b/gravitee-am-ui/src/app/resolvers/dynamic-user-roles.resolver.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed, inject } from '@angular/core/testing';
+
+import {UserRolesResolver} from "./user-roles.resolver";
+import {DynamicUserRolesResolver} from "./dynamic-user-roles.resolver";
+
+describe('DynamicUserRolesResolver', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DynamicUserRolesResolver]
+    });
+  });
+
+  it('should ...', inject([DynamicUserRolesResolver], (service: DynamicUserRolesResolver) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/gravitee-am-ui/src/app/resolvers/dynamic-user-roles.resolver.ts
+++ b/gravitee-am-ui/src/app/resolvers/dynamic-user-roles.resolver.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from "@angular/router";
+import { Observable } from "rxjs";
+import { UserService } from "../services/user.service";
+import { OrganizationService } from "../services/organization.service";
+
+@Injectable()
+export class DynamicUserRolesResolver implements Resolve<any> {
+
+  constructor(private userService: UserService) { }
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any>|Promise<any>|any {
+    const userId = route.paramMap.get('userId');
+    const domainId = route.parent.data['domain'].id;
+    return this.userService.roles(domainId, userId, true);
+  }
+
+}

--- a/gravitee-am-ui/src/app/services/user.service.ts
+++ b/gravitee-am-ui/src/app/services/user.service.ts
@@ -24,7 +24,8 @@ export class UserService {
   private usersURL = AppConfig.settings.domainBaseURL;
 
   constructor(private http: HttpClient,
-              private organizationService: OrganizationService) { }
+              private organizationService: OrganizationService) {
+  }
 
   findByDomain(domainId, page, size): Observable<any> {
     return this.http.get<any>(this.usersURL + domainId + '/users?page=' + page + '&size=' + size);
@@ -40,13 +41,13 @@ export class UserService {
 
   update(domainId, id, user, organizationContext): Observable<any> {
     let updatedUserProfile = {
-      'firstName' : user.firstName,
-      'lastName' : user.lastName,
-      'displayName' : user.displayName,
-      'email' : user.email,
+      'firstName': user.firstName,
+      'lastName': user.lastName,
+      'displayName': user.displayName,
+      'email': user.email,
       'enabled': user.enabled,
-      'client' : user.client,
-      'additionalInformation' : user.additionalInformation
+      'client': user.client,
+      'additionalInformation': user.additionalInformation
     };
 
     if (organizationContext) {
@@ -57,7 +58,7 @@ export class UserService {
 
   updateStatus(domainId, id, status): Observable<any> {
     return this.http.put<any>(this.usersURL + domainId + '/users/' + id + '/status', {
-      'enabled' : status
+      'enabled': status
     });
   }
 
@@ -104,8 +105,8 @@ export class UserService {
     return this.http.delete<any>(this.usersURL + domainId + '/users/' + userId + '/consents/' + consentId);
   }
 
-  roles(domainId, userId): Observable<any> {
-    return this.http.get<any>(this.usersURL + domainId + '/users/' + userId + '/roles');
+  roles(domainId, userId, dynamic = false): Observable<any> {
+    return this.http.get<any>(this.usersURL + domainId + '/users/' + userId + '/roles?dynamic=' + dynamic);
   }
 
   devices(domainId, userId): Observable<any> {


### PR DESCRIPTION
fixes: https://github.com/gravitee-io/issues/issues/6515

⚠️ Please check the section where the OrganizationUserService updates the roles. There are some questions around it.

https://github.com/gravitee-io/gravitee-access-management/blob/d22277611e29a32bdd8e3dac3851217b219b087c/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/service/impl/AuthenticationServiceImpl.java#L92

Right here whenever the user already exists within the Organization users. If there are no roles within the identityProvider, We skip the role update. This causes for any new users from an idp not to be updated whenever the rule is not present anymore.

If we were to replace the roles, we would have to make some specific checks (is the user not from an internal idp, which does not sound really great)

The solution would be to make a mapper and create also its contrary to roll back users from an initial role. This works because users only have one role in Organization settings

We could also make dynamic roles on Memberships but does that make sense ?

Any other ideas ?