### PR TITLE
fix: verify domain settings when sending registration emails

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/UserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/UserServiceImpl.java
@@ -520,9 +520,12 @@ public class UserServiceImpl extends AbstractUserService<io.gravitee.am.service.
     }
 
     private static boolean isSendVerifyRegistrationEmailEnabled(Domain domain, Optional<Application> optClient) {
-        return optClient.map(application -> AccountSettings.getInstance(domain, application).isSendVerifyRegistrationAccountEmail())
-                .orElseGet(() -> domain.getAccountSettings() != null && domain.getAccountSettings().isSendVerifyRegistrationAccountEmail());
-
+        return optClient.map(application -> {
+                    var settings = AccountSettings.getInstance(domain, application);
+                    return settings != null && settings.isSendVerifyRegistrationAccountEmail();
+                })
+                .orElseGet(() -> domain
+                        .getAccountSettings() != null && domain.getAccountSettings().isSendVerifyRegistrationAccountEmail());
     }
 
     private String resoleEventType(Template template) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
@@ -1086,6 +1086,7 @@ public class UserServiceTest {
         var applicationId = "application-id";
 
         return Stream.of(
+                Arguments.of(createDomain(domainId, null), createApplication(domainId, applicationId, null), Template.REGISTRATION_CONFIRMATION),
                 Arguments.of(createDomain(domainId, new AccountSettings()), createApplication(domainId, applicationId, null), Template.REGISTRATION_CONFIRMATION),
                 Arguments.of(createDomain(domainId, createAccountSetting(false, true)), createApplication(domainId, applicationId, null), Template.REGISTRATION_VERIFY),
                 Arguments.of(createDomain(domainId, createAccountSetting(false, true)), createApplication(domainId, applicationId, createAccountSetting(false, true)), Template.REGISTRATION_VERIFY),


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-721
and most likely this one too
https://gravitee.atlassian.net/browse/AM-708

## :pencil2: A description of the changes proposed in the pull request

A check for null value was missing when retrieving domain settings

## :memo: Test scenarios 

Before the fix:

Create a Domain and Application. Keep every setting value as default.
Manually create a user, assign it to the generated application and enable `Pre-registration`.

When the user is created, the expected email is never sent. Same thing if you go inside the user profile and try to send a new confirmation email.

After the fix, emails should flow 📧 📥 

