### PR TITLE
feat(idp): add support for SHA256+MD5 password encoder for JDBC

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/java/io/gravitee/am/identityprovider/jdbc/authentication/spring/JdbcAuthenticationProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/java/io/gravitee/am/identityprovider/jdbc/authentication/spring/JdbcAuthenticationProviderConfiguration.java
@@ -26,6 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.regex.Pattern;
+
 import static io.gravitee.am.identityprovider.jdbc.utils.PasswordEncoder.*;
 
 /**
@@ -56,7 +58,12 @@ public class JdbcAuthenticationProviderConfiguration {
         }
 
         if (configuration.getPasswordEncoder().startsWith(SHA)) {
-            MessageDigestPasswordEncoder passwordEncoder =  new SHAPasswordEncoder(configuration.getPasswordEncoder());
+            MessageDigestPasswordEncoder passwordEncoder;
+            if (configuration.getPasswordEncoder().endsWith("+MD5")) {
+                passwordEncoder = new SHAMD5PasswordEncoder(configuration.getPasswordEncoder().split(Pattern.quote("+"))[0]);
+            } else {
+                passwordEncoder = new SHAPasswordEncoder(configuration.getPasswordEncoder());
+            }
             passwordEncoder.setEncodeSaltAsBase64("Base64".equals(configuration.getPasswordEncoding()));
             passwordEncoder.setSaltLength(configuration.getPasswordSaltLength());
             return passwordEncoder;

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
@@ -87,7 +87,7 @@
     },
     "passwordEncoder" : {
       "type": "string",
-      "enum": ["BCrypt", "SHA", "SHA-1", "SHA-256", "SHA-384", "SHA-512", "MD5", "None"],
+      "enum": ["BCrypt", "SHA", "SHA-1", "SHA-256", "SHA-384", "SHA-512", "MD5", "SHA-256+MD5", "None"],
       "default": "BCrypt",
       "title": "Password encoder",
       "description": "The encoding mechanism used to store user password value."

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/authentication/spring/MongoAuthenticationProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/authentication/spring/MongoAuthenticationProviderConfiguration.java
@@ -32,6 +32,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.regex.Pattern;
+
 import static io.gravitee.am.identityprovider.mongo.utils.PasswordEncoder.*;
 import static java.util.Arrays.asList;
 
@@ -84,7 +86,12 @@ public class MongoAuthenticationProviderConfiguration {
         }
 
         if (configuration.getPasswordEncoder().startsWith(SHA)) {
-            MessageDigestPasswordEncoder passwordEncoder =  new SHAPasswordEncoder(configuration.getPasswordEncoder());
+            MessageDigestPasswordEncoder passwordEncoder;
+            if (configuration.getPasswordEncoder().endsWith("+MD5")) {
+                passwordEncoder = new SHAMD5PasswordEncoder(configuration.getPasswordEncoder().split(Pattern.quote("+"))[0]);
+            } else {
+                passwordEncoder = new SHAPasswordEncoder(configuration.getPasswordEncoder());
+            }
             passwordEncoder.setEncodeSaltAsBase64("Base64".equals(configuration.getPasswordEncoding()));
             passwordEncoder.setSaltLength(configuration.getPasswordSaltLength());
             return passwordEncoder;

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
@@ -86,7 +86,7 @@
     },
     "passwordEncoder" : {
       "type": "string",
-      "enum": ["BCrypt", "SHA", "SHA-1", "SHA-256", "SHA-384", "SHA-512", "MD5", "None"],
+      "enum": ["BCrypt", "SHA", "SHA-1", "SHA-256", "SHA-384", "SHA-512", "MD5", "SHA-256+MD5", "None"],
       "default": "BCrypt",
       "title": "Password encoder",
       "description": "The encoding mechanism to store password value."

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/authentication/crypto/password/SHAMD5PasswordEncoder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/authentication/crypto/password/SHAMD5PasswordEncoder.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.authentication.crypto.password;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SHAMD5PasswordEncoder extends SHAPasswordEncoder {
+
+    private final MD5PasswordEncoder md5PasswordEncoder = new MD5PasswordEncoder();
+    private final SHAPasswordEncoder shaPasswordEncoder = new SHAPasswordEncoder();
+
+    public SHAMD5PasswordEncoder() {
+        md5PasswordEncoder.setSaltLength(0);
+    }
+
+    public SHAMD5PasswordEncoder(String algorithm) {
+        this();
+        shaPasswordEncoder.setAlgorithm(algorithm);
+    }
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return shaPasswordEncoder.encode(md5PasswordEncoder.encode(rawPassword));
+    }
+
+    @Override
+    public String encode(CharSequence rawPassword, byte[] salt) {
+        return shaPasswordEncoder.encode(md5PasswordEncoder.encode(rawPassword), salt);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        final String rawPasswordEncoded = md5PasswordEncoder.encode(rawPassword);
+        return shaPasswordEncoder.matches(rawPasswordEncoded, encodedPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword, byte[] salt) {
+        final String rawPasswordEncoded = md5PasswordEncoder.encode(rawPassword);
+        return shaPasswordEncoder.matches(rawPasswordEncoded, encodedPassword, salt);
+    }
+
+    @Override
+    public void setEncodeSaltAsBase64(boolean encodeSaltAsBase64) {
+        md5PasswordEncoder.setEncodeSaltAsBase64(encodeSaltAsBase64);
+        shaPasswordEncoder.setEncodeSaltAsBase64(encodeSaltAsBase64);
+    }
+
+    @Override
+    public void setSaltLength(int saltLength) {
+        shaPasswordEncoder.setSaltLength(saltLength);
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/authentication/crypto/password/SHAMD5PasswordEncoderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/authentication/crypto/password/SHAMD5PasswordEncoderTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.authentication.crypto.password;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.security.SecureRandom;
+
+/**
+ * @@author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SHAMD5PasswordEncoderTest {
+
+    private MessageDigestPasswordEncoder messageDigestPasswordEncoder = new SHAMD5PasswordEncoder("SHA-256");
+
+    @Test
+    public void testPassword_match_not_equals() {
+        String encodedPassword = messageDigestPasswordEncoder.encode("myPassword");
+        Assert.assertFalse(messageDigestPasswordEncoder.matches("wrongPassword", encodedPassword));
+    }
+
+    @Test
+    public void testPassword_match_equals() {
+        String encodedPassword = messageDigestPasswordEncoder.encode("myPassword");
+        Assert.assertTrue(messageDigestPasswordEncoder.matches("myPassword", encodedPassword));
+    }
+
+    @Test
+    public void testPassword_match_not_equals_dedicated_salt() {
+        byte[] salt = new byte[32];
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(salt);
+        String encodedPassword = messageDigestPasswordEncoder.encode("myPassword", salt);
+        Assert.assertFalse(messageDigestPasswordEncoder.matches("wrongPassword", encodedPassword, salt));
+    }
+
+    @Test
+    public void testPassword_match_equals_dedicated_salt() {
+        byte[] salt = new byte[32];
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(salt);
+        String encodedPassword = messageDigestPasswordEncoder.encode("myPassword", salt);
+        Assert.assertTrue(messageDigestPasswordEncoder.matches("myPassword", encodedPassword, salt));
+    }
+
+    @Test
+    public void testPassword_match_equals_b64_encoded() {
+        String b64EncodedSalt = "Da11RaXXUaGQ39oI/f8WyXxYJ3AWDg9UECmURKKQ1vE=";
+        String b64EncodedPassword = "M/sMmBh2AH+S5jkaMvhab/akUQFGHwxG+Qi7AiC9kIU=";
+        String rawPassword = "Test123!";
+        Assert.assertTrue(messageDigestPasswordEncoder.matches(rawPassword, b64EncodedPassword, b64EncodedSalt));
+    }
+}


### PR DESCRIPTION
closes gravitee-io/issues#7404