### PR TITLE
chore: Add changelog for new 3.19.4 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,29 @@
 # Change Log
 
+==  - 3.19.4 (2023-06-28)
+
+== What's new !
+
+* [gateway] [management] add SSL options for httpClient connections
+* [gateway] [oauth2] add an option to not rotate refresh tokens
+
+=== Gateway
+
+
+
+=== Management API
+
+
+
+=== Console
+
+
+
+=== Other
+
+
+
+
 == AM - 3.20.8 (2023-06-27)
 
 === Other


### PR DESCRIPTION

# New version 3.19.4 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.19.4/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.19.4 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.19.4%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
