### PR TITLE
fix: addition of gateway setting to manage nonce value for inline js …

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -149,4 +149,6 @@ public interface ConstantKeys {
     String HTTP_SSL_ALIASES_ENDPOINTS_CIBA = "backchannel_authentication_endpoint";
 
     String CIBA_AUTH_REQUEST_KEY = "ciba_authentication_request";
+
+    String CSP_SCRIPT_INLINE_NONCE = "script_inline_nonce";
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSPHandlerFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSPHandlerFactory.java
@@ -33,6 +33,8 @@ public class CSPHandlerFactory implements FactoryBean<CSPHandler> {
 
     private static final String HTTP_CSP_REPORT_ONLY = "http.csp.reportOnly";
     private static final String HTTP_CSP_DIRECTIVES = "http.csp.directives[%d]";
+    private static final String HTTP_CSP_SCRIPT_INLINE_NONCE = "http.csp.script-inline-nonce";
+
     private final Environment environment;
 
     private static CSPHandler INSTANCE;
@@ -46,10 +48,11 @@ public class CSPHandlerFactory implements FactoryBean<CSPHandler> {
         if (isNull(INSTANCE)) {
             var reportOnly = environment.getProperty(HTTP_CSP_REPORT_ONLY, Boolean.class);
             var directives = getDirectives();
-            if (isNull(reportOnly) && isNull(directives)) {
+            var scriptInlineNonce = environment.getProperty(HTTP_CSP_SCRIPT_INLINE_NONCE, Boolean.class, false);
+            if (isNull(reportOnly) && isNull(directives) && !scriptInlineNonce) {
                 INSTANCE = new NoOpCspHandler();
             } else {
-                INSTANCE = new CspHandlerImpl(reportOnly, directives);
+                INSTANCE = new CspHandlerImpl(reportOnly, directives, scriptInlineNonce);
             }
         }
         return INSTANCE;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/csp/CspHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/csp/CspHandlerImpl.java
@@ -16,13 +16,16 @@
 
 package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.csp;
 
+import io.gravitee.am.common.utils.SecureRandomString;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.CSPHandler;
 import io.vertx.reactivex.ext.web.RoutingContext;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
+import static io.gravitee.am.common.utils.ConstantKeys.CSP_SCRIPT_INLINE_NONCE;
 import static java.lang.Boolean.TRUE;
 import static java.util.Objects.nonNull;
 
@@ -31,23 +34,41 @@ import static java.util.Objects.nonNull;
  * @author GraviteeSource Team
  */
 public class CspHandlerImpl implements CSPHandler {
-
+    public static final int NONCE_LENGTH = 32;
+    public static final String NONCE_PREFIX = "'nonce-";
+    public static final String NONCE_SUFIX = "'";
+    public static final String SCRIPT_SRC_DIRECTIVE = "script-src";
+    private final boolean scriptInlineNonce;
     private final io.vertx.reactivex.ext.web.handler.CSPHandler delegate;
 
-    public CspHandlerImpl(Boolean isReportOnly, List<String> directives) {
+    private String staticScriptSrcDirective;
+
+    public CspHandlerImpl(Boolean isReportOnly, List<String> directives, boolean scriptInlineNonce) {
         // adds "default-src": "self" as default configuration
         this.delegate = io.vertx.reactivex.ext.web.handler.CSPHandler.create().setReportOnly(TRUE.equals(isReportOnly));
+        this.scriptInlineNonce = scriptInlineNonce;
         addDirectives(directives);
     }
 
     private void addDirectives(List<String> directives) {
         if (nonNull(directives) && directives.size() > 0) {
-            directives.stream().map(directive -> directive.split("[ \t]", 2))
-                    .filter(directive -> directive.length == 2)
-                    .map(this::getDirectiveEntry)
+            final Map<String, String> mapOfDirectives = buildDirectivesMap(directives);
+
+            if (mapOfDirectives.containsKey(SCRIPT_SRC_DIRECTIVE)) {
+                this.staticScriptSrcDirective = mapOfDirectives.get(SCRIPT_SRC_DIRECTIVE);
+            }
+
+            mapOfDirectives.entrySet().stream()
                     .filter(e -> !e.getKey().isEmpty() && !e.getValue().isEmpty())
                     .forEach(e -> this.delegate.addDirective(e.getKey(), e.getValue()));
         }
+    }
+
+    private Map<String, String> buildDirectivesMap(List<String> directives) {
+        return directives.stream().map(directive -> directive.split("[ \t]", 2))
+                .filter(directive -> directive.length == 2)
+                .map(this::getDirectiveEntry)
+                .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
     }
 
     private Entry<String, String> getDirectiveEntry(String[] directive) {
@@ -60,6 +81,13 @@ public class CspHandlerImpl implements CSPHandler {
 
     @Override
     public void handle(RoutingContext event) {
+        if (this.scriptInlineNonce) {
+            final String nonce = SecureRandomString.randomAlphaNumeric(NONCE_LENGTH);
+            event.put(CSP_SCRIPT_INLINE_NONCE, nonce);
+            // reset the scriptDirective to avoid accumulation of nonce values
+            this.delegate.setDirective(SCRIPT_SRC_DIRECTIVE, this.staticScriptSrcDirective);
+            this.delegate.addDirective(SCRIPT_SRC_DIRECTIVE, NONCE_PREFIX + nonce + NONCE_SUFIX);
+        }
         this.delegate.handle(event);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/forgot_password.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/forgot_password.html
@@ -77,7 +77,7 @@
 <![endif]-->
 <script th:src="@{assets/material/material.min.js}"></script>
 <script th:src="@{assets/js/jquery-3.5.1.min.js}"></script>
-<script th:inline="javascript">
+<script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
  $(document).ready(function (){
     $(".mdl-textfield__input").focus(function (){
         if( !this.value ){

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html
@@ -70,7 +70,7 @@
 <![endif]-->
 <script th:src="@{../assets/material/material.min.js}"></script>
 <script th:src="@{../assets/js/jquery-3.5.1.min.js}"></script>
-<script th:inline="javascript">
+<script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
     $(".mdl-textfield__input").focus(function (){
         if( !this.value ){
             $(this).prop('required', true);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
@@ -102,7 +102,7 @@
     <![endif]-->
     <script th:src="@{assets/material/material.min.js}"></script>
     <script th:src="@{assets/js/jquery-3.5.1.min.js}"></script>
-    <script th:inline="javascript">
+    <script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
     $(document).ready(function (){
         $(".mdl-textfield__input").focus(function (){
             if( !this.value ){
@@ -130,7 +130,7 @@
 
     <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
             th:src="@{assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
-    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}">
+    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}" th:attr="nonce=${script_inline_nonce}">
         $(document).ready(function (){
             loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
                 if(fp.visitorId){
@@ -143,7 +143,7 @@
 
     <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
             th:src="@{assets/js/remember-device/fingerprintjs-v3.js}"></script>
-    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}">
+    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}" th:attr="nonce=${script_inline_nonce}">
         $(document).ready(function (){
             loadFingerprintJsV3(fp => {
                 if (fp.visitorId) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login_callback.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login_callback.html
@@ -12,7 +12,7 @@
     <form id="callbackForm" th:action="@{callback}" method="post">
         <input type="hidden" th:name="urlHash" id="urlhash">
     </form>
-    <script>
+    <script th:attr="nonce=${script_inline_nonce}">
         (function() {
             document.getElementById('urlhash').value = window.location.hash;
             document.getElementById('callbackForm').submit();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login_sso_spnego.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login_sso_spnego.html
@@ -7,7 +7,7 @@
     <title>Login SSO SPNEGO</title>
 </head>
 <body>
-    <script th:inline="javascript">
+    <script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
         /*<![CDATA[*/
         var actionUrl = /*[[${action}]]*/;
         window.location.replace(actionUrl);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
@@ -85,7 +85,7 @@
     <![endif]-->
     <script th:src="@{../assets/material/material.min.js}"></script>
     <script th:src="@{../assets/js/jquery-3.5.1.min.js}"></script>
-    <script>
+    <script th:attr="nonce=${script_inline_nonce}">
 
      $(document).ready(function() {
         $(".mdl-textfield__input").focus(function (){

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_enroll.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_enroll.html
@@ -86,7 +86,7 @@
                                             <i th:if="${factor.factorType == 'SMS'}" class="material-icons mdl-list__item-avatar">textsms</i>
                                             <span th:if="${phoneNumber != null}">1. Confirm your phone number </span>
                                             <span th:if="${phoneNumber == null}">1. Enter your phone number </span>
-                                            <input th:id="'phoneFact' + ${factIter.index}" type="tel" th:name="'phoneFact' + ${factIter.index}"  th:value="${phoneNumber}" th:data1="'phoneFact' + ${factIter.index}" onkeydown="javascript:hideError(this.getAttribute('data1'))">
+                                            <input th:id="'phoneFact' + ${factIter.index}" type="tel" th:name="'phoneFact' + ${factIter.index}"  th:value="${phoneNumber}" >
                                         </span>
                                     </li>
                                     <li th:id="'invalidphoneFact' + ${factIter.index}" class="mfa-enroll-error-info error">
@@ -114,7 +114,7 @@
                                             <i class="material-icons mdl-list__item-avatar">email</i>
                                             <span th:if="${emailAddress != null}">1. Confirm your email address </span>
                                             <span th:if="${emailAddress == null}">1. Enter your email address </span>
-                                            <input th:id="'emailFact' + ${factIter.index}" type="email" th:name="'emailFact' + ${factIter.index}"  th:value="${emailAddress}" th:data1="'emailFact' + ${factIter.index}" onkeydown="javascript:hideError(this.getAttribute('data1'))">
+                                            <input th:id="'emailFact' + ${factIter.index}" type="email" th:name="'emailFact' + ${factIter.index}"  th:value="${emailAddress}" >
                                         </span>
                                     </li>
                                     <li th:id="'invalidemailFact' + ${factIter.index}" class="mfa-enroll-error-info error">
@@ -168,10 +168,10 @@
                         <div class="mfa-enroll-form-actions">
                             <button th:if="${mfa_force_enrollment == false}" type="submit" name="user_mfa_enrollment" value="false" class="button--skipped">Skip for now</button>
                             <span style="flex: 1 1 0%;"></span>
-                            <button th:if="${factor.factorType == 'TOTP'}"  type="submit" th:data1="${factor.id}" th:data2="'sharedSecret' + ${factIter.index}" th:onclick="javascript:assignSharedSecret(event, this.getAttribute('data1'), this.getAttribute('data2'))" name="user_mfa_enrollment" value="true" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Next</button>
-                            <button th:if="${factor.factorType == 'SMS' || factor.factorType == 'CALL'}"  type="submit" th:data1="${factor.id}" th:data2="'phoneFact' + ${factIter.index}" th:onclick="javascript:checkPhoneNumber(event, this.getAttribute('data1'), this.getAttribute('data2'))" name="user_mfa_enrollment" value="true" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Next</button>
-                            <button th:if="${factor.factorType == 'EMAIL'}"  type="submit" th:data1="${factor.id}" th:data2="'emailFact' + ${factIter.index}" th:data3="'sharedSecret' + ${factIter.index}" th:onclick="javascript:checkEmail(event, this.getAttribute('data1'), this.getAttribute('data2'), this.getAttribute('data3'))" name="user_mfa_enrollment" value="true" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Next</button>
-                            <button th:if="${factor.factorType == 'HTTP'}"  type="submit" name="user_mfa_enrollment" value="true" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Next</button>
+                            <button th:if="${factor.factorType == 'TOTP'}" th:id="'submit' + ${factor.id}" type="submit" name="user_mfa_enrollment" value="true" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Next</button>
+                            <button th:if="${factor.factorType == 'SMS' || factor.factorType == 'CALL'}" th:id="'submit' + ${factor.id}" type="submit" name="user_mfa_enrollment" value="true" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Next</button>
+                            <button th:if="${factor.factorType == 'EMAIL'}" th:id="'submit' + ${factor.id}" type="submit" name="user_mfa_enrollment" value="true" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Next</button>
+                            <button th:if="${factor.factorType == 'HTTP'}" th:id="'submit' + ${factor.id}" type="submit" name="user_mfa_enrollment" value="true" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">Next</button>
                         </div>
                     </form>
                 </div>
@@ -185,7 +185,7 @@
 <script th:src="@{../assets/material/material.min.js}"></script>
 <script th:src="@{../assets/js/jquery-3.5.1.min.js}"></script>
 <script th:src="@{../assets/js/intl-tel-input-17.0.8.min.js}"></script>
-<script th:inline="javascript">
+<script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
 /*<![CDATA[*/
 
 const intlFields = {};
@@ -210,7 +210,7 @@ function checkPhoneNumber(event, factor, eltId) {
   }
 }
 
-function assignSharedSecret(event, factor, eltId) {
+function assignSharedSecret(factor, eltId) {
   const sharedSecret = $("#" + eltId);
   $("#"+factor).find( '#sharedSecret' )[0].value = sharedSecret.val();
   $("#"+factor).submit();
@@ -233,6 +233,7 @@ function checkEmail(event, factor, eltId, sharedSecretId) {
 }
 
 $(document).ready(function() {
+
     $(".mdl-textfield__input").focus(function() {
         if (!this.value) {
             $(this).prop('required', true);
@@ -263,9 +264,30 @@ $(document).ready(function() {
     /*[# th:each="factor,factIter: ${factors}"]*/
     if ( [[${factor.factorType}]] == 'SMS' || [[${factor.factorType}]] == 'CALL' ) {
         intlFields['phoneFact'+/*[[${factIter.index}]]*/] = initializeIntlTelInput("phoneFact"+/*[[${factIter.index}]]*/, /*[[${factor.enrollment.countries}]]*/);
+        $("#submit"+/*[[${factor.id}]]*/).click((event) => {
+             checkPhoneNumber(event, /*[[${factor.id}]]*/, 'phoneFact' + /*[[${factIter.index}]]*/);
+        });
+
+        $("#phoneFact" + /*[[${factIter.index}]]*/).keydown((event) => {
+             hideError('phoneFact' + /*[[${factIter.index}]]*/);
+        });
     }
+
     if ( [[${factor.factorType}]] == 'EMAIL' ) {
         hideError("emailFact"+/*[[${factIter.index}]]*/);
+        $("#submit"+/*[[${factor.id}]]*/).click((event) => {
+            checkEmail(event, /*[[${factor.id}]]*/, 'emailFact' + /*[[${factIter.index}]]*/, 'sharedSecret' + /*[[${factIter.index}]]*/);
+        });
+
+        $("#emailFact" + /*[[${factIter.index}]]*/).keydown((event) => {
+             hideError('emailFact' + /*[[${factIter.index}]]*/);
+        });
+    }
+
+    if ( [[${factor.factorType}]] == 'TOTP' ) {
+        $("#submit"+/*[[${factor.id}]]*/).click(() => {
+            assignSharedSecret(/*[[${factor.id}]]*/, 'sharedSecret' + /*[[${factIter.index}]]*/);
+        });
     }
     /*[/]*/
 });

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_recovery_code.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_recovery_code.html
@@ -47,7 +47,7 @@
 <script th:src="@{../assets/material/material.min.js}"></script>
 <script th:src="@{../assets/js/jquery-3.5.1.min.js}"></script>
 <script th:src="@{../assets/js/jspdf.umd.min.js}"></script>
-<script th:inline="javascript">
+<script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
     /*<![CDATA[*/
     $(document).ready(function () {
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration.html
@@ -120,7 +120,7 @@
 <![endif]-->
 <script th:src="@{assets/material/material.min.js}"></script>
 <script th:src="@{assets/js/jquery-3.5.1.min.js}"></script>
-<script th:inline="javascript">
+<script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
 
     $(document).ready(function (){
         $(".mdl-textfield__input").focus(function () {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
@@ -85,7 +85,7 @@
 <![endif]-->
 <script th:src="@{assets/material/material.min.js}"></script>
 <script th:src="@{assets/js/jquery-3.5.1.min.js}"></script>
-<script th:inline="javascript">
+<script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
 
     $(document).ready(function() {
         $(".mdl-textfield__input").focus(function (){

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/reset_password.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/reset_password.html
@@ -88,7 +88,7 @@
 <![endif]-->
 <script th:src="@{assets/material/material.min.js}"></script>
 <script th:src="@{assets/js/jquery-3.5.1.min.js}"></script>
-<script th:inline="javascript">
+<script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
 
     $(document).ready(function() {
         $(".mdl-textfield__input").focus(function () {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_login.html
@@ -61,7 +61,7 @@
 
     <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
             th:src="@{../assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
-    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}">
+    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}" th:attr="nonce=${script_inline_nonce}">
         $(document).ready(function (){
             loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
                 if(fp.visitorId){
@@ -74,7 +74,7 @@
 
     <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
             th:src="@{../assets/js/remember-device/fingerprintjs-v3.js}"></script>
-    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}">
+    <script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}" th:attr="nonce=${script_inline_nonce}">
         $(document).ready(function (){
             loadFingerprintJsV3(fp => {
                 if (fp.visitorId) {

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -89,6 +89,9 @@
 #    allow-credentials: true
 #  csp:
 #    reportOnly: false
+#    # set true if you want to include the directive 'script-src' with the nonce value generated for inline script.
+#    # to by marked by the nonce value, your inline script has to contain th:attr="nonce=${script_inline_nonce}"
+#    script-inline-nonce: false
 #    directives:
 #      - "default-src * data: blob: filesystem: about: ws: wss: 'unsafe-inline' 'unsafe-eval' 'unsafe-dynamic';"
 #      - "script-src * 'unsafe-inline' 'unsafe-eval';"


### PR DESCRIPTION
…script

fixes gravitee-io/issues#7724

## :pencil2: A description of the changes proposed in the pull request

This PR introduce a new setting for the CSP Headetrs managed by the gateway in order to generate a nonce value for each inline js script embedded into HTML templates.

Into the gravitee.yaml, the configuration parameter is available in the CSP section :
```
http:
  csp:
    script-inline-nonce: true|false
```

Into the values.yaml of the AM helm chart, the configuration parameter is available in the CSP section for the gateway settings :
```
gateway:
  http:
    csp:
      script-inline-nonce: true|false
```

## :memo: Test scenarios 

Enable this value and define directive in order to allow other resources. Then play with an Application to test all template pages.

Here is the directive I had to defined. 

```
      - "script-src http://localhost:8092/ https://cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.min.js;"
      - "style-src http://localhost:8092/ 'unsafe-inline'"
      - "img-src * data: blob: 'unsafe-inline';"
```

:warning:  Pay attention to the MFA enrollment in particular as there are more changes on this page
