### PR TITLE
fix: always reload and refresh auths and resolvers on application page

### DIFF
--- a/gravitee-am-ui/src/app/app-routing.module.ts
+++ b/gravitee-am-ui/src/app/app-routing.module.ts
@@ -850,7 +850,7 @@ export const routes: Routes = [
                           application: ApplicationResolver,
                           permissions: ApplicationPermissionsResolver
                         },
-                        runGuardsAndResolvers: 'pathParamsOrQueryParamsChange',
+                        runGuardsAndResolvers: 'always',
                         data: {
                           breadcrumb: {
                             label: 'application.name'


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/7929

## :pencil2: A description of the changes proposed in the pull request

This PR fixes the application not being refreshed when saved. 

## :memo: Test scenarios 


### Idp settings

1. Change the application idp selection
2. Save the application 
3. Change to another tab
4. Come back to the app idp selection list
5. You should notice that the change app idp settings stays the same


### Redirect Uri

1. Go to the Application
2. In the Overview tab, notice the initiate the login flow redirect_uri 
3. Change the redirect_uri in Application > Settings
4. Come back to the Overview tab
5. Notice the redirect_uri has changed with the new settings

