### PR TITLE
Update Mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
 pull_request_rules:
-  - name: Apply patches on `master`
+  - name: Apply commits on `master`
     conditions:
       - label=apply-on-master
     actions:
@@ -10,15 +10,15 @@ pull_request_rules:
           - "{{ author }}"
         body: |
           This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
+
           ----
-          
+
           {{ body }}
-          
+
           ----
           {{ cherry_pick_error }}
-        title: "{{ title }} - master"
-  - name: Apply patches on `3.21.x`
+        title: "[master] {{ title }}"
+  - name: Apply commits on `3.21.x`
     conditions:
       - label=apply-on-3-21-x
     actions:
@@ -29,15 +29,15 @@ pull_request_rules:
           - "{{ author }}"
         body: |
           This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
+
           ----
-          
+
           {{ body }}
-          
+
           ----
           {{ cherry_pick_error }}
-        title: "{{ title }} - 3.21.x"
-  - name: Apply patches on `3.20.x`
+        title: "[3.21.x] {{ title }}"
+  - name: Apply commits on `3.20.x`
     conditions:
       - label=apply-on-3-20-x
     actions:
@@ -48,15 +48,15 @@ pull_request_rules:
           - "{{ author }}"
         body: |
           This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
+
           ----
-          
+
           {{ body }}
-          
+
           ----
           {{ cherry_pick_error }}
-        title: "{{ title }} - 3.20.x"
-  - name: Apply patches on `3.19.x`
+        title: "[3.20.x] {{ title }}"
+  - name: Apply commits on `3.19.x`
     conditions:
       - label=apply-on-3-19-x
     actions:
@@ -67,15 +67,15 @@ pull_request_rules:
           - "{{ author }}"
         body: |
           This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
+
           ----
-          
+
           {{ body }}
-          
+
           ----
           {{ cherry_pick_error }}
-        title: "{{ title }} - 3.19.x"          
-  - name: Apply patches on `3.18.x`
+        title: "[3.19.x] {{ title }}"
+  - name: Apply commits on `3.18.x`
     conditions:
       - label=apply-on-3-18-x
     actions:
@@ -83,14 +83,14 @@ pull_request_rules:
         branches:
           - 3.18.x
         assignees:
-          - "{{ author }}"          
+          - "{{ author }}"
         body: |
           This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
+
           ----
-          
+
           {{ body }}
-          
+
           ----
           {{ cherry_pick_error }}
-        title: "{{ title }} - 3.18.x"
+        title: "[3.18.x] {{ title }}"


### PR DESCRIPTION
## Issue

NA

## Description

Unify Mergify config between AM and APIM

- Use copy action instead of backport (it looks to be the same thing under the hood)
- Put the branch name as a prefix in the PR name

For APIM: https://github.com/gravitee-io/gravitee-api-management/pull/3602