### PR TITLE
chore: Add changelog for new 3.20.7 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,19 @@
 # Change Log
 
+== AM - 3.20.7 (2023-06-08)
+
+=== Gateway
+
+* [gateway][mfa] Allow OTP factor to handle clock drift issues https://github.com/gravitee-io/issues/issues/9074[#9074]
+* [gateway][audit] It is impossible to see the user that consented the user consent in the audit log https://github.com/gravitee-io/issues/issues/9049[#9049]
+* WebAuthn post login flow does not contain webAuthnCredentialId
+
+=== Other
+
+* [policies] allow Enrich User Profile policy to accept objects as new claims
+* Column messages in i18n_dictionary_entries  table has too little characters
+
+
 == AM - 3.19.13 (2023-06-08)
 
 === Gateway


### PR DESCRIPTION

# New version 3.20.7 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.20.7/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.20.7 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.20.7%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
