### PR TITLE
chore: Add changelog for new 3.20.9 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,12 @@
 # Change Log
 
+== AM - 3.20.9 (2023-07-07)
+
+=== Other
+
+* Gravitee AM : session expired https://github.com/gravitee-io/issues/issues/9063[#9063]
+
+
 == AM - 3.21.3 (2023-07-07)
 
 === Other

--- a/release/helpers/changelog-helper.mjs
+++ b/release/helpers/changelog-helper.mjs
@@ -37,7 +37,7 @@ export function getChangelogFor(title, issues) {
     })
     .join('\n');
 
-  if (filteredIssues.length > 0) {
+  if (filteredIssues.length === 0) {
     return '';
   }
 

--- a/release/package.json
+++ b/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-am-releaser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "author": "Gravitee Team",
   "license": "MIT",


### PR DESCRIPTION

# New version 3.20.9 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.20.9/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.20.9 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.20.9%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
