### PR TITLE
AM-215 test user.inactive instead of user.registrationCompleted

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
@@ -419,7 +419,7 @@ public class UserServiceImpl implements UserService {
                                         return Single.error(new AccountInactiveException("User [ " + user.getUsername() + " ] needs to complete the activation process"));
                                     }
 
-                                    if (!user.isEnabled() && user.isRegistrationCompleted()) {
+                                    if (!user.isEnabled() && !user.isInactive()) {
                                         return Single.error(new AccountInactiveException("User [ " + user.getUsername() + " ] is disabled."));
                                     }
 


### PR DESCRIPTION
## Test Cases

1. create a user with a password on the UI, you **should** be able to request a password
2. create a user with a password on the UI then disable it, you **should NOT** be able to request a password
3. create a preregistered user on the UI,  you **should NOT** be able to request a password
4. create a preregistered user on the UI and finalize the registration, you **should** be able to request a password
5. create a preregistered user on the UI, finalize the registration and then disable the user, you **should NOT** be able to request a password
6. create a preregistered user on the UI, in user account allow the forgot password to finalize the registration, you **should** be able to request a password
