### PR TITLE
chore(helm): like APIM, ignore helm content from the license checker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -511,6 +511,7 @@
                         <exclude>**/LICENSE_TEMPLATE.txt</exclude>
                         <exclude>sonar-project.properties</exclude>
                         <exclude>gravitee-am-test/api/management/**</exclude>
+                        <exclude>helm/**</exclude>
                     </excludes>
                     <mapping>
                         <ts>SLASHSTAR_STYLE</ts>


### PR DESCRIPTION
As mention on another PR: https://github.com/gravitee-io/gravitee-access-management/pull/2820#pullrequestreview-1551486366
Since helm chart introduction in AM repo we added an issue with the license checker.

To "solve" it, we just tell to license checker to ignore helm content.

