### PR TITLE
chore: move EE dockerfile to am project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ parameters:
     type: enum
     enum: [release, publish_rpms, pull_requests]
     default: pull_requests
+  gio_product:
+    type: enum
+    enum: [am_v3, none]
+    default: none
   dry_run:
     type: boolean
     default: true
@@ -45,11 +49,26 @@ parameters:
     type: string
     default: "cicd"
     description: "Release version number to use to publish the Docker nightly images ?"
+  prune:
+    type: boolean
+    default: false
+    description: "Do you want to [docker system prune -f --all] ? (clean up all cached docker images)"
+  tag_latest:
+    type: boolean
+    default: false
+    description: "Is this latest version of the Product ?"
+  tag_latest_support:
+    type: boolean
+    default: true
+    description: "Is this a latest support version of the Product ? (if so minor version tagging docker images). True by default."
+  
+
 
 orbs:
   gravitee: gravitee-io/gravitee@1.0
-  keeper: gravitee-io/keeper@0.6.1
+  keeper: gravitee-io/keeper@0.6.2
   slack: circleci/slack@4.8.1
+  am: gravitee-io/gravitee-am@1.0
 
 jobs:
   keeper:
@@ -671,6 +690,48 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
                 var-name: AZURE_APPLICATION_SECRET
+                
+
+
+  docker_build_and_push_am_v3:
+    when:
+      equal: [ am_v3, << pipeline.parameters.gio_product >> ]
+    jobs:
+      # ---
+      # Builds and push AM Community Edition Images
+      - am/build_n_push_am_ce_job:
+          name: 'building ce dockerfile'
+          context: cicd-orchestrator
+          dry_run: << pipeline.parameters.dry_run >>
+          tag_latest: << pipeline.parameters.tag_latest >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
+          gio_product: << pipeline.parameters.gio_product >>
+      # ---
+      # Builds and push AM v3 Entreprise Edition Images
+      - am/build_n_push_am_ee_v3_gateway_job:
+          context: cicd-orchestrator
+          requires:
+            - building ce dockerfile
+          dry_run: << pipeline.parameters.dry_run >>
+          tag_latest: << pipeline.parameters.tag_latest >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
+      - am/build_n_push_am_ee_v3_api_job:
+          context: cicd-orchestrator
+          requires:
+            - building ce dockerfile
+          dry_run: << pipeline.parameters.dry_run >>
+          tag_latest: << pipeline.parameters.tag_latest >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
+      - am/build_n_push_am_ee_v3_ui_job:
+          context: cicd-orchestrator
+          requires:
+            - building ce dockerfile
+          dry_run: << pipeline.parameters.dry_run >>
+          tag_latest: << pipeline.parameters.tag_latest >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
+
+
+  
 
 #  build_ciba_container:
 #    when:

--- a/docker/enterprise/am/3.x/gateway/Dockerfile
+++ b/docker/enterprise/am/3.x/gateway/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+FROM graviteeio/java:17
+LABEL maintainer="contact@graviteesource.com"
+
+ARG GRAVITEEIO_AM_VERSION=0
+ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-ee/am/distributions
+ENV GRAVITEEIO_HOME /opt/graviteeio-am-gateway
+
+RUN apk update \
+    && apk add --upgrade \
+    && apk add --update wget unzip htop \
+	&& wget ${GRAVITEEIO_DOWNLOAD_URL}/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}.zip --no-check-certificate -P /tmp \
+    && unzip /tmp/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}.zip -d /tmp/ \
+    && mv /tmp/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}/graviteeio-am-gateway* ${GRAVITEEIO_HOME} \
+    && rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/* \
+	&& chgrp -R 0 ${GRAVITEEIO_HOME} \
+    && chmod -R g=u ${GRAVITEEIO_HOME}
+
+WORKDIR ${GRAVITEEIO_HOME}
+
+EXPOSE 8092
+CMD ["./bin/gravitee"]

--- a/docker/enterprise/am/3.x/management-api/Dockerfile
+++ b/docker/enterprise/am/3.x/management-api/Dockerfile
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+FROM graviteeio/java:17
+LABEL maintainer="contact@graviteesource.com"
+
+ARG GRAVITEEIO_AM_VERSION=0
+ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-ee/am/distributions
+ARG GRAVITEEIO_HOME="/opt/graviteeio-am-management-api"
+ENV GRAVITEEIO_HOME="/opt/graviteeio-am-management-api"
+
+RUN apk update \
+    && apk add --update --no-cache wget unzip \
+	&& wget ${GRAVITEEIO_DOWNLOAD_URL}/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}.zip --no-check-certificate -P /tmp \
+	&& unzip /tmp/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}.zip -d /tmp/ \
+    && apk del unzip \
+	&& mkdir -p ${GRAVITEEIO_HOME} \
+	&& cp -fR /tmp/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}/graviteeio-am-management-api-${GRAVITEEIO_AM_VERSION}/* ${GRAVITEEIO_HOME} \
+	&& rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/* \
+	&& chgrp -R 0 ${GRAVITEEIO_HOME} \
+	&& chmod -R g=u ${GRAVITEEIO_HOME}
+
+WORKDIR /opt/graviteeio-am-management-api
+
+EXPOSE 8093
+CMD ["./bin/gravitee"]

--- a/docker/enterprise/am/3.x/management-ui/Dockerfile
+++ b/docker/enterprise/am/3.x/management-ui/Dockerfile
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+ARG GRAVITEEIO_AM_VERSION=0
+FROM graviteeio/am-management-ui:${GRAVITEEIO_AM_VERSION}
+LABEL maintainer="contact@graviteesource.com"


### PR DESCRIPTION
fixes: https://github.com/gravitee-io/issues/issues/7342

This PR is created in order to add the build and push workflow of v3 and v2 ee dockerfiles, that build and push the ee dockerfiles to the dockerhub repository, also all ee dockerfiles were now moved to this repo,

docker build test was launched using the orb, to build the am_v3 dockerfiles

CircleCI link : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-access-management/6064/workflows/2b9667fa-9fa6-49ce-af75-3c4c58fae59b

see this slab page for documentation on how to build and push the images : https://gravitee.slab.com/posts/build-push-am-ee-docker-image-bzsehw7p

