### PR TITLE
fix: ensure gravitee-am-spring-web have sources

### DIFF
--- a/gravitee-am-spring-web/src/main/java/io/gravitee/am/springweb/package-info.java
+++ b/gravitee-am-spring-web/src/main/java/io/gravitee/am/springweb/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This empty package is here only to use a copy of org.springframework:spring-web:5.3.18
+ * and remove the HttpInvokerServiceExporter.class which is impacted by the CVE-2016-1000027.
+ */
+package io.gravitee.am.springweb;


### PR DESCRIPTION
## :pencil2: A description of the changes proposed in the pull request

When we added the gravitee-am-spring-web package with content of
org.springframework:spring-web:5.3.18 via a maven-dependency-plugin:unpack.
The deploy to maven central failed because this module doesn't have source code.
The hack on the hack here is to add a package-info.java to generate
sources and add a little doc which explain the reason.

