### PR TITLE
fix: login count and last login date not updated when user is updated

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractUserService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractUserService.java
@@ -271,8 +271,6 @@ public abstract class AbstractUserService<T extends CommonUserRepository> implem
                     }
                     oldUser.setEmail(updateUser.getEmail());
                     oldUser.setEnabled(updateUser.isEnabled());
-                    oldUser.setLoggedAt(updateUser.getLoggedAt());
-                    oldUser.setLoginsCount(updateUser.getLoginsCount());
                     if (!StringUtils.isEmpty(updateUser.getPreferredLanguage())) {
                         oldUser.setPreferredLanguage(updateUser.getPreferredLanguage());
                     }


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-453

## :pencil2: A description of the changes proposed in the pull request
Not reset login count and last login date when user data are updated

## :memo: Test scenarios 

1. Login with  a user
2. Update firstname of the user (Settings -> Users -> Your User)
3. Check that `Logins count` and `Last login` don't change (right column of the screen)
