### PR TITLE
fix: try to decode clientId before searching it during auth phase

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/handler/impl/ClientAuthHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/handler/impl/ClientAuthHandlerImpl.java
@@ -16,8 +16,8 @@
 package io.gravitee.am.gateway.handler.oauth2.resources.auth.handler.impl;
 
 import io.gravitee.am.common.oauth2.Parameters;
-import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidClientException;
 import io.gravitee.am.gateway.handler.oauth2.resources.auth.handler.ClientAuthHandler;
 import io.gravitee.am.gateway.handler.oauth2.resources.auth.provider.ClientAuthProvider;
@@ -41,6 +41,7 @@ import java.util.Optional;
 import static io.gravitee.am.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
 import static io.gravitee.am.gateway.handler.oauth2.resources.auth.provider.CertificateUtils.extractPeerCertificate;
 import static io.gravitee.am.gateway.handler.oauth2.resources.auth.provider.CertificateUtils.getThumbprint;
+import static io.gravitee.am.gateway.handler.oauth2.resources.auth.provider.ClientUtils.urlDecode;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -138,8 +139,7 @@ public class ClientAuthHandlerImpl implements Handler<RoutingContext> {
                 return;
             }
             // get client
-            clientSyncService
-                    .findByClientId(clientId)
+            clientSyncService.findByClientId(urlDecode(clientId))
                     .subscribe(
                             client -> handler.handle(Future.succeededFuture(client)),
                             error -> handler.handle(Future.failedFuture(error)),

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/ClientBasicAuthProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/ClientBasicAuthProvider.java
@@ -26,10 +26,9 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import io.vertx.reactivex.ext.web.RoutingContext;
 
-import java.net.URLDecoder;
 import java.util.Base64;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.gravitee.am.gateway.handler.oauth2.resources.auth.provider.ClientUtils.urlDecode;
 
 /**
  * Client Authentication method : client_secret_basic
@@ -80,23 +79,6 @@ public class ClientBasicAuthProvider implements ClientAuthProvider {
         } catch (RuntimeException e) {
             handler.handle(Future.failedFuture(new InvalidClientException("Invalid client: missing or unsupported authentication method", e, authenticationHeader())));
             return;
-        }
-    }
-
-    /**
-     * @param value
-     * @return the URL value version of value or the input value if the URLDecode fails
-     */
-    private static String urlDecode(String value) {
-        try {
-            return URLDecoder.decode(value, UTF_8);
-        } catch (IllegalArgumentException e) {
-            // Introduced to fix https://github.com/gravitee-io/issues/issues/8501.
-            // https://github.com/gravitee-io/issues/issues/7803 introduced a URL decoding
-            // action on the clientSecret/clientId to be compliant to the RFC. To avoid breaking the
-            // behaviour for customer that are using some special characters like '%', we fall back to the
-            // raw value if the URL decode process fails.
-            return value;
         }
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/ClientUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/ClientUtils.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oauth2.resources.auth.provider;
+
+import java.net.URLDecoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ClientUtils {
+
+    /**
+     * @param value
+     * @return the URL value version of value or the input value if the URLDecode fails
+     */
+    public static String urlDecode(String value) {
+        try {
+            return URLDecoder.decode(value, UTF_8);
+        } catch (IllegalArgumentException e) {
+            // Introduced to fix https://github.com/gravitee-io/issues/issues/8501.
+            // https://github.com/gravitee-io/issues/issues/7803 introduced a URL decoding
+            // action on the clientSecret/clientId to be compliant to the RFC. To avoid breaking the
+            // behaviour for customer that are using some special characters like '%', we fall back to the
+            // raw value if the URL decode process fails.
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
fixes gravitee-io/issues#8501

## How to test

Create a service app with a clientId containing % character and try to get an access_token
