### PR TITLE
fix: license INFO logging level enforced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <gravitee-bom.version>2.5</gravitee-bom.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
-        <gravitee-node.version>1.24.1</gravitee-node.version>
+        <gravitee-node.version>1.27.6</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>1.31.2</gravitee-gateway-api.version>
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-506

## :pencil2: A description of the changes proposed in the pull request

This PR upgrades gravitee-node in order to disable license log level enforced to INFO

## :memo: Test scenarios 

Change your `logback.xml`and add 
`<logger name="io.gravitee.node.license.LicenseService" level="WARN" />`

You should be able to hide the license logs