### PR TITLE
fix: mongodb did not allow spaces in find by username

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest.java
@@ -76,6 +76,7 @@ public abstract class JdbcAuthenticationProviderConfigurationTest implements Ini
         Single.fromPublisher(connection.createStatement("insert into users values('3', 'user02', 'user02', 'common@acme.com', null)").execute()).subscribe();
         Single.fromPublisher(connection.createStatement("insert into users values('4', 'user03', 'user03', 'common@acme.com', null)").execute()).subscribe();
         Single.fromPublisher(connection.createStatement("insert into users values('5', 'changeme', 'changepass', null, null)").execute()).subscribe();
+        Single.fromPublisher(connection.createStatement("insert into users values('6', 'b o b', 'changepass', null, null)").execute()).subscribe();
     }
 
     @Bean

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest_MSSQL.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest_MSSQL.java
@@ -73,5 +73,13 @@ public class JdbcAuthenticationProviderConfigurationTest_MSSQL extends JdbcAuthe
                         .bindNull("metadata", String.class)
                         .execute()).flatMap(rp -> Single.fromPublisher(rp.getRowsUpdated()))
                 .blockingGet();
+        Single.fromPublisher(connection.createStatement("insert into users(id, username, password, email, metadata) values( @id, @username, @password, @email , @metadata)")
+                        .bind("id", "6")
+                        .bind("username", "b o b")
+                        .bind("password", "changepass")
+                        .bindNull("email", String.class)
+                        .bindNull("metadata", String.class)
+                        .execute()).flatMap(rp -> Single.fromPublisher(rp.getRowsUpdated()))
+                .blockingGet();
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider_Test.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/user/JdbcUserProvider_Test.java
@@ -46,6 +46,16 @@ public abstract class JdbcUserProvider_Test {
     }
 
     @Test
+    public void shouldSelectUserByUsernameWithSpaces() {
+        TestObserver<User> testObserver = userProvider.findByUsername("b o b").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "b o b".equals(u.getUsername()));
+    }
+
+    @Test
     public void shouldSelectUserByEmail() {
         TestObserver<User> testObserver = userProvider.findByEmail("user01@acme.com").test();
         testObserver.awaitTerminalEvent();
@@ -181,7 +191,7 @@ public abstract class JdbcUserProvider_Test {
     @Test
     public void must_not_updateUsername_user_not_found() {
         var user = new DefaultUser();
-        user.setId("6");
+        user.setId("7");
         TestObserver testObserver = userProvider.updateUsername(user, "newUsername").test();
         testObserver.awaitTerminalEvent();
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
@@ -46,6 +46,11 @@ public abstract class MongoAbstractProvider implements InitializingBean {
 
     protected MongoClient mongoClient;
 
+    protected static final String JSON_SPECIAL_CHARS = "\\{\\}\\[\\],:";
+    protected static final String QUOTE = "\"";
+    protected static final String SAFE_QUOTE_REPLACEMENT = "\\\\\\\\\\\\" + QUOTE;
+
+
     /**
      * This provider is used to create MongoClient when the main backend is JDBC/R2DBC because in that case the commonConnectionProvider will provide R2DBC ConnectionPool.
      * This is useful if the user want to create a Mongo IDP when the main backend if a RDBMS.
@@ -62,5 +67,10 @@ public abstract class MongoAbstractProvider implements InitializingBean {
             this.clientWrapper = mongoProvider.getClientFromConfiguration(this.configuration);
         }
         this.mongoClient = this.clientWrapper.getClient();
+    }
+
+    protected String getSafeUsername(String username) {
+        // lowercase username since case-sensitivity feature
+        return username.toLowerCase().replaceAll(QUOTE, SAFE_QUOTE_REPLACEMENT);
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProviderTestConfiguration.java
@@ -48,7 +48,8 @@ public class MongoAuthenticationProviderTestConfiguration implements Initializin
                 new Document("username", "bob").append("password", "bobspassword"),
                 new Document("username", "user01").append("email", "user01@acme.com").append("password", "user01"),
                 new Document("username", "user02").append("email", "common@acme.com").append("password", "user02"),
-                new Document("username", "user03").append("email", "common@acme.com").append("password", "user03")
+                new Document("username", "user03").append("email", "common@acme.com").append("password", "user03"),
+                new Document("username", "b o b").append("email", "b+o+b@acme.com").append("password", "b o bpassword")
         );
         users.stream().forEach(doc -> Observable.fromPublisher(collection.insertOne(doc)).blockingFirst());
     }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
@@ -55,6 +55,16 @@ public class MongoUserProviderTest {
     }
 
     @Test
+    public void shouldSelectUserByUsernameWithSpaces() {
+        TestObserver<User> testObserver = userProvider.findByUsername("b o b").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "b o b".equals(u.getUsername()));
+    }
+
+    @Test
     public void shouldSelectUserByEmail() {
         TestObserver<User> testObserver = userProvider.findByEmail("user01@acme.com").test();
         testObserver.awaitTerminalEvent();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
@@ -59,6 +59,8 @@ public class MongoUserProviderTestConfiguration implements InitializingBean {
         Observable.fromPublisher(collection.insertOne(doc3)).blockingFirst();
         Document doc4 = new Document("username", "changeme").append("password", "changepass").append("_id", UUID.randomUUID().toString());
         Observable.fromPublisher(collection.insertOne(doc4)).blockingFirst();
+        Document doc5 = new Document("username", "b o b").append("password", "changepass").append("_id", UUID.randomUUID().toString());
+        Observable.fromPublisher(collection.insertOne(doc5)).blockingFirst();
     }
 
     @Bean


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-450

## :pencil2: A description of the changes proposed in the pull request

This PR fixes the MongoDB formatting of the username when registering in MongoDB. 

## :memo: Test scenarios 

- Test on AM with MongoDB backend
- Login with AM user Admin
- Create a user with a space / with several spaces / with no space
- Login with the user
- Update the users' username with the Admin user (several spaces etc ...)
- Logout and log back in

