### PR TITLE
feat: display user email when forgot password contains email

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -90,6 +90,7 @@ import io.gravitee.am.gateway.handler.root.resources.handler.user.register.Regis
 import io.gravitee.am.gateway.handler.root.resources.handler.user.register.RegisterSubmissionRequestParseHandler;
 import io.gravitee.am.gateway.handler.root.resources.handler.webauthn.WebAuthnAccessHandler;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
+import io.gravitee.am.jwt.JWTBuilder;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.service.AuthenticationFlowContextService;
 import io.gravitee.am.service.CredentialService;
@@ -228,6 +229,10 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
 
     @Autowired
     private WebClient webClient;
+
+    @Autowired
+    @Qualifier("managementJwtBuilder")
+    private JWTBuilder jwtBuilder;
 
     @Override
     protected void doStart() throws Exception {
@@ -415,13 +420,13 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
         rootRouter.route(HttpMethod.GET, PATH_FORGOT_PASSWORD)
                 .handler(clientRequestParseHandler)
                 .handler(forgotPasswordAccessHandler)
-                .handler(new ForgotPasswordEndpoint(thymeleafTemplateEngine, domain, botDetectionManager));
+                .handler(new ForgotPasswordEndpoint(thymeleafTemplateEngine, domain, botDetectionManager, userService));
         rootRouter.route(HttpMethod.POST, PATH_FORGOT_PASSWORD)
                 .handler(new ForgotPasswordSubmissionRequestParseHandler(domain))
                 .handler(clientRequestParseHandler)
                 .handler(botDetectionHandler)
                 .handler(forgotPasswordAccessHandler)
-                .handler(new ForgotPasswordSubmissionEndpoint(userService, domain));
+                .handler(new ForgotPasswordSubmissionEndpoint(userService, domain, jwtBuilder));
         rootRouter.route(HttpMethod.GET, PATH_RESET_PASSWORD)
                 .handler(new ResetPasswordRequestParseHandler(userService))
                 .handler(clientRequestParseHandlerOptional)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordSubmissionEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordSubmissionEndpoint.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.user.password;
 
 import io.gravitee.am.common.exception.authentication.AccountStatusException;
 import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
 import io.gravitee.am.gateway.handler.root.resources.handler.user.UserRequestHandler;
@@ -24,6 +25,7 @@ import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.gateway.handler.root.service.user.model.ForgotPasswordParameters;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.jwt.JWTBuilder;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.oidc.Client;
@@ -32,10 +34,15 @@ import io.gravitee.am.service.exception.UserNotFoundException;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.ext.web.RoutingContext;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
+import static io.gravitee.am.common.utils.ConstantKeys.EMAIL_PARAM_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.FORGOT_PASSWORD_CONFIRM;
+import static io.gravitee.am.common.utils.ConstantKeys.TOKEN_PARAM_KEY;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -46,14 +53,17 @@ public class ForgotPasswordSubmissionEndpoint extends UserRequestHandler {
     private final UserService userService;
     private final Domain domain;
 
-    public ForgotPasswordSubmissionEndpoint(UserService userService, Domain domain) {
+    private final JWTBuilder jwtBuilder;
+
+    public ForgotPasswordSubmissionEndpoint(UserService userService, Domain domain, JWTBuilder jwtBuilder) {
         this.userService = userService;
+        this.jwtBuilder = jwtBuilder;
         this.domain = domain;
     }
 
     @Override
     public void handle(RoutingContext context) {
-        final String email = context.request().getParam(ConstantKeys.EMAIL_PARAM_KEY);
+        final String email = context.request().getParam(EMAIL_PARAM_KEY);
         final String username = context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY);
         final Client client = context.get(ConstantKeys.CLIENT_CONTEXT_KEY);
         MultiMap queryParams = RequestUtils.getCleanedQueryParams(context.request());
@@ -63,8 +73,9 @@ public class ForgotPasswordSubmissionEndpoint extends UserRequestHandler {
         final ForgotPasswordParameters parameters = new ForgotPasswordParameters(email, username, settings != null && settings.isResetPasswordCustomForm(), settings != null && settings.isResetPasswordConfirmIdentity());
         userService.forgotPassword(parameters, client, getAuthenticatedUser(context))
                 .subscribe(
-                        () -> {
+                        (user) -> {
                             queryParams.set(ConstantKeys.SUCCESS_PARAM_KEY, "forgot_password_completed");
+                            generateToken(user).ifPresent(token -> queryParams.set(TOKEN_PARAM_KEY, token));
                             redirectToPage(context, queryParams);
                         },
                         error -> {
@@ -72,12 +83,14 @@ public class ForgotPasswordSubmissionEndpoint extends UserRequestHandler {
                             // the actual error continue to be stored in the audit logs
                             if (error instanceof UserNotFoundException || error instanceof AccountStatusException) {
                                 queryParams.set(ConstantKeys.SUCCESS_PARAM_KEY, "forgot_password_completed");
+                                generateFakeToken().ifPresent(token -> queryParams.set(TOKEN_PARAM_KEY, token));
                                 redirectToPage(context, queryParams);
                             } else if (error instanceof EnforceUserIdentityException) {
                                 if (settings.isResetPasswordConfirmIdentity()) {
                                     queryParams.set(ConstantKeys.WARNING_PARAM_KEY, FORGOT_PASSWORD_CONFIRM);
                                 } else {
                                     queryParams.set(ConstantKeys.SUCCESS_PARAM_KEY, "forgot_password_completed");
+                                    generateFakeToken().ifPresent(token -> queryParams.set(TOKEN_PARAM_KEY, token));
                                 }
                                 redirectToPage(context, queryParams);
                             } else {
@@ -87,10 +100,35 @@ public class ForgotPasswordSubmissionEndpoint extends UserRequestHandler {
                         });
     }
 
+    /**
+     * Generate a token with random user id to avoid security issue with the forgot password
+     * if the user doesn't exist by providing the same response parameters as with existing user
+     *
+     * @return
+     */
+    private Optional<String> generateFakeToken() {
+        final io.gravitee.am.model.User fakeUser = new io.gravitee.am.model.User();
+        fakeUser.setId(UUID.randomUUID().toString());
+        return generateToken(fakeUser);
+    }
+
+    private Optional<String> generateToken(io.gravitee.am.model.User user) {
+        final Map<String, Object> claims = new HashMap<>();
+        claims.put(Claims.iat, new Date().getTime() / 1000);
+        claims.put(Claims.exp, new Date(System.currentTimeMillis() + (60 * 1000)).getTime() / 1000);
+        claims.put(Claims.sub, user.getId());
+
+        try {
+            return Optional.ofNullable(jwtBuilder.sign(new JWT(claims)));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
     @Override
     protected User getAuthenticatedUser(RoutingContext routingContext) {
         // override principal user
-        DefaultUser principal = new DefaultUser(routingContext.request().getParam(ConstantKeys.EMAIL_PARAM_KEY));
+        DefaultUser principal = new DefaultUser(routingContext.request().getParam(EMAIL_PARAM_KEY));
         Map<String, Object> additionalInformation = new HashMap<>();
         additionalInformation.put(Claims.ip_address, RequestUtils.remoteAddress(routingContext.request()));
         additionalInformation.put(Claims.user_agent, RequestUtils.userAgent(routingContext.request()));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserService.java
@@ -42,7 +42,7 @@ public interface UserService {
 
     Single<ResetPasswordResponse> resetPassword(Client client, User user, io.gravitee.am.identityprovider.api.User principal);
 
-    Completable forgotPassword(ForgotPasswordParameters inputParameters, Client client, io.gravitee.am.identityprovider.api.User principal);
+    Single<User> forgotPassword(ForgotPasswordParameters inputParameters, Client client, io.gravitee.am.identityprovider.api.User principal);
 
     Completable logout(User user, boolean invalidateTokens, io.gravitee.am.identityprovider.api.User principal);
 
@@ -60,7 +60,7 @@ public interface UserService {
         return resetPassword(client, user, null);
     }
 
-    default Completable forgotPassword(String email, Client client) {
+    default Single<User> forgotPassword(String email, Client client) {
         ForgotPasswordParameters params = new ForgotPasswordParameters(email, false, false);
         return forgotPassword(params, client, null);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
@@ -336,11 +336,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Completable forgotPassword(ForgotPasswordParameters params, Client client, io.gravitee.am.identityprovider.api.User principal) {
+    public Single<User> forgotPassword(ForgotPasswordParameters params, Client client, io.gravitee.am.identityprovider.api.User principal) {
 
         final String email = params.getEmail();
         if (email != null && !emailValidator.validate(email)) {
-            return Completable.error(new EmailFormatInvalidException(email));
+            return Single.error(new EmailFormatInvalidException(email));
         }
 
         return userService.findByDomainAndCriteria(domain.getId(), params.buildCriteria())
@@ -452,8 +452,7 @@ public class UserServiceImpl implements UserService {
                     io.gravitee.am.identityprovider.api.User principal1 = reloadPrincipal(principal, user1);
                     auditService.report(AuditBuilder.builder(UserAuditBuilder.class).domain(domain.getId()).client(client).principal(principal1).type(EventType.FORGOT_PASSWORD_REQUESTED));
                 })
-                .doOnError(throwable -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).domain(domain.getId()).client(client).principal(principal).type(EventType.FORGOT_PASSWORD_REQUESTED).throwable(throwable)))
-                .ignoreElement();
+                .doOnError(throwable -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).domain(domain.getId()).client(client).principal(principal).type(EventType.FORGOT_PASSWORD_REQUESTED).throwable(throwable)));
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordSubmissionEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordSubmissionEndpointTest.java
@@ -19,6 +19,7 @@ import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.jwt.JWTBuilder;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.oidc.Client;
@@ -26,7 +27,7 @@ import io.gravitee.am.service.exception.EmailFormatInvalidException;
 import io.gravitee.am.service.exception.EnforceUserIdentityException;
 import io.gravitee.am.service.exception.UserNotFoundException;
 import io.gravitee.common.http.HttpStatusCode;
-import io.reactivex.Completable;
+import io.reactivex.Single;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.handler.BodyHandler;
@@ -37,7 +38,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static io.vertx.core.http.HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +51,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
 
+    public static final String TOKEN = "token";
     @Mock
     private UserService userService;
 
@@ -57,12 +61,16 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
     @Mock
     private Domain domain;
 
+    @Mock
+    private JWTBuilder jwtBuilder;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
         reset(accountSettings);
         when(domain.getAccountSettings()).thenReturn(accountSettings);
-        ForgotPasswordSubmissionEndpoint forgotPasswordSubmissionEndpoint = new ForgotPasswordSubmissionEndpoint(userService, domain);
+        when(jwtBuilder.sign(any())).thenReturn(TOKEN);
+        ForgotPasswordSubmissionEndpoint forgotPasswordSubmissionEndpoint = new ForgotPasswordSubmissionEndpoint(userService, domain, jwtBuilder);
         router.route(HttpMethod.POST, "/forgotPassword")
                 .handler(BodyHandler.create())
                 .handler(forgotPasswordSubmissionEndpoint)
@@ -80,7 +88,7 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email@test.com")), eq(client), any(User.class))).thenReturn(Completable.complete());
+        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email@test.com")), eq(client), any(User.class))).thenReturn(Single.just(new io.gravitee.am.model.User()));
 
         testRequest(
                 HttpMethod.POST, "/forgotPassword?client_id=client-id",
@@ -88,7 +96,7 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.endsWith("/forgotPassword?client_id=client-id&success=forgot_password_completed"));
+                    assertTrue(location.endsWith("/forgotPassword?client_id=client-id&success=forgot_password_completed&token="+TOKEN));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }
@@ -105,7 +113,7 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email@test.com")), eq(client), any(User.class))).thenReturn(Completable.error(new UserNotFoundException("email@test.com")));
+        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email@test.com")), eq(client), any(User.class))).thenReturn(Single.error(new UserNotFoundException("email@test.com")));
 
         testRequest(
                 HttpMethod.POST, "/forgotPassword?client_id=client-id",
@@ -113,7 +121,7 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.endsWith("/forgotPassword?client_id=client-id&success=forgot_password_completed"));
+                    assertTrue(location.endsWith("/forgotPassword?client_id=client-id&success=forgot_password_completed&token="+TOKEN));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }
@@ -129,7 +137,7 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email.test.com")), eq(client), any(User.class))).thenReturn(Completable.error(new EmailFormatInvalidException("email.test.com")));
+        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email.test.com")), eq(client), any(User.class))).thenReturn(Single.error(new EmailFormatInvalidException("email.test.com")));
 
         testRequest(
                 HttpMethod.POST, "/forgotPassword?client_id=client-id",
@@ -154,7 +162,7 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
         });
 
         when(accountSettings.isResetPasswordConfirmIdentity()).thenReturn(true);
-        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email@test.com")), eq(client), any(User.class))).thenReturn(Completable.error(new EnforceUserIdentityException()));
+        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email@test.com")), eq(client), any(User.class))).thenReturn(Single.error(new EnforceUserIdentityException()));
 
         testRequest(
                 HttpMethod.POST, "/forgotPassword?client_id=client-id",
@@ -180,7 +188,7 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
         });
 
         when(accountSettings.isResetPasswordConfirmIdentity()).thenReturn(false);
-        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email@test.com")), eq(client), any(User.class))).thenReturn(Completable.error(new EnforceUserIdentityException()));
+        when(userService.forgotPassword(argThat(p -> p.getEmail().equals("email@test.com")), eq(client), any(User.class))).thenReturn(Single.error(new EnforceUserIdentityException()));
 
         testRequest(
                 HttpMethod.POST, "/forgotPassword?client_id=client-id",
@@ -188,7 +196,7 @@ public class ForgotPasswordSubmissionEndpointTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.endsWith("/forgotPassword?client_id=client-id&success=forgot_password_completed"));
+                    assertTrue(location.endsWith("/forgotPassword?client_id=client-id&success=forgot_password_completed&token="+TOKEN));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }

--- a/gravitee-am-ui/src/app/domain/components/forms/form/dialog/form-info.component.html
+++ b/gravitee-am-ui/src/app/domain/components/forms/form/dialog/form-info.component.html
@@ -188,6 +188,23 @@
         </html>
       ]]>
     </pre>
+    <p *ngIf="data.rawTemplate === 'FORGOT_PASSWORD'">
+      <b>NOTE:</b> When forgot password succeeded, the token present into the URL is used to populate user profile into the template engine. If the token is invalid or has expired, the user profile will be missing from the template engine context, so pay attention to test if user is null before accessing its attributes.
+      Here after, you can find a snippet of HTML to adapt the message to inform the user on whoch address email the message has been sent. 
+    </p>
+    <pre *ngIf="data.rawTemplate === 'FORGOT_PASSWORD'">
+      <![CDATA[
+
+          <div th:if="${success}" class="forgot-password-form">
+            <div>
+                <label>Forgot password confirmation</label>
+                <p th:if="${user != null && user.email != null}">An email has been sent to <b th:text="${user.email}"></b> asking to reset your password.</p>
+                <p th:if="${user == null || user.email == null}">An email has been sent asking to reset your password.</p>
+            </div>
+        </div>
+
+      ]]>
+    </pre>
     <pre *ngIf="data.rawTemplate === 'RESET_PASSWORD'">
       <![CDATA[
         <!DOCTYPE html>


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/7796

## :pencil2: A description of the changes proposed in the pull request

This PR brings forgot password submission confirmation to display the email

## :memo: Test scenarios 

1. Activate forgot password
2. Initiate the login flow
3. Click to forgot password
4. Input the email of a known user
5. When confirmed your email should be display in the confirmation box
