### PR TITLE
fix: fallback to raw value of client credentials if the URL decoding …

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/ClientBasicAuthProviderTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/ClientBasicAuthProviderTest.java
@@ -75,6 +75,30 @@ public class ClientBasicAuthProviderTest {
     }
 
     @Test
+    public void shouldAuthenticateClient_Secret_NoUrlEncoded_withPercent() throws Exception {
+        Client client = mock(Client.class);
+        when(client.getClientId()).thenReturn("my|%-~totsdf$*!§0");
+        when(client.getClientSecret()).thenReturn("my|%-~totsdf$*!§0");
+
+        HttpServerRequest httpServerRequest = mock(HttpServerRequest.class);
+        HeadersMultiMap vertxHttpHeaders = new HeadersMultiMap();
+        vertxHttpHeaders.add(HttpHeaders.AUTHORIZATION, "Basic bXl8JS1+dG90c2RmJCohwqcwOm15fCUtfnRvdHNkZiQqIcKnMA==");
+        when(httpServerRequest.headers()).thenReturn(MultiMap.newInstance(vertxHttpHeaders));
+
+        RoutingContext context = mock(RoutingContext.class);
+        when(context.request()).thenReturn(httpServerRequest);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        authProvider.handle(client, context, clientAsyncResult -> {
+            latch.countDown();
+            Assert.assertNotNull(clientAsyncResult);
+            Assert.assertNotNull(clientAsyncResult.result());
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+    }
+
+    @Test
     public void shouldAuthenticateClient_urlEncodedCharacters() throws Exception {
         Client client = mock(Client.class);
         when(client.getClientId()).thenReturn("my\"client-id");


### PR DESCRIPTION
…process fails

fixes gravitee-io/issues#8501

# How to test:

* Create a service (B2B) application with a client Secret containing a %
* do a call on the token endpoint to get the token, without encoding the clientSecret before encoding it in base64.
