### PR TITLE
build: fix publish_maven_central by adding gio version parameter

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1183,12 +1183,17 @@ jobs:
         type: boolean
         default: true
         description: "Running in dry run mode means no docker push (Defaults to true)"
+      graviteeio_version:
+        type: string
+        default: ''
+        description: "Gravitee.io Release version number (semver) ?"
     executor:
       name: openjdk
-      class: small
+      class: xlarge
       version: "11.0.16"
     environment:
       DRY_RUN: << parameters.dry_run >>
+      GRAVITEEIO_VERSION: << parameters.graviteeio_version >>
     steps:
       - checkout
       - restore-maven-job-cache:
@@ -1199,6 +1204,8 @@ jobs:
       - run:
           name: Maven Test, Package, and Deploy to Nexus Staging
           command: |
+            git checkout "${GRAVITEEIO_VERSION}"
+            
             if [ "${DRY_RUN}" == "false" ]; then
               echo "# --->>> NO IT IS NOT A DRY RUN => deploy"
             mvn -s /tmp/.gravitee.settings.xml -B -U -P gravitee-release deploy -DskipTests=true
@@ -1547,6 +1554,7 @@ workflows:
           requires:
             - setup
           dry_run: << pipeline.parameters.dry_run >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
 
   publish_rpms:
     when:


### PR DESCRIPTION
This CI fix validate the step workflow 'publish_maven_central'.

There was two issue:
* `class: small` is not enough in term of ressources, medium neither - go back to xlarge.
* we should checkout the commit tag to build and deploy the right version.

To test this CI job, I runned:

```
curl -X POST \
    -H "Content-Type: application/json" \
    -H "Accept: application/json" \
    -H "Circle-Token: ${CCI_TOKEN}" \
    https://circleci.com/api/v2/project/gh/gravitee-io/gravitee-access-management/pipeline -d '{
    "branch": "fix/publish_maven_central",
    "parameters":
    {
        "gio_action": "publish_maven_central",
        "graviteeio_version": "3.19.14",
        "dry_run": true
    }
}'
```

And then in the job logs we see:

```
HEAD is now at f55bd9fae 3.19.14
# --->>> THIS IS A DRY RUN => install only
```
