### PR TITLE
AM-145 upgrade cockpit connector from 2.3.0 to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <gravitee-policy-ipfiltering.version>1.8.0</gravitee-policy-ipfiltering.version>
         <gravitee-policy-request-validation.version>1.12.0</gravitee-policy-request-validation.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
-        <gravitee-cockpit-connectors.version>2.3.0</gravitee-cockpit-connectors.version>
+        <gravitee-cockpit-connectors.version>2.6.0</gravitee-cockpit-connectors.version>
         <gravitee-ae-connectors.version>1.0.0</gravitee-ae-connectors.version>
         <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
         <gravitee-notifier-email.version>1.4.1</gravitee-notifier-email.version>


### PR DESCRIPTION
# How to test

**Prerequisite**: Haveing AM local env (can't do it on nightly as we have to install certificates delivered by cockpit)

1. connect to cockpit preprod env
2. create an organization
3. create an environment
4. go to the How to [How to register a new installation]
5. Select AM and follow the instruction (copy certificates and apply settings) to the AM management API (remember to set also `gravitee_cockpit_ssl_verifyHostname=false` to avoid ssl handcheck issue)
6. you should see the installation with PENDING status on cockpit, activate it.
7. you should be able to connect to AM through cockpit.

Settings should look like this
```
gravitee_cockpit_enabled=true
gravitee_cockpit_keystore_password=7318a4f5-df7a-4554-98a4-f5df7ad554f8
gravitee_cockpit_keystore_path=/path/to/66028a56-85eb-468d-828a-5685eb568d81-cert.p12
gravitee_cockpit_keystore_type=PKCS12
gravitee_cockpit_ssl_verifyHostname=false
gravitee_cockpit_truststore_password=YlRBIy@7eXPtLBBvdrl1VArQsgOtx10
gravitee_cockpit_truststore_path=/path/to/cockpit-ca.p12
gravitee_cockpit_truststore_type=PKCS12
gravitee_cockpit_ws_endpoints_0=https://cockpit-xxx
console_api_url=http://localhost:8093/management
console_ui_url=http://localhost:4200/
```