### PR TITLE
AM-389: change username endpoint.

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/audit/EventType.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/audit/EventType.java
@@ -36,6 +36,7 @@ public interface EventType {
     String USER_LOGOUT = "USER_LOGOUT";
     String USER_CREATED = "USER_CREATED";
     String USER_UPDATED = "USER_UPDATED";
+    String USERNAME_UPDATED = "USER_UPDATED";
     String USER_DELETED = "USER_DELETED";
     String USER_LOCKED = "USER_LOCKED";
     String USER_UNLOCKED = "USER_UNLOCKED";

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UsernameEntity.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UsernameEntity.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.model;
+
+/**
+ * Entity for updating a user's username.
+ */
+public class UsernameEntity {
+    private String username;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/CommonUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/CommonUserService.java
@@ -41,6 +41,8 @@ public interface CommonUserService {
 
     Single<User> updateStatus(ReferenceType referenceType, String referenceId, String id, boolean status, io.gravitee.am.identityprovider.api.User principal);
 
+    Single<User> updateUsername(ReferenceType referenceType, String referenceId, String id, String username, io.gravitee.am.identityprovider.api.User principal);
+
     default Completable delete(ReferenceType referenceType, String referenceId, String userId) {
         return delete(referenceType, referenceId, userId, null);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AbstractUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AbstractUserService.java
@@ -153,6 +153,18 @@ public abstract class AbstractUserService<T extends io.gravitee.am.service.Commo
                 .doOnError(throwable -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).type((status ? EventType.USER_ENABLED : EventType.USER_DISABLED)).throwable(throwable)));
     }
 
+    @Override
+    public Single<User> updateUsername(ReferenceType referenceType, String referenceId, String id, String username, io.gravitee.am.identityprovider.api.User principal) {
+        return getUserService().findById(referenceType, referenceId, id)
+                               .flatMap(user -> {
+                                   user.setUsername(username);
+                                   return getUserService().update(user);
+                               })
+                               .doOnSuccess(user1 -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).type(EventType.USERNAME_UPDATED).user(user1)))
+                               .doOnError(throwable -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).principal(principal).type(EventType.USERNAME_UPDATED).throwable(throwable)));
+
+    }
+
     @SuppressWarnings("ReactiveStreamsUnusedPublisher")
     @Override
     public Completable delete(ReferenceType referenceType, String referenceId, String userId, io.gravitee.am.identityprovider.api.User principal) {


### PR DESCRIPTION
## :id: 
Fixes [AM-389](https://gravitee.atlassian.net/browse/AM-389)

## :pencil2: 

Added new `/username` endpoint to management API for users.


## :memo: Test scenarios 
Should be covered by jest tests; manual tests would be 

- update a username
- fail update unknown user
- fail update permissions insufficien
- fail update username invalid (already used, too short, too long, invalid characters(?))


## :computer: Add screenshots for UI
 📺

## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822


[AM-389]: https://gravitee.atlassian.net/browse/AM-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ