### PR TITLE
AM-447-AM-IDP-When-using-an-internal-API-for-AM-no-validation-of-the-requests-payload-it-provided

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/pom.xml
@@ -165,5 +165,22 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JUnit compatibility -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderServiceProxyImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderServiceProxyImpl.java
@@ -46,6 +46,8 @@ import java.util.Optional;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import static io.gravitee.am.management.service.impl.utils.JsonNodeValidator.validateConfiguration;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -170,6 +172,7 @@ public class IdentityProviderServiceProxyImpl extends AbstractSensitiveProxy imp
                 .switchIfEmpty(Single.error(new IdentityProviderPluginSchemaNotFoundException(oldIdentityProvider.getType())))
                 .map(schema -> {
                     var updateConfig = objectMapper.readTree(updateIdentityProvider.getConfiguration());
+                    validateConfiguration(updateConfig);
                     var oldConfig = objectMapper.readTree(oldIdentityProvider.getConfiguration());
                     var schemaConfig = objectMapper.readTree(schema);
                     if (KERBEROS_AM_IDP.equals(oldIdentityProvider.getType())) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/utils/JsonNodeValidator.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/utils/JsonNodeValidator.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NumericNode;
+
+/**
+ * Validates the values of {@link JsonNode}s.
+ */
+public class JsonNodeValidator {
+
+    private JsonNodeValidator(){}
+
+    /**
+     * Validates a JSON document (in the form of a {@link JsonNode}) for 'correctness' of values.
+     * This is currently restricted to ensuring numeric values are not negative; future enhancement might involve using regex
+     * or similar to validate specific string values.
+     *
+     * @param idpConfig {@link JsonNode} representing a JSON document.
+     */
+    public static void validateConfiguration(JsonNode idpConfig) {
+        idpConfig.elements().forEachRemaining(jsonNode -> {
+            if (jsonNode instanceof NumericNode) {
+                boolean isNegative = false;
+                switch (jsonNode.numberType()) {
+                    case INT:
+                    case LONG:
+                    case BIG_INTEGER:
+                        isNegative = jsonNode.asInt() < 0;
+                        break;
+                    case FLOAT:
+                    case DOUBLE:
+                    case BIG_DECIMAL:
+                        isNegative = jsonNode.asDouble() < 0;
+                }
+                if (isNegative) {
+                    throw new IllegalArgumentException("Negative numbers not allowed");
+                }
+            }
+        });
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/utils/JsonNodeValidatorTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/utils/JsonNodeValidatorTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class JsonNodeValidatorTest {
+
+    @ParameterizedTest
+    @MethodSource("negatives")
+    void shouldThrowIllegalArgForNegativeNumbers(JsonNode negativeNumericNode) {
+        var jsonNode = mock(JsonNode.class);
+        given(jsonNode.elements()).willReturn(List.of(negativeNumericNode).iterator());
+        assertThrows(IllegalArgumentException.class, () -> JsonNodeValidator.validateConfiguration(jsonNode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("positives")
+    void shouldNotThrowForPositiveNumbers(JsonNode positiveNumericNode) {
+        var jsonNode = mock(JsonNode.class);
+        given(jsonNode.elements()).willReturn(List.of(positiveNumericNode).iterator());
+        assertDoesNotThrow(() -> JsonNodeValidator.validateConfiguration(jsonNode));
+    }
+
+    static Stream<JsonNode> negatives() {
+        return Stream.of(
+                new IntNode(-1),
+                new LongNode(-15555555L),
+                new FloatNode(-1.8F),
+                new DoubleNode(-991.10));
+    }
+
+    static Stream<JsonNode> positives() {
+        return Stream.of(
+                new IntNode(1),
+                new LongNode(15555555L),
+                new FloatNode(1.8F),
+                new DoubleNode(991.10));
+    }
+}


### PR DESCRIPTION
## :id: 

Fixes [AM-447](https://gravitee.atlassian.net/browse/AM-447)

## :pencil2: 

Created a util class that checks JSON documents for negative values. 

## :memo: Test scenarios 

See the JIRA for an example IDP configuration that can be used to test this. Essentially, the steps to test are

1. Create an IDP (Suggest HTTP or In-memory as it's one of the easiest to configure)
2. Locate the IDP at the identities mongo table
3. Modify the 'configuration' field JSON to include invalid numeric values, e.g. ```"timeout" : -1000```

[AM-447]: https://gravitee.atlassian.net/browse/AM-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ