### PR TITLE
chore: instrument AM to provide metrics about AM Internals and Activity

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/pom.xml
@@ -126,6 +126,20 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.gravitee.am</groupId>
+            <artifactId>gravitee-am-monitoring</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-monitoring</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Vert.x -->
         <dependency>
             <groupId>io.vertx</groupId>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
@@ -25,6 +25,8 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.monitoring.metrics.CounterHelper;
+import io.gravitee.am.monitoring.metrics.GaugeHelper;
 import io.gravitee.am.plugins.idp.core.AuthenticationProviderConfiguration;
 import io.gravitee.am.plugins.idp.core.IdentityProviderPluginManager;
 import io.gravitee.am.repository.management.api.IdentityProviderRepository;
@@ -40,6 +42,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static io.gravitee.am.monitoring.metrics.Constants.METRICS_IDPS;
+import static io.gravitee.am.monitoring.metrics.Constants.METRICS_IDP_EVENTS;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -64,6 +69,10 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
 
     @Autowired
     private CertificateManager certificateManager;
+
+    private final CounterHelper idpEvtCounter = new CounterHelper(METRICS_IDP_EVENTS);
+
+    private final GaugeHelper idpGauge = new GaugeHelper(METRICS_IDPS);
 
     private final ConcurrentMap<String, AuthenticationProvider> providers = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, IdentityProvider> identities = new ConcurrentHashMap<>();
@@ -93,6 +102,10 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
         try {
             identityProviderRepository.findAll(ReferenceType.DOMAIN, domain.getId())
                     .flatMapSingle(this::updateAuthenticationProvider)
+                    .map(provider -> {
+                        idpGauge.incrementValue();
+                        return provider;
+                    })
                     .blockingLast();
             logger.info("Identity providers loaded for domain {}", domain.getName());
         } catch (Exception e) {
@@ -120,13 +133,16 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
     @Override
     public void onEvent(Event<IdentityProviderEvent, Payload> event) {
         if (event.content().getReferenceType() == ReferenceType.DOMAIN && domain.getId().equals(event.content().getReferenceId())) {
+            idpEvtCounter.increment();
             switch (event.type()) {
                 case DEPLOY:
+                    idpGauge.incrementValue();
                 case UPDATE:
                     updateIdentityProvider(event.content().getId(), event.type());
                     break;
                 case UNDEPLOY:
                     removeIdentityProvider(event.content().getId());
+                    idpGauge.decrementValue();
                     break;
             }
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/listener/AuthenticationEventListener.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/listener/AuthenticationEventListener.java
@@ -16,8 +16,8 @@
 package io.gravitee.am.gateway.handler.common.auth.listener;
 
 import io.gravitee.am.common.event.EventManager;
-import io.gravitee.am.gateway.handler.common.auth.event.AuthenticationEvent;
 import io.gravitee.am.gateway.handler.common.auth.AuthenticationDetails;
+import io.gravitee.am.gateway.handler.common.auth.event.AuthenticationEvent;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/pom.xml
@@ -104,6 +104,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.am</groupId>
+            <artifactId>gravitee-am-monitoring</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-webauthn</artifactId>
         </dependency>

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/pom.xml
@@ -49,6 +49,12 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.am</groupId>
+            <artifactId>gravitee-am-monitoring</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>gravitee-node-vertx</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.gravitee.am</groupId>
+            <artifactId>gravitee-am-monitoring</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/gravitee-am-management-api/gravitee-am-management-api-services/gravitee-am-management-api-services-sync/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-services/gravitee-am-management-api-services-sync/pom.xml
@@ -38,7 +38,12 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.gravitee.am</groupId>
+            <artifactId>gravitee-am-monitoring</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/pom.xml
@@ -77,6 +77,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.gravitee.am</groupId>
+            <artifactId>gravitee-am-monitoring</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Jackson dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/gravitee-am-monitoring/pom.xml
+++ b/gravitee-am-monitoring/pom.xml
@@ -19,30 +19,27 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <groupId>io.gravitee.am.gateway</groupId>
-        <artifactId>gravitee-am-gateway</artifactId>
+        <artifactId>gravitee-am-parent</artifactId>
+        <groupId>io.gravitee.am</groupId>
         <version>3.18.0-RC2-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>gravitee-am-gateway-reactor</artifactId>
-    <name>Gravitee IO - Access Management - Gateway - Reactor</name>
+    <artifactId>gravitee-am-monitoring</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>io.gravitee.am.gateway.handler</groupId>
-            <artifactId>gravitee-am-gateway-handler-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <dependency>
-            <groupId>io.gravitee.am</groupId>
-            <artifactId>gravitee-am-monitoring</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-monitoring</artifactId>
+            <version>${gravitee-node.version}</version>
         </dependency>
+
     </dependencies>
-
 </project>

--- a/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/metrics/Constants.java
+++ b/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/metrics/Constants.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.monitoring.metrics;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface Constants {
+    String METRICS_NAME_PREFIX = "gio_";
+
+    String METRICS_EVENTS_SYNC = METRICS_NAME_PREFIX + "events_sync";
+
+    String METRICS_DOMAINS = METRICS_NAME_PREFIX + "domains";
+    String METRICS_DOMAIN_EVENTS = METRICS_NAME_PREFIX + "domain_evt";
+
+    String METRICS_APP = METRICS_NAME_PREFIX + "apps";
+    String METRICS_APP_EVENTS = METRICS_NAME_PREFIX + "app_evt";
+
+    String METRICS_IDPS = METRICS_NAME_PREFIX + "idps";
+    String METRICS_IDP_EVENTS = METRICS_NAME_PREFIX + "idp_evt";
+
+    String METRICS_AUTH_EVENTS = METRICS_NAME_PREFIX + "auth_evt";
+    String TAG_AUTH_STATUS = "auth_status";
+    String TAG_AUTH_IDP = "idp";
+    String TAG_VALUE_AUTH_IDP_INTERNAL = "internal";
+    String TAG_VALUE_AUTH_IDP_EXTERNAL = "external";
+}

--- a/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/metrics/CounterHelper.java
+++ b/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/metrics/CounterHelper.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.monitoring.metrics;
+
+import io.gravitee.node.monitoring.metrics.Metrics;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tags;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CounterHelper {
+
+    private Counter value;
+
+    public CounterHelper(String name) {
+        this(name, Tags.empty());
+    }
+
+    public CounterHelper(String name, Tags tags) {
+        value = Counter.builder(name)
+                .tags(tags)
+                .register(Metrics.getDefaultRegistry());
+    }
+
+    public void increment() {
+        this.value.increment();
+    }
+}

--- a/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/metrics/GaugeHelper.java
+++ b/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/metrics/GaugeHelper.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.monitoring.metrics;
+
+import io.gravitee.node.monitoring.metrics.Metrics;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tags;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GaugeHelper {
+
+    private AtomicLong value = new AtomicLong(0);
+
+    public GaugeHelper(String name) {
+        this(name, Tags.empty());
+    }
+
+    public GaugeHelper(String name, Tags tags) {
+        Gauge.builder(name, () -> this.value.get())
+                .tags(tags)
+                .register(Metrics.getDefaultRegistry());
+    }
+
+    public void updateValue(long value) {
+        this.value.set(value);
+    }
+
+    public void incrementValue() {
+        this.value.incrementAndGet();
+    }
+
+    public void decrementValue() {
+        this.value.decrementAndGet();
+    }
+}

--- a/gravitee-am-performance/src/test/scala/io/gravitee/am/performance/BasicLoginFlow.scala
+++ b/gravitee-am-performance/src/test/scala/io/gravitee/am/performance/BasicLoginFlow.scala
@@ -40,17 +40,18 @@ class BasicLoginFlow extends Simulation {
     .userAgentHeader("Gatling - Basic Login Flow")
     .disableFollowRedirect
 
+  val userGenerator = userFeeder(WORKLOAD)
+
   val scn = scenario("Basic Login Flow")
-    .feed(userFeeder(WORKLOAD))
+    .feed(userGenerator)
     .exec(initCodeFlow)
     .exec(renderLoginForm)
-    .pause(5)
+    .pause(1)
     .exec(submitLoginForm)
     .exec(callPostLoginRedirect)
     .exec(requestAccessToken)
-    .pause(5)
-    .exec(introspectToken)
     .pause(1)
+    .exec(introspectToken)
     .exec(logout)
 
   setUp(scn.inject(constantUsersPerSec(AGENTS.floatValue()).during(INJECTION_DURATION.seconds)))

--- a/gravitee-am-performance/src/test/scala/io/gravitee/am/performance/CreateUsers.scala
+++ b/gravitee-am-performance/src/test/scala/io/gravitee/am/performance/CreateUsers.scala
@@ -39,14 +39,16 @@ class CreateUsers extends Simulation {
     .userAgentHeader("Gatling - Create Users")
     .disableFollowRedirect
 
+  val userGenerator = userFeeder(DATALOAD)
+
   val scn = scenario("Create Users")
     .exec(login)
     .exec(retrieveDomainId(DOMAIN_NAME))
     .exec(retrieveIdentityProviderId(IDENTITY_PROVIDER_NAME))
-    .feed(userFeeder(DATALOAD))
+    .feed(userGenerator)
     .doWhile(session => session("index").as[Int] < MAX_USER_INDEX) (
         exec(createUser)
-          .feed(userFeeder(DATALOAD))
+          .feed(userGenerator)
     )
 
   setUp(scn.inject(atOnceUsers(AGENTS)).protocols(httpProtocol))

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <module>gravitee-am-password-dictionary</module>
         <module>gravitee-am-authdevice-notifier</module>
         <module>gravitee-am-ciba-delegated-service</module>
+        <module>gravitee-am-monitoring</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
fixes gravitee-io/issues#7114

## How to Test

Enable the metris endpoint on the admin api

`gravitee_services_metrics_enabled=true`

Connect to the endpoint:

* For the GW
`http://localhost:18092/_node/metrics/prometheus`

* For the Manaement API
`http://localhost:18093/_node/metrics/prometheus`

You should see metrics related to am:

![image](https://user-images.githubusercontent.com/3110552/172668118-d355ac97-be7d-4e7c-bd10-8f180123bf0f.png)

We currently have metrics about :

* number of domains
* number of apps
* number of idps
* number of authentication
* number of sync events