### PR TITLE
 AM-60: fixed Kafka audit reporter null pointer exception

### DIFF
--- a/gravitee-am-reporter/gravitee-am-reporter-kafka/src/main/java/io/gravitee/am/reporter/kafka/audit/DtoMapper.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-kafka/src/main/java/io/gravitee/am/reporter/kafka/audit/DtoMapper.java
@@ -74,7 +74,7 @@ public class DtoMapper {
   }
 
   public String map(ReferenceType referenceType) {
-    return referenceType.toString().toUpperCase();
+    return referenceType != null ? referenceType.toString().toUpperCase() : null;
   }
 
   public AuditEntityDto map(AuditEntity auditEntity) {

--- a/gravitee-am-reporter/gravitee-am-reporter-kafka/src/test/java/io/gravitee/am/reporter/kafka/audit/DtoMapperUTests.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-kafka/src/test/java/io/gravitee/am/reporter/kafka/audit/DtoMapperUTests.java
@@ -65,17 +65,6 @@ public class DtoMapperUTests {
 
   }
 
-  private AuditEntity buildAuditEntity(final String prefix) {
-    AuditEntity actor = new AuditEntity();
-    actor.setId(prefix + " id");
-    actor.setType(prefix + " type");
-    actor.setDisplayName(prefix + " display name");
-    actor.setAlternativeId(prefix + " alternative id");
-    actor.setReferenceId(prefix + " reference id");
-    actor.setReferenceType(ReferenceType.APPLICATION);
-    return actor;
-  }
-
   @Test
   public void Should_MapReferenceTypeIntoString() {
     DtoMapper mapper = new DtoMapper();
@@ -122,6 +111,28 @@ public class DtoMapperUTests {
     Assert.assertEquals("alternative id", dto.getAlternativeId());
     Assert.assertEquals("Display Name", dto.getDisplayName());
 
+  }
+
+  @Test
+  public void Should_MapAuditEntryIntoAuditEntryDto_Null_ReferenceType() {
+    DtoMapper mapper = new DtoMapper();
+    AuditEntity auditEntity = new AuditEntity();
+    auditEntity.setId(null);
+    auditEntity.setType("type");
+    auditEntity.setAlternativeId("alternative id");
+    auditEntity.setReferenceId(null);
+    auditEntity.setReferenceType(null);
+    auditEntity.setDisplayName(null);
+    auditEntity.setAttributes(null);
+
+    AuditEntityDto dto = mapper.map(auditEntity);
+
+    Assert.assertEquals("type", dto.getType());
+    Assert.assertEquals("alternative id", dto.getAlternativeId());
+    Assert.assertNull("id is null", dto.getId());
+    Assert.assertNull("reference id is null", dto.getReferenceId());
+    Assert.assertNull("reference type is null", dto.getReferenceType());
+    Assert.assertNull("display name is null", dto.getDisplayName());
   }
 
   /**


### PR DESCRIPTION
Null check added for audit reference type.

**How to test**
1. Follow the instruction in the jira issue [AM-60](https://graviteecommunity.atlassian.net/browse/AM-60) to run kafka locally and configure a kafka reporter
2. Create an application and a user. 
3. Now try to login with an invalid credential. 
4. Kafka reporter should publish the login failure message instead of the null pointer exception.