### PR TITLE
feat: store original token from Github Identity provider

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-common/src/main/java/io/gravitee/am/identityprovider/common/oauth2/authentication/AbstractOpenIDConnectAuthenticationProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-common/src/main/java/io/gravitee/am/identityprovider/common/oauth2/authentication/AbstractOpenIDConnectAuthenticationProvider.java
@@ -78,7 +78,6 @@ public abstract class AbstractOpenIDConnectAuthenticationProvider extends Abstra
     protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
     public static final String HASH_VALUE_PARAMETER = "urlHash";
-    public static final String ACCESS_TOKEN_PARAMETER = "access_token";
     public static final String ID_TOKEN_PARAMETER = "id_token";
 
     protected JWTProcessor jwtProcessor;

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-common/src/main/java/io/gravitee/am/identityprovider/common/oauth2/authentication/AbstractSocialAuthenticationProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-common/src/main/java/io/gravitee/am/identityprovider/common/oauth2/authentication/AbstractSocialAuthenticationProvider.java
@@ -40,6 +40,7 @@ import static io.gravitee.am.common.oidc.Scope.SCOPE_DELIMITER;
 public abstract class AbstractSocialAuthenticationProvider<T extends SocialIdentityProviderConfiguration> implements SocialAuthenticationProvider {
 
     protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+    public static final String ACCESS_TOKEN_PARAMETER = "access_token";
 
     protected abstract T getConfiguration();
     protected abstract IdentityProviderMapper getIdentityProviderMapper();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/main/java/io/gravitee/am/identityprovider/github/GithubIdentityProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/main/java/io/gravitee/am/identityprovider/github/GithubIdentityProviderConfiguration.java
@@ -36,6 +36,7 @@ public class GithubIdentityProviderConfiguration implements SocialIdentityProvid
     private Integer connectTimeout = 10000;
     private Integer idleTimeout = 10000;
     private Integer maxPoolSize = 200;
+    private boolean storeOriginalTokens = false;
 
     public String getClientId() {
         return clientId;
@@ -122,4 +123,12 @@ public class GithubIdentityProviderConfiguration implements SocialIdentityProvid
         return null;
     }
 
+    @Override
+    public boolean isStoreOriginalTokens() {
+        return storeOriginalTokens;
+    }
+
+    public void setStoreOriginalTokens(boolean storeOriginalTokens) {
+        this.storeOriginalTokens = storeOriginalTokens;
+    }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/main/resources/schemas/schema-form.json
@@ -69,6 +69,11 @@
       "minimum": 1,
       "title": "HTTP Client max pool size",
       "description": "Maximum pool of connections can grow to. (default 200)"
+    },
+    "storeOriginalTokens" : {
+      "type" : "boolean",
+      "default" : false,
+      "title": "Store Original Tokens"
     }
   },
   "required": [

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/test/java/io/gravitee/am/identityprovider/github/authentication/DummySocialAuthentication.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/test/java/io/gravitee/am/identityprovider/github/authentication/DummySocialAuthentication.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.identityprovider.github.authentication;
+
+import io.gravitee.am.identityprovider.api.Authentication;
+import io.gravitee.am.identityprovider.api.AuthenticationContext;
+import io.gravitee.am.identityprovider.api.DummyAuthenticationContext;
+import io.gravitee.am.identityprovider.api.DummyRequest;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DummySocialAuthentication implements Authentication {
+
+    private final DummyRequest request;
+    private final Map<String, Object> attributes;
+    private DummyAuthenticationContext dummyAuthenticationContext;
+
+    public DummySocialAuthentication(Map<String, List<String>> parameters, Map<String, Object> attributes) {
+        this.request = new DummyRequest();
+        this.request.setParameters(parameters);
+        this.attributes = attributes;
+        dummyAuthenticationContext = new DummyAuthenticationContext(this.attributes, request);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return "__social__";
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return "__social__";
+    }
+
+    @Override
+    public AuthenticationContext getContext() {
+        return dummyAuthenticationContext;
+    }
+}

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/test/java/io/gravitee/am/identityprovider/github/authentication/GithubAuthenticationProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/test/java/io/gravitee/am/identityprovider/github/authentication/GithubAuthenticationProviderTest.java
@@ -19,9 +19,11 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.gravitee.am.common.exception.authentication.BadCredentialsException;
 import io.gravitee.am.identityprovider.api.*;
 import io.gravitee.am.identityprovider.common.oauth2.utils.URLEncodedUtils;
+import io.gravitee.am.identityprovider.github.GithubIdentityProviderConfiguration;
 import io.gravitee.am.identityprovider.github.authentication.spring.GithubAuthenticationProviderConfiguration;
 import io.gravitee.common.http.HttpHeaders;
 import io.reactivex.observers.TestObserver;
+import java.util.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,20 +32,17 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.*;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { GithubAuthenticationProviderTestConfiguration.class, GithubAuthenticationProviderConfiguration.class }, loader = AnnotationConfigContextLoader.class)
+@ContextConfiguration(classes = {GithubAuthenticationProviderTestConfiguration.class, GithubAuthenticationProviderConfiguration.class}, loader = AnnotationConfigContextLoader.class)
 public class GithubAuthenticationProviderTest {
 
     @Autowired
@@ -52,11 +51,16 @@ public class GithubAuthenticationProviderTest {
     @Autowired
     private DefaultIdentityProviderRoleMapper roleMapper;
 
+    @Autowired
+    private GithubIdentityProviderConfiguration configuration;
+
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(19998));
 
     @Test
     public void shouldLoadUserByUsername_authentication() {
+        configuration.setStoreOriginalTokens(false);
+
         stubFor(any(urlPathEqualTo("/oauth/token"))
                 .withHeader(HttpHeaders.CONTENT_TYPE, containing(URLEncodedUtils.CONTENT_TYPE))
                 .withRequestBody(matching(".*"))
@@ -68,57 +72,33 @@ public class GithubAuthenticationProviderTest {
                 .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token test_token"))
                 .willReturn(okJson("{ \"login\": \"bob\" }")));
 
-        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
-            @Override
-            public Object getCredentials() {
-                return "__social__";
-            }
-
-            @Override
-            public Object getPrincipal() {
-                return "__social__";
-            }
-
-            @Override
-            public AuthenticationContext getContext() {
-                DummyRequest dummyRequest = new DummyRequest();
-                dummyRequest.setParameters(Collections.singletonMap("code", Arrays.asList("test-code")));
-                return new DummyAuthenticationContext(Collections.singletonMap("redirect_uri", "http://redirect_uri"), dummyRequest);
-            }
-        }).test();
+        final HashMap<String, Object> attributes = new HashMap<>(singletonMap("redirect_uri", "http://redirect_uri"));
+        final Map<String, List<String>> parameters = singletonMap("code", Arrays.asList("test-code"));
+        var authentication = new DummySocialAuthentication(parameters, attributes);
+        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(authentication).test();
 
         testObserver.awaitTerminalEvent();
 
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValue(u -> "bob".equals(u.getUsername()));
+
+        assertNull(authentication.getContext().get("access_token"));
     }
 
     @Test
     public void shouldLoadUserByUsername_authentication_badCredentials() {
+        configuration.setStoreOriginalTokens(false);
+
         stubFor(any(urlPathEqualTo("/oauth/token"))
                 .withHeader(HttpHeaders.CONTENT_TYPE, containing(URLEncodedUtils.CONTENT_TYPE))
                 .withRequestBody(matching(".*"))
                 .willReturn(unauthorized()));
 
-        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
-            @Override
-            public Object getCredentials() {
-                return "__social__";
-            }
-
-            @Override
-            public Object getPrincipal() {
-                return "__social__";
-            }
-
-            @Override
-            public AuthenticationContext getContext() {
-                DummyRequest dummyRequest = new DummyRequest();
-                dummyRequest.setParameters(Collections.singletonMap("code", Arrays.asList("wrong-code")));
-                return new DummyAuthenticationContext(Collections.singletonMap("redirect_uri", "http://redirect_uri"), dummyRequest);
-            }
-        }).test();
+        final HashMap<String, Object> attributes = new HashMap<>(singletonMap("redirect_uri", "http://redirect_uri"));
+        final Map<String, List<String>> parameters = singletonMap("code", Arrays.asList("test-code"));
+        var authentication = new DummySocialAuthentication(parameters, attributes);
+        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(authentication).test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertError(BadCredentialsException.class);
@@ -126,6 +106,8 @@ public class GithubAuthenticationProviderTest {
 
     @Test
     public void shouldLoadUserByUsername_authentication_usernameNotFound() {
+        configuration.setStoreOriginalTokens(false);
+
         stubFor(any(urlPathEqualTo("/oauth/token"))
                 .withHeader(HttpHeaders.CONTENT_TYPE, containing(URLEncodedUtils.CONTENT_TYPE))
                 .withRequestBody(matching(".*"))
@@ -137,34 +119,24 @@ public class GithubAuthenticationProviderTest {
                 .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token test_token"))
                 .willReturn(notFound()));
 
-        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
-            @Override
-            public Object getCredentials() {
-                return "__social__";
-            }
-
-            @Override
-            public Object getPrincipal() {
-                return "__social__";
-            }
-
-            @Override
-            public AuthenticationContext getContext() {
-                DummyRequest dummyRequest = new DummyRequest();
-                dummyRequest.setParameters(Collections.singletonMap("code", Arrays.asList("test-code")));
-                return new DummyAuthenticationContext(Collections.singletonMap("redirect_uri", "http://redirect_uri"), dummyRequest);
-            }
-        }).test();
+        final HashMap<String, Object> attributes = new HashMap<>(singletonMap("redirect_uri", "http://redirect_uri"));
+        final Map<String, List<String>> parameters = singletonMap("code", Arrays.asList("test-code"));
+        var authentication = new DummySocialAuthentication(parameters, attributes);
+        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(authentication).test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertError(BadCredentialsException.class);
+
+        assertNull(authentication.getContext().get("access_token"));
     }
 
     @Test
     public void shouldLoadUserByUsername_roleMapping() {
+        configuration.setStoreOriginalTokens(false);
+
         // configure role mapping
         Map<String, String[]> roles = new HashMap<>();
-        roles.put("admin", new String[] { "preferred_username=bob"});
+        roles.put("admin", new String[]{"preferred_username=bob"});
         roleMapper.setRoles(roles);
 
         stubFor(any(urlPathEqualTo("/oauth/token"))
@@ -178,24 +150,10 @@ public class GithubAuthenticationProviderTest {
                 .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token test_token"))
                 .willReturn(okJson("{ \"login\": \"bob\", \"preferred_username\": \"bob\"}")));
 
-        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(new Authentication() {
-            @Override
-            public Object getCredentials() {
-                return "__social__";
-            }
-
-            @Override
-            public Object getPrincipal() {
-                return "__social__";
-            }
-
-            @Override
-            public AuthenticationContext getContext() {
-                DummyRequest dummyRequest = new DummyRequest();
-                dummyRequest.setParameters(Collections.singletonMap("code", Arrays.asList("test-code")));
-                return new DummyAuthenticationContext(Collections.singletonMap("redirect_uri", "http://redirect_uri"), dummyRequest);
-            }
-        }).test();
+        final HashMap<String, Object> attributes = new HashMap<>(singletonMap("redirect_uri", "http://redirect_uri"));
+        final Map<String, List<String>> parameters = singletonMap("code", Arrays.asList("test-code"));
+        var authentication = new DummySocialAuthentication(parameters, attributes);
+        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(authentication).test();
 
         testObserver.awaitTerminalEvent();
 
@@ -203,5 +161,121 @@ public class GithubAuthenticationProviderTest {
         testObserver.assertNoErrors();
         testObserver.assertValue(u -> "bob".equals(u.getUsername()));
         testObserver.assertValue(u -> u.getRoles().contains("admin"));
+
+        assertNull(authentication.getContext().get("access_token"));
+    }
+
+
+    @Test
+    public void shouldLoadUserByUsername_authentication_and_storeToken() {
+        configuration.setStoreOriginalTokens(true);
+
+        stubFor(any(urlPathEqualTo("/oauth/token"))
+                .withHeader(HttpHeaders.CONTENT_TYPE, containing(URLEncodedUtils.CONTENT_TYPE))
+                .withRequestBody(matching(".*"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("access_token=test_token&token_type=bearer")));
+
+        stubFor(any(urlPathEqualTo("/profile"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token test_token"))
+                .willReturn(okJson("{ \"login\": \"bob\" }")));
+
+        final HashMap<String, Object> attributes = new HashMap<>(singletonMap("redirect_uri", "http://redirect_uri"));
+        final Map<String, List<String>> parameters = singletonMap("code", Arrays.asList("test-code"));
+        var authentication = new DummySocialAuthentication(parameters, attributes);
+        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(authentication).test();
+
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "bob".equals(u.getUsername()));
+
+        assertNotNull(authentication.getContext().get("access_token"));
+        assertEquals(authentication.getContext().get("access_token"), "test_token");
+    }
+
+    @Test
+    public void shouldLoadUserByUsername_authentication_badCredentials_and_storeToken() {
+        configuration.setStoreOriginalTokens(true);
+
+        stubFor(any(urlPathEqualTo("/oauth/token"))
+                .withHeader(HttpHeaders.CONTENT_TYPE, containing(URLEncodedUtils.CONTENT_TYPE))
+                .withRequestBody(matching(".*"))
+                .willReturn(unauthorized()));
+
+        final HashMap<String, Object> attributes = new HashMap<>(singletonMap("redirect_uri", "http://redirect_uri"));
+        final Map<String, List<String>> parameters = singletonMap("code", Arrays.asList("test-code"));
+        var authentication = new DummySocialAuthentication(parameters, attributes);
+        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(authentication).test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertError(BadCredentialsException.class);
+
+        assertNull(authentication.getContext().get("access_token"));
+    }
+
+    @Test
+    public void shouldLoadUserByUsername_authentication_usernameNotFound_and_storeToken() {
+        configuration.setStoreOriginalTokens(true);
+
+        stubFor(any(urlPathEqualTo("/oauth/token"))
+                .withHeader(HttpHeaders.CONTENT_TYPE, containing(URLEncodedUtils.CONTENT_TYPE))
+                .withRequestBody(matching(".*"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("access_token=test_token&token_type=bearer")));
+
+        stubFor(any(urlPathEqualTo("/profile"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token test_token"))
+                .willReturn(notFound()));
+
+        final HashMap<String, Object> attributes = new HashMap<>(singletonMap("redirect_uri", "http://redirect_uri"));
+        final Map<String, List<String>> parameters = singletonMap("code", Arrays.asList("test-code"));
+        var authentication = new DummySocialAuthentication(parameters, attributes);
+        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(authentication).test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertError(BadCredentialsException.class);
+
+        assertNotNull(authentication.getContext().get("access_token"));
+        assertEquals(authentication.getContext().get("access_token"), "test_token");
+    }
+
+    @Test
+    public void shouldLoadUserByUsername_roleMapping_and_storeToken() {
+        configuration.setStoreOriginalTokens(true);
+
+        // configure role mapping
+        Map<String, String[]> roles = new HashMap<>();
+        roles.put("admin", new String[]{"preferred_username=bob"});
+        roleMapper.setRoles(roles);
+
+        stubFor(any(urlPathEqualTo("/oauth/token"))
+                .withHeader(HttpHeaders.CONTENT_TYPE, containing(URLEncodedUtils.CONTENT_TYPE))
+                .withRequestBody(matching(".*"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("access_token=test_token&token_type=bearer")));
+
+        stubFor(any(urlPathEqualTo("/profile"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token test_token"))
+                .willReturn(okJson("{ \"login\": \"bob\", \"preferred_username\": \"bob\"}")));
+
+        final HashMap<String, Object> attributes = new HashMap<>(singletonMap("redirect_uri", "http://redirect_uri"));
+        final Map<String, List<String>> parameters = singletonMap("code", Arrays.asList("test-code"));
+        var authentication = new DummySocialAuthentication(parameters, attributes);
+        TestObserver<User> testObserver = authenticationProvider.loadUserByUsername(authentication).test();
+
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "bob".equals(u.getUsername()));
+        testObserver.assertValue(u -> u.getRoles().contains("admin"));
+
+        assertNotNull(authentication.getContext().get("access_token"));
+        assertEquals(authentication.getContext().get("access_token"), "test_token");
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-350

## :pencil2: A description of the changes proposed in the pull request

This PR aims to store the original token provided by github identity providers

## :memo: Test scenarios 

- Create a Github IDP
- Tick the `Store Original Token` checkbox
- Set GITHUB IDP in your Application
- Initiate the Login Flow
- Login with Github
- Go to the Management API > Users > <GH-Users> and notice the `op_access_token`

## :computer: Add screenshots for UI

![image](https://user-images.githubusercontent.com/8531515/212350678-1fba4adc-094e-410c-852b-976690214f9d.png)