### PR TITLE
fix: update user data from IDP response

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationManagerImpl.java
@@ -256,6 +256,7 @@ public class UserAuthenticationManagerImpl implements UserAuthenticationManager 
                     Map<String, Object> additionalInformation = user.getAdditionalInformation() == null ? new HashMap<>() : new HashMap<>(user.getAdditionalInformation());
                     additionalInformation.put("source", authProvider);
                     additionalInformation.put(Parameters.CLIENT_ID, client.getId());
+                    ((DefaultUser) user).setAdditionalInformation(additionalInformation);
                     return new UserAuthentication(user, null);
                 })
                 .onErrorResumeNext(error -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationManagerImpl.java
@@ -256,7 +256,6 @@ public class UserAuthenticationManagerImpl implements UserAuthenticationManager 
                     Map<String, Object> additionalInformation = user.getAdditionalInformation() == null ? new HashMap<>() : new HashMap<>(user.getAdditionalInformation());
                     additionalInformation.put("source", authProvider);
                     additionalInformation.put(Parameters.CLIENT_ID, client.getId());
-                    ((DefaultUser) user).setAdditionalInformation(additionalInformation);
                     return new UserAuthentication(user, null);
                 })
                 .onErrorResumeNext(error -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
@@ -64,6 +64,9 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserAuthenticationServiceImpl.class);
     private static final String SOURCE_FIELD = "source";
+    private static final String FIRST_NAME = "firstName";
+    private static final String LAST_NAME = "lastName";
+    private static final String EMAIL = "email";
 
     @Autowired
     private Domain domain;
@@ -268,6 +271,15 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
             user.setSource((String) extraInformation.remove(SOURCE_FIELD));
             user.setClient((String) extraInformation.remove(Parameters.CLIENT_ID));
             user.setAdditionalInformation(extraInformation);
+            if (additionalInformation.containsKey(FIRST_NAME)) {
+                user.setFirstName((String) additionalInformation.get(FIRST_NAME));
+            }
+            if (additionalInformation.containsKey(LAST_NAME)) {
+                user.setLastName((String) additionalInformation.get(LAST_NAME));
+            }
+            if (additionalInformation.containsKey(EMAIL)) {
+                user.setEmail((String) additionalInformation.get(EMAIL));
+            }
         }
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
@@ -71,8 +71,7 @@ public class UserAuthenticationServiceTest {
         io.gravitee.am.identityprovider.api.User user = mock(io.gravitee.am.identityprovider.api.User.class);
         when(user.getUsername()).thenReturn(username);
         when(user.getId()).thenReturn(id);
-        HashMap<String, Object> additionalInformation = new HashMap<>();
-        additionalInformation.put("source", source);
+        HashMap<String, Object> additionalInformation = getAdditionalInformation(source);
         additionalInformation.put("op_id_token", "somevalue");
         when(user.getAdditionalInformation()).thenReturn(additionalInformation);
 
@@ -90,8 +89,26 @@ public class UserAuthenticationServiceTest {
 
         testObserver.assertComplete();
         testObserver.assertNoErrors();
-        verify(userService, times(1)).create(argThat(u -> u.getAdditionalInformation().containsKey("op_id_token")));
+        verify(userService, times(1)).create(userAssert());
         verify(userService, never()).update(any());
+    }
+
+    private User userAssert() {
+        return argThat(user ->
+                user.getAdditionalInformation().containsKey("op_id_token") &&
+                user.getFirstName().equals("Bob") &&
+                user.getLastName().equals("Test") &&
+                user.getEmail().equals("bob@test.com")
+        );
+    }
+
+    private HashMap<String, Object> getAdditionalInformation(String source) {
+        HashMap<String, Object> additionalInformation = new HashMap<>();
+        additionalInformation.put("source", source);
+        additionalInformation.put("firstName", "Bob");
+        additionalInformation.put("lastName", "Test");
+        additionalInformation.put("email", "bob@test.com");
+        return additionalInformation;
     }
 
     @Test


### PR DESCRIPTION
## :id:  
fixes gravitee-io/issues#7647

## :pencil2: A description of the changes proposed in the pull request
This fixes a bug where `UserAuthenticationService` was not parsing IDP responses for key fields such as email, username etc., and was only updating a user's additional properties. With this fix, a user profile will be updated whenever corresponding values are updated at the IDP.