### PR TITLE
chore: upgrade console image base to graviteeio/nginx:1.24

### DIFF
--- a/docker/management-ui/Dockerfile
+++ b/docker/management-ui/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx:1.23
+FROM graviteeio/nginx:1.24
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0

--- a/docker/management-ui/Dockerfile-dev
+++ b/docker/management-ui/Dockerfile-dev
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM graviteeio/nginx:1.23
+FROM graviteeio/nginx:1.24
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0

--- a/docker/management-ui/Dockerfile-nightly
+++ b/docker/management-ui/Dockerfile-nightly
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM graviteeio/nginx:1.23
+FROM graviteeio/nginx:1.24
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-557

## :pencil2: A description of the changes proposed in the pull request

This upgrade bumps the console to latest Docker image dependencies