### PR TITLE
Add X-Forwarded-Port header to support custom port

### DIFF
--- a/docker/compose/config/nginx.conf
+++ b/docker/compose/config/nginx.conf
@@ -18,6 +18,11 @@ http {
         upstream webui {
             server webui:8080;
         }
+        
+        map $http_host $port {
+            default 80;
+            "~^[^\:]+:(?<p>\d+)$" $p;
+        }
 
         server {
             listen 80;
@@ -27,6 +32,7 @@ http {
                     proxy_set_header   Host $host;
                     proxy_set_header   X-Real-IP $remote_addr;
                     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header   X-Forwarded-Port $port;
                     proxy_set_header   X-Forwarded-Host $server_name;
                     proxy_set_header   X-Forwarded-Proto $scheme;
                     sub_filter '<base href="/"' '<base href="/am/ui/"';
@@ -41,6 +47,7 @@ http {
                     proxy_set_header   Host $host;
                     proxy_set_header   X-Real-IP $remote_addr;
                     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header   X-Forwarded-Port $port;
                     proxy_set_header   X-Forwarded-Host $server_name;
                     proxy_set_header   X-Forwarded-Proto $scheme;
                     proxy_set_header   X-Forwarded-Prefix /am/management;
@@ -51,6 +58,7 @@ http {
                     proxy_set_header   Host $host;
                     proxy_set_header   X-Real-IP $remote_addr;
                     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header   X-Forwarded-Port $port;
                     proxy_set_header   X-Forwarded-Host $server_name;
                     proxy_set_header   X-Forwarded-Prefix /am;
                     proxy_set_header   X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## :id: Reference related issue. 


## :pencil2: A description of the changes proposed in the pull request
 
Adding the X-Forwarded-Port header to support custom port.

## :memo: Test scenarios 

Fixing the issue we have calling (for example with port 9200 configured)
`http://localhost:9200/am/management/auth/authorize?redirect_uri=http://localhost:9200/am/ui/login/callback`
and being redirected to `http://localhost/am/management/auth/login`.

## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@leleueri 
