### PR TITLE
fix: add UTM tag for the HTTP flow idp

### DIFF
--- a/gravitee-am-ui/src/app/services/gio-license.service.ts
+++ b/gravitee-am-ui/src/app/services/gio-license.service.ts
@@ -121,7 +121,7 @@ const featureMoreInformationData = {
       'The SAML 2.0 identity provider is part of Gravitee Enterprise. Identity providers allow you to configure authentication methods familiar to your users and comply with your security requirement.',
   },
   'am-idp-http-flow': {
-    utm: '',
+    utm: 'provider_http_flow',
     image: 'assets/gio-ee-unlock-dialog/gravitee-ee-upgrade.svg',
     description:
       'The HTTP Flow identity provider is part of Gravitee Enterprise. Identity providers allow you to configure authentication methods familiar to your users and comply with your security requirement.',


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-713

## :pencil2: A description of the changes proposed in the pull request

Added missing UTM tag for the HTTP flow idp.

## :memo: Test scenarios 


## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
