### PR TITLE
feat: MongoDB username with case handled

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
@@ -63,4 +63,8 @@ public abstract class MongoAbstractProvider implements InitializingBean {
         }
         this.mongoClient = this.clientWrapper.getClient();
     }
+    protected String getEncodedUsername(String username) {
+        return this.configuration.isUsernameCaseSensitive() ? username : username.toLowerCase();
+    }
+
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoIdentityProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoIdentityProviderConfiguration.java
@@ -49,6 +49,8 @@ public class MongoIdentityProviderConfiguration implements IdentityProviderConfi
 
     private boolean userProvider = true;
 
+    private boolean usernameCaseSensitive = false;
+
     @Override
     public boolean userProvider() {
         return this.userProvider;
@@ -208,5 +210,13 @@ public class MongoIdentityProviderConfiguration implements IdentityProviderConfi
 
     public void setPasswordSaltLength(Integer passwordSaltLength) {
         this.passwordSaltLength = passwordSaltLength;
+    }
+
+    public boolean isUsernameCaseSensitive() {
+        return usernameCaseSensitive;
+    }
+
+    public void setUsernameCaseSensitive(boolean usernameCaseSensitive) {
+        this.usernameCaseSensitive = usernameCaseSensitive;
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProvider.java
@@ -78,7 +78,7 @@ public class MongoAuthenticationProvider extends MongoAbstractProvider implement
     }
 
     public Maybe<User> loadUserByUsername(Authentication authentication) {
-        String username = ((String) authentication.getPrincipal()).toLowerCase();
+        String username = getEncodedUsername(((String) authentication.getPrincipal()));
         return findUserByMultipleField(username)
                 .toList()
                 .flatMapPublisher(users -> {
@@ -139,14 +139,15 @@ public class MongoAuthenticationProvider extends MongoAbstractProvider implement
     }
 
     public Maybe<User> loadUserByUsername(String username) {
-        final String encodedUsername = username.toLowerCase();
+        final String encodedUsername = getEncodedUsername(username);
         return findUserByUsername(encodedUsername)
                 .map(document -> createUser(new SimpleAuthenticationContext(), document));
     }
 
-    private Maybe<Document> findUserByUsername(String username) {
-        MongoCollection<Document> usersCol = this.mongoClient.getDatabase(this.configuration.getDatabase()).getCollection(this.configuration.getUsersCollection());
-        String rawQuery = this.configuration.getFindUserByUsernameQuery().replaceAll("\\?", username);
+    private Maybe<Document> findUserByUsername(String encodedUsername) {
+        MongoCollection<Document> usersCol = this.mongoClient.getDatabase(this.configuration.getDatabase())
+            .getCollection(this.configuration.getUsersCollection());
+        String rawQuery = this.configuration.getFindUserByUsernameQuery().replaceAll("\\?", encodedUsername);
         String jsonQuery = convertToJsonString(rawQuery);
         BsonDocument query = BsonDocument.parse(jsonQuery);
         return Observable.fromPublisher(usersCol.find(query).first()).firstElement();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
@@ -118,6 +118,12 @@
       "default": true,
       "title": "Allow CRUD operations",
       "description": "When enable, the user profile provided by the identity provider can be managed (CRUD operations)"
+    },
+    "usernameCaseSensitive" : {
+      "type" : "boolean",
+      "title": "Handle username with sensitive case",
+      "description": "The case of the username to create, authenticate and search for the user (applies both to findUserByUsername and findUserByMultipleFields). Default is false",
+      "default": false
     }
   },
   "required": [

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProviderTestConfiguration.java
@@ -48,9 +48,10 @@ public class MongoAuthenticationProviderTestConfiguration implements Initializin
                 new Document("username", "bob").append("password", "bobspassword"),
                 new Document("username", "user01").append("email", "user01@acme.com").append("password", "user01"),
                 new Document("username", "user02").append("email", "common@acme.com").append("password", "user02"),
-                new Document("username", "user03").append("email", "common@acme.com").append("password", "user03")
+                new Document("username", "user03").append("email", "common@acme.com").append("password", "user03"),
+                new Document("username", "UserWithCase").append("email", "userwithcase@acme.com").append("password", "UserWithCase")
         );
-        users.stream().forEach(doc -> Observable.fromPublisher(collection.insertOne(doc)).blockingFirst());
+        users.forEach(doc -> Observable.fromPublisher(collection.insertOne(doc)).blockingFirst());
     }
 
     @Bean
@@ -62,7 +63,6 @@ public class MongoAuthenticationProviderTestConfiguration implements Initializin
         configuration.setDatabase("test-idp-mongo");
         configuration.setUsersCollection("users");
         configuration.setFindUserByUsernameQuery("{username: ?}");
-        configuration.setFindUserByMultipleFieldsQuery("{ $or : [{username: ?}, {email: ?}]}");
         configuration.setPasswordField("password");
         configuration.setPasswordEncoder(PasswordEncoder.NONE);
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTest.java
@@ -15,14 +15,20 @@
  */
 package io.gravitee.am.identityprovider.mongo.user;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.identityprovider.api.UserProvider;
+import io.gravitee.am.identityprovider.mongo.MongoIdentityProviderConfiguration;
 import io.gravitee.am.identityprovider.mongo.authentication.spring.MongoAuthenticationProviderConfiguration;
 import io.gravitee.common.util.Maps;
 import io.reactivex.observers.TestObserver;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,20 +43,55 @@ import java.util.HashMap;
  * @author GraviteeSource Team
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { MongoUserProviderTestConfiguration.class, MongoAuthenticationProviderConfiguration.class }, loader = AnnotationConfigContextLoader.class)
+@ContextConfiguration(classes = {
+    MongoUserProviderTestConfiguration.class,
+    MongoAuthenticationProviderConfiguration.class
+}, loader = AnnotationConfigContextLoader.class)
 public class MongoUserProviderTest {
 
     @Autowired
     private UserProvider userProvider;
 
+    @Autowired
+    private MongoIdentityProviderConfiguration configuration;
+
+    @Before
+    public void setup(){
+        configuration.setUsernameCaseSensitive(false);
+    }
+
     @Test
     public void shouldSelectUserByUsername() {
-        TestObserver<User> testObserver = userProvider.findByUsername("bob").test();
+        TestObserver<User> testObserver = userProvider.findByUsername("BoB").test();
         testObserver.awaitTerminalEvent();
 
         testObserver.assertComplete();
         testObserver.assertNoErrors();
-        testObserver.assertValue(u -> "bob".equals(u.getUsername()));
+        testObserver.assertValue(u -> "BoB".toLowerCase().equals(u.getUsername()));
+    }
+
+    @Test
+    public void shouldSelectUserByUsername_caseInsensitive() {
+        configuration.setUsernameCaseSensitive(true);
+
+        TestObserver<User> testObserver = userProvider.findByUsername("UserWithCase").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> "UserWithCase".equals(u.getUsername()));
+    }
+
+    @Test
+    public void shouldNotSelectUserByUsername_caseInsensitive() {
+        configuration.setUsernameCaseSensitive(true);
+
+        TestObserver<User> testObserver = userProvider.findByUsername("BoB").test();
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertNoValues();
     }
 
     @Test
@@ -75,6 +116,8 @@ public class MongoUserProviderTest {
 
     @Test
     public void shouldNotSelectUserByUsername_userNotFound() {
+        configuration.setUsernameCaseSensitive(false);
+
         TestObserver<User> testObserver = userProvider.findByUsername("unknown").test();
         testObserver.awaitTerminalEvent();
 
@@ -92,8 +135,9 @@ public class MongoUserProviderTest {
     }
 
     @Test
-    public void shouldCreateUser() {
-        DefaultUser user = createUserBean();
+    public void shouldCreateUser_insensitiveCase() {
+        final String usernameWithCase = "UsernameWithCase";
+        DefaultUser user = createUserBean(usernameWithCase);
         TestObserver<User> testObserver = userProvider.create(user).test();
 
         testObserver.awaitTerminalEvent();
@@ -101,6 +145,22 @@ public class MongoUserProviderTest {
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValue(u -> assertUserMatch(user, u));
+        testObserver.assertValue(u -> u.getUsername().equals(usernameWithCase.toLowerCase()));
+    }
+
+    @Test
+    public void shouldCreateUser_sensitiveCase() {
+        configuration.setUsernameCaseSensitive(true);
+        final String usernameWithCase = "UsernameWithCase";
+        DefaultUser user = createUserBean(usernameWithCase);
+        TestObserver<User> testObserver = userProvider.create(user).test();
+
+        testObserver.awaitTerminalEvent();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(u -> assertUserMatch(user, u));
+        testObserver.assertValue(u -> u.getUsername().equals(usernameWithCase));
     }
 
     @Test
@@ -179,18 +239,23 @@ public class MongoUserProviderTest {
     }
 
     private boolean assertUserMatch(DefaultUser expectedUser, User testableUser) {
-        Assert.assertTrue(expectedUser.getUsername().equals(testableUser.getUsername()));
-        Assert.assertTrue(expectedUser.getEmail().equals(testableUser.getEmail()));
-        Assert.assertTrue(expectedUser.getFirstName().equals(testableUser.getFirstName()));
-        Assert.assertTrue(expectedUser.getLastName().equals(testableUser.getLastName()));
-        Assert.assertTrue(testableUser.getAdditionalInformation() != null);
-        Assert.assertTrue(testableUser.getAdditionalInformation().containsKey("key")
+        final String username = configuration.isUsernameCaseSensitive() ? expectedUser.getUsername()
+            : expectedUser.getUsername().toLowerCase();
+        assertEquals(username, testableUser.getUsername());
+        assertEquals(expectedUser.getEmail(), testableUser.getEmail());
+        assertEquals(expectedUser.getFirstName(), testableUser.getFirstName());
+        assertEquals(expectedUser.getLastName(), testableUser.getLastName());
+        assertNotNull(testableUser.getAdditionalInformation());
+        assertTrue(testableUser.getAdditionalInformation().containsKey("key")
                 && "value".equals(testableUser.getAdditionalInformation().get("key")));
         return true;
     }
 
     private DefaultUser createUserBean() {
-        final String username = RandomString.generate();
+       return createUserBean(RandomString.generate());
+    }
+
+    private DefaultUser createUserBean(String username) {
         DefaultUser user = new DefaultUser();
         user.setEmail(username+"@acme.com");
         user.setUsername(username);
@@ -198,9 +263,9 @@ public class MongoUserProviderTest {
         user.setLastName("L-"+username);
         user.setCredentials("T0pS3cret");
         user.setAdditionalInformation(new Maps.MapBuilder(new HashMap()).put("key", "value")
-                .put("email", user.getEmail())
-                .put("given_name", user.getFirstName())
-                .put("family_name", user.getLastName()).build()
+            .put("email", user.getEmail())
+            .put("given_name", user.getFirstName())
+            .put("family_name", user.getLastName()).build()
         );
         return user;
     }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
@@ -57,6 +57,8 @@ public class MongoUserProviderTestConfiguration implements InitializingBean {
         Observable.fromPublisher(collection.insertOne(doc2)).blockingFirst();
         Document doc3 = new Document("username", "user02").append("email", "user02@acme.com").append("alternative_email", "user02-alt@acme.com").append("password", "user02").append("_id", UUID.randomUUID().toString());
         Observable.fromPublisher(collection.insertOne(doc3)).blockingFirst();
+        Document doc4 = new Document("username", "UserWithCase").append("email", "user02@acme.com").append("alternative_email", "user02-alt@acme.com").append("password", "user02").append("_id", UUID.randomUUID().toString());
+        Observable.fromPublisher(collection.insertOne(doc4)).blockingFirst();
     }
 
     @Bean


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-528

## :pencil2: A description of the changes proposed in the pull request

This PR brings an option to the MongoDB idp : `Handle username with sensitive case`

## :memo: Test scenarios 

- Create a MongoIDP  with the collection name of your choice (`my_users_idp` for instance)
- Activate the option `Handle username with sensitive case`
- Create 2 users with the same username but different cases
- Create 2 users with the same username but with different cases within the same Mongo IDP
- You should have 2 users in the collections as well as in the AM `users` collection
- Try to authenticate with these users by initiating the login flow of you application
- Both users should connect independently

![image](https://user-images.githubusercontent.com/8531515/232804222-b076d0e0-6d66-4f86-bc1f-bd9008af1920.png)

![image](https://user-images.githubusercontent.com/8531515/232803999-bb7eed97-d059-4c35-8fa4-0ed2603af84a.png)

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 

If duplicates exists with different cases and this option is activated, it may lead to inconsistencies

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 
