### PR TITLE
fix: provide option to apply UserMapper on HTTPUserProvider

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
@@ -160,7 +160,7 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
                 authenticationProvider.start();
                 // init the user provider
                 UserProvider userProvider =
-                        identityProviderPluginManager.create(identityProvider.getType(), identityProvider.getConfiguration());
+                        identityProviderPluginManager.create(identityProvider.getType(), identityProvider.getConfiguration(), identityProvider.getMappers());
                 providers.put(identityProvider.getId(), authenticationProvider);
                 identities.put(identityProvider.getId(), identityProvider);
                 if (userProvider != null) {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/java/io/gravitee/am/identityprovider/http/configuration/HttpUsersResourceConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/java/io/gravitee/am/identityprovider/http/configuration/HttpUsersResourceConfiguration.java
@@ -27,6 +27,8 @@ public class HttpUsersResourceConfiguration {
     private String usernameAttribute = "username";
     private HttpUsersResourcePathsConfiguration paths;
 
+    private boolean applyUserMapper;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -65,5 +67,13 @@ public class HttpUsersResourceConfiguration {
 
     public void setPaths(HttpUsersResourcePathsConfiguration paths) {
         this.paths = paths;
+    }
+
+    public boolean isApplyUserMapper() {
+        return applyUserMapper;
+    }
+
+    public void setApplyUserMapper(boolean applyUserMapper) {
+        this.applyUserMapper = applyUserMapper;
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/resources/schemas/schema-form.json
@@ -234,6 +234,11 @@
           "default": "username",
           "description": "Username field of your users"
         },
+        "applyUserMapper": {
+          "type": "boolean",
+          "title": "Apply User Mapper",
+          "description": "Apply User Mapper transformation on all UserProvider outputs"
+        },
         "paths": {
           "type": "object",
           "id": "urn:jsonschema:io:gravitee:am:identityprovider:http:HttpUsersResourcePathsConfiguration",

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTestConfiguration.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.identityprovider.http.user;
 
+import io.gravitee.am.identityprovider.api.DefaultIdentityProviderMapper;
+import io.gravitee.am.identityprovider.api.IdentityProviderMapper;
 import io.gravitee.am.identityprovider.api.UserProvider;
 import io.gravitee.am.identityprovider.http.configuration.*;
 import io.gravitee.common.http.HttpHeader;
@@ -95,6 +97,7 @@ public class HttpUserProviderTestConfiguration {
         HttpUsersResourceConfiguration usersResourceConfiguration = new HttpUsersResourceConfiguration();
         usersResourceConfiguration.setBaseURL("http://localhost:19998/api");
         usersResourceConfiguration.setIdentifierAttribute("id");
+        usersResourceConfiguration.setApplyUserMapper(true);
 
         HttpUsersResourcePathsConfiguration pathsConfiguration = new HttpUsersResourcePathsConfiguration();
         pathsConfiguration.setCreateResource(createResource);
@@ -111,6 +114,11 @@ public class HttpUserProviderTestConfiguration {
     @Bean
     public UserProvider userProvider() {
         return new HttpUserProvider();
+    }
+
+    @Bean
+    public IdentityProviderMapper mapper() {
+        return new DefaultIdentityProviderMapper();
     }
 
     @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
@@ -391,7 +391,7 @@ public class IdentityProviderManagerImpl extends AbstractService<IdentityProvide
 
     private Maybe<UserProvider> loadUserProvider(IdentityProvider identityProvider) {
         try {
-            UserProvider userProvider = identityProviderPluginManager.create(identityProvider.getType(), identityProvider.getConfiguration());
+            UserProvider userProvider = identityProviderPluginManager.create(identityProvider.getType(), identityProvider.getConfiguration(), identityProvider.getMappers());
             if (userProvider != null) {
                 logger.info("Initializing user provider : {}", identityProvider.getId());
                 userProvider.start();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/IdentityProviderManagerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/IdentityProviderManagerTest.java
@@ -75,7 +75,7 @@ public class IdentityProviderManagerTest {
         role.setName("ORGANIZATION_PRIMARY_OWNER");
 
         when(roleService.findRolesByName(any(), any(), any(), any())).thenReturn(Flowable.just(role));
-        when(idpPluginManager.create(eq("gravitee-am-idp"), any())).thenReturn(mock(UserProvider.class));
+        when(idpPluginManager.create(eq("gravitee-am-idp"), any(), any())).thenReturn(mock(UserProvider.class));
 
         cut.loadIdentityProviders();
 
@@ -93,7 +93,7 @@ public class IdentityProviderManagerTest {
                     Organization.DEFAULT.equals(idp.getReferenceId()) &&
                     idp.getType().equals("gravitee-am-idp");
         }));
-        verify(idpPluginManager).create(eq("gravitee-am-idp"), any());
+        verify(idpPluginManager).create(eq("gravitee-am-idp"), any(), any());
 
     }
 
@@ -104,7 +104,7 @@ public class IdentityProviderManagerTest {
         role.setId("roleid");
         role.setName("ORGANIZATION_PRIMARY_OWNER");
 
-        when(idpPluginManager.create(eq("gravitee-am-idp"), any())).thenReturn(mock(UserProvider.class));
+        when(idpPluginManager.create(eq("gravitee-am-idp"), any(), any())).thenReturn(mock(UserProvider.class));
 
         cut.loadIdentityProviders();
 
@@ -115,7 +115,7 @@ public class IdentityProviderManagerTest {
         }));
 
         verify(listener).registerAuthenticationProvider(any());
-        verify(idpPluginManager).create(eq("gravitee-am-idp"), any());
+        verify(idpPluginManager).create(eq("gravitee-am-idp"), any(), any());
     }
 
     private void defineDefaultSecurityConfig(boolean enabled) {
@@ -130,7 +130,7 @@ public class IdentityProviderManagerTest {
 
     @Test
     public void shouldGetGraviteeProvider() {
-        when(this.idpPluginManager.create(any(), any())).thenReturn(mock(UserProvider.class));
+        when(this.idpPluginManager.create(any(), any(), any())).thenReturn(mock(UserProvider.class));
         cut.loadIdentityProviders();
 
         final TestObserver<UserProvider> observer = this.cut.getUserProvider(IdentityProviderManagerImpl.IDP_GRAVITEE).test();

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-identityprovider/src/main/java/io/gravitee/am/plugins/idp/core/IdentityProviderPluginManager.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-identityprovider/src/main/java/io/gravitee/am/plugins/idp/core/IdentityProviderPluginManager.java
@@ -39,7 +39,7 @@ public interface IdentityProviderPluginManager {
 
     AuthenticationProvider create(String type, String configuration, Map<String, String> mappers, Map<String, String[]> roleMapper, CertificateManager certificateManager);
 
-    UserProvider create(String type, String configuration);
+    UserProvider create(String type, String configuration, Map<String, String> mappers);
 
     boolean hasUserProvider(String pluginType);
 


### PR DESCRIPTION
fixes gravitee-io/issues#7530

## :pencil2: A description of the changes proposed in the pull request

The purpose of this issue is to add an option to apply the UserMapper configuration for each UserProvider methods (for HTTP provider only)

![image](https://user-images.githubusercontent.com/3110552/170304197-27098dcd-b323-4cef-9046-46e6bb7b478d.png)

This can help if the HTTP backend can't change the output to match the one provided by the AuthenticationProvider endpoint.

:warning: If EL are used for the Mapper, only profile is available into the EL context.