### PR TITLE
feat(i18n): manage security domain dictionaries in the gateway

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/SecurityDomainRouterFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/SecurityDomainRouterFactory.java
@@ -27,6 +27,7 @@ import io.gravitee.am.gateway.handler.common.email.EmailManager;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.flow.FlowManager;
 import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
+import io.gravitee.am.gateway.handler.manager.dictionary.I18nDictionaryManager;
 import io.gravitee.am.gateway.handler.manager.domain.CrossDomainManager;
 import io.gravitee.am.gateway.handler.manager.form.FormManager;
 import io.gravitee.am.gateway.handler.manager.resource.ResourceManager;
@@ -114,6 +115,7 @@ public class SecurityDomainRouterFactory {
         components.add(CertificateManager.class);
         components.add(DeviceIdentifierManager.class);
         components.add(AuthenticationDeviceNotifierManager.class);
+        components.add(I18nDictionaryManager.class);
 
         components.forEach(componentClass -> {
             LifecycleComponent lifecyclecomponent = applicationContext.getBean(componentClass);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/dictionary/I18nDictionaryManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/dictionary/I18nDictionaryManager.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.manager.dictionary;
+
+import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.event.I18nDictionaryEvent;
+import io.gravitee.am.gateway.handler.vertx.view.thymeleaf.GraviteeMessageResolver;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.I18nDictionary;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.repository.management.api.I18nDictionaryRepository;
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.service.AbstractService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class I18nDictionaryManager extends AbstractService implements InitializingBean, EventListener<I18nDictionaryEvent, Payload> {
+
+    private static final Logger logger = LoggerFactory.getLogger(I18nDictionaryManager.class);
+    private ConcurrentMap<String, I18nDictionary> i18nDictionaries = new ConcurrentHashMap<>();
+
+    @Autowired
+    private I18nDictionaryRepository i18nDictionaryRepository;
+
+    @Autowired
+    private Domain domain;
+
+    @Autowired
+    private EventManager eventManager;
+
+    @Autowired
+    private GraviteeMessageResolver graviteeMessageResolver;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        logger.info("Initializing i18n dictionaries for domain {}", domain.getName());
+        i18nDictionaryRepository.findAll(ReferenceType.DOMAIN, domain.getId())
+                .subscribe(
+                        i18nDictionary -> {
+                            update(i18nDictionary);
+                            logger.info("I18n dictionary {} loaded for domain {}", i18nDictionary.getId(), domain.getName());
+                        },
+                        error -> logger.error("Unable to initialize i18n dictionaries for domain {}", domain.getName(), error));
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        logger.info("Register event listener for i18n dictionary events for domain {}", domain.getName());
+        eventManager.subscribeForEvents(this, I18nDictionaryEvent.class, domain.getId());
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        logger.info("Dispose event listener for i18n dictionary events for domain {}", domain.getName());
+        eventManager.unsubscribeForEvents(this, I18nDictionaryEvent.class, domain.getId());
+    }
+
+    @Override
+    public void onEvent(Event<I18nDictionaryEvent, Payload> event) {
+        if (event.content().getReferenceType() == ReferenceType.DOMAIN &&
+                domain.getId().equals(event.content().getReferenceId())) {
+            switch (event.type()) {
+                case DEPLOY:
+                case UPDATE:
+                    update(event.content().getId(), event.type());
+                    break;
+                case UNDEPLOY:
+                    remove(event.content().getId());
+                    break;
+            }
+        }
+    }
+
+    private void update(String id, I18nDictionaryEvent event) {
+        final String eventType = event.toString().toLowerCase();
+        logger.info("Domain {} has received {} i18n dictionary event for {}", domain.getName(), eventType, id);
+        i18nDictionaryRepository.findById(id)
+                .subscribe(
+                        i18nDictionary -> {
+                            update(i18nDictionary);
+                            logger.info("I18n dictionary {} {}d for domain {}", id, eventType, domain.getName());
+                        },
+                        error -> logger.error("Unable to {} i18n dictionary for domain {}", eventType, domain.getName(), error),
+                        () -> logger.error("No i18n dictionary found with id {}", id));
+    }
+
+    private void update(I18nDictionary i18nDictionary) {
+        i18nDictionaries.put(i18nDictionary.getId(), i18nDictionary);
+        graviteeMessageResolver.updateDictionary(i18nDictionary);
+    }
+
+    private void remove(String id) {
+        logger.info("Domain {} has received i18n dictionary event, delete i18n dictionary {}", domain.getName(), id);
+        I18nDictionary deletedI18nDictionary = i18nDictionaries.remove(id);
+        if (deletedI18nDictionary != null) {
+            graviteeMessageResolver.removeDictionary(deletedI18nDictionary.getLocale());
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/spring/HandlerConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/spring/HandlerConfiguration.java
@@ -24,6 +24,7 @@ import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
 import io.gravitee.am.gateway.handler.manager.botdetection.impl.BotDetectionManagerImpl;
 import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
 import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManagerImpl;
+import io.gravitee.am.gateway.handler.manager.dictionary.I18nDictionaryManager;
 import io.gravitee.am.gateway.handler.manager.domain.CrossDomainManager;
 import io.gravitee.am.gateway.handler.manager.domain.impl.CrossDomainManagerImpl;
 import io.gravitee.am.gateway.handler.manager.form.FormManager;
@@ -111,6 +112,11 @@ public class HandlerConfiguration {
     @Bean
     public DeviceIdentifierManager rememberDeviceManager() {
         return new DeviceIdentifierManagerImpl();
+    }
+
+    @Bean
+    public I18nDictionaryManager i18nDictionaryManager() {
+        return new I18nDictionaryManager();
     }
 
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
@@ -26,6 +26,7 @@ import io.gravitee.am.gateway.handler.common.client.ClientManager;
 import io.gravitee.am.gateway.handler.common.email.EmailManager;
 import io.gravitee.am.gateway.handler.common.flow.FlowManager;
 import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
+import io.gravitee.am.gateway.handler.manager.dictionary.I18nDictionaryManager;
 import io.gravitee.am.gateway.handler.manager.domain.CrossDomainManager;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.manager.form.FormManager;
@@ -169,6 +170,7 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
         components.add(ClientManager.class);
         components.add(CertificateManager.class);
         components.add(DeviceIdentifierManager.class);
+        components.add(I18nDictionaryManager.class);
 
         components.forEach(componentClass -> {
             LifecycleComponent lifecyclecomponent = applicationContext.getBean(componentClass);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/DomainBasedDictionaryProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/DomainBasedDictionaryProvider.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.vertx.view.thymeleaf;
+
+import io.gravitee.am.common.i18n.DictionaryProvider;
+import io.gravitee.am.model.I18nDictionary;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DomainBasedDictionaryProvider implements DictionaryProvider {
+
+    private Map<String, Properties> propertiesMap = new ConcurrentHashMap<>();
+
+    @Override
+    public Properties getDictionaryFor(Locale locale) {
+        if (locale != null) {
+            return ofNullable(this.propertiesMap.get(locale.toString()))
+                    .or(() -> ofNullable(this.propertiesMap.get(locale.getLanguage())))
+                    .orElse(new Properties());
+        }
+        return new Properties();
+    }
+
+    @Override
+    public boolean hasDictionaryFor(Locale locale) {
+        return this.propertiesMap.containsKey(locale.toString());
+    }
+
+    public void loadDictionary(I18nDictionary i18nDictionary) {
+        final String locale = i18nDictionary.getLocale();
+        Properties properties = new Properties();
+        properties.putAll(i18nDictionary.getEntries());
+        propertiesMap.put(locale, properties);
+    }
+
+    public void removeDictionary(String locale) {
+        propertiesMap.remove(locale);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/botdetection/BotDetectionManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/botdetection/BotDetectionManagerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.gateway.handler.botdetection;
+package io.gravitee.am.gateway.handler.manager.botdetection;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.gateway.handler.manager.botdetection.impl.BotDetectionManagerImpl;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/deviceidentifiers/DeviceIdentifierManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/deviceidentifiers/DeviceIdentifierManagerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.gateway.handler.deviceidentifiers;
+package io.gravitee.am.gateway.handler.manager.deviceidentifiers;
 
 import io.gravitee.am.deviceidentifier.api.DeviceIdentifierProvider;
 import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManagerImpl;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/dictionary/I18nDictionaryManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/dictionary/I18nDictionaryManagerTest.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.manager.dictionary;
+
+import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.event.I18nDictionaryEvent;
+import io.gravitee.am.gateway.handler.vertx.view.thymeleaf.GraviteeMessageResolver;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.I18nDictionary;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.repository.exceptions.TechnicalException;
+import io.gravitee.am.repository.management.api.I18nDictionaryRepository;
+import io.gravitee.common.event.Event;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class I18nDictionaryManagerTest {
+
+    @Mock
+    private EventManager eventManager;
+
+    @Mock
+    private I18nDictionaryRepository i18nDictionaryRepository;
+
+    @Mock
+    private GraviteeMessageResolver graviteeMessageResolver;
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private Payload payload;
+
+    @InjectMocks
+    private I18nDictionaryManager i18nDictionaryManager = new I18nDictionaryManager();
+
+    @Before
+    public void setUp() {
+        when(domain.getId()).thenReturn("domain-id");
+        when(domain.getName()).thenReturn("domain-name");
+
+        when(payload.getReferenceType()).thenReturn(ReferenceType.DOMAIN);
+        when(payload.getReferenceId()).thenReturn("domain-id");
+        when(payload.getId()).thenReturn("dictionary-id");
+    }
+
+    @Test
+    public void shouldLoadDictionaries_after_properties_set() throws Exception {
+        I18nDictionary i18nDictionary = mock(I18nDictionary.class);
+        when(i18nDictionary.getId()).thenReturn("dictionary-id");
+
+        when(i18nDictionaryRepository.findAll(ReferenceType.DOMAIN, domain.getId())).thenReturn(Flowable.just(i18nDictionary));
+
+        i18nDictionaryManager.afterPropertiesSet();
+
+        verify(i18nDictionaryRepository, times(1)).findAll(ReferenceType.DOMAIN, domain.getId());
+        verify(graviteeMessageResolver, times(1)).updateDictionary(any());
+    }
+
+    @Test
+    public void shouldNotLoadDictionaries_after_properties_set_exception() throws Exception {
+        when(i18nDictionaryRepository.findAll(ReferenceType.DOMAIN, domain.getId())).thenReturn(Flowable.error(TechnicalException::new));
+
+        i18nDictionaryManager.afterPropertiesSet();
+
+        verify(i18nDictionaryRepository, times(1)).findAll(ReferenceType.DOMAIN, domain.getId());
+        verify(graviteeMessageResolver, never()).updateDictionary(any());
+    }
+
+    @Test
+    public void shouldSubscribeToEvents() throws Exception {
+        i18nDictionaryManager.doStart();
+
+        verify(eventManager, times(1)).subscribeForEvents(i18nDictionaryManager, I18nDictionaryEvent.class, domain.getId());
+    }
+
+    @Test
+    public void shouldUnSubscribeToEvents() throws Exception {
+        i18nDictionaryManager.doStop();
+
+        verify(eventManager, times(1)).unsubscribeForEvents(i18nDictionaryManager, I18nDictionaryEvent.class, domain.getId());
+    }
+
+    @Test
+    public void shouldNotDeploy_wrong_domain() {
+        Payload payload = mock(Payload.class);
+        when(payload.getReferenceType()).thenReturn(ReferenceType.DOMAIN);
+        when(payload.getReferenceId()).thenReturn("wrong-domain-id");
+
+        Event<I18nDictionaryEvent, Payload> event = mock(Event.class);
+        when(event.content()).thenReturn(payload);
+
+        i18nDictionaryManager.onEvent(event);
+
+        verify(i18nDictionaryRepository, never()).findById(anyString());
+        verify(graviteeMessageResolver, never()).updateDictionary(any());
+    }
+
+    @Test
+    public void shouldDeploy() {
+        shouldDeploy(I18nDictionaryEvent.DEPLOY);
+    }
+
+    @Test
+    public void shouldUpdate() {
+       shouldDeploy(I18nDictionaryEvent.UPDATE);
+    }
+
+    @Test
+    public void shouldNotDeploy_exception() {
+        Event<I18nDictionaryEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(I18nDictionaryEvent.DEPLOY);
+        when(event.content()).thenReturn(payload);
+
+        when(i18nDictionaryRepository.findById("dictionary-id")).thenReturn(Maybe.error(TechnicalException::new));
+
+        i18nDictionaryManager.onEvent(event);
+
+        verify(i18nDictionaryRepository, times(1)).findById(anyString());
+        verify(graviteeMessageResolver, never()).updateDictionary(any());
+    }
+
+    @Test
+    public void shouldNotDeploy_not_found() {
+        Event<I18nDictionaryEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(I18nDictionaryEvent.DEPLOY);
+        when(event.content()).thenReturn(payload);
+
+        when(i18nDictionaryRepository.findById("dictionary-id")).thenReturn(Maybe.empty());
+
+        i18nDictionaryManager.onEvent(event);
+
+        verify(i18nDictionaryRepository, times(1)).findById(anyString());
+        verify(graviteeMessageResolver, never()).updateDictionary(any());
+    }
+
+    @Test
+    public void shouldUndeploy() {
+        Event<I18nDictionaryEvent, Payload> deployEvent = mock(Event.class);
+        when(deployEvent.type()).thenReturn(I18nDictionaryEvent.DEPLOY);
+        when(deployEvent.content()).thenReturn(payload);
+
+        Event<I18nDictionaryEvent, Payload> undeployEvent = mock(Event.class);
+        when(undeployEvent.type()).thenReturn(I18nDictionaryEvent.UNDEPLOY);
+        when(undeployEvent.content()).thenReturn(payload);
+
+        I18nDictionary i18nDictionary = mock(I18nDictionary.class);
+        when(i18nDictionary.getId()).thenReturn("dictionary-id");
+        when(i18nDictionary.getLocale()).thenReturn("dictionary-locale");
+        when(i18nDictionaryRepository.findById("dictionary-id")).thenReturn(Maybe.just(i18nDictionary));
+
+        i18nDictionaryManager.onEvent(deployEvent);
+        i18nDictionaryManager.onEvent(undeployEvent);
+
+        verify(graviteeMessageResolver, times(1)).removeDictionary(anyString());
+    }
+
+    private void shouldDeploy(I18nDictionaryEvent i18nDictionaryEvent) {
+        Event<I18nDictionaryEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(i18nDictionaryEvent);
+        when(event.content()).thenReturn(payload);
+
+        I18nDictionary i18nDictionary = mock(I18nDictionary.class);
+        when(i18nDictionary.getId()).thenReturn("dictionary-id");
+        when(i18nDictionaryRepository.findById("dictionary-id")).thenReturn(Maybe.just(i18nDictionary));
+
+        i18nDictionaryManager.onEvent(event);
+
+        verify(i18nDictionaryRepository, times(1)).findById(anyString());
+        verify(graviteeMessageResolver, times(1)).updateDictionary(any());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/email/EmailManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/email/EmailManagerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.gateway.handler.email;
+package io.gravitee.am.gateway.handler.manager.email;
 
 import io.gravitee.am.gateway.handler.common.email.EmailManager;
 import io.gravitee.am.gateway.handler.common.email.impl.EmailManagerImpl;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/DomainBasedDictionaryProviderTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/DomainBasedDictionaryProviderTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.vertx.view.thymeleaf;
+
+import io.gravitee.am.model.I18nDictionary;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Locale;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DomainBasedDictionaryProviderTest {
+
+    private DomainBasedDictionaryProvider domainBasedDictionaryProvider = new DomainBasedDictionaryProvider();
+
+    @Test
+    public void shouldHasDictionaryFor() {
+        I18nDictionary i18nDictionary = new I18nDictionary();
+        i18nDictionary.setLocale("test-locale");
+        domainBasedDictionaryProvider.loadDictionary(i18nDictionary);
+        assertTrue(domainBasedDictionaryProvider.hasDictionaryFor(new Locale(i18nDictionary.getLocale())));
+    }
+
+    @Test
+    public void shouldNotHasDictionaryFor() {
+        I18nDictionary i18nDictionary = new I18nDictionary();
+        i18nDictionary.setLocale("test-locale");
+        domainBasedDictionaryProvider.loadDictionary(i18nDictionary);
+        assertFalse(domainBasedDictionaryProvider.hasDictionaryFor(new Locale("unknown-locale")));
+    }
+
+    @Test
+    public void shouldNotHasDictionaryFor_after_removal() {
+        I18nDictionary i18nDictionary = new I18nDictionary();
+        i18nDictionary.setLocale("test-locale");
+        domainBasedDictionaryProvider.loadDictionary(i18nDictionary);
+        domainBasedDictionaryProvider.removeDictionary(i18nDictionary.getLocale());
+        assertFalse(domainBasedDictionaryProvider.hasDictionaryFor(new Locale(i18nDictionary.getLocale())));
+    }
+
+    @Test
+    public void shouldGetDictionaryFor() {
+        I18nDictionary i18nDictionary = new I18nDictionary();
+        i18nDictionary.setLocale("test-locale");
+        i18nDictionary.setEntries(Collections.singletonMap("key", "value"));
+        domainBasedDictionaryProvider.loadDictionary(i18nDictionary);
+        assertFalse(domainBasedDictionaryProvider.getDictionaryFor(new Locale(i18nDictionary.getLocale())).isEmpty());
+        assertTrue(domainBasedDictionaryProvider.getDictionaryFor(new Locale(i18nDictionary.getLocale())).getProperty("key").equals("value"));
+    }
+
+    @Test
+    public void shouldGetDictionaryFor_empty_entries() {
+        I18nDictionary i18nDictionary = new I18nDictionary();
+        i18nDictionary.setLocale("test-locale");
+        domainBasedDictionaryProvider.loadDictionary(i18nDictionary);
+        assertTrue(domainBasedDictionaryProvider.getDictionaryFor(new Locale(i18nDictionary.getLocale())).isEmpty());
+    }
+
+    @Test
+    public void shouldGetDictionaryFor_locale_is_null() {
+        I18nDictionary i18nDictionary = new I18nDictionary();
+        i18nDictionary.setLocale("test-locale");
+        i18nDictionary.setEntries(Collections.singletonMap("key", "value"));
+        domainBasedDictionaryProvider.loadDictionary(i18nDictionary);
+        assertTrue(domainBasedDictionaryProvider.getDictionaryFor(null).isEmpty());
+    }
+}


### PR DESCRIPTION
closes gravitee-io/issues#8040

## :memo: Test scenarios 

1. Create a new en dictionary
2. For this dictionary, create one translation  `login.page.title`  : 'New Login title`
3. Try to login to your application, the Login title page should be : **New Login title**

