### PR TITLE
fix: CWE-326: Inadequate Encryption Strength

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/MongoFactory.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/MongoFactory.java
@@ -123,7 +123,7 @@ public class MongoFactory implements FactoryBean<MongoClient> {
                 sslBuilder.enabled(sslEnabled);
             if (keystore != null) {
                 try {
-                    SSLContext ctx = SSLContext.getInstance("TLS");
+                    SSLContext ctx = SSLContext.getInstance("TLSv1.3");
                     KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
                     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
                     ks.load(new FileInputStream(keystore), keystorePassword.toCharArray());


### PR DESCRIPTION
Implement secure HTTPS communication TLSv1.3.
Consider using latest TLSv1.2 instead of TLS.

https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#sslcontext-algorithms
