### PR TITLE
fix: mask password in sensitive URI

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
@@ -6,7 +6,8 @@
       "type" : "string",
       "default": "mongodb://localhost:27017",
       "title": "MongoDB connection URI",
-      "description": "Connection URI used to connect to a MongoDB instance."
+      "description": "Connection URI used to connect to a MongoDB instance.",
+      "sensitive-uri": true
     },
     "host" : {
       "type" : "string",

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AbstractSensitiveProxy.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AbstractSensitiveProxy.java
@@ -18,10 +18,16 @@ package io.gravitee.am.management.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.base.Strings;
 
+import java.net.URI;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.quote;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
@@ -33,6 +39,7 @@ public abstract class AbstractSensitiveProxy {
 
     private static final String PROPERTIES_SCHEMA_KEY = "properties";
     private static final String SENSITIVE_SCHEMA_KEY = "sensitive";
+    private static final String SENSITIVE_URI_SCHEMA_KEY = "sensitive-uri";
 
     protected static final String SENSITIVE_VALUE = "********";
     protected static final Pattern SENSITIVE_VALUE_PATTERN = Pattern.compile("^(\\*+)$");
@@ -47,6 +54,13 @@ public abstract class AbstractSensitiveProxy {
             properties.forEachRemaining(entry -> {
                 if (isSensitive(entry)) {
                     ((ObjectNode) configurationNode).put(entry.getKey(), SENSITIVE_VALUE);
+                }
+                if (isSensitiveUri(entry) && configurationNode.get(entry.getKey()) instanceof TextNode) {
+                    final String uri = configurationNode.get(entry.getKey()).asText();
+                    final String userInfo = URI.create(uri).getUserInfo();
+                    extractUriPassword(userInfo).ifPresent(passwordToHide ->
+                        ((ObjectNode) configurationNode).put(entry.getKey(), uri.replaceFirst(quote(passwordToHide), SENSITIVE_VALUE))
+                    );
                 }
             });
             configurationSetter.accept(configurationNode.toString());
@@ -101,11 +115,43 @@ public abstract class AbstractSensitiveProxy {
             if (isSensitive(entry) && !valueIsUpdatable(updatedConfigurationNode, entry) && updatedConfigurationNode.isObject()) {
                 ((ObjectNode) updatedConfigurationNode).set(entry.getKey(), oldConfigurationNode.get(entry.getKey()));
             }
+            if (isSensitiveUri(entry) && updatedConfigurationNode.isObject()) {
+                final JsonNode newUri = updatedConfigurationNode.get(entry.getKey());
+                if (newUri != null && !Strings.isNullOrEmpty(newUri.asText())) {
+                    final String incomingUserInfo = URI.create(newUri.asText()).getUserInfo();
+                    final JsonNode olrUriNode = oldConfigurationNode.get(entry.getKey());
+                    if (olrUriNode != null && !Strings.isNullOrEmpty(olrUriNode.asText())) {
+                        extractUriPassword(incomingUserInfo).ifPresent(newPassword -> {
+                            if (SENSITIVE_VALUE_PATTERN.matcher(newPassword).matches()) {
+                                final String oldUserInfo = URI.create(olrUriNode.asText()).getUserInfo();
+                                extractUriPassword(oldUserInfo).or(() -> Optional.of(""))
+                                        .ifPresent(oldPwd -> ((ObjectNode) updatedConfigurationNode).put(entry.getKey(), newUri.asText().replaceFirst(quote(newPassword), oldPwd)));
+                            }
+                        });
+                    }
+                }
+            }
         };
+    }
+
+    private Optional<String> extractUriPassword(String userInfo) {
+        Optional<String> result = Optional.empty();
+        if (!Strings.isNullOrEmpty(userInfo)) {
+            final int index = userInfo.indexOf(":");
+            if (index != -1) {
+                final String pwd = userInfo.substring(index+1);
+                result = Optional.of(pwd.trim());
+            }
+        }
+        return result;
     }
 
     protected boolean isSensitive(Entry<String, JsonNode> entry) {
         return entry.getValue().has(SENSITIVE_SCHEMA_KEY) && entry.getValue().get(SENSITIVE_SCHEMA_KEY).asBoolean();
+    }
+
+    protected boolean isSensitiveUri(Entry<String, JsonNode> entry) {
+        return entry.getValue().has(SENSITIVE_URI_SCHEMA_KEY) && entry.getValue().get(SENSITIVE_URI_SCHEMA_KEY).asBoolean();
     }
 
     protected boolean valueIsUpdatable(JsonNode configNode, Entry<String, JsonNode> entry) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/SensitiveDataMaskingTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/SensitiveDataMaskingTest.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.management.service.AbstractSensitiveProxy;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+
+public class SensitiveDataMaskingTest extends AbstractSensitiveProxy {
+
+    private static final String URI_WITHOUT_USERINFO = "mongodb+srv://hostname/dbname?retryWrites=true&w=majority&connectTimeoutMS=10000&maxIdleTimeMS=30000";
+
+    private static final String URI_WITH_USERNAME = "mongodb+srv://user@hostname/dbname?retryWrites=true&w=majority&connectTimeoutMS=10000&maxIdleTimeMS=30000";
+
+    private static final String URI_WITH_CREDENTIALS = "mongodb+srv://user:password@hostname/dbname?retryWrites=true&w=majority&connectTimeoutMS=10000&maxIdleTimeMS=30000";
+
+    private static final String URI_WITH_CREDENTIALS_EMPTY_PWD = "mongodb+srv://user:@hostname/dbname?retryWrites=true&w=majority&connectTimeoutMS=10000&maxIdleTimeMS=30000";
+
+    private static final String URI_WITH_UPDATED_CREDENTIALS = "mongodb+srv://user:password@hostname/dbname?retryWrites=true&w=majority&connectTimeoutMS=10000&maxIdleTimeMS=30000";
+
+    private static final String URI_WITH_MASKED_PWD = "mongodb+srv://user:"+SENSITIVE_VALUE+"@hostname/dbname?retryWrites=true&w=majority&connectTimeoutMS=10000&maxIdleTimeMS=30000";
+
+    private static final String TESTABLE_SCHEMA = "{\n" +
+            "  \"type\" : \"object\",\n" +
+            "  \"id\" : \"urn:jsonschema:io:gravitee:am:identityprovider:mongo:MongoIdentityProviderConfiguration\",\n" +
+            "  \"properties\" : {\n" +
+            "    \"uri\" : {\n" +
+            "      \"type\" : \"string\",\n" +
+            "      \"default\": \"mongodb://localhost:27017\",\n" +
+            "      \"title\": \"MongoDB connection URI\",\n" +
+            "      \"description\": \"Connection URI used to connect to a MongoDB instance.\",\n" +
+            "      \"sensitive-uri\": true\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private JsonNode schema = null;
+
+    @Before
+    public void init() throws Exception {
+        this.schema = objectMapper.readTree(TESTABLE_SCHEMA);
+    }
+
+    @Test
+    public void shouldNoFilter_NullURI() throws Exception {
+        final JsonNode config = objectMapper.readTree("{}");
+        filterSensitiveData(schema, config, (maskedConfig) -> {
+            assertUriEquals("URI should be null", null, maskedConfig);
+        });
+    }
+
+    @Test
+    public void shouldNoFilter_EmptyURI() throws Exception {
+        final JsonNode config = objectMapper.readTree("{ \"uri\" : \"\"}");
+        filterSensitiveData(schema, config, (maskedConfig) -> {
+            assertUriEquals("URI should be empty", "", maskedConfig);
+        });
+    }
+
+    @Test
+    public void shouldFilter_URI_withPassword() throws Exception {
+        final JsonNode config = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_CREDENTIALS + "\"}");
+        filterSensitiveData(schema, config, (maskedConfig) -> {
+            assertUriEquals("Password must be replace by '*'", URI_WITH_MASKED_PWD, maskedConfig);
+        });
+    }
+
+    @Test
+    public void shouldNoFilter_URI_withoutPassword() throws Exception {
+        final JsonNode config = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_USERNAME + "\"}");
+        filterSensitiveData(schema, config, (maskedConfig) -> {
+            assertUriEquals("URI should be the same", URI_WITH_USERNAME, maskedConfig);
+        });
+    }
+
+    @Test
+    public void shouldNoFilter_URI_withoutUserInfo() throws Exception {
+        final JsonNode config = objectMapper.readTree("{ \"uri\": \"" + URI_WITHOUT_USERINFO + "\"}");
+        filterSensitiveData(schema, config, (maskedConfig) -> {
+            assertUriEquals("URI should be the same", URI_WITHOUT_USERINFO, maskedConfig);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_withoutUserInfo() throws Exception {
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITHOUT_USERINFO + "custom-param=toto\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITHOUT_USERINFO+ "\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            assertUriEquals("URI should be updated", URI_WITHOUT_USERINFO+ "custom-param=toto", uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_withoutUserInfo_With_multipleWildcard() throws Exception {
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITHOUT_USERINFO + "custom-param=*******\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITHOUT_USERINFO+ "\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            assertUriEquals("URI should be updated", URI_WITHOUT_USERINFO+ "custom-param=*******", uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_withoutUserPassword() throws Exception {
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_USERNAME + "custom-param=toto\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_USERNAME + "\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            assertUriEquals("URI should be updated", URI_WITH_USERNAME + "custom-param=toto", uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_withoutUserPassword_With_multipleWildcard() throws Exception {
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_USERNAME + "custom-param=*******\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_USERNAME + "\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            assertUriEquals("URI should be updated", URI_WITH_USERNAME + "custom-param=*******", uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_withUserPassword_And_PreservePassword() throws Exception {
+        // receive new URI (additional param) but with masked Password
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_MASKED_PWD + "custom-param=toto\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_CREDENTIALS + "\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            // the final value must be the uri with password present into the old value
+            assertUriEquals("URI should be updated with previous password", URI_WITH_CREDENTIALS + "custom-param=toto", uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldNotUpdate_URI_withUserPassword_IfNoChanges() throws Exception {
+        // receive new URI (additional param) but with masked Password
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_MASKED_PWD + "\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_CREDENTIALS + "\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            // the final value must be the uri with password present into the old value
+            assertUriEquals("URI should not be updated", URI_WITH_CREDENTIALS, uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_withUserPassword_And_UpdatePassword() throws Exception {
+        // receive new URI (additional param) but with new Password
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_UPDATED_CREDENTIALS + "custom-param=toto\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_CREDENTIALS + "\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            // the final value must be the new uri without change
+            assertUriEquals("URI should be updated with the new value", URI_WITH_UPDATED_CREDENTIALS + "custom-param=toto", uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_withUserEmptyPassword_And_UpdatePassword() throws Exception {
+        // receive new URI (additional param) but with new Password
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_CREDENTIALS_EMPTY_PWD + "custom-param=toto\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_CREDENTIALS + "\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            // the final value must be the new uri without change
+            assertUriEquals("URI should be updated with the new value", URI_WITH_CREDENTIALS_EMPTY_PWD + "custom-param=toto", uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_withUserPassword_Previous_Uri_Null() throws Exception {
+        // receive new URI (additional param) but with masked Password
+        final JsonNode newConfig = objectMapper.readTree("{ \"uri\": \"" + URI_WITH_CREDENTIALS + "custom-param=toto\"}");
+        final JsonNode oldConfig = objectMapper.readTree("{}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            // the final value must be the uri with password present into the old value
+            assertUriEquals("URI should be updated with previous password", URI_WITH_CREDENTIALS + "custom-param=toto", uriToUpdate);
+        });
+    }
+
+    @Test
+    public void shouldUpdate_URI_WithNullValue() throws Exception {
+        // receive new URI (additional param) but with masked Password
+        final JsonNode newConfig = objectMapper.readTree("{}");
+        final JsonNode oldConfig = objectMapper.readTree("{\"uri\": \"" + URI_WITH_CREDENTIALS + "custom-param=toto\"}");
+
+        updateSensitiveData(newConfig, oldConfig, schema, (uriToUpdate) -> {
+            // the final value must be the uri with password present into the old value
+            assertUriEquals("URI should be updated with null uri", null, uriToUpdate);
+        });
+    }
+
+    private void assertUriEquals(String message, String expectedValue, String processedConfig) {
+        try {
+            assertEquals(message, expectedValue, (String)objectMapper.readValue(processedConfig, Map.class).get("uri"));
+        } catch (Exception e) {
+            fail();
+        }
+    }
+}

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/resources/schemas/schema-form.json
@@ -6,7 +6,8 @@
       "type" : "string",
       "default": "mongodb://localhost:27017",
       "title": "MongoDB connection URI",
-      "description": "Connection URI used to connect to a MongoDB instance."
+      "description": "Connection URI used to connect to a MongoDB instance.",
+      "sensitive-uri": true
     },
     "host" : {
       "type" : "string",


### PR DESCRIPTION
fixes gravitee-io/issues#7482

The purpose of this PR is to mask the user password when present into the connection URI of a plugin (IDP, reporter...)

![image](https://user-images.githubusercontent.com/3110552/166308563-91fe5b31-352f-42ef-b189-c0ce60f1ba98.png)

On update, 
* if the value provided by the frontend contains only '*', the old password is reused
* if the value provided by the frontend is the same as the one provided by the GET method, the value is not updated (into DB password isn't replace by wilcard)
* if the value doesn't contains only wildcard into the user password, the URI is updated and the new password is persisted