### PR TITLE
fix: check deployed status of a plugin before creating the configuration

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -373,6 +373,9 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - keeper/env-export:
+          secret-url: keeper://w8WBpALVCgYdxtV5pVrQsw/custom_field/base64
+          var-name: GRAVITEE_LICENSE_KEY
       - run:
           name: install test module dependencies
           command: npm --prefix gravitee-am-test i
@@ -453,6 +456,9 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - keeper/env-export:
+          secret-url: keeper://w8WBpALVCgYdxtV5pVrQsw/custom_field/base64
+          var-name: GRAVITEE_LICENSE_KEY
       - run:
           name: install test module dependencies
           command: npm --prefix gravitee-am-test i
@@ -563,6 +569,9 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - keeper/env-export:
+          secret-url: keeper://w8WBpALVCgYdxtV5pVrQsw/custom_field/base64
+          var-name: GRAVITEE_LICENSE_KEY
       - run:
           name: Install Newman
           command: sudo npm i -g newman
@@ -620,6 +629,9 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - keeper/env-export:
+          secret-url: keeper://w8WBpALVCgYdxtV5pVrQsw/custom_field/base64
+          var-name: GRAVITEE_LICENSE_KEY
       - run:
           name: Install Newman
           command: sudo npm i -g newman

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/manager/idp/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/manager/idp/impl/IdentityProviderManagerImpl.java
@@ -28,15 +28,16 @@ import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.event.EventManager;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/BotDetectionsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/BotDetectionsResource.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
+import io.gravitee.am.management.service.BotDetectionPluginService;
 import io.gravitee.am.management.service.BotDetectionServiceProxy;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.BotDetection;
@@ -51,6 +52,9 @@ public class BotDetectionsResource extends AbstractResource {
 
     @Autowired
     private BotDetectionServiceProxy botDetectionService;
+
+    @Autowired
+    private BotDetectionPluginService botDetectionPluginService;
 
     @Autowired
     private DomainService domainService;
@@ -98,6 +102,7 @@ public class BotDetectionsResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_BOT_DETECTION, Acl.CREATE)
+                .andThen(botDetectionPluginService.checkPluginDeployment(newBotDetection.getType()))
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                         .flatMapSingle(__ -> botDetectionService.create(domain, newBotDetection, authenticatedUser))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ExtensionGrantsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ExtensionGrantsResource.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
+import io.gravitee.am.management.service.ExtensionGrantPluginService;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.ExtensionGrant;
 import io.gravitee.am.model.permissions.Permission;
@@ -51,6 +52,9 @@ public class ExtensionGrantsResource extends AbstractResource {
 
     @Autowired
     private ExtensionGrantService extensionGrantService;
+
+    @Autowired
+    private ExtensionGrantPluginService extensionGrantPluginService;
 
     @Autowired
     private DomainService domainService;
@@ -101,6 +105,7 @@ public class ExtensionGrantsResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_EXTENSION_GRANT, Acl.CREATE)
+                .andThen(extensionGrantPluginService.checkPluginDeployment(newExtensionGrant.getType()))
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                         .flatMapSingle(irrelevant -> extensionGrantService.create(domain, newExtensionGrant, authenticatedUser)

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/FactorsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/FactorsResource.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
+import io.gravitee.am.management.service.FactorPluginService;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Factor;
 import io.gravitee.am.model.permissions.Permission;
@@ -51,6 +52,9 @@ public class FactorsResource extends AbstractResource {
 
     @Autowired
     private FactorService factorService;
+
+    @Autowired
+    private FactorPluginService factorPluginService;
 
     @Autowired
     private DomainService domainService;
@@ -102,6 +106,7 @@ public class FactorsResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_FACTOR, Acl.CREATE)
+                .andThen(factorPluginService.checkPluginDeployment(newFactor.getType()))
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                         .flatMapSingle(__ -> factorService.create(domain, newFactor, authenticatedUser))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/FlowResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/FlowResource.java
@@ -18,6 +18,8 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.model.FlowEntity;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
+import io.gravitee.am.management.handlers.management.api.resources.utils.FlowUtils;
+import io.gravitee.am.management.service.PolicyPluginService;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.flow.Flow;
@@ -51,6 +53,9 @@ public class FlowResource extends AbstractResource {
 
     @Autowired
     private FlowService flowService;
+
+    @Autowired
+    private PolicyPluginService policyPluginService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -97,6 +102,7 @@ public class FlowResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_FLOW, Acl.UPDATE)
+                .andThen(FlowUtils.checkPoliciesDeployed(policyPluginService, updateFlow))
                 .andThen(flowService.update(ReferenceType.DOMAIN, domain, flow, convert(updateFlow), authenticatedUser)
                         .map(FlowEntity::new))
                 .subscribe(response::resume, response::resume);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/FlowsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/FlowsResource.java
@@ -18,6 +18,8 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.model.FlowEntity;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
+import io.gravitee.am.management.handlers.management.api.resources.utils.FlowUtils;
+import io.gravitee.am.management.service.PolicyPluginService;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.flow.Flow;
@@ -55,6 +57,9 @@ public class FlowsResource extends AbstractResource {
 
     @Autowired
     private FlowService flowService;
+
+    @Autowired
+    private PolicyPluginService policyPluginService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -104,6 +109,7 @@ public class FlowsResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_FLOW, Acl.UPDATE)
+                .andThen(FlowUtils.checkPoliciesDeployed(policyPluginService, flows))
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                         .flatMapSingle(__ -> flowService.createOrUpdate(ReferenceType.DOMAIN, domain, convert(flows), authenticatedUser))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/IdentityProvidersResource.java
@@ -122,6 +122,7 @@ public class IdentityProvidersResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_IDENTITY_PROVIDER, Acl.CREATE)
+                .andThen(identityProviderManager.checkPluginDeployment(newIdentityProvider.getType()))
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                         .flatMapSingle(__ -> identityProviderService.create(domain, newIdentityProvider, authenticatedUser))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ReportersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ReportersResource.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
+import io.gravitee.am.management.service.ReporterPluginService;
 import io.gravitee.am.management.service.ReporterServiceProxy;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Reporter;
@@ -54,6 +55,9 @@ public class ReportersResource extends AbstractResource {
 
     @Autowired
     private ReporterServiceProxy reporterService;
+
+    @Autowired
+    private ReporterPluginService reporterPluginService;
 
     @Autowired
     private DomainService domainService;
@@ -114,6 +118,7 @@ public class ReportersResource extends AbstractResource {
         User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_REPORTER, Acl.CREATE)
+                .andThen(reporterPluginService.checkPluginDeployment(newReporter.getType()))
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                         .flatMapSingle(irrelevant -> reporterService.create(domain, newReporter, authenticatedUser, false))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ServiceResourcesResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ServiceResourcesResource.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
+import io.gravitee.am.management.service.ResourcePluginService;
 import io.gravitee.am.management.service.ServiceResourceServiceProxy;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.permissions.Permission;
@@ -51,6 +52,9 @@ public class ServiceResourcesResource extends AbstractResource {
 
     @Autowired
     private ServiceResourceServiceProxy resourceService;
+
+    @Autowired
+    private ResourcePluginService resourcePluginService;
 
     @Autowired
     private DomainService domainService;
@@ -102,6 +106,7 @@ public class ServiceResourcesResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_RESOURCE, Acl.CREATE)
+                .andThen(resourcePluginService.checkPluginDeployment(newResource.getType()))
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                         .flatMapSingle(__ -> resourceService.create(domain, newResource, authenticatedUser))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/idps/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/idps/IdentityProvidersResource.java
@@ -103,6 +103,7 @@ public class IdentityProvidersResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_IDENTITY_PROVIDER, Acl.CREATE)
+                .andThen(identityProviderManager.checkPluginDeployment(newIdentityProvider.getType()))
                 .andThen(identityProviderService.create(ReferenceType.ORGANIZATION, organizationId, newIdentityProvider, authenticatedUser, false)
                         .map(identityProvider -> Response
                                 .created(URI.create("/organizations/" + organizationId + "/identities/" + identityProvider.getId()))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/utils/FlowUtils.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/utils/FlowUtils.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.resources.utils;
+
+import io.gravitee.am.management.service.PolicyPluginService;
+import io.gravitee.am.service.model.Flow;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class FlowUtils {
+    public static Completable checkPoliciesDeployed(PolicyPluginService policyPluginService, List<Flow> flows) {
+        return Flowable.fromIterable(flows).concatMapCompletable(flow -> checkPoliciesDeployed(policyPluginService, flow));
+    }
+
+    public static Completable checkPoliciesDeployed(PolicyPluginService policyPluginService, Flow flow) {
+        if (flow != null) {
+            var pre = Optional.ofNullable(flow.getPre()).orElseGet(() -> Collections.emptyList());
+            var post = Optional.ofNullable(flow.getPost()).orElseGet(() -> Collections.emptyList());
+            return Flowable.fromStream(Stream.concat(pre.stream(), post.stream())).concatMapCompletable(step -> policyPluginService.checkPluginDeployment(step.getPolicy()));
+        }
+        return Completable.complete();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/JerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/JerseySpringTest.java
@@ -23,23 +23,7 @@ import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.authentication.view.TemplateResolver;
 import io.gravitee.am.management.handlers.management.api.mapper.ObjectMapperResolver;
 import io.gravitee.am.management.handlers.management.api.preview.PreviewService;
-import io.gravitee.am.management.service.AuditReporterManager;
-import io.gravitee.am.management.service.AuthenticationDeviceNotifierPluginService;
-import io.gravitee.am.management.service.BotDetectionPluginService;
-import io.gravitee.am.management.service.BotDetectionServiceProxy;
-import io.gravitee.am.management.service.CertificateManager;
-import io.gravitee.am.management.service.CertificateServiceProxy;
-import io.gravitee.am.management.service.DeviceIdentifierPluginService;
-import io.gravitee.am.management.service.EmailManager;
-import io.gravitee.am.management.service.ExtensionGrantPluginService;
-import io.gravitee.am.management.service.FactorPluginService;
-import io.gravitee.am.management.service.IdentityProviderManager;
-import io.gravitee.am.management.service.IdentityProviderPluginService;
-import io.gravitee.am.management.service.IdentityProviderServiceProxy;
-import io.gravitee.am.management.service.OrganizationUserService;
-import io.gravitee.am.management.service.PermissionService;
-import io.gravitee.am.management.service.ReporterServiceProxy;
-import io.gravitee.am.management.service.ResourcePluginService;
+import io.gravitee.am.management.service.*;
 import io.gravitee.am.management.service.permissions.PermissionAcls;
 import io.gravitee.am.plugins.handlers.api.core.AmPluginManager;
 import io.gravitee.am.service.ApplicationService;
@@ -251,6 +235,9 @@ public abstract class JerseySpringTest {
     protected PreviewService previewService;
     @Autowired
     protected I18nDictionaryService i18nDictionaryService;
+
+    @Autowired
+    protected PolicyPluginService policyPluginService;
 
     @Before
     public void init() {
@@ -509,6 +496,11 @@ public abstract class JerseySpringTest {
         @Bean
         public PreviewService previewService() {
             return mock(PreviewService.class);
+        }
+
+        @Bean
+        public PolicyPluginService policyPluginService() {
+            return mock(PolicyPluginService.class);
         }
 
         @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AuthenticationDeviceNotifierPluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AuthenticationDeviceNotifierPluginService.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface AuthenticationDeviceNotifierPluginService {
+public interface AuthenticationDeviceNotifierPluginService extends PluginService {
     String EXPAND_ICON = "icon";
 
     Single<List<AuthenticationDeviceNotifierPlugin>> findAll(List<String> expand);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DeviceIdentifierPluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DeviceIdentifierPluginService.java
@@ -25,12 +25,11 @@ import java.util.List;
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface DeviceIdentifierPluginService {
+public interface DeviceIdentifierPluginService extends PluginService {
 
     Single<List<DeviceIdentifierPlugin>> findAll();
 
     Maybe<DeviceIdentifierPlugin> findById(String id);
 
     Maybe<String> getSchema(String id);
-
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/ExtensionGrantPluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/ExtensionGrantPluginService.java
@@ -25,11 +25,12 @@ import java.util.Set;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ExtensionGrantPluginService {
+public interface ExtensionGrantPluginService extends PluginService {
 
     Single<Set<ExtensionGrantPlugin>> findAll();
 
     Maybe<ExtensionGrantPlugin> findById(String id);
 
     Maybe<String> getSchema(String id);
+
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/FactorPluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/FactorPluginService.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface FactorPluginService {
+public interface FactorPluginService extends PluginService {
 
     Single<List<FactorPlugin>> findAll();
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/IdentityProviderManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/IdentityProviderManager.java
@@ -42,4 +42,5 @@ public interface IdentityProviderManager extends Service<IdentityProviderManager
 
     Completable loadIdentityProviders();
 
+    Completable checkPluginDeployment(String type);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/IdentityProviderPluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/IdentityProviderPluginService.java
@@ -26,7 +26,7 @@ import java.util.List;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface IdentityProviderPluginService {
+public interface IdentityProviderPluginService extends PluginService {
 
     String EXPAND_DISPLAY_NAME = "displayName";
     String EXPAND_ICON = "icon";

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/PluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/PluginService.java
@@ -15,25 +15,12 @@
  */
 package io.gravitee.am.management.service;
 
-import io.gravitee.am.service.model.plugin.ResourcePlugin;
-import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Single;
-
-import java.util.List;
+import io.reactivex.rxjava3.core.Completable;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ResourcePluginService extends PluginService {
-    String MANIFEST_KEY_CATEGORIES = "categories";
-    String EXPAND_ICON = "icon";
-
-    Single<List<ResourcePlugin>> findAll(List<String> expand);
-
-    Maybe<ResourcePlugin> findById(String id);
-
-    Maybe<String> getSchema(String id);
-
-    Maybe<String> getIcon(String resourceId);
+public interface PluginService {
+    Completable checkPluginDeployment(String type);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/PolicyPluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/PolicyPluginService.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface PolicyPluginService {
+public interface PolicyPluginService extends PluginService {
 
     Single<List<PolicyPlugin>> findAll(List<String> expand);
 
@@ -36,4 +36,5 @@ public interface PolicyPluginService {
     Maybe<String> getIcon(String policyId);
 
     Maybe<String> getDocumentation(String policyId);
+
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/ReporterPluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/ReporterPluginService.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ReporterPluginService {
+public interface ReporterPluginService extends PluginService {
 
     Single<List<ReporterPlugin>> findAll();
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DeviceIdentifierPluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DeviceIdentifierPluginServiceImpl.java
@@ -17,6 +17,7 @@
 package io.gravitee.am.management.service.impl;
 
 import io.gravitee.am.management.service.DeviceIdentifierPluginService;
+import io.gravitee.am.management.service.impl.plugins.AbstractPluginService;
 import io.gravitee.am.plugins.deviceidentifier.core.DeviceIdentifierPluginManager;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.plugin.DeviceIdentifierPlugin;
@@ -37,12 +38,17 @@ import java.util.Optional;
  * @author GraviteeSource Team
  */
 @Component
-public class DeviceIdentifierPluginServiceImpl implements DeviceIdentifierPluginService {
+public class DeviceIdentifierPluginServiceImpl extends AbstractPluginService implements DeviceIdentifierPluginService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeviceIdentifierPluginServiceImpl.class);
 
-    @Autowired
     private DeviceIdentifierPluginManager deviceIdentifierPluginManager;
+
+    @Autowired
+    public DeviceIdentifierPluginServiceImpl(DeviceIdentifierPluginManager deviceIdentifierPluginManager) {
+        super(deviceIdentifierPluginManager);
+        this.deviceIdentifierPluginManager = deviceIdentifierPluginManager;
+    }
 
     @Override
     public Single<List<DeviceIdentifierPlugin>> findAll() {
@@ -98,4 +104,5 @@ public class DeviceIdentifierPluginServiceImpl implements DeviceIdentifierPlugin
         deviceIdentifierPlugin.setFeature(plugin.manifest().feature());
         return deviceIdentifierPlugin;
     }
+
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.plugins.idp.core.IdentityProviderPluginManager;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.RoleService;
+import io.gravitee.am.service.exception.PluginNotDeployedException;
 import io.gravitee.am.service.model.NewIdentityProvider;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
@@ -404,5 +405,13 @@ public class IdentityProviderManagerImpl extends AbstractService<IdentityProvide
             userProviders.remove(identityProvider.getId());
             identityProviders.remove(identityProvider.getId());
         });
+    }
+
+    public Completable checkPluginDeployment(String type) {
+        if (!this.identityProviderPluginManager.isPluginDeployed(type)) {
+            logger.debug("Plugin {} not deployed", type);
+            return Completable.error(PluginNotDeployedException.forType(type));
+        }
+        return Completable.complete();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/AbstractPluginService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/AbstractPluginService.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.plugins;
+
+import io.gravitee.am.plugins.handlers.api.core.AmPluginManager;
+import io.gravitee.am.service.exception.PluginNotDeployedException;
+import io.reactivex.rxjava3.core.Completable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AbstractPluginService {
+    private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+    protected AmPluginManager pluginManager;
+
+    protected AbstractPluginService(AmPluginManager pluginManager) {
+        this.pluginManager = pluginManager;
+    }
+
+    public Completable checkPluginDeployment(String type) {
+        if (!this.pluginManager.isPluginDeployed(type)) {
+            LOGGER.debug("Plugin {} not deployed", type);
+            return Completable.error(PluginNotDeployedException.forType(type));
+        }
+        return Completable.complete();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/AuthenticationDeviceNotifierPluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/AuthenticationDeviceNotifierPluginServiceImpl.java
@@ -35,12 +35,17 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 @Component
-public class AuthenticationDeviceNotifierPluginServiceImpl implements AuthenticationDeviceNotifierPluginService {
+public class AuthenticationDeviceNotifierPluginServiceImpl extends AbstractPluginService implements AuthenticationDeviceNotifierPluginService {
 
     private final Logger LOGGER = LoggerFactory.getLogger(AuthenticationDeviceNotifierPluginServiceImpl.class);
 
-    @Autowired
     private AuthenticationDeviceNotifierPluginManager pluginManager;
+
+    @Autowired
+    public AuthenticationDeviceNotifierPluginServiceImpl(AuthenticationDeviceNotifierPluginManager pluginManager) {
+        super(pluginManager);
+        this.pluginManager = pluginManager;
+    }
 
     @Override
     public Single<List<AuthenticationDeviceNotifierPlugin>> findAll(List<String> expand) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/BotDetectionPluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/BotDetectionPluginServiceImpl.java
@@ -17,9 +17,11 @@ package io.gravitee.am.management.service.impl.plugins;
 
 import io.gravitee.am.management.service.BotDetectionPluginService;
 import io.gravitee.am.plugins.botdetection.core.BotDetectionPluginManager;
+import io.gravitee.am.service.exception.PluginNotDeployedException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.plugin.BotDetectionPlugin;
 import io.gravitee.plugin.core.api.Plugin;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
@@ -34,7 +36,7 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
-public class BotDetectionPluginServiceImpl implements BotDetectionPluginService {
+public class BotDetectionPluginServiceImpl extends AbstractPluginService implements BotDetectionPluginService {
 
     private final Logger LOGGER = LoggerFactory.getLogger(BotDetectionPluginServiceImpl.class);
 
@@ -42,6 +44,7 @@ public class BotDetectionPluginServiceImpl implements BotDetectionPluginService 
 
     @Autowired
     public BotDetectionPluginServiceImpl(BotDetectionPluginManager pluginManager) {
+        super(pluginManager);
         this.pluginManager = pluginManager;
     }
 
@@ -100,4 +103,5 @@ public class BotDetectionPluginServiceImpl implements BotDetectionPluginService 
         botDetectionPlugin.setFeature(plugin.manifest().feature());
         return botDetectionPlugin;
     }
+
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/ExtensionGrantPluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/ExtensionGrantPluginServiceImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.service.impl.plugins;
 
 import io.gravitee.am.management.service.ExtensionGrantPluginService;
 import io.gravitee.am.plugins.extensiongrant.core.ExtensionGrantPluginManager;
+import io.gravitee.am.plugins.handlers.api.core.AmPluginManager;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.plugin.ExtensionGrantPlugin;
 import io.gravitee.plugin.core.api.Plugin;
@@ -35,15 +36,20 @@ import java.util.stream.Collectors;
  * @author GraviteeSource Team
  */
 @Component
-public class ExtensionGrantPluginServiceImpl implements ExtensionGrantPluginService {
+public class ExtensionGrantPluginServiceImpl extends AbstractPluginService implements ExtensionGrantPluginService {
 
     /**
      * Logger.
      */
     private final Logger LOGGER = LoggerFactory.getLogger(ExtensionGrantPluginServiceImpl.class);
 
-    @Autowired
     private ExtensionGrantPluginManager extensionGrantPluginManager;
+
+    @Autowired
+    public ExtensionGrantPluginServiceImpl(ExtensionGrantPluginManager extensionGrantPluginManager) {
+        super(extensionGrantPluginManager);
+        this.extensionGrantPluginManager = extensionGrantPluginManager;
+    }
 
     @Override
     public Single<Set<ExtensionGrantPlugin>> findAll() {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/FactorPluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/FactorPluginServiceImpl.java
@@ -17,9 +17,12 @@ package io.gravitee.am.management.service.impl.plugins;
 
 import io.gravitee.am.management.service.FactorPluginService;
 import io.gravitee.am.plugins.factor.core.FactorPluginManager;
+import io.gravitee.am.plugins.handlers.api.core.AmPluginManager;
+import io.gravitee.am.service.exception.PluginNotDeployedException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.plugin.FactorPlugin;
 import io.gravitee.plugin.core.api.Plugin;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
@@ -35,12 +38,16 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 @Component
-public class FactorPluginServiceImpl implements FactorPluginService {
+public class FactorPluginServiceImpl extends AbstractPluginService implements FactorPluginService {
 
     private final Logger LOGGER = LoggerFactory.getLogger(FactorPluginServiceImpl.class);
 
-    @Autowired
     private FactorPluginManager factorPluginManager;
+
+    public FactorPluginServiceImpl(FactorPluginManager factorPluginManager) {
+        super(factorPluginManager);
+        this.factorPluginManager = factorPluginManager;
+    }
 
     @Override
     public Single<List<FactorPlugin>> findAll() {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/IdentityProviderPluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/IdentityProviderPluginServiceImpl.java
@@ -35,15 +35,20 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
-public class IdentityProviderPluginServiceImpl implements IdentityProviderPluginService {
+public class IdentityProviderPluginServiceImpl extends AbstractPluginService implements IdentityProviderPluginService {
 
     /**
      * Logger.
      */
     private final Logger LOGGER = LoggerFactory.getLogger(IdentityProviderPluginServiceImpl.class);
 
-    @Autowired
     private IdentityProviderPluginManager identityProviderPluginManager;
+
+    @Autowired
+    public IdentityProviderPluginServiceImpl(IdentityProviderPluginManager identityProviderPluginManager) {
+        super(identityProviderPluginManager);
+        this.identityProviderPluginManager = identityProviderPluginManager;
+    }
 
     @Override
     public Single<List<IdentityProviderPlugin>> findAll(List<String> expand) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/PolicyPluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/PolicyPluginServiceImpl.java
@@ -21,9 +21,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.am.management.service.PolicyPluginService;
 import io.gravitee.am.plugins.policy.core.PolicyPluginManager;
+import io.gravitee.am.service.exception.PluginNotDeployedException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.plugin.PolicyPlugin;
 import io.gravitee.plugin.core.api.Plugin;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
@@ -174,5 +176,13 @@ public class PolicyPluginServiceImpl implements PolicyPluginService {
         }
         policyPlugin.setFeature(plugin.manifest().feature());
         return policyPlugin;
+    }
+
+    public Completable checkPluginDeployment(String type) {
+        if (this.policyPluginManager.get(type) == null || !this.policyPluginManager.get(type).deployed()) {
+            LOGGER.debug("Plugin {} not deployed", type);
+            return Completable.error(PluginNotDeployedException.forType(type));
+        }
+        return Completable.complete();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/ReporterPluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/ReporterPluginServiceImpl.java
@@ -35,12 +35,17 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 @Component
-public class ReporterPluginServiceImpl implements ReporterPluginService {
+public class ReporterPluginServiceImpl extends AbstractPluginService implements ReporterPluginService {
 
     private final Logger LOGGER = LoggerFactory.getLogger(ReporterPluginServiceImpl.class);
 
-    @Autowired
     private ReporterPluginManager reporterPluginManager;
+
+    @Autowired
+    public ReporterPluginServiceImpl(ReporterPluginManager reporterPluginManager) {
+        super(reporterPluginManager);
+        this.reporterPluginManager = reporterPluginManager;
+    }
 
     @Override
     public Single<List<ReporterPlugin>> findAll() {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/ResourcePluginServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/plugins/ResourcePluginServiceImpl.java
@@ -35,13 +35,18 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 @Component
-public class ResourcePluginServiceImpl implements ResourcePluginService {
+public class ResourcePluginServiceImpl extends AbstractPluginService implements ResourcePluginService {
 
     private static final String MANIFEST_KEY_CATEGORIES_SEPARATOR = ",";
     private final Logger LOGGER = LoggerFactory.getLogger(ResourcePluginServiceImpl.class);
 
-    @Autowired
     private ResourcePluginManager resourcePluginManager;
+
+    @Autowired
+    public ResourcePluginServiceImpl(ResourcePluginManager resourcePluginManager) {
+        super(resourcePluginManager);
+        this.resourcePluginManager = resourcePluginManager;
+    }
 
     @Override
     public Single<List<ResourcePlugin>> findAll(List<String> expand) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/FactorPluginServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/FactorPluginServiceTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl;
+
+import io.gravitee.am.management.service.FactorPluginService;
+import io.gravitee.am.management.service.impl.plugins.FactorPluginServiceImpl;
+import io.gravitee.am.plugins.factor.core.FactorPluginManager;
+import io.gravitee.am.service.exception.PluginNotDeployedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+public class FactorPluginServiceTest {
+
+    @Mock
+    private FactorPluginManager factorPluginManager;
+    private FactorPluginService factorPluginService;
+
+    @BeforeEach
+    public void setUp() {
+        factorPluginService = new FactorPluginServiceImpl(factorPluginManager);
+    }
+
+    @Test
+    public void must_accept_deployed_plugins() throws IOException {
+        String pluginId = "pluginId";
+        when(factorPluginManager.isPluginDeployed(pluginId)).thenReturn(true);
+
+        var observer = factorPluginService.checkPluginDeployment(pluginId).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertComplete();
+        observer.assertNoErrors();
+    }
+
+    @Test
+    public void must_reject_not_deployed_plugins() throws IOException {
+        String pluginId = "pluginId";
+
+        when(factorPluginManager.isPluginDeployed(pluginId)).thenReturn(false);
+
+        var observer = factorPluginService.checkPluginDeployment(pluginId).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertError(PluginNotDeployedException.class);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/policy/dummy/DummyPolicy.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/policy/dummy/DummyPolicy.java
@@ -27,9 +27,16 @@ import java.nio.file.Path;
  */
 public class DummyPolicy implements PolicyPlugin {
 
+    private final boolean deployed;
+
     private final PluginManifest manifest;
 
     public DummyPolicy(PluginManifest manifest) {
+        this(manifest, true);
+    }
+
+    public DummyPolicy(PluginManifest manifest, boolean deployed) {
+        this.deployed = deployed;
         this.manifest = manifest;
     }
 
@@ -80,6 +87,6 @@ public class DummyPolicy implements PolicyPlugin {
 
     @Override
     public boolean deployed() {
-        return false;
+        return deployed;
     }
 }

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-api/src/main/java/io/gravitee/am/plugins/handlers/api/core/AmPluginManager.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-api/src/main/java/io/gravitee/am/plugins/handlers/api/core/AmPluginManager.java
@@ -32,4 +32,6 @@ public interface AmPluginManager<TYPE> {
     Plugin findById(String pluginId);
 
     String getSchema(String pluginId) throws IOException;
+
+    boolean isPluginDeployed(String pluginTypeId);
 }

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-api/src/main/java/io/gravitee/am/plugins/handlers/api/core/ProviderPluginManager.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-api/src/main/java/io/gravitee/am/plugins/handlers/api/core/ProviderPluginManager.java
@@ -96,4 +96,8 @@ public abstract class ProviderPluginManager<INSTANCE extends AmPlugin<?, PROVIDE
             throw ex;
         }
     }
+
+    public boolean isPluginDeployed(String pluginTypeId) {
+        return this.findAll().stream().anyMatch(p -> p.getDelegate().id().equals(pluginTypeId));
+    }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/PluginNotDeployedException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/PluginNotDeployedException.java
@@ -13,24 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.management.service;
+package io.gravitee.am.service.exception;
 
-import io.gravitee.am.service.model.plugin.BotDetectionPlugin;
-import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Single;
+import io.gravitee.am.model.PasswordSettings;
+import io.gravitee.common.http.HttpStatusCode;
 
-import java.util.List;
+public class PluginNotDeployedException extends AbstractManagementException {
 
-/**
- * @author Eric LELEU (eric.leleu at graviteesource.com)
- * @author GraviteeSource Team
- */
-public interface BotDetectionPluginService extends PluginService {
+    protected PluginNotDeployedException(String message) {
+        super(message);
+    }
 
-    Single<List<BotDetectionPlugin>> findAll();
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
 
-    Maybe<BotDetectionPlugin> findById(String id);
-
-    Maybe<String> getSchema(String id);
-
+    public static PluginNotDeployedException forType(String type) {
+        return new PluginNotDeployedException(String.format("Plugin type %s not deployed", type));
+    }
 }

--- a/gravitee-am-test/specs/gateway/mfa.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/mfa.jest.spec.ts
@@ -288,7 +288,7 @@ describe("MFA", () => {
         });
     });
 
-/*    describe('recovery code factor test', () => {
+    describe('recovery code factor test', () => {
         let user4;
         let validRecoveryCode;
 
@@ -383,7 +383,7 @@ describe("MFA", () => {
             await deleteUser(domain.id, accessToken, user4.id);
         });
 
-    });*/
+    });
 });
 
 afterAll(async () => {

--- a/postman/collections/graviteeio-am-login-collection-app-version.json
+++ b/postman/collections/graviteeio-am-login-collection-app-version.json
@@ -5101,6 +5101,1698 @@
 					]
 				},
 				{
+					"name": "MFA - Recovery Code",
+					"item": [
+						{
+							"name": "Prepare",
+							"item": [
+								{
+									"name": "List users",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"should be able to set user id\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const userData = jsonData.data.find(data => {",
+													"        return data.username === \"user\";",
+													"    });",
+													"",
+													"    const userId = userData.id;",
+													"    tests['user id is not null'] = userId && userId.length > 0;    ",
+													"    pm.environment.set('userId', userId);",
+													"    ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/users",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"users"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete user MFA",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}",
+												"type": "text"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/users/{{userId}}/factors/{{mfaFactorId}}",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"users",
+												"{{userId}}",
+												"factors",
+												"{{mfaFactorId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Recovery Code Factor",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													"",
+													"var body = JSON.parse(responseBody);",
+													"pm.environment.set('recoveryCodeFactorId', body.id);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}",
+												"type": "text"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"type\": \"recovery-code-am-factor\",\n    \"factorType\": \"Recovery Code\",\n    \"configuration\": \"{\\\"digit\\\":8,\\\"count\\\":10}\",\n    \"name\": \"Recovery Code Factor\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/factors",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"factors"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Enable SMS and Recovery Code MFA",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"setTimeout(function(){}, 10000);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"factors\": [\n       \"{{mfaFactorId}}\",\n       \"{{recoveryCodeFactorId}}\"\n    ],\n    \"settings\": {\n        \"mfa\": {}\n    }\n}"
+										},
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/applications/{{app4}}",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"applications",
+												"{{app4}}"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Generate",
+							"item": [
+								{
+									"name": "Initiate Login Flow",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"});",
+													"",
+													"pm.test(\"Should be a redirection to login page\", function() {",
+													"    const location = postman.getResponseHeader('Location');",
+													"    const domain = pm.environment.get(\"domainHrid\");",
+													"    tests['Redirect to login page with client_id'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/login') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"    ",
+													"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{gateway_url}}/{{domainHrid}}/oauth/authorize/?response_type=code&client_id={{clientId4}}&redirect_uri=http://localhost:4000/&state=1234-5678-9876",
+											"host": [
+												"{{gateway_url}}"
+											],
+											"path": [
+												"{{domainHrid}}",
+												"oauth",
+												"authorize",
+												""
+											],
+											"query": [
+												{
+													"key": "response_type",
+													"value": "code"
+												},
+												{
+													"key": "client_id",
+													"value": "{{clientId4}}"
+												},
+												{
+													"key": "redirect_uri",
+													"value": "http://localhost:4000/"
+												},
+												{
+													"key": "state",
+													"value": "1234-5678-9876"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to login form",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Should be ok\", function () {",
+													"    pm.response.to.be.ok;",
+													"    ",
+													"    // Extract the XSRF token to send it with the next request.",
+													"    const responseHTML = cheerio.load(pm.response.text());",
+													"    const xsrfToken = responseHTML('[name=\"X-XSRF-TOKEN\"]').val();",
+													"    const action = responseHTML('form').attr('action');",
+													"    pm.environment.set('xsrf', xsrfToken);",
+													"    pm.environment.set('action', action);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								},
+								{
+									"name": "Post login form",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to authorize\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"",
+													"    const location = postman.getResponseHeader(\"Location\");",
+													"    pm.environment.set('redirection', location);",
+													"    // if login was ok, we replay the authorize flow",
+													"    console.log(location);",
+													"    tests['Redirect to authorize page'] = location.includes('/oauth/authorize') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/x-www-form-urlencoded"
+											}
+										],
+										"body": {
+											"mode": "urlencoded",
+											"urlencoded": [
+												{
+													"key": "X-XSRF-TOKEN",
+													"value": "{{xsrf}}",
+													"type": "text"
+												},
+												{
+													"key": "client_id",
+													"value": "{{clientId4}}",
+													"type": "text"
+												},
+												{
+													"key": "username",
+													"value": "user",
+													"type": "text"
+												},
+												{
+													"key": "password",
+													"value": "#CoMpL3X-P@SsW0Rd",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{action}}",
+											"host": [
+												"{{action}}"
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to Authorize",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"});",
+													"",
+													"pm.test(\"Should be a redirection to MFA enroll page\", function() {",
+													"    const location = postman.getResponseHeader('Location');",
+													"    const domain = pm.environment.get(\"domainHrid\");",
+													"        ",
+													"    console.log(location);",
+													"    tests['Redirect to enroll with client_id'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/mfa/enroll') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"    ",
+													"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to Enroll Form",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to MFA enroll\", function () {",
+													"   pm.response.to.be.ok;",
+													"    ",
+													"    // Extract the XSRF token to send it with the next request.",
+													"    const responseHTML = cheerio.load(pm.response.text());",
+													"    const xsrfToken = responseHTML('[name=\"X-XSRF-TOKEN\"]').val();",
+													"    const action = responseHTML('form').attr('action');",
+													"    pm.environment.set('xsrf', xsrfToken);",
+													"    pm.environment.set('action', action);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": []
+										},
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "MFA Enroll",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to authorize\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"",
+													"    const location = postman.getResponseHeader(\"Location\");",
+													"    pm.environment.set('redirection', location);",
+													"    // if login was ok, we replay the authorize flow",
+													"    tests['Redirect to authorize'] = location.includes('/oauth/authorize');",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "urlencoded",
+											"urlencoded": [
+												{
+													"key": "X-XSRF-TOKEN",
+													"value": "{{xsrf}}",
+													"type": "text"
+												},
+												{
+													"key": "factorId",
+													"value": "{{mfaFactorId}}",
+													"type": "text"
+												},
+												{
+													"key": "phoneFact0",
+													"value": "0600000000",
+													"type": "text"
+												},
+												{
+													"key": "phone",
+													"value": "+33600000000",
+													"type": "text"
+												},
+												{
+													"key": "user_mfa_enrollment",
+													"value": "true",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{action}}",
+											"host": [
+												"{{action}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to Authorize 2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"});",
+													"",
+													"pm.test(\"Should be a redirection to challenge page\", function() {",
+													"    const location = postman.getResponseHeader('Location');",
+													"    const domain = pm.environment.get(\"domainHrid\");",
+													"        ",
+													"    tests['Redirect to login page with client_id'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/mfa/challenge') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"    ",
+													"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "MFA Challenge",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to recovery code\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"",
+													"    const location = postman.getResponseHeader(\"Location\");",
+													"    pm.environment.set('redirection', location);",
+													"    console.log(location); ",
+													"    tests['Location contains authorize'] = location.includes('/oauth/authorize');",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "urlencoded",
+											"urlencoded": [
+												{
+													"key": "X-XSRF-TOKEN",
+													"value": "{{xsrf}}",
+													"type": "text"
+												},
+												{
+													"key": "factorId",
+													"value": "{{mfaFactorId}}",
+													"type": "text"
+												},
+												{
+													"key": "code",
+													"value": "333-333",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to Authorize 3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"});",
+													"",
+													"pm.test(\"Should be a redirection to recovery code page\", function() {",
+													"    const location = postman.getResponseHeader('Location');",
+													"    const domain = pm.environment.get(\"domainHrid\");",
+													"        ",
+													"    tests['Redirect to recovery page with client_id'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/mfa/recovery_code') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"    ",
+													"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Recovery Codes",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Should be ok\", function () {",
+													"    pm.response.to.be.ok;",
+													"    ",
+													"    // Extract the XSRF token to send it with the next request.",
+													"    const responseHTML = cheerio.load(pm.response.text());",
+													"    const xsrfToken = responseHTML('[name=\"X-XSRF-TOKEN\"]').val();",
+													"    const action = responseHTML('form').attr('action');",
+													"    pm.environment.set('xsrf', xsrfToken);",
+													"    pm.environment.set('action', action);",
+													"});",
+													"",
+													"pm.test(\"Should contain recovery code\", function() {",
+													"    const body = cheerio(responseBody);",
+													"    const recoveryCode = body.find('.code-item').first().text();",
+													"    ",
+													"    tests['recovery code is not null'] = recoveryCode && recoveryCode.length > 0;",
+													"    pm.environment.set('recoveryCode', recoveryCode); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								},
+								{
+									"name": "Logout user",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"    ",
+													"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{logoutEndpoint}}",
+											"host": [
+												"{{logoutEndpoint}}"
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Login Verify",
+							"item": [
+								{
+									"name": "Initiate Login Flow",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"});",
+													"",
+													"pm.test(\"Should be a redirection to login page\", function() {",
+													"    const location = postman.getResponseHeader('Location');",
+													"    const domain = pm.environment.get(\"domainHrid\");",
+													"    ",
+													"    tests['Redirect to login page with client_id'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/login') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"    ",
+													"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{gateway_url}}/{{domainHrid}}/oauth/authorize/?response_type=code&client_id={{clientId4}}&redirect_uri=http://localhost:4000/&state=1234-5678-9876",
+											"host": [
+												"{{gateway_url}}"
+											],
+											"path": [
+												"{{domainHrid}}",
+												"oauth",
+												"authorize",
+												""
+											],
+											"query": [
+												{
+													"key": "response_type",
+													"value": "code"
+												},
+												{
+													"key": "client_id",
+													"value": "{{clientId4}}"
+												},
+												{
+													"key": "redirect_uri",
+													"value": "http://localhost:4000/"
+												},
+												{
+													"key": "state",
+													"value": "1234-5678-9876"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to login form",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Should be ok\", function () {",
+													"    pm.response.to.be.ok;",
+													"    ",
+													"    // Extract the XSRF token to send it with the next request.",
+													"    const responseHTML = cheerio.load(pm.response.text());",
+													"    const xsrfToken = responseHTML('[name=\"X-XSRF-TOKEN\"]').val();",
+													"    const action = responseHTML('form').attr('action');",
+													"    pm.environment.set('xsrf', xsrfToken);",
+													"    pm.environment.set('action', action);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								},
+								{
+									"name": "Post login form",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to authorize\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"",
+													"    const location = postman.getResponseHeader(\"Location\");",
+													"    pm.environment.set('redirection', location);",
+													"    // if login was ok, we replay the authorize flow",
+													"    console.log(location);",
+													"    tests['Redirect to authorize page'] = location.includes('/oauth/authorize') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/x-www-form-urlencoded"
+											}
+										],
+										"body": {
+											"mode": "urlencoded",
+											"urlencoded": [
+												{
+													"key": "X-XSRF-TOKEN",
+													"value": "{{xsrf}}",
+													"type": "text"
+												},
+												{
+													"key": "client_id",
+													"value": "{{clientId4}}",
+													"type": "text"
+												},
+												{
+													"key": "username",
+													"value": "user",
+													"type": "text"
+												},
+												{
+													"key": "password",
+													"value": "#CoMpL3X-P@SsW0Rd",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{action}}",
+											"host": [
+												"{{action}}"
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to Authorize",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"});",
+													"",
+													"pm.test(\"Should be a redirection to challenge page\", function() {",
+													"    const location = postman.getResponseHeader('Location');",
+													"    const domain = pm.environment.get(\"domainHrid\");",
+													"        ",
+													"    tests['Redirect to login page with client_id'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/mfa/challenge') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"    ",
+													"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to Challenge Form",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to MFA enroll\", function () {",
+													"   pm.response.to.be.ok;",
+													"    ",
+													"    // Extract the XSRF token to send it with the next request.",
+													"    var responseHTML = cheerio.load(pm.response.text());",
+													"    var xsrfToken = responseHTML('[name=\"X-XSRF-TOKEN\"]').val();",
+													"    const action = responseHTML('form').attr('action');",
+													"    pm.environment.set('xsrf', xsrfToken);",
+													"    pm.environment.set('action', action);",
+													"});",
+													"",
+													"pm.test(\"Should contain recovery code\", function() {",
+													"    const body = cheerio(responseBody);",
+													"    const alternativeLink = body.find('a').attr(\"href\");",
+													"    ",
+													"    tests['alternative link is present'] = alternativeLink && alternativeLink.length > 0;",
+													"    pm.environment.set('alternativeLink', alternativeLink); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": []
+										},
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Alternative option form",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Should be ok\", function () {",
+													"    pm.response.to.be.ok;",
+													"    ",
+													"    // Extract the XSRF token to send it with the next request.",
+													"    const responseHTML = cheerio.load(pm.response.text());",
+													"    const xsrfToken = responseHTML('[name=\"X-XSRF-TOKEN\"]').val();",
+													"    const action = responseHTML('form').attr('action');",
+													"    pm.environment.set('xsrf', xsrfToken);",
+													"    pm.environment.set('action', action);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								},
+								{
+									"name": "Select alternative option",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to challenge\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"",
+													"    const location = postman.getResponseHeader(\"Location\");",
+													"    pm.environment.set('redirection', location);",
+													"    // if login was ok, we replay the authorize flow",
+													"    tests['Redirect to authorize page'] = location.includes('/mfa/challenge') && location.includes('client_id=' + pm.environment.get('clientId4'));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/x-www-form-urlencoded"
+											}
+										],
+										"body": {
+											"mode": "urlencoded",
+											"urlencoded": [
+												{
+													"key": "X-XSRF-TOKEN",
+													"value": "{{xsrf}}",
+													"type": "text"
+												},
+												{
+													"key": "factorId",
+													"value": "{{recoveryCodeFactorId}}",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{gateway_url}}/{{domainHrid}}/mfa/challenge/alternatives?response_type=token&client_id={{clientId4}}&redirect_uri=http://localhost:4000/&state=1234-5678-9876",
+											"host": [
+												"{{gateway_url}}"
+											],
+											"path": [
+												"{{domainHrid}}",
+												"mfa",
+												"challenge",
+												"alternatives"
+											],
+											"query": [
+												{
+													"key": "response_type",
+													"value": "token"
+												},
+												{
+													"key": "client_id",
+													"value": "{{clientId4}}"
+												},
+												{
+													"key": "redirect_uri",
+													"value": "http://localhost:4000/"
+												},
+												{
+													"key": "state",
+													"value": "1234-5678-9876"
+												}
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								},
+								{
+									"name": "Redirect to Challenge Form 2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to MFA enroll\", function () {",
+													"   pm.response.to.be.ok;",
+													"    ",
+													"    // Extract the XSRF token to send it with the next request.",
+													"    const responseHTML = cheerio.load(pm.response.text());",
+													"    const xsrfToken = responseHTML('[name=\"X-XSRF-TOKEN\"]').val();",
+													"    const action = responseHTML('form').attr('action');",
+													"    pm.environment.set('xsrf', xsrfToken);",
+													"    pm.environment.set('action', action);",
+													"});",
+													"",
+													"pm.test(\"Should contain recovery code\", function() {",
+													"    const body = cheerio(responseBody);",
+													"    const alternativeLink = body.find('a').attr(\"href\");",
+													"    console.log(alternativeLink)",
+													"    ",
+													"    tests['alternative link is present'] = alternativeLink && alternativeLink.length > 0;",
+													"    pm.environment.set('alternativeLink', alternativeLink); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": []
+										},
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Challenge verify Fail",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected to MFA challenge page\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"",
+													"    const location = postman.getResponseHeader(\"Location\");",
+													"    pm.environment.set('redirection', location);",
+													"    tests['Redirect to challenge error'] = location.includes('/mfa/challenge');",
+													"    tests['Should contain error'] = location.includes('mfa_challenge_failed');",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "urlencoded",
+											"urlencoded": [
+												{
+													"key": "X-XSRF-TOKEN",
+													"value": "{{xsrf}}",
+													"type": "text"
+												},
+												{
+													"key": "factorId",
+													"value": "{{recoveryCodeFactorId}}",
+													"type": "text"
+												},
+												{
+													"key": "code",
+													"value": "invalidCode",
+													"type": "text"
+												},
+												{
+													"key": "recoveryCodefactorId",
+													"value": "{{recoveryCodeFactorId}}",
+													"type": "default"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Challenge verify Success",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Redirected to authorize\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"",
+													"    const location = postman.getResponseHeader(\"Location\");",
+													"    pm.environment.set('redirection', location);",
+													"    tests['Location contains authorize'] = location.includes('/oauth/authorize');",
+													"    tests['Should not contain error'] = !location.includes('mfa_challenge_failed');",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "urlencoded",
+											"urlencoded": [
+												{
+													"key": "X-XSRF-TOKEN",
+													"value": "{{xsrf}}",
+													"type": "text"
+												},
+												{
+													"key": "factorId",
+													"value": "{{recoveryCodeFactorId}}",
+													"type": "text"
+												},
+												{
+													"key": "code",
+													"value": "{{recoveryCode}}",
+													"type": "text"
+												},
+												{
+													"key": "recoveryCodefactorId",
+													"value": "{{recoveryCodeFactorId}}",
+													"type": "default"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{redirection}}",
+											"host": [
+												"{{redirection}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Logout user",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 302\", function () {",
+													"    pm.response.to.have.status(302);",
+													"});",
+													"",
+													"pm.test(\"Should be redirected\", function () {",
+													"    pm.response.to.be.redirection;",
+													"    pm.response.to.have.header('Location');",
+													"    ",
+													"    pm.environment.set('redirection', postman.getResponseHeader(\"Location\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{logoutEndpoint}}",
+											"host": [
+												"{{logoutEndpoint}}"
+											]
+										},
+										"description": "The client does not have a redirect_uri define"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Clean up",
+							"item": [
+								{
+									"name": "Delete user recovvery factor",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}",
+												"type": "text"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/users/{{userId}}/factors/{{recoveryCodeFactorId}}",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"users",
+												"{{userId}}",
+												"factors",
+												"{{recoveryCodeFactorId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Remove recovery factor from app",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"setTimeout(function(){}, 10000);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"factors\": [\n       \"{{mfaFactorId}}\"\n    ],\n    \"settings\": {\n        \"mfa\": {}\n    }\n}"
+										},
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/applications/{{app4}}",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"applications",
+												"{{app4}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete recovery Code Factor",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}",
+												"type": "text"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"type\": \"recovery-code-am-factor\",\n    \"factorType\": \"Recovery Code\",\n    \"configuration\": \"{\\\"digit\\\":8,\\\"count\\\":10}\",\n    \"name\": \"Recovery Code Factor\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/factors/{{recoveryCodeFactorId}}",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"factors",
+												"{{recoveryCodeFactorId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						}
+					]
+				},
+				{
 					"name": "MFA - Step Up Authentication",
 					"item": [
 						{

--- a/postman/collections/graviteeio-am-self-account-management-collection-app-version.json
+++ b/postman/collections/graviteeio-am-self-account-management-collection-app-version.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "0151f2c3-8c17-4181-b4c3-0dc70c214f7c",
+		"_postman_id": "d0fdab08-fbf7-4671-8952-b41c118261cf",
 		"name": "Gravitee.io - AM - Self Account Management - app version",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "7568294"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -1702,6 +1701,414 @@
 										"account",
 										"api",
 										"factors"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Recovery code",
+					"item": [
+						{
+							"name": "prepare",
+							"item": [
+								{
+									"name": "Create recovery code factor",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													"",
+													"var body = JSON.parse(responseBody);",
+													"pm.environment.set('recoveryCodeFactorId', body.id);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}",
+												"type": "text"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"type\": \"recovery-code-am-factor\",\n    \"factorType\": \"Recovery Code\",\n    \"configuration\": \"{\\\"digit\\\":8,\\\"count\\\":10}\",\n    \"name\": \"Recovery Code Factor\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/factors",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"factors"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Enable recovery code factor",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"setTimeout(function(){}, 10000);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"factors\": [      \n       \"{{recoveryCodeFactorId}}\"\n    ],\n    \"settings\": {\n        \"mfa\": {}\n    }\n}"
+										},
+										"url": {
+											"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/applications/{{client}}",
+											"host": [
+												"{{management_url}}"
+											],
+											"path": [
+												"management",
+												"organizations",
+												"{{defaultOrganizationId}}",
+												"environments",
+												"{{defaultEnvironmentId}}",
+												"domains",
+												"{{domain}}",
+												"applications",
+												"{{client}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Enroll recovery code factor",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{gateway_url}}/{{domainHrid}}/account/api/auth/recovery_code",
+											"host": [
+												"{{gateway_url}}"
+											],
+											"path": [
+												"{{domainHrid}}",
+												"account",
+												"api",
+												"auth",
+												"recovery_code"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Get recovery codes",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Has proper response\", function () {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.be.lengthOf(10)",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{gateway_url}}/{{domainHrid}}/account/api/auth/recovery_code",
+									"host": [
+										"{{gateway_url}}"
+									],
+									"path": [
+										"{{domainHrid}}",
+										"account",
+										"api",
+										"auth",
+										"recovery_code"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Remove recovery code form user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{gateway_url}}/{{domainHrid}}/account/api/auth/recovery_code",
+									"host": [
+										"{{gateway_url}}"
+									],
+									"path": [
+										"{{domainHrid}}",
+										"account",
+										"api",
+										"auth",
+										"recovery_code"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get recovery codes - after deletion",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Has proper response\", function () {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.be.lengthOf(0)",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{gateway_url}}/{{domainHrid}}/account/api/auth/recovery_code",
+									"host": [
+										"{{gateway_url}}"
+									],
+									"path": [
+										"{{domainHrid}}",
+										"account",
+										"api",
+										"auth",
+										"recovery_code"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Remove recovery factor from app",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"factors\": [\n       \"{{mfaFactorId}}\"\n    ],\n    \"settings\": {\n        \"mfa\": {}\n    }\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/applications/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"organizations",
+										"{{defaultOrganizationId}}",
+										"environments",
+										"{{defaultEnvironmentId}}",
+										"domains",
+										"{{domain}}",
+										"applications",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete recovery Code factor",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"type\": \"recovery-code-am-factor\",\n    \"factorType\": \"Recovery Code\",\n    \"configuration\": \"{\\\"digit\\\":8,\\\"count\\\":10}\",\n    \"name\": \"Recovery Code Factor\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{management_url}}/management/organizations/{{defaultOrganizationId}}/environments/{{defaultEnvironmentId}}/domains/{{domain}}/factors/{{recoveryCodeFactorId}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"organizations",
+										"{{defaultOrganizationId}}",
+										"environments",
+										"{{defaultEnvironmentId}}",
+										"domains",
+										"{{domain}}",
+										"factors",
+										"{{recoveryCodeFactorId}}"
 									]
 								}
 							},


### PR DESCRIPTION
fixes AM-732

## description

This PR aims to reject a EE plugin creation if the plugin is not deployed (plugin not part of the license or missing from the installation)
Check apply on:
* IdentityProvider
* BotDetection
* Factor
* Resources
* Policies
* Reporter
* ExtensionGrantType

## How to test

On EE environment
* Open network view of the brower
* create EE IDP
* copy the curl command from the network view
* do the same for EE factor, EE resource, and a EE plugin.

On CE environmen:
* use the curl commands to have the right payloas (adapt the internal ids)
* the request should fail with the message '`Plugin type xxx not deployed`'
