### PR TITLE
build: add trivy script to easily scan AM docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ gravitee-am-test/cypress/screenshots/
 .dccache
 cypress.env.json
 gravitee-am-test/api/config/development.json
+
+# local data when running docker compose
+docker/compose/data/
+

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+java adoptopenjdk-17.0.3+7
+nodejs 14.15.5
+trivy 0.42.1

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# am-gateway:3.18
+# snakeyaml-1.31.jar - didn't upgrade until 3.20 for compatibility
+CVE-2022-1471
+
+# am-management-api:3.18
+# spring-web-5.3.26.jar - false positiver as we exclude vulnerable HttpInvokerServiceExporter class
+CVE-2016-1000027
+
+# am-management-ui:3.18
+# golang.org/x/net : not impacted as we don't use it at runtime
+CVE-2022-41721
+CVE-2022-41723
+

--- a/trivy-scan.sh
+++ b/trivy-scan.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAINTAINED_VERSION=(3.18 3.19 3.20 3.21 latest)
+COMPONENTS=(am-gateway am-management-api am-management-ui)
+REGISTRY="graviteeio"
+
+for version in "${MAINTAINED_VERSION[@]}"
+do
+    for component in "${COMPONENTS[@]}"
+    do
+        docker_image="${REGISTRY}/${component}:${version}"
+        echo "##### Scan ${docker_image}:"
+        docker pull --quiet "${docker_image}"
+        trivy image --severity HIGH,CRITICAL --quiet --format table "${docker_image}"
+    done
+done


### PR DESCRIPTION
This PR add a trivy script and mainly the .trivyignore file to complement usage of snyk.
