### PR TITLE
fix(idp): make multifields query parsable for the MongoDB UserProvider

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
@@ -267,7 +267,7 @@ public class MongoUserProvider implements UserProvider, InitializingBean {
     }
 
     private String convertToJsonString(String rawString) {
-        rawString = rawString.replaceAll("[^\\{\\}\\[\\],:]+", "\"$0\"").replaceAll("\\s+","");
+        rawString = rawString.replaceAll("[^\\{\\}\\[\\],:\\s]+", "\"$0\"").replaceAll("\\s+", "");
         return rawString;
     }
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
@@ -64,6 +64,16 @@ public class MongoUserProviderTest {
     }
 
     @Test
+    public void shouldSelectUserByEmail_AlternativeAttribute() {
+        TestObserver<User> testObserver = userProvider.findByEmail("user02-alt@acme.com").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "user02".equals(u.getUsername()));
+    }
+
+    @Test
     public void shouldNotSelectUserByUsername_userNotFound() {
         TestObserver<User> testObserver = userProvider.findByUsername("unknown").test();
         testObserver.awaitTerminalEvent();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
@@ -51,6 +51,8 @@ public class MongoUserProviderTestConfiguration implements InitializingBean {
         Observable.fromPublisher(collection.insertOne(doc)).blockingFirst();
         Document doc2 = new Document("username", "user01").append("email", "user01@acme.com").append("password", "user01").append("_id", UUID.randomUUID().toString());
         Observable.fromPublisher(collection.insertOne(doc2)).blockingFirst();
+        Document doc3 = new Document("username", "user02").append("email", "user02@acme.com").append("alternative_email", "user02-alt@acme.com").append("password", "user02").append("_id", UUID.randomUUID().toString());
+        Observable.fromPublisher(collection.insertOne(doc3)).blockingFirst();
     }
 
     @Bean
@@ -63,6 +65,7 @@ public class MongoUserProviderTestConfiguration implements InitializingBean {
         configuration.setUsersCollection("users");
         configuration.setFindUserByUsernameQuery("{username: ?}");
         configuration.setFindUserByMultipleFieldsQuery("{ $or : [{username: ?}, {email: ?}]}");
+        configuration.setFindUserByEmailQuery("{ $or : [{email: ?}, {alternative_email: ?}]}");
         configuration.setPasswordField("password");
         configuration.setPasswordEncoder(PasswordEncoder.NONE);
 


### PR DESCRIPTION
fixes gravitee-io/issues#8383
backport gravitee-io/issues#8379

