### PR TITLE
cicd: EE Dockerfiles migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,71 @@
 version: 2.1
 setup: true
+
+parameters:
+  gio_action:
+    type: enum
+    enum: [release, publish_rpms, pull_requests]
+    default: pull_requests
+  gio_product:
+    type: enum
+    enum: [am_v3, none]
+    default: none
+  dry_run:
+    type: boolean
+    default: true
+    description: "Run in dry run mode?"
+  maven_profile_id:
+    type: string
+    default: "gravitee-dry-run"
+    description: "Maven ID of the Maven profile to use for a dry run ?"
+  ee_id_provider_cas_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the CAS identity provider plugin to bundle with Gravitee AM Enterprise Edition"
+  ee_id_provider_kerberos_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the Kerberos identity provider plugin to bundle with Gravitee AM Enterprise Edition"
+  ee_id_provider_saml_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the SAML2 identity provider plugin to bundle with Gravitee AM Enterprise Edition"
+  ee_gravitee_license_version:
+    type: string
+    default: ''
+    description: "The semver version number of the Gravitee License to bundle with Gravitee AM Enterprise Edition"
+  ee_gravitee_ae_connector_version:
+    type: string
+    default: ''
+    description: "The semver version number of the Gravitee Alert Engine connector to bundle with Gravitee AM Enterprise Edition"
+  secrethub_org:
+    type: string
+    default: "gravitee-lab"
+    description: "SecretHub Org to use to fetch secrets ?"
+  secrethub_repo:
+    type: string
+    default: "cicd"
+    description: "SecretHub Repo to use to fetch secrets ?"
+  graviteeio_version:
+    type: string
+    default: "cicd"
+    description: "Release version number to use to publish the Docker nightly images ?"
+  run-container-test:
+    type: boolean
+    default: false
+  prune:
+    type: boolean
+    default: false
+    description: "Do you want to [docker system prune -f --all] ? (clean up all cached docker images)"
+  tag_latest:
+    type: boolean
+    default: false
+    description: "Is this latest version of the Product ?"
+  tag_latest_support:
+    type: boolean
+    default: true
+    description: "Is this a latest support version of the Product ? (if so minor version tagging docker images). True by default."
+    
 orbs:
   path-filtering: circleci/path-filtering@0.0.2
 workflows:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -5,6 +5,10 @@ parameters:
     type: enum
     enum: [release, publish_rpms, pull_requests]
     default: pull_requests
+  gio_product:
+    type: enum
+    enum: [am_v3, none]
+    default: none
   dry_run:
     type: boolean
     default: true
@@ -48,12 +52,25 @@ parameters:
   run-container-test:
     type: boolean
     default: false
+  prune:
+    type: boolean
+    default: false
+    description: "Do you want to [docker system prune -f --all] ? (clean up all cached docker images)"
+  tag_latest:
+    type: boolean
+    default: false
+    description: "Is this latest version of the Product ?"
+  tag_latest_support:
+    type: boolean
+    default: true
+    description: "Is this a latest support version of the Product ? (if so minor version tagging docker images). True by default."
+    
 orbs:
   gravitee: gravitee-io/gravitee@1.0
   keeper: gravitee-io/keeper@0.6.2
   slack: circleci/slack@4.8.1
   snyk: snyk/snyk@1.1.2
-  am: gravitee-io/gravitee-am@1.0.8
+  am: gravitee-io/gravitee-am@1.0
 
 commands:
   docker-scan:
@@ -799,6 +816,43 @@ workflows:
             - cicd-orchestrator
           requires:
             - coverage_build
+
+  docker_build_and_push_am_v3:
+    when:
+      equal: [ am_v3, << pipeline.parameters.gio_product >> ]
+    jobs:
+      # ---
+      # Builds and push AM Community Edition Images
+      - am/build_n_push_am_ce_job:
+          name: 'building ce dockerfile'
+          context: cicd-orchestrator
+          dry_run: << pipeline.parameters.dry_run >>
+          tag_latest: << pipeline.parameters.tag_latest >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
+          gio_product: << pipeline.parameters.gio_product >>
+      # ---
+      # Builds and push AM v3 Entreprise Edition Images
+      - am/build_n_push_am_ee_v3_gateway_job:
+          context: cicd-orchestrator
+          requires:
+            - building ce dockerfile
+          dry_run: << pipeline.parameters.dry_run >>
+          tag_latest: << pipeline.parameters.tag_latest >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
+      - am/build_n_push_am_ee_v3_api_job:
+          context: cicd-orchestrator
+          requires:
+            - building ce dockerfile
+          dry_run: << pipeline.parameters.dry_run >>
+          tag_latest: << pipeline.parameters.tag_latest >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
+      - am/build_n_push_am_ee_v3_ui_job:
+          context: cicd-orchestrator
+          requires:
+            - building ce dockerfile
+          dry_run: << pipeline.parameters.dry_run >>
+          tag_latest: << pipeline.parameters.tag_latest >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
 
 #  build_ciba_container:
 #    when:

--- a/docker/enterprise/am/3.x/gateway/Dockerfile
+++ b/docker/enterprise/am/3.x/gateway/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+FROM graviteeio/java:17
+LABEL maintainer="contact@graviteesource.com"
+
+ARG GRAVITEEIO_AM_VERSION=0
+ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-ee/am/distributions
+ENV GRAVITEEIO_HOME /opt/graviteeio-am-gateway
+
+RUN apk update \
+    && apk add --upgrade \
+    && apk add --update wget unzip htop \
+	&& wget ${GRAVITEEIO_DOWNLOAD_URL}/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}.zip --no-check-certificate -P /tmp \
+    && unzip /tmp/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}.zip -d /tmp/ \
+    && mv /tmp/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}/graviteeio-am-gateway* ${GRAVITEEIO_HOME} \
+    && rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/* \
+	&& chgrp -R 0 ${GRAVITEEIO_HOME} \
+    && chmod -R g=u ${GRAVITEEIO_HOME}
+
+WORKDIR ${GRAVITEEIO_HOME}
+
+EXPOSE 8092
+CMD ["./bin/gravitee"]

--- a/docker/enterprise/am/3.x/management-api/Dockerfile
+++ b/docker/enterprise/am/3.x/management-api/Dockerfile
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+FROM graviteeio/java:17
+LABEL maintainer="contact@graviteesource.com"
+
+ARG GRAVITEEIO_AM_VERSION=0
+ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-ee/am/distributions
+ARG GRAVITEEIO_HOME="/opt/graviteeio-am-management-api"
+ENV GRAVITEEIO_HOME="/opt/graviteeio-am-management-api"
+
+RUN apk update \
+    && apk add --update --no-cache wget unzip \
+	&& wget ${GRAVITEEIO_DOWNLOAD_URL}/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}.zip --no-check-certificate -P /tmp \
+	&& unzip /tmp/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}.zip -d /tmp/ \
+    && apk del unzip \
+	&& mkdir -p ${GRAVITEEIO_HOME} \
+	&& cp -fR /tmp/graviteeio-ee-am-full-${GRAVITEEIO_AM_VERSION}/graviteeio-am-management-api-${GRAVITEEIO_AM_VERSION}/* ${GRAVITEEIO_HOME} \
+	&& rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/* \
+	&& chgrp -R 0 ${GRAVITEEIO_HOME} \
+	&& chmod -R g=u ${GRAVITEEIO_HOME}
+
+WORKDIR /opt/graviteeio-am-management-api
+
+EXPOSE 8093
+CMD ["./bin/gravitee"]

--- a/docker/enterprise/am/3.x/management-ui/Dockerfile
+++ b/docker/enterprise/am/3.x/management-ui/Dockerfile
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+ARG GRAVITEEIO_AM_VERSION=0
+FROM graviteeio/am-management-ui:${GRAVITEEIO_AM_VERSION}
+LABEL maintainer="contact@graviteesource.com"

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>
         <gravitee-platform-repository-api.version>1.0.0</gravitee-platform-repository-api.version>
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
-        <spring.version>5.3.15</spring.version>
+        <spring.version>5.3.18</spring.version>
         <spring-security.version>5.5.5</spring-security.version>
         <spring-integration.version>5.5.6</spring-integration.version>
         <nimbus.version>8.17</nimbus.version>


### PR DESCRIPTION
fixes: https://github.com/gravitee-io/issues/issues/7342

This PR is created in order to add the build and push workflow of v3 and v2 ee dockerfiles, that build and push the ee dockerfiles to the dockerhub repository, also all ee dockerfiles were now moved to this repo,

docker build test was launched using the orb, to build the am_v3 dockerfiles

CircleCI link : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-access-management/6082/workflows/164555e4-154a-4f0b-855d-0d56681a43ec

see this slab page for documentation on how to build and push the images : https://gravitee.slab.com/posts/build-push-am-ee-docker-image-bzsehw7p