### PR TITLE
AM-146 provide request parameters in the Thymeleaf template for all e…

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -203,4 +203,6 @@ public interface ConstantKeys {
     String REGISTER_ACTION_KEY = "registerAction";
     String WEBAUTHN_ACTION_KEY = "passwordlessAction";
     String FORGOT_ACTION_KEY = "forgotPasswordAction";
+
+    String REQUEST_CONTEXT_KEY = "request";
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpoint.java
@@ -51,6 +51,7 @@ import static io.gravitee.am.common.utils.ConstantKeys.ERROR_PARAM_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.FORGOT_ACTION_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.REGISTER_ACTION_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.REQUEST_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.WEBAUTHN_ACTION_KEY;
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
@@ -67,8 +68,6 @@ import static java.util.Optional.ofNullable;
 public class IdentifierFirstLoginEndpoint extends AbstractEndpoint implements Handler<RoutingContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(IdentifierFirstLoginEndpoint.class);
-    private static final String REQUEST_CONTEXT_KEY = "request";
-
 
     private final Domain domain;
     private final BotDetectionManager botDetectionManager;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpoint.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static io.gravitee.am.common.utils.ConstantKeys.ACTION_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.REQUEST_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.TEMPLATE_KEY_ALLOW_FORGOT_PASSWORD_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.TEMPLATE_KEY_ALLOW_PASSWORDLESS_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.TEMPLATE_KEY_ALLOW_REGISTER_CONTEXT_KEY;
@@ -62,8 +63,6 @@ import static java.util.Optional.ofNullable;
  */
 public class LoginEndpoint extends AbstractEndpoint implements Handler<RoutingContext> {
     private static final Logger logger = LoggerFactory.getLogger(LoginEndpoint.class);
-
-    private static final String REQUEST_CONTEXT_KEY = "request";
 
     private final Domain domain;
     private final BotDetectionManager botDetectionManager;

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
@@ -55,6 +55,8 @@ import static io.gravitee.am.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.DOMAIN_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.ERROR_PARAM_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.REQUEST_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.TEMPLATE_KEY_RECOVERY_CODES_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.TEMPLATE_KEY_RECOVERY_CODES_URL_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.TOKEN_CONTEXT_KEY;
@@ -127,6 +129,8 @@ public class PreviewBuilder {
         variables.put(CLIENT_CONTEXT_KEY, new ClientProperties(this.client));
         variables.put(USER_CONTEXT_KEY, generateFakeUser());
         variables.put("theme", this.theme);
+
+        variables.put(PARAM_CONTEXT_KEY, Map.of());
 
         org.thymeleaf.context.Context context = new org.thymeleaf.context.Context();
         context.setLocale(this.locale);


### PR DESCRIPTION
…ndpoint

fixes gravitee-io/issues#8674

## How to test:

Try to access to query parameter in all templates:
Ex: 
`<span th:text="${param['my-param-name']}"></span>`
![image](https://user-images.githubusercontent.com/3110552/203818906-71965bf8-73d5-4a1a-aef3-94d0d181ea65.png)

![image](https://user-images.githubusercontent.com/3110552/203818833-a3a860af-c87c-4e01-9d67-eeea37d3db41.png)