### PR TITLE
chore: Add changelog for new 3.21.0 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -9,11 +9,7 @@
 * Passwordless - enforce webauthn devices control
 * Passwordless - enforce password usage
 * Manage MFA factors that use username as SEED
-* Delete loginAttempts for brute force when username is changed
-* Provide option to logout/make all tokens/sessions invalid when username is changed
-* Update username in view for Group Members
-* [console] Change username UI
-* [management] Change username Management API
+* Management - Change Username
 * CORS configuration on Security Domain level
 * [management-ui] [menu unification] integrate the gio-sub-menu component
 


### PR DESCRIPTION

# New version 3.21.0 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.0/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.0 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.0%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
