### PR TITLE
chore: Add changelog for new 3.18.19 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,12 @@
 # Change Log
 
+== AM - 3.18.19 (2023-05-26)
+
+=== Management API
+
+* Users can't logged in after inline-idp update
+
+
 == AM - 3.21.0 (2023-05-25)
 
 == What's new !


### PR DESCRIPTION

# New version 3.18.19 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.18.19/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.18.19 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.18.19%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
