### PR TITLE
chore: Add changelog for new 3.19.15 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,20 @@
 # Change Log
 
+== AM - 3.19.15 (2023-07-17)
+
+
+
+
+
+
+
+
+
+=== Other
+
+* Gravitee AM : session expired https://github.com/gravitee-io/issues/issues/9063[#9063]
+
+
 == AM - 3.20.9 (2023-07-07)
 
 === Other

--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,14 +1,13 @@
 # Change Log
 
-== AM - 3.19.15 (2023-07-17)
+== AM - 3.18.22 (2023-07-07)
+
+=== Other
+
+* Gravitee AM : session expired https://github.com/gravitee-io/issues/issues/9063[#9063]
 
 
-
-
-
-
-
-
+== AM - 3.19.15 (2023-07-07)
 
 === Other
 


### PR DESCRIPTION

# New version 3.19.15 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.19.15/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.19.15 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.19.15%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
