### PR TITLE
fix: introduce implicit consent settings for the IP & user agent

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -290,7 +290,7 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
         Handler<RoutingContext> clientRequestParseHandlerOptional = new ClientRequestParseHandler(clientSyncService);
         Handler<RoutingContext> passwordPolicyRequestParseHandler = new PasswordPolicyRequestParseHandler(passwordService, domain);
         Handler<RoutingContext> botDetectionHandler = new BotDetectionHandler(domain, botDetectionManager);
-        Handler<RoutingContext> dataConsentHandler = new DataConsentHandler();
+        Handler<RoutingContext> dataConsentHandler = new DataConsentHandler(environment);
         Handler<RoutingContext> geoIpHandler = new GeoIpHandler(userActivityService, vertx.eventBus());
         Handler<RoutingContext> loginAttemptHandler = new LoginAttemptHandler(domain, identityProviderManager, loginAttemptService, userActivityService);
         Handler<RoutingContext> rememberDeviceSettingsHandler = new RememberDeviceSettingsHandler();
@@ -304,6 +304,7 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
                 // for instance, the OAuthProvider will not execute the /oauth/authorize and there will have 500 ERROR instead of "missing client_id" OAuth 2.0 error
                 // See https://github.com/gravitee-io/issues/issues/5035
                 .handler(new ClientRequestParseHandler(clientSyncService).setContinueOnError(true))
+                .handler(dataConsentHandler)
                 .handler(geoIpHandler)
                 .handler(policyChainHandler.create(ExtensionPoint.ROOT));
 
@@ -318,7 +319,6 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
         rootRouter.post(PATH_IDENTIFIER_FIRST_LOGIN)
                 .handler(clientRequestParseHandler)
                 .handler(botDetectionHandler)
-                .handler(dataConsentHandler)
                 .handler(new LoginSocialAuthenticationHandler(identityProviderManager, jwtService, certificateManager))
                 .handler(policyChainHandler.create(ExtensionPoint.POST_LOGIN_IDENTIFIER))
                 .handler(new LoginSelectionRuleHandler(true))
@@ -336,7 +336,6 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
         rootRouter.post(PATH_LOGIN)
                 .handler(clientRequestParseHandler)
                 .handler(botDetectionHandler)
-                .handler(dataConsentHandler)
                 .handler(loginAttemptHandler)
                 .handler(new LoginFormHandler(userAuthProvider))
                 .handler(deviceIdentifierHandler)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/consent/DataHandlerConsentImplicitTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/consent/DataHandlerConsentImplicitTest.java
@@ -19,22 +19,24 @@ package io.gravitee.am.gateway.handler.root.resources.handler.consent;
 import io.gravitee.am.gateway.handler.root.resources.handler.dummies.SpyRoutingContext;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.buffer.Buffer;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.core.env.Environment;
 
+import java.util.Map;
+
 import static io.gravitee.am.common.utils.ConstantKeys.USER_CONSENT_IP_LOCATION;
 import static io.gravitee.am.common.utils.ConstantKeys.USER_CONSENT_USER_AGENT;
 import static io.gravitee.common.http.MediaType.APPLICATION_JSON;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class DataHandlerConsentTest {
+public class DataHandlerConsentImplicitTest {
 
     private SpyRoutingContext routingContext;
     private DataConsentHandler handler;
@@ -50,30 +52,30 @@ public class DataHandlerConsentTest {
 
     private void setNoImplicitConsent() {
         mockEnv = Mockito.mock(Environment.class);
-        Mockito.when(mockEnv.getProperty(DataConsentHandler.CONFIG_KEY_IMPLICIT_CONSENT_IP, boolean.class, false)).thenReturn(false);
-        Mockito.when(mockEnv.getProperty(DataConsentHandler.CONFIG_KEY_IMPLICIT_CONSENT_USER_AGENT, boolean.class, false)).thenReturn(false);
+        Mockito.when(mockEnv.getProperty(DataConsentHandler.CONFIG_KEY_IMPLICIT_CONSENT_IP, boolean.class, false)).thenReturn(true);
+        Mockito.when(mockEnv.getProperty(DataConsentHandler.CONFIG_KEY_IMPLICIT_CONSENT_USER_AGENT, boolean.class, false)).thenReturn(true);
     }
 
     @Test
-    public void must_do_nothing_when_no_request_param() {
+    public void default_implicit_value_when_no_request_param() {
         handler.handle(routingContext);
-        assertFalse(routingContext.session().get(USER_CONSENT_IP_LOCATION));
-        assertFalse(routingContext.session().get(USER_CONSENT_USER_AGENT));
+        assertTrue(routingContext.session().get(USER_CONSENT_IP_LOCATION));
+        assertTrue(routingContext.session().get(USER_CONSENT_USER_AGENT));
     }
 
     @Test
-    public void must_have_user_ip_location_when_no_request_param() {
+    public void must_have_user_ip_location_with_default_implicit_value_when_no_request_param() {
         routingContext.putParam(USER_CONSENT_IP_LOCATION, "on");
         handler.handle(routingContext);
         assertTrue(routingContext.session().get(USER_CONSENT_IP_LOCATION));
-        assertFalse(routingContext.session().get(USER_CONSENT_USER_AGENT));
+        assertTrue(routingContext.session().get(USER_CONSENT_USER_AGENT));
     }
 
     @Test
-    public void must_have_user_agent_when_no_request_param() {
+    public void must_have_user_agent_with_default_implicit_value_when_no_request_param() {
         routingContext.putParam(USER_CONSENT_USER_AGENT, "on");
         handler.handle(routingContext);
-        assertFalse(routingContext.session().get(USER_CONSENT_IP_LOCATION));
+        assertTrue(routingContext.session().get(USER_CONSENT_IP_LOCATION));
         assertTrue(routingContext.session().get(USER_CONSENT_USER_AGENT));
     }
 
@@ -114,20 +116,20 @@ public class DataHandlerConsentTest {
     }
 
     @Test
-    public void must_have_user_ip_location_when_no_request_param_body() {
+    public void must_have_user_ip_location_with_default_implicit_value_when_no_request_param_body() {
         routingContext.request().headers().set("Content-type", APPLICATION_JSON);
         routingContext.setBody(new Buffer(new JsonObject(Map.of(USER_CONSENT_IP_LOCATION, "on")).toBuffer()));
         handler.handle(routingContext);
         assertTrue(routingContext.session().get(USER_CONSENT_IP_LOCATION));
-        assertFalse(routingContext.session().get(USER_CONSENT_USER_AGENT));
+        assertTrue(routingContext.session().get(USER_CONSENT_USER_AGENT));
     }
 
     @Test
-    public void must_have_user_agent_when_no_request_param_body() {
+    public void must_have_user_agent_with_default_implicit_value_when_no_request_param_body() {
         routingContext.request().headers().set("Content-type", APPLICATION_JSON);
         routingContext.setBody(new Buffer(new JsonObject(Map.of(USER_CONSENT_USER_AGENT, "on")).toBuffer()));
         handler.handle(routingContext);
-        assertFalse(routingContext.session().get(USER_CONSENT_IP_LOCATION));
+        assertTrue(routingContext.session().get(USER_CONSENT_IP_LOCATION));
         assertTrue(routingContext.session().get(USER_CONSENT_USER_AGENT));
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -402,3 +402,13 @@ liquibase:
 #          LOW: 0.2777778
 ##          MEDIUM: 6.9444445 # (25km/h)
 ##          HIGH: 69.444445 # (250km/h)
+
+
+## This section allows implicit user consent to store remote IP and userAgent
+## into the user profile and audit logs. This consent is disabled by default
+## and should be enabled only if the end users of your applications
+## have given their consent.
+#
+#consent:
+#  ip: false
+#  user-agent: false


### PR DESCRIPTION
fixes gravitee-io/issues#8448

## :memo: Test scenarios 

* Start the GW with the following settings or env vars: 

[settings]
```
consent:
  ip: true
  user-agent: true
```
[env var]
```
gravitee_consent_ip=true
gravitee_consent_useragent=true
```
* sign in a user and enroll webauthn
* check into the audit 'USER_LOGIN' event contains the IP address and the UserAgent
* check into the user profile, the credentials details contains the IP address and the UserAgent
