### PR TITLE
Update pom.xml

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-jdbc/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/pom.xml
@@ -251,6 +251,11 @@
         </dependency>
 
         <dependency>
+            <!--
+            Gravitee only uses this dependency to test the connectivity to MariaDB databases
+            and does not supply or bundle the mariadb-java-client in the software as per the license in:
+            https://github.com/mariadb-corporation/mariadb-connector-j/blob/master/LICENSE
+            -->
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>${jdbc-mariadb.version}</version>


### PR DESCRIPTION
As per the licensing issue with mysql connector and the update on the dependencies manifest we need the same to be done to mariadb connector:
mariadb-java-client under LGPL-2.1:
<dependency>
            <!--
            Gravitee only uses this dependency to test the connectivity to MariaDB databases
            and does not supply or bundle the mariadb-java-client in the software as per the license in:
            https://github.com/mariadb-corporation/mariadb-connector-j/blob/master/LICENSE
            -->