### PR TITLE
chore: update gravitee-node.version to 3.0.0-alpha.3 and hazelcast to 4.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
         <gravitee-node.version>3.0.0-alpha.3</gravitee-node.version>
+        <hazelcast.version>4.1.10</hazelcast.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>1.31.2</gravitee-gateway-api.version>
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>
@@ -211,7 +212,24 @@
                 <version>${gravitee-node.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.hazelcast</groupId>
+                        <artifactId>hazelcast</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
+
+            <!-- Hazelcast
+                We do temporary upgrade HZ dependency here rather than in gravitee-node to pass security checks
+             -->
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>${hazelcast.version}</version>
+            </dependency>
+
+
             <dependency>
                 <groupId>io.gravitee.definition</groupId>
                 <artifactId>gravitee-definition-jackson</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <gravitee-bom.version>4.0.0-alpha.1</gravitee-bom.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
-        <gravitee-node.version>3.0.0-alpha.2</gravitee-node.version>
+        <gravitee-node.version>3.0.0-alpha.3</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>1.31.2</gravitee-gateway-api.version>
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>


### PR DESCRIPTION
- chore: update gravitee-node.version to 3.0.0-alpha.3
- chore: upgrade hazelcast to 4.1.10
