### PR TITLE
chore: Add changelog for new 3.21.5 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,13 @@
 # Change Log
 
+== AM - 3.21.5 (2023-08-03)
+
+== What's new !
+
+=== Gateway
+
+* [gateway] EventType null leads to NPE https://github.com/gravitee-io/issues/issues/9143[#9143]
+
 == AM - 4.0.0 (2023-07-26)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.5 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.5/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.5 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.5%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
