### PR TITLE
fix(webauthn): added user login status in the session

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnResponseEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnResponseEndpoint.java
@@ -145,10 +145,11 @@ public class WebAuthnResponseEndpoint extends WebAuthnEndpoint {
                                         ctx.fail(401);
                                         return;
                                     }
-                                    // save the user into the context
+                                    // save the user and login completed status into the context
                                     ctx.getDelegate().setUser(user);
                                     ctx.session().put(ConstantKeys.PASSWORDLESS_AUTH_COMPLETED_KEY, true);
                                     ctx.session().put(ConstantKeys.WEBAUTHN_CREDENTIAL_ID_CONTEXT_KEY, credentialId);
+                                    ctx.session().put(ConstantKeys.USER_LOGIN_COMPLETED_KEY, Boolean.TRUE);
 
                                     // Now redirect back to authorization endpoint.
                                     final MultiMap queryParams = RequestUtils.getCleanedQueryParams(ctx.request());


### PR DESCRIPTION
The bug relates to the fact that the application did not know the user login status wile prompt='login' parameter was present. Hence, the app tried to log in the user repeatedly. Adding the extra information in session solve the problem.