### PR TITLE
fix: application description not saved during create

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -229,6 +229,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         Application application = new Application();
         application.setId(RandomString.generate());
         application.setName(newApplication.getName());
+        application.setDescription(newApplication.getDescription());
         application.setType(newApplication.getType());
         application.setDomain(domain);
         application.setMetadata(newApplication.getMetadata());


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/7222

## :pencil2: A description of the changes proposed in the pull request

This PR fixes the application description not set at application creation

## :memo: Test scenarios 

1. Create a domain
2. Create an application with a description
3. Description should appear in the Application `Settings`

## :computer: Add screenshots for UI

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/8531515/173545256-c7b0d698-251e-4cc2-b9be-1ec303a5f628.png">

<img width="1236" alt="image" src="https://user-images.githubusercontent.com/8531515/173545409-5f61c7e1-f9f5-47c8-876b-5d129faf5696.png">
