### PR TITLE
fix: encoding the clientId in overview so the login flow can be initiated correctly

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -60,6 +60,7 @@ import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.ext.web.client.WebClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -94,7 +95,7 @@ public class CommonConfiguration {
                 .setMaxPoolSize(Integer.valueOf(environment.getProperty("oidc.http.pool.maxTotalConnection", "200")))
                 .setTrustAll(Boolean.valueOf(environment.getProperty("oidc.http.client.trustAll", "true")));
 
-        return WebClient.create(vertx,options);
+        return WebClient.create(vertx, options);
     }
 
     @Bean
@@ -188,8 +189,24 @@ public class CommonConfiguration {
     }
 
     @Bean
-    public EmailService emailService() {
-        return new EmailServiceImpl();
+    public EmailService emailService(
+            @Value("${email.enabled:false}") boolean enabled,
+            @Value("${user.resetPassword.email.subject:Please reset your password}") String resetPasswordSubject,
+            @Value("${user.resetPassword.token.expire-after:300}") int resetPasswordExpireAfter,
+            @Value("${user.blockedAccount.email.subject:Account has been locked}") String blockedAccountSubject,
+            @Value("${user.blockedAccount.token.expire-after:86400}") int blockedAccountExpireAfter,
+            @Value("${user.mfaChallenge.email.subject:Verification Code}") String mfaChallengeSubject,
+            @Value("${user.mfaChallenge.token.expire-after:300}") int mfaChallengeExpireAfter
+    ) {
+        return new EmailServiceImpl(
+                enabled,
+                resetPasswordSubject,
+                resetPasswordExpireAfter,
+                blockedAccountSubject,
+                blockedAccountExpireAfter,
+                mfaChallengeSubject,
+                mfaChallengeExpireAfter
+        );
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceImplTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.common.email;
+
+import freemarker.cache.TemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapperBuilder;
+import io.gravitee.am.gateway.handler.common.email.impl.EmailServiceImpl;
+import io.gravitee.am.jwt.JWTBuilder;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Email;
+import io.gravitee.am.model.Template;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.service.AuditService;
+import io.gravitee.am.service.DomainService;
+import java.io.IOException;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import static freemarker.template.Configuration.AUTO_DETECT_NAMING_CONVENTION;
+import static freemarker.template.Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EmailServiceImplTest {
+
+    @Mock
+    private EmailManager emailManager;
+
+    @Mock
+    private io.gravitee.am.service.EmailService emailService;
+
+    @Mock
+    private Configuration freemarkerConfiguration;
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    @Qualifier("managementJwtBuilder")
+    private JWTBuilder jwtBuilder;
+
+    @Mock
+    private DomainService domainService;
+
+    @InjectMocks
+    private EmailService emailServiceSpy;
+
+    @Test
+    public void must_not_send_email_due_to_not_enabled() throws IOException {
+        var emailService = new EmailServiceImpl(
+                false,
+                "Please reset your password",
+                300,
+                "Account has been locked",
+                86400,
+                "Verification Code",
+                300
+        );
+
+        emailServiceSpy = Mockito.spy(emailService);
+        MockitoAnnotations.openMocks(this);
+
+        emailServiceSpy.send(Template.RESET_PASSWORD, Mockito.mock(User.class), Mockito.mock(Client.class));
+
+        verify(freemarkerConfiguration, times(0)).getTemplate(anyString());
+        verify(emailManager, times(0)).getEmail(any(), any(), anyInt());
+        verify(auditService, times(0)).report(any());
+        verify(this.emailService, times(0)).send(any());
+    }
+
+    @Test
+    public void must_send_email() throws IOException {
+        var emailService = new EmailServiceImpl(
+                true,
+                "Please reset your password",
+                300,
+                "Account has been locked",
+                86400,
+                "Verification Code",
+                300
+        );
+        emailServiceSpy = Mockito.spy(emailService);
+        MockitoAnnotations.openMocks(this);
+
+        var templateLoader = Mockito.mock(TemplateLoader.class);
+        when(templateLoader.findTemplateSource(anyString())).thenReturn(Mockito.mock(freemarker.template.Template.class));
+        when(this.freemarkerConfiguration.getTemplateLoader()).thenReturn(templateLoader);
+
+        final Email email = buildEmail();
+
+        when(emailManager.getEmail(anyString(), any(), anyInt())).thenReturn(email);
+
+        when(freemarkerConfiguration.getTemplate(anyString())).thenReturn(Mockito.mock(freemarker.template.Template.class));
+        when(freemarkerConfiguration.getIncompatibleImprovements()).thenReturn(DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+        when(freemarkerConfiguration.getNamingConvention()).thenReturn(AUTO_DETECT_NAMING_CONVENTION);
+        when(freemarkerConfiguration.getObjectWrapper()).thenReturn(new DefaultObjectWrapperBuilder(DEFAULT_INCOMPATIBLE_IMPROVEMENTS).build());
+
+        final Client client = new Client();
+        client.setClientId(email.getClient());
+        emailServiceSpy.send(Template.RESET_PASSWORD, Mockito.mock(User.class), client);
+
+        verify(freemarkerConfiguration, times(1)).getTemplate(eq(email.getTemplate() + ".html"));
+        verify(emailManager, times(1)).getEmail(any(), any(), anyInt());
+        verify(auditService, times(1)).report(any());
+        verify(this.emailService, times(1)).send(any());
+    }
+
+    private Email buildEmail() {
+        final Email email = new Email();
+        email.setEnabled(true);
+        email.setFrom("from@gravitee.io");
+        email.setExpiresAfter(300);
+        email.setTemplate("some_template");
+        email.setSubject("subject");
+        email.setFromName("Gravitee.io");
+        email.setContent("Reset password content");
+        email.setClient("some # client");
+        return email;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordEndpoint.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.gravitee.am.common.web.UriBuilder.encodeURIComponent;
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
 
 /**
@@ -74,7 +75,7 @@ public class ResetPasswordEndpoint extends AbstractEndpoint implements Handler<R
         params.computeIfAbsent(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, val -> errorDescription);
         routingContext.put(ConstantKeys.PARAM_CONTEXT_KEY, params);
 
-        final Map<String, String> actionParams = (client != null) ? Map.of(Parameters.CLIENT_ID, client.getClientId()) : Map.of();
+        final Map<String, String> actionParams = (client != null) ? Map.of(Parameters.CLIENT_ID, encodeURIComponent(client.getClientId())) : Map.of();
         routingContext.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), actionParams));
 
         // render the reset password page

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterConfirmationEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterConfirmationEndpoint.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.gravitee.am.common.web.UriBuilder.encodeURIComponent;
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
 
 /**
@@ -91,7 +92,7 @@ public class RegisterConfirmationEndpoint extends UserRequestHandler {
             return;
         }
 
-        final Map<String, String> actionParams = (client != null) ? Map.of(Parameters.CLIENT_ID, client.getClientId()) : Map.of();
+        final Map<String, String> actionParams = (client != null) ? Map.of(Parameters.CLIENT_ID, encodeURIComponent(client.getClientId())) : Map.of();
         routingContext.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), actionParams));
 
         // render the registration confirmation page

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/RegisterConfirmationEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/RegisterConfirmationEndpointTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.endpoints.user;
+
+import io.gravitee.am.gateway.handler.root.resources.endpoint.user.register.RegisterConfirmationEndpoint;
+import io.gravitee.am.gateway.handler.root.resources.handler.dummies.SpyRoutingContext;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.oidc.Client;
+import io.vertx.reactivex.ext.web.templ.thymeleaf.ThymeleafTemplateEngine;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static io.gravitee.am.common.utils.ConstantKeys.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RegisterConfirmationEndpointTest {
+
+    @Test
+    public void must_render_engine_with_encoded_client_id() {
+        final Domain domain = new Domain();
+        domain.setId("domain-id");
+
+        final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
+        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain);
+
+        var routingContext = Mockito.spy(new SpyRoutingContext());
+        final Client client = new Client();
+        client.setClientId("some # clientId");
+        routingContext.put(CLIENT_CONTEXT_KEY, client);
+        registrationConfirmation.handle(routingContext);
+
+
+        assertTrue(routingContext.<String>get(ACTION_KEY).contains("client_id=some+%23+clientId"));
+        verify(engine, times(1)).render(anyMap(), anyString(), any());
+    }
+
+    @Test
+    public void must_render_engine_with_regular_client_id() {
+        final Domain domain = new Domain();
+        domain.setId("domain-id");
+
+        final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
+        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain);
+
+        var routingContext = Mockito.spy(new SpyRoutingContext());
+        final Client client = new Client();
+        client.setClientId("some__clientId");
+        routingContext.put(CLIENT_CONTEXT_KEY, client);
+        registrationConfirmation.handle(routingContext);
+
+        assertTrue(routingContext.<String>get(ACTION_KEY).contains("client_id=some__clientId"));
+        verify(engine, times(1)).render(anyMap(), anyString(), any());
+    }
+
+    @Test
+    public void must_not_render_due_to_existing_registered_user() {
+        final Domain domain = new Domain();
+        domain.setId("domain-id");
+
+        final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
+        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain);
+
+        var routingContext = Mockito.spy(new SpyRoutingContext());
+
+        final User user = mock(User.class);
+        when(user.isPreRegistration()).thenReturn(true);
+        when(user.isRegistrationCompleted()).thenReturn(true);
+        routingContext.put(USER_CONTEXT_KEY, user);
+
+
+        final Client client = new Client();
+        client.setClientId("some__clientId");
+        routingContext.put(CLIENT_CONTEXT_KEY, client);
+        registrationConfirmation.handle(routingContext);
+
+        assertNull(routingContext.<String>get(ACTION_KEY));
+        verify(engine, times(0)).render(anyMap(), anyString(), any());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/ResetPasswordEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/ResetPasswordEndpointTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.endpoints.user;
+
+import io.gravitee.am.gateway.handler.root.resources.endpoint.user.password.ResetPasswordEndpoint;
+import io.gravitee.am.gateway.handler.root.resources.handler.dummies.SpyRoutingContext;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.oidc.Client;
+import io.vertx.reactivex.ext.web.templ.thymeleaf.ThymeleafTemplateEngine;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static io.gravitee.am.common.utils.ConstantKeys.*;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ResetPasswordEndpointTest {
+
+    @Test
+    public void must_render_engine_with_encoded_client_id() {
+        final Domain domain = new Domain();
+        domain.setId("domain-id");
+
+        final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
+        var registrationConfirmation = new ResetPasswordEndpoint(engine, domain);
+
+        var routingContext = Mockito.spy(new SpyRoutingContext());
+        final Client client = new Client();
+        client.setClientId("some # clientId");
+        routingContext.put(CLIENT_CONTEXT_KEY, client);
+        registrationConfirmation.handle(routingContext);
+
+
+        assertTrue(routingContext.<String>get(ACTION_KEY).contains("client_id=some+%23+clientId"));
+        verify(engine, times(1)).render(anyMap(), anyString(), any());
+    }
+
+    @Test
+    public void must_render_engine_with_regular_client_id() {
+        final Domain domain = new Domain();
+        domain.setId("domain-id");
+
+        final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
+        var resetPassword = new ResetPasswordEndpoint(engine, domain);
+
+        var routingContext = Mockito.spy(new SpyRoutingContext());
+        final Client client = new Client();
+        client.setClientId("some__clientId");
+        routingContext.put(CLIENT_CONTEXT_KEY, client);
+        resetPassword.handle(routingContext);
+
+        assertTrue(routingContext.<String>get(ACTION_KEY).contains("client_id=some__clientId"));
+        verify(engine, times(1)).render(anyMap(), anyString(), any());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/dummies/DummyHttpRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/dummies/DummyHttpRequest.java
@@ -34,6 +34,8 @@ import javax.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
@@ -140,7 +142,7 @@ public class DummyHttpRequest implements HttpServerRequest {
 
     @Override
     public HttpServerResponse response() {
-        return null;
+        return mock(HttpServerResponse.class);
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/dummies/SpyRoutingContext.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/dummies/SpyRoutingContext.java
@@ -39,6 +39,7 @@ public class SpyRoutingContext extends RoutingContext {
     private int next = 0;
     private Buffer body;
     private User user;
+    private int statusCode;
 
     public SpyRoutingContext() {
         super(null);
@@ -84,8 +85,6 @@ public class SpyRoutingContext extends RoutingContext {
         return next == expected;
     }
 
-
-
     @Override
     public User user() {
         return user;
@@ -99,6 +98,16 @@ public class SpyRoutingContext extends RoutingContext {
     @Override
     public HttpServerRequest request() {
         return httpServerRequest;
+    }
+
+    @Override
+    public void fail(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    public int statusCode() {
+        return statusCode;
     }
 
     public void putParam(String key, Object value) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/handler/impl/ClientAuthHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/handler/impl/ClientAuthHandlerImpl.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.gravitee.am.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
+import static io.gravitee.am.common.web.UriBuilder.decodeURIComponent;
 import static io.gravitee.am.gateway.handler.oauth2.resources.auth.provider.CertificateUtils.extractPeerCertificate;
 import static io.gravitee.am.gateway.handler.oauth2.resources.auth.provider.CertificateUtils.getThumbprint;
 
@@ -139,7 +140,7 @@ public class ClientAuthHandlerImpl implements Handler<RoutingContext> {
             }
             // get client
             clientSyncService
-                    .findByClientId(clientId)
+                    .findByClientId(decodeURIComponent(clientId))
                     .subscribe(
                             client -> handler.handle(Future.succeededFuture(client)),
                             error -> handler.handle(Future.failedFuture(error)),

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/EmailServiceImplTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/EmailServiceImplTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.management.service.impl;
+
+import freemarker.cache.TemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapperBuilder;
+import io.gravitee.am.jwt.JWTBuilder;
+import io.gravitee.am.management.service.EmailManager;
+import io.gravitee.am.management.service.EmailService;
+import io.gravitee.am.model.*;
+import io.gravitee.am.model.application.ApplicationOAuthSettings;
+import io.gravitee.am.model.application.ApplicationSettings;
+import io.gravitee.am.service.AuditService;
+import io.gravitee.am.service.DomainService;
+import io.reactivex.Maybe;
+import java.io.IOException;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import static freemarker.template.Configuration.AUTO_DETECT_NAMING_CONVENTION;
+import static freemarker.template.Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EmailServiceImplTest {
+
+    @Mock
+    private EmailManager emailManager;
+
+    @Mock
+    private io.gravitee.am.service.EmailService emailService;
+
+    @Mock
+    private Configuration freemarkerConfiguration;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    @Qualifier("managementJwtBuilder")
+    private JWTBuilder jwtBuilder;
+
+    @Mock
+    private DomainService domainService;
+
+    @InjectMocks
+    private EmailService emailServiceSpy;
+
+    @Test
+    public void must_not_send_email_due_to_not_enabled() throws IOException {
+        var emailService = new EmailServiceImpl(
+                false,
+                "New user registration",
+                86400,
+                "Certificate will expire soon"
+        );
+
+        emailServiceSpy = Mockito.spy(emailService);
+        MockitoAnnotations.openMocks(this);
+
+        emailServiceSpy.send(mock(Domain.class), mock(Application.class), Template.REGISTRATION_CONFIRMATION, mock(User.class))
+                .blockingGet();
+
+        verify(freemarkerConfiguration, times(0)).getTemplate(anyString());
+        verify(emailManager, times(0)).getEmail(any(), any(), any(), anyInt());
+        verify(auditService, times(0)).report(any());
+        verify(this.emailService, times(0)).send(any());
+    }
+
+    @Test
+    public void must_send_email() throws IOException {
+        var emailService = new EmailServiceImpl(
+                true,
+                "New user registration",
+                86400,
+                "Certificate will expire soon"
+        );
+
+        emailServiceSpy = Mockito.spy(emailService);
+        MockitoAnnotations.openMocks(this);
+
+        var templateLoader = mock(TemplateLoader.class);
+        when(templateLoader.findTemplateSource(anyString())).thenReturn(mock(freemarker.template.Template.class));
+        when(this.freemarkerConfiguration.getTemplateLoader()).thenReturn(templateLoader);
+
+        final Email email = buildEmail();
+
+        when(emailManager.getEmail(any(), any(), any(), anyInt())).thenReturn(Maybe.just(email));
+
+        when(freemarkerConfiguration.getTemplate(anyString())).thenReturn(mock(freemarker.template.Template.class));
+        when(freemarkerConfiguration.getIncompatibleImprovements()).thenReturn(DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+        when(freemarkerConfiguration.getNamingConvention()).thenReturn(AUTO_DETECT_NAMING_CONVENTION);
+        when(freemarkerConfiguration.getObjectWrapper()).thenReturn(new DefaultObjectWrapperBuilder(DEFAULT_INCOMPATIBLE_IMPROVEMENTS).build());
+
+        var client = new Application();
+        client.setId(email.getClient());
+        var oauth = new ApplicationOAuthSettings();
+        oauth.setClientId(email.getClient());
+        var settings = new ApplicationSettings();
+        settings.setOauth(oauth);
+        client.setSettings(settings);
+
+        var domain = new Domain();
+        domain.setName("domain");
+        domain.setPath("/domain");
+
+        emailServiceSpy.send(domain, client, Template.REGISTRATION_CONFIRMATION, mock(User.class)).test()
+                .assertNoErrors()
+                .assertComplete();
+
+        verify(freemarkerConfiguration, times(1)).getTemplate(eq(email.getTemplate() + ".html"));
+        verify(emailManager, times(1)).getEmail(any(), any(), any(), anyInt());
+        verify(auditService, times(1)).report(any());
+        verify(this.emailService, times(1)).send(any());
+    }
+
+    private Email buildEmail() {
+        final Email email = new Email();
+        email.setEnabled(true);
+        email.setFrom("from@gravitee.io");
+        email.setExpiresAfter(300);
+        email.setTemplate("some_template");
+        email.setSubject("subject");
+        email.setFromName("Gravitee.io");
+        email.setContent("Reset password content");
+        email.setClient("some # client");
+        return email;
+    }
+}

--- a/gravitee-am-ui/src/app/domain/applications/application/overview/overview.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/overview/overview.component.html
@@ -54,7 +54,7 @@
             <button mat-icon-button matSuffix matTooltip="Copy to clipboard" (click)="copyToClipboard(pre_authorize);">
               <mat-icon>content_copy</mat-icon>
             </button>
-            <pre #pre_authorize>{{baseUrl}}/oauth/authorize?client_id={{clientId}}&response_type={{getAuthorizationFlowResponseType()}}&redirect_uri={{encodedRedirectUri}}{{getCodeChallenge()}}</pre>
+            <pre #pre_authorize>{{baseUrl}}/oauth/authorize?client_id={{getEncodedClientId()}}&response_type={{getAuthorizationFlowResponseType()}}&redirect_uri={{encodedRedirectUri}}{{getCodeChallenge()}}</pre>
           </div>
 
           <p>Users will be redirected to the login page and will start the Authentication Flow.</p>
@@ -97,7 +97,7 @@
   {{baseUrl}}/oauth/token \
   -H 'Authorization: Basic {{safeAuthorizationHeader}}' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'grant_type=authorization_code&code=|code|&redirect_uri={{redirectUri}}&client_id={{clientId}}{{getCodeVerifier()}}'</pre>
+  -d 'grant_type=authorization_code&code=|code|&redirect_uri={{redirectUri}}&client_id={{getEncodedClientId()}}{{getCodeVerifier()}}'</pre>
           </div>
 
           <h2>Proof Key for Code Exchange (PKCE)</h2>

--- a/gravitee-am-ui/src/app/domain/applications/application/overview/overview.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/overview/overview.component.ts
@@ -65,7 +65,7 @@ export class ApplicationOverviewComponent implements OnInit {
       this.clientSecret = applicationOAuthSettings.clientSecret;
       this.redirectUri = applicationOAuthSettings.redirectUris && applicationOAuthSettings.redirectUris[0] !== undefined ? applicationOAuthSettings.redirectUris[0] : 'Not defined';
       this.encodedRedirectUri = encodeURIComponent(this.redirectUri);
-      this.authorizationHeader = btoa(encodeURIComponent(this.clientId) + ':' + encodeURIComponent(this.clientSecret));
+      this.authorizationHeader = btoa(this.getEncodedClientId() + ':' + encodeURIComponent(this.clientSecret));
       this.tokenEndpointAuthMethod = applicationOAuthSettings.tokenEndpointAuthMethod;
       this.forcePKCE = applicationOAuthSettings.forcePKCE;
     } else {
@@ -158,5 +158,9 @@ export class ApplicationOverviewComponent implements OnInit {
 
   displayAuthBasicExample(): boolean {
     return !this.tokenEndpointAuthMethod || this.tokenEndpointAuthMethod === 'client_secret_basic';
+  }
+
+  getEncodedClientId() {
+    return encodeURIComponent(this.clientId);
   }
 }


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/8808

## :pencil2: A description of the changes proposed in the pull request

This PR encodes the clientId in the Login Flow URL presented by the Overview page

It also ensure that in the email template, the client_id is encoded correctly

## :memo: Test scenarios 

- Create am application with characters that needs URI encoding (`my # client-app`)
Test 1:
- Go to `Applications > Your App > Overview` and try the  `Initiate the login flow` and login with you actual user, you should be able to login with the client id being encoded

Test 2: (separately)
- Try the forgot password in order for the user to receive an email with reset password
- Try creating a user with registration confirmation email
These two last cases should have a link where the client_id is encoded

