### PR TITLE
fix: use correct entity wrapper for patch username

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UserResource.java
@@ -28,7 +28,6 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.IdentityProviderService;
-import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.UserInvalidException;
 import io.gravitee.am.service.model.UpdateUser;
 import io.gravitee.common.http.MediaType;
@@ -154,6 +153,7 @@ public class UserResource extends AbstractResource {
 
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_USER, Acl.UPDATE)
                 .andThen(organizationUserService.updateUsername(ReferenceType.ORGANIZATION, organizationId, userId, username.getUsername(), authenticatedUser))
+                .map(UserEntity::new)
                 .subscribe(response::resume, response::resume);
     }
 


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-692

## :pencil2: A description of the changes proposed in the pull request

Use the correct entity around `PATCH /username`