### PR TITLE
chore: Added ExitOnOutOfMemoryError JVM option as default into gravit…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -88,6 +88,9 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 # space for a full heap dump.
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
+# JVM exits on the first occurrence of an out-of-memory error.
+JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -89,9 +89,13 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
 # JVM exits on the first occurrence of an out-of-memory error.
-if [ "$GIO_EXIT_ON_OOM_ERROR" = "true" ]; then
-  JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+if [ "$GIO_EXIT_ON_OOM_ERROR" = "false" ]; then
+  GIO_EXIT_ON_OOM_ERROR=""
+else
+  GIO_EXIT_ON_OOM_ERROR="-XX:+ExitOnOutOfMemoryError"
 fi
+
+JAVA_OPTS="$JAVA_OPTS $GIO_EXIT_ON_OOM_ERROR"
 
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -89,7 +89,9 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
 # JVM exits on the first occurrence of an out-of-memory error.
-JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+if [ "$GIO_EXIT_ON_OOM_ERROR" = "true" ]; then
+  JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+fi
 
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -82,11 +82,14 @@ if [ "x$GIO_USE_IPV4" != "x" ]; then
   JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
 fi
 
-# Causes the JVM to dump its heap on OutOfMemory.
-JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-# The path to the heap dump location, note directory must exists and have enough
-# space for a full heap dump.
-#JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
+# Causes the JVM to dump its heap on OutOfMemory if the heap dump path exists. 
+# Note that the heap dump path could be a file or directory.
+GIO_HEAP_DUMP_FILE=${GIO_HEAP_DUMP_FILE:-"heapdump.hprof"}
+if [ -d $GIO_HEAP_DUMP_DIR ]; then
+  JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$GIO_HEAP_DUMP_DIR/$GIO_HEAP_DUMP_FILE"
+else
+  echo "The directory $GIO_HEAP_DUMP_DIR is not specified or does not exist. Heap dump on OutOfMemoryError is disabled."
+fi
 
 # JVM exits on the first occurrence of an out-of-memory error.
 GIO_EXIT_ON_OOM_ERROR=${GIO_EXIT_ON_OOM_ERROR:-true}

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -89,14 +89,10 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
 # JVM exits on the first occurrence of an out-of-memory error.
-if [ "$GIO_EXIT_ON_OOM_ERROR" = "false" ]; then
-  GIO_EXIT_ON_OOM_ERROR=""
-else
-  GIO_EXIT_ON_OOM_ERROR="-XX:+ExitOnOutOfMemoryError"
+GIO_EXIT_ON_OOM_ERROR=${GIO_EXIT_ON_OOM_ERROR:-true}
+if [ "$GIO_EXIT_ON_OOM_ERROR" = "true" ]; then
+  JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
 fi
-
-JAVA_OPTS="$JAVA_OPTS $GIO_EXIT_ON_OOM_ERROR"
-
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -88,6 +88,9 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 # space for a full heap dump.
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
+# JVM exits on the first occurrence of an out-of-memory error.
+JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -89,9 +89,13 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
 # JVM exits on the first occurrence of an out-of-memory error.
-if [ "$GIO_EXIT_ON_OOM_ERROR" = "true" ]; then
-  JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+if [ "$GIO_EXIT_ON_OOM_ERROR" = "false" ]; then
+  GIO_EXIT_ON_OOM_ERROR=""
+else
+  GIO_EXIT_ON_OOM_ERROR="-XX:+ExitOnOutOfMemoryError"
 fi
+
+JAVA_OPTS="$JAVA_OPTS $GIO_EXIT_ON_OOM_ERROR"
 
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -89,7 +89,9 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
 # JVM exits on the first occurrence of an out-of-memory error.
-JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+if [ "$GIO_EXIT_ON_OOM_ERROR" = "true" ]; then
+  JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+fi
 
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -82,11 +82,14 @@ if [ "x$GIO_USE_IPV4" != "x" ]; then
   JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
 fi
 
-# Causes the JVM to dump its heap on OutOfMemory.
-JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-# The path to the heap dump location, note directory must exists and have enough
-# space for a full heap dump.
-#JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
+# Causes the JVM to dump its heap on OutOfMemory if the heap dump path exists. 
+# Note that the heap dump path could be a file or directory.
+GIO_HEAP_DUMP_FILE=${GIO_HEAP_DUMP_FILE:-"heapdump.hprof"}
+if [ -d $GIO_HEAP_DUMP_DIR ]; then
+  JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$GIO_HEAP_DUMP_DIR/$GIO_HEAP_DUMP_FILE"
+else
+  echo "The directory $GIO_HEAP_DUMP_DIR is not specified or does not exist. Heap dump on OutOfMemoryError is disabled."
+fi
 
 # JVM exits on the first occurrence of an out-of-memory error.
 GIO_EXIT_ON_OOM_ERROR=${GIO_EXIT_ON_OOM_ERROR:-true}

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -89,14 +89,10 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
 # JVM exits on the first occurrence of an out-of-memory error.
-if [ "$GIO_EXIT_ON_OOM_ERROR" = "false" ]; then
-  GIO_EXIT_ON_OOM_ERROR=""
-else
-  GIO_EXIT_ON_OOM_ERROR="-XX:+ExitOnOutOfMemoryError"
+GIO_EXIT_ON_OOM_ERROR=${GIO_EXIT_ON_OOM_ERROR:-true}
+if [ "$GIO_EXIT_ON_OOM_ERROR" = "true" ]; then
+  JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
 fi
-
-JAVA_OPTS="$JAVA_OPTS $GIO_EXIT_ON_OOM_ERROR"
-
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 


### PR DESCRIPTION
In case of OOM sometimes the JVM (vertx) does not respond, while the liveness and readiness probes are working in Kubernetes. This is a problem because Kubernetes does not restart the pods in this case. 

A Java option "-XX:+ExitOnOutOfMemoryError" is added by default in the gravitee startup scripts. JVM exits on the first occurrence of an out-of-memory error.