### PR TITLE
fix: set an organisation group domain owner raise a GroupNotFoundException

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainNotificationServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainNotificationServiceTest.java
@@ -227,6 +227,21 @@ public class DomainNotificationServiceTest {
 
         verify(notifierService, times(11)).register(any(), any(), any());
         verify(userService, never()).findById(any(), any(), any());
+    }
 
+    @Test
+    public void shouldNotNotifyIfGroupIsEmpty() throws Exception {
+        final Membership member = new Membership();
+        member.setMemberType(MemberType.GROUP);
+        member.setMemberId("groupId");
+        when(membershipService.findByCriteria(eq(ReferenceType.DOMAIN), eq(DOMAIN_ID), any())).thenReturn(Flowable.just(member), Flowable.empty());
+        when(groupService.findMembers(any(), any(), any(), anyInt(), anyInt())).thenReturn(Single.just(new Page<>(null, 0, 0)));
+
+        cut.registerCertificateExpiration(certificate);
+
+        Thread.sleep(1000); // wait subscription execution
+
+        verify(notifierService, never()).register(any(), any(), any());
+        verify(userService, never()).findById(any(), any(), any());
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/8667

## :pencil2: A description of the changes proposed in the pull request

Instead of searching for groups at the domain level, groups are searched in the default organisation. If the group is empty an empty list of users is returned to avoid NPE

## :memo: Test scenarios 

Test 1: Group with one user

1 .Create a group in organisation level with 1 member.
2. Now select Administrative role in domain level and assign the group  “DOMAIN_OWNER“ role.
3. Upload an expired certificate in the domain.
4. Restart API Management

Test 2: Group without user

1 .Create a group in organisation level without member.
2. Now select Administrative role in domain level and assign the group  “DOMAIN_OWNER“ role.
3. Upload an expired certificate in the domain.
4. Restart API Management