### PR TITLE
fix: set FakeSMTP to supported version

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -351,8 +351,8 @@ jobs:
       - run:
           name: Start FakeSMTP
           command: |
-            docker pull gessnerfl/fake-smtp-server
-            docker run -d --rm -p 5080:5080 -p 5025:5025 gessnerfl/fake-smtp-server
+            docker pull gessnerfl/fake-smtp-server:1.10.4
+            docker run -d --rm -p 5080:5080 -p 5025:5025 gessnerfl/fake-smtp-server:1.10.4
       - run:
           name: Wait services bootstrap
           command: |
@@ -414,8 +414,8 @@ jobs:
       - run:
           name: Start FakeSMTP
           command: |
-            docker pull gessnerfl/fake-smtp-server
-            docker run -d --rm -p 5080:5080 -p 5025:5025 gessnerfl/fake-smtp-server
+            docker pull gessnerfl/fake-smtp-server:1.10.4
+            docker run -d --rm -p 5080:5080 -p 5025:5025 gessnerfl/fake-smtp-server:1.10.4
       - run:
           name: Wait services bootstrap
           command: |


### PR DESCRIPTION
This PR fixes the FakeSMTP version for 3.18.x
It has been applied through other PRs but this one escaped the FakeSMTP 2.0 change