### PR TITLE
fix: update accountNonLocked attribute after successful login

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
@@ -202,6 +202,7 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
         if (afterAuthentication) {
             existingUser.setLoggedAt(new Date());
             existingUser.setLoginsCount(existingUser.getLoginsCount() + 1);
+            existingUser.setAccountNonLocked(true);
         }
         // set roles
         existingUser.setDynamicRoles(principal.getRoles());


### PR DESCRIPTION
fixes gravitee-io/issues#7831
