### PR TITLE
fix: user is unlocked if the username is updated

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AbstractUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AbstractUserService.java
@@ -191,8 +191,7 @@ public abstract class AbstractUserService<T extends io.gravitee.am.service.Commo
                                             return updateCredentialUsername(referenceType, referenceId, oldUsername.get(), idpUser);
                                         })
                                         .flatMap(idpUser -> {
-                                            user.setUsername(username);
-                                            user.setLastUsernameReset(new Date());
+                                            user.updateUsername(username);
 
                                             // Generate a new moving factor based on user id instead of username. Necessary
                                             // since username can be changed.

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
@@ -771,4 +771,15 @@ public class User implements IUser {
         putAdditionalInformation(StandardClaims.ADDRESS, address);
     }
 
+    public void updateUsername(String username) {
+        setUsername(username);
+        setLastUsernameReset(new Date());
+        unlockUser();
+    }
+
+    public void unlockUser() {
+        setAccountNonLocked(true);
+        setAccountLockedAt(null);
+        setAccountLockedUntil(null);
+    }
 }

--- a/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.ts
@@ -127,9 +127,7 @@ export class UserProfileComponent implements OnInit {
       .subscribe(res => {
         if (res) {
           this.userService.unlock(this.domainId, this.user.id).subscribe(() => {
-            this.user.accountNonLocked = true;
-            this.user.accountLockedAt = null;
-            this.user.accountLockedUntil = null;
+            this.unlockUser(this.user);
             this.snackbarService.open('User unlocked');
           });
         }
@@ -229,9 +227,16 @@ export class UserProfileComponent implements OnInit {
         if (res) {
           this.userService.updateUsername(this.domainId, this.user.id, this.organizationContext, this.user.username).subscribe(() => {
             this.usernameForm.resetForm({ username: this.user.username });
+            this.unlockUser(this.user);
             this.snackbarService.open('Username updated');
           })
         }
       });
+  }
+
+  private unlockUser(user) {
+    user.accountNonLocked = true;
+    user.accountLockedAt = null;
+    user.accountLockedUntil = null;
   }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-385

## :pencil2: A description of the changes proposed in the pull request
Unlock the user when his username is changed

## :memo: Test scenarios 

1. Create a user
2. Enable the brut force detection at security domain level or application level (Settings -> User Accounts -> Login)
3. Try to connect with the previous user with a wrong password
4. Go to the user (Settings -> Users -> Your user)
5. The user is locked
6. Change the username
7. The user is unlocked