### PR TITLE
build: backport CI fix for publish_maven_central release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ setup: true
 parameters:
   gio_action:
     type: enum
-    enum: [ release, publish_rpms, publish_docker_images, pull_requests, release_notes_am ]
+    enum: [ release, publish_rpms, publish_docker_images, pull_requests, release_notes_am, publish_maven_central ]
     default: pull_requests
   gio_product:
     type: enum

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1229,12 +1229,17 @@ jobs:
         type: boolean
         default: true
         description: "Running in dry run mode means no docker push (Defaults to true)"
+      graviteeio_version:
+        type: string
+        default: ''
+        description: "Gravitee.io Release version number (semver) ?"
     executor:
       name: openjdk
-      class: small
+      class: xlarge
       version: "11.0.16"
     environment:
       DRY_RUN: << parameters.dry_run >>
+      GRAVITEEIO_VERSION: << parameters.graviteeio_version >>
     steps:
       - checkout
       - restore-maven-job-cache:
@@ -1245,6 +1250,8 @@ jobs:
       - run:
           name: Maven Test, Package, and Deploy to Nexus Staging
           command: |
+            git checkout "${GRAVITEEIO_VERSION}"
+            
             if [ "${DRY_RUN}" == "false" ]; then
               echo "# --->>> NO IT IS NOT A DRY RUN => deploy"
             mvn -s /tmp/.gravitee.settings.xml -B -U -P gravitee-release deploy -DskipTests=true
@@ -1610,6 +1617,7 @@ workflows:
           requires:
             - setup
           dry_run: << pipeline.parameters.dry_run >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
 
   publish_rpms:
     when:


### PR DESCRIPTION
Usage example:
```
curl -X POST \
    -H "Content-Type: application/json" \
    -H "Accept: application/json" \
    -H "Circle-Token: ${CCI_TOKEN}" \
    https://circleci.com/api/v2/project/gh/gravitee-io/gravitee-access-management/pipeline -d '{
    "branch": "3.21.x",
    "parameters":
    {
        "gio_action": "publish_maven_central",
        "graviteeio_version": "3.21.2",
        "dry_run": true
    }
}'
```

