### PR TITLE
AM-117 add the requested redirect_uri in the error message when this …

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestParseParametersHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestParseParametersHandler.java
@@ -337,7 +337,7 @@ public class AuthorizationRequestParseParametersHandler extends AbstractAuthoriz
         if (registeredClientRedirectUris
                 .stream()
                 .noneMatch(registeredClientUri -> redirectMatches(requestedRedirect, registeredClientUri, this.domain.isRedirectUriStrictMatching() || this.domain.usePlainFapiProfile()))) {
-            throw new RedirectMismatchException("The redirect_uri MUST match the registered callback URL for this application");
+            throw new RedirectMismatchException(String.format("The redirect_uri [ %s ] MUST match the registered callback URL for this application", requestedRedirect));
         }
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/AuthorizationEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/AuthorizationEndpointTest.java
@@ -337,7 +337,7 @@ public class AuthorizationEndpointTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.contains("/test/oauth/error?client_id=client-id&error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application"));
+                    assertTrue(location.contains("/test/oauth/error?client_id=client-id&error=redirect_uri_mismatch&error_description=The+redirect_uri+%255B+http%253A%252F%252Flocalhost%253A9999%252Fwrong%252Fcallback+%255D+MUST+match+the+registered+callback+URL+for+this+application"));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }
@@ -365,7 +365,7 @@ public class AuthorizationEndpointTest extends RxWebTestBase {
                 resp -> {
                     String location = resp.headers().get("location");
                     assertNotNull(location);
-                    assertTrue(location.contains("/test/oauth/error?client_id=client-id&error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application"));
+                    assertTrue(location.contains("/test/oauth/error?client_id=client-id&error=redirect_uri_mismatch&error_description=The+redirect_uri+%255B+http%253A%252F%252Flocalhost%253A9999%252Fauthorize%252Fcallback%253Fparam%253Dparam1+%255D+MUST+match+the+registered+callback+URL+for+this+application"));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }

--- a/postman/collections/graviteeio-am-oauth2-collection-app-version.json
+++ b/postman/collections/graviteeio-am-oauth2-collection-app-version.json
@@ -8635,7 +8635,7 @@
 													"pm.test(\"Should be a location error\", function() {",
 													"    var location = postman.getResponseHeader('Location');",
 													"    tests['Contains an error query-parameter'] = location.includes('error=redirect_uri_mismatch');",
-													"    tests['Contains an error description query-parameter'] = location.includes('error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application');",
+													"    tests['Contains an error description query-parameter'] = location.includes('error_description=The+redirect_uri+%255B+http%253A%252F%252Fmy_bad_host%253A4000+%255D+MUST+match+the+registered+callback+URL+for+this+application');",
 													"});"
 												],
 												"type": "text/javascript"
@@ -8746,7 +8746,7 @@
 													"pm.test(\"Should be a location error\", function() {",
 													"    var location = postman.getResponseHeader('Location');",
 													"    tests['Contains an error query-parameter'] = location.includes('error=redirect_uri_mismatch');",
-													"    tests['Contains an error description query-parameter'] = location.includes('error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application');",
+													"    tests['Contains an error description query-parameter'] = location.includes('error_description=The+redirect_uri+%255B+http%253A%252F%252Flocalhost%253A4000%253FextraParam%253Dtest+%255D+MUST+match+the+registered+callback+URL+for+this+application');",
 													"});"
 												],
 												"type": "text/javascript"
@@ -8809,7 +8809,7 @@
 													"pm.test(\"Should be a location error\", function() {",
 													"    var location = postman.getResponseHeader('Location');",
 													"    tests['Contains an error query-parameter'] = location.includes('error=redirect_uri_mismatch');",
-													"    tests['Contains an error description query-parameter'] = location.includes('error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application');",
+													"    tests['Contains an error description query-parameter'] = location.includes('error_description=The+redirect_uri+%255B+http%253A%252F%252Fmy_bad_host%253A4000+%255D+MUST+match+the+registered+callback+URL+for+this+application');",
 													"    tests['Contains the initial state parameter'] = location.includes('state=xxx-yyy-zzz');",
 													"});"
 												],


### PR DESCRIPTION
…uri doesn't match the ones defined at application level

fixes gravitee-io/issues#7728


# How to test

Initiate the login flow using a redirect_uri that is not defined into the application settings as allowed URL.
The error message should display the URL (the URL may contains escaped character to avoid security issue if the URL is pasted into a brower)

![image](https://user-images.githubusercontent.com/3110552/205725446-c8bea067-3d4e-42e3-86bc-a81020125ec1.png)

