### PR TITLE
fix: Allow secondary LDAP URL

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-ldap/src/main/java/io/gravitee/am/identityprovider/ldap/authentication/spring/LdapAuthenticationProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-ldap/src/main/java/io/gravitee/am/identityprovider/ldap/authentication/spring/LdapAuthenticationProviderConfiguration.java
@@ -114,7 +114,7 @@ public class LdapAuthenticationProviderConfiguration {
         ConnectionConfig connectionConfig = new ConnectionConfig();
         connectionConfig.setConnectTimeout(Duration.ofMillis(configuration.getConnectTimeout()));
         connectionConfig.setResponseTimeout(Duration.ofMillis(configuration.getResponseTimeout()));
-        connectionConfig.setLdapUrl(configuration.getContextSourceUrl());
+        configureConnection(configuration.getContextSourceUrl(), connectionConfig);
         connectionConfig.setUseStartTLS(configuration.isUseStartTLS());
         BindConnectionInitializer connectionInitializer =
                 new BindConnectionInitializer(configuration.getContextSourceUsername(), new Credential(configuration.getContextSourcePassword()));
@@ -220,5 +220,14 @@ public class LdapAuthenticationProviderConfiguration {
         }
 
         throw new IllegalArgumentException("Unknown password encoder algorithm");
+    }
+
+    static void configureConnection(String connectionUrl, ConnectionConfig connectionConfig) {
+        var ldapUrl = connectionUrl.replace(",", " ");
+        if (ldapUrl.split("\\s+").length > 1) {
+            connectionConfig.setConnectionStrategy(new ActivePassiveConnectionStrategy());
+            ldapUrl = String.join(" ", ldapUrl.split("\\s+"));
+        }
+        connectionConfig.setLdapUrl(ldapUrl);
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-ldap/src/test/java/io/gravitee/am/identityprovider/ldap/authentication/spring/LdapAuthenticationProviderConfigurationTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-ldap/src/test/java/io/gravitee/am/identityprovider/ldap/authentication/spring/LdapAuthenticationProviderConfigurationTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.identityprovider.ldap.authentication.spring;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.ldaptive.ActivePassiveConnectionStrategy;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.ConnectionStrategy;
+import org.ldaptive.DefaultConnectionStrategy;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static io.gravitee.am.identityprovider.ldap.authentication.spring.LdapAuthenticationProviderConfiguration.configureConnection;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class LdapAuthenticationProviderConfigurationTest {
+
+    private final String connectionUrl;
+    private final String expectedUrl;
+    private final Class<ConnectionStrategy> expectedConnectionStrategy;
+
+    public LdapAuthenticationProviderConfigurationTest(String connectionUrl, String expectedUrl, Class<ConnectionStrategy> expectedConnectionStrategy) {
+        this.connectionUrl = connectionUrl;
+        this.expectedUrl = expectedUrl;
+        this.expectedConnectionStrategy = expectedConnectionStrategy;
+    }
+
+    @Parameters
+    public static Collection<Object[]> ldapConnectionUrls() {
+        return Arrays.asList(new Object[][]{
+                {
+                        "ldap://localhost:6700",
+                        "ldap://localhost:6700",
+                        DefaultConnectionStrategy.class},
+                {
+                        "ldap://localhost:6700 ldap://localhost:6800 ldap://localhost:6900",
+                        "ldap://localhost:6700 ldap://localhost:6800 ldap://localhost:6900",
+                        ActivePassiveConnectionStrategy.class
+                },
+                {
+                        "ldap://localhost:6700        ldap://localhost:6800    ldap://localhost:6900    ",
+                        "ldap://localhost:6700 ldap://localhost:6800 ldap://localhost:6900",
+                        ActivePassiveConnectionStrategy.class
+                },
+                {
+                        "ldap://localhost:6700,ldap://localhost:6800,ldap://localhost:6900",
+                        "ldap://localhost:6700 ldap://localhost:6800 ldap://localhost:6900",
+                        ActivePassiveConnectionStrategy.class
+                }
+        });
+    }
+
+    @Test
+    public void shouldUseAppropriateConnectionStrategy() {
+        ConnectionConfig connectionConfig = new ConnectionConfig();
+        configureConnection(connectionUrl, connectionConfig);
+        assertThat(connectionConfig.getConnectionStrategy(), instanceOf(expectedConnectionStrategy));
+        assertEquals(expectedUrl, connectionConfig.getLdapUrl());
+    }
+}


### PR DESCRIPTION
## :id:
fixes gravitee-io/issues#8504
See [AM-50](https://graviteecommunity.atlassian.net/browse/AM-50)

## :pencil2: A description of the changes proposed in the pull request
The existing Ldaptive setup used the default connection strategy (i.e. the implicit one, not a declared one) which is why providing anything other than a valid URL, such as a comma separated list, leads to an `IllegalArgumentException` from Ldaptive. This changes detects comma or space separated lists of URLs and selects `ActivePassiveConnectionStrategy` in these instances. Commas are replaced by spaces as Ldaptive only seems to accept space separators.

