### PR TITLE
8463: added missing property factor.target

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
@@ -72,6 +72,7 @@ public class PreviewBuilder {
     public static final String PARAMETER_NAME = "parameterName";
     public static final String FACTOR_TYPE = "factorType";
     public static final String ENROLLMENT = "enrollment";
+    public static final String TARGET = "target";
     public static final String ID = "id";
 
     private final TemplateEngine templateEngine;
@@ -209,11 +210,11 @@ public class PreviewBuilder {
 
                 final Enrollment smsEnrollment = new Enrollment();
                 smsEnrollment.setCountries(List.of("us", "en", "fr"));
-                final Map<String, Object> factorSms = Map.of(ID, "idsms" , FACTOR_TYPE, FactorType.SMS.getType(), ENROLLMENT, smsEnrollment);
+                final Map<String, Object> factorSms = Map.of(ID, "idsms" , FACTOR_TYPE, FactorType.SMS.getType(), ENROLLMENT, smsEnrollment, TARGET, "123456");
 
                 final Enrollment emailEnrollment = new Enrollment();
                 emailEnrollment.setKey(EMPTY_STRING);
-                final Map<String, Object> factorEmail = Map.of(ID, "idemail", FACTOR_TYPE, FactorType.EMAIL.getType(), ENROLLMENT, emailEnrollment);
+                final Map<String, Object> factorEmail = Map.of(ID, "idemail", FACTOR_TYPE, FactorType.EMAIL.getType(), ENROLLMENT, emailEnrollment, TARGET, "john@doe.com");
 
                 variables.put(ConstantKeys.FACTORS_KEY, List.of(factorOTP, factorSms, factorEmail));
                 break;


### PR DESCRIPTION
Added missing property `factor.target` so that user who has custom templates 3.18 or before can view the preview for mfa challenge alternative.

This fix linked to :https://github.com/gravitee-io/issues/issues/8463

### How to test
1. Copy the 3.18 MFA challenge alternative template from : https://am.management.v3-18-x.gravitee.xyz/
2. In 3.19 toggle and enable custom mfa alternatives page.
3. Copy the custom templates
4. Select the review
5. The review should be viewable without error 