### PR TITLE
feat(backend): risk assessment in application settings

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -236,7 +236,7 @@ jobs:
     docker:
       - image: cimg/openjdk:17.0.1-node
       - image: mongo:4.2
-    resource_class: small
+    resource_class: medium
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -288,7 +288,7 @@ jobs:
       - image: postgres:14-alpine
         environment:
           POSTGRES_PASSWORD: T0pS3cr3t
-    resource_class: small
+    resource_class: medium
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationResource.java
@@ -321,6 +321,7 @@ public class ApplicationResource extends AbstractResource {
                 filteredApplicationSettings.setPasswordSettings(settings.getPasswordSettings());
                 filteredApplicationSettings.setMfa(settings.getMfa());
                 filteredApplicationSettings.setCookieSettings(settings.getCookieSettings());
+                filteredApplicationSettings.setRiskAssessment(settings.getRiskAssessment());
             }
 
             if (hasAnyPermission(userPermissions, Permission.APPLICATION_OPENID, Acl.READ)) {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationResourceTest.java
@@ -28,13 +28,14 @@ import io.gravitee.am.model.idp.ApplicationIdentityProvider;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.exception.ApplicationNotFoundException;
 import io.gravitee.am.service.model.PatchApplication;
+import io.gravitee.am.service.model.PatchApplicationSettings;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
-import org.junit.Test;
-
-import javax.ws.rs.core.Response;
 import java.util.*;
+import javax.ws.rs.core.Response;
+import org.junit.Test;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -178,6 +179,10 @@ public class ApplicationResourceTest extends JerseySpringTest {
         PatchApplication patchApplication = new PatchApplication();
         patchApplication.setDescription(Optional.of("New description"));
 
+        final PatchApplicationSettings applicationSettings = new PatchApplicationSettings();
+        applicationSettings.setRiskAssessment(Optional.of(new RiskAssessmentSettings()));
+        patchApplication.setSettings(Optional.of(applicationSettings));
+
         doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
         doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.APPLICATION))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
@@ -207,6 +212,7 @@ public class ApplicationResourceTest extends JerseySpringTest {
         assertNotNull(settings.getAccount());
         assertNotNull(settings.getOauth());
         assertNotNull(settings.getPasswordSettings());
+        assertNotNull(settings.getRiskAssessment());
     }
 
     @Test
@@ -368,6 +374,7 @@ public class ApplicationResourceTest extends JerseySpringTest {
         filteredApplicationSettings.setAccount(new AccountSettings());
         filteredApplicationSettings.setOauth(new ApplicationOAuthSettings());
         filteredApplicationSettings.setPasswordSettings(new PasswordSettings());
+        filteredApplicationSettings.setRiskAssessment(new RiskAssessmentSettings());
 
         mockApplication.setSettings(filteredApplicationSettings);
         mockApplication.setMetadata(Collections.singletonMap("key", "value"));

--- a/gravitee-am-model/pom.xml
+++ b/gravitee-am-model/pom.xml
@@ -43,5 +43,10 @@
             <artifactId>gravitee-node-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.risk.assessment.api</groupId>
+            <artifactId>gravitee-risk-assessment-api</artifactId>
+            <version>${gravitee-risk-assessment-api.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationSettings.java
@@ -22,6 +22,7 @@ import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.oidc.Client;
 
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
 import java.util.Optional;
 
 /**
@@ -64,6 +65,13 @@ public class ApplicationSettings {
      * Cookie settings
      */
     private CookieSettings cookieSettings;
+
+    /**
+     * Risk Assessment Settings
+     * Note: configuration can be set but effective only if EE
+     */
+    private RiskAssessmentSettings riskAssessment;
+
 
     public ApplicationSettings() {
     }
@@ -143,6 +151,14 @@ public class ApplicationSettings {
         this.cookieSettings = cookieSettings;
     }
 
+    public RiskAssessmentSettings getRiskAssessment() {
+        return riskAssessment;
+    }
+
+    public void setRiskAssessment(RiskAssessmentSettings riskAssessment) {
+        this.riskAssessment = riskAssessment;
+    }
+
     public void copyTo(Client client) {
         client.setAccountSettings(this.account);
         client.setLoginSettings(this.login);
@@ -151,6 +167,7 @@ public class ApplicationSettings {
         Optional.ofNullable(getAdvanced()).ifPresent(a -> a.copyTo(client));
         client.setMfaSettings(this.mfa);
         client.setCookieSettings(this.getCookieSettings());
-        Optional.ofNullable(this.saml).ifPresent(s->s.copyTo(client));
+        client.setRiskAssessment(this.getRiskAssessment());
+        Optional.ofNullable(this.saml).ifPresent(s -> s.copyTo(client));
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
@@ -25,6 +25,7 @@ import io.gravitee.am.model.application.ApplicationScopeSettings;
 import io.gravitee.am.model.idp.ApplicationIdentityProvider;
 import io.gravitee.am.model.login.LoginSettings;
 
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -201,6 +202,8 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     private CookieSettings cookieSettings;
 
+    private RiskAssessmentSettings riskAssessment;
+
     private boolean singleSignOut;
 
     private boolean silentReAuthentication;
@@ -295,6 +298,7 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
         this.flowsInherited = other.flowsInherited;
         this.mfaSettings = other.mfaSettings;
         this.cookieSettings = other.cookieSettings;
+        this.riskAssessment = other.riskAssessment;
         this.singleSignOut = other.singleSignOut;
         this.silentReAuthentication = other.silentReAuthentication;
         this.tlsClientCertificateBoundAccessTokens = other.tlsClientCertificateBoundAccessTokens;
@@ -898,6 +902,14 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
         this.cookieSettings = cookieSettings;
     }
 
+    public RiskAssessmentSettings getRiskAssessment() {
+        return riskAssessment;
+    }
+
+    public void setRiskAssessment(RiskAssessmentSettings riskAssessment) {
+        this.riskAssessment = riskAssessment;
+    }
+
     public boolean isTlsClientCertificateBoundAccessTokens() {
         return tlsClientCertificateBoundAccessTokens;
     }
@@ -984,6 +996,10 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     public void setSamlCertificate(String samlCertificate) {
         this.samlCertificate = samlCertificate;
+    }
+
+    public boolean isBackchannelUserCodeParameter() {
+        return backchannelUserCodeParameter;
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -29,6 +29,8 @@ import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.repository.management.api.ApplicationRepository;
 import io.gravitee.am.repository.mongodb.management.internal.model.*;
+import io.gravitee.am.repository.mongodb.management.internal.model.risk.RiskAssessmentSettingsMongo;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
 import io.reactivex.Observable;
 import io.reactivex.*;
 import org.bson.BsonDocument;
@@ -43,6 +45,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.mongodb.client.model.Filters.*;
+import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
@@ -249,6 +252,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationSettingsMongo.setPasswordSettings(convert(other.getPasswordSettings()));
         applicationSettingsMongo.setMfa(convert(other.getMfa()));
         applicationSettingsMongo.setCookieSettings(convert(other.getCookieSettings()));
+        applicationSettingsMongo.setRiskAssessment(convert(other.getRiskAssessment()));
         return applicationSettingsMongo;
     }
 
@@ -266,6 +270,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationSettings.setPasswordSettings(convert(other.getPasswordSettings()));
         applicationSettings.setMfa(convert(other.getMfa()));
         applicationSettings.setCookieSettings(convert(other.getCookieSettings()));
+        applicationSettings.setRiskAssessment(convert(other.getRiskAssessment()));
         return applicationSettings;
     }
 
@@ -527,6 +532,17 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
 
     private static CookieSettings convert(CookieSettingsMongo cookieSettingsMongo) {
         return cookieSettingsMongo != null ? cookieSettingsMongo.convert() : null;
+    }
+
+    private static RiskAssessmentSettingsMongo convert(RiskAssessmentSettings riskAssessment) {
+        return RiskAssessmentSettingsMongo.convert(riskAssessment);
+    }
+
+    private static RiskAssessmentSettings convert(RiskAssessmentSettingsMongo riskAssessment) {
+        if (isNull(riskAssessment)) {
+            return null;
+        }
+        return riskAssessment.convert();
     }
 
     private static List<TokenClaim> getTokenClaims(List<TokenClaimMongo> mongoTokenClaims) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationSettingsMongo.java
@@ -15,6 +15,12 @@
  */
 package io.gravitee.am.repository.mongodb.management.internal.model;
 
+import io.gravitee.am.repository.mongodb.management.internal.model.risk.AssessmentSettingsMongo;
+import io.gravitee.am.repository.mongodb.management.internal.model.risk.RiskAssessmentSettingsMongo;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
+
+import static java.util.Objects.isNull;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -29,6 +35,7 @@ public class ApplicationSettingsMongo {
     private PasswordSettingsMongo passwordSettings;
     private MFASettingsMongo mfa;
     private CookieSettingsMongo cookieSettings;
+    private RiskAssessmentSettingsMongo riskAssessment;
 
     public ApplicationOAuthSettingsMongo getOauth() {
         return oauth;
@@ -92,5 +99,14 @@ public class ApplicationSettingsMongo {
 
     public void setCookieSettings(CookieSettingsMongo cookieSettings) {
         this.cookieSettings = cookieSettings;
+    }
+
+    public RiskAssessmentSettingsMongo getRiskAssessment() {
+        return riskAssessment;
+    }
+
+    public ApplicationSettingsMongo setRiskAssessment(RiskAssessmentSettingsMongo riskAssessment) {
+        this.riskAssessment = riskAssessment;
+        return this;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/risk/AssessmentSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/risk/AssessmentSettingsMongo.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.repository.mongodb.management.internal.model.risk;
+
+import io.gravitee.risk.assessment.api.assessment.Assessment;
+import io.gravitee.risk.assessment.api.assessment.settings.AssessmentSettings;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import static io.gravitee.risk.assessment.api.assessment.Assessment.valueOf;
+import static java.util.Objects.isNull;
+import static java.util.Optional.ofNullable;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AssessmentSettingsMongo {
+
+    private boolean enabled;
+    private Map<String, Double> thresholds;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Map<String, Double> getThresholds() {
+        return thresholds;
+    }
+
+    public AssessmentSettingsMongo setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public AssessmentSettingsMongo setThresholds(Map<String, Double> thresholds) {
+        this.thresholds = thresholds;
+        return this;
+    }
+
+    public static AssessmentSettingsMongo convert(AssessmentSettings riskAssessment) {
+        if (isNull(riskAssessment)) {
+            return null;
+        }
+        return new AssessmentSettingsMongo()
+                .setEnabled(riskAssessment.isEnabled())
+                .setThresholds(getMongoThresholds(riskAssessment));
+    }
+
+    private static Map<String, Double> getMongoThresholds(AssessmentSettings riskAssessment) {
+        return ofNullable(riskAssessment.getThresholds()).orElse(Map.of()).entrySet().stream()
+                .map(e -> Map.entry(e.getKey().name(), e.getValue()))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    }
+
+    public AssessmentSettings convert() {
+        return new AssessmentSettings().setEnabled(this.isEnabled()).setThresholds(this.getRiskThresholds());
+    }
+
+    private Map<Assessment, Double> getRiskThresholds() {
+        return ofNullable(this.getThresholds()).orElse(Map.of()).entrySet().stream()
+                .map(e -> Map.entry(valueOf(e.getKey()), e.getValue()))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/risk/RiskAssessmentSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/risk/RiskAssessmentSettingsMongo.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.repository.mongodb.management.internal.model.risk;
+
+import io.gravitee.risk.assessment.api.assessment.settings.AssessmentSettings;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
+
+import static java.util.Objects.isNull;
+import static java.util.Optional.ofNullable;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RiskAssessmentSettingsMongo {
+
+    private boolean enabled;
+
+    private AssessmentSettingsMongo deviceAssessment;
+    private AssessmentSettingsMongo ipReputationAssessment;
+    private AssessmentSettingsMongo geoVelocityAssessment;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public AssessmentSettingsMongo getDeviceAssessment() {
+        return deviceAssessment;
+    }
+
+    public AssessmentSettingsMongo getIpReputationAssessment() {
+        return ipReputationAssessment;
+    }
+
+    public AssessmentSettingsMongo getGeoVelocityAssessment() {
+        return geoVelocityAssessment;
+    }
+
+    public RiskAssessmentSettingsMongo setDeviceAssessment(AssessmentSettingsMongo deviceAssessment) {
+        this.deviceAssessment = deviceAssessment;
+        return this;
+    }
+
+    public RiskAssessmentSettingsMongo setIpReputationAssessment(AssessmentSettingsMongo ipReputationAssessment) {
+        this.ipReputationAssessment = ipReputationAssessment;
+        return this;
+    }
+
+    public RiskAssessmentSettingsMongo setGeoVelocityAssessment(AssessmentSettingsMongo geoVelocityAssessment) {
+        this.geoVelocityAssessment = geoVelocityAssessment;
+        return this;
+    }
+
+    public RiskAssessmentSettingsMongo setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public static RiskAssessmentSettingsMongo convert(RiskAssessmentSettings riskAssessment) {
+        if (isNull(riskAssessment)) {
+            return null;
+        }
+        return new RiskAssessmentSettingsMongo()
+                .setEnabled(riskAssessment.isEnabled())
+                .setDeviceAssessment(AssessmentSettingsMongo.convert(riskAssessment.getDeviceAssessment()))
+                .setGeoVelocityAssessment(AssessmentSettingsMongo.convert(riskAssessment.getGeoVelocityAssessment()))
+                .setIpReputationAssessment(AssessmentSettingsMongo.convert(riskAssessment.getIpReputationAssessment()));
+    }
+
+    public RiskAssessmentSettings convert() {
+        return new RiskAssessmentSettings()
+                .setEnabled(this.isEnabled())
+                .setDeviceAssessment(convertAssessement(getDeviceAssessment()))
+                .setGeoVelocityAssessment(convertAssessement(getGeoVelocityAssessment()))
+                .setIpReputationAssessment(convertAssessement(getIpReputationAssessment()));
+    }
+
+    private AssessmentSettings convertAssessement(AssessmentSettingsMongo deviceAssessment) {
+        return ofNullable(deviceAssessment).map(AssessmentSettingsMongo::convert).orElse(null);
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplication.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplication.java
@@ -18,6 +18,7 @@ package io.gravitee.am.service.model;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.idp.ApplicationIdentityProvider;
 import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.utils.PermissionSettingUtils;
 import io.gravitee.am.service.utils.SetterUtils;
 
 import java.util.*;
@@ -144,42 +145,7 @@ public class PatchApplication {
         }).collect(toCollection(TreeSet::new));
     }
 
-    /**
-     * Returns the list of required permission depending on what fields are filled.
-     *
-     * Ex: if settings.oauth is filled, {@link Permission#APPLICATION_OPENID} will be added to the list of required permissions cause it means the user want to update this information.
-     *
-     * @return the list of required permissions.
-     */
     public Set<Permission> getRequiredPermissions() {
-
-        Set<Permission> requiredPermissions = new HashSet<>();
-
-        if (name != null && name.isPresent()
-                || description != null && description.isPresent()
-                || enabled != null && enabled.isPresent()
-                || template != null && template.isPresent()
-                || metadata != null && metadata.isPresent()) {
-
-            requiredPermissions.add(Permission.APPLICATION_SETTINGS);
-        }
-
-        if (identityProviders != null && identityProviders.isPresent()) {
-            requiredPermissions.add(Permission.APPLICATION_IDENTITY_PROVIDER);
-        }
-
-        if (factors != null && factors.isPresent()) {
-            requiredPermissions.add(Permission.APPLICATION_FACTOR);
-        }
-
-        if (certificate != null) {
-            requiredPermissions.add(Permission.APPLICATION_CERTIFICATE);
-        }
-
-        if (settings != null && settings.isPresent()) {
-            requiredPermissions.addAll(settings.get().getRequiredPermissions());
-        }
-
-        return requiredPermissions;
+        return PermissionSettingUtils.getRequiredPermissions(this);
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationSettings.java
@@ -20,8 +20,9 @@ import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.application.ApplicationSettings;
 import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.utils.PermissionSettingUtils;
 import io.gravitee.am.service.utils.SetterUtils;
-import java.util.HashSet;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
 import java.util.Optional;
 import java.util.Set;
 
@@ -39,6 +40,7 @@ public class PatchApplicationSettings {
     private Optional<PatchPasswordSettings> passwordSettings;
     private Optional<PatchMFASettings> mfa;
     private Optional<CookieSettings> cookieSettings;
+    private Optional<RiskAssessmentSettings> riskAssessment;
 
     public Optional<AccountSettings> getAccount() {
         return account;
@@ -104,6 +106,14 @@ public class PatchApplicationSettings {
         this.mfa = mfa;
     }
 
+    public Optional<RiskAssessmentSettings> getRiskAssessment() {
+        return riskAssessment;
+    }
+
+    public void setRiskAssessment(Optional<RiskAssessmentSettings> riskAssessment) {
+        this.riskAssessment = riskAssessment;
+    }
+
     public ApplicationSettings patch(ApplicationSettings _toPatch) {
         // create new object for audit purpose (patch json result)
         ApplicationSettings toPatch = _toPatch == null ? new ApplicationSettings() : new ApplicationSettings(_toPatch);
@@ -112,6 +122,7 @@ public class PatchApplicationSettings {
         SetterUtils.safeSet(toPatch::setAccount, this.getAccount());
         SetterUtils.safeSet(toPatch::setLogin, this.getLogin());
         SetterUtils.safeSet(toPatch::setCookieSettings, this.getCookieSettings());
+        SetterUtils.safeSet(toPatch::setRiskAssessment, this.getRiskAssessment());
         if (this.getOauth() != null && this.getOauth().isPresent()) {
             toPatch.setOauth(this.getOauth().get().patch(toPatch.getOauth()));
         }
@@ -131,27 +142,6 @@ public class PatchApplicationSettings {
     }
 
     public Set<Permission> getRequiredPermissions() {
-
-        Set<Permission> requiredPermissions = new HashSet<>();
-
-        if (account != null && account.isPresent()
-                || login != null && login.isPresent()
-                || advanced != null && advanced.isPresent()
-                || passwordSettings != null && passwordSettings.isPresent()
-                || mfa != null && mfa.isPresent()
-                || cookieSettings != null && cookieSettings.isPresent()
-        ) {
-            requiredPermissions.add(Permission.APPLICATION_SETTINGS);
-        }
-
-        if (oauth != null && oauth.isPresent()) {
-            requiredPermissions.add(Permission.APPLICATION_OPENID);
-        }
-
-        if (saml != null && saml.isPresent()) {
-            requiredPermissions.add(Permission.APPLICATION_SAML);
-        }
-
-        return requiredPermissions;
+        return PermissionSettingUtils.getRequiredPermissions(this);
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/PermissionSettingUtils.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/PermissionSettingUtils.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.service.utils;
+
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.model.PatchApplication;
+import io.gravitee.am.service.model.PatchApplicationSettings;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PermissionSettingUtils {
+
+    /**
+     * Returns the list of required permission depending on what fields are filled.
+     *
+     * Ex: if settings.oauth is filled, {@link Permission#APPLICATION_OPENID} will be added to the list of required permissions cause it means the user want to update this information.
+     *
+     * @return the list of required permissions.
+     */
+
+    public static Set<Permission> getRequiredPermissions(PatchApplication application) {
+        var requiredPermissions = new HashSet<Permission>();
+
+        if (application == null) {
+            return requiredPermissions;
+        }
+
+        setApplicationSettingsPermissions(application, requiredPermissions);
+        setIdentityProvidersPermissions(application, requiredPermissions);
+        setFactorsPermissions(application, requiredPermissions);
+        setCertificatePermission(application, requiredPermissions);
+        setSubApplicationSettingsPermissions(application, requiredPermissions);
+
+        return requiredPermissions;
+    }
+
+    private static void setApplicationSettingsPermissions(PatchApplication application, Set<Permission> requiredPermissions) {
+        var name = application.getName();
+        var description = application.getDescription();
+        var enabled = application.getEnabled();
+        var template = application.getTemplate();
+        var metadata = application.getMetadata();
+
+        if (name != null && name.isPresent()
+                || description != null && description.isPresent()
+                || enabled != null && enabled.isPresent()
+                || template != null && template.isPresent()
+                || metadata != null && metadata.isPresent()) {
+
+            requiredPermissions.add(Permission.APPLICATION_SETTINGS);
+        }
+    }
+
+    private static void setIdentityProvidersPermissions(PatchApplication application, Set<Permission> requiredPermissions) {
+        var identityProviders = application.getIdentityProviders();
+        if (identityProviders != null && identityProviders.isPresent()) {
+            requiredPermissions.add(Permission.APPLICATION_IDENTITY_PROVIDER);
+        }
+    }
+
+    private static void setFactorsPermissions(PatchApplication application, Set<Permission> requiredPermissions) {
+        var factors = application.getFactors();
+        if (factors != null && factors.isPresent()) {
+            requiredPermissions.add(Permission.APPLICATION_FACTOR);
+        }
+    }
+
+    private static void setCertificatePermission(PatchApplication application, HashSet<Permission> requiredPermissions) {
+        var certificate = application.getCertificate();
+        if (certificate != null) {
+            requiredPermissions.add(Permission.APPLICATION_CERTIFICATE);
+        }
+    }
+
+    private static void setSubApplicationSettingsPermissions(PatchApplication application, HashSet<Permission> requiredPermissions) {
+        var settings = application.getSettings();
+        if (settings != null && settings.isPresent()) {
+            requiredPermissions.addAll(settings.get().getRequiredPermissions());
+        }
+    }
+
+    public static Set<Permission> getRequiredPermissions(PatchApplicationSettings settings) {
+        var requiredPermissions = new HashSet<Permission>();
+
+        if (settings == null) {
+            return requiredPermissions;
+        }
+
+        setApplicationSettingsPermission(settings, requiredPermissions);
+        setOpenIDPermission(settings, requiredPermissions);
+        setSamlPermission(settings, requiredPermissions);
+
+        return requiredPermissions;
+    }
+
+    private static void setApplicationSettingsPermission(PatchApplicationSettings settings, Set<Permission> requiredPermissions) {
+        var account = settings.getAccount();
+        var login = settings.getLogin();
+        var advanced = settings.getAdvanced();
+        var passwordSettings = settings.getPasswordSettings();
+        var mfa = settings.getMfa();
+        var cookieSettings = settings.getCookieSettings();
+        var riskAssessment = settings.getRiskAssessment();
+
+        if (account != null && account.isPresent()
+                || login != null && login.isPresent()
+                || advanced != null && advanced.isPresent()
+                || passwordSettings != null && passwordSettings.isPresent()
+                || mfa != null && mfa.isPresent()
+                || cookieSettings != null && cookieSettings.isPresent()
+                || riskAssessment != null && riskAssessment.isPresent()
+        ) {
+            requiredPermissions.add(Permission.APPLICATION_SETTINGS);
+        }
+    }
+
+    private static void setOpenIDPermission(PatchApplicationSettings settings, Set<Permission> requiredPermissions) {
+        var oauth = settings.getOauth();
+        if (oauth != null && oauth.isPresent()) {
+            requiredPermissions.add(Permission.APPLICATION_OPENID);
+        }
+    }
+
+    private static void setSamlPermission(PatchApplicationSettings settings, Set<Permission> requiredPermissions) {
+        var saml = settings.getSaml();
+        if (saml != null && saml.isPresent()) {
+            requiredPermissions.add(Permission.APPLICATION_SAML);
+        }
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/PermissionSettingsUtilsTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/PermissionSettingsUtilsTest.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.service.utils;
+
+import io.gravitee.am.model.CookieSettings;
+import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.model.*;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+
+import static io.gravitee.am.model.permissions.Permission.*;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PermissionSettingsUtilsTest {
+
+    @Test
+    public void must_have_nothing() {
+        var app = new PatchApplication();
+        assertTrue(app.getRequiredPermissions().isEmpty());
+    }
+
+    @Test
+    public void must_have_nothing_with_null_app() {
+        assertTrue(PermissionSettingUtils.getRequiredPermissions((PatchApplication) null).isEmpty());
+        assertTrue(PermissionSettingUtils.getRequiredPermissions((PatchApplicationSettings) null).isEmpty());
+    }
+
+    @Test
+    public void must_have_application_settings_permissions_with_basic_info() {
+        var app = new PatchApplication();
+
+        app.setName(Optional.of("A sample value"));
+        app.setDescription(Optional.of("A sample value"));
+        app.setEnabled(Optional.of(true));
+        app.setTemplate(Optional.of(false));
+        app.setMetadata(Optional.of(Map.of()));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 1 && permissions.contains(APPLICATION_SETTINGS));
+    }
+
+    @Test
+    public void must_have_nothing_with_empty_options() {
+        var app = new PatchApplication();
+
+        app.setName(Optional.empty());
+        app.setDescription(Optional.empty());
+        app.setEnabled(Optional.empty());
+        app.setTemplate(Optional.empty());
+        app.setMetadata(Optional.empty());
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void must_have_idp_permissions() {
+        var app = new PatchApplication();
+        app.setIdentityProviders(Optional.of(Set.of(new PatchApplicationIdentityProvider())));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 1 && permissions.contains(APPLICATION_IDENTITY_PROVIDER));
+    }
+
+    @Test
+    public void must_not_have_idp_permissions() {
+        var app = new PatchApplication();
+        app.setIdentityProviders(Optional.empty());
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void must_have_factor_permissions() {
+        var app = new PatchApplication();
+        app.setFactors(Optional.of(Set.of("factor1", "factor2")));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 1 && permissions.contains(APPLICATION_FACTOR));
+    }
+
+    @Test
+    public void must_not_have_factor_permissions() {
+        var app = new PatchApplication();
+        app.setFactors(Optional.empty());
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void must_have_certificate_permissions() {
+        var app = new PatchApplication();
+        app.setCertificate(Optional.of("certificate-id"));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 1 && permissions.contains(APPLICATION_CERTIFICATE));
+    }
+
+    @Test
+    public void must_not_have_certificate_permissions() {
+        var app = new PatchApplication();
+        app.setCertificate(Optional.empty());
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 1 && permissions.contains(APPLICATION_CERTIFICATE));
+    }
+
+    @Test
+    public void must_have_application_settings_permissions_with_sub_settings() {
+        var app = new PatchApplication();
+        final PatchApplicationSettings settings = new PatchApplicationSettings();
+
+        settings.setAccount(Optional.of(new AccountSettings()));
+        settings.setLogin(Optional.of(new LoginSettings()));
+        settings.setAdvanced(Optional.of(new PatchApplicationAdvancedSettings()));
+        settings.setPasswordSettings(Optional.of(new PatchPasswordSettings()));
+        settings.setMfa(Optional.of(new PatchMFASettings()));
+        settings.setCookieSettings(Optional.of(new CookieSettings()));
+        settings.setRiskAssessment(Optional.of(new RiskAssessmentSettings()));
+
+        app.setSettings(Optional.of(settings));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 1 && permissions.contains(APPLICATION_SETTINGS));
+    }
+
+    @Test
+    public void must_have_nothing_with_application_settings_permissions_optional() {
+        var app = new PatchApplication();
+        final PatchApplicationSettings settings = new PatchApplicationSettings();
+
+        settings.setAccount(Optional.empty());
+        settings.setLogin(Optional.empty());
+        settings.setAdvanced(Optional.empty());
+        settings.setPasswordSettings(Optional.empty());
+        settings.setMfa(Optional.empty());
+        settings.setCookieSettings(Optional.empty());
+        settings.setRiskAssessment(Optional.empty());
+
+        app.setSettings(Optional.of(settings));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void must_have_openid_permissions_with_sub_settings() {
+        var app = new PatchApplication();
+        final PatchApplicationSettings settings = new PatchApplicationSettings();
+        settings.setOauth(Optional.of(new PatchApplicationOAuthSettings()));
+        app.setSettings(Optional.of(settings));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 1 && permissions.contains(APPLICATION_OPENID));
+    }
+
+    @Test
+    public void must_have_saml_permissions_with_sub_settings() {
+        var app = new PatchApplication();
+        final PatchApplicationSettings settings = new PatchApplicationSettings();
+        settings.setSaml(Optional.of(new PatchApplicationSAMLSettings()));
+        app.setSettings(Optional.of(settings));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 1 && permissions.contains(APPLICATION_SAML));
+    }
+
+    @Test
+    public void must_have_all_permissions() {
+        var app = new PatchApplication();
+
+        app.setName(Optional.of("A sample value"));
+        app.setDescription(Optional.of("A sample value"));
+        app.setEnabled(Optional.of(true));
+        app.setTemplate(Optional.of(false));
+        app.setMetadata(Optional.of(Map.of()));
+        app.setIdentityProviders(Optional.of(Set.of(new PatchApplicationIdentityProvider())));
+        app.setFactors(Optional.of(Set.of("factor1", "factor2")));
+        app.setCertificate(Optional.of("certificate-id"));
+        final PatchApplicationSettings settings = new PatchApplicationSettings();
+
+        settings.setAccount(Optional.of(new AccountSettings()));
+        settings.setLogin(Optional.of(new LoginSettings()));
+        settings.setAdvanced(Optional.of(new PatchApplicationAdvancedSettings()));
+        settings.setPasswordSettings(Optional.of(new PatchPasswordSettings()));
+        settings.setMfa(Optional.of(new PatchMFASettings()));
+        settings.setCookieSettings(Optional.of(new CookieSettings()));
+        settings.setRiskAssessment(Optional.of(new RiskAssessmentSettings()));
+        settings.setOauth(Optional.of(new PatchApplicationOAuthSettings()));
+        settings.setSaml(Optional.of(new PatchApplicationSAMLSettings()));
+        app.setSettings(Optional.of(settings));
+
+        final Set<Permission> permissions = app.getRequiredPermissions();
+        assertTrue(permissions.size() == 6 && permissions.containsAll(
+                List.of(
+                        APPLICATION_SETTINGS,
+                        APPLICATION_IDENTITY_PROVIDER,
+                        APPLICATION_FACTOR,
+                        APPLICATION_CERTIFICATE,
+                        APPLICATION_OPENID,
+                        APPLICATION_SAML
+                )
+        ));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <gravitee-notifier-email.version>1.4.1</gravitee-notifier-email.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
+        <gravitee-risk-assessment-api.version>1.0.0</gravitee-risk-assessment-api.version>
         <jdk.version>11</jdk.version>
 
         <!-- Sonar - Jacoco -->

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,11 +17,14 @@ sonar.inclusions=**/*.java
 sonar.exclusions= **/pom.xml,\
    **/target/**,\
    gravitee-am-ui/**,\
+   gravitee-am-model/**,\
+   gravitee-am-service/src/main/java/io/gravitee/am/service/model/**\
    gravitee-am-performance/**,\
    gravitee-am-cypress/**,\
    gravitee-am-fapi-resource-api/**,\
-   gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/** \
-   gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/** \
+   gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/**, \
+   gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/**, \
+   gravitee-am-repository/**, \
    **/assembly.xml,\
    **/src/main/resources,\
    postman/**,\
@@ -42,3 +45,4 @@ sonar.test=.
 sonar.test.inclusions=**/*Test.java
 sonar.test.exclusions=gravitee-am-repository/**
 sonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml
+


### PR DESCRIPTION
## :id: Reference related issue. 

issue: https://github.com/gravitee-io/issues/issues/7556
Note this is only the backend part.

Also needs this one to be released before merging: 
- https://github.com/gravitee-io/gravitee-risk-assessment-api

## :pencil2: A description of the changes proposed in the pull request

This PR brings the Risk Assessment configuration in the AM

## :memo: Test scenarios 

1. Get a token

```bash
curl -X POST \
  http(s)://AM_MANAGEMENT_API/management/auth/token \
  -H 'Authorization: Basic base64(username:password)' 
```
2.  Make sure you have a domain and an application

Then   
```
curl -X 'PATCH' -H "Authorization: Bearer <token>"  http://AM_MANAGEMENT_API/management/organizations/DEFAULT/environments/DEFAULT/domains/<domainId>/applications/<app_id>
  --data-raw '{
  "settings": {
    "riskAssessment": {
      "enabled": true,
      "deviceAssessment": {
        "enabled": true,
        "thresholds": {
          "HIGH": 0
        }
      },
      "ipReputationAssessment": {
        "enabled": true,
        "thresholds": {
          "HIGH": 75,
          "MEDIUM": 50,
          "REGULAR": 25,
          "LOW": 12.5
        }
      },
      "geoVelocityAssessment": {
        "enabled": true,
        "thresholds": {
          "HIGH": 250,
          "MEDIUM": 125,
          "REGULAR": 75,
          "LOW": 37.5
        }
      }
    },
    "account": {
      "inherited": true
    }
  }
}' \
  --compressed
```

