### PR TITLE
fix: audit log sort is broken

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/audits/audits.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/audits/audits.component.html
@@ -108,7 +108,7 @@
         </ng-template>
       </ngx-datatable-row-detail>
       <!-- Column Templates -->
-      <ngx-datatable-column *hasPermission="[requiredReadPermission]">
+      <ngx-datatable-column [sortable]='false' *hasPermission="[requiredReadPermission]">
         <ng-template let-row="row" let-expanded="expanded" ngx-datatable-cell-template>
           <a class="expanded"
             href="javascript:void(0)"
@@ -119,29 +119,29 @@
           </a>
         </ng-template>
       </ngx-datatable-column>
-      <ngx-datatable-column name="Date" [flexGrow]="2">
+      <ngx-datatable-column [sortable]='true' name="Date" [flexGrow]="2"  prop="timestamp">
         <ng-template let-row="row" ngx-datatable-cell-template>
           {{row.timestamp | date:'medium'}}
         </ng-template>
       </ngx-datatable-column>
-      <ngx-datatable-column name="Event" [flexGrow]="2">
+      <ngx-datatable-column [sortable]='true' name="Event" [flexGrow]="2" prop="type">
         <ng-template let-row="row" ngx-datatable-cell-template>
           <pre style="margin: 0;">{{row.type}}</pre>
         </ng-template>
       </ngx-datatable-column>
-      <ngx-datatable-column name="Actor" [flexGrow]="2">
+      <ngx-datatable-column [sortable]='true' name="Actor" [flexGrow]="2" prop="actor.sortDisplayName">
         <ng-template let-row="row" ngx-datatable-cell-template>
           <span *ngIf="isUnknownActor(row)">{{row.actor?.alternativeId}}</span>
           <a *ngIf="!isUnknownActor(row) && hasActorUrl(row)" [routerLink]="getActorUrl(row)">{{row.actor?.displayName}} | <small>{{row.actor?.alternativeId}}</small></a>
           <span *ngIf="!isUnknownActor(row) && !hasActorUrl(row)">{{row.actor?.displayName}} | <small>{{row.actor?.alternativeId}}</small></span>
         </ng-template>
       </ngx-datatable-column>
-      <ngx-datatable-column name="Target" [flexGrow]="2">
+      <ngx-datatable-column [sortable]='true' name="Target" [flexGrow]="2" prop="target.sortDisplayName">
         <ng-template let-row="row" ngx-datatable-cell-template>
-          <a *ngIf="row.target" [routerLink]="getTargetUrl(row)" [queryParams]="getTargetParams(row)">{{row.target?.displayName}} <span *ngIf="row.target.alternativeId">| <small>{{row.target?.alternativeId}}</small></span></a>
+          <a *ngIf="row.target" [routerLink]="getTargetUrl(row)" [queryParams]="getTargetParams(row)">{{row.target?.displayName}}<span *ngIf="row.target.alternativeId"> | <small>{{row.target?.alternativeId}}</small></span></a>
         </ng-template>
       </ngx-datatable-column>
-      <ngx-datatable-column name="Status" [flexGrow]="1">
+      <ngx-datatable-column [sortable]='true' name="Status" [flexGrow]="1" prop="outcome.status">
         <ng-template let-row="row" ngx-datatable-cell-template>
           <mat-chip-list>
             <mat-chip style="font-size: 10px; line-height: 4px; margin: 0px;" [color]="row.outcome?.status === 'SUCCESS'? 'primary':'warn'" selected>
@@ -150,7 +150,7 @@
           </mat-chip-list>
         </ng-template>
       </ngx-datatable-column>
-      <ngx-datatable-column name="Actions" [flexGrow]="1" *hasPermission="[requiredReadPermission]">
+      <ngx-datatable-column [sortable]='false' name="Actions" [flexGrow]="1" *hasPermission="[requiredReadPermission]">
         <ng-template let-row="row" ngx-datatable-cell-template>
           <div fxLayout="row" class="gv-table-cell-actions">
             <a mat-icon-button [routerLink]="[row.id]"><mat-icon matTooltip="More info">more_horiz</mat-icon></a>


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-162

## :pencil2: A description of the changes proposed in the pull request

This PR fixes the audit log sort

## :memo: Test scenarios 

Try clicking on the sortable columns in the audit logs

## :computer: Add screenshots for UI
At organization level

<img width="1763" alt="image" src="https://user-images.githubusercontent.com/8531515/233040803-8547e551-8049-41d6-ba9b-a54e009b873c.png">

At domain level
<img width="1395" alt="image" src="https://user-images.githubusercontent.com/8531515/233041011-bf8f6feb-057e-47c3-8719-04206f5157bb.png">
