### PR TITLE
fix: mfa.enrollement not initialized the first time

### DIFF
--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/factors/factors.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/factors/factors.component.ts
@@ -57,10 +57,17 @@ export class ApplicationFactorsComponent implements OnInit {
     this.application = this.route.snapshot.data['application'];
     this.deviceIdentifiers = this.route.snapshot.data['deviceIdentifiers'] || [];
     this.mfa = this.application.settings == null ? {} : (this.application.settings.mfa || {});
+    this.mfa.enrollment = {
+      ...(this.mfa.enrollment ? this.mfa.enrollment : {
+        "forceEnrollment": false,
+        "skipTimeSeconds": null
+      })
+    };
     this.mfaStepUpRule = this.mfa.stepUpAuthenticationRule ? this.mfa.stepUpAuthenticationRule.slice() : "";
     this.adaptiveMfaRule = this.mfa.adaptiveAuthenticationRule ? this.mfa.adaptiveAuthenticationRule.slice() : "";
     this.rememberDevice = {...this.mfa.rememberDevice};
     this.enrollment = {...this.mfa.enrollment};
+
     this.application.settings.riskAssessment = this.application.settings.riskAssessment || ApplicationFactorsComponent.getDefaultRiskAssessment();
     this.riskAssessment = {...this.application.settings.riskAssessment};
 


### PR DESCRIPTION
Co-authored-by: aurelien-pacaud <aurelien.pacaud@graviteesource.com>

## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/8836

## :pencil2: A description of the changes proposed in the pull request

This PR initializes the `mfa.enrollement` instance to be able to save on the first try the Activate MFA section 

## :memo: Test scenarios 

Check issue https://github.com/gravitee-io/issues/issues/8836
