### PR TITLE
chore: upgrade email notifier version for authentication methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <gravitee-cockpit-connectors.version>2.3.0</gravitee-cockpit-connectors.version>
         <gravitee-ae-connectors.version>1.0.0</gravitee-ae-connectors.version>
         <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
-        <gravitee-notifier-email.version>1.4.1</gravitee-notifier-email.version>
+        <gravitee-notifier-email.version>1.5.0</gravitee-notifier-email.version>
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/8655

⚠️ ⚠️ Wait until https://github.com/gravitee-io/gravitee-notifier-email/pull/46 is merged and update with the according version ⚠️ ⚠️

## :pencil2: A description of the changes proposed in the pull request

This PR encourages to upgrade the email notifier to benefit from restricting `authMethod` choices

## :memo: Test scenarios 

- Set up an Alert in Alert Engine.
- Configure an Email Notifier to this Alert and select the appropriate authMethods
- Expect to receive an alert on an email

## :computer: Add screenshots for UI

![image](https://user-images.githubusercontent.com/8531515/203070858-cb50cdb4-86e2-4618-9f8d-2846b20a855c.png)