### PR TITLE
fix: rely on gravitee bom for jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
         <wiremock.version>2.6.0</wiremock.version>
         <embedded-ldap-junit.version>0.7</embedded-ldap-junit.version>
         <json-smart.version>2.4.7</json-smart.version>
-        <jackson-bom.version>2.10.5.20201202</jackson-bom.version>
         <reactor-netty.version>1.0.15</reactor-netty.version>
         <commons-io.version>2.11.0</commons-io.version>
         <common-text.version>1.10.0</common-text.version>
@@ -150,15 +149,6 @@
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
                 <version>${json-smart.version}</version>
-            </dependency>
-
-            <!-- Security upgrades -->
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-486

## :pencil2: A description of the changes proposed in the pull request

AM was overriding the gravitee bom with the jackson bom.
We should only rely on gravitee bom for this dependency
