### PR TITLE
fix: provide new option to force S256 as challenge method in PKCE

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/AuthorizationRequestParseParametersHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/AuthorizationRequestParseParametersHandlerTest.java
@@ -140,6 +140,100 @@ public class AuthorizationRequestParseParametersHandlerTest extends RxWebTestBas
     }
 
     @Test
+    public void shouldRejectRequest_ChallengeMethod_Invalid_defaultValue_plain() throws Exception {
+        OpenIDProviderMetadata openIDProviderMetadata = new OpenIDProviderMetadata();
+        openIDProviderMetadata.setResponseTypesSupported(Arrays.asList(ResponseType.CODE));
+        Client client = new Client();
+        client.setAuthorizedGrantTypes(Collections.singletonList(GrantType.AUTHORIZATION_CODE));
+        client.setResponseTypes(Collections.singletonList(ResponseType.CODE));
+        client.setRedirectUris(List.of("https://callback/strict"));
+        client.setForceS256CodeChallengeMethod(true);
+        client.setForcePKCE(true);
+
+        router.route().order(-1).handler(routingContext -> {
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            routingContext.put(ConstantKeys.PROVIDER_METADATA_CONTEXT_KEY, openIDProviderMetadata);
+            routingContext.next();
+        });
+        testRequest(
+                HttpMethod.GET,
+                "/oauth/authorize?response_type=code&redirect_uri=https://callback/strict&code_challenge=plaincodevalueplaincodevalueplaincodevalue123465789",
+                null,
+                HttpStatusCode.BAD_REQUEST_400, "Bad Request", null);
+    }
+
+    @Test
+    public void shouldAcceptRequest_ChallengeMethod_Plain() throws Exception {
+        doReturn(true).when(domain).isRedirectUriStrictMatching();
+        OpenIDProviderMetadata openIDProviderMetadata = new OpenIDProviderMetadata();
+        openIDProviderMetadata.setResponseTypesSupported(Arrays.asList(ResponseType.CODE));
+        Client client = new Client();
+        client.setAuthorizedGrantTypes(Collections.singletonList(GrantType.AUTHORIZATION_CODE));
+        client.setResponseTypes(Collections.singletonList(ResponseType.CODE));
+        client.setRedirectUris(List.of("https://callback/strict"));
+        client.setForceS256CodeChallengeMethod(false);
+        client.setForcePKCE(true);
+
+        router.route().order(-1).handler(routingContext -> {
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            routingContext.put(ConstantKeys.PROVIDER_METADATA_CONTEXT_KEY, openIDProviderMetadata);
+            routingContext.next();
+        });
+        testRequest(
+                HttpMethod.GET,
+                "/oauth/authorize?response_type=code&redirect_uri=https://callback/strict&code_challenge=plaincodevalueplaincodevalueplaincodevalue123465789",
+                null,
+                HttpStatusCode.OK_200, "OK", null);
+    }
+
+    @Test
+    public void shouldRejectRequest_ChallengeMethod_Invalid_provided_plain() throws Exception {
+        OpenIDProviderMetadata openIDProviderMetadata = new OpenIDProviderMetadata();
+        openIDProviderMetadata.setResponseTypesSupported(Arrays.asList(ResponseType.CODE));
+        Client client = new Client();
+        client.setAuthorizedGrantTypes(Collections.singletonList(GrantType.AUTHORIZATION_CODE));
+        client.setResponseTypes(Collections.singletonList(ResponseType.CODE));
+        client.setRedirectUris(List.of("https://callback/strict"));
+        client.setForceS256CodeChallengeMethod(true);
+        client.setForcePKCE(true);
+
+        router.route().order(-1).handler(routingContext -> {
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            routingContext.put(ConstantKeys.PROVIDER_METADATA_CONTEXT_KEY, openIDProviderMetadata);
+            routingContext.next();
+        });
+        testRequest(
+                HttpMethod.GET,
+                "/oauth/authorize?response_type=code&redirect_uri=https://callback/strict&code_challenge=plaincodevalueplaincodevalueplaincodevalue123465789&code_challenge_method=plain",
+                null,
+                HttpStatusCode.BAD_REQUEST_400, "Bad Request", null);
+    }
+
+    @Test
+    public void shouldAcceptRequest_ChallengeMethod_S256() throws Exception {
+        doReturn(true).when(domain).isRedirectUriStrictMatching();
+        OpenIDProviderMetadata openIDProviderMetadata = new OpenIDProviderMetadata();
+        openIDProviderMetadata.setResponseTypesSupported(Arrays.asList(ResponseType.CODE));
+        Client client = new Client();
+        client.setAuthorizedGrantTypes(Collections.singletonList(GrantType.AUTHORIZATION_CODE));
+        client.setResponseTypes(Collections.singletonList(ResponseType.CODE));
+        client.setRedirectUris(List.of("https://callback/strict"));
+        client.setForceS256CodeChallengeMethod(true);
+        client.setForcePKCE(true);
+
+        router.route().order(-1).handler(routingContext -> {
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            routingContext.put(ConstantKeys.PROVIDER_METADATA_CONTEXT_KEY, openIDProviderMetadata);
+            routingContext.next();
+        });
+        testRequest(
+                HttpMethod.GET,
+                "/oauth/authorize?response_type=code&redirect_uri=https://callback/strict&code_challenge=codechallenges256codechallenges256codechallenges256codechallenges256&code_challenge_method=S256",
+                null,
+                HttpStatusCode.OK_200, "OK", null);
+    }
+
+    @Test
     public void shouldAcceptRequest_redirect_URI_ok_2() throws Exception {
         doReturn(false).when(domain).isRedirectUriStrictMatching();
         OpenIDProviderMetadata openIDProviderMetadata = new OpenIDProviderMetadata();

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationOAuthSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationOAuthSettings.java
@@ -276,6 +276,12 @@ public class ApplicationOAuthSettings {
     private boolean forcePKCE;
 
     /**
+     * Ensure usage of the S256 challenge method with Proof Key for Code Exchange (PKCE)
+     * https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
+     */
+    private boolean forceS256CodeChallengeMethod;
+
+    /**
      * Array of URLs supplied by the RP to which it MAY request that the End-User's User Agent be redirected using the post_logout_redirect_uri parameter after a logout has been performed.
      */
     private List<String> postLogoutRedirectUris;
@@ -367,6 +373,7 @@ public class ApplicationOAuthSettings {
         this.authorizationEncryptedResponseAlg = other.authorizationEncryptedResponseAlg;
         this.authorizationEncryptedResponseEnc = other.authorizationEncryptedResponseEnc;
         this.forcePKCE = other.forcePKCE;
+        this.forceS256CodeChallengeMethod = other.forceS256CodeChallengeMethod;
         this.postLogoutRedirectUris = other.postLogoutRedirectUris;
         this.singleSignOut = other.singleSignOut;
         this.silentReAuthentication = other.silentReAuthentication;
@@ -866,6 +873,14 @@ public class ApplicationOAuthSettings {
         this.forcePKCE = forcePKCE;
     }
 
+    public boolean isForceS256CodeChallengeMethod() {
+        return forceS256CodeChallengeMethod;
+    }
+
+    public void setForceS256CodeChallengeMethod(boolean forceS256CodeChallengeMethod) {
+        this.forceS256CodeChallengeMethod = forceS256CodeChallengeMethod;
+    }
+
     public List<String> getPostLogoutRedirectUris() {
         return postLogoutRedirectUris;
     }
@@ -994,6 +1009,7 @@ public class ApplicationOAuthSettings {
         client.setAuthorizationEncryptedResponseAlg(this.authorizationEncryptedResponseAlg);
         client.setAuthorizationEncryptedResponseEnc(this.authorizationEncryptedResponseEnc);
         client.setForcePKCE(this.forcePKCE);
+        client.setForceS256CodeChallengeMethod(this.forceS256CodeChallengeMethod);
         client.setPostLogoutRedirectUris(this.postLogoutRedirectUris);
         client.setSingleSignOut(this.singleSignOut);
         client.setSilentReAuthentication(this.silentReAuthentication);

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
@@ -192,6 +192,8 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     private boolean forcePKCE;
 
+    private boolean forceS256CodeChallengeMethod;
+
     private List<String> postLogoutRedirectUris;
 
     private boolean flowsInherited;
@@ -842,6 +844,14 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     public void setForcePKCE(boolean forcePKCE) {
         this.forcePKCE = forcePKCE;
+    }
+
+    public boolean isForceS256CodeChallengeMethod() {
+        return forceS256CodeChallengeMethod;
+    }
+
+    public void setForceS256CodeChallengeMethod(boolean forceS256CodeChallengeMethod) {
+        this.forceS256CodeChallengeMethod = forceS256CodeChallengeMethod;
     }
 
     public List<String> getPostLogoutRedirectUris() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -318,6 +318,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationOAuthSettingsMongo.setAuthorizationEncryptedResponseAlg(other.getAuthorizationEncryptedResponseAlg());
         applicationOAuthSettingsMongo.setAuthorizationEncryptedResponseEnc(other.getAuthorizationEncryptedResponseEnc());
         applicationOAuthSettingsMongo.setForcePKCE(other.isForcePKCE());
+        applicationOAuthSettingsMongo.setForceS256CodeChallengeMethod(other.isForceS256CodeChallengeMethod());
         applicationOAuthSettingsMongo.setPostLogoutRedirectUris(other.getPostLogoutRedirectUris());
         applicationOAuthSettingsMongo.setSingleSignOut(other.isSingleSignOut());
         applicationOAuthSettingsMongo.setSilentReAuthentication(other.isSilentReAuthentication());
@@ -397,6 +398,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationOAuthSettings.setAuthorizationEncryptedResponseAlg(other.getAuthorizationEncryptedResponseAlg());
         applicationOAuthSettings.setAuthorizationEncryptedResponseEnc(other.getAuthorizationEncryptedResponseEnc());
         applicationOAuthSettings.setForcePKCE(other.isForcePKCE());
+        applicationOAuthSettings.setForceS256CodeChallengeMethod(other.isForceS256CodeChallengeMethod());
         applicationOAuthSettings.setPostLogoutRedirectUris(other.getPostLogoutRedirectUris());
         applicationOAuthSettings.setSingleSignOut(other.isSingleSignOut());
         applicationOAuthSettings.setSilentReAuthentication(other.isSilentReAuthentication());

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationOAuthSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationOAuthSettingsMongo.java
@@ -84,6 +84,7 @@ public class ApplicationOAuthSettingsMongo {
     private String authorizationEncryptedResponseAlg;
     private String authorizationEncryptedResponseEnc;
     private boolean forcePKCE;
+    private boolean forceS256CodeChallengeMethod;
     private List<String> postLogoutRedirectUris;
     private boolean singleSignOut;
     private boolean silentReAuthentication;
@@ -548,6 +549,14 @@ public class ApplicationOAuthSettingsMongo {
 
     public void setForcePKCE(boolean forcePKCE) {
         this.forcePKCE = forcePKCE;
+    }
+
+    public boolean isForceS256CodeChallengeMethod() {
+        return forceS256CodeChallengeMethod;
+    }
+
+    public void setForceS256CodeChallengeMethod(boolean forceS256CodeChallengeMethod) {
+        this.forceS256CodeChallengeMethod = forceS256CodeChallengeMethod;
     }
 
     public List<String> getPostLogoutRedirectUris() {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/ApplicationBrowserTemplate.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/ApplicationBrowserTemplate.java
@@ -75,6 +75,7 @@ public class ApplicationBrowserTemplate extends ApplicationAbstractTemplate {
             oAuthSettings.setGrantTypes(Arrays.asList(GrantType.AUTHORIZATION_CODE));
             oAuthSettings.setResponseTypes(new ArrayList<>(defaultAuthorizationCodeResponseTypes()));
             oAuthSettings.setForcePKCE(true);
+            oAuthSettings.setForceS256CodeChallengeMethod(true);
             // browser applications cannot securely store a Client Secret, set client authentication method to none
             oAuthSettings.setTokenEndpointAuthMethod(ClientAuthenticationMethod.NONE);
         } else {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/ApplicationNativeTemplate.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/ApplicationNativeTemplate.java
@@ -76,6 +76,7 @@ public class ApplicationNativeTemplate extends ApplicationAbstractTemplate {
             oAuthSettings.setGrantTypes(Arrays.asList(GrantType.AUTHORIZATION_CODE));
             oAuthSettings.setResponseTypes(new ArrayList<>(defaultAuthorizationCodeResponseTypes()));
             oAuthSettings.setForcePKCE(true);
+            oAuthSettings.setForceS256CodeChallengeMethod(true);
             // native applications cannot securely store a Client Secret, set client authentication method to none
             oAuthSettings.setTokenEndpointAuthMethod(ClientAuthenticationMethod.NONE);
         } else {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationOAuthSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationOAuthSettings.java
@@ -83,6 +83,7 @@ public class PatchApplicationOAuthSettings {
     private Optional<String> authorizationEncryptedResponseAlg;
     private Optional<String> authorizationEncryptedResponseEnc;
     private Optional<Boolean> forcePKCE;
+    private Optional<Boolean> forceS256CodeChallengeMethod;
     private Optional<List<String>> postLogoutRedirectUris;
     private Optional<Boolean> singleSignOut;
     private Optional<Boolean> silentReAuthentication;
@@ -504,6 +505,14 @@ public class PatchApplicationOAuthSettings {
         this.forcePKCE = forcePKCE;
     }
 
+    public Optional<Boolean> getForceS256CodeChallengeMethod() {
+        return forceS256CodeChallengeMethod;
+    }
+
+    public void setForceS256CodeChallengeMethod(Optional<Boolean> forceS256CodeChallengeMethod) {
+        this.forceS256CodeChallengeMethod = forceS256CodeChallengeMethod;
+    }
+
     public Optional<List<String>> getPostLogoutRedirectUris() {
         return postLogoutRedirectUris;
     }
@@ -594,6 +603,7 @@ public class PatchApplicationOAuthSettings {
         SetterUtils.safeSet(toPatch::setAuthorizationEncryptedResponseAlg, this.getAuthorizationEncryptedResponseAlg());
         SetterUtils.safeSet(toPatch::setAuthorizationEncryptedResponseEnc, this.getAuthorizationEncryptedResponseEnc());
         SetterUtils.safeSet(toPatch::setForcePKCE, this.getForcePKCE());
+        SetterUtils.safeSet(toPatch::setForceS256CodeChallengeMethod, this.getForceS256CodeChallengeMethod());
         SetterUtils.safeSet(toPatch::setPostLogoutRedirectUris, this.getPostLogoutRedirectUris());
         SetterUtils.safeSet(toPatch::setSingleSignOut, this.getSingleSignOut());
         SetterUtils.safeSet(toPatch::setSilentReAuthentication, this.getSilentReAuthentication());

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/grantFlows/application-grant-flows.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/grantFlows/application-grant-flows.component.html
@@ -57,6 +57,15 @@
           </mat-slide-toggle>
           <mat-hint style="font-size: 75%;">Force PKCE for public clients who cannot securely store their Client Secret</mat-hint>
         </div>
+        <div fxLayout="column">
+          <mat-slide-toggle
+            (change)="forceS256CodeChallengeMethod($event)"
+            [checked]="isS256CodeChallengeMethodForced()" [disabled]="readonly">
+            Force S256 challenge method
+          </mat-slide-toggle>
+          <mat-hint style="font-size: 75%;">Force S256 challenge method to protect against disclosure of the "code_verifier"
+            value to an attacker.</mat-hint>
+        </div>
       </div>
 
       <div class="gv-form-section">

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/grantFlows/application-grant-flows.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/grantFlows/application-grant-flows.component.ts
@@ -74,6 +74,7 @@ export class ApplicationGrantFlowsComponent implements OnInit {
     let oauthSettings: any = {};
     oauthSettings.grantTypes = this.selectedGrantTypes.concat(this.selectedCustomGrantTypes);
     oauthSettings.forcePKCE = this.applicationOauthSettings.forcePKCE;
+    oauthSettings.forceS256CodeChallengeMethod = this.applicationOauthSettings.forceS256CodeChallengeMethod;
     oauthSettings.tokenEndpointAuthMethod = this.applicationOauthSettings.tokenEndpointAuthMethod;
     oauthSettings.tlsClientAuthSubjectDn = this.applicationOauthSettings.tlsClientAuthSubjectDn;
     oauthSettings.tlsClientAuthSanDns = this.applicationOauthSettings.tlsClientAuthSanDns;
@@ -112,6 +113,15 @@ export class ApplicationGrantFlowsComponent implements OnInit {
 
   isPKCEForced() {
     return this.applicationOauthSettings.forcePKCE;
+  }
+
+  forceS256CodeChallengeMethod(event) {
+    this.applicationOauthSettings.forceS256CodeChallengeMethod = event.checked;
+    this.formChanged = true;
+  }
+
+  isS256CodeChallengeMethodForced() {
+    return this.applicationOauthSettings.forceS256CodeChallengeMethod;
   }
 
   get selectedGrantTypes() {


### PR DESCRIPTION
fixes gravitee-io/issues#7965

# How to test

* Create 4 apps (one for each type)
* Check for each app if the "Force S256 Challenge" toggle is active (should be if the Force PKCE is active)
![image](https://user-images.githubusercontent.com/3110552/177331824-eb300bcc-6a19-4f1e-b727-1e5f1361b796.png)

## Test 1
* try to follow authentication steps described in the "overview" page of the tested app

## Test 2
* For SPA & Native App, try to request the` /authorization `endpoint using "`plain`" as value for the `code_challenge_method` (authent should fail with "`invalid code_challenge_method`" error)

## Test 3
* For SPA & Native App, switch off the "Force S256 Challenge" toggle and try to request the` /authorization `endpoint using "`plain`" as value for the `code_challenge_method` (should be OK)