### PR TITLE
fix: enable the saml feat if the license contains it

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/saml2/saml2.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/saml2/saml2.component.ts
@@ -55,8 +55,8 @@ export class Saml2Component implements OnInit {
       this.publicKeys(this.domainSamlSettings.certificate);
     }
 
-    this.pluginMetadata = {'deployed': false, 'feature': 'am-idp-saml2'};
-    const samlPlugin = this.route.snapshot.data['identities']['am-idp-saml'];
+    this.pluginMetadata = {'deployed': false, 'feature': 'am-idp-saml'};
+    const samlPlugin = this.route.snapshot.data['identities']['saml2-generic-am-idp'];
     if (samlPlugin != null) {
       this.pluginMetadata.deployed = samlPlugin.deployed;
     }


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-706

## :pencil2: A description of the changes proposed in the pull request

The id of the identity was not what we have defined in the plugin.

## :memo: Test scenarios 

Go to settings / SAML 2.0 and click on the toggle:
- on CE: it should display a popup
- on EE without the plugin in the license: it should display a popup
- on EE with the plugin in the license: it should display the form

## :computer: Add screenshots for UI

<img width="1364" alt="Capture d’écran 2023-07-21 à 13 27 21" src="https://github.com/gravitee-io/gravitee-access-management/assets/1580262/2165ece1-4e61-444b-8faa-b9aed5a3896c">

## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
