### PR TITLE
AM-472-management-Shouldn-t-be-possible-to-create-two-dictionaries-with-same-locale

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/I18nDictionaryRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/I18nDictionaryRepository.java
@@ -22,7 +22,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 
 public interface I18nDictionaryRepository extends CrudRepository<I18nDictionary, String> {
-    Maybe<I18nDictionary> findByName(ReferenceType referenceType, String referenceId, String name);
+    Maybe<I18nDictionary> findByLocale(ReferenceType referenceType, String referenceId, String locale);
 
     Flowable<I18nDictionary> findAll(ReferenceType referenceType, String referenceId);
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcI18nDictionaryRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcI18nDictionaryRepository.java
@@ -168,9 +168,9 @@ public class JdbcI18nDictionaryRepository extends AbstractJdbcRepository impleme
     }
 
     @Override
-    public Maybe<I18nDictionary> findByName(ReferenceType referenceType, String referenceId, String name) {
-        LOGGER.debug("findByName({}, {}, {})", referenceType, referenceId, name);
-        return repository.findByName(referenceType.toString(), referenceId, name)
+    public Maybe<I18nDictionary> findByLocale(ReferenceType referenceType, String referenceId, String locale) {
+        LOGGER.debug("findByLocale({}, {}, {})", referenceType, referenceId, locale);
+        return repository.findByLocale(referenceType.toString(), referenceId, locale)
                          .map(this::toEntity)
                          .flatMapSingleElement(this::completeDictionary);
     }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringI18nDictionaryRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringI18nDictionaryRepository.java
@@ -39,6 +39,6 @@ public interface SpringI18nDictionaryRepository extends RxJava2CrudRepository<Jd
     @Query("select * from i18n_dictionaries f where f.reference_id = :refId and f.reference_type = :refType and f.id = :id")
     Maybe<JdbcI18nDictionary> findById(@Param("refType") String referenceType, @Param("refId") String referenceId, @Param("id") String id);
 
-    @Query("select * from i18n_dictionaries f where f.reference_id = :refId and f.reference_type = :refType and f.name = :name")
-    Maybe<JdbcI18nDictionary> findByName(@Param("refType") String referenceType, @Param("refId") String referenceId, @Param("name") String name);
+    @Query("select * from i18n_dictionaries f where f.reference_id = :refId and f.reference_type = :refType and f.locale = :locale")
+    Maybe<JdbcI18nDictionary> findByLocale(@Param("refType") String referenceType, @Param("refId") String referenceId, @Param("locale") String locale);
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoI18nDictionaryRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoI18nDictionaryRepository.java
@@ -29,7 +29,6 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-
 import java.util.Objects;
 
 import static com.mongodb.client.model.Filters.and;
@@ -40,6 +39,7 @@ import static io.gravitee.am.model.ReferenceType.valueOf;
 @Component
 public class MongoI18nDictionaryRepository extends AbstractManagementMongoRepository implements I18nDictionaryRepository {
 
+    private static final String FIELD_LOCALE = "locale";
     private MongoCollection<I18nDictionaryMongo> mongoCollection;
 
     @PostConstruct
@@ -89,10 +89,10 @@ public class MongoI18nDictionaryRepository extends AbstractManagementMongoReposi
     }
 
     @Override
-    public Maybe<I18nDictionary> findByName(ReferenceType referenceType, String referenceId, String name) {
+    public Maybe<I18nDictionary> findByLocale(ReferenceType referenceType, String referenceId, String locale) {
         return Observable.fromPublisher(
                                  mongoCollection
-                                         .find(and(eq(FIELD_REFERENCE_TYPE, referenceType.name()), eq(FIELD_REFERENCE_ID, referenceId), eq(FIELD_NAME, name)))
+                                         .find(and(eq(FIELD_REFERENCE_TYPE, referenceType.name()), eq(FIELD_REFERENCE_ID, referenceId), eq(FIELD_LOCALE, locale)))
                                          .limit(1)
                                          .first())
                          .firstElement()

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/I18nDictionaryRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/I18nDictionaryRepositoryTest.java
@@ -70,10 +70,10 @@ public class I18nDictionaryRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
-    public void shouldFindByName() {
+    public void shouldFindByNameAndLocale() {
         String referenceId = randomUUID().toString();
         var created = repository.create(buildDictionary(referenceId)).blockingGet();
-        var observer = repository.findByName(DOMAIN, referenceId, created.getName()).test();
+        var observer = repository.findByLocale(DOMAIN, referenceId, "fr").test();
         observer.awaitTerminalEvent();
         observer.assertComplete();
         observer.assertNoErrors();
@@ -93,7 +93,7 @@ public class I18nDictionaryRepositoryTest extends AbstractManagementTest {
 
     @Test
     public void shouldNotFindByName() {
-        repository.findByName(DOMAIN, "1234", "no").test().assertEmpty();
+        repository.findByLocale(DOMAIN, "1234", null).test().assertEmpty();
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/InvalidLocaleException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/InvalidLocaleException.java
@@ -15,29 +15,13 @@
  */
 package io.gravitee.am.service.exception;
 
-import io.gravitee.common.http.HttpStatusCode;
-
-/**
- * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class DictionaryAlreadyExistsException extends AbstractManagementException {
-
-    private final String name;
-    private final String locale;
-
-    public DictionaryAlreadyExistsException(String name, String locale) {
-        this.name = name;
-        this.locale = locale;
+public class InvalidLocaleException extends AbstractManagementException {
+    public InvalidLocaleException() {
+        super("Invalid locale provided");
     }
 
     @Override
     public int getHttpStatusCode() {
-        return HttpStatusCode.BAD_REQUEST_400;
-    }
-
-    @Override
-    public String getMessage() {
-        return "An i18n dictionary [" + name + "] already exists for " + locale;
+        return 400;
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/I18nDictionaryServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/I18nDictionaryServiceTest.java
@@ -35,32 +35,19 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
 import static io.gravitee.am.model.ReferenceType.DOMAIN;
 import static io.reactivex.Maybe.just;
-import static org.junit.Assert.*;
+import static java.util.Locale.ENGLISH;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 @RunWith(MockitoJUnitRunner.class)
 public class I18nDictionaryServiceTest {
 
@@ -79,9 +66,9 @@ public class I18nDictionaryServiceTest {
     public void shouldCreateEmptyDictionary() {
         var newDictionary = new NewDictionary();
         newDictionary.setName("Français");
-        newDictionary.setLocale("fr");
+        newDictionary.setLocale(Locale.FRENCH.getLanguage());
 
-        given(repository.findByName(DOMAIN, REFERENCE_ID, newDictionary.getName())).willReturn(Maybe.empty());
+        given(repository.findByLocale(DOMAIN, REFERENCE_ID, Locale.FRENCH.getLanguage())).willReturn(Maybe.empty());
         given(repository.create(any(I18nDictionary.class))).willReturn(Single.just(new I18nDictionary()));
         given(eventService.create(any())).willReturn(Single.just(new Event()));
 
@@ -115,7 +102,7 @@ public class I18nDictionaryServiceTest {
         var dictionary = new I18nDictionary();
 
         when(repository.findById(DOMAIN, REFERENCE_ID, ID)).thenReturn(just(dictionary));
-        when(repository.findByName(DOMAIN, REFERENCE_ID, updateDict.getName())).thenReturn(Maybe.empty());
+        when(repository.findByLocale(DOMAIN, REFERENCE_ID, null)).thenReturn(Maybe.empty());
         when(repository.update(any(I18nDictionary.class))).thenReturn(Single.just(dictionary));
         when(eventService.create(any())).thenReturn(Single.just(new Event()));
 
@@ -165,10 +152,10 @@ public class I18nDictionaryServiceTest {
     public void shouldFindByName() {
         var dictionary = new I18nDictionary();
         String english = "English";
-        dictionary.setName(english);
-        given(repository.findByName(eq(DOMAIN), any(), eq(english))).willReturn(just(dictionary));
+        dictionary.setLocale(ENGLISH.getLanguage());
+        given(repository.findByLocale(eq(DOMAIN), any(), eq(ENGLISH.getLanguage()))).willReturn(just(dictionary));
 
-        var observer = service.findByName(DOMAIN, "", english).test();
+        var observer = service.findByLocale(DOMAIN, "", ENGLISH.getLanguage()).test();
         observer.awaitTerminalEvent();
         observer.assertComplete();
         observer.assertNoErrors();
@@ -191,8 +178,8 @@ public class I18nDictionaryServiceTest {
 
     @Test
     public void shouldReturnTechnicalManagementExceptionWhenErrorThrownDuringFindByName() {
-        given(repository.findByName(eq(DOMAIN), any(), any())).willReturn(Maybe.error(Exception::new));
-        var observer = service.findByName(DOMAIN, REFERENCE_ID, "test").test();
+        given(repository.findByLocale(eq(DOMAIN), any(), eq(ENGLISH.getLanguage()))).willReturn(Maybe.error(Exception::new));
+        var observer = service.findByLocale(DOMAIN, REFERENCE_ID, ENGLISH.getLanguage()).test();
         observer.awaitTerminalEvent();
         observer.assertError(TechnicalManagementException.class);
     }

--- a/gravitee-am-test/specs/management/dictionaries.jest.spec.ts
+++ b/gravitee-am-test/specs/management/dictionaries.jest.spec.ts
@@ -26,6 +26,7 @@ import {
     updateDictionary,
     updateDictionaryEntries
 } from "@management-commands/dictionary-management-commands";
+import {ResponseError} from "../../api/management/runtime";
 
 global.fetch = fetch;
 
@@ -35,26 +36,21 @@ let dictionary;
 let i18nLanguages;
 beforeAll(async () => {
     i18nLanguages = [
-        {"locale": "aa", "country": "Afar"},
-        {"locale":"ab", "country": "Abkhazian"},
-        {"locale":"ae", "country": "Avestan"},
         {"locale":"af", "country": "Afrikaans"},
-        {"locale":"ak", "country": "Akan"},
-        {"locale":"am", "country": "Amharic"},
-        {"locale":"an", "country": "Aragonese"},
         {"locale":"ar", "country": "Arabic"},
-        {"locale":"as", "country": "Assamese"},
-        {"locale":"av", "country": "Avaric"},
-        {"locale":"ay", "country": "Aymara"},
         {"locale":"az", "country": "Azerbaijani"},
-        {"locale":"ba", "country": "Bashkir"},
         {"locale":"be", "country": "Belarusian"},
         {"locale":"bg", "country": "Bulgarian"},
-        {"locale":"bh", "country": "Bihari i18nLanguages"},
-        {"locale":"bi", "country": "Bislama"},
-        {"locale":"bm", "country": "Bambara"},
         {"locale":"bn", "country": "Bengali"},
-        {"locale":"bo", "country": "Tibetan"}
+        {"locale":"cy", "country": "Cymraeg"},
+        {"locale":"de", "country": "German"},
+        {"locale":"eu", "country": "Basque"},
+        {"locale":"fa", "country": "Persian"},
+        {"locale":"hr", "country": "Croatian"},
+        {"locale":"it", "country": "Italian"},
+        {"locale":"zh", "country": "Chinese"},
+        {"locale":"sv", "country": "Swedish"},
+        {"locale":"tr", "country": "Turkish"},
     ];
 
     const adminTokenResponse = await requestAdminAccessToken();
@@ -76,7 +72,7 @@ async function testCreate() {
     const i18Language = i18nLanguages.pop();
     const name = i18Language.country;
     const locale = i18Language.locale;
-    const created = await createDictionary(domain.id, accessToken, {name: name, "locale": locale})
+    const created = await createDictionary(domain.id, accessToken, {name: name, "locale": locale});
     expect(created).toBeDefined();
     expect(created.id).toBeDefined();
     expect(created.name).toEqual(name);
@@ -98,6 +94,17 @@ describe("Testing dictionaries api...", () => {
             const dictionaries = await getAllDictionaries(domain.id, accessToken);
             expect(dictionaries).toHaveLength(ids.length);
             dictionaries.forEach(value => expect(ids).toContain(value.id));
+        });
+        it('should error when attempting to create dictionary with used locale', async () => {
+            await expect(async () => {
+                const res = await createDictionary(domain.id, accessToken, {name: 'German2', "locale": 'de'});
+                console.log(res);
+            }).rejects.toThrow(ResponseError);
+        });
+        it('should error when attempting to create dictionary with invalid locale', async () => {
+            await expect(async () => {
+                await createDictionary(domain.id, accessToken, {name: 'Mumbo Jumbo', "locale": 'mj'});
+            }).rejects.toThrow(ResponseError);
         });
     });
 


### PR DESCRIPTION
## :id: 

Fixes [AM-472](https://gravitee.atlassian.net/browse/AM-472)  and [AM-471](https://gravitee.atlassian.net/browse/AM-471) 

## :pencil2: 

The dictionary service previously searched by name before any CRUD operation. I've simply changed it to search on locale instead. Also for 471 I check the requested locale against those in the JVM (Locale.getAvailableLanguages()) for validation.

## :memo: 

1. Try and create a dictionary with an existing locale using curl/postman (or attempt to create two identical dictionaries).
2. It should be rejected with a 400

1. Try and create a dictionary with an invalid locale e.g. 'xxx'
2. SHould reject with a 400

[AM-472]: https://gravitee.atlassian.net/browse/AM-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-471]: https://gravitee.atlassian.net/browse/AM-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ