### PR TITLE
AM-77-add-argon2id-support-to-am-

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/spring/PasswordHistoryConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/spring/PasswordHistoryConfiguration.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.am.management.service.spring;
 
+import io.gravitee.am.service.authentication.crypto.password.Argon2IdPasswordEncoder;
 import io.gravitee.am.service.authentication.crypto.password.PasswordEncoder;
-import io.gravitee.am.service.authentication.crypto.password.bcrypt.BCryptPasswordEncoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,6 +25,6 @@ public class PasswordHistoryConfiguration {
 
     @Bean
     public PasswordEncoder passwordEncoder(){
-        return new BCryptPasswordEncoder();
+        return new Argon2IdPasswordEncoder();
     }
 }

--- a/gravitee-am-service/pom.xml
+++ b/gravitee-am-service/pom.xml
@@ -108,6 +108,12 @@
             <artifactId>spring-context</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
+
         <!-- Validation API-->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/authentication/crypto/password/Argon2IdPasswordEncoder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/authentication/crypto/password/Argon2IdPasswordEncoder.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.authentication.crypto.password;
+
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+
+/**
+ * Wraps the Spring argon2 encoder.
+ */
+public class Argon2IdPasswordEncoder implements PasswordEncoder {
+
+    private static final int MEMORY_MIB = 15360;
+    private static final int SALT_LENGTH = 128;
+    private static final int HASH_LENGTH = 128;
+    private static final int PARALLELISM = 1;
+    private static final int ITERATIONS = 2;
+    private final Argon2PasswordEncoder argon2PasswordEncoder = new Argon2PasswordEncoder(SALT_LENGTH, HASH_LENGTH, PARALLELISM, MEMORY_MIB, ITERATIONS);
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return argon2PasswordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return argon2PasswordEncoder.matches(rawPassword, encodedPassword);
+    }
+}


### PR DESCRIPTION
## :id: Reference related issue. 
Fixes [AM-77](https://graviteecommunity.atlassian.net/browse/AM-77)

## :pencil2: 

Adds Spring's Argon2 encrypter to AM and `PasswordHistoryService`.
