### PR TITLE
feat: Update user_code in metadata

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/impl/DynamicClientRegistrationServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/impl/DynamicClientRegistrationServiceImpl.java
@@ -874,10 +874,6 @@ public class DynamicClientRegistrationServiceImpl implements DynamicClientRegist
                             (!request.getBackchannelClientNotificationEndpoint().get().startsWith("https")) )) {
                 return Single.error(new InvalidClientMetadataException("Missing or Invalid backchannel_client_notification_endpoint"));
             }
-
-            if (request.getBackchannelUserCodeParameter() != null && request.getBackchannelUserCodeParameter().isPresent() && request.getBackchannelUserCodeParameter().get()) {
-                return Single.error(new InvalidClientMetadataException("Unsupported backchannel_user_code_parameter"));
-            }
         }
 
         return Single.just(request);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
@@ -178,7 +178,7 @@ public class OpenIDDiscoveryServiceImpl implements OpenIDDiscoveryService, Initi
             openIDProviderMetadata.setBackchannelAuthenticationSigningAlg(JWAlgorithmUtils.getSupportedBackchannelAuthenticationSigningAl());
             openIDProviderMetadata.setBackchannelTokenDeliveryModesSupported(CIBADeliveryMode.SUPPORTED_DELIVERY_MODES);
             openIDProviderMetadata.setBackchannelAuthenticationEndpoint(getEndpointAbsoluteURL(basePath, CIBA_AUTHENTICATION_ENDPOINT));
-            openIDProviderMetadata.setBackchannelUserCodeSupported(false);
+            openIDProviderMetadata.setBackchannelUserCodeSupported(true);
         }
 
         final boolean mtlsEnabled = clientCert != null || (secured && !clientAuth.equalsIgnoreCase("none"));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationServiceTest.java
@@ -1323,12 +1323,13 @@ public class DynamicClientRegistrationServiceTest {
         request.setRequestObjectEncryptionAlg(Optional.of(JWEAlgorithm.RSA_OAEP_256.getName()));
         request.setRequestObjectEncryptionEnc(Optional.of(EncryptionMethod.A256GCM.getName()));
         request.setJwksUri(Optional.of(DUMMY_JWKS_URI));
-        request.setRedirectUris(Optional.of(Arrays.asList(DUMMY_REDIRECTURI)));
+        request.setRedirectUris(Optional.of(List.of(DUMMY_REDIRECTURI)));
         request.setGrantTypes(Optional.of(List.of(GrantType.CIBA_GRANT_TYPE)));
 
         request.setBackchannelAuthRequestSignAlg(Optional.of(JWSAlgorithm.RS256.getName()));
         request.setBackchannelClientNotificationEndpoint(Optional.of("https://127.0.0..1/ciba/notif"));
         request.setBackchannelTokenDeliveryMode(Optional.of(CIBADeliveryMode.POLL));
+        request.setBackchannelUserCodeParameter(Optional.of(true));
 
         when(domain.useCiba()).thenReturn(true);
 
@@ -1340,7 +1341,7 @@ public class DynamicClientRegistrationServiceTest {
         testObserver.assertNoErrors();
         testObserver.assertComplete();
 
-        testObserver.assertValue(client -> !client.getBackchannelUserCodeParameter());
+        testObserver.assertValue(Client::getBackchannelUserCodeParameter);
         testObserver.assertValue(client -> client.getBackchannelAuthRequestSignAlg() != null && client.getBackchannelAuthRequestSignAlg().equals(JWSAlgorithm.RS256.getName()));
         testObserver.assertValue(client -> client.getBackchannelClientNotificationEndpoint() != null && client.getBackchannelClientNotificationEndpoint().equals("https://127.0.0..1/ciba/notif"));
         testObserver.assertValue(client -> client.getBackchannelTokenDeliveryMode() != null && client.getBackchannelTokenDeliveryMode().equals(CIBADeliveryMode.POLL));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
@@ -39,9 +39,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -175,7 +172,7 @@ public class OpenIDDiscoveryServiceTest {
     public void shouldContainsCIBAMetadata() {
         when(domain.useCiba()).thenReturn(true);
         final OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
-        assertFalse(openIDProviderMetadata.isBackchannelUserCodeSupported());
+        assertTrue(openIDProviderMetadata.isBackchannelUserCodeSupported());
         assertTrue("ciba auth endpoint is required", openIDProviderMetadata.getBackchannelAuthenticationEndpoint().contains("ciba/authenticate"));
         assertNotNull(openIDProviderMetadata.getBackchannelAuthenticationSigningAlg());
         assertTrue(openIDProviderMetadata.getBackchannelAuthenticationSigningAlg().containsAll(JWAlgorithmUtils.getSupportedBackchannelAuthenticationSigningAl()));

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.html
@@ -52,6 +52,6 @@
   </div>
   <app-emptystate *ngIf="!dcrIsEnabled"
                   [message]="'Openid Connect Dynamic Client Registration is disabled.'"
-                  [subMessage]="'This feature can be enable through the Settings tab.'">
+                  [subMessage]="'This feature can be enabled through the Settings tab.'">
   </app-emptystate>
 </div>

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.html
@@ -43,6 +43,6 @@
   </div>
   <app-emptystate *ngIf="!dcrIsEnabled"
                   [message]="'Openid Connect Dynamic Client Registration is disabled.'"
-                  [subMessage]="'This feature can be enable through the Settings tab.'">
+                  [subMessage]="'This feature can be enabled through the Settings tab.'">
   </app-emptystate>
 </div>

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/templates/templates.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/templates/templates.component.html
@@ -73,7 +73,7 @@
   </div>
   <app-emptystate *ngIf="!(dcrIsEnabled && templateIsEnabled)"
                   [message]="emptyStateMessage"
-                  [subMessage]="'This feature can be enable through the Settings tab.'">
+                  [subMessage]="'This feature can be enabled through the Settings tab.'">
   </app-emptystate>
 </div>
 


### PR DESCRIPTION
Fixes gravitee-io/issues#7152

I've set the well-known document `backchannel_user_code_parameter_supported` parameter to `true` and removed the code that threw an exception if the `backchannel_user_code_parameter=true` property is included in a client registration request. I've also updated the respective tests to reflect these changes.

This work relates to the CIBA epic #6313 for adding support for the `user_code` . 