### PR TITLE
feat: handle login attempt count with 'alias' username

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/AuthenticationProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/AuthenticationProvider.java
@@ -26,6 +26,8 @@ import io.reactivex.Maybe;
  */
 public interface AuthenticationProvider extends Service<AuthenticationProvider> {
 
+    String ACTUAL_USERNAME = "actual_username";
+
     Maybe<User> loadUserByUsername(Authentication authentication);
 
     Maybe<User> loadUserByUsername(String username);

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserCredentialEvaluation.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserCredentialEvaluation.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.identityprovider.api;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UserCredentialEvaluation<T> {
+
+    private final boolean passwordValid;
+    private final T user;
+
+    public UserCredentialEvaluation(boolean passwordCorrect, T user) {
+        this.passwordValid = passwordCorrect;
+        this.user = user;
+    }
+
+    public boolean isPasswordValid() {
+        return passwordValid;
+    }
+
+    public T getUser() {
+        return user;
+    }
+}

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-inline/src/test/java/io/gravitee/am/identityprovider/inline/authentication/InlineAuthenticationProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-inline/src/test/java/io/gravitee/am/identityprovider/inline/authentication/InlineAuthenticationProviderTest.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.am.identityprovider.inline.authentication;
 
+import io.gravitee.am.common.exception.authentication.BadCredentialsException;
+import io.gravitee.am.common.exception.authentication.UsernameNotFoundException;
 import io.gravitee.am.identityprovider.api.Authentication;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.identityprovider.inline.authentication.provisioning.InlineInMemoryUserDetailsManager;
 import io.gravitee.am.service.authentication.crypto.password.PasswordEncoder;
-import io.gravitee.am.common.exception.authentication.BadCredentialsException;
-import io.gravitee.am.common.exception.authentication.UsernameNotFoundException;
 import io.reactivex.Maybe;
 import io.reactivex.observers.TestObserver;
 import org.junit.Test;
@@ -29,8 +29,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/authentication/JdbcAuthenticationProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/authentication/JdbcAuthenticationProviderTest.java
@@ -22,11 +22,13 @@ import io.gravitee.am.identityprovider.api.AuthenticationContext;
 import io.gravitee.am.identityprovider.api.AuthenticationProvider;
 import io.gravitee.am.identityprovider.api.User;
 import io.reactivex.observers.TestObserver;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -41,6 +43,8 @@ public abstract class JdbcAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "bobspassword";
@@ -53,7 +57,9 @@ public abstract class JdbcAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
 
@@ -67,6 +73,8 @@ public abstract class JdbcAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication_multifield_username() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "user01";
@@ -79,7 +87,9 @@ public abstract class JdbcAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
 
@@ -93,6 +103,8 @@ public abstract class JdbcAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication_multifield_email() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "user01";
@@ -105,7 +117,9 @@ public abstract class JdbcAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
 
@@ -119,6 +133,9 @@ public abstract class JdbcAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication_badCredentials() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "wrongpassword";
@@ -131,7 +148,9 @@ public abstract class JdbcAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
         testObserver.awaitTerminalEvent();
@@ -141,6 +160,9 @@ public abstract class JdbcAuthenticationProviderTest {
     @Test
     public void shouldNotLoadUserByUsername_authentication_usernameNotFound() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "bobspassword";
@@ -153,7 +175,9 @@ public abstract class JdbcAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(null).when(authenticationContext).get("unknownUsername");
+                return authenticationContext;
             }
         }).test();
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-ldap/src/main/java/io/gravitee/am/identityprovider/ldap/authentication/LdapAuthenticationProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-ldap/src/main/java/io/gravitee/am/identityprovider/ldap/authentication/LdapAuthenticationProvider.java
@@ -154,7 +154,7 @@ public class LdapAuthenticationProvider extends AbstractService<AuthenticationPr
                     LdapEntry userEntry = response.getLdapEntry();
                     return userEntry;
                 } else { // authentication failed
-                    LOGGER.debug("Failed to authenticate user", response.getMessage());
+                    LOGGER.debug("Failed to authenticate user {}", response.getMessage());
                     throw new BadCredentialsException(response.getMessage());
                 }
             } catch (LdapException e) {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProviderTest.java
@@ -15,13 +15,13 @@
  */
 package io.gravitee.am.identityprovider.mongo.authentication;
 
+import io.gravitee.am.common.exception.authentication.BadCredentialsException;
+import io.gravitee.am.common.exception.authentication.UsernameNotFoundException;
 import io.gravitee.am.identityprovider.api.Authentication;
 import io.gravitee.am.identityprovider.api.AuthenticationContext;
 import io.gravitee.am.identityprovider.api.AuthenticationProvider;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.identityprovider.mongo.authentication.spring.MongoAuthenticationProviderConfiguration;
-import io.gravitee.am.common.exception.authentication.BadCredentialsException;
-import io.gravitee.am.common.exception.authentication.UsernameNotFoundException;
 import io.reactivex.observers.TestObserver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,12 +30,16 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { MongoAuthenticationProviderTestConfiguration.class, MongoAuthenticationProviderConfiguration.class }, loader = AnnotationConfigContextLoader.class)
+@ContextConfiguration(classes = {MongoAuthenticationProviderTestConfiguration.class, MongoAuthenticationProviderConfiguration.class}, loader = AnnotationConfigContextLoader.class)
 public class MongoAuthenticationProviderTest {
 
     @Autowired
@@ -44,6 +48,8 @@ public class MongoAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "bobspassword";
@@ -56,7 +62,9 @@ public class MongoAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
 
@@ -70,6 +78,8 @@ public class MongoAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication_multifield_username() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "user01";
@@ -82,7 +92,9 @@ public class MongoAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
 
@@ -96,6 +108,8 @@ public class MongoAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication_multifield_email() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "user01";
@@ -108,7 +122,9 @@ public class MongoAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
 
@@ -122,6 +138,9 @@ public class MongoAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication_case_insensitive() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "bobspassword";
@@ -134,7 +153,9 @@ public class MongoAuthenticationProviderTest {
 
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
 
@@ -148,6 +169,9 @@ public class MongoAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication_badCredentials() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "wrongpassword";
@@ -158,9 +182,12 @@ public class MongoAuthenticationProviderTest {
                 return "bob";
             }
 
+
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
         testObserver.awaitTerminalEvent();
@@ -170,6 +197,9 @@ public class MongoAuthenticationProviderTest {
     @Test
     public void shouldLoadUserByUsername_authentication_usernameNotFound() {
         TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
+
+            private final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+
             @Override
             public Object getCredentials() {
                 return "bobspassword";
@@ -180,9 +210,12 @@ public class MongoAuthenticationProviderTest {
                 return "unknownUsername";
             }
 
+
             @Override
             public AuthenticationContext getContext() {
-                return null;
+                doReturn(authenticationContext).when(authenticationContext).set(anyString(), anyString());
+                doReturn(getPrincipal().toString()).when(authenticationContext).get(getPrincipal().toString());
+                return authenticationContext;
             }
         }).test();
 


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/7797

## :pencil2: A description of the changes proposed in the pull request

This PR brings to MongoDB and JDBC identity providers to count login attempt failures based on both username and email which allows to find the user back regardless of their input username/email

## :memo: Test scenarios 

Test login in with JDBC or MongoDB at least once. 
Logout and then try to fail logins with both username and email.

## :computer: Add screenshots for UI

<img width="924" alt="image" src="https://user-images.githubusercontent.com/8531515/172179964-e19cf48f-2838-4bbd-8717-f2f8bb2ae01a.png">

<img width="991" alt="image" src="https://user-images.githubusercontent.com/8531515/172180121-9d0abf27-ee38-4f08-a314-84ad8d2b4429.png">
