### PR TITLE
fix(theme): manage the secondary Text color on theme creation

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ThemesResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ThemesResourceTest.java
@@ -149,6 +149,7 @@ public class ThemesResourceTest extends JerseySpringTest {
         theme.setPrimaryTextColorHex("#787787");
         theme.setPrimaryButtonColorHex("#877787");
         theme.setSecondaryButtonColorHex("#799955");
+        theme.setSecondaryTextColorHex("#795955");
         final Date now = new Date();
         theme.setCreatedAt(now);
         theme.setUpdatedAt(now);
@@ -176,6 +177,7 @@ public class ThemesResourceTest extends JerseySpringTest {
         assertEquals(theme.getPrimaryTextColorHex(), entity.getPrimaryTextColorHex());
         assertEquals(theme.getPrimaryButtonColorHex(), entity.getPrimaryButtonColorHex());
         assertEquals(theme.getSecondaryButtonColorHex(), entity.getSecondaryButtonColorHex());
+        assertEquals(theme.getSecondaryTextColorHex(), entity.getSecondaryTextColorHex());
 
         assertNotNull(response.getHeaderString(HttpHeaders.LOCATION));
         assertTrue(response.getHeaderString(HttpHeaders.LOCATION).endsWith("/themes/"+theme.getId()));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ThemeServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ThemeServiceImpl.java
@@ -89,6 +89,7 @@ public class ThemeServiceImpl implements ThemeService {
         theme.setPrimaryTextColorHex(newTheme.getPrimaryTextColorHex());
         theme.setPrimaryButtonColorHex(newTheme.getPrimaryButtonColorHex());
         theme.setSecondaryButtonColorHex(newTheme.getSecondaryButtonColorHex());
+        theme.setSecondaryTextColorHex(newTheme.getSecondaryTextColorHex());
 
         final Date now = new Date();
         theme.setCreatedAt(now);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewTheme.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewTheme.java
@@ -38,6 +38,7 @@ public class NewTheme  {
     private String primaryButtonColorHex;
     private String secondaryButtonColorHex;
     private String primaryTextColorHex;
+    private String secondaryTextColorHex;
     private String css;
 
     public String getLogoUrl() {
@@ -86,6 +87,14 @@ public class NewTheme  {
 
     public void setPrimaryTextColorHex(String primaryTextColorHex) {
         this.primaryTextColorHex = primaryTextColorHex;
+    }
+
+    public String getSecondaryTextColorHex() {
+        return secondaryTextColorHex;
+    }
+
+    public void setSecondaryTextColorHex(String secondaryTextColorHex) {
+        this.secondaryTextColorHex = secondaryTextColorHex;
     }
 
     public String getCss() {


### PR DESCRIPTION
fixes gravitee-io/issues#8378
