### PR TITLE
fix: create & use updatePassword on UserProvider

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
@@ -43,13 +43,22 @@ import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.CredentialService;
 import io.gravitee.am.service.LoginAttemptService;
 import io.gravitee.am.service.TokenService;
-import io.gravitee.am.service.exception.*;
+import io.gravitee.am.service.exception.ClientNotFoundException;
+import io.gravitee.am.service.exception.EmailFormatInvalidException;
+import io.gravitee.am.service.exception.EnforceUserIdentityException;
+import io.gravitee.am.service.exception.UserAlreadyExistsException;
+import io.gravitee.am.service.exception.UserInvalidException;
+import io.gravitee.am.service.exception.UserNotFoundException;
+import io.gravitee.am.service.exception.UserProviderNotFoundException;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.management.UserAuditBuilder;
 import io.gravitee.am.service.validators.email.EmailValidator;
 import io.gravitee.am.service.validators.user.UserValidator;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeSource;
 import io.reactivex.Observable;
-import io.reactivex.*;
+import io.reactivex.Single;
 import io.reactivex.functions.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +66,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.util.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -259,11 +273,7 @@ public class UserServiceImpl implements UserService {
                 // update the idp user
                 .flatMapSingle(userProvider -> userProvider.findByUsername(user.getUsername())
                         .switchIfEmpty(Maybe.error(new UserNotFoundException(user.getUsername())))
-                        .flatMapSingle(idpUser -> {
-                            // set password
-                            ((DefaultUser) idpUser).setCredentials(user.getPassword());
-                            return userProvider.update(idpUser.getId(), idpUser);
-                        })
+                        .flatMapSingle(idpUser -> userProvider.updatePassword(idpUser, user.getPassword()))
                         .onErrorResumeNext(ex -> {
                             if (ex instanceof UserNotFoundException) {
                                 // idp user not found, create its account

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
@@ -120,7 +120,7 @@ public class UserServiceTest {
 
         UserProvider userProvider = mock(UserProvider.class);
         when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
-        when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
+        when(userProvider.updatePassword(any(), any())).thenReturn(Single.just(idpUser));
 
         when(domain.getAccountSettings()).thenReturn(accountSettings);
         when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
@@ -150,7 +150,7 @@ public class UserServiceTest {
 
         UserProvider userProvider = mock(UserProvider.class);
         when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
-        when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
+        when(userProvider.updatePassword(any(), any())).thenReturn(Single.just(idpUser));
 
         when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
         when(commonUserService.update(any())).thenReturn(Single.just(user));
@@ -179,7 +179,7 @@ public class UserServiceTest {
 
         UserProvider userProvider = mock(UserProvider.class);
         when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
-        when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
+        when(userProvider.updatePassword(any(), any())).thenReturn(Single.just(idpUser));
 
         when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
         when(commonUserService.update(any())).thenReturn(Single.just(user));
@@ -537,7 +537,7 @@ public class UserServiceTest {
 
         UserProvider userProvider = mock(UserProvider.class);
         when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
-        when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
+        when(userProvider.updatePassword(any(), any())).thenReturn(Single.just(idpUser));
 
         when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
         when(commonUserService.update(any())).thenReturn(Single.just(user));
@@ -571,7 +571,7 @@ public class UserServiceTest {
 
         UserProvider userProvider = mock(UserProvider.class);
         when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
-        when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
+        when(userProvider.updatePassword(any(), any())).thenReturn(Single.just(idpUser));
 
         when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
         when(commonUserService.update(any())).thenReturn(Single.just(user));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/UserServiceImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.scim.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Strings;
 import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.common.scim.filter.Filter;
 import io.gravitee.am.common.utils.RandomString;
@@ -41,7 +42,15 @@ import io.gravitee.am.repository.management.api.search.FilterCriteria;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.PasswordService;
 import io.gravitee.am.service.RoleService;
-import io.gravitee.am.service.exception.*;
+import io.gravitee.am.service.exception.AbstractManagementException;
+import io.gravitee.am.service.exception.AbstractNotFoundException;
+import io.gravitee.am.service.exception.IdentityProviderNotFoundException;
+import io.gravitee.am.service.exception.RoleNotFoundException;
+import io.gravitee.am.service.exception.TechnicalManagementException;
+import io.gravitee.am.service.exception.UserAlreadyExistsException;
+import io.gravitee.am.service.exception.UserInvalidException;
+import io.gravitee.am.service.exception.UserNotFoundException;
+import io.gravitee.am.service.exception.UserProviderNotFoundException;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.management.UserAuditBuilder;
 import io.gravitee.am.service.utils.UserFactorUpdater;
@@ -57,11 +66,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
 
@@ -255,6 +262,15 @@ public class UserServiceImpl implements UserService {
                                 userToUpdate.setUpdatedAt(new Date());
                                 userToUpdate.setFactors(existingUser.getFactors());
                                 userToUpdate.setDynamicRoles(existingUser.getDynamicRoles());
+                                // keep previous login attempts information
+                                userToUpdate.setLoggedAt(existingUser.getLoggedAt());
+                                userToUpdate.setLoginsCount(existingUser.getLoginsCount());
+                                if (isNullOrEmpty(userToUpdate.getPassword())) {
+                                    // if password is missing, do not unlock the account
+                                    userToUpdate.setAccountLockedAt(existingUser.getAccountLockedAt());
+                                    userToUpdate.setAccountLockedUntil(existingUser.getAccountLockedUntil());
+                                    userToUpdate.setAccountNonLocked(existingUser.isAccountNonLocked());
+                                }
 
                                 // We remove the dynamic roles from the user roles to be updated in order to preserve
                                 // the roles that were assigned by the RoleMappers so that whenever the rule from the
@@ -294,7 +310,12 @@ public class UserServiceImpl implements UserService {
                                                                 if (userToUpdate.getExternalId() == null) {
                                                                     return userProvider.create(UserMapper.convert(userToUpdate));
                                                                 } else {
-                                                                    return userProvider.update(userToUpdate.getExternalId(), UserMapper.convert(userToUpdate));
+                                                                    if (isNullOrEmpty(userToUpdate.getPassword())) {
+                                                                        return userProvider.update(userToUpdate.getExternalId(), UserMapper.convert(userToUpdate));
+                                                                    } else {
+                                                                        return userProvider.update(userToUpdate.getExternalId(), UserMapper.convert(userToUpdate))
+                                                                                .flatMap(updatedUser -> userProvider.updatePassword(updatedUser, user.getPassword()));
+                                                                    }
                                                                 }
                                                             });
                                                 })

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
@@ -37,6 +37,8 @@ public interface UserProvider extends Service<UserProvider> {
 
     Single<User> update(String id, User updateUser);
 
+    Single<User> updatePassword(User user, String password);
+
     Completable delete(String id);
 
     default Lifecycle.State lifecycleState() {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-gravitee/src/main/java/io/gravitee/am/identityprovider/gravitee/user/GraviteeUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-gravitee/src/main/java/io/gravitee/am/identityprovider/gravitee/user/GraviteeUserProvider.java
@@ -45,6 +45,12 @@ public class GraviteeUserProvider implements UserProvider {
     }
 
     @Override
+    public Single<User> updatePassword(User user, String password) {
+        // update will be performed by the repository layer called by the OrganizationUserService
+        return Single.just(user);
+    }
+
+    @Override
     public Completable delete(String id) {
         // delete will be performed by the repository layer called by the OrganizationUserService
         return Completable.complete();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/java/io/gravitee/am/identityprovider/http/configuration/HttpUsersResourcePathsConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/java/io/gravitee/am/identityprovider/http/configuration/HttpUsersResourcePathsConfiguration.java
@@ -25,6 +25,7 @@ public class HttpUsersResourcePathsConfiguration {
     private HttpResourceConfiguration readResource;
     private HttpResourceConfiguration readResourceByEmail;
     private HttpResourceConfiguration updateResource;
+    private HttpResourceConfiguration updatePasswordResource;
     private HttpResourceConfiguration deleteResource;
 
     public HttpResourceConfiguration getCreateResource() {
@@ -65,5 +66,13 @@ public class HttpUsersResourcePathsConfiguration {
 
     public void setDeleteResource(HttpResourceConfiguration deleteResource) {
         this.deleteResource = deleteResource;
+    }
+
+    public HttpResourceConfiguration getUpdatePasswordResource() {
+        return updatePasswordResource;
+    }
+
+    public void setUpdatePasswordResource(HttpResourceConfiguration updatePasswordResource) {
+        this.updatePasswordResource = updatePasswordResource;
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/resources/schemas/schema-form.json
@@ -607,6 +607,101 @@
                 }
               }
             },
+            "updatePasswordResource": {
+              "type": "object",
+              "id": "urn:jsonschema:io:gravitee:am:identityprovider:http:HttpResourceConfiguration",
+              "htmlClass": "path",
+              "title": "Update Password",
+              "properties": {
+                "baseURL" : {
+                  "type" : "string",
+                  "title": "Path",
+                  "default": "/users/{#user.id}/password",
+                  "description": "Resource path (will be append to the base URL, must start with a '/', support EL)"
+                },
+                "httpMethod" : {
+                  "type" : "string",
+                  "default": "PUT",
+                  "enum" : ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE", "OTHER"],
+                  "title": "HTTP Method",
+                  "description": "HTTP method used to call the resource"
+                },
+                "httpHeaders" : {
+                  "type" : "array",
+                  "title": "HTTP Headers",
+                  "items" : {
+                    "type" : "object",
+                    "id" : "urn:jsonschema:io:gravitee:common:http:HttpHeader",
+                    "title": "HTTP Header",
+                    "properties" : {
+                      "name" : {
+                        "title": "Name",
+                        "description": "HTTP Header name",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title": "Value",
+                        "description": "HTTP Header value (support EL)",
+                        "type" : "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ]
+                  }
+                },
+                "httpBody" : {
+                  "type" : "string",
+                  "title": "Body Request",
+                  "widget": "textarea",
+                  "description": "HTTP body request used to call the resource (support EL)"
+                },
+                "httpResponseErrorConditions" : {
+                  "type" : "array",
+                  "title": "Response Error Conditions (one of)",
+                  "items" : {
+                    "type" : "object",
+                    "id" : "urn:jsonschema:io:gravitee:am:identityprovider:http:configuration:HttpResponseError",
+                    "title": "Error Condition",
+                    "properties" : {
+                      "value" : {
+                        "title": "Value",
+                        "description": "The condition which will be verified after the remote call (support EL)",
+                        "default": "{#usersResponse.status == 404}",
+                        "type" : "string"
+                      },
+                      "exception" : {
+                        "title": "Exception",
+                        "description": "Exception send to the consumer if the condition is true",
+                        "type" : "string",
+                        "default": "io.gravitee.am.service.exception.UserNotFoundException",
+                        "enum" : [
+                          "io.gravitee.am.service.exception.UserAlreadyExistsException",
+                          "io.gravitee.am.service.exception.UserNotFoundException"
+                        ],
+                        "x-schema-form": {
+                          "type": "select",
+                          "titleMap": {
+                            "io.gravitee.am.service.exception.UserAlreadyExistsException" : "UserAlreadyExistsException",
+                            "io.gravitee.am.service.exception.UserNotFoundException" : "UserNotFoundException"
+                          }
+                        }
+                      },
+                      "message" : {
+                        "title": "Message",
+                        "description": "The message of the error if the condition is true (support EL)",
+                        "type" : "string"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "exception"
+                    ]
+                  }
+                }
+              }
+            },
             "deleteResource": {
               "type": "object",
               "id": "urn:jsonschema:io:gravitee:am:identityprovider:http:HttpResourceConfiguration",

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTest.java
@@ -172,6 +172,24 @@ public class HttpUserProviderTest {
     }
 
     @Test
+    public void shouldUpdatePasswrd() {
+        DefaultUser user = new DefaultUser("johndoe");
+        user.setId("123456789");
+
+        stubFor(put(urlPathEqualTo("/api/users/123456789/password"))
+                .withHeader(HttpHeaders.CONTENT_TYPE, containing("application/"))
+                .withRequestBody(matching(".*"))
+                .willReturn(okJson("{\"id\" : \"123456789\", \"username\" : \"johndoe\"}")));
+
+        TestObserver<User> testObserver = userProvider.updatePassword(user, "password").test();
+        testObserver.awaitTerminalEvent();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "123456789".equals(u.getId()));
+        testObserver.assertValue(u -> "johndoe".equals(u.getUsername()));
+    }
+
+    @Test
     public void shouldUpdateUser_userNotFound() {
         DefaultUser user = new DefaultUser("johndoe");
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTestConfiguration.java
@@ -84,6 +84,21 @@ public class HttpUserProviderTestConfiguration {
         updateErrorCondition.setException("io.gravitee.am.service.exception.UserNotFoundException");
         updateResource.setHttpResponseErrorConditions(Arrays.asList(updateErrorCondition));
 
+        HttpResourceConfiguration updatePwdResource = new HttpResourceConfiguration();
+        updatePwdResource.setBaseURL("/users/{#user.id}/password");
+        updatePwdResource.setHttpMethod(HttpMethod.PUT);
+        HttpHeader updatePwdHttpHeader = new HttpHeader();
+        updatePwdHttpHeader.setName("Content-Type");
+        updatePwdHttpHeader.setValue("application/json");
+        updatePwdResource.setHttpHeaders(Collections.singletonList(updatePwdHttpHeader));
+        JsonObject updatePwdJsonObject = new JsonObject();
+        createJsonObject.put("username", "{#user.username}");
+        updatePwdResource.setHttpBody(updatePwdJsonObject.encode());
+        HttpResponseErrorCondition updatePwdErrorCondition = new HttpResponseErrorCondition();
+        updatePwdErrorCondition.setValue("{#usersResponse.status == 404}");
+        updatePwdErrorCondition.setException("io.gravitee.am.service.exception.UserNotFoundException");
+        updatePwdResource.setHttpResponseErrorConditions(Arrays.asList(updatePwdErrorCondition));
+
         HttpResourceConfiguration deleteResource = new HttpResourceConfiguration();
         deleteResource.setBaseURL("/users/{#user.id}");
         deleteResource.setHttpMethod(HttpMethod.DELETE);
@@ -100,6 +115,7 @@ public class HttpUserProviderTestConfiguration {
         pathsConfiguration.setCreateResource(createResource);
         pathsConfiguration.setReadResource(readResource);
         pathsConfiguration.setReadResourceByEmail(readByEmailResource);
+        pathsConfiguration.setUpdatePasswordResource(updatePwdResource);
         pathsConfiguration.setUpdateResource(updateResource);
         pathsConfiguration.setDeleteResource(deleteResource);
         usersResourceConfiguration.setPaths(pathsConfiguration);

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.identityprovider.jdbc.user;
 
+import com.google.common.base.Strings;
 import io.gravitee.am.common.oidc.StandardClaims;
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.identityprovider.api.DefaultUser;
@@ -273,6 +274,51 @@ public class JdbcUserProvider extends JdbcAbstractProvider<UserProvider> impleme
                     }
                     ((DefaultUser) updateUser).setId(id);
                     return Single.just(updateUser);
+                });
+    }
+
+    @Override
+    public Single<User> updatePassword(User user, String password) {
+        final String sql;
+        final Object[] args;
+
+        if (Strings.isNullOrEmpty(password)) {
+            return Single.error(new IllegalArgumentException("Password required for UserProvider.updatePassword"));
+        }
+        if (configuration.isUseDedicatedSalt()) {
+            args = new Object[3];
+            sql = String.format("UPDATE %s SET %s = %s, %s = %s WHERE %s = %s",
+                    configuration.getUsersTable(),
+                    configuration.getPasswordAttribute(),
+                    getIndexParameter(1, configuration.getPasswordAttribute()),
+                    configuration.getPasswordSaltAttribute(),
+                    getIndexParameter(2, configuration.getPasswordSaltAttribute()),
+                    configuration.getIdentifierAttribute(),
+                    getIndexParameter(3, configuration.getIdentifierAttribute()));
+            byte[] salt = createSalt();
+            args[0] = passwordEncoder.encode(password, salt);
+            args[1] = binaryToTextEncoder.encode(salt);
+            args[2] = user.getId();
+        } else {
+            args = new Object[2];
+            sql = String.format("UPDATE %s SET %s = %s WHERE %s = %s",
+                    configuration.getUsersTable(),
+                    configuration.getPasswordAttribute(),
+                    getIndexParameter(1, configuration.getPasswordAttribute()),
+                    configuration.getIdentifierAttribute(),
+                    getIndexParameter(2, configuration.getIdentifierAttribute()));
+            args[0] = passwordEncoder.encode(password);
+            args[1] = user.getId();
+        }
+
+        return query(sql, args)
+                .flatMap(Result::getRowsUpdated)
+                .first(0)
+                .flatMap(rowsUpdated -> {
+                    if (rowsUpdated == 0) {
+                        return Single.error(new UserNotFoundException(user.getId()));
+                    }
+                    return Single.just(user);
                 });
     }
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider_Test.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider_Test.java
@@ -131,4 +131,5 @@ public abstract class JdbcUserProvider_Test {
         testObserver.assertError(UserNotFoundException.class);
         testObserver.assertNoValues();
     }
+
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.am.identityprovider.mongo.user;
 
+import com.google.common.base.Strings;
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.model.Updates;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import io.gravitee.am.common.oidc.StandardClaims;
@@ -34,6 +37,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import org.bson.BsonDocument;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -143,24 +147,20 @@ public class MongoUserProvider implements UserProvider, InitializingBean {
 
     @Override
     public Single<User> update(String id, User updateUser) {
-        return findById(id)
+        return findById(id, false)
                 .switchIfEmpty(Maybe.error(new UserNotFoundException(id)))
                 .flatMapSingle(oldUser -> {
                     Document document = new Document();
                     // set username (keep the original value)
                     document.put(configuration.getUsernameField(), oldUser.getUsername());
-                    // set password
-                    if (updateUser.getCredentials() != null) {
-                        if (configuration.isUseDedicatedSalt()) {
-                            byte[] salt = createSalt();
-                            document.put(configuration.getPasswordField(), passwordEncoder.encode(updateUser.getCredentials(), salt));
-                            document.put(configuration.getPasswordSaltAttribute(), binaryToTextEncoder.encode(salt));
-                        } else {
-                            document.put(configuration.getPasswordField(), passwordEncoder.encode(updateUser.getCredentials()));
-                        }
-                    } else {
-                        document.put(configuration.getPasswordField(), oldUser.getCredentials());
+
+                    // set password & salt coming from existing user data
+                    document.put(configuration.getPasswordField(), oldUser.getCredentials());
+                    if (configuration.isUseDedicatedSalt()) {
+                        // TODO to check with test
+                        document.put(configuration.getPasswordSaltAttribute(), oldUser.getAdditionalInformation().get(configuration.getPasswordSaltAttribute()));
                     }
+
                     // set additional information
                     if (updateUser.getAdditionalInformation() != null) {
                         document.putAll(updateUser.getAdditionalInformation());
@@ -169,6 +169,41 @@ public class MongoUserProvider implements UserProvider, InitializingBean {
                     document.put(FIELD_CREATED_AT, oldUser.getCreatedAt());
                     document.put(FIELD_UPDATED_AT, new Date());
                     return Single.fromPublisher(usersCollection.replaceOne(eq(FIELD_ID, oldUser.getId()), document)).flatMap(updateResult -> findById(oldUser.getId()).toSingle());
+                });
+    }
+
+    @Override
+    public Single<User> updatePassword(User user, String password) {
+
+        if (Strings.isNullOrEmpty(password)) {
+            return Single.error(new IllegalArgumentException("Password required for UserProvider.updatePassword"));
+        }
+
+        return findById(user.getId(), false)
+                .switchIfEmpty(Maybe.error(new UserNotFoundException(user.getId())))
+                .flatMapSingle(oldUser -> {
+                    // set password
+                    Bson passwordField = null;
+                    Bson passwordSaltField = null;
+                    if (configuration.isUseDedicatedSalt()) {
+                        byte[] salt = createSalt();
+                        passwordField = Updates.set(configuration.getPasswordField(), passwordEncoder.encode(password, salt));
+                        passwordSaltField = Updates.set(configuration.getPasswordSaltAttribute(), binaryToTextEncoder.encode(salt));
+                    } else {
+                        passwordField = Updates.set(configuration.getPasswordField(), passwordEncoder.encode(password));
+                    }
+
+                    Bson updates = passwordSaltField == null ?
+                            Updates.combine(
+                                    passwordField,
+                                    Updates.set(FIELD_UPDATED_AT, new Date())) :
+                            Updates.combine(
+                                    passwordField,
+                                    passwordSaltField,
+                                    Updates.set(FIELD_UPDATED_AT, new Date()));
+
+                    return Single.fromPublisher(usersCollection.updateOne(eq(FIELD_ID, oldUser.getId()), updates))
+                            .flatMap(updateResult -> findById(oldUser.getId()).toSingle());
                 });
     }
 
@@ -188,10 +223,18 @@ public class MongoUserProvider implements UserProvider, InitializingBean {
     }
 
     private Maybe<User> findById(String userId) {
-        return Observable.fromPublisher(usersCollection.find(eq(FIELD_ID, userId)).first()).firstElement().map(this::convert);
+        return this.findById(userId, true);
+    }
+
+    private Maybe<User> findById(String userId, boolean filterSalt) {
+        return Observable.fromPublisher(usersCollection.find(eq(FIELD_ID, userId)).first()).firstElement().map(u -> convert(u, filterSalt));
     }
 
     private User convert(Document document) {
+        return this.convert(document, true);
+    }
+
+    private User convert(Document document, boolean filterSalt) {
         String username = document.getString(configuration.getUsernameField());
         DefaultUser user = new DefaultUser(username);
         user.setId(document.getString(FIELD_ID));
@@ -207,6 +250,11 @@ public class MongoUserProvider implements UserProvider, InitializingBean {
         document.remove(configuration.getUsernameField());
         document.remove(configuration.getPasswordField());
         document.entrySet().forEach(entry -> claims.put(entry.getKey(), entry.getValue()));
+
+        if (filterSalt && configuration.isUseDedicatedSalt()) {
+                claims.remove(configuration.getPasswordSaltAttribute());
+        }
+
         user.setAdditionalInformation(claims);
         return user;
     }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.identityprovider.mongo.user;
+
+import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.identityprovider.api.DefaultUser;
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.identityprovider.api.UserProvider;
+import io.gravitee.am.identityprovider.mongo.authentication.spring.MongoAuthenticationProviderConfiguration;
+import io.gravitee.common.util.Maps;
+import io.reactivex.observers.TestObserver;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { MongoUserProviderTestConfiguration.class, MongoAuthenticationProviderConfiguration.class }, loader = AnnotationConfigContextLoader.class)
+public class MongoUserProviderTest {
+
+    @Autowired
+    private UserProvider userProvider;
+
+    @Test
+    public void shouldSelectUserByUsername() {
+        TestObserver<User> testObserver = userProvider.findByUsername("bob").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "bob".equals(u.getUsername()));
+    }
+
+    @Test
+    public void shouldSelectUserByEmail() {
+        TestObserver<User> testObserver = userProvider.findByEmail("user01@acme.com").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "user01".equals(u.getUsername()));
+    }
+
+    @Test
+    public void shouldNotSelectUserByUsername_userNotFound() {
+        TestObserver<User> testObserver = userProvider.findByUsername("unknown").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoValues();
+    }
+
+    @Test
+    public void shouldNotSelectUserByEmail_userNotFound() {
+        TestObserver<User> testObserver = userProvider.findByEmail("unknown@acme.com").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoValues();
+    }
+
+    @Test
+    public void shouldCreateUser() {
+        DefaultUser user = createUserBean();
+        TestObserver<User> testObserver = userProvider.create(user).test();
+
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> assertUserMatch(user, u));
+    }
+
+    private boolean assertUserMatch(DefaultUser expectedUser, User testableUser) {
+        Assert.assertTrue(expectedUser.getUsername().equals(testableUser.getUsername()));
+        Assert.assertTrue(expectedUser.getEmail().equals(testableUser.getEmail()));
+        Assert.assertTrue(expectedUser.getFirstName().equals(testableUser.getFirstName()));
+        Assert.assertTrue(expectedUser.getLastName().equals(testableUser.getLastName()));
+        Assert.assertTrue(testableUser.getAdditionalInformation() != null);
+        Assert.assertTrue(testableUser.getAdditionalInformation().containsKey("key")
+                && "value".equals(testableUser.getAdditionalInformation().get("key")));
+        return true;
+    }
+
+    private DefaultUser createUserBean() {
+        final String username = RandomString.generate();
+        DefaultUser user = new DefaultUser();
+        user.setEmail(username+"@acme.com");
+        user.setUsername(username);
+        user.setFirstName("F-"+username);
+        user.setLastName("L-"+username);
+        user.setCredentials("T0pS3cret");
+        user.setAdditionalInformation(new Maps.MapBuilder(new HashMap()).put("key", "value")
+                .put("email", user.getEmail())
+                .put("given_name", user.getFirstName())
+                .put("family_name", user.getLastName()).build()
+        );
+        return user;
+    }
+
+    @Test
+    public void shouldUpdateUser() {
+        DefaultUser user = createUserBean();
+        User createdUser = userProvider.create(user).blockingGet();
+
+        assertUserMatch(user, createdUser);
+
+        DefaultUser userToUpdate = (DefaultUser) createdUser;
+        userToUpdate.setLastName("LUPDATE");
+        userToUpdate.setFirstName("FUPDATE");
+        userToUpdate.setEmail("update@acme.fr");
+        userToUpdate.setCredentials("toto");
+        userToUpdate.getAdditionalInformation().put("email", userToUpdate.getEmail());
+        userToUpdate.getAdditionalInformation().put("given_name", userToUpdate.getFirstName());
+        userToUpdate.getAdditionalInformation().put("family_name", userToUpdate.getLastName());
+
+        final TestObserver<User> observer = userProvider.update(createdUser.getId(), userToUpdate).test();
+        observer.awaitTerminalEvent();
+        observer.assertNoErrors();
+        observer.assertValue(u -> assertUserMatch(userToUpdate, u));
+    }
+
+    @Test
+    public void shouldUpdatePassword_NothingExceptedPassord_isUpdated() {
+        DefaultUser user = createUserBean();
+        User createdUser = userProvider.create(user).blockingGet();
+
+        assertUserMatch(user, createdUser);
+
+        DefaultUser userToUpdate = (DefaultUser) createdUser;
+        userToUpdate.setLastName("LUPDATE");
+        userToUpdate.setFirstName("FUPDATE");
+        userToUpdate.setEmail("update@acme.fr");
+        userToUpdate.setCredentials("toto");
+        userToUpdate.getAdditionalInformation().put("email", userToUpdate.getEmail());
+        userToUpdate.getAdditionalInformation().put("given_name", userToUpdate.getFirstName());
+        userToUpdate.getAdditionalInformation().put("family_name", userToUpdate.getLastName());
+
+        final TestObserver<User> observer = userProvider.updatePassword(userToUpdate, "something").test();
+        observer.awaitTerminalEvent();
+        observer.assertNoErrors();
+        observer.assertValue(u -> assertUserMatch(user, u));
+    }
+
+}

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.identityprovider.mongo.user;
+
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+import io.gravitee.am.identityprovider.api.AuthenticationProvider;
+import io.gravitee.am.identityprovider.api.DefaultIdentityProviderMapper;
+import io.gravitee.am.identityprovider.api.DefaultIdentityProviderRoleMapper;
+import io.gravitee.am.identityprovider.api.IdentityProviderMapper;
+import io.gravitee.am.identityprovider.api.IdentityProviderRoleMapper;
+import io.gravitee.am.identityprovider.api.UserProvider;
+import io.gravitee.am.identityprovider.mongo.MongoIdentityProviderConfiguration;
+import io.gravitee.am.identityprovider.mongo.authentication.EmbeddedClient;
+import io.gravitee.am.identityprovider.mongo.authentication.MongoAuthenticationProvider;
+import io.gravitee.am.identityprovider.mongo.utils.PasswordEncoder;
+import io.reactivex.Observable;
+import org.bson.Document;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.UUID;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class MongoUserProviderTestConfiguration implements InitializingBean {
+
+    @Autowired
+    private MongoDatabase mongoDatabase;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        MongoCollection<Document> collection = mongoDatabase.getCollection("users");
+        Document doc = new Document("username", "bob").append("password", "bobspassword").append("_id", UUID.randomUUID().toString());
+        Observable.fromPublisher(collection.insertOne(doc)).blockingFirst();
+        Document doc2 = new Document("username", "user01").append("email", "user01@acme.com").append("password", "user01").append("_id", UUID.randomUUID().toString());
+        Observable.fromPublisher(collection.insertOne(doc2)).blockingFirst();
+    }
+
+    @Bean
+    public MongoIdentityProviderConfiguration mongoIdentityProviderConfiguration() {
+        MongoIdentityProviderConfiguration configuration = new MongoIdentityProviderConfiguration();
+
+        String host = embeddedClient().getMongoClient().getClusterDescription().getClusterSettings().getHosts().get(0).toString();
+        configuration.setUri("mongodb://" + host);
+        configuration.setDatabase("test-idp-mongo");
+        configuration.setUsersCollection("users");
+        configuration.setFindUserByUsernameQuery("{username: ?}");
+        configuration.setFindUserByMultipleFieldsQuery("{ $or : [{username: ?}, {email: ?}]}");
+        configuration.setPasswordField("password");
+        configuration.setPasswordSaltAttribute("password-salt");
+        configuration.setUseDedicatedSalt(true);
+        configuration.setPasswordEncoder(PasswordEncoder.SHA);
+
+        return configuration;
+    }
+
+    @Bean
+    public UserProvider userProvider() {
+        return new MongoUserProvider();
+    }
+
+    @Bean
+    public IdentityProviderMapper mapper() {
+        return new DefaultIdentityProviderMapper();
+    }
+
+    @Bean
+    public IdentityProviderRoleMapper roleMapper() {
+        return new DefaultIdentityProviderRoleMapper();
+    }
+
+    @Bean
+    public EmbeddedClient embeddedClient() {
+        return new EmbeddedClient("test-idp-mongo");
+    }
+
+    @Bean
+    public MongoDatabase mongoDatabase() {
+        return embeddedClient().mongoDatabase();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/UserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/UserServiceImpl.java
@@ -274,11 +274,7 @@ public class UserServiceImpl extends AbstractUserService<io.gravitee.am.service.
                                             // update idp user
                                             return userProvider.findByUsername(user.getUsername())
                                                     .switchIfEmpty(Maybe.error(new UserNotFoundException(user.getUsername())))
-                                                    .flatMapSingle(idpUser -> {
-                                                        // set password
-                                                        ((DefaultUser) idpUser).setCredentials(password);
-                                                        return userProvider.update(idpUser.getId(), idpUser);
-                                                    })
+                                                    .flatMapSingle(idpUser -> userProvider.updatePassword(idpUser, password))
                                                     .onErrorResumeNext(ex -> {
                                                         if (ex instanceof UserNotFoundException) {
                                                             // idp user not found, create its account

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
@@ -428,7 +428,7 @@ public class UserServiceTest {
 
         UserProvider userProvider = mock(UserProvider.class);
         when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
-        when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
+        when(userProvider.updatePassword(any(), any())).thenReturn(Single.just(idpUser));
 
         doReturn(true).when(passwordService).isValid(eq(password), eq(null), any());
         when(commonUserService.findById(eq(ReferenceType.DOMAIN), eq(domain.getId()), eq("user-id"))).thenReturn(Single.just(user));


### PR DESCRIPTION
fixes gravitee-io/issues#7800

## :id: Reference related issue. 


## :pencil2: A description of the changes proposed in the pull request

Purpose of this change is to provide dedicated method in the UserProvider interface to update user password instead of relying on a single update user method.

## :memo: Test scenarios 

You need to do these tests with Mongo IDP, JBDBC IDP and HTTP IDP.
:warning: For JDBC & Mongo, test a configuration with and withour dedicated salf field

* Update a user attribute through UI ==> password and salt are not changed
* Update a user attribute through SCIM (do not include the password field) ==> password and salt are not changed

* Update a user password through UI ==> password and salt are changed
* Update a user attribute through SCIM by including the password field ==> password and salt are changed

* Request a new password on the GW using forgot password link ==> after the reset password workflow, password and salt are changed

**NOTE:** after each point, try to connect the end user on the GW to confirm that the password has changed or not according to the case