### PR TITLE
Sanitise for inner html

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-login-v2.js
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-login-v2.js
@@ -6,7 +6,7 @@ const errorElement = document.getElementById('webauthn-error');
 const endpoint = loginForm.action.replace('/webauthn/login', '/webauthn/login/credentials');
 
 const displayMessage = message => {
-    errorElement.getElementsByClassName('error_description')[0].innerHTML = message;
+    errorElement.getElementsByClassName('error_description')[0].textContent = message;
     errorElement.style.display = 'block';
 };
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-login.js
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-login.js
@@ -9,7 +9,7 @@ const w = new WebAuthn({
 });
 
 const displayMessage = message => {
-    errorElement.getElementsByClassName('error_description')[0].innerHTML = message;
+    errorElement.getElementsByClassName('error_description')[0].textContent = message;
     errorElement.style.display = 'block';
 };
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-register-v2.js
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-register-v2.js
@@ -6,7 +6,7 @@ const errorElement = document.getElementById('webauthn-error');
 const endpoint = registerForm.action.replace('/webauthn/register', '/webauthn/register/credentials');
 
 const displayMessage = message => {
-    errorElement.getElementsByClassName('error_description')[0].innerHTML = message;
+    errorElement.getElementsByClassName('error_description')[0].textContent = message;
     errorElement.style.display = 'block';
 };
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-register.js
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/js/webauthn-register.js
@@ -9,7 +9,7 @@ const w = new WebAuthn({
 });
 
 const displayMessage = message => {
-    errorElement.getElementsByClassName('error_description')[0].innerHTML = message;
+    errorElement.getElementsByClassName('error_description')[0].textContent = message;
     errorElement.style.display = 'block';
 };
 


### PR DESCRIPTION
## :id: 
Replaces `innerHTML` with `textContent`. The latter only allows text, not markup, so can guard against XSS.

