### PR TITLE
AM-232: redirected to callback url for pre-login exit

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -351,7 +351,7 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
                 .handler(new LoginPostEndpoint());
 
         rootRouter.route(PATH_LOGIN)
-                .failureHandler(new LoginFailureHandler(authenticationFlowContextService));
+                .failureHandler(new LoginFailureHandler(authenticationFlowContextService, domain, identityProviderManager));
 
         // logout route
         rootRouter.route(PATH_LOGOUT)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandler.java
@@ -19,13 +19,17 @@ import com.google.common.net.HttpHeaders;
 import io.gravitee.am.common.exception.authentication.AccountPasswordExpiredException;
 import io.gravitee.am.common.exception.authentication.AuthenticationException;
 import io.gravitee.am.common.oidc.Parameters;
-import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
 import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.policy.PolicyChainException;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.AuthenticationFlowContextService;
-import io.vertx.core.Handler;
+import io.gravitee.common.http.HttpStatusCode;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import io.vertx.reactivex.core.http.HttpServerResponse;
@@ -33,17 +37,32 @@ import io.vertx.reactivex.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.gravitee.am.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
+import static io.gravitee.am.service.utils.ResponseTypeUtils.isHybridFlow;
+import static io.gravitee.am.service.utils.ResponseTypeUtils.isImplicitFlow;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class LoginFailureHandler implements Handler<RoutingContext> {
+public class LoginFailureHandler extends LoginAbstractHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(LoginFailureHandler.class);
 
-    private AuthenticationFlowContextService authenticationFlowContextService;
+    private final AuthenticationFlowContextService authenticationFlowContextService;
+    private final Domain domain;
+    private final IdentityProviderManager identityProviderManager;
 
-    public LoginFailureHandler(AuthenticationFlowContextService authenticationFlowContextService) {
+    public LoginFailureHandler(AuthenticationFlowContextService authenticationFlowContextService,
+                               Domain domain, IdentityProviderManager identityProviderManager) {
         this.authenticationFlowContextService = authenticationFlowContextService;
+        this.domain = domain;
+        this.identityProviderManager = identityProviderManager;
     }
 
     @Override
@@ -52,7 +71,7 @@ public class LoginFailureHandler implements Handler<RoutingContext> {
             Throwable throwable = routingContext.failure();
             if (throwable instanceof PolicyChainException) {
                 PolicyChainException policyChainException = (PolicyChainException) throwable;
-                handleException(routingContext, policyChainException.key(), policyChainException.getMessage());
+                handlePolicyChainException(routingContext, policyChainException.key(), policyChainException.getMessage());
             } else if (throwable instanceof AccountPasswordExpiredException) {
                 handleException(routingContext, ((AccountPasswordExpiredException) throwable).getErrorCode(), throwable.getMessage());
             } else if (throwable instanceof AuthenticationException) {
@@ -64,20 +83,80 @@ public class LoginFailureHandler implements Handler<RoutingContext> {
         }
     }
 
+    private void handlePolicyChainException(RoutingContext context, String errorCode, String errorDescription)  {
+        final Client client = context.get(ConstantKeys.CLIENT_CONTEXT_KEY);
+        final long externalIdentities = Optional.ofNullable(client.getIdentityProviders()).stream()
+                .flatMap(Collection::stream)
+                .map(idp -> identityProviderManager.getIdentityProvider(idp.getIdentity()))
+                .filter(idp -> idp != null && idp.isExternal())
+                .count();
+
+        final LoginSettings loginSettings = LoginSettings.getInstance(domain, client);
+        if (loginSettings != null && loginSettings.isHideForm() && externalIdentities == 1) {
+            logoutUser(context);
+            final MultiMap originalParams = context.get(PARAM_CONTEXT_KEY);
+            redirectToCallbackUrl(originalParams, client, context, errorCode, errorDescription);
+        } else {
+            handleException(context, errorCode, errorDescription);
+        }
+    }
+
+    private void redirectToCallbackUrl(MultiMap originalParams, Client client, RoutingContext context,
+                                       String errorCode, String errorDescription) {
+        // Get the SP redirect_uri
+        final String clientRedirectUri = (originalParams != null && originalParams.get(io.gravitee.am.common.oauth2.Parameters.REDIRECT_URI) != null) ?
+                originalParams.get(io.gravitee.am.common.oauth2.Parameters.REDIRECT_URI) :
+                client.getRedirectUris().get(0);
+
+        // append error message
+        final Map<String, String> query = new LinkedHashMap<>();
+        query.put(ConstantKeys.ERROR_PARAM_KEY, "login_failed");
+        query.put(ConstantKeys.ERROR_CODE_PARAM_KEY, errorCode);
+        query.put(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, errorDescription);
+        if (originalParams != null && originalParams.get(io.gravitee.am.common.oauth2.Parameters.STATE) != null) {
+            query.put(io.gravitee.am.common.oauth2.Parameters.STATE, originalParams.get(io.gravitee.am.common.oauth2.Parameters.STATE));
+        }
+
+        final boolean fragment = originalParams != null &&
+                originalParams.get(io.gravitee.am.common.oauth2.Parameters.RESPONSE_TYPE) != null &&
+                (isImplicitFlow(originalParams.get(io.gravitee.am.common.oauth2.Parameters.RESPONSE_TYPE)) || isHybridFlow(originalParams.get(io.gravitee.am.common.oauth2.Parameters.RESPONSE_TYPE)));
+
+        // prepare final redirect uri
+        final UriBuilder template = UriBuilder.newInstance();
+
+        // get URI from the redirect_uri parameter
+        final UriBuilder builder = UriBuilder.fromURIString(clientRedirectUri);
+        try {
+            final URI redirectUri = builder.build();
+
+            // create final redirect uri
+            template.scheme(redirectUri.getScheme())
+                    .host(redirectUri.getHost())
+                    .port(redirectUri.getPort())
+                    .userInfo(redirectUri.getUserInfo())
+                    .path(redirectUri.getPath());
+
+            // append error parameters in "application/x-www-form-urlencoded" format
+            if (fragment) {
+                query.forEach((k, v) -> template.addFragmentParameter(k, UriBuilder.encodeURIComponent(v)));
+            } else {
+                query.forEach((k, v) -> template.addParameter(k, UriBuilder.encodeURIComponent(v)));
+            }
+            doRedirect(context, template.build().toString());
+        } catch (Exception ex) {
+            LOGGER.error("An error has occurred while redirecting to the login page", ex);
+            context
+                    .response()
+                    .setStatusCode(HttpStatusCode.SERVICE_UNAVAILABLE_503)
+                    .end();
+        }
+    }
+
     private void handleException(RoutingContext context, String errorCode, String errorDescription) {
         final HttpServerRequest req = context.request();
         final HttpServerResponse resp = context.response();
 
-        // logout user if exists
-        if (context.user() != null) {
-            // clear AuthenticationFlowContext. data of this context have a TTL so we can fire and forget in case on error.
-            authenticationFlowContextService.clearContext(context.session().get(ConstantKeys.TRANSACTION_ID_KEY))
-                    .doOnError((error) -> LOGGER.info("Deletion of some authentication flow data fails '{}'", error.getMessage()))
-                    .subscribe();
-
-            context.clearUser();
-            context.session().destroy();
-        }
+        logoutUser(context);
 
         // redirect to the login page with error message
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(req);
@@ -102,5 +181,17 @@ public class LoginFailureHandler implements Handler<RoutingContext> {
                 .putHeader(HttpHeaders.LOCATION, url)
                 .setStatusCode(302)
                 .end();
+    }
+
+    private void logoutUser(RoutingContext context){
+        if (context.user() != null) {
+            // clear AuthenticationFlowContext. data of this context have a TTL so we can fire and forget in case on error.
+            authenticationFlowContextService.clearContext(context.session().get(ConstantKeys.TRANSACTION_ID_KEY))
+                    .doOnError((error) -> LOGGER.info("Deletion of some authentication flow data fails '{}'", error.getMessage()))
+                    .subscribe();
+
+            context.clearUser();
+            context.session().destroy();
+        }
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandlerTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.resources.handler.login;
+
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
+import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.policy.PolicyChainException;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.idp.ApplicationIdentityProvider;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.service.AuthenticationFlowContextService;
+import io.gravitee.common.http.HttpStatusCode;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.reactivex.core.MultiMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.TreeSet;
+
+import static io.gravitee.am.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoginFailureHandlerTest extends RxWebTestBase {
+
+    @Mock
+    private AuthenticationFlowContextService authenticationFlowContextService;
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private IdentityProviderManager identityProviderManager;
+
+    @Mock
+    private PolicyChainException policyChainException;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        router.route(HttpMethod.GET, "/login")
+                .handler(rc -> rc.fail(policyChainException))
+                .failureHandler(new LoginFailureHandler(authenticationFlowContextService, domain, identityProviderManager));
+    }
+
+    @Test
+    public void shouldRedirectToLoginCallbackUrl_loginFormHidden_OneIdp() throws Exception {
+        LoginSettings loginSettings = new LoginSettings();
+        loginSettings.setInherited(false);
+        loginSettings.setHideForm(true);
+        when(domain.getLoginSettings()).thenReturn(loginSettings);
+
+        IdentityProvider idp = mock(IdentityProvider.class);
+        when(idp.isExternal()).thenReturn(true);
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(idp);
+
+        Client mockClient = mock(Client.class);
+        final ApplicationIdentityProvider applicationIdentityProvider = new ApplicationIdentityProvider();
+        TreeSet<ApplicationIdentityProvider> idps = new TreeSet<>();
+        idps.add(applicationIdentityProvider);
+        applicationIdentityProvider.setIdentity("idp");
+        when(mockClient.getIdentityProviders()).thenReturn(idps);
+
+
+        MultiMap multiMap = new MultiMap(new HeadersMultiMap());
+        multiMap.add("redirect_uri", "http://myhost/login/callback");
+
+        when(policyChainException.key()).thenReturn("CALLOUT_EXIT_ON_ERROR");
+        when(policyChainException.getMessage()).thenReturn("{\"errorTest\": \"Test Error\"}");
+
+
+        router.route().order(-1).handler(routingContext -> {
+            Client client = mockClient;
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            routingContext.put(PARAM_CONTEXT_KEY, multiMap);
+            routingContext.next();
+        });
+
+        testRequest(
+                HttpMethod.GET, "/login",
+                null,
+                resp -> {
+                    String location = resp.headers().get("location");
+                    assertNotNull(location);
+                    assertTrue(location.contains("http://myhost/login/callback?error=login_failed&error_code=CALLOUT_EXIT_ON_ERROR&error_description=%257B%2522errorTest%2522%253A+%2522Test+Error%2522%257D"));
+                },
+                HttpStatusCode.FOUND_302, "Found", null);
+    }
+
+    @Test
+    public void shouldRedirectToAM_loginFormNotHidden_OneIdp() throws Exception {
+        LoginSettings loginSettings = new LoginSettings();
+        loginSettings.setInherited(false);
+        loginSettings.setHideForm(false);
+        when(domain.getLoginSettings()).thenReturn(loginSettings);
+
+        IdentityProvider idp = mock(IdentityProvider.class);
+        when(idp.isExternal()).thenReturn(true);
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(idp);
+
+        Client mockClient = mock(Client.class);
+        final ApplicationIdentityProvider applicationIdentityProvider = new ApplicationIdentityProvider();
+        TreeSet<ApplicationIdentityProvider> idps = new TreeSet<>();
+        idps.add(applicationIdentityProvider);
+        applicationIdentityProvider.setIdentity("idp");
+        when(mockClient.getIdentityProviders()).thenReturn(idps);
+
+
+        MultiMap multiMap = new MultiMap(new HeadersMultiMap());
+        multiMap.add("redirect_uri", "http://myhost/login/callback");
+
+        when(policyChainException.key()).thenReturn("CALLOUT_EXIT_ON_ERROR");
+        when(policyChainException.getMessage()).thenReturn("{\"errorTest\": \"Test Error\"}");
+
+
+        router.route().order(-1).handler(routingContext -> {
+            Client client = mockClient;
+            routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+            routingContext.put(PARAM_CONTEXT_KEY, multiMap);
+            routingContext.next();
+        });
+
+        testRequest(
+                HttpMethod.GET, "/login",
+                null,
+                resp -> {
+                    String location = resp.headers().get("location");
+                    assertNotNull(location);
+                    assertTrue(location.contains("/login?error=login_failed&error_code=CALLOUT_EXIT_ON_ERROR&error_description=%7B%22errorTest%22%3A+%22Test+Error%22%7D"));
+                },
+                HttpStatusCode.FOUND_302, "Found", null);
+    }
+}


### PR DESCRIPTION
Align with the behaviour for post-login exit when there is only one IDP and the login form is hidden

Detailed of this issue can be found here: https://gravitee.atlassian.net/browse/AM-232

What to test:
I have added an Excel shit with before and after modification behaviours. Only one cell (D9) behaviour has been changed after this fix. Please ping me for further details. Thanks   