### PR TITLE
Improve validation for dictionary create and update

### DIFF
--- a/gravitee-am-service/pom.xml
+++ b/gravitee-am-service/pom.xml
@@ -172,5 +172,10 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/DictionaryAlreadyExistsException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/DictionaryAlreadyExistsException.java
@@ -23,11 +23,10 @@ import io.gravitee.common.http.HttpStatusCode;
  */
 public class DictionaryAlreadyExistsException extends AbstractManagementException {
 
-    private final String name;
+
     private final String locale;
 
-    public DictionaryAlreadyExistsException(String name, String locale) {
-        this.name = name;
+    public DictionaryAlreadyExistsException(String locale) {
         this.locale = locale;
     }
 
@@ -38,6 +37,6 @@ public class DictionaryAlreadyExistsException extends AbstractManagementExceptio
 
     @Override
     public String getMessage() {
-        return "An i18n dictionary [" + name + "] already exists for " + locale;
+        return "An i18n dictionary already exists for " + locale;
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewDictionary.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewDictionary.java
@@ -15,12 +15,19 @@
  */
 package io.gravitee.am.service.model;
 
+import io.gravitee.am.service.validators.dictionary.ValidLocale;
+
+import javax.validation.constraints.NotBlank;
+
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class NewDictionary {
+    @NotBlank
     private String name;
+    @NotBlank
+    @ValidLocale
     private String locale;
 
     public String getName() {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateI18nDictionary.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateI18nDictionary.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.am.service.model;
 
+import io.gravitee.am.service.validators.annotations.IfNotNullThenNotBlank;
+import io.gravitee.am.service.validators.dictionary.ValidLocale;
+
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -23,7 +26,10 @@ import java.util.TreeMap;
  * @author GraviteeSource Team
  */
 public class UpdateI18nDictionary {
+    @IfNotNullThenNotBlank
     private String name;
+    @IfNotNullThenNotBlank
+    @ValidLocale
     private String locale;
     private Map<String, String> entries;
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/annotations/IfNotNullThenNotBlank.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/annotations/IfNotNullThenNotBlank.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.validators.annotations;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Constrains string properties that may be null but cannot be blank.
+ */
+@Documented
+@Constraint(validatedBy = {IfNotNullThenNotBlankValidator.class})
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+public @interface IfNotNullThenNotBlank {
+    String message() default "Empty string not valid for property";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/annotations/IfNotNullThenNotBlankValidator.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/annotations/IfNotNullThenNotBlankValidator.java
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.service.exception;
+package io.gravitee.am.service.validators.annotations;
 
-public class InvalidLocaleException extends AbstractManagementException {
-    public InvalidLocaleException() {
-        super("Invalid locale provided");
-    }
+import org.apache.commons.lang3.StringUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class IfNotNullThenNotBlankValidator implements ConstraintValidator<IfNotNullThenNotBlank, String> {
 
     @Override
-    public int getHttpStatusCode() {
-        return 400;
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value == null || StringUtils.isNotBlank(value);
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/dictionary/LocaleValidator.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/dictionary/LocaleValidator.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.validators.dictionary;
+
+import javax.annotation.Nullable;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * Validator for {@link ValidLocale}. This will let null locales pass as it is expected that those constraints will be
+ * provided by other annotations as required.
+ */
+public class LocaleValidator implements ConstraintValidator<ValidLocale, String> {
+    @Override
+    public boolean isValid(@Nullable String locale, ConstraintValidatorContext context) {
+        return locale == null || Stream.of(Locale.getAvailableLocales()).filter(l -> !isNullOrEmpty(l.getLanguage()))
+              .anyMatch(l -> l.getLanguage().equals(locale));
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/dictionary/ValidLocale.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/dictionary/ValidLocale.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.validators.dictionary;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Locale strings must be valid for the runtime JRE, i.e. the value is contained within <code>Locales.getAvailableLocales</code>
+ */
+@Documented
+@Constraint(validatedBy = {LocaleValidator.class})
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+public @interface ValidLocale {
+    String message() default "Invalid locale";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/I18nDictionaryServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/I18nDictionaryServiceTest.java
@@ -102,7 +102,7 @@ public class I18nDictionaryServiceTest {
         var dictionary = new I18nDictionary();
 
         when(repository.findById(DOMAIN, REFERENCE_ID, ID)).thenReturn(just(dictionary));
-        when(repository.findByLocale(DOMAIN, REFERENCE_ID, null)).thenReturn(Maybe.empty());
+        when(repository.findByLocale(DOMAIN, REFERENCE_ID, expectedLocale)).thenReturn(Maybe.empty());
         when(repository.update(any(I18nDictionary.class))).thenReturn(Single.just(dictionary));
         when(eventService.create(any())).thenReturn(Single.just(new Event()));
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/annotations/IfNotNullThenNotBlankValidatorTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/annotations/IfNotNullThenNotBlankValidatorTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.validators.annotations;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class IfNotNullThenNotBlankValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"blah", "_", "  test  "})
+    void isValid(String value) {
+        assertTrue(new IfNotNullThenNotBlankValidator().isValid(value, null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   "})
+    void isNotValid(String value) {
+        assertFalse(new IfNotNullThenNotBlankValidator().isValid(value, null));
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/dictionary/LocaleValidatorTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/dictionary/LocaleValidatorTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.validators.dictionary;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocaleValidatorTest {
+
+    @ParameterizedTest
+    @MethodSource("validLocales")
+    void isValid(String locale) {
+        assertTrue(new LocaleValidator().isValid(locale, null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "x", "y", "z", "123"})
+    void isNotValid(String locale) {
+        assertFalse(new LocaleValidator().isValid(locale, null));
+    }
+
+    public static Stream<String> validLocales() {
+        return Stream.of(Locale.getAvailableLocales()).map(Locale::getLanguage).filter(l -> !"".equals(l));
+    }
+}

--- a/gravitee-am-test/specs/management/dictionaries.jest.spec.ts
+++ b/gravitee-am-test/specs/management/dictionaries.jest.spec.ts
@@ -127,7 +127,7 @@ describe("Testing dictionaries api...", () => {
             dictionary = await testCreate();
             const beforeUpdate = await getDictionary(domain.id, accessToken, dictionary.id);
             let updateName = "updated name";
-            let updateLocale = "updated locale";
+            let updateLocale = "ja";
             let entries = {
                 "login.title": "Welcome"
             };


### PR DESCRIPTION
## :id: Reference related issue. 
Fixes [AM-511](https://gravitee.atlassian.net/browse/AM-511)

## :pencil2: 

Updated the DictionaryAlreadyExists exception, added an InvalidDictionaryException and added additional checks for blank name and locale (was already checking locale but "" is a valid locale in the current JRE).

[AM-511]: https://gravitee.atlassian.net/browse/AM-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ