### PR TITLE
fix: remove changelist before install and deploy

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1013,6 +1013,7 @@ jobs:
             - run:
                 name: "Maven Test, Package, and Deploy to Gravitee's private Artifactory"
                 command: |
+                  sed -ri "s#<changelist>.*</changelist>#<changelist></changelist>#g" pom.xml
                   mvn -s /tmp/.gravitee.settings.xml -B -U -P gio-artifactory-release,gio-release clean deploy
       - when:
           condition: << parameters.dry_run>>
@@ -1020,6 +1021,7 @@ jobs:
             - run:
                 name: "Maven Test, Package and install"
                 command: |
+                  sed -ri "s#<changelist>.*</changelist>#<changelist></changelist>#g" pom.xml
                   mvn -s /tmp/.gravitee.settings.xml -B -U -P gio-artifactory-release,gio-release clean install
       - save-maven-job-cache:
           jobName: release


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/CJ-275

## :pencil2: A description of the changes proposed in the pull request

The release process doesn't persist the pom.xml changes when done manually, we then enforce the changelist before install and deploy