### PR TITLE
feat(theme): manage security domain themes in the gateway

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/SecurityDomainRouterFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/SecurityDomainRouterFactory.java
@@ -31,6 +31,7 @@ import io.gravitee.am.gateway.handler.manager.dictionary.I18nDictionaryManager;
 import io.gravitee.am.gateway.handler.manager.domain.CrossDomainManager;
 import io.gravitee.am.gateway.handler.manager.form.FormManager;
 import io.gravitee.am.gateway.handler.manager.resource.ResourceManager;
+import io.gravitee.am.gateway.handler.manager.theme.ThemeManager;
 import io.gravitee.am.gateway.handler.spring.HandlerConfiguration;
 import io.gravitee.am.gateway.handler.vertx.VertxSecurityDomainHandler;
 import io.gravitee.am.model.Domain;
@@ -116,6 +117,7 @@ public class SecurityDomainRouterFactory {
         components.add(DeviceIdentifierManager.class);
         components.add(AuthenticationDeviceNotifierManager.class);
         components.add(I18nDictionaryManager.class);
+        components.add(ThemeManager.class);
 
         components.forEach(componentClass -> {
             LifecycleComponent lifecyclecomponent = applicationContext.getBean(componentClass);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/theme/ThemeManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/theme/ThemeManager.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.manager.theme;
+
+import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.event.ThemeEvent;
+import io.gravitee.am.gateway.handler.vertx.view.thymeleaf.DomainBasedThemeResolver;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.Theme;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.repository.management.api.ThemeRepository;
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.service.AbstractService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ThemeManager extends AbstractService<ThemeManager> implements InitializingBean, EventListener<ThemeEvent, Payload> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ThemeManager.class);
+    private ConcurrentMap<String, Theme> domainThemes = new ConcurrentHashMap<>();
+
+    @Autowired
+    private ThemeRepository themeRepository;
+
+    @Autowired
+    private Domain domain;
+
+    @Autowired
+    private EventManager eventManager;
+
+    @Autowired
+    private DomainBasedThemeResolver domainBasedThemeResolver;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        logger.info("Initializing themes for domain {}", domain.getName());
+        themeRepository.findByReference(ReferenceType.DOMAIN, domain.getId())
+                .subscribe(
+                        theme -> {
+                            update(theme);
+                            logger.info("Theme {} loaded for domain {}", theme.getId(), domain.getName());
+                        },
+                        error -> logger.error("Unable to initialize themes for domain {}", domain.getName(), error),
+                        () -> logger.debug("No theme found for domain {}", domain.getName()));
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        logger.info("Register event listener for theme events for domain {}", domain.getName());
+        eventManager.subscribeForEvents(this, ThemeEvent.class, domain.getId());
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        logger.info("Dispose event listener for theme events for domain {}", domain.getName());
+        eventManager.unsubscribeForEvents(this, ThemeEvent.class, domain.getId());
+    }
+
+    @Override
+    public void onEvent(Event<ThemeEvent, Payload> event) {
+        if (event.content().getReferenceType() == ReferenceType.DOMAIN &&
+                domain.getId().equals(event.content().getReferenceId())) {
+            switch (event.type()) {
+                case DEPLOY:
+                case UPDATE:
+                    update(event.content().getId(), event.type());
+                    break;
+                case UNDEPLOY:
+                    remove(event.content().getId());
+                    break;
+            }
+        }
+    }
+
+    private void update(String id, ThemeEvent event) {
+        final String eventType = event.toString().toLowerCase();
+        logger.info("Domain {} has received {} theme event for {}", domain.getName(), eventType, id);
+        themeRepository.findById(id)
+                .subscribe(
+                        theme -> {
+                            update(theme);
+                            logger.info("Theme {} {}d for domain {}", id, eventType, domain.getName());
+                        },
+                        error -> logger.error("Unable to {} theme for domain {}", eventType, domain.getName(), error),
+                        () -> logger.error("No theme found with id {}", id));
+    }
+
+    private void update(Theme theme) {
+        domainThemes.put(theme.getId(), theme);
+        domainBasedThemeResolver.updateTheme(theme);
+    }
+
+    private void remove(String id) {
+        logger.info("Domain {} has received theme event, delete theme {}", domain.getName(), id);
+        Theme deletedTheme = domainThemes.remove(id);
+        if (deletedTheme != null) {
+            domainBasedThemeResolver.removeTheme(deletedTheme.getReferenceId());
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/spring/HandlerConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/spring/HandlerConfiguration.java
@@ -31,6 +31,7 @@ import io.gravitee.am.gateway.handler.manager.form.FormManager;
 import io.gravitee.am.gateway.handler.manager.form.impl.FormManagerImpl;
 import io.gravitee.am.gateway.handler.manager.resource.ResourceManager;
 import io.gravitee.am.gateway.handler.manager.resource.impl.ResourceManagerImpl;
+import io.gravitee.am.gateway.handler.manager.theme.ThemeManager;
 import io.gravitee.am.gateway.handler.root.spring.RootConfiguration;
 import io.gravitee.am.gateway.handler.vertx.auth.webauthn.WebAuthnFactory;
 import io.gravitee.am.gateway.handler.vertx.auth.webauthn.store.RepositoryCredentialStore;
@@ -117,6 +118,11 @@ public class HandlerConfiguration {
     @Bean
     public I18nDictionaryManager i18nDictionaryManager() {
         return new I18nDictionaryManager();
+    }
+
+    @Bean
+    public ThemeManager themeManager() {
+        return new ThemeManager();
     }
 
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
@@ -30,6 +30,7 @@ import io.gravitee.am.gateway.handler.manager.dictionary.I18nDictionaryManager;
 import io.gravitee.am.gateway.handler.manager.domain.CrossDomainManager;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.manager.form.FormManager;
+import io.gravitee.am.gateway.handler.manager.theme.ThemeManager;
 import io.gravitee.am.gateway.handler.root.RootProvider;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.plugins.protocol.core.ProtocolPluginManager;
@@ -171,6 +172,7 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
         components.add(CertificateManager.class);
         components.add(DeviceIdentifierManager.class);
         components.add(I18nDictionaryManager.class);
+        components.add(ThemeManager.class);
 
         components.forEach(componentClass -> {
             LifecycleComponent lifecyclecomponent = applicationContext.getBean(componentClass);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/DomainBasedThemeResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/DomainBasedThemeResolver.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.vertx.view.thymeleaf;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Theme;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.ObjectUtils;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DomainBasedThemeResolver {
+
+    private static final String THEME_CONTEXT_KEY = "theme";
+    private static final String THEME_BACKGROUND_COLOR_CONTEXT_KEY = "--primary-background-color";
+    private static final String THEME_TEXT_COLOR_CONTEXT_KEY = "--primary-foreground-color";
+    private static final String THEME_LIGHT_BACKGROUND_COLOR_CONTEXT_KEY = "--secondary-background-color";
+    private static final String THEME_LIGHT_TEXT_COLOR_CONTEXT_KEY = "--secondary-foreground-color";
+    private static final String THEME_LOGO_WIDTH_CONTEXT_KEY = "--logo-width";
+    private final ConcurrentMap<String, ThemeResolution> themes = new ConcurrentHashMap<>();
+    private final ThemeResolution defaultThemeResolution = new ThemeResolution();
+
+    @Autowired
+    private Domain domain;
+
+    public void resolveTheme(Map<String, Object> context) {
+        ThemeResolution themeResolution = themes.getOrDefault(domain.getId(), defaultThemeResolution);
+        context.put(THEME_CONTEXT_KEY, themeResolution);
+    }
+
+    public void updateTheme(Theme theme) {
+        if (theme != null) {
+            ThemeResolution themeResolution = new ThemeResolution();
+            themeResolution.setFaviconUrl(theme.getFaviconUrl());
+            themeResolution.setLogoUrl(theme.getLogoUrl());
+            themeResolution.setLogoWidth(theme.getLogoWidth());
+            themeResolution.setCss(buildCss(theme));
+            themeResolution.setCustomCss(theme.getCss());
+            themes.put(theme.getReferenceId(), themeResolution);
+        }
+    }
+
+    public void removeTheme(String referenceId) {
+        themes.remove(referenceId);
+    }
+
+    private static String buildCss(Theme theme) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(":root {");
+        buildCss(sb, THEME_BACKGROUND_COLOR_CONTEXT_KEY, theme.getPrimaryButtonColorHex());
+        buildCss(sb, THEME_TEXT_COLOR_CONTEXT_KEY, theme.getPrimaryTextColorHex());
+        buildCss(sb, THEME_LIGHT_BACKGROUND_COLOR_CONTEXT_KEY, theme.getSecondaryButtonColorHex());
+        buildCss(sb, THEME_LIGHT_TEXT_COLOR_CONTEXT_KEY, theme.getSecondaryTextColorHex());
+        if (theme.getLogoWidth() > 0) {
+            buildCss(sb, THEME_LOGO_WIDTH_CONTEXT_KEY, theme.getLogoWidth() + "px");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private static void buildCss(StringBuilder sb, String key, Object value) {
+        if (!ObjectUtils.isEmpty(value)) {
+            sb.append(key);
+            sb.append(":");
+            sb.append(value);
+            sb.append(";");
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/GraviteeThymeleafTemplateEngine.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/GraviteeThymeleafTemplateEngine.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.vertx.view.thymeleaf;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.templ.thymeleaf.ThymeleafTemplateEngine;
+
+import java.util.Map;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GraviteeThymeleafTemplateEngine extends ThymeleafTemplateEngine {
+
+    private DomainBasedThemeResolver themeResolver;
+
+    public GraviteeThymeleafTemplateEngine(Vertx vertx) {
+        super(ThymeleafTemplateEngine.create(vertx).getDelegate());
+    }
+
+    public void setThemeResolver(DomainBasedThemeResolver themeResolver) {
+        this.themeResolver = themeResolver;
+    }
+
+    @Override
+    public void render(Map<String, Object> context, String templateFileName, Handler<AsyncResult<Buffer>> handler) {
+        themeResolver.resolveTheme(context);
+        super.render(context, templateFileName, handler);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/ThemeResolution.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/ThemeResolution.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.vertx.view.thymeleaf;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ThemeResolution {
+
+    private String faviconUrl;
+    private String logoUrl;
+    private int logoWidth;
+    private String css;
+    private String customCss;
+
+    public String getFaviconUrl() {
+        return faviconUrl;
+    }
+
+    public void setFaviconUrl(String faviconUrl) {
+        this.faviconUrl = faviconUrl;
+    }
+
+    public String getLogoUrl() {
+        return logoUrl;
+    }
+
+    public void setLogoUrl(String logoUrl) {
+        this.logoUrl = logoUrl;
+    }
+
+    public int getLogoWidth() {
+        return logoWidth;
+    }
+
+    public void setLogoWidth(int logoWidth) {
+        this.logoWidth = logoWidth;
+    }
+
+    public String getCss() {
+        return css;
+    }
+
+    public void setCss(String css) {
+        this.css = css;
+    }
+
+    public String getCustomCss() {
+        return customCss;
+    }
+
+    public void setCustomCss(String customCss) {
+        this.customCss = customCss;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/ThymeleafConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/ThymeleafConfiguration.java
@@ -40,9 +40,11 @@ public class ThymeleafConfiguration {
     private String templatesDirectory;
 
     @Bean
-    public ThymeleafTemplateEngine getTemplateEngine(GraviteeMessageResolver messageResolver) {
-        ThymeleafTemplateEngine thymeleafTemplateEngine = ThymeleafTemplateEngine.create(vertx);
-        TemplateEngine templateEngine = thymeleafTemplateEngine.getDelegate().getThymeleafTemplateEngine();
+    public ThymeleafTemplateEngine getTemplateEngine(GraviteeMessageResolver messageResolver,
+                                                     DomainBasedThemeResolver themeResolver) {
+        GraviteeThymeleafTemplateEngine thymeleafTemplateEngine = new GraviteeThymeleafTemplateEngine(vertx);
+        thymeleafTemplateEngine.setThemeResolver(themeResolver);
+        TemplateEngine templateEngine = thymeleafTemplateEngine.unwrap();
 
         // set template resolvers
         DomainBasedTemplateResolver overrideTemplateResolver = (DomainBasedTemplateResolver) overrideTemplateResolver();
@@ -63,6 +65,12 @@ public class ThymeleafConfiguration {
         return new DomainBasedTemplateResolver();
 
     }
+
+    @Bean
+    public DomainBasedThemeResolver themeResolver() {
+        return new DomainBasedThemeResolver();
+    }
+
     private ITemplateResolver defaultTemplateResolver() {
         ClassLoaderTemplateResolver templateResolver = new CustomClassLoaderTemplateResolver();
         templateResolver.setPrefix("/webroot/views/");

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/main.css
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/main.css
@@ -55,12 +55,11 @@ body, body * {
 }
 
 :root {
-    --top-borderColor: #6A4FF7;
+    --primary-background-color: #6A4FF7;
+    --primary-foreground-color: #FFFFFF;
+    --secondary-background-color: #DAD3FD;
+    --secondary-foreground-color: #000000;
     --logo-width: 222px;
-    --submit-backgroundColor: #6A4FF7;
-    --submit-textColor: #FFFFFF;
-    --submit-light-backgroundColor: #DAD3FD;
-    --submit-light-textColor: #25213A;
 }
 
 .container {
@@ -76,7 +75,7 @@ body, body * {
     background: #FFFFFF;
     border: 1px solid rgba(0, 0, 0, 0.12);
     border-radius: 4px;
-    border-top: 5px solid var(--top-borderColor);
+    border-top: 5px solid var(--primary-background-color);
 }
 
 .header {
@@ -88,7 +87,6 @@ body, body * {
     gap: 32px;
     height: 231px;
     flex: none;
-    order: 0;
     align-self: stretch;
     flex-grow: 0;
 }
@@ -118,7 +116,6 @@ body, body * {
     width: var(--logo-width);
     height: auto;
     flex: none;
-    order: 0;
     flex-grow: 0;
 }
 
@@ -138,7 +135,6 @@ body, body * {
     line-height: 24px;
     color: #A5A5A9;
     flex: none;
-    order: 2;
     flex-grow: 0;
 
     width: 440px;
@@ -157,7 +153,6 @@ body, body * {
     border: 1px solid rgba(0, 0, 0, 0.12);
     border-radius: 8px;
     flex: none;
-    order: 0;
     flex-grow: 0;
 }
 
@@ -201,7 +196,6 @@ div.short-section > input + input {
     background: #6A4FF7;
     border-radius: 8px;
     flex: none;
-    order: 3;
     align-self: stretch;
     flex-grow: 0;
     font-weight: 700;
@@ -212,7 +206,6 @@ div.short-section > input + input {
 }
 
 .error-text {
-    order: 0;
     background: #FFFFFF;
     border: 2px solid rgba(202, 71, 71, 0.2);
     border-radius: 8px;
@@ -266,13 +259,13 @@ div.short-section > input + input {
 }
 
 .submit-button {
-    color: var(--submit-textColor);
-    background: var(--submit-backgroundColor);
+    color: var(--primary-foreground-color);
+    background: var(--primary-background-color);
 }
 
 .submit-button-light {
-    color: var(--submit-light-textColor);
-    background: var(--submit-light-backgroundColor);
+    color: var(--secondary-foreground-color);
+    background: var(--secondary-background-color);
 }
 
 .submit-button-light:hover {
@@ -282,13 +275,11 @@ div.short-section > input + input {
 .disabled-button {
     color: #7C7C7C;
     background: #DFDFDF;
-    order: 3;
 }
 
 .social {
-    background: rgba(106, 79, 247, 0.25);
-    order: 4;
-    color: #25213A;
+    background: var(--secondary-background-color);
+    color: var(--secondary-foreground-color);
     padding: 0;
     align-self: auto;
 }
@@ -305,7 +296,6 @@ div.short-section > input + input {
     text-decoration-line: underline;
     color: #22233B;
     flex: none;
-    order: 0;
     flex-grow: 0;
 }
 
@@ -337,7 +327,6 @@ a {
 
 button.button.submit-button:hover:enabled {
     cursor: pointer;
-    background: rgba(106, 79, 247, 0.8);
 }
 
 a.left-arrow:hover, a.download:hover {
@@ -413,7 +402,6 @@ div#passwordSettings > P {
     width: 408px;
     height: 68px;
     flex: none;
-    order: 0;
     align-self: stretch;
     flex-grow: 0;
 }
@@ -434,7 +422,6 @@ div#passwordSettings > P {
     width: 372px;
     height: 48px;
     flex: none;
-    order: 1;
     flex-grow: 1;
 }
 
@@ -543,7 +530,6 @@ div#passwordSettings > P {
     border: 1px solid #B8B8BC;
     border-radius: 2px;
     flex: none;
-    order: 0;
     flex-grow: 0;
 }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/error.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/error.html
@@ -9,8 +9,12 @@
     <link rel="stylesheet" th:href="@{assets/material/material.blue_grey-blue.min.css}">
     <link rel="stylesheet" th:href="@{assets/css/access_error.css}">
 
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
+
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{assets/ico/favicon.ico}">
 </head>
 
 <body>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/forgot_password.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/forgot_password.html
@@ -11,7 +11,11 @@
     <link rel="stylesheet" th:href="@{assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 
     <script th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}" th:src="${'https://www.google.com/recaptcha/api.js?render=' + bot_detection_configuration.siteKey}"></script>
 
@@ -20,7 +24,7 @@
 <body>
 <div th:if="${error == null && success == null}" class="container">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Change your password</span>
         </div>
@@ -55,7 +59,7 @@
 
 <div th:if="${success}" class="container">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Check your email</span>
         </div>
@@ -72,7 +76,7 @@
 
 <div th:if="${error}" class="container">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Forgot password error</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html
@@ -10,7 +10,11 @@
     <link rel="stylesheet" th:href="@{../assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{../assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{../assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 
     <script th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}" th:src="${'https://www.google.com/recaptcha/api.js?render=' + bot_detection_configuration.siteKey}"></script>
 
@@ -19,7 +23,7 @@
 <body>
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{../assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{../assets/images/gravitee-logo.svg}">
         <div class="title">
             <span th:text="#{login.page.title} + ' ' + ${client.name}"></span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
@@ -11,7 +11,11 @@
     <link rel="stylesheet" th:href="@{assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 
     <script th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}"
             th:src="${'https://www.google.com/recaptcha/api.js?render=' + bot_detection_configuration.siteKey}"></script>
@@ -20,7 +24,7 @@
 <body>
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span th:text="#{login.page.title} + ' ' + ${client.name}"></span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
@@ -11,13 +11,17 @@
     <link rel="stylesheet" th:href="@{../assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{../assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{../assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 
 <body>
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{../assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{../assets/images/gravitee-logo.svg}">
         <div class="title">
             <span id="enrollment-title">Authenticate your account</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge_alternatives.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge_alternatives.html
@@ -9,12 +9,16 @@
     <link rel="stylesheet" th:href="@{../../assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{../../assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{../../assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 <body>
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{../../assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{../../assets/images/gravitee-logo.svg}">
         <div class="title">
             <span id="enrollment-title">Select a method</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_enroll.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_enroll.html
@@ -7,16 +7,19 @@
     <title>MFA Enroll</title>
     <!-- CSS -->
     <link rel="stylesheet" th:href="@{../assets/css/intl-tel-input.css}">
-
     <link rel="stylesheet" th:href="@{../assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{../assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{../assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 <body>
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{../assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{../assets/images/gravitee-logo.svg}">
         <div class="title">
             <span id="enrollment-title">Select a method</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_recovery_code.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_recovery_code.html
@@ -9,12 +9,16 @@
     <link rel="stylesheet" th:href="@{../assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{../assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{../assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 <body>
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{../assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{../assets/images/gravitee-logo.svg}">
         <div class="title">
             <span id="enrollment-title">Recovery codes</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/oauth2_user_consent.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/oauth2_user_consent.html
@@ -11,14 +11,18 @@
     <link rel="stylesheet" th:href="@{assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 
 <body>
 
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <label>Permissions requested</label>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration.html
@@ -11,16 +11,20 @@
     <link rel="stylesheet" th:href="@{assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{assets/ico/favicon.ico}">
 
-    <script th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}" th:src="${'https://www.google.com/recaptcha/api.js?render=' + bot_detection_configuration.siteKey}"></script>
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 
+    <script th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}"
+            th:src="${'https://www.google.com/recaptcha/api.js?render=' + bot_detection_configuration.siteKey}"></script>
 </head>
 
 <body>
 <div class="container" th:if="${error == null && success == null}">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span th:text="'Register to' + ' ' + ${client.name}"></span>
         </div>
@@ -81,7 +85,7 @@
 
 <div class="container" th:if="${success}">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span >Registered successfully</span>
         </div>
@@ -98,7 +102,7 @@
 
 <div class="container" th:if="${error}">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Registration failed</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
@@ -11,13 +11,17 @@
     <link rel="stylesheet" th:href="@{assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 
 <body>
 <div class="container" th:if="${error == null && success == null}">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Sign-up confirmation</span>
         </div>
@@ -71,7 +75,7 @@
 </div>
 <div class="container" th:if="${success}">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Account confirmation</span>
         </div>
@@ -83,7 +87,7 @@
 
 <div class="container" th:if="${error}">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Account confirmation error</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/reset_password.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/reset_password.html
@@ -11,13 +11,17 @@
     <link rel="stylesheet" th:href="@{assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 
 <body>
 <div th:if="${error == null && success == null}" class="container">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Set new password</span>
         </div>
@@ -67,7 +71,7 @@
 
 <div th:if="${success}" class="container">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Reset password confirmation</span>
         </div>
@@ -79,7 +83,7 @@
 
 <div th:if="${error}" class="container">
     <div class="header">
-        <img class="logo" th:src="@{assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Reset password error</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_login.html
@@ -10,12 +10,16 @@
     <link rel="stylesheet" th:href="@{../assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{../assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{../assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 <body>
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{../assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{../assets/images/gravitee-logo.svg}">
         <div class="title">
             <span th:text="#{login.page.title} + ' ' + ${client.name}"></span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_register.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_register.html
@@ -10,12 +10,16 @@
     <link rel="stylesheet" th:href="@{../assets/css/main.css}">
 
     <!-- Favicon and touch icons -->
-    <link rel="shortcut icon" th:href="@{../assets/ico/favicon.ico}">
+    <link rel="shortcut icon" th:href="${theme.faviconUrl} ?: @{../assets/ico/favicon.ico}">
+
+    <!-- Custom CSS -->
+    <style th:if="${theme.css}" th:text="${theme.css}"></style>
+    <style th:if="${theme.customCss}" th:text="${theme.customCss}"></style>
 </head>
 <body>
 <div class="container">
     <div class="header">
-        <img class="logo" th:src="@{../assets/images/gravitee-logo.svg}">
+        <img class="logo" th:src="${theme.logoUrl} ?: @{../assets/images/gravitee-logo.svg}">
         <div class="title">
             <span>Passwordless Authentication</span>
         </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/theme/ThemeManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/theme/ThemeManagerTest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.manager.theme;
+
+import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.event.ThemeEvent;
+import io.gravitee.am.gateway.handler.vertx.view.thymeleaf.DomainBasedThemeResolver;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.Theme;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.repository.exceptions.TechnicalException;
+import io.gravitee.am.repository.management.api.ThemeRepository;
+import io.gravitee.common.event.Event;
+import io.reactivex.Maybe;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ThemeManagerTest {
+
+    @Mock
+    private EventManager eventManager;
+
+    @Mock
+    private ThemeRepository themeRepository;
+
+    @Mock
+    private DomainBasedThemeResolver domainBasedThemeResolver;
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private Payload payload;
+
+    @InjectMocks
+    private ThemeManager themeManager = new ThemeManager();
+
+    @Before
+    public void setUp() {
+        when(domain.getId()).thenReturn("domain-id");
+        when(domain.getName()).thenReturn("domain-name");
+
+        when(payload.getReferenceType()).thenReturn(ReferenceType.DOMAIN);
+        when(payload.getReferenceId()).thenReturn("domain-id");
+        when(payload.getId()).thenReturn("theme-id");
+    }
+
+    @Test
+    public void shouldLoadThemes_after_properties_set() throws Exception {
+        Theme theme = mock(Theme.class);
+        when(theme.getId()).thenReturn("theme-id");
+
+        when(themeRepository.findByReference(ReferenceType.DOMAIN, domain.getId())).thenReturn(Maybe.just(theme));
+
+        themeManager.afterPropertiesSet();
+
+        verify(themeRepository, times(1)).findByReference(ReferenceType.DOMAIN, domain.getId());
+        verify(domainBasedThemeResolver, times(1)).updateTheme(any());
+    }
+
+    @Test
+    public void shouldNotLoadThemes_after_properties_set_exception() throws Exception {
+        when(themeRepository.findByReference(ReferenceType.DOMAIN, domain.getId())).thenReturn(Maybe.error(TechnicalException::new));
+
+        themeManager.afterPropertiesSet();
+
+        verify(themeRepository, times(1)).findByReference(ReferenceType.DOMAIN, domain.getId());
+        verify(domainBasedThemeResolver, never()).updateTheme(any());
+    }
+
+    @Test
+    public void shouldSubscribeToEvents() throws Exception {
+        themeManager.doStart();
+
+        verify(eventManager, times(1)).subscribeForEvents(themeManager, ThemeEvent.class, domain.getId());
+    }
+
+    @Test
+    public void shouldUnSubscribeToEvents() throws Exception {
+        themeManager.doStop();
+
+        verify(eventManager, times(1)).unsubscribeForEvents(themeManager, ThemeEvent.class, domain.getId());
+    }
+
+    @Test
+    public void shouldNotDeploy_wrong_domain() {
+        Payload payload = mock(Payload.class);
+        when(payload.getReferenceType()).thenReturn(ReferenceType.DOMAIN);
+        when(payload.getReferenceId()).thenReturn("wrong-domain-id");
+
+        Event<ThemeEvent, Payload> event = mock(Event.class);
+        when(event.content()).thenReturn(payload);
+
+        themeManager.onEvent(event);
+
+        verify(themeRepository, never()).findById(anyString());
+        verify(domainBasedThemeResolver, never()).updateTheme(any());
+    }
+
+    @Test
+    public void shouldDeploy() {
+        shouldDeploy(ThemeEvent.DEPLOY);
+    }
+
+    @Test
+    public void shouldUpdate() {
+        shouldDeploy(ThemeEvent.UPDATE);
+    }
+
+    @Test
+    public void shouldNotDeploy_exception() {
+        Event<ThemeEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(ThemeEvent.DEPLOY);
+        when(event.content()).thenReturn(payload);
+
+        when(themeRepository.findById("theme-id")).thenReturn(Maybe.error(TechnicalException::new));
+
+        themeManager.onEvent(event);
+
+        verify(themeRepository, times(1)).findById(anyString());
+        verify(domainBasedThemeResolver, never()).updateTheme(any());
+    }
+
+    @Test
+    public void shouldNotDeploy_not_found() {
+        Event<ThemeEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(ThemeEvent.DEPLOY);
+        when(event.content()).thenReturn(payload);
+
+        when(themeRepository.findById("theme-id")).thenReturn(Maybe.empty());
+
+        themeManager.onEvent(event);
+
+        verify(themeRepository, times(1)).findById(anyString());
+        verify(domainBasedThemeResolver, never()).updateTheme(any());
+    }
+
+    @Test
+    public void shouldUndeploy() {
+        Event<ThemeEvent, Payload> deployEvent = mock(Event.class);
+        when(deployEvent.type()).thenReturn(ThemeEvent.DEPLOY);
+        when(deployEvent.content()).thenReturn(payload);
+
+        Event<ThemeEvent, Payload> undeployEvent = mock(Event.class);
+        when(undeployEvent.type()).thenReturn(ThemeEvent.UNDEPLOY);
+        when(undeployEvent.content()).thenReturn(payload);
+
+        Theme theme = mock(Theme.class);
+        when(theme.getId()).thenReturn("theme-id");
+        when(theme.getReferenceId()).thenReturn("domain-id");
+        when(themeRepository.findById("theme-id")).thenReturn(Maybe.just(theme));
+
+        themeManager.onEvent(deployEvent);
+        themeManager.onEvent(undeployEvent);
+
+        verify(domainBasedThemeResolver, times(1)).removeTheme("domain-id");
+    }
+
+    private void shouldDeploy(ThemeEvent themeEvent) {
+        Event<ThemeEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(themeEvent);
+        when(event.content()).thenReturn(payload);
+
+        Theme theme = mock(Theme.class);
+        when(theme.getId()).thenReturn("theme-id");
+        when(themeRepository.findById("theme-id")).thenReturn(Maybe.just(theme));
+
+        themeManager.onEvent(event);
+
+        verify(themeRepository, times(1)).findById(anyString());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/DomainBasedThemeResolverTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/view/thymeleaf/DomainBasedThemeResolverTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.vertx.view.thymeleaf;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.Theme;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DomainBasedThemeResolverTest {
+
+    @Mock
+    private Domain domain;
+
+    @InjectMocks
+    private DomainBasedThemeResolver domainBasedThemeResolver = new DomainBasedThemeResolver();
+
+    @Before
+    public void setUp() {
+        when(domain.getId()).thenReturn("domain-id");
+    }
+
+    @Test
+    public void shouldResolveTheme_no_custom_theme() {
+        Map<String, Object> context = new HashMap<>();
+        domainBasedThemeResolver.resolveTheme(context);
+
+        ThemeResolution themeResolution = (ThemeResolution) context.get("theme");
+        Assert.assertTrue(themeResolution != null);
+        Assert.assertTrue(isEmpty(themeResolution));
+    }
+
+    @Test
+    public void shouldResolveTheme_custom_theme() {
+        Theme customTheme = buildTheme();
+
+        Map<String, Object> context = new HashMap<>();
+        domainBasedThemeResolver.updateTheme(customTheme);
+        domainBasedThemeResolver.resolveTheme(context);
+
+        ThemeResolution themeResolution = (ThemeResolution) context.get("theme");
+        Assert.assertTrue(themeResolution != null);
+        Assert.assertTrue(customTheme.getFaviconUrl().equals(themeResolution.getFaviconUrl()));
+        Assert.assertTrue(customTheme.getLogoUrl().equals(themeResolution.getLogoUrl()));
+        Assert.assertTrue(customTheme.getLogoWidth() == (themeResolution.getLogoWidth()));
+        Assert.assertTrue(customTheme.getCss().equals(themeResolution.getCustomCss()));
+        Assert.assertTrue(themeResolution.getCss().equals(":root {--primary-background-color:#ffffff;--primary-foreground-color:#000000;--secondary-background-color:#fafafa;--secondary-foreground-color:#000000;--logo-width:250px;}"));
+    }
+
+    @Test
+    public void shouldRemoveTheme() {
+        Theme customTheme = buildTheme();
+
+        Map<String, Object> context = new HashMap<>();
+        domainBasedThemeResolver.updateTheme(customTheme);
+        domainBasedThemeResolver.removeTheme(customTheme.getReferenceId());
+        domainBasedThemeResolver.resolveTheme(context);
+
+        ThemeResolution themeResolution = (ThemeResolution) context.get("theme");
+        Assert.assertTrue(themeResolution != null);
+        Assert.assertTrue(isEmpty(themeResolution));
+    }
+
+    private static Theme buildTheme() {
+        Theme customTheme = new Theme();
+        customTheme.setReferenceType(ReferenceType.DOMAIN);
+        customTheme.setReferenceId("domain-id");
+        customTheme.setCss("a { text-decoration: none; }");
+        customTheme.setPrimaryButtonColorHex("#ffffff");
+        customTheme.setPrimaryTextColorHex("#000000");
+        customTheme.setSecondaryButtonColorHex("#fafafa");
+        customTheme.setSecondaryTextColorHex("#000000");
+        customTheme.setFaviconUrl("https://favicon.ico");
+        customTheme.setLogoUrl("https://logo.png");
+        customTheme.setLogoWidth(250);
+
+        return customTheme;
+    }
+
+    private static boolean isEmpty(ThemeResolution themeResolution) {
+        return Stream.of(
+                themeResolution.getCss(),
+                themeResolution.getCustomCss(),
+                themeResolution.getFaviconUrl(),
+                themeResolution.getLogoUrl()).allMatch(Objects::isNull);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/ThemeEntity.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/ThemeEntity.java
@@ -34,6 +34,7 @@ public class ThemeEntity {
     private String primaryButtonColorHex;
     private String secondaryButtonColorHex;
     private String primaryTextColorHex;
+    private String secondaryTextColorHex;
     private String css;
     private Date createdAt;
     private Date updatedAt;
@@ -52,7 +53,7 @@ public class ThemeEntity {
         this.primaryTextColorHex = theme.getPrimaryTextColorHex();
         this.primaryButtonColorHex = theme.getPrimaryButtonColorHex();
         this.secondaryButtonColorHex = theme.getSecondaryButtonColorHex();
-
+        this.secondaryTextColorHex = theme.getSecondaryTextColorHex();
         this.createdAt = theme.getCreatedAt();
         this.updatedAt = theme.getUpdatedAt();
     }
@@ -129,6 +130,14 @@ public class ThemeEntity {
         this.primaryTextColorHex = primaryTextColorHex;
     }
 
+    public String getSecondaryTextColorHex() {
+        return secondaryTextColorHex;
+    }
+
+    public void setSecondaryTextColorHex(String secondaryTextColorHex) {
+        this.secondaryTextColorHex = secondaryTextColorHex;
+    }
+
     public String getCss() {
         return css;
     }
@@ -165,6 +174,7 @@ public class ThemeEntity {
         theme.setPrimaryTextColorHex(this.primaryTextColorHex);
         theme.setPrimaryButtonColorHex(this.primaryButtonColorHex);
         theme.setSecondaryButtonColorHex(this.secondaryButtonColorHex);
+        theme.setSecondaryTextColorHex(this.secondaryTextColorHex);
 
         theme.setCreatedAt(this.createdAt);
         theme.setUpdatedAt(this.updatedAt);

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Theme.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Theme.java
@@ -31,6 +31,7 @@ public class Theme {
     private String primaryButtonColorHex;
     private String secondaryButtonColorHex;
     private String primaryTextColorHex;
+    private String secondaryTextColorHex;
     private String css;
     private Date createdAt;
     private Date updatedAt;
@@ -105,6 +106,14 @@ public class Theme {
 
     public void setPrimaryTextColorHex(String primaryTextColorHex) {
         this.primaryTextColorHex = primaryTextColorHex;
+    }
+
+    public String getSecondaryTextColorHex() {
+        return secondaryTextColorHex;
+    }
+
+    public void setSecondaryTextColorHex(String secondaryTextColorHex) {
+        this.secondaryTextColorHex = secondaryTextColorHex;
     }
 
     public String getCss() {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcTheme.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcTheme.java
@@ -45,6 +45,8 @@ public class JdbcTheme {
     private String secondaryButtonColorHex;
     @Column("primary_text_color")
     private String primaryTextColorHex;
+    @Column("secondary_text_color")
+    private String secondaryTextColorHex;
     private String css;
     @Column("created_at")
     private LocalDateTime createdAt;
@@ -121,6 +123,14 @@ public class JdbcTheme {
 
     public void setPrimaryTextColorHex(String primaryTextColorHex) {
         this.primaryTextColorHex = primaryTextColorHex;
+    }
+
+    public String getSecondaryTextColorHex() {
+        return secondaryTextColorHex;
+    }
+
+    public void setSecondaryTextColorHex(String secondaryTextColorHex) {
+        this.secondaryTextColorHex = secondaryTextColorHex;
     }
 
     public String getCss() {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_19_0/3.19.0-add-theme-table.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_19_0/3.19.0-add-theme-table.yml
@@ -4,7 +4,7 @@ databaseChangeLog:
       author: GraviteeSource Team
       changes:
         #############################
-        # User Geo Time Coordinates #
+        # Theme #
         ############################
         - createTable:
             tableName: themes
@@ -18,6 +18,7 @@ databaseChangeLog:
               - column: { name: primary_text_color, type: nvarchar(12), constraints: { nullable: true } }
               - column: { name: primary_button_color, type: nvarchar(12), constraints: { nullable: true } }
               - column: { name: secondary_button_color, type: nvarchar(12), constraints: { nullable: true } }
+              - column: { name: secondary_text_color, type: nvarchar(12), constraints: { nullable: true } }
               - column: { name: css, type: clob, constraints: { nullable: true } }
               - column: { name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: { name: updated_at, type: timestamp(6), constraints: { nullable: true } }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoThemeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoThemeRepository.java
@@ -100,6 +100,7 @@ public class MongoThemeRepository extends AbstractManagementMongoRepository impl
         theme.setPrimaryTextColorHex(themeMongo.getPrimaryTextColorHex());
         theme.setPrimaryButtonColorHex(themeMongo.getPrimaryButtonColorHex());
         theme.setSecondaryButtonColorHex(themeMongo.getSecondaryButtonColorHex());
+        theme.setSecondaryTextColorHex(themeMongo.getSecondaryTextColorHex());
 
         return theme;
     }
@@ -122,6 +123,7 @@ public class MongoThemeRepository extends AbstractManagementMongoRepository impl
         themeMongo.setPrimaryTextColorHex(theme.getPrimaryTextColorHex());
         themeMongo.setPrimaryButtonColorHex(theme.getPrimaryButtonColorHex());
         themeMongo.setSecondaryButtonColorHex(theme.getSecondaryButtonColorHex());
+        themeMongo.setSecondaryTextColorHex(theme.getSecondaryTextColorHex());
 
         return themeMongo;
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ThemeMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ThemeMongo.java
@@ -21,7 +21,7 @@ import org.bson.codecs.pojo.annotations.BsonId;
 import java.util.Date;
 
 /**
- * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class ThemeMongo extends Auditable {
@@ -40,6 +40,7 @@ public class ThemeMongo extends Auditable {
     private String primaryButtonColorHex;
     private String secondaryButtonColorHex;
     private String primaryTextColorHex;
+    private String secondaryTextColorHex;
     private String css;
 
     public String getId() {
@@ -112,6 +113,14 @@ public class ThemeMongo extends Auditable {
 
     public void setPrimaryTextColorHex(String primaryTextColorHex) {
         this.primaryTextColorHex = primaryTextColorHex;
+    }
+
+    public String getSecondaryTextColorHex() {
+        return secondaryTextColorHex;
+    }
+
+    public void setSecondaryTextColorHex(String secondaryTextColorHex) {
+        this.secondaryTextColorHex = secondaryTextColorHex;
     }
 
     public String getCss() {

--- a/gravitee-am-ui/src/app/domain/settings/theme/theme.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/theme/theme.component.ts
@@ -33,22 +33,22 @@ export class DomainSettingsThemeComponent implements OnInit {
   themes: any[];
   theme: any;
   colorPalettes: any[] = [
-    { 'name': 'light-blue', 'primaryButtonColorHex': '#2AA7E3', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#CAE9F8' },
-    { 'name': 'blue', 'primaryButtonColorHex': '#3F71F4', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#CFDCFC' },
-    { 'name': 'deep-purple', 'primaryButtonColorHex': '#6A4FF7', 'primaryTextColorHex': '#FFFFFF', 'secondaryButtonColorHex': '#DAD3FD' },
-    { 'name': 'purple', 'primaryButtonColorHex': '#9346E9', 'primaryTextColorHex': '#FFFFFF', 'secondaryButtonColorHex': '#E4D1FA' },
-    { 'name': 'light-purple', 'primaryButtonColorHex': '#CC63D6', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#F2D8F5' },
-    { 'name': 'deep-pink', 'primaryButtonColorHex': '#D8549A', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#F5D4E6' },
-    { 'name': 'pink', 'primaryButtonColorHex': '#FE8AA8', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#FFE2E9' },
-    { 'name': 'deep-red', 'primaryButtonColorHex': '#C52852', 'primaryTextColorHex': '#FFFFFF', 'secondaryButtonColorHex': '#F1C9D4' },
-    { 'name': 'deep-orange', 'primaryButtonColorHex': '#D94C3E', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#F6D2CF' },
-    { 'name': 'orange', 'primaryButtonColorHex': '#EA9345', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#FAE4D0' },
-    { 'name': 'yellow', 'primaryButtonColorHex': '#EED052', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#FBF3D4' },
-    { 'name': 'light-green', 'primaryButtonColorHex': '#9FC929', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#E7F2C9' },
-    { 'name': 'green', 'primaryButtonColorHex': '#7FCF79', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#DFF3DE' },
-    { 'name': 'teal', 'primaryButtonColorHex': '#66C2AC', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#D9F0EA' },
-    { 'name': 'grey', 'primaryButtonColorHex': '#8A979E', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#E2E5E7' },
-    { 'name': 'deep-grey', 'primaryButtonColorHex': '#252829', 'primaryTextColorHex': '#FFFFFF', 'secondaryButtonColorHex': '#C8C9C9' }
+    { 'name': 'light-blue', 'primaryButtonColorHex': '#2AA7E3', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#CAE9F8', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'blue', 'primaryButtonColorHex': '#3F71F4', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#CFDCFC', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'deep-purple', 'primaryButtonColorHex': '#6A4FF7', 'primaryTextColorHex': '#FFFFFF', 'secondaryButtonColorHex': '#DAD3FD', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'purple', 'primaryButtonColorHex': '#9346E9', 'primaryTextColorHex': '#FFFFFF', 'secondaryButtonColorHex': '#E4D1FA', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'light-purple', 'primaryButtonColorHex': '#CC63D6', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#F2D8F5', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'deep-pink', 'primaryButtonColorHex': '#D8549A', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#F5D4E6', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'pink', 'primaryButtonColorHex': '#FE8AA8', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#FFE2E9', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'deep-red', 'primaryButtonColorHex': '#C52852', 'primaryTextColorHex': '#FFFFFF', 'secondaryButtonColorHex': '#F1C9D4', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'deep-orange', 'primaryButtonColorHex': '#D94C3E', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#F6D2CF', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'orange', 'primaryButtonColorHex': '#EA9345', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#FAE4D0', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'yellow', 'primaryButtonColorHex': '#EED052', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#FBF3D4', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'light-green', 'primaryButtonColorHex': '#9FC929', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#E7F2C9', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'green', 'primaryButtonColorHex': '#7FCF79', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#DFF3DE', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'teal', 'primaryButtonColorHex': '#66C2AC', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#D9F0EA', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'grey', 'primaryButtonColorHex': '#8A979E', 'primaryTextColorHex': '#000000', 'secondaryButtonColorHex': '#E2E5E7', 'secondaryTextColorHex': '#000000' },
+    { 'name': 'deep-grey', 'primaryButtonColorHex': '#252829', 'primaryTextColorHex': '#FFFFFF', 'secondaryButtonColorHex': '#C8C9C9', 'secondaryTextColorHex': '#000000' }
   ];
   selectedColorPalette: string;
   config: any = { lineNumbers: true };
@@ -112,6 +112,7 @@ export class DomainSettingsThemeComponent implements OnInit {
         themeToPublish.primaryButtonColorHex = filteredObj.primaryButtonColorHex;
         themeToPublish.secondaryButtonColorHex = filteredObj.secondaryButtonColorHex;
         themeToPublish.primaryTextColorHex = filteredObj.primaryTextColorHex;
+        themeToPublish.secondaryTextColorHex = filteredObj.secondaryTextColorHex;
       }
     }
     const publishAction = (!this.theme.id) ?


### PR DESCRIPTION
closes gravitee-io/issues#8125

**NOTE: Currently we can't change the color of the svg icons (eyes, arrows, ...)**

## :memo: Test scenarios 

1. Publish a theme with a custom color palette and a logo
2. Visit all the pages (login, reset password, registration, ...) and check if the theme has been applied

## :computer: Add screenshots for UI

<img width="1674" alt="theme-1" src="https://user-images.githubusercontent.com/1927438/185969162-e492bce3-0f85-4bf9-b95c-fbf8f6d085fc.png">
<img width="860" alt="theme-2" src="https://user-images.githubusercontent.com/1927438/185969178-a6052d63-8edf-4617-977f-ec8b30363301.png">


