### PR TITLE
fix: set autofocus on password if login_hint is provided

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
@@ -33,13 +33,13 @@
                         <div class="input-textfield">
                             <label for="username">Username</label>
                             <input type="text" id="username" name="username"
-                                   th:value="${param.username}" autofocus="autofocus" required
+                                   th:value="${param.username}" th:autofocus="${param.username == null}" required
                                    th:readonly="${param.username != null}"
                             />
                         </div>
                         <div class="input-textfield">
                             <label for="password">Password</label>
-                            <input type="password" id="password" name="password" required />
+                            <input type="password" id="password" name="password" th:autofocus="${param.username != null}" required />
                         </div>
                         <div th:if="${error}" class="login-error-info">
                             <span>


### PR DESCRIPTION
fixes gravitee-io/issues#8219

## :memo: Test scenarios 

* Call login endpoint without `login_hint` parameter ==> focus should be on the usename field
`http://localhost:8092/domain/login?client_id=62db61e3-b4ec-40a8-9b61-e3b4ecc0a863&response_type=code&redirect_uri=https%3A%2F%2Fcallback`

* Call login endpoint with `login_hint` parameter ==> focus should be on the password field and username field is readonly
`http://localhost:8092/domain/login?client_id=62db61e3-b4ec-40a8-9b61-e3b4ecc0a863&response_type=code&redirect_uri=https%3A%2F%2Fcallback&login_hint=myusername`
