### PR TITLE
fix: webAuthn post login flow does not contain webAuthnCredentialId

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnLoginHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnLoginHandler.java
@@ -36,6 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.thymeleaf.util.StringUtils;
 
+import static io.gravitee.am.common.utils.ConstantKeys.WEBAUTHN_CREDENTIAL_ID_CONTEXT_KEY;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -181,9 +183,10 @@ public class WebAuthnLoginHandler extends WebAuthnHandler {
                                 return;
                             }
                             final User user = h.result();
-                            // save the user into the context
+                            // save the user and credential id into the context
                             ctx.getDelegate().setUser(user);
                             ctx.put(ConstantKeys.USER_CONTEXT_KEY, ((io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User) user).getUser());
+                            ctx.put(WEBAUTHN_CREDENTIAL_ID_CONTEXT_KEY, credentialId);
                             // the user has upgraded from unauthenticated to authenticated
                             // session should be upgraded as recommended by owasp
                             session.regenerateId();


### PR DESCRIPTION
Added webAuthnCredentialId is added in the application context.

**How to test**

1. Enable Passwordless from "Settings -> Login"
2. Add a HTTP Callout to Post Login flow (he policy doesn't have to be HTTP Callout, any other suitable policy is fine as well).
3. Add "{#context.attributes['webAuthnCredentialId']}" in the HTTP Callout body
4. Now register the user with Passwordless authentication.
5. User Passwordless login.
6. This should post the webAuthnCredentialId in the HTTP Callout body.

