### PR TITLE
chore: Add changelog for new 3.20.5 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,14 +1,6 @@
 # Change Log
 
-==  - 3.20.5 (2023-05-02)
-
-== What's new !
-
-
-
-=== Gateway
-
-
+== AM - 3.20.5 (2023-05-02)
 
 === Management API
 


### PR DESCRIPTION

# New version 3.20.5 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.20.5/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.20.5 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.20.5%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
