### PR TITLE
fix: allow to render old templates and manage StandardDialect for thy…

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/pom.xml
@@ -20,7 +20,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>io.gravitee.am.management</groupId>
         <artifactId>gravitee-am-management-api</artifactId>
@@ -86,8 +85,7 @@
         <dependency>
             <groupId>ognl</groupId>
             <artifactId>ognl</artifactId>
-            <version>3.1.12</version>
-            <scope>test</scope>
+            <version>${ognl.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/view/ThymeleafConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/view/ThymeleafConfiguration.java
@@ -15,13 +15,12 @@
  */
 package io.gravitee.am.management.handlers.management.api.authentication.view;
 
-import io.gravitee.am.model.Organization;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.ViewResolver;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 import org.thymeleaf.spring5.view.ThymeleafViewResolver;
-import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.standard.StandardDialect;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 
 /**
@@ -35,6 +34,7 @@ public class ThymeleafConfiguration {
     public SpringTemplateEngine getTemplateEngine() {
         SpringTemplateEngine templateEngine = new SpringTemplateEngine();
         templateEngine.setEnableSpringELCompiler(true);
+        templateEngine.setDialect(new StandardDialect());
 
         // set template resolvers
         TemplateResolver overrideTemplateResolver = (TemplateResolver) overrideTemplateResolver();

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
@@ -71,8 +71,9 @@ public class PreviewBuilder {
     public static final String SITE_KEY = "siteKey";
     public static final String PARAMETER_NAME = "parameterName";
     public static final String FACTOR_TYPE = "factorType";
+    public static final String FACTOR_NAME = "name";
+    public static final String FACTOR_TARGET = "target";
     public static final String ENROLLMENT = "enrollment";
-    public static final String TARGET = "target";
     public static final String ID = "id";
 
     private final TemplateEngine templateEngine;
@@ -206,15 +207,27 @@ public class PreviewBuilder {
             case MFA_CHALLENGE_ALTERNATIVES:
                 final Enrollment otpEnrollment = new Enrollment();
                 otpEnrollment.setBarCode("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADIAQAAAACFI5MzAAABuElEQVR4Xu2WWWoEMQwFDb6WwVc36FqGTpXCLAzJn5X8tGiGtmtA27Pc7frN2ufG025yE+0vyWqtr75GXzP2mC5LSPCsvtme1+65rCGrR6y528A17zxlZI1htpNMS8l17abvaxcSntgN749y1hAlES/70M45opEgAkGKoXftPFkzK3nFtpSI/hXbWdJtGwk2TtXgZ8wSEh7f5vkFjGxgCUHtnt6lRnCfMikh6d2WpeSbBa4gTgl6Rr7T0rouISxpGnvB4HPQPit6lviG4q0s7sU1xFKaXeSfmOmEUkIQIJ1ja3SS5vUZwVGCWwafVxOnC8W3WUSmOSJ6JyBlHYnOE66+ruCppH9x3NaQHgoju+eYWK8IjpLIGLYtW770SztPnOK2zVpmE58RHCare6xUh8G8TaSzhEKSLRE0QnBkvGnnJGGbSjqV8rJ1p4gs76O58iC7fijxLKGgXOYL5+EXkaGUEI1LI2cFT1a4giw/sUI9ZjBegyUkrKmKN4TUyqwhWVL2bVzk/V5GLpsH8ihT2zqS5yny20v/JYQnch7x6UVpvyVynqgQ9Q70gLF+ZHqW/Gw3uYn2/+QLiTKJ//OwuCgAAAAASUVORK5CYII=");
-                final Map<String, Object> factorOTP = Map.of(ID, "idotp" , FACTOR_TYPE, FactorType.OTP.getType(), ENROLLMENT, otpEnrollment);
+                final Map<String, Object> factorOTP = Map.of(ID, "idotp" ,
+                        FACTOR_TYPE, FactorType.OTP.getType(),
+                        FACTOR_NAME, "OTP Factor name",
+                        ENROLLMENT, otpEnrollment);
 
                 final Enrollment smsEnrollment = new Enrollment();
                 smsEnrollment.setCountries(List.of("us", "en", "fr"));
-                final Map<String, Object> factorSms = Map.of(ID, "idsms" , FACTOR_TYPE, FactorType.SMS.getType(), ENROLLMENT, smsEnrollment, TARGET, "123456");
+                final Map<String, Object> factorSms = Map.of(
+                        ID, "idsms" ,
+                        FACTOR_TYPE, FactorType.SMS.getType(),
+                        FACTOR_TARGET, "123456",
+                        FACTOR_NAME, "SMS Factor name",
+                        ENROLLMENT, smsEnrollment);
 
                 final Enrollment emailEnrollment = new Enrollment();
                 emailEnrollment.setKey(EMPTY_STRING);
-                final Map<String, Object> factorEmail = Map.of(ID, "idemail", FACTOR_TYPE, FactorType.EMAIL.getType(), ENROLLMENT, emailEnrollment, TARGET, "john@doe.com");
+                final Map<String, Object> factorEmail = Map.of(ID, "idemail",
+                        FACTOR_TYPE, FactorType.EMAIL.getType(),
+                        FACTOR_TARGET, "john@doe.com",
+                        FACTOR_NAME, "EMAIL Factor name",
+                        ENROLLMENT, emailEnrollment);
 
                 variables.put(ConstantKeys.FACTORS_KEY, List.of(factorOTP, factorSms, factorEmail));
                 break;

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewService.java
@@ -39,9 +39,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.expression.Sets;
 import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.thymeleaf.spring5.dialect.SpringStandardDialect;
+import org.thymeleaf.standard.StandardDialect;
 
 import java.util.Locale;
+import java.util.Set;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
         <reactor-netty.version>1.0.15</reactor-netty.version>
         <commons-io.version>2.11.0</commons-io.version>
         <common-text.version>1.9</common-text.version>
+        <ognl.version>3.1.12</ognl.version>
         <!-- External plugins versions -->
-
         <gravitee-policy-callout-http.version>1.15.1</gravitee-policy-callout-http.version>
         <gravitee-policy-groovy.version>2.0.0</gravitee-policy-groovy.version>
         <gravitee-policy-ipfiltering.version>1.8.0</gravitee-policy-ipfiltering.version>
@@ -128,6 +128,7 @@
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-risk-assessment-api.version>1.0.1</gravitee-risk-assessment-api.version>
+
         <jdk.version>11</jdk.version>
 
         <ongres.scram.version>2.1</ongres.scram.version>


### PR DESCRIPTION
…meleaf to avoid case sensitive variable interpolation

fixes gravitee-io/issues#8526

fixes gravitee-io/issues#8463

## how to test

For each template, override the default 3.19 template using [the default template in 3.18](https://github.com/gravitee-io/gravitee-access-management/blob/3.18.x/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views). and check that the preview works.
