### PR TITLE
AM-202 Make UserProvider optional for Mongo & JDBC IDPs

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcIdentityProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcIdentityProviderConfiguration.java
@@ -54,9 +54,15 @@ public class JdbcIdentityProviderConfiguration implements IdentityProviderConfig
     private List<Map<String, String>> options;
     private boolean autoProvisioning = false;
 
+    private boolean userProvider = true;
+
     @Override
     public boolean userProvider() {
-        return true;
+        return this.userProvider;
+    }
+
+    public void setUserProvider(boolean userProvider) {
+        this.userProvider = userProvider;
     }
 
     public String getHost() {
@@ -230,4 +236,5 @@ public class JdbcIdentityProviderConfiguration implements IdentityProviderConfig
     public void setAutoProvisioning(boolean autoProvisioning) {
         this.autoProvisioning = autoProvisioning;
     }
+
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
@@ -113,6 +113,12 @@
       "title": "User password salt length in bytes",
       "description": "Password salt length in bytes"
     },
+    "userProvider" : {
+      "type" : "boolean",
+      "default": true,
+      "title": "Allow CRUD operations",
+      "description": "When enable, the user profile provided by the identity provider can be managed (CRUD operations)"
+    },
     "options" : {
       "title": "Connection options",
       "type": "array",

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoIdentityProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoIdentityProviderConfiguration.java
@@ -47,9 +47,15 @@ public class MongoIdentityProviderConfiguration implements IdentityProviderConfi
     private String passwordSaltAttribute = "salt";
     private Integer passwordSaltLength = 32;
 
+    private boolean userProvider = true;
+
     @Override
     public boolean userProvider() {
-        return true;
+        return this.userProvider;
+    }
+
+    public void setUserProvider(boolean userProvider) {
+        this.userProvider = userProvider;
     }
 
     public String getUri() {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
@@ -112,6 +112,12 @@
       "default" : 32,
       "title": "User password salt length in bytes",
       "description": "Password salt length in bytes"
+    },
+    "userProvider" : {
+      "type" : "boolean",
+      "default": true,
+      "title": "Allow CRUD operations",
+      "description": "When enable, the user profile provided by the identity provider can be managed (CRUD operations)"
     }
   },
   "required": [

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserResource.java
@@ -320,10 +320,16 @@ public class UserResource extends AbstractResource {
     private Maybe<UserEntity> enhanceIdentityProvider(UserEntity userEntity) {
         if (userEntity.getSource() != null) {
             return identityProviderService.findById(userEntity.getSource())
-                    .map(idP -> {
+                    .flatMap(idP -> {
                         userEntity.setSource(idP.getName());
-                        userEntity.setInternal(identityProviderManager.userProviderExists(idP.getType()));
-                        return userEntity;
+                        userEntity.setInternal(false);
+                        // try to load the UserProvider to mark the user as internal or not
+                        // Since Github issue #8695, the UserProvider maybe disabled for MongoDB & JDBC implementation
+                        return identityProviderManager.getUserProvider(userEntity.getSourceId())
+                                .map(up -> {
+                                    userEntity.setInternal(true);
+                                    return userEntity;
+                                }).defaultIfEmpty(userEntity);
                     })
                     .defaultIfEmpty(userEntity);
         }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/IdentityProviderManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/IdentityProviderManager.java
@@ -37,8 +37,6 @@ public interface IdentityProviderManager extends Service<IdentityProviderManager
 
     String createProviderConfiguration(String referenceId, NewIdentityProvider identityProvider);
 
-    boolean userProviderExists(String identityProviderId);
-
     void setListener(InMemoryIdentityProviderListener listener);
 
     void loadIdentityProviders();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
@@ -370,11 +370,6 @@ public class IdentityProviderManagerImpl extends AbstractService<IdentityProvide
         return create(ReferenceType.DOMAIN, domain);
     }
 
-    @Override
-    public boolean userProviderExists(String identityProviderType) {
-        return identityProviderPluginManager.hasUserProvider(identityProviderType);
-    }
-
     private void removeUserProvider(String identityProviderId) {
         logger.info("Management API has received a undeploy identity provider event for {}", identityProviderId);
         UserProvider userProvider = userProviders.remove(identityProviderId);

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-identityprovider/src/main/java/io/gravitee/am/plugins/idp/core/IdentityProviderPluginManager.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-identityprovider/src/main/java/io/gravitee/am/plugins/idp/core/IdentityProviderPluginManager.java
@@ -41,8 +41,6 @@ public interface IdentityProviderPluginManager {
 
     UserProvider create(String type, String configuration);
 
-    boolean hasUserProvider(String pluginType);
-
     String getSchema(String identityProviderId) throws IOException;
 
     default AuthenticationProvider create(String type, String configuration, Map<String, String> mappers, Map<String, String[]> roleMapper) {

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-identityprovider/src/main/java/io/gravitee/am/plugins/idp/core/impl/IdentityProviderPluginManagerImpl.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-identityprovider/src/main/java/io/gravitee/am/plugins/idp/core/impl/IdentityProviderPluginManagerImpl.java
@@ -16,8 +16,19 @@
 package io.gravitee.am.plugins.idp.core.impl;
 
 import io.gravitee.am.certificate.api.CertificateManager;
-import io.gravitee.am.identityprovider.api.*;
-import io.gravitee.am.plugins.idp.core.*;
+import io.gravitee.am.identityprovider.api.AuthenticationProvider;
+import io.gravitee.am.identityprovider.api.IdentityProvider;
+import io.gravitee.am.identityprovider.api.IdentityProviderConfiguration;
+import io.gravitee.am.identityprovider.api.IdentityProviderMapper;
+import io.gravitee.am.identityprovider.api.IdentityProviderRoleMapper;
+import io.gravitee.am.identityprovider.api.NoIdentityProviderMapper;
+import io.gravitee.am.identityprovider.api.NoIdentityProviderRoleMapper;
+import io.gravitee.am.identityprovider.api.UserProvider;
+import io.gravitee.am.plugins.idp.core.IdentityProviderConfigurationFactory;
+import io.gravitee.am.plugins.idp.core.IdentityProviderDefinition;
+import io.gravitee.am.plugins.idp.core.IdentityProviderMapperFactory;
+import io.gravitee.am.plugins.idp.core.IdentityProviderPluginManager;
+import io.gravitee.am.plugins.idp.core.IdentityProviderRoleMapperFactory;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginContextFactory;
 import io.gravitee.plugin.core.internal.AnnotationBasedPluginContextConfigurer;
@@ -37,7 +48,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -83,13 +101,6 @@ public class IdentityProviderPluginManagerImpl implements IdentityProviderPlugin
     @Override
     public Map<IdentityProvider, Plugin> getAll() {
         return identityProviderPlugins;
-    }
-
-    @Override
-    public boolean hasUserProvider(String pluginType) {
-        logger.debug("Looking for an user provider for [{}]", pluginType);
-        IdentityProvider identityProvider = identityProviders.get(pluginType);
-        return identityProvider != null && identityProvider.userProvider() != null;
     }
 
     @Override


### PR DESCRIPTION
fixes gravitee-io/issues#8695

# How to Test

1. Create a custom MongoDB IDP and/or JDBC IDP
2. Create some users inside this idp (at least 2)
3. try to reset password, update user profile
4. sign in with one of this user
5. go back to the console UI, and delete the user you just used
6. try to sign in with this user (it should fail)
7. go back to the console UI and uncheck the "Allow CRUD operations"
8. try to reset password, update user profile from UI (it shouldn't be possible)
9. signin with a user you didn't deleted
10. go back to the console UI, and delete the user you just used
11. signin with this user (it should work because the user profile has not been deleted from the identity provider as CRUD is not allowed)