### PR TITLE
fix: success auth event returned twice when risk assessment enabled

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/alert/AlertEventProcessor.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/alert/AlertEventProcessor.java
@@ -40,7 +40,6 @@ import java.util.Map;
 
 import static io.gravitee.am.common.event.AlertEventKeys.*;
 import static io.gravitee.am.gateway.handler.common.auth.event.AuthenticationEvent.SUCCESS;
-import static io.gravitee.risk.assessment.api.assessment.Assessment.NONE;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -137,7 +136,6 @@ public class AlertEventProcessor extends AbstractService {
                                 PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_IP_REPUTATION, result.getIpReputation().getAssessment(),
                                 PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_GEO_VELOCITY, result.getGeoVelocity().getAssessment()
                         ).forEach((property, assessment) -> eventBuilder.property(property, assessment.name()));
-                        sendEvent(eventBuilder.build());
                         return eventBuilder;
                     })
                     .switchIfEmpty(Maybe.just(eventBuilder))
@@ -145,17 +143,6 @@ public class AlertEventProcessor extends AbstractService {
         } else {
             sendEvent(eventBuilder.build());
         }
-    }
-
-    private Consumer<AssessmentMessageResult> sendAssessmentMessageResult(DefaultEvent.Builder eventBuilder) {
-        return result -> {
-            Map.of(
-                    PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_UNKNOWN_DEVICES, result.getDevices().getAssessment(),
-                    PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_IP_REPUTATION, result.getIpReputation().getAssessment(),
-                    PROPERTY_RISK_ASSESSMENT + "." + PROPERTY_GEO_VELOCITY, result.getGeoVelocity().getAssessment()
-            ).forEach((property, assessment) -> eventBuilder.property(property, assessment.name()));
-            sendEvent(eventBuilder.build());
-        };
     }
 
     private void sendEvent(io.gravitee.alert.api.event.Event event) {


### PR DESCRIPTION
## :id: Reference related issue. 

related to https://gravitee.atlassian.net/browse/AM-194

## :pencil2: A description of the changes proposed in the pull request

When refactoring with RxJava3 event is now returned twice

## :memo: Test scenarios 

Enable alerting risk assessment on a domain

Either try login in from: 
- 2 different location
- From a different device (MFA with remember device necessary)
