### PR TITLE
AM-125 add forgotPassword action into identity first login page

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -169,4 +169,12 @@ public interface ConstantKeys {
     // entry into the io.gravitee.am.model.AuthenticationFlowContext to get access to the
     // content of the OAuth2 parameters retrieved using PAR
     String REQUEST_PARAMETERS_KEY = "requestParameters";
+
+
+    String ALLOW_REGISTER_CONTEXT_KEY = "allowRegister";
+    String ALLOW_PASSWORDLESS_CONTEXT_KEY = "allowPasswordless";
+    String ALLOW_FORGOT_PASSWORD_CONTEXT_KEY = "allowForgotPassword";
+    String REGISTER_ACTION_KEY = "registerAction";
+    String WEBAUTHN_ACTION_KEY = "passwordlessAction";
+    String FORGOT_ACTION_KEY = "forgotPasswordAction";
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpoint.java
@@ -32,15 +32,21 @@ import io.vertx.core.Handler;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.ext.web.RoutingContext;
 import io.vertx.reactivex.ext.web.common.template.TemplateEngine;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
 import static io.gravitee.am.common.utils.ConstantKeys.ACTION_KEY;
-import static io.gravitee.am.common.utils.ConstantKeys.USER_ACTIVITY_ENABLED;
+import static io.gravitee.am.common.utils.ConstantKeys.ALLOW_FORGOT_PASSWORD_CONTEXT_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.ALLOW_PASSWORDLESS_CONTEXT_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.ALLOW_REGISTER_CONTEXT_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.FORGOT_ACTION_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.REGISTER_ACTION_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.WEBAUTHN_ACTION_KEY;
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils.getCleanedQueryParams;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
@@ -54,15 +60,9 @@ import static java.util.Optional.ofNullable;
 public class LoginEndpoint extends AbstractEndpoint implements Handler<RoutingContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(LoginEndpoint.class);
-    private static final String ALLOW_FORGOT_PASSWORD_CONTEXT_KEY = "allowForgotPassword";
-    private static final String ALLOW_REGISTER_CONTEXT_KEY = "allowRegister";
-    private static final String ALLOW_PASSWORDLESS_CONTEXT_KEY = "allowPasswordless";
     private static final String HIDE_FORM_CONTEXT_KEY = "hideLoginForm";
     private static final String IDENTIFIER_FIRST_LOGIN_CONTEXT_KEY = "identifierFirstLoginEnabled";
     private static final String REQUEST_CONTEXT_KEY = "request";
-    private static final String FORGOT_ACTION_KEY = "forgotPasswordAction";
-    private static final String REGISTER_ACTION_KEY = "registerAction";
-    private static final String WEBAUTHN_ACTION_KEY = "passwordlessAction";
     private static final String LOGIN_IDENTIFIER_ACTION_KEY = "backToLoginIdentifierAction";
 
     private final Domain domain;


### PR DESCRIPTION
# How to test 

* enable "Identity First login" (at domain or application level)

![image](https://user-images.githubusercontent.com/3110552/199523800-22f284f3-5740-4769-a05f-76488a80e93b.png)

* initiate the login flow, the forgot password isn't display
* enable "forgot password" (at domain or application level)

![image](https://user-images.githubusercontent.com/3110552/199523861-12b9989c-47a7-44f6-a899-f0adbeb1fdc1.png)

* initiate the login flow, the forgot password isn't display

![image](https://user-images.githubusercontent.com/3110552/199524308-1997e365-44bc-4834-914b-4cac5577bc8e.png)


* Create a custom template for the IdentityLoginFlow based of this page https://github.com/gravitee-io/gravitee-access-management/blob/3.18.x/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html and add the following snippet of code:

```
                        <div th:if="${allowForgotPassword}">
                            <a th:href="${forgotPasswordAction}">Forgot Password ?</a>
                        </div>
```

* initiate the login flow, the forgot password link should be display
* following the link, the forgot password form is displayed and you can reset your password