### PR TITLE
fix: redirect to RP after post login error

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -242,7 +242,7 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
         Handler<RoutingContext> socialAuthHandler = SocialAuthHandler.create(new SocialAuthenticationProvider(userAuthenticationManager, eventManager, domain));
         Handler<RoutingContext> loginCallbackParseHandler = new LoginCallbackParseHandler(clientSyncService, identityProviderManager, jwtService, certificateManager);
         Handler<RoutingContext> loginCallbackOpenIDConnectFlowHandler = new LoginCallbackOpenIDConnectFlowHandler(thymeleafTemplateEngine);
-        Handler<RoutingContext> loginCallbackFailureHandler = new LoginCallbackFailureHandler(authenticationFlowContextService);
+        Handler<RoutingContext> loginCallbackFailureHandler = new LoginCallbackFailureHandler(domain, authenticationFlowContextService, identityProviderManager);
         Handler<RoutingContext> loginCallbackEndpoint = new LoginCallbackEndpoint();
         Handler<RoutingContext> loginSSOPOSTEndpoint = new LoginSSOPOSTEndpoint(thymeleafTemplateEngine);
         rootRouter.get(PATH_LOGIN_CALLBACK)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackFailureHandler.java
@@ -20,9 +20,13 @@ import io.gravitee.am.common.exception.authentication.AuthenticationException;
 import io.gravitee.am.common.exception.oauth2.OAuth2Exception;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
 import io.gravitee.am.gateway.handler.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.policy.PolicyChainException;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.AuthenticationFlowContextService;
 import io.gravitee.am.service.exception.AbstractManagementException;
@@ -34,25 +38,33 @@ import io.vertx.reactivex.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
+import static io.gravitee.am.service.utils.ResponseTypeUtils.isHybridFlow;
+import static io.gravitee.am.service.utils.ResponseTypeUtils.isImplicitFlow;
 
 /**
- * In case of login callback failures, the user will be redirected to the login page with error message
- *
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class LoginCallbackFailureHandler implements Handler<RoutingContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(LoginCallbackFailureHandler.class);
+    private final Domain domain;
+    private final AuthenticationFlowContextService authenticationFlowContextService;
+    private final IdentityProviderManager identityProviderManager;
 
-    private AuthenticationFlowContextService authenticationFlowContextService;
-
-    public LoginCallbackFailureHandler(AuthenticationFlowContextService authenticationFlowContextService) {
+    public LoginCallbackFailureHandler(Domain domain,
+                                       AuthenticationFlowContextService authenticationFlowContextService,
+                                       IdentityProviderManager identityProviderManager) {
+        this.domain = domain;
         this.authenticationFlowContextService = authenticationFlowContextService;
+        this.identityProviderManager = identityProviderManager;
     }
 
     @Override
@@ -63,7 +75,7 @@ public class LoginCallbackFailureHandler implements Handler<RoutingContext> {
                     || throwable instanceof AbstractManagementException
                     || throwable instanceof AuthenticationException
                     || throwable instanceof PolicyChainException) {
-                redirectToLoginPage(routingContext, throwable);
+                redirect(routingContext, throwable);
             } else {
                 logger.error(throwable.getMessage(), throwable);
                 if (routingContext.statusCode() != -1) {
@@ -81,7 +93,7 @@ public class LoginCallbackFailureHandler implements Handler<RoutingContext> {
         }
     }
 
-    private void redirectToLoginPage(RoutingContext context, Throwable throwable) {
+    private void redirect(RoutingContext context, Throwable throwable) {
         try {
             // logout user if exists
             if (context.user() != null) {
@@ -93,20 +105,27 @@ public class LoginCallbackFailureHandler implements Handler<RoutingContext> {
                 context.clearUser();
                 context.session().destroy();
             }
-            Client client = context.get(ConstantKeys.CLIENT_CONTEXT_KEY);
-            final MultiMap params = MultiMap.caseInsensitiveMultiMap();
+
+            // redirect the user to either the login page or the SP redirect uri if hide login option is enabled
+            final Client client = context.get(ConstantKeys.CLIENT_CONTEXT_KEY);
             final MultiMap originalParams = context.get(PARAM_CONTEXT_KEY);
-            if (originalParams != null) {
-                params.setAll(originalParams);
+            final LoginSettings loginSettings = LoginSettings.getInstance(domain, client);
+
+            // if client has activated hide login form and has only one active external IdP
+            // redirect to the SP redirect_uri to avoid an infinite loop between AM and the external IdP
+            long externalIdentities = Optional.ofNullable(client.getIdentities())
+                    .map(Collection::stream)
+                    .orElseGet(Stream::empty)
+                    .map(idp -> identityProviderManager.getIdentityProvider(idp))
+                    .filter(idp -> idp != null && idp.isExternal())
+                    .count();
+            if (loginSettings != null && loginSettings.isHideForm() && externalIdentities == 1) {
+                redirectToSP(originalParams, client, context, throwable);
+            } else {
+                redirectToLoginPage(originalParams, client, context, throwable);
             }
-            params.set(Parameters.CLIENT_ID, client.getClientId());
-            params.set(ConstantKeys.ERROR_PARAM_KEY, "social_authentication_failed");
-            params.set(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, UriBuilder.encodeURIComponent(throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage()));
-            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.request().path().replaceFirst("/callback", ""), params);
-            doRedirect(context.response(), uri);
         } catch (Exception ex) {
             logger.error("An error has occurred while redirecting to the login page", ex);
-            // Note: we can't invoke context.fail cause it'll lead to infinite failure handling.
             context
                     .response()
                     .setStatusCode(HttpStatusCode.SERVICE_UNAVAILABLE_503)
@@ -114,7 +133,67 @@ public class LoginCallbackFailureHandler implements Handler<RoutingContext> {
         }
     }
 
+    private void redirectToSP(MultiMap originalParams,
+                              Client client,
+                              RoutingContext context,
+                              Throwable throwable) throws URISyntaxException {
+        // Get the SP redirect_uri
+        final String spRedirectUri = (originalParams != null && originalParams.get(Parameters.REDIRECT_URI) != null) ?
+                originalParams.get(Parameters.REDIRECT_URI) :
+                client.getRedirectUris().get(0);
+
+        // append error message
+        Map<String, String> query = new LinkedHashMap<>();
+        query.put(ConstantKeys.ERROR_PARAM_KEY, "server_error");
+        query.put(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage());
+        if (originalParams != null && originalParams.get(Parameters.STATE) != null) {
+            query.put(Parameters.STATE, originalParams.get(Parameters.STATE));
+        }
+        boolean fragment = (originalParams != null && originalParams.get(Parameters.RESPONSE_TYPE) != null) ?
+                (isImplicitFlow(originalParams.get(Parameters.RESPONSE_TYPE)) || isHybridFlow(originalParams.get(Parameters.RESPONSE_TYPE))) : false;
+
+        // prepare final redirect uri
+        UriBuilder template = UriBuilder.newInstance();
+
+        // get URI from the redirect_uri parameter
+        UriBuilder builder = UriBuilder.fromURIString(spRedirectUri);
+        URI redirectUri = builder.build();
+
+        // create final redirect uri
+        template.scheme(redirectUri.getScheme())
+                .host(redirectUri.getHost())
+                .port(redirectUri.getPort())
+                .userInfo(redirectUri.getUserInfo())
+                .path(redirectUri.getPath());
+
+        // append error parameters in "application/x-www-form-urlencoded" format
+        if (fragment) {
+            query.forEach((k, v) -> template.addFragmentParameter(k, UriBuilder.encodeURIComponent(v)));
+        } else {
+            query.forEach((k, v) -> template.addParameter(k, UriBuilder.encodeURIComponent(v)));
+        }
+        doRedirect(context.response(), template.build().toString());
+    }
+
+    private void redirectToLoginPage(MultiMap originalParams,
+                                     Client client,
+                                     RoutingContext context,
+                                     Throwable throwable) {
+        final MultiMap params = MultiMap.caseInsensitiveMultiMap();
+        if (originalParams != null) {
+            params.setAll(originalParams);
+        }
+        params.set(Parameters.CLIENT_ID, client.getClientId());
+        params.set(ConstantKeys.ERROR_PARAM_KEY, "social_authentication_failed");
+        params.set(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, UriBuilder.encodeURIComponent(throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage()));
+        String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.request().path().replaceFirst("/callback", ""), params);
+        doRedirect(context.response(), uri);
+    }
+
     private void doRedirect(HttpServerResponse response, String url) {
-        response.putHeader(HttpHeaders.LOCATION, url).setStatusCode(302).end();
+        response
+                .putHeader(HttpHeaders.LOCATION, url)
+                .setStatusCode(302)
+                .end();
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackFailureHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackFailureHandlerTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.resources.handler.login;
+
+import io.gravitee.am.common.oauth2.Parameters;
+import io.gravitee.am.common.oauth2.ResponseType;
+import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
+import io.gravitee.am.gateway.handler.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.policy.PolicyChainException;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.service.AuthenticationFlowContextService;
+import io.gravitee.common.http.HttpStatusCode;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.reactivex.core.MultiMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static io.gravitee.am.gateway.handler.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LoginCallbackFailureHandlerTest extends RxWebTestBase {
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private AuthenticationFlowContextService authenticationFlowContextService;
+
+    @Mock
+    private IdentityProviderManager identityProviderManager;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        router.route(HttpMethod.GET, "/login/callback")
+                .handler(rc -> rc.fail(new PolicyChainException("policy_exception")))
+                .failureHandler(new LoginCallbackFailureHandler(domain, authenticationFlowContextService, identityProviderManager));
+    }
+
+    @Test
+    public void shouldRedirectToLoginPage_nominalCase() throws Exception {
+        router.route().order(-1).handler(routingContext -> {
+            Client client = new Client();
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            routingContext.next();
+        });
+
+        testRequest(
+                HttpMethod.GET, "/login/callback",
+                null,
+                resp -> {
+                    String location = resp.headers().get("location");
+                    assertNotNull(location);
+                    assertTrue(location.contains("/login?error=social_authentication_failed&error_description=policy_exception"));
+                },
+                HttpStatusCode.FOUND_302, "Found", null);
+    }
+
+    @Test
+    public void shouldRedirectToLoginPage_hideLoginForm_multipleIdP() throws Exception {
+        router.route().order(-1).handler(routingContext -> {
+            Client client = new Client();
+            client.setIdentities(new HashSet<>(Arrays.asList("idp1", "idp2", "idp3")));
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            routingContext.next();
+        });
+
+        IdentityProvider idp = mock(IdentityProvider.class);
+        when(idp.isExternal()).thenReturn(false);
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(idp);
+
+        testRequest(
+                HttpMethod.GET, "/login/callback",
+                null,
+                resp -> {
+                    String location = resp.headers().get("location");
+                    assertNotNull(location);
+                    assertTrue(location.contains("/login?error=social_authentication_failed&error_description=policy_exception"));
+                },
+                HttpStatusCode.FOUND_302, "Found", null);
+    }
+
+    @Test
+    public void shouldRedirectToSPRedirectUri_hideLogin_oneExternalIdP_codeFlow() throws Exception {
+        router.route().order(-1).handler(routingContext -> {
+            Client client = new Client();
+            client.setIdentities(new HashSet<>(Arrays.asList("idp1")));
+            LoginSettings loginSettings = new LoginSettings();
+            loginSettings.setInherited(false);
+            loginSettings.setHideForm(true);
+            client.setLoginSettings(loginSettings);
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+
+            // original parameters
+            final MultiMap originalParams = MultiMap.caseInsensitiveMultiMap();
+            originalParams.set(Parameters.REDIRECT_URI, "https://sp-app/callback");
+            originalParams.set(Parameters.RESPONSE_TYPE, ResponseType.CODE);
+            originalParams.set(Parameters.STATE, "12345");
+            routingContext.put(PARAM_CONTEXT_KEY, originalParams);
+            routingContext.next();
+        });
+
+        IdentityProvider idp = mock(IdentityProvider.class);
+        when(idp.isExternal()).thenReturn(true);
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(idp);
+
+        testRequest(
+                HttpMethod.GET, "/login/callback",
+                null,
+                resp -> {
+                    String location = resp.headers().get("location");
+                    assertNotNull(location);
+                    assertTrue(location.equals("https://sp-app/callback?error=server_error&error_description=policy_exception&state=12345"));
+                },
+                HttpStatusCode.FOUND_302, "Found", null);
+    }
+
+    @Test
+    public void shouldRedirectToSPRedirectUri_hideLogin_oneExternalIdP_implicitFlow() throws Exception {
+        router.route().order(-1).handler(routingContext -> {
+            Client client = new Client();
+            client.setIdentities(new HashSet<>(Arrays.asList("idp1")));
+            LoginSettings loginSettings = new LoginSettings();
+            loginSettings.setInherited(false);
+            loginSettings.setHideForm(true);
+            client.setLoginSettings(loginSettings);
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+
+            // original parameters
+            final MultiMap originalParams = MultiMap.caseInsensitiveMultiMap();
+            originalParams.set(Parameters.REDIRECT_URI, "https://sp-app/callback");
+            originalParams.set(Parameters.RESPONSE_TYPE, ResponseType.TOKEN);
+            originalParams.set(Parameters.STATE, "12345");
+            routingContext.put(PARAM_CONTEXT_KEY, originalParams);
+            routingContext.next();
+        });
+
+        IdentityProvider idp = mock(IdentityProvider.class);
+        when(idp.isExternal()).thenReturn(true);
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(idp);
+
+        testRequest(
+                HttpMethod.GET, "/login/callback",
+                null,
+                resp -> {
+                    String location = resp.headers().get("location");
+                    assertNotNull(location);
+                    assertTrue(location.equals("https://sp-app/callback#error=server_error&error_description=policy_exception&state=12345"));
+                },
+                HttpStatusCode.FOUND_302, "Found", null);
+    }
+}


### PR DESCRIPTION
## :id: 
fixes gravitee-io/issues#7708

## :pencil2: 
Changed the policy chain handler to add a property to the RoutingContext indicating a post login error and replaced call to `context.fail` with `context.next` so that the handler chain continues, rather than being interrupted.

## 💻 

Here's the cloudapp page after authenticating with a post login error (note the error=server_error fragment):

![Screenshot 2022-06-01 at 09 38 04](https://user-images.githubusercontent.com/99647292/171363731-6012d7ed-72cc-441f-ad66-3316e0081ee0.png)
