### PR TITLE
chore: Add changelog for new 3.19.16 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,12 @@
 # Change Log
 
+== AM - 3.19.16 (2023-07-20)
+
+=== Gateway
+
+* Custom translation in mails does not works https://github.com/gravitee-io/issues/issues/9002[#9002]
+
+
 == AM - 3.18.22 (2023-07-07)
 
 === Other


### PR DESCRIPTION

# New version 3.19.16 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.19.16/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.19.16 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.19.16%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
