### PR TITLE
fix: propagate error when it is SendChallengeException

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
@@ -157,6 +157,8 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
             final io.gravitee.am.model.User endUser = ((io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User) routingContext.user().getDelegate()).getUser();
             final Factor factor = getFactor(routingContext, client, endUser);
             final String error = routingContext.request().getParam(ConstantKeys.ERROR_PARAM_KEY);
+            final String errorDescription = routingContext.request().getParam(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY);
+            final String errorCode = routingContext.request().getParam(ConstantKeys.ERROR_CODE_PARAM_KEY);
 
             // prepare context
             final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
@@ -173,6 +175,8 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
 
             routingContext.put(ConstantKeys.ACTION_KEY, action);
             routingContext.put(ConstantKeys.ERROR_PARAM_KEY, error);
+            routingContext.put(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, errorDescription);
+            routingContext.put(ConstantKeys.ERROR_CODE_PARAM_KEY, errorCode);
             //Include deviceId, so we can show/hide the "save my device" checkbox
             var deviceId = routingContext.session().get(ConstantKeys.DEVICE_ID);
             if (deviceId != null) {
@@ -186,7 +190,7 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
             final FactorProvider factorProvider = factorManager.get(factor.getId());
             // send challenge
             sendChallenge(factorProvider, routingContext, factor, endUser, resChallenge -> {
-                if (resChallenge.failed()) {
+                if (resChallenge.failed() && error == null) {
                     logger.error("An error has occurred when sending MFA challenge", resChallenge.cause());
                     routingContext.fail(resChallenge.cause());
                     return;
@@ -342,8 +346,7 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
         }
 
         EnrolledFactor enrolledFactor = getEnrolledFactor(routingContext, factorProvider, factor, endUser);
-        Map<String, Object> factorData = new HashMap<>();
-        factorData.putAll(getEvaluableAttributes(routingContext));
+        Map<String, Object> factorData = new HashMap<>(getEvaluableAttributes(routingContext));
         factorData.put(FactorContext.KEY_CLIENT, routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY));
         factorData.put(KEY_USER, endUser);
         factorData.put(FactorContext.KEY_REQUEST, new EvaluableRequest(new VertxHttpServerRequest(routingContext.request().getDelegate())));
@@ -591,17 +594,15 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
     private boolean enableAlternateMFAOptions(Client client, io.gravitee.am.model.User endUser) {
         if (endUser.getFactors() == null || endUser.getFactors().size() <= 1) {
             return false;
-        } else if (client.getFactors() == null || client.getFactors().size() <= 1) {
-            return false;
-        } else {
-            final Set<String> clientFactorIds = client.getFactors();
-            final List<EnrolledFactor> activeEnrolledFactors = endUser.getFactors()
-                    .stream()
-                    .filter(enrolledFactor -> factorManager.get(enrolledFactor.getFactorId()) != null)
-                    .filter(enrolledFactor -> clientFactorIds.contains(enrolledFactor.getFactorId()))
-                    .collect(Collectors.toList());
-
-            return activeEnrolledFactors.size() > 1;
         }
+        if (client.getFactors() == null || client.getFactors().size() <= 1) {
+            return false;
+        }
+        final Set<String> clientFactorIds = client.getFactors();
+        return endUser.getFactors()
+                .stream()
+                .filter(enrolledFactor -> factorManager.get(enrolledFactor.getFactorId()) != null)
+                .filter(enrolledFactor -> clientFactorIds.contains(enrolledFactor.getFactorId()))
+                .count() > 1L;
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeFailureHandler.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.root.resources.endpoint.mfa;
 
 import com.google.common.net.HttpHeaders;
+import io.gravitee.am.common.exception.mfa.SendChallengeException;
 import io.gravitee.am.common.oidc.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.common.web.UriBuilder;
@@ -51,14 +52,19 @@ public class MFAChallengeFailureHandler extends AbstractErrorHandler {
 
     @Override
     public void doHandle(RoutingContext routingContext) {
-        Throwable throwable = routingContext.failure();
-        handleException(routingContext, throwable == null ? "MFA Challenge failed for unexpected reason" : throwable.getMessage());
+        handleException(routingContext, routingContext.failure());
     }
 
-    private void handleException(RoutingContext context, String errorDescription) {
-        logoutUser(context);
+    private void handleException(RoutingContext context, Throwable throwable) {
+        String errorDescription = throwable == null ? "MFA Challenge failed for unexpected reason" : throwable.getMessage();
         final MultiMap queryParams = updateQueryParams(context, errorDescription);
-        final String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true);
+        String uri;
+        if (throwable instanceof SendChallengeException) {
+            uri =  UriBuilderRequest.resolveProxyRequest(context.request(), context.request().uri(), queryParams, true);
+        } else {
+            logoutUser(context);
+            uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true);
+        }
 
         doRedirect(context.response(), uri);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpointTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.root.resources.endpoint.mfa;
 
+import io.gravitee.am.common.exception.mfa.SendChallengeException;
 import io.gravitee.am.common.factor.FactorSecurityType;
 import io.gravitee.am.common.factor.FactorType;
 import io.gravitee.am.common.utils.ConstantKeys;
@@ -94,7 +95,6 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
 
         localSessionStore = LocalSessionStore.create(vertx);
         router.route("/mfa/challenge")
@@ -195,4 +195,113 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
     }
+
+    @Test
+    public void shouldRedirectToMfaChallenge_errorCouldNotSendCode() throws Exception {
+        FactorProvider factorProvider = mock(FactorProvider.class);
+        when(factorProvider.needChallengeSending()).thenReturn(true);
+        Factor factor = mock(Factor.class);
+        when(factor.getId()).thenReturn("factorId");
+        when(factor.is(FactorType.FIDO2)).thenReturn(false);
+        when(factorManager.get("factorId")).thenReturn(factorProvider);
+        when(factorManager.getFactor("factorId")).thenReturn(factor);
+        when(factorProvider.sendChallenge(any())).thenReturn(Completable.error(new SendChallengeException("Could not send code")));
+
+      router.route(HttpMethod.GET, "/mfa/challenge")
+          .handler(ctx -> {
+              User user = createUser();
+              Client client = new Client();
+              client.setFactors(Collections.singleton("factorId"));
+              ctx.setUser(io.vertx.reactivex.ext.auth.User.newInstance(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(user)));
+              ctx.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+              ctx.next();
+          })
+          .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService, factorService))
+          .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService));
+
+      testRequest(
+          HttpMethod.GET,
+          "/mfa/challenge",
+          req -> {},
+          resp -> {
+            String location = resp.headers().get("location");
+            assertNotNull(location);
+            assertTrue(location.contains("/mfa/challenge?error=mfa_challenge_failed&error_code=send_challenge_failed&error_description=Could+not+send+code"));
+          },
+          HttpStatusCode.FOUND_302, "Found", null);
+    }
+
+  @Test
+  public void shouldRedirectToError_unexpectedError() throws Exception {
+    FactorProvider factorProvider = mock(FactorProvider.class);
+    when(factorProvider.needChallengeSending()).thenReturn(true);
+    Factor factor = mock(Factor.class);
+    when(factor.getId()).thenReturn("factorId");
+    when(factor.is(FactorType.FIDO2)).thenReturn(false);
+    when(factorManager.get("factorId")).thenReturn(factorProvider);
+    when(factorManager.getFactor("factorId")).thenReturn(factor);
+    when(factorProvider.sendChallenge(any())).thenReturn(Completable.error(new IllegalArgumentException("Unexpected Error")));
+
+    router.route(HttpMethod.GET, "/mfa/challenge")
+        .handler(ctx -> {
+          User user = createUser();
+          Client client = new Client();
+          client.setFactors(Collections.singleton("factorId"));
+          ctx.setUser(io.vertx.reactivex.ext.auth.User.newInstance(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(user)));
+          ctx.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+          ctx.next();
+        })
+        .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService, factorService))
+        .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService));
+
+    testRequest(
+        HttpMethod.GET,
+        "/mfa/challenge",
+        req -> {},
+        resp -> {
+          String location = resp.headers().get("location");
+          assertNotNull(location);
+          assertTrue(location.contains("/error?error=server_error&error_description=Unexpected+error+occurred"));
+        },
+        HttpStatusCode.FOUND_302, "Found", null);
+  }
+
+  @Test
+  public void shouldRedirectToError_userNotPresentMFASendChallenge() throws Exception {
+    router.route(HttpMethod.GET, "/mfa/challenge")
+        .handler(ctx -> {
+          Client client = new Client();
+          client.setFactors(Collections.singleton("factorId"));
+          ctx.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+          ctx.next();
+        })
+        .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService, factorService))
+        .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService));
+
+    testRequest(
+        HttpMethod.GET,
+        "/mfa/challenge",
+        req -> {},
+        resp -> {
+          String location = resp.headers().get("location");
+          assertNotNull(location);
+          System.out.println(location);
+          assertTrue(location.contains("/login?error=mfa_challenge_failed&error_code=send_challenge_failed&error_description=MFA+Challenge+failed+for+unexpected+reason"));
+        },
+        HttpStatusCode.FOUND_302, "Found", null);
+  }
+  private static User createUser() {
+      User user = new User();
+      user.setId("userId");
+      createUserFactor(user);
+      return user;
+  }
+
+  private static void createUserFactor(User user) {
+      EnrolledFactor enrolledFactor = new EnrolledFactor();
+      EnrolledFactorSecurity enrolledFactorSecurity = new EnrolledFactorSecurity();
+      enrolledFactor.setFactorId("factorId");
+      enrolledFactor.setSecurity(enrolledFactorSecurity);
+      user.setFactors(Collections.singletonList(enrolledFactor));
+  }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-552


This PR allows to redirect to MFA challenge even if there was a code send exception
