### PR TITLE
fix: use unregisterAll method to remove all notificiation trigger reg…

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcNotificationAcknowledgeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcNotificationAcknowledgeRepository.java
@@ -37,8 +37,9 @@ import static reactor.adapter.rxjava.RxJava2Adapter.*;
 public class JdbcNotificationAcknowledgeRepository extends AbstractJdbcRepository implements NotificationAcknowledgeRepository {
 
     public static final String COL_ID = "id";
-    public static final String COL_RESOURCE = "resourceId";
-    public static final String COL_AUDIENCE = "audienceId";
+    public static final String COL_RESOURCE = "resource_id";
+    public static final String COL_RESOURCE_TYPE = "resource_type";
+    public static final String COL_AUDIENCE = "audience_id";
     public static final String COL_TYPE = "type";
 
     protected NotificationAcknowledge toEntity(JdbcNotificationAcknowledge entity) {
@@ -59,10 +60,13 @@ public class JdbcNotificationAcknowledgeRepository extends AbstractJdbcRepositor
     }
 
     @Override
-    public Maybe<NotificationAcknowledge> findByResourceIdAndTypeAndAudienceId(String resource, String type, String audience) {
-        LOGGER.debug("findByResourceIdAndAudienceId({},{},{})", resource, type, audience);
+    public Maybe<NotificationAcknowledge> findByResourceIdAndTypeAndAudienceId(String resourceId, String resourceType, String type, String audience) {
+        LOGGER.debug("findByResourceIdAndAudienceId({},{},{},{})", resourceId, resourceType, type, audience);
         return monoToMaybe(this.template.select(JdbcNotificationAcknowledge.class)
-                .matching(query(where(COL_RESOURCE).is(resource).and(where(COL_TYPE).is(type)).and(where(COL_AUDIENCE).is(audience))))
+                .matching(query(where(COL_RESOURCE).is(resourceId)
+                        .and(where(COL_RESOURCE_TYPE).is(resourceType))
+                        .and(where(COL_TYPE).is(type))
+                        .and(where(COL_AUDIENCE).is(audience))))
                 .first())
                 .map(this::toEntity);
     }
@@ -83,9 +87,11 @@ public class JdbcNotificationAcknowledgeRepository extends AbstractJdbcRepositor
     }
 
     @Override
-    public Completable deleteByResourceId(String id) {
-        LOGGER.debug("deleteByResourceId({})", id);
-        return monoToCompletable(this.template.delete(JdbcNotificationAcknowledge.class).matching(query(where(COL_RESOURCE).is(id))).all());
+    public Completable deleteByResourceId(String resourceId, String resourceType) {
+        LOGGER.debug("deleteByResourceId({}, {})", resourceId, resourceType);
+        return monoToCompletable(this.template.delete(JdbcNotificationAcknowledge.class)
+                .matching(query(where(COL_RESOURCE).is(resourceId).and(where(COL_RESOURCE_TYPE).is(resourceType))))
+                .all());
     }
 
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_17_0/schema-notification-acknowledges.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_17_0/schema-notification-acknowledges.yml
@@ -26,8 +26,10 @@ databaseChangeLog:
               - column:
                   name: resource_id
               - column:
+                  name: resource_type
+              - column:
                   name: type
               - column:
                   name: audience_id
-            indexName: notification_acknowledgements_3col
+            indexName: notification_acknowledgements_4col
             unique: true

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoNotificationAcknowledgeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoNotificationAcknowledgeRepository.java
@@ -40,6 +40,7 @@ import static com.mongodb.client.model.Filters.eq;
 public class MongoNotificationAcknowledgeRepository extends AbstractManagementMongoRepository implements NotificationAcknowledgeRepository {
 
     private static final String FIELD_RESOURCE_ID = "resourceId";
+    private static final String FIELD_RESOURCE_TYPE = "resourceType";
     private static final String FIELD_TYPE = "type";
     private static final String FIELD_AUDIENCE_ID = "audienceId";
 
@@ -62,9 +63,10 @@ public class MongoNotificationAcknowledgeRepository extends AbstractManagementMo
     }
 
     @Override
-    public Maybe<NotificationAcknowledge> findByResourceIdAndTypeAndAudienceId(String resource, String type, String audience) {
+    public Maybe<NotificationAcknowledge> findByResourceIdAndTypeAndAudienceId(String resourceId, String resourceType, String type, String audience) {
         return Observable.fromPublisher(collection.find(and(
-                    eq(FIELD_RESOURCE_ID, resource),
+                    eq(FIELD_RESOURCE_ID, resourceId),
+                    eq(FIELD_RESOURCE_TYPE, resourceType),
                     eq(FIELD_TYPE, type),
                     eq(FIELD_AUDIENCE_ID, audience)))
                 .first())
@@ -73,8 +75,8 @@ public class MongoNotificationAcknowledgeRepository extends AbstractManagementMo
     }
 
     @Override
-    public Completable deleteByResourceId(String id) {
-        return Completable.fromPublisher(collection.deleteOne(eq(FIELD_RESOURCE_ID, id)));
+    public Completable deleteByResourceId(String id, String resourceType) {
+        return Completable.fromPublisher(collection.deleteOne(and(eq(FIELD_RESOURCE_ID, id), eq(FIELD_RESOURCE_TYPE, resourceType))));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/NotificationAcknowledgeRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/NotificationAcknowledgeRepositoryTest.java
@@ -108,7 +108,7 @@ public class NotificationAcknowledgeRepositoryTest extends AbstractManagementTes
         acknowledge.setCounter(1);
         repository.create(acknowledge).blockingGet();
 
-        TestObserver<NotificationAcknowledge> testObserver = repository.findByResourceIdAndTypeAndAudienceId(acknowledge.getResourceId(), acknowledge.getType(), acknowledge.getAudienceId()).test();
+        TestObserver<NotificationAcknowledge> testObserver = repository.findByResourceIdAndTypeAndAudienceId(acknowledge.getResourceId(), acknowledge.getResourceType(), acknowledge.getType(), acknowledge.getAudienceId()).test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertComplete();
@@ -118,7 +118,7 @@ public class NotificationAcknowledgeRepositoryTest extends AbstractManagementTes
 
     @Test
     public void testNotFound() throws TechnicalException {
-        final TestObserver<NotificationAcknowledge> test = repository.findByResourceIdAndTypeAndAudienceId("unknown", "unknown", "unknonwn").test();
+        final TestObserver<NotificationAcknowledge> test = repository.findByResourceIdAndTypeAndAudienceId("unknown", "unknown", "unknown", "unknonwn").test();
         test.awaitTerminalEvent();
         test.assertNoValues();
     }
@@ -142,7 +142,7 @@ public class NotificationAcknowledgeRepositoryTest extends AbstractManagementTes
         testObserver.assertNoErrors();
         testObserver.assertValue(d -> d.getId().equals(acknowledge.getId()));
 
-        final TestObserver<Void> test = repository.deleteByResourceId(acknowledge.getResourceId()).test();
+        final TestObserver<Void> test = repository.deleteByResourceId(acknowledge.getResourceId(), acknowledge.getResourceType()).test();
         test.awaitTerminalEvent();
         test.assertNoErrors();
 


### PR DESCRIPTION
…istered into the gravitee node. This allows to delete notifierTrigger without audience id.

fixes gravitee-io/issues#7274