### PR TITLE
[WIP] Add changelog for new 3.18.18 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,25 @@
 # Change Log
 
+==  - 3.18.18 (2023-04-24)
+
+=== Gateway
+
+* Do not display default "Internal Server Error" page https://github.com/gravitee-io/issues/issues/9000[#9000]
+* SCIM - additionalInformation entries are lost when using PATCH method https://github.com/gravitee-io/issues/issues/null[#null]
+
+=== Management API
+
+
+
+=== Console
+
+* Audit Log sort is broken https://github.com/gravitee-io/issues/issues/null[#null]
+
+=== Other
+
+* Mongodb: long running server side queries cause outage https://github.com/gravitee-io/issues/issues/8910[#8910]
+
+
 
 == https://github.com/gravitee-io/issues/milestone/664?closed=1[AM - 3.20.4 (2023-04-17)]
 


### PR DESCRIPTION
# New version 3.18.18 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.18.18/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.18.18 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.18.18%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
