### PR TITLE
refactor: remove find after create / update in mongo implementation

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractUserRepository.java
@@ -154,10 +154,10 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
     @Override
     public Maybe<User> findByUsernameAndSource(ReferenceType referenceType, String referenceId, String username, String source) {
         return Observable.fromPublisher(
-                usersCollection
-                        .find(and(eq(FIELD_REFERENCE_TYPE, referenceType.name()), eq(FIELD_REFERENCE_ID, referenceId), eq(FIELD_USERNAME, username), eq(FIELD_SOURCE, source)))
-                        .limit(1)
-                        .first())
+                        usersCollection
+                                .find(and(eq(FIELD_REFERENCE_TYPE, referenceType.name()), eq(FIELD_REFERENCE_ID, referenceId), eq(FIELD_USERNAME, username), eq(FIELD_SOURCE, source)))
+                                .limit(1)
+                                .first())
                 .firstElement()
                 .map(this::convert);
     }
@@ -165,10 +165,10 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
     @Override
     public Maybe<User> findByExternalIdAndSource(ReferenceType referenceType, String referenceId, String externalId, String source) {
         return Observable.fromPublisher(
-                usersCollection
-                        .find(and(eq(FIELD_REFERENCE_TYPE, referenceType.name()), eq(FIELD_REFERENCE_ID, referenceId), eq(FIELD_EXTERNAL_ID, externalId), eq(FIELD_SOURCE, source)))
-                        .limit(1)
-                        .first())
+                        usersCollection
+                                .find(and(eq(FIELD_REFERENCE_TYPE, referenceType.name()), eq(FIELD_REFERENCE_ID, referenceId), eq(FIELD_EXTERNAL_ID, externalId), eq(FIELD_SOURCE, source)))
+                                .limit(1)
+                                .first())
                 .firstElement()
                 .map(this::convert);
     }
@@ -192,13 +192,18 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
     public Single<User> create(User item) {
         UserMongo user = convert(item);
         user.setId(user.getId() == null ? RandomString.generate() : user.getId());
-        return Single.fromPublisher(usersCollection.insertOne((T)user)).flatMap(success -> findById(user.getId()).toSingle());
+        return Single.fromPublisher(usersCollection.insertOne((T) user))
+                .flatMap(success -> {
+                    item.setId(user.getId());
+                    return Single.just(item);
+                });
     }
 
     @Override
     public Single<User> update(User item) {
         UserMongo user = convert(item);
-        return Single.fromPublisher(usersCollection.replaceOne(eq(FIELD_ID, user.getId()), (T)user)).flatMap(updateResult -> findById(user.getId()).toSingle());
+        return Single.fromPublisher(usersCollection.replaceOne(eq(FIELD_ID, user.getId()), (T) user))
+                .flatMap(updateResult -> Single.just(item));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoAuthorizationCodeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoAuthorizationCodeRepository.java
@@ -73,7 +73,7 @@ public class MongoAuthorizationCodeRepository extends AbstractOAuth2MongoReposit
 
         return Single
                 .fromPublisher(authorizationCodeCollection.insertOne(convert(authorizationCode)))
-                .flatMap(success -> findById(authorizationCode.getId()).toSingle());
+                .flatMap(success -> Single.just(authorizationCode));
     }
 
     @Override
@@ -104,7 +104,7 @@ public class MongoAuthorizationCodeRepository extends AbstractOAuth2MongoReposit
 
         if (authorizationCodeMongo.getRequestParameters() != null) {
             MultiValueMap<String, String> requestParameters = new LinkedMultiValueMap<>();
-            authorizationCodeMongo.getRequestParameters().entrySet().forEach(entry -> requestParameters.put(entry.getKey(), (List<String>) entry.getValue()));
+            authorizationCodeMongo.getRequestParameters().forEach((key, value) -> requestParameters.put(key, (List<String>) value));
             authorizationCode.setRequestParameters(requestParameters);
         }
         return authorizationCode;
@@ -128,9 +128,7 @@ public class MongoAuthorizationCodeRepository extends AbstractOAuth2MongoReposit
 
         if (authorizationCode.getRequestParameters() != null) {
             Document document = new Document();
-            authorizationCode.getRequestParameters().forEach((key, value) -> {
-                document.append(key, value);
-            });
+            authorizationCode.getRequestParameters().forEach(document::append);
             authorizationCodeMongo.setRequestParameters(document);
         }
         return authorizationCodeMongo;

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoPushedAuthorizationRequestRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoPushedAuthorizationRequestRepository.java
@@ -69,7 +69,7 @@ public class MongoPushedAuthorizationRequestRepository extends AbstractOAuth2Mon
         par.setId(par.getId() == null ? RandomString.generate() : par.getId());
         return Single
                 .fromPublisher(parCollection.insertOne(convert(par)))
-                .flatMap(success -> findById(par.getId()).toSingle());
+                .flatMap(success -> Single.just(par));
     }
 
     @Override
@@ -91,9 +91,7 @@ public class MongoPushedAuthorizationRequestRepository extends AbstractOAuth2Mon
 
         if (par.getParameters() != null) {
             Document document = new Document();
-            par.getParameters().forEach((key, value) -> {
-                document.append(key, value);
-            });
+            par.getParameters().forEach(document::append);
             parMongo.setParameters(document);
         }
 
@@ -114,7 +112,7 @@ public class MongoPushedAuthorizationRequestRepository extends AbstractOAuth2Mon
 
         if (parMongo.getParameters() != null) {
             MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-            parMongo.getParameters().entrySet().forEach(entry -> parameters.put(entry.getKey(), (List<String>) entry.getValue()));
+            parMongo.getParameters().forEach((key, value) -> parameters.put(key, (List<String>) value));
             par.setParameters(parameters);
         }
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoRefreshTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoRefreshTokenRepository.java
@@ -85,7 +85,7 @@ public class MongoRefreshTokenRepository extends AbstractOAuth2MongoRepository i
 
         return Single
                 .fromPublisher(refreshTokenCollection.insertOne(convert(refreshToken)))
-                .flatMap(success -> findById(refreshToken.getId()).toSingle());
+                .flatMap(success -> Single.just(refreshToken));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoRequestObjectRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoRequestObjectRepository.java
@@ -64,7 +64,7 @@ public class MongoRequestObjectRepository extends AbstractOAuth2MongoRepository 
     public Single<RequestObject> create(RequestObject requestObject) {
         return Single
                 .fromPublisher(requestObjectCollection.insertOne(convert(requestObject)))
-                .flatMap(success -> findById(requestObject.getId()).toSingle());
+                .flatMap(success -> Single.just(requestObject));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoScopeApprovalRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoScopeApprovalRepository.java
@@ -80,7 +80,7 @@ public class MongoScopeApprovalRepository extends AbstractOAuth2MongoRepository 
     public Single<ScopeApproval> create(ScopeApproval scopeApproval) {
         ScopeApprovalMongo scopeApprovalMongo = convert(scopeApproval);
         scopeApprovalMongo.setId(scopeApprovalMongo.getId() == null ? RandomString.generate() : scopeApprovalMongo.getId());
-        return Single.fromPublisher(scopeApprovalsCollection.insertOne(scopeApprovalMongo)).flatMap(success -> _findById(scopeApprovalMongo.getId()));
+        return Single.fromPublisher(scopeApprovalsCollection.insertOne(scopeApprovalMongo)).flatMap(success -> Single.just(scopeApproval));
     }
 
     @Override
@@ -92,7 +92,7 @@ public class MongoScopeApprovalRepository extends AbstractOAuth2MongoRepository 
                         eq(FIELD_CLIENT_ID, scopeApproval.getClientId()),
                         eq(FIELD_USER_ID, scopeApproval.getUserId()),
                         eq(FIELD_SCOPE, scopeApproval.getScope()))
-                , scopeApprovalMongo)).flatMap(updateResult -> _findById(scopeApprovalMongo.getId()));
+                , scopeApprovalMongo)).flatMap(updateResult -> Single.just(scopeApproval));
     }
 
     @Override
@@ -106,7 +106,7 @@ public class MongoScopeApprovalRepository extends AbstractOAuth2MongoRepository 
                 .map(Optional::of)
                 .defaultIfEmpty(Optional.empty())
                 .flatMapSingle(optionalApproval -> {
-                    if (!optionalApproval.isPresent()) {
+                    if (optionalApproval.isEmpty()) {
                         scopeApproval.setCreatedAt(new Date());
                         scopeApproval.setUpdatedAt(scopeApproval.getCreatedAt());
                         return create(scopeApproval);


### PR DESCRIPTION
This was just a spike where we are removing the findById when not necessary on mongo collection for gatling tests.