### PR TITLE
chore: resource class update

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -109,7 +109,7 @@ commands:
                       }
                     ]
                   }
-                event: fail   
+                event: always   
 jobs:
   keeper:
     docker:
@@ -147,7 +147,7 @@ jobs:
   build:
     docker:
       - image: cimg/openjdk:17.0.1
-    resource_class: xlarge
+    resource_class: large
     steps:
       - attach_workspace:
           at: /tmp
@@ -307,7 +307,7 @@ jobs:
       os_name: "ubuntu"
       os_version: "2004"
       os_patch: "202101-01"
-      machine_size: "xlarge"
+      machine_size: "large"
 
     steps:
       - attach_workspace:
@@ -543,7 +543,7 @@ jobs:
   coverage_build:
     docker:
       - image: cimg/openjdk:17.0.1
-    resource_class: xlarge
+    resource_class: large
     steps:
       - attach_workspace:
           at: /tmp
@@ -611,7 +611,7 @@ workflows:
           # container_gun_image_org: 'cimg'
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '17.0.1'
-          container_size: 'xlarge'
+          container_size: 'large'
           filters:
             branches:
               ignore:


### PR DESCRIPTION
Updated resource class - xlarge to large. Now only sonarcloud is using xlarge as it is failing when we are running with large due to memory. Also updated slack notification for snyk scan as always instead of fail as it is now notifying the scan result in slack.  Notification only on failure is something we are working with circleci to check the feature of adding condition in steps

https://app.zenhub.com/workspaces/graviteeio---access-management-5b17f74af58c642fb89cc49f/issues/gravitee-io/issues/7579