### PR TITLE
fix: change the description of the idp domain whitelist

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
@@ -47,7 +47,7 @@
                              [value]="domainWhitelistPattern || ''" (input)='domainWhitelistPattern = $event.target.value'
                       />
                     </mat-chip-list>
-                    <mat-hint>Enables Identifier-first login automatic redirection to the provider when the user email domain matches the list</mat-hint>
+                    <mat-hint>Filters the user based on their email domain matching the list, post authentication of the provider. The user will be logged out otherwise</mat-hint>
                   </mat-form-field>
             </div>
           </div>


### PR DESCRIPTION
## :id: Reference related issue. 

relates to closed: https://github.com/gravitee-io/issues/issues/7827

fixes gravitee-io/issues#8311

## :pencil2: A description of the changes proposed in the pull request

This fixes a typo on the domain whitelist description

<img width="1576" alt="image" src="https://user-images.githubusercontent.com/8531515/183924515-748babb5-d4d9-4e2c-8676-ae394ad28efb.png">
