### PR TITLE
fix: group update using SCIM must preserve the roles assigned to the …

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/GroupServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/GroupServiceImpl.java
@@ -184,6 +184,8 @@ public class GroupServiceImpl implements GroupService {
                             groupToUpdate.setReferenceId(existingGroup.getReferenceId());
                             groupToUpdate.setCreatedAt(existingGroup.getCreatedAt());
                             groupToUpdate.setUpdatedAt(new Date());
+                            groupToUpdate.setRoles(existingGroup.getRoles());
+                            groupToUpdate.setDescription(existingGroup.getDescription());
                             return groupRepository.update(groupToUpdate);
                         })
                         .doOnSuccess(grp -> auditService.report(AuditBuilder.builder(GroupAuditBuilder.class).principal(principal).type(EventType.GROUP_UPDATED).oldValue(existingGroup).group(grp)))


### PR DESCRIPTION
…group

fixes AM-108

# How to test

1. Enable SCIM on the domain ![image](https://user-images.githubusercontent.com/3110552/197473504-91f0a5d4-2951-471d-81f2-ce02cd8601c3.png)
2. Create a role (if no role exist to your domain)
3. Create a group
4. assign a role to the group  
![image](https://user-images.githubusercontent.com/3110552/197473670-19e1be95-ecd5-4696-8865-10eeccd2bcae.png)
5. create an app B2B with SCIM scope enabled by default 
![image](https://user-images.githubusercontent.com/3110552/197473750-667450e5-5c65-4abb-8ea4-66bab41dbd32.png)

6. get a token from the B2B app 
![image](https://user-images.githubusercontent.com/3110552/197473823-1d185c53-0040-4ba9-bcfa-4bca18b67a3c.png)

7. call the SCIM Groups endpoint to get the group description
```
curl "http://localhost:8092/domain/scim/Groups" -H"Authorization: Bearer eyJraWQiOiJk...VFiYW2tWwQ3n9pAeIQ"`
8. update the group using SCIM curl "http://localhost:8092/domain/scim/Groups/01402058-f068-4e62-8020-58f068fe62fd" -H"Authorization: Bearer eyJraWQiOiJkZWZ...3n9pAeIQ"  -X PUT -d '{
  "schemas" : [ "urn:ietf:params:scim:schemas:core:2.0:Group" ],
  "id" : "01402058-f068-4e62-8020-58f068fe62fd",
  "meta" : {
    "resourceType" : "Group",
    "created" : "2022-10-24T07:16:34.325Z",
    "lastModified" : "2022-10-24T07:16:46.812Z",
    "location" : "http://localhost:8092/domain/scim/Groups/01402058-f068-4e62-8020-58f068fe62fd"
  },
"displayName" : "GroupeTest2",
"members" : [ {
    "value" : "f8230c79-4a42-4a2c-a30c-794a423a2cef",
    "display" : "user01 user01",
    "$ref" : "http://localhost:8092/domain/scim/Users/f8230c79-4a42-4a2c-a30c-794a423a2cef"
  } ]
}
'
```
9. check that the role is still assign to the group


