### PR TITLE
fix: full distribution path naming

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -213,8 +213,8 @@ commands:
                     md5sum gravitee-am-management-api-standalone-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-management-api-standalone-${RELEASE_VERSION_NUMBER}.zip.md5
                     sha512sum gravitee-am-management-api-standalone-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-management-api-standalone-${RELEASE_VERSION_NUMBER}.zip.sha512sum
                     sha1sum gravitee-am-management-api-standalone-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-management-api-standalone-${RELEASE_VERSION_NUMBER}.zip.sha1
-                    mkdir -p ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/gravitee-am-management-api-${RELEASE_VERSION_NUMBER}/
-                    cp -R ~/project/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/target/distribution/* ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/gravitee-am-management-api-${RELEASE_VERSION_NUMBER}/
+                    mkdir -p ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/graviteeio-am-management-api-${RELEASE_VERSION_NUMBER}/
+                    cp -R ~/project/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/target/distribution/* ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/graviteeio-am-management-api-${RELEASE_VERSION_NUMBER}/
                     
                     mkdir -p ~/release/graviteeio-am/components/gravitee-am-gateway/
                     cp -R ~/project/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/target/gravitee-am-gateway-standalone-${RELEASE_VERSION_NUMBER}.zip ~/release/graviteeio-am/components/gravitee-am-gateway/
@@ -222,8 +222,8 @@ commands:
                     md5sum gravitee-am-gateway-standalone-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-gateway-standalone-${RELEASE_VERSION_NUMBER}.zip.md5
                     sha512sum gravitee-am-gateway-standalone-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-gateway-standalone-${RELEASE_VERSION_NUMBER}.zip.sha512sum
                     sha1sum gravitee-am-gateway-standalone-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-gateway-standalone-${RELEASE_VERSION_NUMBER}.zip.sha1
-                    mkdir -p ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/gravitee-am-gateway-${RELEASE_VERSION_NUMBER}/
-                    cp -R ~/project/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/target/distribution/* ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/gravitee-am-gateway-${RELEASE_VERSION_NUMBER}/
+                    mkdir -p ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/graviteeio-am-gateway-${RELEASE_VERSION_NUMBER}/
+                    cp -R ~/project/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/target/distribution/* ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/graviteeio-am-gateway-${RELEASE_VERSION_NUMBER}/
 
                     mkdir -p ~/release/graviteeio-am/components/gravitee-am-webui/
                     cp -R ~/project/gravitee-am-ui/target/gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip ~/release/graviteeio-am/components/gravitee-am-webui/
@@ -231,8 +231,8 @@ commands:
                     md5sum gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip.md5
                     sha512sum gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip.sha512sum
                     sha1sum gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip.sha1
-                    mkdir -p ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/gravitee-am-management-ui-${RELEASE_VERSION_NUMBER}/
-                    cp -R ~/project/gravitee-am-ui/dist/* ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/gravitee-am-management-ui-${RELEASE_VERSION_NUMBER}/
+                    mkdir -p ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/graviteeio-am-management-ui-${RELEASE_VERSION_NUMBER}/
+                    cp -R ~/project/gravitee-am-ui/dist/* ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/graviteeio-am-management-ui-${RELEASE_VERSION_NUMBER}/
                     
                     cd ~/release/graviteeio-am/distributions/
                     zip -rm graviteeio-am-full-${RELEASE_VERSION_NUMBER}.zip graviteeio-am-full-${RELEASE_VERSION_NUMBER}


### PR DESCRIPTION
refers to: https://github.com/gravitee-io/gravitee-access-management/pull/2421