### PR TITLE
chore: Add changelog for new 3.19.14 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,12 @@
 # Change Log
 
+== AM - 3.19.14 (2023-06-28)
+
+=== Other
+
+*  Error on ECDSA token exchange https://github.com/gravitee-io/issues/issues/8990[#8990]
+
+
 == AM - 3.20.8 (2023-06-27)
 
 === Other


### PR DESCRIPTION

# New version 3.19.14 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.19.14/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.19.14 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.19.14%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
