### PR TITLE
chore: Add changelog for new 4.0.1 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,8 +1,13 @@
 # Change Log
 
-== AM - 3.21.5 (2023-08-03)
+== AM - 4.0.1 (2023-08-03)
 
-== What's new !
+=== Other
+
+* Fix indexes issues on reporter and migration script https://github.com/gravitee-io/issues/issues/9155[#9155]
+
+
+== AM - 3.21.5 (2023-08-03)
 
 === Gateway
 


### PR DESCRIPTION

# New version 4.0.1 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-4.0.1/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 4.0.1 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%204.0.1%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
