### PR TITLE
fix: match templates and ui to figma

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -42,7 +42,7 @@ email.registration_verify.subject=New user registration
 email.registration_verify.header.title=Hello {0}, welcome to {1}.
 email.registration_verify.header.description=To complete your registration, simply confirm that we have the correct email address. If you didn't create this account, you can ignore this message.
 email.registration_verify.button=Complete registration
-email.registration_verify.description=This link will expire in {0,number,integer} {1}. After that, you must submit a new request to your administrator to resend a new account activation email.
+email.registration_verify.description=This link will expire in {0,number,integer} {1}. After that, you must contact your administrator to resend a new account activation email.
 
 forgot_password.title=Change your password
 forgot_password.description=We'll send you reset instructions

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/registration_verify.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/registration_verify.html
@@ -43,8 +43,8 @@
                 <span th:unless="${error == 'registration_verify_link_expired'}" th:text="#{registration_verify.error.title}"/>
             </div>
             <div class="header-description">
-                <span th:if="${error == 'registration_verify_link_expired'}" class="medium-font grey regular" th:text="#{registration_verify.link.expired.description}"></span>
-                <span th:unless="${error == 'registration_verify_link_expired'}"  class="medium-font grey regular" th:text="#{registration_verify.error.description}"/>
+                <span th:if="${error == 'registration_verify_link_expired'}" class="grey regular" th:text="#{registration_verify.link.expired.description}"></span>
+                <span th:unless="${error == 'registration_verify_link_expired'}"  class="grey regular" th:text="#{registration_verify.error.description}"/>
             </div>
         </div>
         <div th:unless="${error == 'registration_verify_link_expired'}" class="item error-text">

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -42,7 +42,7 @@ email.registration_verify.subject=New user registration
 email.registration_verify.header.title=Hello {0}, welcome to {1}.
 email.registration_verify.header.description=To complete your registration, simply confirm that we have the correct email address. If you didn't create this account, you can ignore this message.
 email.registration_verify.button=Complete registration
-email.registration_verify.description=This link will expire in {0,number,integer} {1}. After that, you must submit a new request to your administrator to resend a new account activation email.
+email.registration_verify.description=This link will expire in {0,number,integer} {1}. After that, you must contact your administrator to resend a new account activation email.
 
 forgot_password.title=Change your password
 forgot_password.description=We'll send you reset instructions

--- a/gravitee-am-ui/src/app/domain/components/account/account-settings.component.html
+++ b/gravitee-am-ui/src/app/domain/components/account/account-settings.component.html
@@ -176,7 +176,7 @@
           <mat-slide-toggle
             (change)="enableSendVerifyRegistrationAccountEmail($event)"
             [checked]="isSendVerifyRegistrationAccountEmail()" [disabled]="readonly">
-            Account Verification via email
+            Account verification via email
           </mat-slide-toggle>
           <mat-hint style="font-size: 75%;">Once a user has registered, automatically send them an email with an account registration link.</mat-hint>
         </div>


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-600
https://gravitee.atlassian.net/browse/AM-603

## :pencil2: A description of the changes proposed in the pull request

- Fixes the UI typos and design to match the one proposed in Figma

ps: we don't handle the pluralize as this might break previous as seen with @karen-rai 
![image](https://github.com/gravitee-io/gravitee-access-management/assets/8531515/78290340-fad9-4847-a1e8-0076879ca690)

![image](https://github.com/gravitee-io/gravitee-access-management/assets/8531515/47661827-b93d-4a79-ba21-9b1955f68c29)


![image](https://github.com/gravitee-io/gravitee-access-management/assets/8531515/6bc19803-83d0-4b04-ba96-d67670dfb676)

