### PR TITLE
fix: ensure gravitee-am-spring-web have javadoc

### DIFF
--- a/gravitee-am-spring-web/src/main/java/io/gravitee/am/springweb/Dummy.java
+++ b/gravitee-am-spring-web/src/main/java/io/gravitee/am/springweb/Dummy.java
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * This empty package is here only to use a copy of org.springframework:spring-web:5.3.18
- * and remove the HttpInvokerServiceExporter.class which is impacted by the CVE-2016-1000027.
- *
- * @since 3.21.0
- * @version 3.21.0
- */
 package io.gravitee.am.springweb;
+
+/**
+ * This class exist only to not have an empty package and let generate source and javadoc.
+ */
+public class Dummy {
+}


### PR DESCRIPTION
## :pencil2: A description of the changes proposed in the pull request

When we added the gravitee-am-spring-web package with content of
org.springframework:spring-web:5.3.18 via a maven-dependency-plugin:unpack.
The deploy to maven central failed because this module doesn't have javadoc.
The hack on the hack here is to add a Dummy.java class to generate
sources and add a little doc which explain the reason.
