### PR TITLE
fix: fix default value initialization on HttpServerOptions

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxServerConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxServerConfiguration.java
@@ -45,9 +45,8 @@ public class VertxServerConfiguration {
         return VertxHttpServerOptions.builder()
                 .prefix(HTTP_PREFIX)
                 .environment(environment)
-                .port(8092)
+                .port(environment.getProperty(HTTP_PREFIX + ".port", Integer.class, 8092))
                 .keyStoreLoaderManager(keyStoreLoaderManager)
-                .maxFormAttributeSize(2048)
                 .id(HTTP_PREFIX)
                 .build();
     }


### PR DESCRIPTION
fixes AM-717

## description

By using the gravitee-node 4.0.0, the wait HttpServerOptions are initialized has changed.
Initialization is made by the builder using the Environment object, the default value for maxSizeFormAttribute is manage by the builder, for the port the builder set a default value to 8080 so we override the port settings with default value set to 8092
