### PR TITLE
fix: do not make remember device skip MFA until factor is active

### DIFF
--- a/gravitee-am-factor/gravitee-am-factor-email/src/main/java/io/gravitee/am/factor/email/provider/EmailFactorProvider.java
+++ b/gravitee-am-factor/gravitee-am-factor-email/src/main/java/io/gravitee/am/factor/email/provider/EmailFactorProvider.java
@@ -46,8 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static io.gravitee.am.model.factor.FactorStatus.ACTIVATED;
-import static io.gravitee.am.model.factor.FactorStatus.PENDING_ACTIVATION;
 import static java.util.Arrays.asList;
 
 /**
@@ -57,7 +55,6 @@ import static java.util.Arrays.asList;
 public class EmailFactorProvider implements FactorProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(EmailFactorProvider.class);
-    public static final String TEMPLATE_SUFFIX = ".html";
 
     @Autowired
     private EmailFactorConfiguration configuration;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAChallengeStep.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAChallengeStep.java
@@ -49,8 +49,7 @@ public class MFAChallengeStep extends MFAStep {
     @Override
     public void execute(RoutingContext routingContext, AuthenticationFlowChain flow) {
         final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
-        final Session session = routingContext.session();
-        var context = new MfaFilterContext(routingContext, client);
+        var context = new MfaFilterContext(routingContext, client, factorManager);
 
         // Rules that makes you skip MFA challenge
         var mfaFilterChain = new MfaFilterChain(

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStep.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStep.java
@@ -18,16 +18,12 @@ package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mf
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.ruleengine.RuleEngine;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
-import io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.AuthenticationFlowChain;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa.chain.MfaFilterChain;
-import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa.filter.AdaptiveMfaFilter;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa.filter.ClientNullFilter;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa.filter.EndUserEnrolledFilter;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa.filter.MfaSkipFilter;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa.filter.NoFactorFilter;
-import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa.filter.RememberDeviceFilter;
-import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa.filter.StepUpAuthenticationFilter;
 import io.gravitee.am.model.oidc.Client;
 import io.vertx.core.Handler;
 import io.vertx.reactivex.ext.web.RoutingContext;
@@ -50,7 +46,7 @@ public class MFAEnrollStep extends MFAStep {
     @Override
     public void execute(RoutingContext routingContext, AuthenticationFlowChain flow) {
         final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
-        var context = new MfaFilterContext(routingContext, client);
+        var context = new MfaFilterContext(routingContext, client, factorManager);
 
         // Rules that makes you skip MFA enroll
         var mfaFilterChain = new MfaFilterChain(

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/filter/MfaSkipUserStronglyAuthFilter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/filter/MfaSkipUserStronglyAuthFilter.java
@@ -34,9 +34,14 @@ public class MfaSkipUserStronglyAuthFilter extends MfaContextHolder implements S
     @Override
     public Boolean get() {
         final boolean userStronglyAuth = context.isUserStronglyAuth();
-        // We need to check whether the AMFA, Device and Step Up rule is false since we don't know of other MFA return False
         final boolean mfaSkipped = context.isMfaSkipped();
-        if (    // Whether Adaptive MFA is not true
+        //If user has not matching activated factors, we enforce MFA
+        if (!mfaSkipped && !context.userHasMatchingActivatedFactors()){
+            return false;
+        }
+        // We need to check whether the AMFA, Device and Step Up rule is false since we don't know of other MFA return False
+        else if (
+                // Whether Adaptive MFA is not true
                 !mfaSkipped && context.isAmfaActive() && !context.isAmfaRuleTrue() ||
                 // Or We don't remember the device and that mfa is not skipped
                 !mfaSkipped && context.getRememberDeviceSettings().isActive() && !context.deviceAlreadyExists() ||

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/filter/NoFactorFilter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/filter/NoFactorFilter.java
@@ -44,8 +44,8 @@ public class NoFactorFilter implements Supplier<Boolean> {
         return isNull(factors) || factors.isEmpty() || onlyRecoveryCodeFactor();
     }
 
-    private boolean onlyRecoveryCodeFactor(){
-        if(factors.size() == 1){
+    private boolean onlyRecoveryCodeFactor() {
+        if (factors.size() == 1) {
             final String factorId = factors.stream().findFirst().get();
             final Factor factor = factorManager.getFactor(factorId);
             return factor.getFactorType().equals(FactorType.RECOVERY_CODE);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/filter/RememberDeviceFilter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/filter/RememberDeviceFilter.java
@@ -38,7 +38,9 @@ public class RememberDeviceFilter extends MfaContextHolder implements Supplier<B
             return false;
         }
         var rememberDeviceSettings = context.getRememberDeviceSettings();
-        return !context.isStepUpActive() && rememberDeviceSettings.isActive() && context.deviceAlreadyExists();
+        return context.userHasMatchingActivatedFactors() &&
+                !context.isStepUpActive() &&
+                rememberDeviceSettings.isActive() && context.deviceAlreadyExists();
     }
 
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/AuthenticationFlowHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/AuthenticationFlowHandlerTest.java
@@ -40,6 +40,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.Single;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -89,7 +90,12 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
 
         Factor factor = new Factor();
         factor.setFactorType(FactorType.SMS);
+
+        Factor recoveryCodeFactor = new Factor();
+        recoveryCodeFactor.setFactorType(FactorType.RECOVERY_CODE);
+
         when(factorManager.getFactor(anyString())).thenReturn(factor);
+        when(factorManager.getFactor("factor-recovery-code")).thenReturn(recoveryCodeFactor);
 
         router.route("/login")
                 .order(Integer.MIN_VALUE)
@@ -188,6 +194,7 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
             MFASettings mfaSettings = new MFASettings();
             mfaSettings.setAdaptiveAuthenticationRule("{context.attributes['geoip']['country_iso_code'] == 'FR'");
+            client.setMfaSettings(mfaSettings);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "FR").getMap());
 
             // set user
@@ -318,7 +325,6 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
                 HttpStatusCode.OK_200, "OK");
     }
 
-
     @Test
     public void shouldContinue_user_device_known() throws Exception {
         router.route().order(-1).handler(rc -> {
@@ -344,10 +350,91 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
             rc.next();
         });
 
+
         testRequest(
                 HttpMethod.GET,
                 "/login",
                 HttpStatusCode.OK_200, "OK");
+    }
+
+
+    @Test
+    public void shouldRedirectToMFAChallengePage_device_remembered_but_no_matching_active_factor() throws Exception {
+        router.route().order(-1).handler(rc -> {
+            // set client
+            Client client = new Client();
+            client.setFactors(Collections.singleton("factor-1"));
+            rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            // set user
+            MFASettings mfaSettings = new MFASettings();
+            final RememberDeviceSettings rememberDevice = new RememberDeviceSettings();
+            rememberDevice.setActive(true);
+            mfaSettings.setRememberDevice(rememberDevice);
+            rc.session().put(DEVICE_ALREADY_EXISTS_KEY, true);
+            client.setMfaSettings(mfaSettings);
+            // set user
+            EnrolledFactor enrolledFactor = new EnrolledFactor();
+            enrolledFactor.setFactorId("factor-1");
+            enrolledFactor.setStatus(PENDING_ACTIVATION);
+            io.gravitee.am.model.User endUser = new io.gravitee.am.model.User();
+            endUser.setFactors(Collections.singletonList(enrolledFactor));
+            rc.getDelegate().setUser(new User(endUser));
+            rc.session().put(ConstantKeys.STRONG_AUTH_COMPLETED_KEY, true);
+            rc.next();
+        });
+
+        testRequest(
+                HttpMethod.GET, "/login",
+                null,
+                resp -> {
+                    String location = resp.headers().get("location");
+                    assertNotNull(location);
+                    assertTrue(location.endsWith("/mfa/challenge"));
+                },
+                HttpStatusCode.FOUND_302, "Found", null);
+    }
+
+    @Test
+    public void shouldRedirectToMFAChallengePage_device_remembered_but_active_factor_is_recovery_code() throws Exception {
+        router.route().order(-1).handler(rc -> {
+            // set client
+            Client client = new Client();
+            client.setFactors(Set.of("factor-recovery-code", "factor-id"));
+            rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            // set user
+            MFASettings mfaSettings = new MFASettings();
+            final RememberDeviceSettings rememberDevice = new RememberDeviceSettings();
+            rememberDevice.setActive(true);
+            mfaSettings.setRememberDevice(rememberDevice);
+            rc.session().put(DEVICE_ALREADY_EXISTS_KEY, true);
+            client.setMfaSettings(mfaSettings);
+
+            // set user
+            EnrolledFactor enrolledRecovery = new EnrolledFactor();
+            enrolledRecovery.setFactorId("factor-recovery-code");
+            enrolledRecovery.setStatus(ACTIVATED);
+
+            // set user
+            EnrolledFactor enrolledFactor = new EnrolledFactor();
+            enrolledFactor.setFactorId("factor-id");
+            enrolledFactor.setStatus(PENDING_ACTIVATION);
+
+            io.gravitee.am.model.User endUser = new io.gravitee.am.model.User();
+            endUser.setFactors(List.of(enrolledRecovery, enrolledFactor));
+            rc.getDelegate().setUser(new User(endUser));
+            rc.session().put(ConstantKeys.STRONG_AUTH_COMPLETED_KEY, false);
+            rc.next();
+        });
+
+        testRequest(
+                HttpMethod.GET, "/login",
+                null,
+                resp -> {
+                    String location = resp.headers().get("location");
+                    assertNotNull(location);
+                    assertTrue(location.endsWith("/mfa/challenge"));
+                },
+                HttpStatusCode.FOUND_302, "Found", null);
     }
 
     @Test


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/7971

## :pencil2: A description of the changes proposed in the pull request

This PR fixes the MFA challenge not being prompted when the end user has a remembered device

## :memo: Test scenarios 

1. Create a domain with OTP factor
2. Create an instance of FingerPrint plugins
3. Create an app with OTP enabled as factor and the remember device toggle active (for 10 minutes to have time to do the use case)
4. Create a fresh new user
5. Authenticate this user
6. Register the OTP factor (select remember device) and provide challenge code
7. Logout the user
8. In the Management UI, check that the user have an active device id
9. Go the factor tab linked to the user and remove the OTP factor
10. Authenticate this user
11.  Flash their OTP QRCode and click verify
12. Challenge should be prompted even if device is remembered
