### PR TITLE
feat: make sure service level updates username

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
@@ -37,7 +37,13 @@ public interface UserProvider extends Service<UserProvider> {
 
     Single<User> update(String id, User updateUser);
 
-    Completable updateUsername(String id, String username);
+    default Single<User> updateUsername(User user, String username) {
+        if (username == null || username.isEmpty()) {
+            return Single.error(new IllegalArgumentException("Username required for UserProvider.updatePassword"));
+        }
+        ((DefaultUser) user).setUsername(username);
+        return this.update(user.getId(), user);
+    }
 
     default Single<User> updatePassword(User user, String password) {
         if (password == null || password.isEmpty()) {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
@@ -39,7 +39,7 @@ public interface UserProvider extends Service<UserProvider> {
 
     default Single<User> updateUsername(User user, String username) {
         if (username == null || username.isEmpty()) {
-            return Single.error(new IllegalArgumentException("Username required for UserProvider.updatePassword"));
+            return Single.error(new IllegalArgumentException("Username required for UserProvider.updateUsername"));
         }
         ((DefaultUser) user).setUsername(username);
         return this.update(user.getId(), user);

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
@@ -37,7 +37,7 @@ public interface UserProvider extends Service<UserProvider> {
 
     Single<User> update(String id, User updateUser);
 
-    Completable updateUsername(String oldUsername, String username);
+    Completable updateUsername(String id, String username);
 
     default Single<User> updatePassword(User user, String password) {
         if (password == null || password.isEmpty()) {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/UserProvider.java
@@ -37,6 +37,8 @@ public interface UserProvider extends Service<UserProvider> {
 
     Single<User> update(String id, User updateUser);
 
+    Completable updateUsername(String oldUsername, String username);
+
     default Single<User> updatePassword(User user, String password) {
         if (password == null || password.isEmpty()) {
             return Single.error(new IllegalArgumentException("Password required for UserProvider.updatePassword"));

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-gravitee/src/main/java/io/gravitee/am/identityprovider/gravitee/user/GraviteeUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-gravitee/src/main/java/io/gravitee/am/identityprovider/gravitee/user/GraviteeUserProvider.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.identityprovider.gravitee.user;
 
+import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.identityprovider.api.UserProvider;
 import io.reactivex.Completable;
@@ -29,7 +30,7 @@ public class GraviteeUserProvider implements UserProvider {
 
     @Override
     public Maybe<User> findByUsername(String username) {
-        return Maybe.empty();
+        return Maybe.just(new DefaultUser(username));
     }
 
     @Override

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-gravitee/src/main/java/io/gravitee/am/identityprovider/gravitee/user/GraviteeUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-gravitee/src/main/java/io/gravitee/am/identityprovider/gravitee/user/GraviteeUserProvider.java
@@ -45,12 +45,6 @@ public class GraviteeUserProvider implements UserProvider {
     }
 
     @Override
-    public Completable updateUsername(String id, String username) {
-        // update will be performed by the repository layer called by the OrganizationUserService
-        return Completable.complete();
-    }
-
-    @Override
     public Single<User> updatePassword(User user, String password) {
         // update will be performed by the repository layer called by the OrganizationUserService
         return Single.just(user);

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-gravitee/src/main/java/io/gravitee/am/identityprovider/gravitee/user/GraviteeUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-gravitee/src/main/java/io/gravitee/am/identityprovider/gravitee/user/GraviteeUserProvider.java
@@ -45,6 +45,12 @@ public class GraviteeUserProvider implements UserProvider {
     }
 
     @Override
+    public Completable updateUsername(String id, String username) {
+        // update will be performed by the repository layer called by the OrganizationUserService
+        return Completable.complete();
+    }
+
+    @Override
     public Single<User> updatePassword(User user, String password) {
         // update will be performed by the repository layer called by the OrganizationUserService
         return Single.just(user);

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/java/io/gravitee/am/identityprovider/http/user/HttpUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/java/io/gravitee/am/identityprovider/http/user/HttpUserProvider.java
@@ -194,11 +194,6 @@ public class HttpUserProvider implements UserProvider {
     }
 
     @Override
-    public Completable updateUsername(String id, String username) {
-        return Completable.complete();
-    }
-
-    @Override
     public Completable delete(String id) {
         try {
             // prepare context

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/java/io/gravitee/am/identityprovider/http/user/HttpUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/java/io/gravitee/am/identityprovider/http/user/HttpUserProvider.java
@@ -194,6 +194,11 @@ public class HttpUserProvider implements UserProvider {
     }
 
     @Override
+    public Completable updateUsername(String id, String username) {
+        return Completable.complete();
+    }
+
+    @Override
     public Completable delete(String id) {
         try {
             // prepare context

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTest.java
@@ -223,6 +223,28 @@ public class HttpUserProviderTest {
     }
 
     @Test
+    public void must_update_username_with_user() {
+        DefaultUser user = new DefaultUser("johndoe");
+        user.setId("123456789");
+
+        stubFor(put(urlPathEqualTo("/api/users/123456789"))
+                .withHeader(HttpHeaders.CONTENT_TYPE, containing("application/"))
+                .withRequestBody(matching(".*"))
+                .willReturn(okJson("{\"id\" : \"123456789\", \"username\" : \"newUsername\"}")));
+
+        this.mapper.setMappers(Map.of("username", "username", "id", "id", "copy_of_id", "id"));
+
+        TestObserver<User> testObserver = userProvider.updateUsername(user, "newUsername").test();
+        testObserver.awaitTerminalEvent();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "123456789".equals(u.getId()));
+        testObserver.assertValue(u -> "newUsername".equals(u.getUsername()));
+        testObserver.assertValue(u -> u.getAdditionalInformation().containsKey("copy_of_id")
+                && "123456789".equals(u.getAdditionalInformation().get("copy_of_id")));
+    }
+
+    @Test
     public void shouldUpdatePasswrd() {
         DefaultUser user = new DefaultUser("johndoe");
         user.setId("123456789");

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider.java
@@ -346,7 +346,7 @@ public class JdbcUserProvider extends JdbcAbstractProvider<UserProvider> impleme
     @Override
     public Single<User> updateUsername(User user, String username) {
         if (Strings.isNullOrEmpty(username)) {
-            return Single.error(new IllegalArgumentException("Username required for UserProvider.updatePassword"));
+            return Single.error(new IllegalArgumentException("Username required for UserProvider.updateUsername"));
         }
 
         var sql = String.format("UPDATE %s SET %s = %s WHERE %s = %s",

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest.java
@@ -75,6 +75,7 @@ public abstract class JdbcAuthenticationProviderConfigurationTest implements Ini
         Single.fromPublisher(connection.createStatement("insert into users values('2', 'user01', 'user01', 'user01@acme.com', null)").execute()).subscribe();
         Single.fromPublisher(connection.createStatement("insert into users values('3', 'user02', 'user02', 'common@acme.com', null)").execute()).subscribe();
         Single.fromPublisher(connection.createStatement("insert into users values('4', 'user03', 'user03', 'common@acme.com', null)").execute()).subscribe();
+        Single.fromPublisher(connection.createStatement("insert into users values('5', 'changeme', 'changepass', null, null)").execute()).subscribe();
     }
 
     @Bean

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest_MSSQL.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest_MSSQL.java
@@ -50,7 +50,7 @@ public class JdbcAuthenticationProviderConfigurationTest_MSSQL extends JdbcAuthe
                 .execute()).flatMap(rp -> Single.fromPublisher(rp.getRowsUpdated()))
                 .blockingGet();
         Single.fromPublisher(connection.createStatement("insert into users(id, username, password, email, metadata) values( @id, @username, @password, @email , @metadata)")
-                .bind("id", "2")
+                .bind("id", "3")
                 .bind("username", "user02")
                 .bind("password", "user02")
                 .bind("email", "common@acme.com")
@@ -58,12 +58,20 @@ public class JdbcAuthenticationProviderConfigurationTest_MSSQL extends JdbcAuthe
                 .execute()).flatMap(rp -> Single.fromPublisher(rp.getRowsUpdated()))
                 .blockingGet();
         Single.fromPublisher(connection.createStatement("insert into users(id, username, password, email, metadata) values( @id, @username, @password, @email , @metadata)")
-                .bind("id", "2")
+                .bind("id", "4")
                 .bind("username", "user03")
                 .bind("password", "user03")
                 .bind("email", "common@acme.com")
                 .bindNull("metadata", String.class)
                 .execute()).flatMap(rp -> Single.fromPublisher(rp.getRowsUpdated()))
+                .blockingGet();
+        Single.fromPublisher(connection.createStatement("insert into users(id, username, password, email, metadata) values( @id, @username, @password, @email , @metadata)")
+                        .bind("id", "5")
+                        .bind("username", "changeme")
+                        .bind("password", "changepass")
+                        .bindNull("email", String.class)
+                        .bindNull("metadata", String.class)
+                        .execute()).flatMap(rp -> Single.fromPublisher(rp.getRowsUpdated()))
                 .blockingGet();
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider_Test.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider_Test.java
@@ -108,7 +108,7 @@ public abstract class JdbcUserProvider_Test {
         final String username = "userToUpdateNoPwd";
         DefaultUser user = new DefaultUser(username);
         user.setCredentials("password");
-        user.setEmail(username+"@acme.fr");
+        user.setEmail(username + "@acme.fr");
         User createdUser = userProvider.create(user).blockingGet();
 
         DefaultUser updateUser = new DefaultUser(username);
@@ -156,4 +156,43 @@ public abstract class JdbcUserProvider_Test {
         testObserver.assertNoValues();
     }
 
+    @Test
+    public void must_not_updateUsername_null_username() {
+        TestObserver testObserver = userProvider.updateUsername("5", null).test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertError(IllegalArgumentException.class);
+        testObserver.assertNoValues();
+    }
+
+    @Test
+    public void must_not_updateUsername_empty_username() {
+        TestObserver testObserver = userProvider.updateUsername("5", "").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertError(IllegalArgumentException.class);
+        testObserver.assertNoValues();
+    }
+
+    @Test
+    public void must_not_updateUsername_user_not_found() {
+        TestObserver testObserver = userProvider.updateUsername("6", "newUsername").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertError(UserNotFoundException.class);
+        testObserver.assertNoValues();
+    }
+
+    @Test
+    public void must_updateUsername() {
+        TestObserver testObserver = userProvider.updateUsername("5", "newUsername").test();
+        testObserver.awaitTerminalEvent();
+        testObserver.assertComplete();
+
+        TestObserver<User> testObserver2 = userProvider.findByUsername("newUsername").test();
+        testObserver2.awaitTerminalEvent();
+        testObserver2.assertComplete();
+        testObserver2.assertNoErrors();
+        testObserver2.assertValue(u -> "newUsername".equals(u.getUsername()));
+    }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider_Test.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider_Test.java
@@ -158,7 +158,9 @@ public abstract class JdbcUserProvider_Test {
 
     @Test
     public void must_not_updateUsername_null_username() {
-        TestObserver testObserver = userProvider.updateUsername("5", null).test();
+        var user = new DefaultUser();
+        user.setId("5");
+        TestObserver testObserver = userProvider.updateUsername(user, null).test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertError(IllegalArgumentException.class);
@@ -167,7 +169,9 @@ public abstract class JdbcUserProvider_Test {
 
     @Test
     public void must_not_updateUsername_empty_username() {
-        TestObserver testObserver = userProvider.updateUsername("5", "").test();
+        var user = new DefaultUser();
+        user.setId("5");
+        TestObserver testObserver = userProvider.updateUsername(user, "").test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertError(IllegalArgumentException.class);
@@ -176,7 +180,9 @@ public abstract class JdbcUserProvider_Test {
 
     @Test
     public void must_not_updateUsername_user_not_found() {
-        TestObserver testObserver = userProvider.updateUsername("6", "newUsername").test();
+        var user = new DefaultUser();
+        user.setId("6");
+        TestObserver testObserver = userProvider.updateUsername(user, "newUsername").test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertError(UserNotFoundException.class);
@@ -185,7 +191,10 @@ public abstract class JdbcUserProvider_Test {
 
     @Test
     public void must_updateUsername() {
-        TestObserver testObserver = userProvider.updateUsername("5", "newUsername").test();
+        var user = new DefaultUser();
+        user.setId("5");
+
+        TestObserver testObserver = userProvider.updateUsername(user, "newUsername").test();
         testObserver.awaitTerminalEvent();
         testObserver.assertComplete();
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
@@ -177,13 +177,13 @@ public class MongoUserProvider extends MongoAbstractProvider implements UserProv
             return Completable.error(new IllegalArgumentException("Username required for UserProvider.updateUsername"));
         }
 
-        return Completable.fromMaybe(findById(id)
-                .switchIfEmpty(Maybe.error(new UserNotFoundException(null, id)))
-                .flatMap(oldUser -> {
+        return Completable.fromSingle(findById(id)
+                .switchIfEmpty(Single.error(new UserNotFoundException(id)))
+                .flatMap(user -> {
                     var updates = Updates.combine(
                             Updates.set(configuration.getUsernameField(), username),
                             Updates.set(FIELD_UPDATED_AT, new Date()));
-                    return Maybe.just(usersCollection.updateOne(eq(FIELD_ID, oldUser.getId()), updates));
+                    return Single.fromPublisher(usersCollection.updateOne(eq(FIELD_ID, id), updates));
                 }));
     }
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
@@ -208,7 +208,10 @@ public class MongoUserProviderTest {
 
     @Test
     public void must_not_updateUsername_null_username() {
-        TestObserver testObserver = userProvider.updateUsername("5", null).test();
+        var user = new DefaultUser();
+        user.setId("5");
+
+        TestObserver testObserver = userProvider.updateUsername(user, null).test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertError(IllegalArgumentException.class);
@@ -217,7 +220,10 @@ public class MongoUserProviderTest {
 
     @Test
     public void must_not_updateUsername_empty_username() {
-        TestObserver testObserver = userProvider.updateUsername("5", "").test();
+        var user = new DefaultUser();
+        user.setId("6");
+
+        TestObserver testObserver = userProvider.updateUsername(user, "").test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertError(IllegalArgumentException.class);
@@ -226,7 +232,9 @@ public class MongoUserProviderTest {
 
     @Test
     public void must_not_updateUsername_user_not_found() {
-        TestObserver testObserver = userProvider.updateUsername("6", "newUsername").test();
+        var user = new DefaultUser();
+        user.setId("6");
+        TestObserver testObserver = userProvider.updateUsername(user, "newusername").test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertError(UserNotFoundException.class);
@@ -235,10 +243,10 @@ public class MongoUserProviderTest {
 
     @Test
     public void must_updateUsername() {
+        var user = new DefaultUser();
+        user.setId(userProvider.findByUsername("changeme").blockingGet().getId());
 
-        var id = userProvider.findByUsername("changeme").blockingGet().getId();
-
-        TestObserver testObserver = userProvider.updateUsername(id, "newusername").test();
+        TestObserver testObserver = userProvider.updateUsername(user, "newusername").test();
         testObserver.awaitTerminalEvent();
         testObserver.assertComplete();
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
@@ -57,6 +57,8 @@ public class MongoUserProviderTestConfiguration implements InitializingBean {
         Observable.fromPublisher(collection.insertOne(doc2)).blockingFirst();
         Document doc3 = new Document("username", "user02").append("email", "user02@acme.com").append("alternative_email", "user02-alt@acme.com").append("password", "user02").append("_id", UUID.randomUUID().toString());
         Observable.fromPublisher(collection.insertOne(doc3)).blockingFirst();
+        Document doc4 = new Document("username", "changeme").append("password", "changepass").append("_id", UUID.randomUUID().toString());
+        Observable.fromPublisher(collection.insertOne(doc4)).blockingFirst();
     }
 
     @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AbstractUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AbstractUserService.java
@@ -173,6 +173,7 @@ public abstract class AbstractUserService<T extends io.gravitee.am.service.Commo
                         ).flatMap(user -> identityProviderManager.getUserProvider(user.getSource())
                                 .switchIfEmpty(Single.error(new UserProviderNotFoundException(user.getSource())))
                                 .flatMap(userProvider -> userProvider.findByUsername(user.getUsername())
+                                        .switchIfEmpty(Maybe.error(new UserNotFoundException()))
                                         .flatMapSingle(idpUser -> userProvider.updateUsername(idpUser, username))
                                         .flatMap(idpUser -> {
                                             var oldUsername = user.getUsername();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
@@ -763,7 +763,7 @@ public class UserServiceTest {
         final DefaultUser defaultUser = new DefaultUser(user.getUsername());
         defaultUser.setId("idp-user-id");
         when(userProvider.findByUsername(anyString())).thenReturn(Maybe.just(defaultUser));
-        when(userProvider.updateUsername(anyString(), anyString())).thenReturn(Completable.error(new InvalidUserException("Could not update find user")));
+        when(userProvider.updateUsername(any(), anyString())).thenReturn(Single.error(new InvalidUserException("Could not update find user")));
 
         when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
 
@@ -795,17 +795,17 @@ public class UserServiceTest {
         final DefaultUser defaultUser = new DefaultUser(user.getUsername());
         defaultUser.setId("idp-user-id");
         when(userProvider.findByUsername(anyString())).thenReturn(Maybe.just(defaultUser));
-        when(userProvider.updateUsername(anyString(), anyString())).thenReturn(Completable.complete());
+        when(userProvider.updateUsername(any(), anyString())).thenReturn(Single.just(defaultUser));
 
         when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
 
         var observer = userService.updateUsername(DOMAIN, domain.getId(), user.getId(), user.getUsername(), null).test();
 
         observer.awaitTerminalEvent();
-        observer.assertComplete();
+        observer.assertError(TechnicalManagementException.class);
 
         verify(commonUserService, times(1)).update(any());
-        verify(userProvider, times(2)).updateUsername(anyString(), anyString());
+        verify(userProvider, times(2)).updateUsername(any(), anyString());
     }
 
     @Test
@@ -828,7 +828,7 @@ public class UserServiceTest {
         final DefaultUser defaultUser = new DefaultUser(user.getUsername());
         defaultUser.setId("idp-user-id");
         when(userProvider.findByUsername(anyString())).thenReturn(Maybe.just(defaultUser));
-        when(userProvider.updateUsername(anyString(), anyString())).thenReturn(Completable.complete());
+        when(userProvider.updateUsername(any(), anyString())).thenReturn(Single.just(defaultUser));
 
         when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
 
@@ -838,6 +838,6 @@ public class UserServiceTest {
         observer.assertComplete();
 
         verify(commonUserService, times(1)).update(any());
-        verify(userProvider, times(1)).updateUsername(anyString(), anyString());
+        verify(userProvider, times(1)).updateUsername(any(), anyString());
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/CommonUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/CommonUserRepository.java
@@ -40,6 +40,7 @@ public interface CommonUserRepository extends CrudRepository<User, String> {
     Single<Page<User>> search(ReferenceType referenceType, String referenceId, String query, int page, int size);
 
     Single<Page<User>> search(ReferenceType referenceType, String referenceId, FilterCriteria criteria, int page, int size);
+
     Flowable<User> search(ReferenceType referenceType, String referenceId, FilterCriteria criteria);
 
     Maybe<User> findByUsernameAndSource(ReferenceType referenceType, String referenceId, String username, String source);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/UserNotFoundException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/UserNotFoundException.java
@@ -45,8 +45,7 @@ public class UserNotFoundException extends AbstractNotFoundException {
         if (id != null) {
             return "User [" + id + "] can not be found.";
         } else if (username != null) {
-            final String usernameMessage = "User [" + username + "] can not be found";
-            return domain == null ? usernameMessage + "." : usernameMessage + " for domain[" + domain + "].";
+            return  "User [" + username + "] can not be found for domain[" + domain + "].";
         } else {
             return "No user found";
         }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/UserNotFoundException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/UserNotFoundException.java
@@ -25,7 +25,8 @@ public class UserNotFoundException extends AbstractNotFoundException {
     private String domain;
     private String username;
 
-    public UserNotFoundException() { }
+    public UserNotFoundException() {
+    }
 
     public UserNotFoundException(String id) {
         this.id = id;
@@ -43,8 +44,9 @@ public class UserNotFoundException extends AbstractNotFoundException {
     public String getMessage() {
         if (id != null) {
             return "User [" + id + "] can not be found.";
-        } else if (username != null ){
-            return "User [" + username + "] can not be found for domain[" + domain + "].";
+        } else if (username != null) {
+            final String usernameMessage = "User [" + username + "] can not be found";
+            return domain == null ? usernameMessage + "." : usernameMessage + " for domain[" + domain + "].";
         } else {
             return "No user found";
         }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/user/UserValidator.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/user/UserValidator.java
@@ -19,10 +19,13 @@ package io.gravitee.am.service.validators.user;
 import io.gravitee.am.model.IUser;
 import io.gravitee.am.service.validators.Validator;
 import io.reactivex.Completable;
+import java.util.regex.Pattern;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface UserValidator extends Validator<IUser, Completable> {
+
+    Completable validateUsername(String username);
 }

--- a/gravitee-am-test/api/commands/management/organisation-user-commands.ts
+++ b/gravitee-am-test/api/commands/management/organisation-user-commands.ts
@@ -15,7 +15,7 @@
  */
 import {getUserApi} from "@management-commands/service/utils";
 
-export const createUser = (accessToken, user) =>
+export const createOrganisationUser = (accessToken, user) =>
     getUserApi(accessToken).createOrganisationUser({
         organizationId: process.env.AM_DEF_ORG_ID,
         user: user

--- a/gravitee-am-test/specs/management/organisation.users.jest.spec.ts
+++ b/gravitee-am-test/specs/management/organisation.users.jest.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fetch from "cross-fetch";
+import * as faker from 'faker';
+import {afterAll, beforeAll, expect} from "@jest/globals";
+import {createDomain, deleteDomain, startDomain} from "@management-commands/domain-management-commands";
+import {
+    buildCreateAndTestUser, deleteUser,
+    getAllUsers,
+    getUser,
+    getUserPage, lockUser, resetUserPassword, sendRegistrationConfirmation, unlockUser, updateUser, updateUsername,
+    updateUserStatus
+} from "@management-commands/user-management-commands";
+import {
+    createOrganisationUser, deleteOrganisationUser,
+    getOrganisationUserPage,
+    updateOrganisationUsername
+} from "@management-commands/organisation-user-commands";
+
+import {requestAdminAccessToken} from "@management-commands/token-management-commands";
+import {ResponseError} from "../../api/management/runtime";
+
+global.fetch = fetch;
+
+let accessToken;
+let domain;
+let organisationUser;
+
+beforeAll(async () => {
+    const adminTokenResponse = await requestAdminAccessToken();
+    accessToken = adminTokenResponse.body.access_token;
+    expect(accessToken).toBeDefined()
+});
+
+describe("when using the users commands", () => {
+    it('should create organisation user', async () => {
+        const firstName = "orgUserFirstName";
+        const lastName = "orgUserLastName";
+        const payload = {
+            firstName: firstName,
+            lastName: lastName,
+            email: `${firstName}.${lastName}@mail.com`,
+            username: "orgUsername",
+            password: "SomeP@ssw0rd",
+            preRegistration: false
+        };
+        organisationUser = await createOrganisationUser(accessToken, payload);
+        expect(organisationUser.id).toBeDefined();
+        expect(organisationUser.firstName).toEqual(payload.firstName);
+        expect(organisationUser.lastName).toEqual(payload.lastName);
+        expect(organisationUser.username).toEqual(payload.username);
+        expect(organisationUser.email).toEqual(payload.email);
+    });
+});
+
+describe("when managing users at organisation level", () => {
+    it('should change organisation username', async () => {
+        const username = "my-new-username";
+        const updatedUser = await updateOrganisationUsername(accessToken, organisationUser.id, username);
+        expect(updatedUser.username).toEqual(username);
+    });
+});
+
+afterAll(async () => {
+    if (organisationUser && organisationUser.id) {
+        await deleteOrganisationUser(accessToken, organisationUser.id);
+        const userPage = await getOrganisationUserPage(accessToken);
+        expect(userPage.data.find(user => user.id === organisationUser.id)).toBeUndefined();
+    }
+});

--- a/gravitee-am-test/specs/management/users.jest.spec.ts
+++ b/gravitee-am-test/specs/management/users.jest.spec.ts
@@ -26,14 +26,13 @@ import {
     updateUserStatus
 } from "@management-commands/user-management-commands";
 import {
-    createUser, deleteOrganisationUser,
+    createOrganisationUser, deleteOrganisationUser,
     getOrganisationUserPage,
     updateOrganisationUsername
 } from "@management-commands/organisation-user-commands";
 
 import {requestAdminAccessToken} from "@management-commands/token-management-commands";
 import {ResponseError} from "../../api/management/runtime";
-import {fake} from "faker";
 
 global.fetch = fetch;
 
@@ -163,40 +162,6 @@ describe("after creating users", () => {
         expect(UserPage.totalCount).toEqual(9);
         expect(UserPage.data.length).toEqual(9);
         expect(UserPage.data.find(u => u.id === user.id)).toBeFalsy();
-    });
-});
-
-describe("when managing users at organisation level", () => {
-    let newOrgUser;
-    it('should create organisation user', async () => {
-        const firstName = faker.name.firstName();
-        const lastName = faker.name.lastName();
-        const payload = {
-            firstName: firstName,
-            lastName: lastName,
-            email: `${firstName}.${lastName}@mail.com`,
-            username: faker.internet.userName(),
-            password: "SomeP@ssw0rd",
-            preRegistration: false
-        };
-        newOrgUser = await createUser(accessToken, payload);
-        expect(newOrgUser.id).toBeDefined();
-        expect(newOrgUser.firstName).toEqual(payload.firstName);
-        expect(newOrgUser.lastName).toEqual(payload.lastName);
-        expect(newOrgUser.username).toEqual(payload.username);
-        expect(newOrgUser.email).toEqual(payload.email);
-    });
-
-    it('should change organisation username', async () => {
-        const username = "my-new-username";
-        const updatedUser = await updateOrganisationUsername(accessToken, newOrgUser.id, username);
-        expect(updatedUser.username).toEqual(username);
-    });
-
-    it('should delete organisation user', async () => {
-        await deleteOrganisationUser(accessToken, newOrgUser.id);
-        const userPage = await getOrganisationUserPage(accessToken);
-        expect(userPage.data.find(user => user.id === newOrgUser.id)).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-445

## :pencil2: A description of the changes proposed in the pull request

This PR ensures that the username is update where necessary if possible

## :memo: Test Scenarios

`curl -vvv -X POST http://localhost:8093/management/auth/token -H 'authorization: Basic base64(username:password)'`

Will get you an access token

```curl -vvv -X PATCH -H "content-type: application/json" -H "Authorization: Bearer <access-token>" http://localhost:8093/management/organizations/DEFAULT/environments/DEFAULT/domains/<domainId>/users/<userId>/username -d '{ "username"  : "<newUsername>" }' ```

- Test if the username respects the username pattern -- should fail
- Test if the username already exists -- should fail
- Finally update a user with its actual username -- should succeed
- Try updating the username of a non UserProvider IDP (Everything but Mongo/Jdbc/Http) -- should fail