### PR TITLE
fix: gateway forms error rendering

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/main.css
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/main.css
@@ -346,10 +346,12 @@ div.short-section > input + input {
     color: var(--error-text-color);
     flex-grow: 1;
     padding: 0;
+    height: auto;
 }
 
 .error-text > span {
     padding-top: 7px;
+    padding-bottom: 7px;
 }
 
 .large-font {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/mfa_challenge.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/mfa_challenge.html
@@ -53,7 +53,7 @@
             <div th:if="${error}" class="button error-text">
                 <span class="description">
                     <span class="error" th:text="${error}"></span>
-                    <small th:text="*{error_description}?: 'Invalide code'"></small>
+                    <small th:text="*{error_description}?: 'Invalid code'"></small>
                 </span>
             </div>
 


### PR DESCRIPTION
## :id: 
fixes gravitee-io/issues#8368


## :pencil2: 

Added `height:auto` to the `.error-text` css class.

## :computer: 

<img width="609" alt="Screenshot 2022-09-07 at 20 28 04" src="https://user-images.githubusercontent.com/99647292/188961455-d8aaee15-07cd-4abe-ba8f-3d9511ba52df.png">
