### PR TITLE
fix: leave the defaul storeType managed by the builder, as null is by…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxServerConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxServerConfiguration.java
@@ -39,8 +39,6 @@ public class VertxServerConfiguration {
     public HttpServerConfiguration httpServerConfiguration(Environment environment) {
         return HttpServerConfiguration.builder().withEnvironment(environment)
                 .withDefaultPort(8092)
-                .withDefaultKeyStoreType(null)
-                .withDefaultTrustStoreType(null)
                 .withDefaultMaxFormAttributeSize(2048)
                 .build();
     }


### PR DESCRIPTION
… default bind to JKS. This will avoid NullPointer for node version  1.20.1 & 1.20.1

fixes gravitee-io/issues#7107