### PR TITLE
fix(idp): make multifields query parsable for the MongoDB UserProvider

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
@@ -251,7 +251,7 @@ public class MongoUserProvider extends MongoAbstractProvider implements UserProv
     }
 
     private String convertToJsonString(String rawString) {
-        rawString = rawString.replaceAll("[^\\{\\}\\[\\],:]+", "\"$0\"").replaceAll("\\s+","");
+        rawString = rawString.replaceAll("[^\\{\\}\\[\\],:\\s]+", "\"$0\"").replaceAll("\\s+", "");
         return rawString;
     }
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
@@ -64,6 +64,16 @@ public class MongoUserProviderTest {
     }
 
     @Test
+    public void shouldSelectUserByEmail_AlternativeAttribute() {
+        TestObserver<User> testObserver = userProvider.findByEmail("user02-alt@acme.com").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "user02".equals(u.getUsername()));
+    }
+
+    @Test
     public void shouldNotSelectUserByUsername_userNotFound() {
         TestObserver<User> testObserver = userProvider.findByUsername("unknown").test();
         testObserver.awaitTerminalEvent();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
@@ -55,6 +55,8 @@ public class MongoUserProviderTestConfiguration implements InitializingBean {
         Observable.fromPublisher(collection.insertOne(doc)).blockingFirst();
         Document doc2 = new Document("username", "user01").append("email", "user01@acme.com").append("password", "user01").append("_id", UUID.randomUUID().toString());
         Observable.fromPublisher(collection.insertOne(doc2)).blockingFirst();
+        Document doc3 = new Document("username", "user02").append("email", "user02@acme.com").append("alternative_email", "user02-alt@acme.com").append("password", "user02").append("_id", UUID.randomUUID().toString());
+        Observable.fromPublisher(collection.insertOne(doc3)).blockingFirst();
     }
 
     @Bean
@@ -67,6 +69,7 @@ public class MongoUserProviderTestConfiguration implements InitializingBean {
         configuration.setUsersCollection("users");
         configuration.setFindUserByUsernameQuery("{username: ?}");
         configuration.setFindUserByMultipleFieldsQuery("{ $or : [{username: ?}, {email: ?}]}");
+        configuration.setFindUserByEmailQuery("{ $or : [{email: ?}, {alternative_email: ?}]}");
         configuration.setPasswordField("password");
         configuration.setPasswordEncoder(PasswordEncoder.NONE);
 


### PR DESCRIPTION
fixes gravitee-io/issues#8379

## :memo: Test scenarios 

1. Create a new MongoDB IDP on your domain
2. configure this idp to use the collection "idp-test-8379"
3. update the query to find the user by email with this one : `{ $or : [{email: ?}, {alternative_email: ?}]}`
4. insert in this collection the following user 
```
{"_id":"ed22436d-1257-463e-a243-6d1257663e33",
"username":"user01",
"password":"$2a$10$lYYqk8RHX5OQZ2QDW2boJeB3J431WuYZk2Slnwqx7IVGqOIXawZXe",
"given_name":"user01",
"family_name":"user01",
"email":"user01@acme.fr",
"alternative_email":"user01-alt@acme.fr"
}
```
5. enable a new APP and enable only this IDP
6. enable the forgot password option
7. request a new password for the user using the email or the alternative_email, the email should be received.