### PR TITLE
fix: display OPTIONAL option in MFA settings first when an application is newly created

### DIFF
--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/factors/mfa-activate/mfa-activate.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/factors/mfa-activate/mfa-activate.component.ts
@@ -55,9 +55,9 @@ export class MfaActivateComponent implements OnInit {
   ngOnInit(): void {
     if (this.riskAssessment && this.riskAssessment.enabled) {
       this.currentMode = MfaActivateComponent.modeOptions.INTELLIGENT;
-    } else if (this.adaptiveMfaRule !== null && this.adaptiveMfaRule !== "") {
+    } else if (this.adaptiveMfaRule && this.adaptiveMfaRule !== "") {
       this.currentMode = MfaActivateComponent.modeOptions.CONDITIONAL;
-    } else if (this.enrollment.forceEnrollment) {
+    } else if (this.enrollment && this.enrollment.forceEnrollment) {
       this.currentMode = MfaActivateComponent.modeOptions.REQUIRED;
     } else {
       this.currentMode = MfaActivateComponent.modeOptions.OPTIONAL;


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/7969

## :pencil2: A description of the changes proposed in the pull request

This PR fixes the display of `Activate MFA` option when a newly create application is done

## :memo: Test scenarios 

1. Create An Application
2. Create a Factor
3. Go to your application MFA settings
4. Select a factor
5. Notice the option chosen is `Optional`
