### PR TITLE
chore: bump minidev to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <bouncycastle.version>1.69</bouncycastle.version>
         <wiremock.version>2.6.0</wiremock.version>
         <embedded-ldap-junit.version>0.7</embedded-ldap-junit.version>
-        <json-smart.version>2.4.7</json-smart.version>
+        <json-smart.version>2.4.10</json-smart.version>
         <reactor-netty.version>1.0.15</reactor-netty.version>
         <commons-io.version>2.11.0</commons-io.version>
         <common-text.version>1.10.0</common-text.version>


### PR DESCRIPTION
This PR bumps minidev to the latest version