### PR TITLE
Am 128 expose social urls

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -441,6 +441,7 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
         rootRouter.route(HttpMethod.GET, PATH_REGISTER)
                 .handler(clientRequestParseHandler)
                 .handler(registerAccessHandler)
+                .handler(new LoginSocialAuthenticationHandler(identityProviderManager, jwtService, certificateManager))
                 .handler(policyChainHandler.create(ExtensionPoint.PRE_REGISTER))
                 .handler(new RegisterEndpoint(thymeleafTemplateEngine, domain, botDetectionManager));
         rootRouter.route(HttpMethod.POST, PATH_REGISTER)


### PR DESCRIPTION
### How to test

Create a custom register template based on the default template by adding this code snipet.
Social button should be displayed on the register page.

```
<div th:if="${socialProviders and !socialProviders.empty}" class="social-login-buttons">
                    <div th:if="${!hideLoginForm}" class="signup-or-separator">
                        <h6 class="text">or Sign in with</h6>
                        <hr>
                    </div>
                    <div class="mdl-social-button">
                        <a th:href="${authorizeUrls.get(socialProvider.getId())}"
                           th:class="'mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect btn-' + ${socialProvider.getType()}"
                           th:each="socialProvider : ${socialProviders}">
                            <img th:if="${socialProvider.getType()} == 'franceconnect'" th:src="@{assets/images/FCboutons-10.svg}" height="70">
                            <span th:if="${socialProvider.getType()} != 'franceconnect'">
                                <i th:class="'fab fa-' + ${socialProvider.getType()}"></i> <span th:text="${socialProvider.getName()}"></span>
                            </span>
                        </a>
                    </div>
                </div>
```

