### PR TITLE
fix: decorate with initial parameters when handler is failing

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -58,6 +58,9 @@ public interface ConstantKeys {
     String PEER_CERTIFICATE_THUMBPRINT = "x509_thumbprint_s256";
     String DEVICE_TYPE = "deviceType";
     String DEVICE_ID = "deviceId";
+    String X_XSRF_TOKEN = "X-XSRF-TOKEN";
+    String _CSRF = "_csrf";
+    String __BODY_HANDLED = "__body-handled";
 
     // enrich authentication flow keys
     String AUTH_FLOW_CONTEXT_KEY = "authFlowContext";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -20,8 +20,11 @@ import io.gravitee.common.http.HttpHeaders;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import io.vertx.reactivex.ext.web.RoutingContext;
-
 import java.util.Map;
+import java.util.Map.Entry;
+
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * Handle proxy specific things such as resolving external url via X-Forwarded-* proxy headers
@@ -69,12 +72,18 @@ public class UriBuilderRequest {
 
         if(parameters != null) {
             queryParameters = MultiMap.caseInsensitiveMultiMap();
-            queryParameters.addAll(parameters);
+            queryParameters.addAll(getSafeParameters(parameters));
         } else {
             queryParameters = null;
         }
 
         return resolveProxyRequest(request, path, queryParameters, encoded);
+    }
+
+    private static Map<String, String> getSafeParameters(Map<String, String> parameters) {
+        return parameters.entrySet()
+                .stream().filter(entry -> nonNull(entry.getValue()))
+                .collect(toMap(Entry::getKey, Entry::getValue));
     }
 
     public static String resolveProxyRequest(final HttpServerRequest request, final String path, final MultiMap parameters){

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/logout/LogoutCallbackEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/logout/LogoutCallbackEndpointHandlerTest.java
@@ -131,7 +131,7 @@ public class LogoutCallbackEndpointHandlerTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.endsWith("/error?client_id=client-id&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
+                    assertTrue(location.endsWith("/error?state=myappstate&client_id=client-id&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/logout/LogoutEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/logout/LogoutEndpointHandlerTest.java
@@ -208,7 +208,7 @@ public class LogoutEndpointHandlerTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.endsWith("/error?client_id=client-id&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
+                    assertTrue(location.endsWith("/error?target_url=https%3A%2F%2Ftest&client_id=client-id&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }
@@ -240,7 +240,7 @@ public class LogoutEndpointHandlerTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.endsWith("/error?client_id=client-id&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
+                    assertTrue(location.endsWith("/error?post_logout_redirect_uri=https%3A%2F%2Ftest&id_token_hint=idToken&client_id=client-id&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }
@@ -257,7 +257,7 @@ public class LogoutEndpointHandlerTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.endsWith("/error?error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
+                    assertTrue(location.endsWith("/error?target_url=https%3A%2F%2Ftest&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }
@@ -301,7 +301,7 @@ public class LogoutEndpointHandlerTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.endsWith("/error?client_id=client-id&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
+                    assertTrue(location.endsWith("/error?target_url=https%3A%2F%2Ftest&client_id=client-id&error=invalid_request&error_description=The+post_logout_redirect_uri+MUST+match+the+registered+callback+URLs"));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/7808

## :pencil2: A description of the changes proposed in the pull request

This PR handles decorating the redirect request with original parameters when there is an error in the Gateway

## :memo: Test scenarios 

Configure a failing procedure (like HTTP callout and make it exit on error)

## :computer: Add screenshots for UI

<img width="1590" alt="image" src="https://user-images.githubusercontent.com/8531515/172664192-988344fb-1d7c-4bd5-82bd-495345e8ea0d.png">
