### PR TITLE
AM-76-mfa-rate-limit-gateway

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -40,6 +40,7 @@ public interface ConstantKeys {
     String ID_TOKEN_HINT_KEY = "id_token_hint";
     String EMAIL_PARAM_KEY = "email";
     String ERROR_PARAM_KEY = "error";
+    String RATE_LIMIT_ERROR_PARAM_KEY = "request_limit_error";
     String ERROR_CODE_PARAM_KEY = "error_code";
     String ERROR_DESCRIPTION_PARAM_KEY = "error_description";
     String SUCCESS_PARAM_KEY = "success";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/AccountProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/AccountProvider.java
@@ -26,6 +26,7 @@ import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
+import io.gravitee.am.service.RateLimiterService;
 import io.gravitee.am.model.Domain;
 import io.gravitee.common.service.AbstractService;
 import io.vertx.reactivex.core.Vertx;
@@ -65,6 +66,9 @@ public class AccountProvider extends AbstractService<ProtocolProvider> implement
     @Autowired
     private CorsHandler corsHandler;
 
+    @Autowired
+    private RateLimiterService rateLimiterService;
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -94,7 +98,7 @@ public class AccountProvider extends AbstractService<ProtocolProvider> implement
 
             // Account factors routes
             AccountFactorsEndpointHandler accountFactorsEndpointHandler =
-                    new AccountFactorsEndpointHandler(accountService, factorManager, applicationContext);
+                    new AccountFactorsEndpointHandler(accountService, factorManager, applicationContext, rateLimiterService);
 
             accountRouter.get(AccountRoutes.FACTORS.getRoute())
                     .handler(accountHandler::getUser)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/test/java/io/gravitee/am/gateway/handler/account/resources/AccountFactorsEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/test/java/io/gravitee/am/gateway/handler/account/resources/AccountFactorsEndpointHandlerTest.java
@@ -22,6 +22,7 @@ import io.gravitee.am.gateway.handler.account.services.AccountService;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
+import io.gravitee.am.service.RateLimiterService;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.factor.EnrolledFactor;
 import io.gravitee.am.model.factor.EnrolledFactorChannel;
@@ -58,13 +59,16 @@ public class AccountFactorsEndpointHandlerTest extends RxWebTestBase {
     @Mock
     ApplicationContext applicationContext;
 
+    @Mock
+    RateLimiterService rateLimiterService;
+
     private AccountFactorsEndpointHandler accountFactorsEndpointHandler;
     private User user;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        accountFactorsEndpointHandler = new AccountFactorsEndpointHandler(accountService, factorManager, applicationContext);
+        accountFactorsEndpointHandler = new AccountFactorsEndpointHandler(accountService, factorManager, applicationContext, rateLimiterService);
         user = new User();
 
         router.route()

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/RequestUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/RequestUtils.java
@@ -94,6 +94,7 @@ public class RequestUtils {
     public static MultiMap getCleanedQueryParams(String uri) {
         final MultiMap queryParams = getQueryParams(uri);
         queryParams.remove(ConstantKeys.ERROR_PARAM_KEY);
+        queryParams.remove(ConstantKeys.RATE_LIMIT_ERROR_PARAM_KEY);
         queryParams.remove(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY);
         queryParams.remove(ConstantKeys.WARNING_PARAM_KEY);
         queryParams.remove(SUCCESS_PARAM_KEY);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -92,6 +92,7 @@ import io.gravitee.am.gateway.handler.root.resources.handler.user.register.Regis
 import io.gravitee.am.gateway.handler.root.resources.handler.user.register.RegisterProcessHandler;
 import io.gravitee.am.gateway.handler.root.resources.handler.user.register.RegisterSubmissionRequestParseHandler;
 import io.gravitee.am.gateway.handler.root.resources.handler.webauthn.*;
+import io.gravitee.am.service.RateLimiterService;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.monitoring.provider.GatewayMetricProvider;
@@ -260,6 +261,9 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
     @Autowired
     private WebAuthnCookieService webAuthnCookieService;
 
+    @Autowired
+    private RateLimiterService rateLimiterService;
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -402,7 +406,8 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
                 .handler(clientRequestParseHandler)
                 .handler(rememberDeviceSettingsHandler)
                 .handler(localeHandler)
-                .handler(new MFAChallengeEndpoint(factorManager, userService, thymeleafTemplateEngine, deviceService, applicationContext, domain, credentialService, factorService))
+                .handler(new MFAChallengeEndpoint(factorManager, userService, thymeleafTemplateEngine, deviceService, applicationContext,
+                        domain, credentialService, factorService, rateLimiterService))
                 .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService));
         rootRouter.route(PATH_MFA_CHALLENGE_ALTERNATIVES)
                 .handler(clientRequestParseHandler)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/spring/RootConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/spring/RootConfiguration.java
@@ -39,4 +39,5 @@ public class RootConfiguration implements ProtocolConfiguration {
     public ProtocolProvider rootProvider() {
         return new RootProvider();
     }
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
@@ -48,6 +48,13 @@
                 </span>
             </div>
 
+            <div th:if="${request_limit_error}" class="item error-text">
+                <span>
+                    <span class="error" th:text="${request_limit_error}"></span>
+                    <small th:text="*{error_description}?: #{mfa_challenge.rate.limit.error}"></small>
+                </span>
+            </div>
+
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
             <input id="factorId" type="hidden" th:name="factorId" th:value="${factor.id}"/>
             <input th:if="${factor.factorType.type == 'FIDO2'}" type="hidden" id="webAuthnLoginPath" th:value="${webAuthnLoginPath}"/>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/UserServiceImpl.java
@@ -40,6 +40,7 @@ import io.gravitee.am.repository.management.api.UserRepository;
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.PasswordService;
+import io.gravitee.am.service.RateLimiterService;
 import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.UserActivityService;
 import io.gravitee.am.service.exception.AbstractManagementException;
@@ -109,6 +110,9 @@ public class UserServiceImpl implements UserService {
 
     @Autowired
     private UserActivityService userActivityService;
+
+    @Autowired
+    private RateLimiterService rateLimiterService;
 
     @Override
     public Single<ListResponse<User>> list(Filter filter, int page, int size, String baseUrl) {
@@ -419,6 +423,7 @@ public class UserServiceImpl implements UserService {
                                 }
                             })
                             .andThen(userActivityService.deleteByDomainAndUser(domain.getId(), userId))
+                            .andThen(rateLimiterService.deleteByUser(user))
                             .andThen(userRepository.delete(userId))
                             .doOnComplete(() -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).domain(domain.getId()).type(EventType.USER_DELETED).user(user)))
                             .doOnError((error) -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).domain(domain.getId()).type(EventType.USER_DELETED).throwable(error)));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/UserServiceTest.java
@@ -32,6 +32,7 @@ import io.gravitee.am.model.Role;
 import io.gravitee.am.repository.management.api.UserRepository;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.PasswordService;
+import io.gravitee.am.service.RateLimiterService;
 import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.UserActivityService;
 import io.gravitee.am.service.validators.email.EmailValidatorImpl;
@@ -108,6 +109,9 @@ public class UserServiceTest {
 
     @Mock
     private AuditService auditService;
+
+    @Mock
+    private RateLimiterService rateLimiterService;
 
     @Test
     public void shouldCreateUser_no_user_provider() {
@@ -406,6 +410,7 @@ public class UserServiceTest {
         when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
         when(userRepository.delete(userId)).thenReturn(Completable.complete());
         when(userActivityService.deleteByDomainAndUser(domain.getId(), userId)).thenReturn(Completable.complete());
+        when(rateLimiterService.deleteByUser(any())).thenReturn(Completable.complete());
 
         TestObserver testObserver = userService.delete(userId, null).test();
         testObserver.assertNoErrors();
@@ -429,6 +434,7 @@ public class UserServiceTest {
         when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.empty());
         when(userRepository.delete(userId)).thenReturn(Completable.complete());
         when(userActivityService.deleteByDomainAndUser(domain.getId(), userId)).thenReturn(Completable.complete());
+        when(rateLimiterService.deleteByUser(any())).thenReturn(Completable.complete());
 
         TestObserver testObserver = userService.delete(userId, null).test();
         testObserver.assertNoErrors();

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -416,3 +416,12 @@ liquibase:
 #consent:
 #  ip: false
 #  user-agent: false
+
+## This section allows rate limit for SMS and Email factors.
+## The number of SMS or Email challenge can be limited for a specific time period of Hours, Minutes or Seconds
+
+#mfa_rate:
+#  enabled: true
+#  limit: 5
+#  timePeriod: 15
+#  timeUnit: Minutes

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -124,6 +124,7 @@ mfa_challenge.error=Invalid code
 mfa_challenge.button.submit=Verify
 mfa_challenge.remember.device=Remember my device for
 mfa_challenge.alternate=Having trouble? Try other methods
+mfa_challenge.rate.limit.error=Too many code requests received
 
 mfa_alternative.title=Select a method
 mfa_alternative.description=Try to sign in using other options

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
@@ -124,6 +124,7 @@ mfa_challenge.error=Code invalide
 mfa_challenge.button.submit=Vérifier
 mfa_challenge.remember.device=Mémoriser mon appareil pour
 mfa_challenge.alternate=Vous rencontrez des problèmes ? Essayez d'autres méthodes
+mfa_challenge.rate.limit.error=Le maximum d'émissions a été atteint
 
 mfa_alternative.title=Sélectionnez une méthode
 mfa_alternative.description=Essayez de vous connecter en utilisant d'autres options

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/mfa_challenge.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/mfa_challenge.html
@@ -48,6 +48,13 @@
                 </span>
             </div>
 
+            <div th:if="${request_limit_error}" class="item error-text">
+                <span>
+                    <span class="error" th:text="${request_limit_error}"></span>
+                    <small th:text="*{error_description}?: #{mfa_challenge.rate.limit.error}"></small>
+                </span>
+            </div>
+
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
             <input id="factorId" type="hidden" th:name="factorId" th:value="${factor.id}"/>
             <input th:if="${factor.factorType.type == 'FIDO2'}" type="hidden" id="webAuthnLoginPath" th:value="${webAuthnLoginPath}"/>

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/OrganizationUserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/OrganizationUserServiceTest.java
@@ -25,6 +25,7 @@ import io.gravitee.am.model.User;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.MembershipService;
 import io.gravitee.am.service.PasswordService;
+import io.gravitee.am.service.RateLimiterService;
 import io.gravitee.am.service.exception.*;
 import io.gravitee.am.service.model.NewUser;
 import io.gravitee.am.service.validators.email.EmailValidatorImpl;
@@ -76,6 +77,9 @@ public class OrganizationUserServiceTest {
     @Mock
     private MembershipService membershipService;
 
+    @Mock
+    private RateLimiterService rateLimiterService;
+
     @Spy
     private UserValidatorImpl userValidator = new UserValidatorImpl(
             NAME_STRICT_PATTERN,
@@ -97,6 +101,7 @@ public class OrganizationUserServiceTest {
         when(identityProviderManager.getUserProvider(any())).thenReturn(Maybe.empty());
         when(commonUserService.delete(anyString())).thenReturn(Completable.complete());
         when(membershipService.findByMember(any(), any())).thenReturn(Flowable.empty());
+        when(rateLimiterService.deleteByUser(any())).thenReturn(Completable.complete());
 
         organizationUserService.delete(ReferenceType.ORGANIZATION, organization, userId)
                 .test()
@@ -127,6 +132,7 @@ public class OrganizationUserServiceTest {
         when(commonUserService.delete(anyString())).thenReturn(Completable.complete());
         when(membershipService.findByMember(any(), any())).thenReturn(Flowable.just(m1, m2, m3));
         when(membershipService.delete(anyString())).thenReturn(Completable.complete());
+        when(rateLimiterService.deleteByUser(any())).thenReturn(Completable.complete());
 
         organizationUserService.delete(ReferenceType.ORGANIZATION, organization, userId)
                 .test()

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -124,6 +124,7 @@ mfa_challenge.error=Invalid code
 mfa_challenge.button.submit=Verify
 mfa_challenge.remember.device=Remember my device for
 mfa_challenge.alternate=Having trouble? Try other methods
+mfa_challenge.rate.limit.error=Too many code requests received
 
 mfa_alternative.title=Select a method
 mfa_alternative.description=Try to sign in using other options

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
@@ -124,6 +124,7 @@ mfa_challenge.error=Code invalide
 mfa_challenge.button.submit=Vérifier
 mfa_challenge.remember.device=Mémoriser mon appareil pour
 mfa_challenge.alternate=Vous rencontrez des problèmes ? Essayez d'autres méthodes
+mfa_challenge.rate.limit.error=Le maximum d'émissions a été atteint
 
 mfa_alternative.title=Sélectionnez une méthode
 mfa_alternative.description=Essayez de vous connecter en utilisant d'autres options

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/RateLimit.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/RateLimit.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model;
+
+import java.util.Date;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+
+public class RateLimit {
+    private String id;
+    private String userId;
+    private String client;
+    private String factorId;
+    private long tokenLeft;
+    private boolean allowRequest;
+    private Date createdAt;
+    private Date updatedAt;
+    private String referenceId;
+    private ReferenceType referenceType;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getClient() {
+        return client;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
+    }
+
+    public String getFactorId() {
+        return factorId;
+    }
+
+    public void setFactorId(String factorId) {
+        this.factorId = factorId;
+    }
+
+    public long getTokenLeft() {
+        return tokenLeft;
+    }
+
+    public void setTokenLeft(long tokenLeft) {
+        this.tokenLeft = tokenLeft;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public boolean isAllowRequest() {
+        return allowRequest;
+    }
+
+    public void setAllowRequest(boolean allowRequest) {
+        this.allowRequest = allowRequest;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    public ReferenceType getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(ReferenceType referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    @Override
+    public String toString() {
+        return "RateLimit{" +
+                "id='" + id + '\'' +
+                ", userId='" + userId + '\'' +
+                ", client='" + client + '\'' +
+                ", factorId='" + factorId + '\'' +
+                ", tokenLeft=" + tokenLeft +
+                ", allowRequest=" + allowRequest +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", referenceId='" + referenceId + '\'' +
+                ", referenceType=" + referenceType +
+                '}';
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/RateLimitRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/RateLimitRepository.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.management.api;
+
+import io.gravitee.am.model.RateLimit;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.common.CrudRepository;
+import io.gravitee.am.repository.management.api.search.RateLimitCriteria;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface RateLimitRepository extends CrudRepository<RateLimit, String> {
+    Maybe<RateLimit> findByCriteria(RateLimitCriteria criteria);
+
+    Completable delete(RateLimitCriteria criteria);
+
+    Completable deleteByUser(String userId);
+
+    Completable deleteByDomain(String domainId, ReferenceType referenceType);
+
+}

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/search/RateLimitCriteria.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/search/RateLimitCriteria.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.management.api.search;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RateLimitCriteria {
+
+    private final String userId;
+    private final String client;
+    private final String factorId;
+
+    public RateLimitCriteria(Builder builder) {
+        this.userId = builder.userId;
+        this.client = builder.client;
+        this.factorId = builder.factorId;
+    }
+
+    public String userId(){
+        return userId;
+    }
+
+    public String client(){
+        return client;
+    }
+
+    public String factorId(){
+        return factorId;
+    }
+
+    public static class Builder {
+        private String userId;
+        private String client;
+        private String factorId;
+
+        public Builder userId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder client(String client) {
+            this.client = client;
+            return this;
+        }
+
+        public Builder factorId(String factorId) {
+            this.factorId = factorId;
+            return this;
+        }
+
+        public RateLimitCriteria build() {
+            return new RateLimitCriteria(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "{\"_class\":\"RateLimitCriteria\", " +
+                "\"factorId\":" + (factorId == null ? "null" : "\"" + factorId + "\"") + ", " +
+                "\"client\":" + (client == null ? "null" : "\"" + client + "\"") + ", " +
+                "\"userId\":" + (userId == null ? "null" : "\"" + userId + "\"") +
+                "}";
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcRateLimitRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcRateLimitRepository.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.management.api;
+
+import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.model.RateLimit;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.jdbc.exceptions.RepositoryIllegalQueryException;
+import io.gravitee.am.repository.jdbc.management.AbstractJdbcRepository;
+import io.gravitee.am.repository.jdbc.management.api.model.JdbcRateLimit;
+import io.gravitee.am.repository.jdbc.management.api.spring.SpringRateLimitRepository;
+import io.gravitee.am.repository.management.api.RateLimitRepository;
+import io.gravitee.am.repository.management.api.search.RateLimitCriteria;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.data.relational.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import static org.springframework.data.relational.core.query.Criteria.where;
+import static reactor.adapter.rxjava.RxJava2Adapter.monoToCompletable;
+import static reactor.adapter.rxjava.RxJava2Adapter.monoToMaybe;
+import static reactor.adapter.rxjava.RxJava2Adapter.monoToSingle;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Repository
+public class JdbcRateLimitRepository extends AbstractJdbcRepository implements RateLimitRepository {
+
+    @Autowired
+    protected SpringRateLimitRepository rateLimitRepository;
+
+    protected RateLimit toEntity(JdbcRateLimit entity) { return mapper.map(entity, RateLimit.class);}
+    protected JdbcRateLimit toJdbcEntity(RateLimit entity) {return mapper.map(entity, JdbcRateLimit.class);}
+
+    @Override
+    public Maybe<RateLimit> findById(String id) {
+        LOGGER.debug("RateLimit findById({})", id);
+        return rateLimitRepository.findById(id)
+                .map(this::toEntity);
+    }
+
+    @Override
+    public Maybe<RateLimit> findByCriteria(RateLimitCriteria criteria) {
+        Criteria whereClause = buildWhereClause(criteria);
+        return monoToMaybe(template.select(Query.query(whereClause).with(PageRequest.of(0,1, Sort.by("id"))), JdbcRateLimit.class)
+                .singleOrEmpty()).map(this::toEntity);
+    }
+
+    @Override
+    public Single<RateLimit> create(RateLimit item) {
+        item.setId(item.getId() == null ? RandomString.generate() : item.getId());
+        LOGGER.debug("create RateLimit with id {}", item.getId());
+        return monoToSingle(template.insert(toJdbcEntity(item))).map(this::toEntity);
+    }
+
+    @Override
+    public Single<RateLimit> update(RateLimit item) {
+        LOGGER.debug("update RateLimit with id '{}'", item.getId());
+        return rateLimitRepository.save(toJdbcEntity(item))
+                .map(this::toEntity);
+    }
+
+    @Override
+    public Completable delete(String id) {
+        LOGGER.debug("delete RateLimit with id '{}'", id);
+        return rateLimitRepository.deleteById(id);
+    }
+
+    @Override
+    public Completable delete(RateLimitCriteria criteria) {
+        LOGGER.debug("delete RateLimit with id '{}'", criteria);
+        Criteria whereClause = buildWhereClause(criteria);
+
+        if (!whereClause.isEmpty()) {
+            return monoToCompletable(template.delete(JdbcRateLimit.class).matching(Query.query(whereClause)).all());
+        }
+
+        throw new RepositoryIllegalQueryException("Unable to delete from RateLimit with criteria");
+    }
+
+    @Override
+    public Completable deleteByUser(String userId) {
+        LOGGER.debug("delete RateLimit with user id '{}'", userId);
+
+        Criteria whereClause = Criteria.empty();
+        if(userId != null && !userId.isEmpty()){
+            whereClause = whereClause.and(where("user_id").is(userId));
+        }
+
+        if (!whereClause.isEmpty()) {
+            return monoToCompletable(template.delete(JdbcRateLimit.class).matching(Query.query(whereClause)).all());
+        }
+
+        throw new RepositoryIllegalQueryException("Unable to delete from RateLimit with userId");
+    }
+
+    @Override
+    public Completable deleteByDomain(String domainId, ReferenceType referenceType) {
+        LOGGER.debug("delete RateLimit with domain id '{}' and reference type {}", domainId, referenceType);
+
+        Criteria whereClause = Criteria.empty();
+        if(domainId != null && !domainId.isEmpty()){
+            whereClause = whereClause.and(where("reference_id").is(domainId)).and(where("reference_type").is(referenceType));
+        }
+
+        if (!whereClause.isEmpty()) {
+            return monoToCompletable(template.delete(JdbcRateLimit.class).matching(Query.query(whereClause)).all());
+        }
+
+        throw new RepositoryIllegalQueryException("Unable to delete from RateLimit with domainId");
+    }
+
+    protected Criteria buildWhereClause(RateLimitCriteria criteria){
+        Criteria whereClause = Criteria.empty();
+
+        if(criteria.userId() != null && !criteria.userId().isEmpty()){
+            whereClause = whereClause.and(where("user_id").is(criteria.userId()));
+        }
+
+        if(criteria.factorId() != null && !criteria.factorId().isEmpty()){
+            whereClause = whereClause.and(where("factor_id").is(criteria.factorId()));
+        }
+
+        if(criteria.client() != null && !criteria.client().isEmpty()){
+            whereClause = whereClause.and(where("client").is(criteria.client()));
+        }
+
+        return whereClause;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcRateLimit.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcRateLimit.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.management.api.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Table("rate_limit")
+public class JdbcRateLimit {
+    @Id
+    private String id;
+    @Column("reference_id")
+    private String referenceId;
+    @Column("reference_type")
+    private String referenceType;
+    @Column("user_id")
+    private String userId;
+    private String client;
+    @Column("factor_id")
+    private String factorId;
+    @Column("token_left")
+    private long tokenLeft;
+    @Column("allow_request")
+    private boolean allowRequest;
+    @Column("created_at")
+    private LocalDateTime createdAt;
+    @Column("updated_at")
+    private LocalDateTime updatedAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getClient() {
+        return client;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
+    }
+
+    public String getFactorId() {
+        return factorId;
+    }
+
+    public void setFactorId(String factorId) {
+        this.factorId = factorId;
+    }
+
+    public long getTokenLeft() {
+        return tokenLeft;
+    }
+
+    public void setTokenLeft(long tokenLeft) {
+        this.tokenLeft = tokenLeft;
+    }
+
+    public boolean isAllowRequest() {
+        return allowRequest;
+    }
+
+    public void setAllowRequest(boolean allowRequest) {
+        this.allowRequest = allowRequest;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(String referenceType) {
+        this.referenceType = referenceType;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringRateLimitRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringRateLimitRepository.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.management.api.spring;
+
+import io.gravitee.am.repository.jdbc.management.api.model.JdbcRateLimit;
+import org.springframework.data.repository.reactive.RxJava2CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Repository
+public interface SpringRateLimitRepository extends RxJava2CrudRepository<JdbcRateLimit, String> {
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_0/3.20.0-add-rate-limit-table.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_0/3.20.0-add-rate-limit-table.yml
@@ -1,0 +1,38 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.20.0-add-rate-limit-table
+      author: GraviteeSource Team
+      changes:
+        #############################
+        # Rate_Limit #
+        ############################
+        - createTable:
+            tableName: rate_limit
+            columns:
+              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: reference_id, type: nvarchar(255), constraints: { nullable: false } }
+              - column: { name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: user_id, type: nvarchar(255), constraints: { nullable: false } }
+              - column: { name: client, type: nvarchar(255), constraints: { nullable: false } }
+              - column: { name: factor_id, type: nvarchar(255), constraints: { nullable: false } }
+              - column: { name: token_left, type: integer, constraints: { nullable: false } }
+              - column: { name: allow_request, type: boolean, constraints: { nullable: false } }
+              - column: { name: created_at, type: timestamp(6), constraints: { nullable: false } }
+              - column: { name: updated_at, type: timestamp(6), constraints: { nullable: false } }
+
+        - addPrimaryKey:
+            constraintName: pk_rate_limit
+            columnNames: id
+            tableName: rate_limit
+
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+              - column:
+                  name: client
+              - column:
+                  name: factor_id
+            indexName: idx_rate_limit_userid_client_factorid
+            tableName: rate_limit
+            unique: false

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -83,3 +83,6 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_19_0/3.19.0-add-theme-table.yml
   - include:
       - file: liquibase/changelogs/v3_20_0/3.20.0-add-password-histories-table.yml
+  - include:
+      - file: liquibase/changelogs/v3_20_0/3.20.0-add-rate-limit-table.yml
+

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/JdbcRepositoriesTestInitializer.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/JdbcRepositoriesTestInitializer.java
@@ -125,6 +125,7 @@ public class JdbcRepositoriesTestInitializer implements RepositoriesTestInitiali
 
         tables.add("themes");
         tables.add("password_histories");
+        tables.add("rate_limit");
 
         io.r2dbc.spi.Connection connection = Flowable.fromPublisher(connectionFactory.create()).blockingFirst();
         connection.beginTransaction();

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoRateLimitRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoRateLimitRepository.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.management;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.model.RateLimit;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.management.api.RateLimitRepository;
+import io.gravitee.am.repository.management.api.search.RateLimitCriteria;
+import io.gravitee.am.repository.mongodb.management.internal.model.RateLimitMongo;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class MongoRateLimitRepository extends AbstractManagementMongoRepository implements RateLimitRepository {
+    private static final String RATE_LIMIT = "rate_limit";
+    private static final String FIELD_FACTOR_ID = "factorId";
+
+    private MongoCollection<RateLimitMongo> rateLimitCollection;
+
+    @PostConstruct
+    public void init() {
+        rateLimitCollection = mongoOperations.getCollection(RATE_LIMIT, RateLimitMongo.class);
+        super.init(rateLimitCollection);
+        super.createIndex(rateLimitCollection, new Document(FIELD_USER_ID, 1)
+                .append(FIELD_CLIENT, 1)
+                .append(FIELD_FACTOR_ID,1));
+    }
+
+    @Override
+    public Maybe<RateLimit> findById(String id) {
+        return Observable.fromPublisher(rateLimitCollection.find(eq(FIELD_ID, id)).first()).firstElement().map(this::convert);
+    }
+
+    @Override
+    public Maybe<RateLimit> findByCriteria(RateLimitCriteria criteria) {
+        return Observable.fromPublisher(rateLimitCollection.find(query(criteria)).first()).firstElement().map(this::convert);
+    }
+
+    @Override
+    public Single<RateLimit> create(RateLimit item) {
+        RateLimitMongo rateLimitMongo = convert(item);
+        return Single.fromPublisher(rateLimitCollection.insertOne(rateLimitMongo)).flatMap(success -> {
+            item.setId(rateLimitMongo.getId());
+            return Single.just(item);
+        });
+    }
+
+    @Override
+    public Single<RateLimit> update(RateLimit item) {
+        RateLimitMongo rateLimitMongo = convert(item);
+        return Single.fromPublisher(rateLimitCollection.replaceOne(eq(FIELD_ID, rateLimitMongo.getId()), rateLimitMongo)).flatMap(success -> Single.just(item));
+    }
+
+    @Override
+    public Completable delete(String id) {
+        return Completable.fromPublisher(rateLimitCollection.deleteOne(eq(FIELD_ID, id)));
+    }
+
+    @Override
+    public Completable delete(RateLimitCriteria criteria) {
+        return Completable.fromPublisher(rateLimitCollection.deleteOne(query(criteria)));
+    }
+
+    @Override
+    public Completable deleteByUser(String userId) {
+        return Completable.fromPublisher(rateLimitCollection.deleteMany(eq(FIELD_USER_ID, userId)));
+    }
+
+    @Override
+    public Completable deleteByDomain(String domainId, ReferenceType referenceType) {
+        return Completable.fromPublisher(rateLimitCollection.deleteMany(and(eq(FIELD_REFERENCE_ID, domainId), eq(FIELD_REFERENCE_TYPE, referenceType.name()))));
+    }
+
+    private Bson query(RateLimitCriteria criteria) {
+        final List<Bson> filters = new ArrayList<>();
+
+        if (criteria.client() != null && !criteria.client().isEmpty()) {
+            filters.add(eq(FIELD_CLIENT, criteria.client()));
+        }
+
+        if (criteria.userId() != null && !criteria.userId().isEmpty()) {
+            filters.add(eq(FIELD_USER_ID, criteria.userId()));
+        }
+
+        if (criteria.factorId() != null && !criteria.factorId().isEmpty()) {
+            filters.add(eq(FIELD_FACTOR_ID, criteria.factorId()));
+        }
+
+        return (filters.isEmpty()) ? new BasicDBObject() : and(filters);
+    }
+
+    private RateLimit convert(RateLimitMongo rateLimitMongo) {
+        if (rateLimitMongo == null) {
+            return null;
+        }
+
+        final RateLimit rateLimit = new RateLimit();
+        rateLimit.setId(rateLimitMongo.getId());
+        rateLimit.setUserId(rateLimitMongo.getUserId());
+        rateLimit.setFactorId(rateLimitMongo.getFactorId());
+        rateLimit.setClient(rateLimitMongo.getClient());
+        rateLimit.setTokenLeft(rateLimitMongo.getTokenLeft());
+        rateLimit.setAllowRequest(rateLimitMongo.isAllowRequest());
+        rateLimit.setUpdatedAt(rateLimitMongo.getUpdatedAt());
+        rateLimit.setCreatedAt(rateLimitMongo.getCreatedAt());
+        rateLimit.setReferenceId(rateLimitMongo.getReferenceId());
+        rateLimit.setReferenceType(rateLimitMongo.getReferenceType());
+
+        return rateLimit;
+    }
+
+    private RateLimitMongo convert(RateLimit rateLimit) {
+        if (rateLimit == null) {
+            return null;
+        }
+
+        final RateLimitMongo rateLimitMongo = new RateLimitMongo();
+        rateLimitMongo.setId(rateLimit.getId() != null ? rateLimit.getId() : RandomString.generate());
+        rateLimitMongo.setUserId(rateLimit.getUserId());
+        rateLimitMongo.setClient(rateLimit.getClient());
+        rateLimitMongo.setFactorId(rateLimit.getFactorId());
+        rateLimitMongo.setTokenLeft(rateLimit.getTokenLeft());
+        rateLimitMongo.setAllowRequest(rateLimit.isAllowRequest());
+        rateLimitMongo.setCreatedAt(rateLimit.getCreatedAt());
+        rateLimitMongo.setUpdatedAt(rateLimit.getUpdatedAt());
+        rateLimitMongo.setReferenceId(rateLimit.getReferenceId());
+        rateLimitMongo.setReferenceType(rateLimit.getReferenceType());
+        return rateLimitMongo;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/RateLimitMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/RateLimitMongo.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.management.internal.model;
+
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.mongodb.common.model.Auditable;
+import org.bson.codecs.pojo.annotations.BsonId;
+
+import java.util.Date;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RateLimitMongo extends Auditable {
+    @BsonId
+    private String id;
+
+    private String userId;
+    private String client;
+    private String factorId;
+    private long tokenLeft;
+    private boolean allowRequest;
+    private Date createdAt;
+    private Date updatedAt;
+    private String referenceId;
+    private ReferenceType referenceType;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getClient() {
+        return client;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
+    }
+
+    public String getFactorId() {
+        return factorId;
+    }
+
+    public void setFactorId(String factorId) {
+        this.factorId = factorId;
+    }
+
+    public long getTokenLeft() {
+        return tokenLeft;
+    }
+
+    public void setTokenLeft(long tokenLeft) {
+        this.tokenLeft = tokenLeft;
+    }
+
+    public boolean isAllowRequest() {
+        return allowRequest;
+    }
+
+    public void setAllowRequest(boolean allowRequest) {
+        this.allowRequest = allowRequest;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    public ReferenceType getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(ReferenceType referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    @Override
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @Override
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    @Override
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RateLimitMongo that = (RateLimitMongo) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/RateLimitRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/RateLimitRepositoryTest.java
@@ -1,0 +1,265 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.management.api;
+
+import io.gravitee.am.model.RateLimit;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.management.AbstractManagementTest;
+import io.gravitee.am.repository.management.api.search.RateLimitCriteria;
+import io.reactivex.observers.TestObserver;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RateLimitRepositoryTest extends AbstractManagementTest {
+
+    @Autowired
+    protected RateLimitRepository repository;
+
+    @Test
+    public void shouldCreate() {
+        RateLimit rateLimit = createRateLimit();
+
+        TestObserver<RateLimit> observer = repository.create(rateLimit).test();
+        observer.awaitTerminalEvent();
+
+        observer.assertNoErrors();
+        observer.assertValue(obj -> obj.getId() != null);
+        assertEqualsTo(rateLimit, observer);
+    }
+
+    @Test
+    public void shouldFindById() {
+        RateLimit rateLimit = createRateLimit();
+        RateLimit createdRateLimit = repository.create(rateLimit).blockingGet();
+
+        TestObserver<RateLimit> observer = repository.findById(createdRateLimit.getId()).test();
+        observer.awaitTerminalEvent();
+
+        observer.assertNoErrors();
+        observer.assertValue(obj -> obj.getId().equals(createdRateLimit.getId()));
+        assertEqualsTo(rateLimit, observer);
+    }
+
+    @Test
+    public void shouldFindByCriteria() {
+        RateLimit rateLimit = createRateLimit();
+        RateLimit createdRateLimit = repository.create(rateLimit).blockingGet();
+        RateLimitCriteria criteria = new RateLimitCriteria.Builder()
+                .userId(createdRateLimit.getUserId())
+                .factorId(createdRateLimit.getFactorId())
+                .client(createdRateLimit.getClient())
+                .build();
+
+        TestObserver<RateLimit> observer = repository.findByCriteria(criteria).test();
+        observer.awaitTerminalEvent();
+
+        observer.assertNoErrors();
+        observer.assertValue(obj -> obj.getId().equals(createdRateLimit.getId()));
+        assertEqualsTo(rateLimit, observer);
+    }
+
+    @Test
+    public void shouldNotFindByCriteria_invalidFactorId() {
+        RateLimit rateLimit = createRateLimit();
+        RateLimit createdRateLimit = repository.create(rateLimit).blockingGet();
+        RateLimitCriteria criteria = new RateLimitCriteria.Builder()
+                .userId(createdRateLimit.getUserId())
+                .factorId("invalid-factor-id")
+                .client(createdRateLimit.getClient())
+                .build();
+
+        TestObserver<RateLimit> observer = repository.findByCriteria(criteria).test();
+        observer.awaitTerminalEvent();
+
+        observer.assertNoErrors();
+        observer.assertNoErrors();
+    }
+
+    @Test
+    public void shouldUpdate() {
+        RateLimit rateLimit = createRateLimit();
+        RateLimit createdRateLimit = repository.create(rateLimit).blockingGet();
+
+        TestObserver<RateLimit> observer = repository.findById(createdRateLimit.getId()).test();
+        observer.awaitTerminalEvent();
+
+        observer.assertNoErrors();
+        observer.assertValue(obj -> obj.getId().equals(createdRateLimit.getId()));
+
+        RateLimit updatableRateLimit = createRateLimit();
+        updatableRateLimit.setId(createdRateLimit.getId());
+        updatableRateLimit.setTokenLeft(999);
+        updatableRateLimit.setAllowRequest(true);
+
+        TestObserver<RateLimit> updatedObserver = repository.update(updatableRateLimit).test();
+        updatedObserver.awaitTerminalEvent();
+
+        updatedObserver.assertNoErrors();
+        updatedObserver.assertValue(obj -> obj.getId().equals(createdRateLimit.getId()));
+        updatedObserver.assertValue(obj -> obj.getTokenLeft() == updatableRateLimit.getTokenLeft());
+        updatedObserver.assertValue(obj -> obj.isAllowRequest() == updatableRateLimit.isAllowRequest());
+        assertEqualsTo(updatableRateLimit, updatedObserver);
+    }
+
+    @Test
+    public void shouldDeleteById() {
+        RateLimit rateLimit = createRateLimit();
+        RateLimit createdRateLimit = repository.create(rateLimit).blockingGet();
+
+        TestObserver<RateLimit> observer = repository.findById(createdRateLimit.getId()).test();
+        observer.awaitTerminalEvent();
+        observer.assertNoErrors();
+        observer.assertValue(obj -> obj.getId().equals(createdRateLimit.getId()));
+
+        TestObserver<Void> deleteObserver = repository.delete(createdRateLimit.getId()).test();
+        deleteObserver.awaitTerminalEvent();
+        deleteObserver.assertNoErrors();
+
+        TestObserver<RateLimit> afterDeleteObserver = repository.findById(createdRateLimit.getId()).test();
+        afterDeleteObserver.awaitTerminalEvent();
+        afterDeleteObserver.assertNoErrors();
+        afterDeleteObserver.assertNoValues();
+    }
+
+    @Test
+    public void shouldDeleteByCriteria() {
+        RateLimit rateLimit = createRateLimit();
+        RateLimit createdRateLimit = repository.create(rateLimit).blockingGet();
+
+        TestObserver<RateLimit> observer = repository.findById(createdRateLimit.getId()).test();
+        observer.awaitTerminalEvent();
+        observer.assertNoErrors();
+        observer.assertValue(obj -> obj.getId().equals(createdRateLimit.getId()));
+
+        RateLimitCriteria criteria = new RateLimitCriteria.Builder()
+                .userId(createdRateLimit.getUserId())
+                .factorId(createdRateLimit.getFactorId())
+                .client(createdRateLimit.getClient())
+                .build();
+
+        TestObserver<Void> deleteObserver = repository.delete(criteria).test();
+        deleteObserver.awaitTerminalEvent();
+        deleteObserver.assertNoErrors();
+
+        TestObserver<RateLimit> afterDeleteFindObserver = repository.findById(createdRateLimit.getId()).test();
+        afterDeleteFindObserver.awaitTerminalEvent();
+        afterDeleteFindObserver.assertNoErrors();
+        afterDeleteFindObserver.assertNoValues();
+    }
+
+    @Test
+    public void shouldDeleteByUser() {
+        final String userId= "123-xyz";
+        RateLimit rateLimit1 = createRateLimit();
+        rateLimit1.setUserId(userId);
+        RateLimit createdRateLimit1 = repository.create(rateLimit1).blockingGet();
+        TestObserver<RateLimit> observer = repository.findById(createdRateLimit1.getId()).test();
+        observer.awaitTerminalEvent();
+        observer.assertNoErrors();
+        observer.assertValue(obj -> obj.getId().equals(createdRateLimit1.getId()));
+        observer.assertValue(obj -> obj.getUserId().equals(userId));
+
+        RateLimit rateLimit2 = createRateLimit();
+        rateLimit2.setUserId(userId);
+        RateLimit createdRateLimit2 = repository.create(rateLimit2).blockingGet();
+        TestObserver<RateLimit> observer2 = repository.findById(createdRateLimit2.getId()).test();
+        observer2.awaitTerminalEvent();
+        observer2.assertNoErrors();
+        observer2.assertValue(obj -> obj.getId().equals(createdRateLimit2.getId()));
+        observer2.assertValue(obj -> obj.getUserId().equals(userId));
+
+        TestObserver<Void> deleteObserver = repository.deleteByUser(userId).test();
+        deleteObserver.awaitTerminalEvent();
+        deleteObserver.assertNoErrors();
+
+        TestObserver<RateLimit> afterDeleteFindObserver = repository.findById(createdRateLimit1.getId()).test();
+        afterDeleteFindObserver.awaitTerminalEvent();
+        afterDeleteFindObserver.assertNoErrors();
+        afterDeleteFindObserver.assertNoValues();
+
+        TestObserver<RateLimit> afterDeleteFindObserver2 = repository.findById(createdRateLimit2.getId()).test();
+        afterDeleteFindObserver2.awaitTerminalEvent();
+        afterDeleteFindObserver2.assertNoErrors();
+        afterDeleteFindObserver2.assertNoValues();
+    }
+
+    @Test
+    public void shouldDeleteByDomain() {
+        final String domainId= "123-xyz";
+        RateLimit rateLimit1 = createRateLimit();
+        rateLimit1.setReferenceId(domainId);
+        RateLimit createdRateLimit1 = repository.create(rateLimit1).blockingGet();
+        TestObserver<RateLimit> observer = repository.findById(createdRateLimit1.getId()).test();
+        observer.awaitTerminalEvent();
+        observer.assertNoErrors();
+        observer.assertValue(obj -> obj.getId().equals(createdRateLimit1.getId()));
+        observer.assertValue(obj -> obj.getReferenceId().equals(domainId));
+
+        RateLimit rateLimit2 = createRateLimit();
+        rateLimit2.setReferenceId(domainId);
+        RateLimit createdRateLimit2 = repository.create(rateLimit2).blockingGet();
+        TestObserver<RateLimit> observer2 = repository.findById(createdRateLimit2.getId()).test();
+        observer2.awaitTerminalEvent();
+        observer2.assertNoErrors();
+        observer2.assertValue(obj -> obj.getId().equals(createdRateLimit2.getId()));
+        observer2.assertValue(obj -> obj.getReferenceId().equals(domainId));
+
+        TestObserver<Void> deleteObserver = repository.deleteByDomain(domainId, ReferenceType.DOMAIN).test();
+        deleteObserver.awaitTerminalEvent();
+        deleteObserver.assertNoErrors();
+
+        TestObserver<RateLimit> afterDeleteFindObserver = repository.findById(createdRateLimit1.getId()).test();
+        afterDeleteFindObserver.awaitTerminalEvent();
+        afterDeleteFindObserver.assertNoErrors();
+        afterDeleteFindObserver.assertNoValues();
+
+        TestObserver<RateLimit> afterDeleteFindObserver2 = repository.findById(createdRateLimit2.getId()).test();
+        afterDeleteFindObserver2.awaitTerminalEvent();
+        afterDeleteFindObserver2.assertNoErrors();
+        afterDeleteFindObserver2.assertNoValues();
+    }
+
+    private void assertEqualsTo(RateLimit rateLimit, TestObserver<RateLimit> observer) {
+        observer.assertValue(observable -> observable.getUserId().equals(rateLimit.getUserId()));
+        observer.assertValue(observable -> observable.getClient().equals(rateLimit.getClient()));
+        observer.assertValue(observable -> observable.getFactorId().equals(rateLimit.getFactorId()));
+        observer.assertValue(observable -> observable.getTokenLeft() == rateLimit.getTokenLeft());
+    }
+
+    private RateLimit createRateLimit() {
+        final RateLimit rateLimit = new RateLimit();
+        final String random = UUID.randomUUID().toString();
+        rateLimit.setClient("client-id" + random);
+        rateLimit.setUserId("user-id" + random);
+        rateLimit.setFactorId("factor-id" + random);
+        rateLimit.setTokenLeft(10);
+        rateLimit.setAllowRequest(true);
+        final Date date = new Date();
+        rateLimit.setCreatedAt(date);
+        rateLimit.setUpdatedAt(date);
+        rateLimit.setReferenceId("domain-id" + random);
+        rateLimit.setReferenceType(ReferenceType.DOMAIN);
+
+        return rateLimit;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/RateLimiterService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/RateLimiterService.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.RateLimit;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.User;
+import io.reactivex.Completable;
+import io.reactivex.Single;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface RateLimiterService {
+    Single<Boolean> tryConsume(String userId, String factorId, String applicationId, String domainId);
+
+    boolean isRateLimitEnabled();
+
+    Completable deleteByUser(User user);
+
+    Completable deleteByDomain(Domain domain, ReferenceType referenceType);
+
+    default void calculateAndSetTokenLeft(RateLimit rateLimit, String timeUnit, int timePeriod, int limit) {
+        final int consumeOne = 1;
+        long now = Instant.now().toEpochMilli();
+        long lastRequested = rateLimit.getUpdatedAt().toInstant().toEpochMilli();
+        long timeElapsed = now - lastRequested;
+        long periodDuration = timePeriodToMillSeconds(timeUnit, timePeriod) / limit;
+        // We need to know how many tokens could be generated in between current time and the last request time (which is timeElapsed variable)
+        //periodDuration is calculated form timeUnit and timePeriod
+        long newTokens = Math.max(0, timeElapsed / periodDuration);
+        long tokenLeft = Math.max(0, rateLimit.getTokenLeft() + newTokens);
+
+        if (tokenLeft > limit) {
+            rateLimit.setTokenLeft(limit - consumeOne);
+            rateLimit.setAllowRequest(true);
+        } else {
+            if (tokenLeft > 0) {
+                rateLimit.setTokenLeft(tokenLeft - consumeOne);
+                rateLimit.setAllowRequest(true);
+            } else {
+                rateLimit.setTokenLeft(0);
+                rateLimit.setAllowRequest(false);
+            }
+        }
+    }
+
+    private long timePeriodToMillSeconds(String timeUnit, int timePeriod){
+        ChronoUnit unit = ChronoUnit.valueOf(timeUnit.trim().toUpperCase());
+        long seconds = 0;
+        switch (unit) {
+            case HOURS:
+                seconds = timePeriod * 60 * 60;
+                break;
+            case MINUTES:
+                seconds = timePeriod * 60;
+                break;
+            case SECONDS:
+                seconds = timePeriod;
+        }
+
+        return TimeUnit.SECONDS.toMillis(seconds);
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/RateLimitException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/RateLimitException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.exception;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RateLimitException extends AbstractManagementException {
+
+    public RateLimitException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return 0;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RateLimiterServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RateLimiterServiceImpl.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.impl;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.RateLimit;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.User;
+import io.gravitee.am.repository.management.api.RateLimitRepository;
+import io.gravitee.am.repository.management.api.search.RateLimitCriteria;
+import io.gravitee.am.service.AuditService;
+import io.gravitee.am.service.EventService;
+import io.gravitee.am.service.RateLimiterService;
+import io.gravitee.am.service.exception.AbstractManagementException;
+import io.gravitee.am.service.exception.TechnicalManagementException;
+import io.reactivex.Completable;
+import io.reactivex.Single;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.Optional;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class RateLimiterServiceImpl implements RateLimiterService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RateLimiterServiceImpl.class);
+
+    @Value("${mfa_rate.enabled:false}")
+    private boolean isEnabled;
+
+    @Value("${mfa_rate.limit:5}")
+    private int limit;
+
+    @Value("${mfa_rate.timePeriod:15}")
+    private int timePeriod;
+
+    @Value("${mfa_rate.timeUnit:Minutes}")
+    private String timeUnit;
+
+    @Lazy
+    @Autowired
+    RateLimitRepository rateLimitRepository;
+
+    @Autowired
+    private EventService eventService;
+
+    @Autowired
+    private AuditService auditService;
+
+    @Override
+    public boolean isRateLimitEnabled() {
+        return isEnabled;
+    }
+
+    @Override
+    public Single<Boolean> tryConsume(String userId, String factorId, String client, String domainId) {
+        if (timePeriod <= 0 || limit <= 0) {
+            LOGGER.warn("Either timePeriod or limit is set to 0. Current value timePeriod: {}, limit: {}", limit, timePeriod);
+            return Single.just(false);
+        }
+
+        final RateLimitCriteria criteria = buildCriteria(userId, factorId, client);
+        return getRateLimit(criteria, domainId).flatMap(rateLimit -> {
+            LOGGER.debug("RateLimit value: [{}]", rateLimit);
+            return Single.just(rateLimit.isAllowRequest());
+        });
+    }
+
+    @Override
+    public Completable deleteByUser(User user) {
+        LOGGER.debug("deleteByUser userID: {}", user.getId());
+        return rateLimitRepository.deleteByUser(user.getId());
+    }
+
+    @Override
+    public Completable deleteByDomain(Domain domain, ReferenceType referenceType) {
+        LOGGER.debug("deleteByDomain domainId: {}", domain.getId());
+        return rateLimitRepository.deleteByDomain(domain.getId(), referenceType);
+    }
+
+    private Single<RateLimit> getRateLimit(RateLimitCriteria criteria, String domainId) {
+        return rateLimitRepository.findByCriteria(criteria)
+                .map(Optional::of)
+                .defaultIfEmpty(Optional.empty())
+                .flatMapSingle(optionalRateLimit -> {
+                    if (optionalRateLimit.isPresent()) {
+                        final RateLimit rateLimit = optionalRateLimit.get();
+                        calculateAndSetTokenLeft(rateLimit, timeUnit, timePeriod, limit);
+                        rateLimit.setUpdatedAt(new Date());
+                        return rateLimitRepository.update(rateLimit);
+                    } else {
+                        final RateLimit rateLimit = new RateLimit();
+                        rateLimit.setUserId(criteria.userId());
+                        rateLimit.setFactorId(criteria.factorId());
+                        rateLimit.setClient(criteria.client());
+                        rateLimit.setReferenceId(domainId);
+                        rateLimit.setReferenceType(ReferenceType.DOMAIN);
+                        rateLimit.setCreatedAt(new Date());
+                        rateLimit.setUpdatedAt(rateLimit.getCreatedAt());
+                        //value of left tokens should be "limit -1" for the first request
+                        rateLimit.setTokenLeft(limit - 1);
+                        rateLimit.setAllowRequest(true);
+                        return rateLimitRepository.create(rateLimit);
+                    }
+
+                })
+                .onErrorResumeNext(ex -> {
+                    if (ex instanceof AbstractManagementException) {
+                        return Single.error(ex);
+                    }
+                    LOGGER.error("An error occurs while trying to add/update rate limit", ex);
+                    return Single.error(new TechnicalManagementException("An error occurs while trying to add/update rate limit.", ex));
+                });
+    }
+
+    private RateLimitCriteria buildCriteria(String userId, String factorId, String client) {
+        return new RateLimitCriteria.Builder()
+                .userId(userId)
+                .factorId(factorId)
+                .client(client)
+                .build();
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainServiceTest.java
@@ -228,6 +228,9 @@ public class DomainServiceTest {
     @Mock
     private ThemeService themeService;
 
+    @Mock
+    private RateLimiterService rateLimiterService;
+
     @Test
     public void shouldFindById() {
         when(domainRepository.findById("my-domain")).thenReturn(Maybe.just(new Domain()));
@@ -658,6 +661,7 @@ public class DomainServiceTest {
 
         when(eventService.create(any())).thenReturn(Single.just(new Event()));
         when(themeService.findByReference(any(), any())).thenReturn(Maybe.empty());
+        when(rateLimiterService.deleteByDomain(any(), any())).thenReturn(Completable.complete());
 
         TestObserver testObserver = domainService.delete(DOMAIN_ID).test();
         testObserver.awaitTerminalEvent();
@@ -709,6 +713,7 @@ public class DomainServiceTest {
         when(i18nDictionaryService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
         when(eventService.create(any())).thenReturn(Single.just(new Event()));
         when(themeService.findByReference(any(), any())).thenReturn(Maybe.empty());
+        when(rateLimiterService.deleteByDomain(any(), any())).thenReturn(Completable.complete());
 
         TestObserver testObserver = domainService.delete(DOMAIN_ID).test();
         testObserver.awaitTerminalEvent();

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/RateLimiterServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/RateLimiterServiceImplTest.java
@@ -1,0 +1,317 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service;
+
+import io.gravitee.am.model.RateLimit;
+import io.gravitee.am.repository.management.api.RateLimitRepository;
+import io.gravitee.am.service.exception.TechnicalManagementException;
+import io.gravitee.am.service.impl.RateLimiterServiceImpl;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import io.reactivex.observers.TestObserver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RateLimiterServiceImplTest {
+
+    @InjectMocks
+    private RateLimiterService rateLimiterService = new RateLimiterServiceImpl();
+
+    @Mock
+    RateLimitRepository repository;
+
+    private static final String USER_ID ="user-id";
+    private static final String FACTOR_ID ="factor-d";
+    private static final String CLIENT ="client-id";
+    private static final String DOMAIN ="domain-id";
+
+    private Calendar calendar;
+
+    @Test
+    public void should_create_rateLimit() {
+        RateLimit rateLimit = createRateLimit();
+        when(repository.findByCriteria(any())).thenReturn(Maybe.empty());
+        when(repository.create(any())).thenReturn(Single.just(rateLimit));
+        ReflectionTestUtils.setField(rateLimiterService, "limit", 2);
+        ReflectionTestUtils.setField(rateLimiterService, "timePeriod", 2);
+
+        TestObserver<Boolean> observer = rateLimiterService.tryConsume(USER_ID, FACTOR_ID, CLIENT,DOMAIN).test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        verify(repository, times(1)).create(any());
+        verify(repository, never()).update(any());
+    }
+
+    @Test
+    public void should_update_rateLimit() {
+        ReflectionTestUtils.setField(rateLimiterService, "limit", 2);
+        ReflectionTestUtils.setField(rateLimiterService, "timePeriod", 1);
+        ReflectionTestUtils.setField(rateLimiterService, "timeUnit", "Minutes");
+
+        RateLimit rateLimit = createRateLimit();
+        when(repository.findByCriteria(any())).thenReturn(Maybe.just(rateLimit));
+        when(repository.update(any())).thenReturn(Single.just(rateLimit));
+
+        TestObserver<Boolean> observer = rateLimiterService.tryConsume(USER_ID, FACTOR_ID, CLIENT,DOMAIN).test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(allowRequest -> allowRequest);
+        verify(repository, times(1)).update(any());
+        verify(repository, never()).create(any());
+    }
+
+    @Test
+    public void should_not_exceed_limit(){
+        RateLimit rateLimit = createRateLimit();
+        rateLimit.setTokenLeft(0);
+        calendar = Calendar.getInstance();
+        calendar.setTime(rateLimit.getUpdatedAt());
+        calendar.add(Calendar.HOUR, -3);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 1,12);
+        assertThat("Number of tokens should be 11", rateLimit.getTokenLeft(), is(11L));
+        assertThat("Should not allow request", rateLimit.isAllowRequest(), is(true));
+    }
+
+    @Test
+    public void shouldThrow_TechnicalManagementException_wrong_timeUnit() {
+        final String wrongTimeUnit = "minute";
+        ReflectionTestUtils.setField(rateLimiterService, "timeUnit", wrongTimeUnit);
+        ReflectionTestUtils.setField(rateLimiterService, "timePeriod", 2);
+        ReflectionTestUtils.setField(rateLimiterService, "limit", 2);
+        RateLimit rateLimit = createRateLimit();
+        when(repository.findByCriteria(any())).thenReturn(Maybe.just(rateLimit));
+
+        TestObserver<Boolean> observer = rateLimiterService.tryConsume(USER_ID, FACTOR_ID, CLIENT, DOMAIN).test();
+        observer.assertNotComplete();
+        observer.assertError(TechnicalManagementException.class);
+        observer.assertErrorMessage("An error occurs while trying to add/update rate limit.");
+    }
+
+    @Test
+    public void case1_0_token_same_time_period() {
+        RateLimit rateLimit = createRateLimit();
+        rateLimit.setTokenLeft(0);
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 1,1);
+        assertThat("Number of tokens should be 0", rateLimit.getTokenLeft(), is(0L));
+        assertThat("Should not allow request", rateLimit.isAllowRequest(), is(false));
+    }
+
+    @Test
+    public void timeUnite_minutes_last_request_1_mns_ago() {
+        RateLimit rateLimit = createRateLimit();
+        rateLimit.setTokenLeft(0);
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(rateLimit.getUpdatedAt());
+        calendar.add(Calendar.MINUTE, -1);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 1, 1);
+        assertThat("Number of tokens should be 0", rateLimit.getTokenLeft(), is(0L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 1, 2);
+        assertThat("Number of tokens should be 1", rateLimit.getTokenLeft(), is(1L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+    }
+
+    @Test
+    public void timeUnit_minutes_last_request_12_mns_ago() {
+        RateLimit rateLimit = createRateLimit();
+        rateLimit.setTokenLeft(0);
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(rateLimit.getUpdatedAt());
+        calendar.add(Calendar.MINUTE, -12);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 1, 12);
+        assertThat("Number of tokens should be 0", rateLimit.getTokenLeft(), is(11L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 1, 50);
+        assertThat("Number of tokens should be 1", rateLimit.getTokenLeft(), is(49L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+    }
+
+    @Test
+    public void timeUnit_minutes_last_request_x_seconds_ago() {
+        RateLimit rateLimit = createRateLimit();
+        rateLimit.setTokenLeft(3);
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(rateLimit.getUpdatedAt());
+        calendar.add(Calendar.SECOND, -12);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 10, 13);
+        assertThat("Number of tokens should be 3", rateLimit.getTokenLeft(), is(2L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.add(Calendar.SECOND, -10);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 10, 13);
+        assertThat("Number of tokens should be 0", rateLimit.getTokenLeft(), is(1L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.add(Calendar.SECOND, -10);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 10, 13);
+        assertThat("Number of tokens should be 0", rateLimit.getTokenLeft(), is(0L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.add(Calendar.SECOND, -10);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Minutes", 10, 13);
+        assertThat("Number of tokens should be 0", rateLimit.getTokenLeft(), is(0L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(false));
+    }
+
+    @Test
+    public void timeUnit_hours_last_request_x_mns_sec_ago() {
+        RateLimit rateLimit = createRateLimit();
+        rateLimit.setTokenLeft(1);
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(rateLimit.getUpdatedAt());
+        calendar.add(Calendar.MINUTE, -17);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Hours", 1, 10);
+        assertThat("Number of tokens should be 3", rateLimit.getTokenLeft(), is(2L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.add(Calendar.MINUTE, -5);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Hours", 1, 10);
+        assertThat("Number of tokens should be 3", rateLimit.getTokenLeft(), is(1L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.add(Calendar.SECOND, -30);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Hours", 1, 10);
+        assertThat("Number of tokens should be 3", rateLimit.getTokenLeft(), is(0L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(true));
+
+        calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.add(Calendar.MINUTE, -2);
+        rateLimit.setUpdatedAt(calendar.getTime());
+
+        rateLimiterService.calculateAndSetTokenLeft(rateLimit, "Hours", 1, 10);
+        assertThat("Number of tokens should be 3", rateLimit.getTokenLeft(), is(0L));
+        assertThat("Should allow request", rateLimit.isAllowRequest(), is(false));
+    }
+
+    @Test
+    public void limit_zero_or_negative() {
+        ReflectionTestUtils.setField(rateLimiterService, "timePeriod", 1);
+        ReflectionTestUtils.setField(rateLimiterService, "limit", 0);
+
+        TestObserver<Boolean> observer = rateLimiterService.tryConsume("any-id", "any-factor-id", "any-application-id", "any").test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(allowRequest -> !allowRequest);
+
+        ReflectionTestUtils.setField(rateLimiterService, "limit", -1);
+
+        TestObserver<Boolean> observer2 = rateLimiterService.tryConsume(USER_ID, FACTOR_ID, CLIENT,DOMAIN).test();
+
+        observer2.assertComplete();
+        observer2.assertNoErrors();
+        observer2.assertValue(allowRequest -> !allowRequest);
+    }
+
+    @Test
+    public void timePeriod_zero_or_negative() {
+        ReflectionTestUtils.setField(rateLimiterService, "limit", 1);
+        ReflectionTestUtils.setField(rateLimiterService, "timePeriod", 0);
+
+        TestObserver<Boolean> observer = rateLimiterService.tryConsume(USER_ID, FACTOR_ID, CLIENT,DOMAIN).test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(allowRequest -> !allowRequest);
+
+        ReflectionTestUtils.setField(rateLimiterService, "timePeriod", -1);
+
+        TestObserver<Boolean> observer2 = rateLimiterService.tryConsume(USER_ID, FACTOR_ID, CLIENT,DOMAIN).test();
+
+        observer2.assertComplete();
+        observer2.assertNoErrors();
+        observer2.assertValue(allowRequest -> !allowRequest);
+    }
+
+    private RateLimit createRateLimit() {
+        final RateLimit rateLimit = new RateLimit();
+        final String random = UUID.randomUUID().toString();
+        rateLimit.setClient("client-id" + random);
+        rateLimit.setUserId("user-id" + random);
+        rateLimit.setFactorId("factor-id" + random);
+        rateLimit.setTokenLeft(10);
+        final Date date = new Date();
+        rateLimit.setCreatedAt(date);
+        rateLimit.setUpdatedAt(date);
+
+        return rateLimit;
+    }
+
+}


### PR DESCRIPTION
This implementation of rate limit is applied for SMS and OTP factor. Current implementation is based on sliding token bucket algorithm.

## #: https://graviteecommunity.atlassian.net/browse/AM-76

### How to test

1. Uncomment `mfa_rate` section in gateway gravitee.yml and decrease the value for testing
2. Create SMS factor
3. In challenge page refresh the page so that it reaches `limit` value in gravitee.yml file
4. Now refresh again and you should get `mfa_request_limit_exceed` message.