### PR TITLE
fix: DOS vuln on org.json:json due to infobip-api-java-client

### DIFF
--- a/gravitee-am-resource/gravitee-am-resource-infobip/pom.xml
+++ b/gravitee-am-resource/gravitee-am-resource-infobip/pom.xml
@@ -49,13 +49,24 @@
         <dependency>
             <groupId>com.infobip</groupId>
             <artifactId>infobip-api-java-client</artifactId>
-            <version>3.0.1</version>
+            <version>3.2.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>gson</artifactId>
                     <groupId>com.google.code.gson</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>org.json</artifactId>
+                    <groupId>json</groupId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- import JSON to fix vuln in org.json:json dep -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${json-version}</version>
         </dependency>
 
         <!-- import GSON to fix vuln in gson dep -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <nimbus.version>8.17</nimbus.version>
         <tink.version>1.7.0</tink.version>
         <gson-version>2.8.9</gson-version>
+        <json-version>20230618</json-version>
         <freemarker.version>2.3.31</freemarker.version>
         <jsoup.version>1.15.3</jsoup.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
The lib `com.infobip:infobip-api-java-client` use vulnerable version of `org.json:json`.

The lastest version 4.0 of `infobip` solve the issue but doesn’t compile anymore.

But exclude `org.json` from `infobip` and import latest fixed version by ourselve fix the issue.

