### PR TITLE
feat: risk-based alerts

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/event/AlertEventKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/event/AlertEventKeys.java
@@ -37,4 +37,9 @@ public interface AlertEventKeys {
     String PROPERTY_ENVIRONMENT = "environment";
     String PROPERTY_ORGANIZATION = "organization";
     String TYPE_AUTHENTICATION = "AUTHENTICATION";
+
+    String PROPERTY_RISK_ASSESSMENT = "risk_assessment";
+    String PROPERTY_UNKNOWN_DEVICES = "unknownDevices";
+    String PROPERTY_IP_REPUTATION = "ipReputation";
+    String PROPERTY_GEO_VELOCITY = "geoVelocity";
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/alert/AlertEventProcessor.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/alert/AlertEventProcessor.java
@@ -19,16 +19,18 @@ import io.gravitee.alert.api.event.DefaultEvent;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.gateway.handler.common.auth.AuthenticationDetails;
 import io.gravitee.am.gateway.handler.common.auth.event.AuthenticationEvent;
+import io.gravitee.am.gateway.handler.common.utils.RiskAssessmentService;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.service.EnvironmentService;
-import io.gravitee.am.service.OrganizationService;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.node.api.Node;
 import io.gravitee.plugin.alert.AlertEventProducer;
+import io.gravitee.risk.assessment.api.assessment.AssessmentMessageResult;
+import io.reactivex.Maybe;
+import io.reactivex.functions.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +39,8 @@ import org.springframework.core.env.Environment;
 import java.util.Map;
 
 import static io.gravitee.am.common.event.AlertEventKeys.*;
+import static io.gravitee.am.gateway.handler.common.auth.event.AuthenticationEvent.SUCCESS;
+import static io.gravitee.risk.assessment.api.assessment.Assessment.NONE;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -48,21 +52,18 @@ public class AlertEventProcessor extends AbstractService {
 
     @Autowired
     private EventManager eventManager;
-
     @Autowired
     private AlertEventProducer eventProducer;
-
     @Autowired
     private Domain domain;
-
     @Autowired
     private Node node;
-
     @Autowired
     private Environment environment;
-
     @Autowired
     private EnvironmentService environmentService;
+    @Autowired
+    private RiskAssessmentService riskAssessmentHelper;
 
     private final EventListener<AuthenticationEvent, AuthenticationDetails> authenticationEventListener = this::onAuthenticationEvent;
 
@@ -127,7 +128,27 @@ public class AlertEventProcessor extends AbstractService {
             }
         }
 
-        sendEvent(eventBuilder.build());
+        if (SUCCESS.equals(eventItem.type())) {
+            this.riskAssessmentHelper
+                    .computeRiskAssessment(authenticationDetails, sendAssessmentMessageResult(eventBuilder))
+                    .switchIfEmpty(Maybe.defer(() -> {
+                        sendEvent(eventBuilder.build());
+                        return Maybe.empty();
+                    })).ignoreElement().subscribe();
+        } else {
+            sendEvent(eventBuilder.build());
+        }
+    }
+
+    private Consumer<AssessmentMessageResult> sendAssessmentMessageResult(DefaultEvent.Builder eventBuilder) {
+        return result -> {
+            Map.of(
+                    PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_UNKNOWN_DEVICES, result.getDevices().getAssessment(),
+                    PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_IP_REPUTATION, result.getIpReputation().getAssessment(),
+                    PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_GEO_VELOCITY, result.getGeoVelocity().getAssessment()
+            ).forEach((property, assessment) -> eventBuilder.property(property, assessment.name()));
+            sendEvent(eventBuilder.build());
+        };
     }
 
     private void sendEvent(io.gravitee.alert.api.event.Event event) {
@@ -138,6 +159,4 @@ public class AlertEventProcessor extends AbstractService {
             logger.error("An error occurs while sending event to alert engine", e);
         }
     }
-
-
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -60,6 +60,7 @@ import io.vertx.reactivex.ext.web.client.WebClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
@@ -69,7 +70,13 @@ import org.springframework.core.env.Environment;
  * @author GraviteeSource Team
  */
 @Configuration
-@Import({WebConfiguration.class, FreemarkerConfiguration.class, PolicyConfiguration.class, ContextConfiguration.class})
+@ComponentScan("io.gravitee.am.gateway.handler.common.utils")
+@Import({
+        WebConfiguration.class,
+        FreemarkerConfiguration.class,
+        PolicyConfiguration.class,
+        ContextConfiguration.class,
+        RiskAssessmentConfiguration.class})
 public class CommonConfiguration {
 
     @Autowired

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/RiskAssessmentConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/RiskAssessmentConfiguration.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.common.spring;
+
+import io.gravitee.risk.assessment.api.assessment.Assessment;
+import io.gravitee.risk.assessment.api.assessment.settings.AssessmentSettings;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.Function;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class RiskAssessmentConfiguration {
+
+    private static final String RISK_ASSESSMENT_SETTINGS = "alerts.risk_assessment.settings";
+    private static final String DEVICES_PREFIX = RISK_ASSESSMENT_SETTINGS + ".devices";
+    private static final String IP_REPUTATION_PREFIX = RISK_ASSESSMENT_SETTINGS + ".ipReputation";
+    private static final String GEO_VELOCITY_PREFIX = RISK_ASSESSMENT_SETTINGS + ".geoVelocity";
+
+    private static final Map<String, Map<Assessment, Double>> DEFAULT_THRESHOLDS = Map.of(
+            DEVICES_PREFIX, Map.of(Assessment.HIGH, 1.0D), // Arbitrary Value
+            IP_REPUTATION_PREFIX, Map.of(Assessment.LOW, 1.0D), // Percentage
+            GEO_VELOCITY_PREFIX, Map.of(Assessment.LOW, (5.0 / 18.0)) // 1km/h
+    );
+
+    @Bean
+    public RiskAssessmentSettings riskAssessmentSettings(Environment environment) {
+        return new RiskAssessmentSettings()
+                .setEnabled(environment.getProperty(RISK_ASSESSMENT_SETTINGS + ".enabled", Boolean.class, true))
+                .setDeviceAssessment(getAssessment(environment, DEVICES_PREFIX))
+                .setIpReputationAssessment(getAssessment(environment, IP_REPUTATION_PREFIX))
+                .setGeoVelocityAssessment(getAssessment(environment, GEO_VELOCITY_PREFIX));
+    }
+
+    private AssessmentSettings getAssessment(Environment environment, String propertyPrefix) {
+        var thresholds = Arrays.stream(Assessment.values())
+                .map(getThreshold(environment, propertyPrefix))
+                .filter(entry -> entry.getValue().isPresent())
+                .map(entry -> Map.entry(entry.getKey(), entry.getValue().get()))
+                .collect(toMap(Entry::getKey, Entry::getValue));
+
+        return new AssessmentSettings()
+                .setEnabled(environment.getProperty(propertyPrefix + ".enabled", Boolean.class, true))
+                .setThresholds(thresholds.isEmpty() ? DEFAULT_THRESHOLDS.get(propertyPrefix) : thresholds);
+    }
+
+    private Function<Assessment, Entry<Assessment, Optional<Double>>> getThreshold(Environment env, String prefix) {
+        return assessment -> {
+            final String key = prefix + ".thresholds." + assessment.name();
+            final Double threshold = env.getProperty(key, Double.class);
+            return Map.entry(assessment, ofNullable(threshold));
+        };
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/utils/RiskAssessmentService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/utils/RiskAssessmentService.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.gateway.handler.common.auth.AuthenticationDetails;
+import io.gravitee.am.model.Device;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.UserActivity;
+import io.gravitee.am.service.DeviceService;
+import io.gravitee.am.service.UserActivityService;
+import io.gravitee.risk.assessment.api.assessment.AssessmentMessage;
+import io.gravitee.risk.assessment.api.assessment.AssessmentMessageResult;
+import io.gravitee.risk.assessment.api.assessment.AssessmentResult;
+import io.gravitee.risk.assessment.api.assessment.data.AssessmentData;
+import io.gravitee.risk.assessment.api.assessment.settings.AssessmentSettings;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
+import io.gravitee.risk.assessment.api.devices.Devices;
+import io.gravitee.risk.assessment.api.geovelocity.GeoTimeCoordinate;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
+import io.vertx.core.AsyncResult;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.eventbus.EventBus;
+import io.vertx.reactivex.core.eventbus.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static io.gravitee.am.common.utils.ConstantKeys.DEVICE_ID;
+import static io.gravitee.risk.assessment.api.assessment.Assessment.NONE;
+import static java.util.Objects.nonNull;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Michael CARTER (michael.carter at graviteesource.com)
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class RiskAssessmentService {
+
+    private static final Logger logger = LoggerFactory.getLogger(RiskAssessmentService.class);
+    private static final String RISK_ASSESSMENT_SERVICE = "service:risk-assessment";
+
+    private final DeviceService deviceService;
+    private final UserActivityService userActivityService;
+    private final ObjectMapper objectMapper;
+    private final EventBus eventBus;
+    private final RiskAssessmentSettings riskAssessmentSettings;
+
+    public RiskAssessmentService(
+            DeviceService deviceService,
+            UserActivityService userActivityService,
+            ObjectMapper objectMapper,
+            RiskAssessmentSettings riskAssessmentSettings,
+            Vertx vertx) {
+        this.deviceService = deviceService;
+        this.userActivityService = userActivityService;
+        this.objectMapper = objectMapper;
+        this.riskAssessmentSettings = riskAssessmentSettings;
+        this.eventBus = vertx.eventBus();
+    }
+
+    public Maybe<AssessmentMessage> computeRiskAssessment(
+            AuthenticationDetails authenticationDetails,
+            Consumer<AssessmentMessageResult> resultConsumer) {
+        if (riskAssessmentSettings.isEnabled()) {
+            var assessmentMessage = Single.just(new AssessmentMessage().setSettings(riskAssessmentSettings).setData(new AssessmentData()));
+            Domain domain = authenticationDetails.getDomain();
+            User user = authenticationDetails.getUser();
+            return assessmentMessage
+                    .flatMap(buildDeviceAssessmentMessage(authenticationDetails, domain, user))
+                    .flatMap(buildIpReputationMessage(authenticationDetails))
+                    .flatMap(buildGeoVelocityMessage(domain, user))
+                    .doOnSuccess(processedMessage -> consumeRiskAssessmentResult(processedMessage, resultConsumer))
+                    .doOnError(throwable -> logger.error("An unexpected error has occurred while trying to apply risk assessment: ", throwable))
+                    .toMaybe();
+        }
+        return Maybe.empty();
+    }
+
+    private Function<AssessmentMessage, Single<AssessmentMessage>> buildDeviceAssessmentMessage(
+            AuthenticationDetails authDetails,
+            Domain domain,
+            User user) {
+        return assessmentMessage -> {
+            var deviceAssessment = ofNullable(riskAssessmentSettings.getDeviceAssessment()).orElse(new AssessmentSettings());
+            if (deviceAssessment.isEnabled()) {
+                logger.debug("Decorating assessment with devices");
+                return deviceService.findByDomainAndUser(domain.getId(), user.getId())
+                        .map(Device::getDeviceId)
+                        .toList().flatMap(deviceIds -> {
+                            assessmentMessage.getData().setDevices(new Devices()
+                                    .setKnownDevices(deviceIds)
+                                    .setEvaluatedDevice((String) authDetails.getPrincipal().getContext().get(DEVICE_ID))
+                            );
+                            return Single.just(assessmentMessage);
+                        });
+            }
+            return Single.just(assessmentMessage);
+        };
+    }
+
+    private Function<AssessmentMessage, Single<AssessmentMessage>> buildIpReputationMessage(AuthenticationDetails authDetails) {
+        return assessmentMessage -> {
+            var ipReputationAssessment = ofNullable(riskAssessmentSettings.getIpReputationAssessment()).orElse(new AssessmentSettings());
+            if (ipReputationAssessment.isEnabled()) {
+                logger.debug("Decorating assessment with IP reputation");
+                String ip = (String) authDetails.getPrincipal().getContext().get(Claims.ip_address);
+                assessmentMessage.getData().setCurrentIp(ip);
+            }
+            return Single.just(assessmentMessage);
+        };
+    }
+
+    private Function<AssessmentMessage, Single<AssessmentMessage>> buildGeoVelocityMessage(Domain domain, User user) {
+        return assessmentMessage -> {
+            var geoVelocityAssessment = ofNullable(riskAssessmentSettings.getGeoVelocityAssessment()).orElse(new AssessmentSettings());
+            if (geoVelocityAssessment.isEnabled()) {
+                return userActivityService.findByDomainAndTypeAndUserAndLimit(domain.getId(), UserActivity.Type.LOGIN, user.getId(), 2)
+                        .toList()
+                        .flatMap(activityList -> {
+                            assessmentMessage.getData().setGeoTimeCoordinates(computeGeoTimeCoordinates(activityList));
+                            return Single.just(assessmentMessage);
+                        });
+            }
+            return Single.just(assessmentMessage);
+        };
+    }
+
+    private List<GeoTimeCoordinate> computeGeoTimeCoordinates(List<UserActivity> activityList) {
+        return activityList.stream().filter(ua -> nonNull(ua.getLatitude())).filter(ua -> nonNull(ua.getLongitude()))
+                .map(ua -> new GeoTimeCoordinate(
+                        ua.getLatitude(),
+                        ua.getLongitude(),
+                        ua.getCreatedAt().toInstant().getEpochSecond())
+                ).collect(toList());
+    }
+
+    private void consumeRiskAssessmentResult(AssessmentMessage message, Consumer<AssessmentMessageResult> resultConsumer) throws JsonProcessingException {
+        eventBus.<String>request(RISK_ASSESSMENT_SERVICE, objectMapper.writeValueAsString(message), response -> {
+            if (response.succeeded()) {
+                try {
+                    resultConsumer.accept(extractMessageResult(response));
+                } catch (Exception e) {
+                    logger.error("Error processing risk assessment response.", e);
+                }
+            } else if (response.failed()) {
+                logger.warn("{} could not be called, reason: {}", RISK_ASSESSMENT_SERVICE, response.cause().getMessage());
+                logger.debug("", response.cause());
+            }
+        });
+    }
+
+    private AssessmentMessageResult extractMessageResult(AsyncResult<Message<String>> response) {
+        try {
+            return objectMapper.readValue(response.result().body(), AssessmentMessageResult.class);
+        } catch (JsonProcessingException e) {
+            logger.error("An unexpected error has occurred: ", e);
+            return new AssessmentMessageResult()
+                    .setDevices(new AssessmentResult<Double>().setAssessment(NONE))
+                    .setGeoVelocity(new AssessmentResult<Double>().setAssessment(NONE))
+                    .setIpReputation(new AssessmentResult<Double>().setAssessment(NONE));
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/provider/impl/UserAuthProviderImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/provider/impl/UserAuthProviderImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.exception.oauth2.ServerErrorException;
+import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.auth.user.EndUserAuthentication;
 import io.gravitee.am.gateway.handler.common.auth.user.UserAuthenticationManager;
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
@@ -80,6 +81,7 @@ public class UserAuthProviderImpl implements UserAuthProvider {
             authenticationContext.set(Claims.ip_address, ipAddress);
             authenticationContext.set(Claims.user_agent, userAgent);
             authenticationContext.set(Claims.domain, client.getDomain());
+            authenticationContext.set(ConstantKeys.DEVICE_ID, context.request().getParam(DEVICE_ID));
 
             userAuthenticationManager.authenticate(client, authentication)
                     .subscribe(

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/utils/RiskAssessmentServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/utils/RiskAssessmentServiceTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.common.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.gateway.handler.common.auth.AuthenticationDetails;
+import io.gravitee.am.identityprovider.api.Authentication;
+import io.gravitee.am.identityprovider.api.AuthenticationContext;
+import io.gravitee.am.model.Device;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.UserActivity;
+import io.gravitee.am.service.DeviceService;
+import io.gravitee.am.service.UserActivityService;
+import io.gravitee.risk.assessment.api.assessment.settings.AssessmentSettings;
+import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
+import io.reactivex.Flowable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.eventbus.EventBus;
+import io.vertx.reactivex.core.eventbus.Message;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Date;
+import java.util.Map;
+
+import static io.gravitee.risk.assessment.api.assessment.Assessment.LOW;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+
+/**
+ * @author Michael CARTER (michael.carter at graviteesource.com)
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RiskAssessmentServiceTest {
+
+    @Mock
+    private Vertx vertx;
+    @Mock
+    private DeviceService deviceService;
+    @Mock
+    private UserActivityService userActivityService;
+    @Mock
+    private EventBus eventBus;
+
+    private RiskAssessmentService riskAssessmentService;
+
+    @Before
+    public void setUp() throws Exception {
+        when(vertx.eventBus()).thenReturn(eventBus);
+    }
+
+    @Test
+    public void must_test_not_computeRiskAssessment_disabled() {
+        riskAssessmentService = new RiskAssessmentService(deviceService, userActivityService, new ObjectMapper(), new RiskAssessmentSettings(), vertx);
+        var testObserver = riskAssessmentService.computeRiskAssessment(authDetailsStub(), Assert::assertNotNull).test();
+        testObserver.awaitTerminalEvent();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(eventBus, times(0)).request(
+                any(), anyString(), (Handler<AsyncResult<Message<Object>>>) Mockito.any());
+    }
+
+    @Test
+    public void must_test_not_computeRiskAssessment_enabled_but_not_other_assessment() {
+        var settings = new RiskAssessmentSettings()
+                .setEnabled(true)
+                .setDeviceAssessment(new AssessmentSettings().setEnabled(false))
+                .setIpReputationAssessment(new AssessmentSettings().setEnabled(false))
+                .setGeoVelocityAssessment(new AssessmentSettings().setEnabled(false));
+
+        riskAssessmentService = new RiskAssessmentService(deviceService, userActivityService, new ObjectMapper(), settings, vertx);
+        var testObserver = riskAssessmentService.computeRiskAssessment(authDetailsStub(), Assert::assertNotNull).test();
+        testObserver.awaitTerminalEvent();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(eventBus, times(1)).request(
+                any(), anyString(), (Handler<AsyncResult<Message<Object>>>) Mockito.any());
+    }
+
+    @Test
+    public void must_test_computeRiskAssessment() {
+        var settings = new RiskAssessmentSettings()
+                .setEnabled(true)
+                .setDeviceAssessment(new AssessmentSettings().setEnabled(true).setThresholds(Map.of(LOW, 1.0D)))
+                .setIpReputationAssessment(new AssessmentSettings().setEnabled(true).setThresholds(Map.of(LOW, 30D)))
+                .setGeoVelocityAssessment(new AssessmentSettings().setEnabled(true).setThresholds(Map.of(LOW, 5.0D / 18D)));
+
+        riskAssessmentService = new RiskAssessmentService(deviceService, userActivityService, new ObjectMapper(), settings, vertx);
+
+        //device
+        doReturn(Flowable.just(new Device().setDeviceId("1"), new Device().setDeviceId("2")))
+                .when(deviceService).findByDomainAndUser(anyString(), anyString());
+        //geo
+        doReturn(Flowable.just(
+                new UserActivity().setLatitude(50.34D).setLongitude(3.025D).setCreatedAt(new Date()),
+                new UserActivity().setLatitude(50.34D).setLongitude(3.025D).setCreatedAt(new Date())
+        )).when(userActivityService).findByDomainAndTypeAndUserAndLimit(anyString(), any(), anyString(), eq(2));
+
+        var testObserver = riskAssessmentService.computeRiskAssessment(authDetailsStub(), Assert::assertNotNull).test();
+        testObserver.awaitTerminalEvent();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(eventBus, times(1)).request(
+                any(), anyString(), (Handler<AsyncResult<Message<Object>>>) Mockito.any());
+    }
+
+    private AuthenticationDetails authDetailsStub() {
+        return new AuthenticationDetails() {
+            @Override
+            public Domain getDomain() {
+                return new Domain() {
+                    @Override
+                    public String getId() {
+                        return "1234";
+                    }
+                };
+            }
+
+            @Override
+            public User getUser() {
+                return new User() {
+                    @Override
+                    public String getId() {
+                        return "1234";
+                    }
+                };
+            }
+
+            @Override
+            public Authentication getPrincipal() {
+                Authentication principal = mock(Authentication.class);
+                AuthenticationContext context = mock(AuthenticationContext.class);
+                given(context.get(anyString())).willReturn("myDeviceId");
+                given(principal.getContext()).willReturn(context);
+                return principal;
+            }
+        };
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -218,6 +218,18 @@ email:
 
 # User management configuration
 user:
+#  activity:
+#    enabled: true # default is false
+#    anon: #used to anonymize the user activity
+#      algorithm: SHA256 # possible values: SHA256, SHA512, NONE. default SHA256
+#      salt: some-salt #default is null meaning the key generated will change every time and data won't be exploitable
+#    retention:
+#      time: 3
+#      unit: MONTHS
+#    geolocation:
+#      variation:
+#        latitude: 0.07 # default to have a geolocation randomised, 0 will give the exact position
+#        longitude: 0.07 # default to have a geolocation randomised, 0 will give the exact position
   email:
     policy:
       pattern: ^[a-zA-Z0-9_+-]+(?:\.[a-zA-Z0-9_+-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,7}$
@@ -358,3 +370,26 @@ ds:
 liquibase:
   enabled: false
 
+#alerts:
+#  risk_assessment:
+#    settings:
+#      enabled: true # default is true
+#      devices:
+#        enabled: true # default is true
+#        thresholds:
+#          HIGH: 1 # Arbitrary value
+#      ipReputation:
+#        enabled: true # default is true
+#        thresholds:
+#          #Default is only LOW, but you can add more thresholds
+#          #percentage
+#          LOW: 1
+##          MEDIUM: 30
+##          HIGH: 70
+#      geoVelocity:
+#        enabled: true # default is true
+#        thresholds:
+#          # meter per second, default is 0.2777778 (1km/h)
+#          LOW: 0.2777778
+##          MEDIUM: 6,9444445 (25km/h)
+##          HIGH: 69,444445 (250km/h)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/alerts/risk/GeoVelocityAlert.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/alerts/risk/GeoVelocityAlert.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.alerts.risk;
+
+import io.gravitee.alert.api.condition.Condition;
+import io.gravitee.alert.api.condition.StringCondition;
+import io.gravitee.alert.api.trigger.Dampening;
+import io.gravitee.alert.api.trigger.Trigger;
+import io.gravitee.am.common.event.AlertEventKeys;
+import io.gravitee.am.model.alert.AlertTrigger;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.springframework.core.env.Environment;
+
+import static io.gravitee.alert.api.condition.StringCondition.matches;
+import static io.gravitee.am.common.event.AlertEventKeys.*;
+import static io.gravitee.am.management.service.alerts.AlertTriggerFactory.AUTHENTICATION_SOURCE;
+import static io.gravitee.risk.assessment.api.assessment.Assessment.LOW;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Michael CARTER (michael.carter at graviteesource.com)
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GeoVelocityAlert extends RiskAssessmentAlert {
+
+    private static final int DEFAULT_DAMPENING = 1;
+    private static final String DEFAULT_NAME = "Geo velocity alert";
+    private static final String DEFAULT_DESCRIPTION = "A geo velocity risk-based alert has been triggered";
+    private static final Severity DEFAULT_SEVERITY = Severity.WARNING;
+
+    private static final String ALERT_NAME_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_GEO_VELOCITY + NAME_SUFFIX;
+    private static final String ALERT_DESCRIPTION_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_GEO_VELOCITY + DESCRIPTION_SUFFIX;
+    private static final String ALERT_SEVERITY_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_GEO_VELOCITY + SEVERITY_SUFFIX;
+
+    public GeoVelocityAlert(AlertTrigger alertTrigger, Environment environment) {
+        super(alertTrigger.getId(), DEFAULT_NAME, DEFAULT_SEVERITY, AUTHENTICATION_SOURCE, alertTrigger.isEnabled());
+
+        final String name = environment.getProperty(ALERT_NAME_KEY, DEFAULT_NAME);
+        final String description = environment.getProperty(ALERT_DESCRIPTION_KEY, DEFAULT_DESCRIPTION);
+
+        this.setId(alertTrigger.getId() + "-" + this.getClass().getSimpleName());
+        this.setName(name);
+        this.setDescription(description);
+        this.setSeverity(environment.getProperty(ALERT_SEVERITY_KEY, Severity.class, DEFAULT_SEVERITY));
+
+        this.setConditions(singletonList(getCondition(environment, PROPERTY_GEO_VELOCITY, LOW.name())));
+
+        final StringCondition domainFilter = StringCondition.equals(PROPERTY_DOMAIN, alertTrigger.getReferenceId()).build();
+        this.setFilters(singletonList(domainFilter));
+
+        this.setDampening(Dampening.strictCount(DEFAULT_DAMPENING));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/alerts/risk/IpReputationAlert.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/alerts/risk/IpReputationAlert.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.alerts.risk;
+
+import io.gravitee.alert.api.condition.Condition;
+import io.gravitee.alert.api.condition.StringCondition;
+import io.gravitee.alert.api.trigger.Dampening;
+import io.gravitee.alert.api.trigger.Trigger;
+import io.gravitee.am.common.event.AlertEventKeys;
+import io.gravitee.am.model.alert.AlertTrigger;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.springframework.core.env.Environment;
+
+import static io.gravitee.alert.api.condition.StringCondition.matches;
+import static io.gravitee.am.common.event.AlertEventKeys.*;
+import static io.gravitee.am.management.service.alerts.AlertTriggerFactory.AUTHENTICATION_SOURCE;
+import static io.gravitee.risk.assessment.api.assessment.Assessment.LOW;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Michael CARTER (michael.carter at graviteesource.com)
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class IpReputationAlert extends RiskAssessmentAlert {
+
+    private static final int DEFAULT_DAMPENING = 1;
+    private static final String DEFAULT_NAME = "IP reputation alert";
+    private static final String DEFAULT_DESCRIPTION = "An IP reputation risk-based alert has been triggered";
+    private static final Severity DEFAULT_SEVERITY = Severity.WARNING;
+
+    private static final String ALERT_NAME_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_IP_REPUTATION + NAME_SUFFIX;
+    private static final String ALERT_DESCRIPTION_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_IP_REPUTATION + DESCRIPTION_SUFFIX;
+    private static final String ALERT_SEVERITY_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_IP_REPUTATION + SEVERITY_SUFFIX;
+
+    public IpReputationAlert(AlertTrigger alertTrigger, Environment environment) {
+        super(alertTrigger.getId(), DEFAULT_NAME, DEFAULT_SEVERITY, AUTHENTICATION_SOURCE, alertTrigger.isEnabled());
+
+
+        final String name = environment.getProperty(ALERT_NAME_KEY, DEFAULT_NAME);
+        final String description = environment.getProperty(ALERT_DESCRIPTION_KEY, DEFAULT_DESCRIPTION);
+
+        this.setId(alertTrigger.getId() + "-" + this.getClass().getSimpleName());
+        this.setName(name);
+        this.setDescription(description);
+        this.setSeverity(environment.getProperty(ALERT_SEVERITY_KEY, Severity.class, DEFAULT_SEVERITY));
+
+        this.setConditions(singletonList(getCondition(environment, PROPERTY_IP_REPUTATION, LOW.name())));
+
+        final StringCondition domainFilter = StringCondition.equals(PROPERTY_DOMAIN, alertTrigger.getReferenceId()).build();
+        this.setFilters(singletonList(domainFilter));
+
+        this.setDampening(Dampening.strictCount(DEFAULT_DAMPENING));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/alerts/risk/RiskAssessmentAlert.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/alerts/risk/RiskAssessmentAlert.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.management.service.alerts.risk;
+
+import io.gravitee.alert.api.condition.Condition;
+import io.gravitee.alert.api.trigger.Trigger;
+import io.gravitee.am.common.event.AlertEventKeys;
+import io.gravitee.notifier.api.Period;
+import io.gravitee.risk.assessment.api.assessment.Assessment;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.springframework.core.env.Environment;
+
+import static io.gravitee.alert.api.condition.StringCondition.matches;
+import static io.gravitee.am.common.event.AlertEventKeys.PROPERTY_RISK_ASSESSMENT;
+import static io.gravitee.risk.assessment.api.assessment.Assessment.LOW;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+abstract class RiskAssessmentAlert extends Trigger {
+
+    protected static final String PROPERTY_ALERTS = "alerts.";
+    protected static final String DESCRIPTION_SUFFIX = ".description";
+    protected static final String SEVERITY_SUFFIX = ".severity";
+    protected static final String NAME_SUFFIX = ".name";
+
+    private static final String ASSESSMENTS_SUFFIX = ".assessments";
+
+    protected RiskAssessmentAlert(String id, String name, Severity severity, String source, boolean enabled) {
+        super(id, name, severity, source, enabled);
+    }
+
+    protected Condition getCondition(Environment environment, String alertProperty, String defaultAssessment) {
+        final String assessmentProperty = PROPERTY_RISK_ASSESSMENT + "." + alertProperty;
+        final String envProperty = PROPERTY_ALERTS + assessmentProperty + ASSESSMENTS_SUFFIX;
+        final String assessments = environment.getProperty(envProperty, defaultAssessment);
+        final String expression = Stream.of(assessments.split(", *")).map(Pattern::quote).collect(joining("|"));
+        return matches(assessmentProperty, "^(" + expression + ")$").build();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/alerts/risk/UnknownDeviceAlert.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/alerts/risk/UnknownDeviceAlert.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.alerts.risk;
+
+import io.gravitee.alert.api.condition.StringCondition;
+import io.gravitee.alert.api.trigger.Dampening;
+import io.gravitee.am.model.alert.AlertTrigger;
+import io.gravitee.risk.assessment.api.assessment.Assessment;
+import org.springframework.core.env.Environment;
+
+import static io.gravitee.am.common.event.AlertEventKeys.*;
+import static io.gravitee.am.management.service.alerts.AlertTriggerFactory.AUTHENTICATION_SOURCE;
+import static io.gravitee.risk.assessment.api.assessment.Assessment.HIGH;
+import static java.util.Collections.singletonList;
+
+/**
+ * @author Michael CARTER (michael.carter at graviteesource.com)
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UnknownDeviceAlert extends RiskAssessmentAlert {
+
+    private static final int DEFAULT_DAMPENING = 1;
+    private static final String DEFAULT_NAME = "Unknown Device alert";
+    private static final String DEFAULT_DESCRIPTION = "An unknown device risk-based alert has been triggered";
+    private static final Severity DEFAULT_SEVERITY = Severity.WARNING;
+
+    private static final String ALERT_NAME_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_UNKNOWN_DEVICES + NAME_SUFFIX;
+    private static final String ALERT_DESCRIPTION_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_UNKNOWN_DEVICES + DESCRIPTION_SUFFIX;
+    private static final String ALERT_SEVERITY_KEY = PROPERTY_ALERTS + PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_UNKNOWN_DEVICES + SEVERITY_SUFFIX;
+
+
+    public UnknownDeviceAlert(AlertTrigger alertTrigger, Environment environment) {
+        super(alertTrigger.getId(), DEFAULT_NAME, DEFAULT_SEVERITY, AUTHENTICATION_SOURCE, alertTrigger.isEnabled());
+
+        final String name = environment.getProperty(ALERT_NAME_KEY, DEFAULT_NAME);
+        final String description = environment.getProperty(ALERT_DESCRIPTION_KEY, DEFAULT_DESCRIPTION);
+
+        this.setId(alertTrigger.getId() + "-" + this.getClass().getSimpleName());
+        this.setName(name);
+        this.setDescription(description);
+        this.setSeverity(environment.getProperty(ALERT_SEVERITY_KEY, Severity.class, DEFAULT_SEVERITY));
+
+        this.setConditions(singletonList(super.getCondition(environment, PROPERTY_UNKNOWN_DEVICES, HIGH.name())));
+
+        final StringCondition domainFilter = StringCondition.equals(PROPERTY_DOMAIN, alertTrigger.getReferenceId()).build();
+        this.setFilters(singletonList(domainFilter));
+
+        this.setDampening(Dampening.strictCount(DEFAULT_DAMPENING));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/alerts/AlertTriggerFactoryTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/alerts/AlertTriggerFactoryTest.java
@@ -20,6 +20,7 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.alert.AlertNotifier;
 import io.gravitee.am.model.alert.AlertTrigger;
 import io.gravitee.am.model.alert.AlertTriggerType;
+import java.util.List;
 import org.junit.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -33,7 +34,6 @@ import static org.junit.Assert.assertTrue;
  * @author GraviteeSource Team
  */
 public class AlertTriggerFactoryTest {
-
 
     @Test
     public void createTooManyLoginFailuresTrigger() {
@@ -53,11 +53,43 @@ public class AlertTriggerFactoryTest {
         alertNotifier.setType("webhook");
 
         final MockEnvironment environment = new MockEnvironment();
-        final Trigger trigger = AlertTriggerFactory.create(alertTrigger, Collections.singletonList(alertNotifier), environment);
+        final List<Trigger> triggers = AlertTriggerFactory.create(alertTrigger, Collections.singletonList(alertNotifier), environment);
+
+        assertEquals(1, triggers.size());
+        var trigger = triggers.get(0);
 
         assertEquals(alertTrigger.getId(), trigger.getId());
         assertEquals(1, trigger.getConditions().size());
         assertEquals(1, trigger.getFilters().size());
         assertTrue(trigger.isEnabled());
+    }
+
+    @Test
+    public void createRiskAssessmentAlert() {
+
+        final AlertTrigger alertTrigger = new AlertTrigger();
+
+        alertTrigger.setId("alertTrigger#1");
+        alertTrigger.setEnabled(true);
+        alertTrigger.setType(AlertTriggerType.RISK_ASSESSMENT);
+        alertTrigger.setReferenceType(ReferenceType.DOMAIN);
+        alertTrigger.setReferenceId("domain#1");
+
+        final AlertNotifier alertNotifier = new AlertNotifier();
+        alertNotifier.setId("alertNotifier#1");
+        alertNotifier.setName("test");
+        alertNotifier.setConfiguration("{}");
+        alertNotifier.setType("webhook");
+
+        final MockEnvironment environment = new MockEnvironment();
+        final List<Trigger> triggers = AlertTriggerFactory.create(alertTrigger, Collections.singletonList(alertNotifier), environment);
+
+        assertEquals(3, triggers.size());
+        triggers.forEach(trigger -> {
+            assertTrue(trigger.getId().startsWith(alertTrigger.getId()));
+            assertEquals(1, trigger.getConditions().size());
+            assertEquals(1, trigger.getFilters().size());
+            assertTrue(trigger.isEnabled());
+        });
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -273,6 +273,11 @@ email:
 
 # User management configuration
 user:
+#  activity:
+#    enabled: true # default is false
+#    anon: #used to anonymize the user activity. You need to use the same values in your gateway
+#      algorithm: SHA256 # possible values: SHA256, SHA512, NONE. default SHA256
+#      salt: some-salt #default is null meaning the key generated will change every time and data won't be exploitable
   email:
     policy:
       pattern: ^[a-zA-Z0-9_+-]+(?:\.[a-zA-Z0-9_+-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,7}$
@@ -387,6 +392,23 @@ gateway:
 
 # Beta subject to change
 alerts:
+#  risk_assessment:
+#  # You need the Risk Assessment Service plugin for these alerts
+#    geoVelocity:
+#      name: Geo velocity alert
+#      description: A geo velocity risk-based alert has been triggered
+#      assessments: LOW # Default is LOW
+#      severity: WARNING
+#    ipReputation:
+#      name: IP reputation alert
+#      description: An IP reputation risk-based alert has been triggered
+#      assessments: LOW # Default is LOW
+#      severity: WARNING
+#    unknownDevices:
+#      name: Unknown Device alert
+#      description: An unknown device risk-based alert has been triggered
+#      assessments: HIGH # Default is HIGH
+#      severity: WARNING
   too_many_login_failures:
     name: "Too many login failures detected"
     description: "More than {threshold}% of logins are in failure over the last {window} second(s)"

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/alert/AlertTriggerType.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/alert/AlertTriggerType.java
@@ -21,7 +21,8 @@ package io.gravitee.am.model.alert;
  */
 public enum AlertTriggerType {
 
-    TOO_MANY_LOGIN_FAILURES(1);
+    TOO_MANY_LOGIN_FAILURES(1),
+    RISK_ASSESSMENT(2);
 
     private final int order;
 

--- a/gravitee-am-ui/src/app/domain/alerts/general/general.component.ts
+++ b/gravitee-am-ui/src/app/domain/alerts/general/general.component.ts
@@ -106,6 +106,12 @@ export class DomainAlertGeneralComponent implements OnInit {
         icon: 'account_box',
         available: true
       },
+      risk_assessment: {
+        name: 'Risk-based',
+        description: 'Alert based on user behavior (new device, IP reputation, geo velocity)',
+        icon: 'add_alert',
+        available: true
+      },
       too_many_reset_passwords: {
         name: 'Too many reset passwords',
         description: 'Alert when the number of reset passwords is abnormally high',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,6 +24,7 @@ sonar.exclusions= **/pom.xml,\
    gravitee-am-fapi-resource-api/**,\
    gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/**, \
    gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/**, \
+   gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/** \
    gravitee-am-repository/**, \
    **/assembly.xml,\
    **/src/main/resources,\


### PR DESCRIPTION
## :id: 
Fixes https://github.com/gravitee-io/issues/issues/7638

## :pencil2: 

Two main changes in this PR:

1. Additional Risk Assessment alert that can be enabled/disabled in the UI (see screenshot below)
2. New class in `RiskAssessmentHelper`, used by `AlertEventProcessor` for retrieving these configured values which are then used to compute the risk assessment at the risk assessment service.

## :memo: Test scenarios 

In the absence of the risk assessment service the most that can be manually tested is that enabling/disabling the risk assessment alert in AM leads to an alert trigger being created/removed in the Alert Engine. An instance of Alert Engine is therefore required as well as the AM plugin for connecting to Alert Engine.

## :computer: Add screenshots for UI

![Screenshot 2022-06-20 at 09 03 54](https://user-images.githubusercontent.com/99647292/174554768-7dd891fb-5cc3-4039-a906-cb053e181645.png)

## How to configure

### Management API

You can use coma-separated values to configure the Trigger (there will be a default configuration) in the `gravitee.yml`:
```yml
alerts:
  risk_assessment:
    geoVelocity:
      name: Geo velocity alert
      description: A geo velocity risk-based alert has been triggered
      assessements:  HIGH, MEDIUM, LOW # Default is LOW
      severity: CRITICAL
    ipReputation:
      name: IP reputation alert
      description: An IP reputation risk-based alert has been triggered
      assessements:  HIGH, LOW # Default is LOW
      severity: CRITICAL
    unknownDevices:
      name: Unknown Device alert
      description: An unknown device risk-based alert has been triggered
      assessements: HIGH # Default is LOW
      severity: CRITICAL
```
Here are the possible values to use:

```
HIGH, MEDIUM, REGULAR, LOW. SAFE, NONE
```

### Gateway

```yml
alerts:
  risk_assessment:
    settings:
      enabled: false # default is true
      devices:
        enabled: false # default is true
        thresholds:
          HIGH: 1 # Arbitrary value
      ipReputation:
        enabled: false # default is true
        thresholds:
          LOW: 1 # percentage
          MEDIDUM: 30 # percentage
          HIGH: 70 # percentage
      geoVelocity:
        enabled: false # default is true
        thresholds:
          LOW: 0.2777778 # meter per second, default is 0.2777778 (25km/h)
```


### Notifiers

I used an Email notifier. Here is the configuration for the freemarker body:

```
An alert '${alert.name}' has been fired.<br><br>Date: ${notification.timestamp?number?number_to_datetime}<br>Domain: ${domain.name} (${domain.id})<br>Application: ${application.name} (${application.id})<br>User: ${notification.properties['user']}<br><br>Assessments:<br> Unknown Devices: ${notification.properties['risk_assessment.unknownDevices']}<br> IP reputation: ${notification.properties['risk_assessment.ipReputation']}<br>Velocity: ${notification.properties['risk_assessment.geoVelocity']}
```