### PR TITLE
feat: persistent session at application level

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -58,6 +58,7 @@
 #    sameSite: Lax
 #    session:
 #      name: session-name
+#      persistent: true
 #      timeout: 1800000 # (in milliseconds)
 #  csrf:
 #    secret: s3cR3t4grAv1t3310AMS1g1ingDftK3y

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationResource.java
@@ -320,6 +320,7 @@ public class ApplicationResource extends AbstractResource {
                 filteredApplicationSettings.setLogin(settings.getLogin());
                 filteredApplicationSettings.setPasswordSettings(settings.getPasswordSettings());
                 filteredApplicationSettings.setMfa(settings.getMfa());
+                filteredApplicationSettings.setCookieSettings(settings.getCookieSettings());
             }
 
             if (hasAnyPermission(userPermissions, Permission.APPLICATION_OPENID, Acl.READ)) {

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/CookieSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/CookieSettings.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.model;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CookieSettings {
+
+    /**
+     * Cookie settings configuration inherited ?
+     */
+    private boolean inherited = true;
+
+    private SessionSettings session;
+
+    public CookieSettings() {}
+
+    public CookieSettings(CookieSettings other) {
+        this.inherited = other.inherited;
+        this.session = other.session != null ? new SessionSettings(other.session) : null;
+    }
+
+    public SessionSettings getSession() {
+        return session;
+    }
+
+    public void setSession(SessionSettings session) {
+        this.session = session;
+    }
+
+    public boolean isInherited() {
+        return inherited;
+    }
+
+    public void setInherited(boolean inherited) {
+        this.inherited = inherited;
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/SessionSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/SessionSettings.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.model;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SessionSettings {
+
+    private boolean persistent;
+
+    public SessionSettings() {}
+
+    public SessionSettings(SessionSettings cookieSettings) {
+        this.persistent = cookieSettings.persistent;
+    }
+
+    public boolean isPersistent() {
+        return persistent;
+    }
+
+    public void setPersistent(boolean persistent) {
+        this.persistent = persistent;
+    }
+
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationSettings.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model.application;
 
+import io.gravitee.am.model.CookieSettings;
 import io.gravitee.am.model.MFASettings;
 import io.gravitee.am.model.PasswordSettings;
 import io.gravitee.am.model.account.AccountSettings;
@@ -55,6 +56,11 @@ public class ApplicationSettings {
      */
     private MFASettings mfa;
 
+    /**
+     * Cookie settings
+     */
+    private CookieSettings cookieSettings;
+
     public ApplicationSettings() {
     }
 
@@ -65,6 +71,7 @@ public class ApplicationSettings {
         this.advanced = other.advanced != null ? new ApplicationAdvancedSettings(other.advanced) : null;
         this.passwordSettings = Optional.ofNullable(other.passwordSettings).map(PasswordSettings::new).orElse(null);
         this.mfa = other.mfa != null ? new MFASettings(other.mfa) : null;
+        this.cookieSettings = other.cookieSettings != null ? new CookieSettings(other.cookieSettings) : null;
     }
 
     public ApplicationOAuthSettings getOauth() {
@@ -115,12 +122,21 @@ public class ApplicationSettings {
         this.mfa = mfa;
     }
 
+    public CookieSettings getCookieSettings() {
+        return cookieSettings;
+    }
+
+    public void setCookieSettings(CookieSettings cookieSettings) {
+        this.cookieSettings = cookieSettings;
+    }
+
     public void copyTo(Client client) {
         client.setAccountSettings(this.account);
         client.setLoginSettings(this.login);
         client.setPasswordSettings(this.passwordSettings);
-        Optional.ofNullable(this.oauth).ifPresent(o->o.copyTo(client));
-        Optional.ofNullable(getAdvanced()).ifPresent(a->a.copyTo(client));
+        Optional.ofNullable(this.oauth).ifPresent(o -> o.copyTo(client));
+        Optional.ofNullable(getAdvanced()).ifPresent(a -> a.copyTo(client));
         client.setMfaSettings(this.mfa);
+        client.setCookieSettings(this.getCookieSettings());
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
@@ -199,6 +199,8 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     private MFASettings mfaSettings;
 
+    private CookieSettings cookieSettings;
+
     private boolean singleSignOut;
 
     private boolean silentReAuthentication;
@@ -275,6 +277,7 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
         this.postLogoutRedirectUris = other.postLogoutRedirectUris;
         this.flowsInherited = other.flowsInherited;
         this.mfaSettings = other.mfaSettings;
+        this.cookieSettings = other.cookieSettings;
         this.singleSignOut = other.singleSignOut;
         this.silentReAuthentication = other.silentReAuthentication;
     }
@@ -882,6 +885,14 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     public void setSilentReAuthentication(boolean silentReAuthentication) {
         this.silentReAuthentication = silentReAuthentication;
+    }
+
+    public CookieSettings getCookieSettings() {
+        return cookieSettings;
+    }
+
+    public void setCookieSettings(CookieSettings cookieSettings) {
+        this.cookieSettings = cookieSettings;
     }
 
     @Override

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/ClientProperties.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/ClientProperties.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.model.safe;
 
 import io.gravitee.am.model.Application;
+import io.gravitee.am.model.CookieSettings;
 import io.gravitee.am.model.oidc.Client;
 
 import java.util.HashMap;
@@ -32,6 +33,7 @@ public class ClientProperties {
     private String clientId;
     private String clientName;
     private String name;
+    private CookieSettings cookieSettings;
     private Map<String, Object> metadata;
 
     public ClientProperties() {
@@ -43,6 +45,7 @@ public class ClientProperties {
         this.clientId = client.getClientId();
         this.clientName = client.getClientName();
         this.name = client.getClientName();
+        this.cookieSettings = client.getCookieSettings();
         this.metadata = client.getMetadata() == null ? new HashMap<>() : new HashMap<>(client.getMetadata());
     }
 
@@ -88,6 +91,14 @@ public class ClientProperties {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public CookieSettings getCookieSettings() {
+        return cookieSettings;
+    }
+
+    public void setCookieSettings(CookieSettings cookieSettings) {
+        this.cookieSettings = cookieSettings;
     }
 
     public Map<String, Object> getMetadata() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -19,10 +19,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import io.gravitee.am.common.oauth2.TokenTypeHint;
 import io.gravitee.am.common.utils.RandomString;
-import io.gravitee.am.model.Application;
-import io.gravitee.am.model.MFASettings;
-import io.gravitee.am.model.PasswordSettings;
-import io.gravitee.am.model.TokenClaim;
+import io.gravitee.am.model.*;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.application.ApplicationAdvancedSettings;
 import io.gravitee.am.model.application.ApplicationOAuthSettings;
@@ -241,6 +238,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationSettingsMongo.setAdvanced(convert(other.getAdvanced()));
         applicationSettingsMongo.setPasswordSettings(convert(other.getPasswordSettings()));
         applicationSettingsMongo.setMfa(convert(other.getMfa()));
+        applicationSettingsMongo.setCookieSettings(convert(other.getCookieSettings()));
         return applicationSettingsMongo;
     }
 
@@ -256,6 +254,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationSettings.setAdvanced(convert(other.getAdvanced()));
         applicationSettings.setPasswordSettings(convert(other.getPasswordSettings()));
         applicationSettings.setMfa(convert(other.getMfa()));
+        applicationSettings.setCookieSettings(convert(other.getCookieSettings()));
         return applicationSettings;
     }
 
@@ -447,6 +446,14 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
 
     private static MFASettingsMongo convert(MFASettings mfaSettings) {
         return MFASettingsMongo.convert(mfaSettings);
+    }
+
+    private static CookieSettingsMongo convert(CookieSettings cookieSettings) {
+        return CookieSettingsMongo.convert(cookieSettings);
+    }
+
+    private static CookieSettings convert(CookieSettingsMongo cookieSettingsMongo) {
+        return cookieSettingsMongo != null ? cookieSettingsMongo.convert() : null;
     }
 
     private static List<TokenClaim> getTokenClaims(List<TokenClaimMongo> mongoTokenClaims) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationSettingsMongo.java
@@ -27,6 +27,7 @@ public class ApplicationSettingsMongo {
     private ApplicationAdvancedSettingsMongo advanced;
     private PasswordSettingsMongo passwordSettings;
     private MFASettingsMongo mfa;
+    private CookieSettingsMongo cookieSettings;
 
     public ApplicationOAuthSettingsMongo getOauth() {
         return oauth;
@@ -74,5 +75,13 @@ public class ApplicationSettingsMongo {
 
     public void setMfa(MFASettingsMongo mfa) {
         this.mfa = mfa;
+    }
+
+    public CookieSettingsMongo getCookieSettings() {
+        return cookieSettings;
+    }
+
+    public void setCookieSettings(CookieSettingsMongo cookieSettings) {
+        this.cookieSettings = cookieSettings;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/CookieSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/CookieSettingsMongo.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.repository.mongodb.management.internal.model;
+
+import io.gravitee.am.model.CookieSettings;
+import io.gravitee.am.model.SessionSettings;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CookieSettingsMongo {
+
+    private boolean inherited;
+
+    private SessionSettingsMongo session;
+
+    public boolean isInherited() {
+        return inherited;
+    }
+
+    public void setInherited(boolean inherited) {
+        this.inherited = inherited;
+    }
+
+    public SessionSettingsMongo getSession() {
+        return session;
+    }
+
+    public void setSession(SessionSettingsMongo session) {
+        this.session = session;
+    }
+
+    public CookieSettings convert() {
+        var cookieSettings = new CookieSettings();
+        if (this.getSession() != null) {
+            var sessionSettings = new SessionSettings();
+            sessionSettings.setPersistent(this.getSession().isPersistent());
+            cookieSettings.setSession(sessionSettings);
+        }
+        cookieSettings.setInherited(this.isInherited());
+        return cookieSettings;
+    }
+
+    public static CookieSettingsMongo convert(CookieSettings cookieSettings) {
+        if (cookieSettings == null) {
+            return null;
+        }
+        var cookieSettingsMongo = new CookieSettingsMongo();
+        var sessionSettings = getSessionSettingsMongo(cookieSettings.getSession());
+        cookieSettingsMongo.setInherited(cookieSettings.isInherited());
+        cookieSettingsMongo.setSession(sessionSettings);
+        return cookieSettingsMongo;
+    }
+
+    private static SessionSettingsMongo getSessionSettingsMongo(SessionSettings sessionSettings) {
+        if (sessionSettings == null) {
+            return null;
+        }
+        final SessionSettingsMongo sessionSettingsMongo = new SessionSettingsMongo();
+        sessionSettingsMongo.setPersistent(sessionSettings.isPersistent());
+        return sessionSettingsMongo;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/SessionSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/SessionSettingsMongo.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.repository.mongodb.management.internal.model;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SessionSettingsMongo {
+
+    private boolean persistent;
+
+    public boolean isPersistent() {
+        return persistent;
+    }
+
+    public void setPersistent(boolean persistent) {
+        this.persistent = persistent;
+    }
+
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationSettings.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.am.service.model;
 
+import io.gravitee.am.model.CookieSettings;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.application.ApplicationSettings;
 import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.utils.SetterUtils;
-
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -37,6 +37,7 @@ public class PatchApplicationSettings {
     private Optional<PatchApplicationAdvancedSettings> advanced;
     private Optional<PatchPasswordSettings> passwordSettings;
     private Optional<PatchMFASettings> mfa;
+    private Optional<CookieSettings> cookieSettings;
 
     public Optional<AccountSettings> getAccount() {
         return account;
@@ -78,6 +79,14 @@ public class PatchApplicationSettings {
         this.passwordSettings = passwordSettings;
     }
 
+    public Optional<CookieSettings> getCookieSettings() {
+        return cookieSettings;
+    }
+
+    public void setCookieSettings(Optional<CookieSettings> cookieSettings) {
+        this.cookieSettings = cookieSettings;
+    }
+
     public Optional<PatchMFASettings> getMfa() {
         return mfa;
     }
@@ -93,6 +102,7 @@ public class PatchApplicationSettings {
         // set values
         SetterUtils.safeSet(toPatch::setAccount, this.getAccount());
         SetterUtils.safeSet(toPatch::setLogin, this.getLogin());
+        SetterUtils.safeSet(toPatch::setCookieSettings, this.getCookieSettings());
         if (this.getOauth() != null && this.getOauth().isPresent()) {
             toPatch.setOauth(this.getOauth().get().patch(toPatch.getOauth()));
         }
@@ -105,6 +115,7 @@ public class PatchApplicationSettings {
         if (this.getMfa() != null && this.getMfa().isPresent()) {
             toPatch.setMfa(this.getMfa().get().patch(toPatch.getMfa()));
         }
+
         return toPatch;
     }
 
@@ -116,7 +127,9 @@ public class PatchApplicationSettings {
                 || login != null && login.isPresent()
                 || advanced != null && advanced.isPresent()
                 || passwordSettings != null && passwordSettings.isPresent()
-                || mfa != null && mfa.isPresent()) {
+                || mfa != null && mfa.isPresent()
+                || cookieSettings != null && cookieSettings.isPresent()
+        ) {
             requiredPermissions.add(Permission.APPLICATION_SETTINGS);
         }
 

--- a/gravitee-am-ui/src/app/app-routing.module.ts
+++ b/gravitee-am-ui/src/app/app-routing.module.ts
@@ -210,6 +210,7 @@ import { BotDetectionPluginsResolver } from './resolvers/bot-detection-plugins.r
 import { BotDetectionComponent } from './domain/settings/botdetections/bot-detection/bot-detection.component';
 import { BotDetectionResolver } from './resolvers/bot-detection.resolver';
 import { ScopesAllResolver } from "./resolvers/scopes-all.resolver";
+import { ApplicationCookieSettingsComponent } from './domain/applications/application/advanced/cookie/cookie.component';
 
 let applyOnLabel = (label) => label.toLowerCase().replace(/_/g, ' ');
 
@@ -1140,6 +1141,20 @@ export const routes: Routes = [
                                 data: {
                                   menu: {
                                     label: 'Password policy',
+                                    section: 'Security'
+                                  },
+                                  perms: {
+                                    only: ['application_settings_read']
+                                  }
+                                }
+                              },
+                              {
+                                path: 'session',
+                                component: ApplicationCookieSettingsComponent,
+                                canActivate: [AuthGuard],
+                                data: {
+                                  menu: {
+                                    label: 'Session management',
                                     section: 'Security'
                                   },
                                   perms: {

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -332,6 +332,7 @@ import {ApplicationResourcePolicyComponent} from './domain/applications/applicat
 import {ApplicationResourcePolicyResolver} from './resolvers/application-resource-policy.resolver';
 import {LoginSettingsComponent} from './domain/components/login/login-settings.component';
 import {ApplicationLoginSettingsComponent} from './domain/applications/application/advanced/login/login.component';
+import {ApplicationCookieSettingsComponent} from './domain/applications/application/advanced/cookie/cookie.component';
 import {ApplicationFlowsComponent} from './domain/applications/application/design/flows/flows.component';
 import {IdentitiesResolver} from './resolvers/identities.resolver';
 import {PluginPoliciesResolver} from './resolvers/plugin-policies.resolver';
@@ -372,6 +373,7 @@ import { BotDetectionFormComponent } from './domain/settings/botdetections/bot-d
 import { BotDetectionResolver } from './resolvers/bot-detection.resolver';
 import { ScopesAllResolver } from "./resolvers/scopes-all.resolver";
 import { GvFormControlDirective } from "./directives/gv-form-control.directive";
+import { CookieSettingsComponent } from "./domain/components/cookie/cookie-settings.component";
 
 @NgModule({
   declarations: [
@@ -540,6 +542,7 @@ import { GvFormControlDirective } from "./directives/gv-form-control.directive";
     ApplicationResourceComponent,
     ApplicationResourcePolicyComponent,
     ApplicationLoginSettingsComponent,
+    ApplicationCookieSettingsComponent,
     ApplicationFlowsComponent,
     ManagementRolesComponent,
     ManagementRoleComponent,
@@ -560,6 +563,7 @@ import { GvFormControlDirective } from "./directives/gv-form-control.directive";
     UserAvatarComponent,
     NotFoundComponent,
     UmaComponent,
+    CookieSettingsComponent,
     LoginSettingsComponent,
     UsersSearchInfoDialog,
     NewsletterComponent,

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/cookie/cookie.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/cookie/cookie.component.html
@@ -1,0 +1,34 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div>
+  <div>
+    <div fxFlex="70">
+      <app-cookie-settings [cookieSettings]="cookieSettings"
+                          [inheritMode]="true"
+                          [readonly]="readonly"
+                          (onSavedCookieSettings)="updateCookieSettings($event)">
+      </app-cookie-settings>
+    </div>
+    <div class="gv-page-description" fxFlex>
+      <h3>Session management</h3>
+      <div class="gv-page-description-content">
+        <p>Features to handle session settings</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/cookie/cookie.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/cookie/cookie.component.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { ApplicationCookieSettingsComponent } from './cookie.component';
+
+describe('ApplicationCookieSettingsComponent', () => {
+  let component: ApplicationCookieSettingsComponent;
+  let fixture: ComponentFixture<ApplicationCookieSettingsComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ApplicationCookieSettingsComponent ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ApplicationCookieSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/cookie/cookie.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/cookie/cookie.component.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {ApplicationService} from '../../../../../services/application.service';
+import {SnackbarService} from '../../../../../services/snackbar.service';
+import {AuthService} from '../../../../../services/auth.service';
+
+@Component({
+  selector: 'app-application-cookie-settings',
+  templateUrl: './cookie.component.html',
+  styleUrls: ['./cookie.component.scss']
+})
+export class ApplicationCookieSettingsComponent implements OnInit {
+  private domainId: string;
+  application: any;
+  cookieSettings: any;
+  readonly = false;
+
+  constructor(private route: ActivatedRoute,
+              private applicationService: ApplicationService,
+              private authService: AuthService,
+              private snackbarService: SnackbarService) {
+  }
+
+  ngOnInit() {
+    this.domainId = this.route.snapshot.data['domain']?.id;
+    this.application = this.route.snapshot.data['application'];
+    this.cookieSettings = this.application.settings.cookieSettings || {'inherited': true};
+    this.readonly = !this.authService.hasPermissions(['application_settings_update']);
+  }
+
+  updateCookieSettings(cookieSettings) {
+    this.cookieSettings = cookieSettings;
+    this.applicationService.patch(this.domainId, this.application.id,
+      {'settings': {'cookieSettings': cookieSettings}}).subscribe(data => {
+      this.application = data;
+      this.route.snapshot.data['application'] = this.application;
+      this.snackbarService.open('Application updated');
+    });
+  }
+}

--- a/gravitee-am-ui/src/app/domain/components/cookie/cookie-settings.component.html
+++ b/gravitee-am-ui/src/app/domain/components/cookie/cookie-settings.component.html
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form (ngSubmit)="save()" fxLayout="column">
+  <div *ngIf="inheritMode" fxLayout="column" class="gv-form-section">
+    <div fxLayout="column">
+        <mat-slide-toggle
+        (change)="enableInheritMode($event)"
+        [checked]="isInherited()" [disabled]="readonly">
+        Inherit configuration
+      </mat-slide-toggle>
+      <mat-hint style="font-size: 75%;">Inherit session settings from the platform settings.</mat-hint>
+    </div>
+  </div>
+
+  <div *ngIf="!inheritMode || !cookieSettings.inherited">
+    <div class="gv-form-section">
+      <div fxLayout="column">
+        <mat-slide-toggle
+          (change)="enableSessionPersistent($event)"
+          [checked]="isSessionPersistent()" [disabled]="readonly">
+          Persistent session
+        </mat-slide-toggle>
+        <mat-hint style="font-size: 75%;">Enable persistent session cookie settings. If set to <b>false</b>, the session will be evicted by the browser when closed.</mat-hint>
+      </div>
+    </div>
+  </div>
+
+  <div fxLayout="row" *ngIf="!readonly">
+    <button mat-raised-button color="primary" [disabled]="(!formChanged)" type="submit">SAVE</button>
+  </div>
+</form>

--- a/gravitee-am-ui/src/app/domain/components/cookie/cookie-settings.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/components/cookie/cookie-settings.component.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { CookieSettingsComponent } from './cookie-settings.component';
+
+describe('LoginSettingsComponent', () => {
+  let component: CookieSettingsComponent;
+  let fixture: ComponentFixture<CookieSettingsComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CookieSettingsComponent ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CookieSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/gravitee-am-ui/src/app/domain/components/cookie/cookie-settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/cookie/cookie-settings.component.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+
+@Component({
+  selector: 'app-cookie-settings',
+  templateUrl: './cookie-settings.component.html',
+  styleUrls: ['./cookie-settings.component.scss']
+})
+export class CookieSettingsComponent implements OnInit, OnChanges {
+  @Output() onSavedCookieSettings = new EventEmitter<any>();
+  @Input() cookieSettings: any;
+  @Input() inheritMode = false;
+  @Input() readonly = false;
+  formChanged = false;
+  private domainId: string;
+
+  constructor(private route: ActivatedRoute) {
+  }
+
+  ngOnInit(): void {
+    this.domainId = this.route.snapshot.data['domain']?.id;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.cookieSettings.previousValue && changes.cookieSettings.currentValue) {
+      this.cookieSettings = changes.cookieSettings.currentValue;
+    }
+  }
+
+  save() {
+    let cookieSettings = Object.assign({}, this.cookieSettings);
+    if (cookieSettings.inherited) {
+      cookieSettings = {'inherited': true};
+    } else {
+      if (!cookieSettings.session) {
+        cookieSettings.session = {'persistent': false};
+      }
+    }
+    this.onSavedCookieSettings.emit(cookieSettings);
+    this.formChanged = false;
+  }
+
+  enableInheritMode(event) {
+    this.cookieSettings.inherited = event.checked;
+    this.formChanged = true;
+  }
+
+  isInherited() {
+    return this.cookieSettings && this.cookieSettings.inherited;
+  }
+
+  isSessionPersistent() {
+    return this.cookieSettings.session && this.cookieSettings.session.persistent;
+  }
+
+  enableSessionPersistent($event) {
+    if (!this.cookieSettings.session) {
+      this.cookieSettings.session = {};
+    }
+    this.cookieSettings.session.persistent = $event.checked;
+    this.formChanged = true;
+  }
+}


### PR DESCRIPTION
fixes https://github.com/gravitee-io/issues/issues/7526

This PR brings session persistence configuration at application level.

## How to Test

### First case : Inherited Configuration
![image](https://user-images.githubusercontent.com/8531515/164556974-ec926872-13f9-4d55-8680-37cfc0640dd2.png)

- Login to AM console
- Go to `Application > Your App > Settings > Cookie Settings`
- Configure your Cookie Settings with `Inherited Configuration`
- Initiate the login flow (`/domain/oauth/authorize`) and login normally
- Once logged in close your browser entirely
- Initiate the login flow (`/domain/oauth/authorize`

Result: You should be able to be redirected automatically without a second login

### Second case: Non persisted session

<img width="1777" alt="Screenshot 2022-04-21 at 23 34 11" src="https://user-images.githubusercontent.com/8531515/164556753-573e9a42-c967-4cb7-969f-7f505423d5a0.png">

- Login to AM console
- Go to `Application > Your App > Settings > Cookie Settings`
- Configure your Cookie Settings with `Persistent session` to `false`
- Initiate the login flow (`/domain/oauth/authorize`) and login normally
- Once logged in close your browser entirely
- Initiate the login flow (`/domain/oauth/authorize`) and login normally

Result: You should be redirected to `/login`

### Third case: Persisted session

![image](https://user-images.githubusercontent.com/8531515/164557622-ccda6876-57eb-42d9-b0bc-ec5f7d9c99d2.png)

- Login to AM console
- Go to `Application > Your App > Settings > Cookie Settings`
- Configure your Cookie Settings with `Persistent session` to `true`
- Initiate the login flow (`/domain/oauth/authorize`) and login normally
- Once logged in close your browser entirely
- Initiate the login flow (`/domain/oauth/authorize`

Result: You should be able to be redirected automatically without a second login