### PR TITLE
fix: deviceId with webauthn

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -9,8 +9,8 @@
 
 - Merge 3.13.4 https://github.com/gravitee-io/issues/issues/6852[#6852]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/491?closed=1[AM - 3.13.4 (2022-01-04)]
 
@@ -20,8 +20,8 @@
 
 - Merge 3.10.13 https://github.com/gravitee-io/issues/issues/6844[#6844]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/490?closed=1[AM - 3.10.13 (2022-01-03)]
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/DeviceIdentifierHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/DeviceIdentifierHandler.java
@@ -36,11 +36,11 @@ import static java.util.Optional.ofNullable;
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class PostLoginRememberDeviceHandler implements Handler<RoutingContext> {
+public class DeviceIdentifierHandler implements Handler<RoutingContext> {
 
     private final DeviceService deviceService;
 
-    public PostLoginRememberDeviceHandler(DeviceService deviceService) {
+    public DeviceIdentifierHandler(DeviceService deviceService) {
         this.deviceService = deviceService;
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/RememberDeviceSettingsHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/RememberDeviceSettingsHandler.java
@@ -38,9 +38,9 @@ import static java.util.Optional.ofNullable;
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class RememberDeviceHandler implements Handler<RoutingContext> {
+public class RememberDeviceSettingsHandler implements Handler<RoutingContext> {
 
-    public RememberDeviceHandler() {
+    public RememberDeviceSettingsHandler() {
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-login.js
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-login.js
@@ -17,11 +17,18 @@ const clearMessage = () => {
     errorElement.style.display = 'none';
 };
 
-loginForm.onsubmit = () => {
-    w
-        .login({
-            name: this.username.value
-        })
+loginForm.addEventListener("submit", function(e){
+    e.preventDefault();
+    let user = {
+        name: this.username.value
+    };
+    if(this.deviceId && this.deviceId.value){
+        user.deviceId = this.deviceId.value;
+    }
+    if(this.deviceType && this.deviceType.value){
+        user.deviceType = this.deviceType.value;
+    }
+    w.login(user)
         .then(res => {
             clearMessage();
             setTimeout(() => {
@@ -32,4 +39,4 @@ loginForm.onsubmit = () => {
             displayMessage(err instanceof DOMException ? err.message : 'Invalid user');
         });
     return false;
-};
+});

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
@@ -103,7 +103,7 @@
     <script th:src="@{assets/material/material.min.js}"></script>
     <script th:src="@{assets/js/jquery-3.5.1.min.js}"></script>
     <script th:inline="javascript">
- $(document).ready(function (){
+    $(document).ready(function (){
         $(".mdl-textfield__input").focus(function (){
             if( !this.value ){
                 $(this).prop('required', true);
@@ -125,31 +125,35 @@
             $(this).siblings(".mdl-textfield").addClass('is-invalid');
             $(this).siblings(".mdl-textfield").children(".mdl-textfield__input").prop('required', true);
         });
-        });
+    });
     </script>
 
     <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
             th:src="@{assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
     <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}">
-        loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
-            if(fp.visitorId){
-                $( "#form" )
-                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
-            }
+        $(document).ready(function (){
+            loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
+                if(fp.visitorId){
+                    $( "#form" )
+                        .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+                }
+            });
         });
     </script>
 
     <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
             th:src="@{assets/js/remember-device/fingerprintjs-v3.js}"></script>
     <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}">
-        loadFingerprintJsV3(fp => {
-            if (fp.visitorId) {
-                $("#form")
-                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
-            }
-            if (fp.components && fp.components.platform && fp.components.platform.value) {
-                $("#form").append('<input type="hidden" name="deviceType" value="' + fp.components.platform.value + '"/>');
-            }
+        $(document).ready(function (){
+            loadFingerprintJsV3(fp => {
+                if (fp.visitorId) {
+                    $("#form")
+                        .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+                }
+                if (fp.components && fp.components.platform && fp.components.platform.value) {
+                    $("#form").append('<input type="hidden" name="deviceType" value="' + fp.components.platform.value + '"/>');
+                }
+            });
         });
     </script>
 </body>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_login.html
@@ -57,5 +57,35 @@
     </div>
     <script th:src="@{../assets/js/webauthn.auth.js}"></script>
     <script th:src="@{../assets/js/webauthn-login.js}"></script>
+    <script th:if="${rememberDeviceIsActive}" th:src="@{../assets/js/jquery-3.5.1.min.js}"></script>
+
+    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
+            th:src="@{../assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
+    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}">
+        $(document).ready(function (){
+            loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
+                if(fp.visitorId){
+                    $( "#login" )
+                        .append('<input type="hidden" id="deviceId" name="deviceId" value="' + fp.visitorId + '"/>')
+                }
+            });
+        });
+    </script>
+
+    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
+            th:src="@{../assets/js/remember-device/fingerprintjs-v3.js}"></script>
+    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}">
+        $(document).ready(function (){
+            loadFingerprintJsV3(fp => {
+                if (fp.visitorId) {
+                    $("#login")
+                        .append('<input type="hidden" id="deviceId" name="deviceId" value="' + fp.visitorId + '"/>')
+                }
+                if (fp.components && fp.components.platform && fp.components.platform.value) {
+                    $("#login").append('<input type="hidden" id="deviceType" name="deviceType" value="' + fp.components.platform.value + '"/>');
+                }
+            });
+        });
+    </script>
 </body>
 </html>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/DeviceIdentifierHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/DeviceIdentifierHandlerTest.java
@@ -45,13 +45,13 @@ import static org.mockito.Mockito.*;
  * @author GraviteeSource Team
  */
 @RunWith(MockitoJUnitRunner.class)
-public class PostLoginRememberDeviceHandlerTest {
+public class DeviceIdentifierHandlerTest {
 
     private DeviceService deviceService;
 
     private SpyRoutingContext spyRoutingContext;
     private Client client;
-    private PostLoginRememberDeviceHandler handler;
+    private DeviceIdentifierHandler handler;
     private String userId;
     private String deviceIdentifierId;
 
@@ -64,7 +64,7 @@ public class PostLoginRememberDeviceHandlerTest {
         client.setId(UUID.randomUUID().toString());
         client.setClientId(UUID.randomUUID().toString());
         deviceService = spy(DeviceService.class);
-        handler = new PostLoginRememberDeviceHandler(deviceService);
+        handler = new DeviceIdentifierHandler(deviceService);
 
         userId = UUID.randomUUID().toString();
         deviceIdentifierId = UUID.randomUUID().toString();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/RememberDeviceHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/RememberDeviceHandlerTest.java
@@ -40,7 +40,7 @@ public class RememberDeviceHandlerTest extends RxWebTestBase {
 
     private SpyRoutingContext spyRoutingContext;
     private Client client;
-    private RememberDeviceHandler handler;
+    private RememberDeviceSettingsHandler handler;
 
     @Before
     public void setUp() {
@@ -50,7 +50,7 @@ public class RememberDeviceHandlerTest extends RxWebTestBase {
         client.setId(UUID.randomUUID().toString());
         client.setClientId(UUID.randomUUID().toString());
 
-        handler = new RememberDeviceHandler();
+        handler = new RememberDeviceSettingsHandler();
 
         spyRoutingContext = spy(new SpyRoutingContext());
         doNothing().when(spyRoutingContext).next();


### PR DESCRIPTION
closes: https://github.com/gravitee-io/issues/issues/6871

This PR enables remember device with WebauthN.

If testing with chrome, make sure that cross-origin security is not enabled since FpJs pro makes Cross-Origin requests to get a visitorId