### PR TITLE
chore: upgrade gson from 2.8.6 to 2.8.9 in infobeep dependency

### DIFF
--- a/gravitee-am-resource/gravitee-am-resource-infobip/pom.xml
+++ b/gravitee-am-resource/gravitee-am-resource-infobip/pom.xml
@@ -50,6 +50,19 @@
             <groupId>com.infobip</groupId>
             <artifactId>infobip-api-java-client</artifactId>
             <version>3.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>gson</artifactId>
+                    <groupId>com.google.code.gson</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- import GSON to fix vuln in gson dep -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson-version}</version>
         </dependency>
 
         <!-- rxjava -->

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <spring-integration.version>5.5.6</spring-integration.version>
         <nimbus.version>8.17</nimbus.version>
         <tink.version>1.7.0</tink.version>
+        <gson-version>2.8.9</gson-version>
         <freemarker.version>2.3.31</freemarker.version>
         <jsoup.version>1.14.2</jsoup.version>
         <snakeyaml.version>1.31</snakeyaml.version>


### PR DESCRIPTION
related-to gravitee-io/issues#8557
