### PR TITLE
Update Changelog Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 .idea/
 *.iml
 .DS_Store
+.tmp/
 
 # eclipse
 .settings/

--- a/release/helpers/changelog-helper.mjs
+++ b/release/helpers/changelog-helper.mjs
@@ -1,23 +1,23 @@
 /**
- * Get the Ascii doc formatted changelog for input issues
+ * Get the MarkDown doc formatted changelog for input issues
  *
  * @param title {string}
- * @param issues {Array<{id: string, fields: Array<{customfield_10115: string, summary: string}>}>}
+ * @param issues {Array<{id: string, key: string, githubIssue: string, summary: string, components: Array<string>, issueTypeName: string, statusName: string}>}
  */
 export function getChangelogFor(title, issues) {
-  const authorizedIssueTypes = ['Public Bug', 'Story'];
+  const authorizedIssueTypes = ['Public Bug', 'Public Security', 'Story'];
 
   const filteredIssues = issues
     .filter((issue) => {
-      return !!issue.fields.issuetype.name && authorizedIssueTypes.includes(issue.fields.issuetype.name);
+      return !!issue.issueTypeName && authorizedIssueTypes.includes(issue.issueTypeName);
     })
     .filter((issue) => {
-      return issue.fields.status.name === 'Done';
+      return issue.statusName === 'Done';
     })
     .sort((issue1, issue2) => {
       // if null or undefined, put it at the end
-      const githubIssueNumber1 = issue1.fields.customfield_10115;
-      const githubIssueNumber2 = issue2.fields.customfield_10115;
+      const githubIssueNumber1 = issue1.githubIssue;
+      const githubIssueNumber2 = issue2.githubIssue;
       if (!githubIssueNumber1) {
         return 1;
       }
@@ -27,13 +27,13 @@ export function getChangelogFor(title, issues) {
       return githubIssueNumber1 - githubIssueNumber2;
     })
     .map((issue) => {
-      const githubIssue = issue.fields.customfield_10115;
+      const githubIssue = issue.githubIssue;
       let publicIssueContent = '';
       if (githubIssue) {
         const githubLink = `https://github.com/gravitee-io/issues/issues/${githubIssue}`;
         publicIssueContent = ` ${githubLink}[#${githubIssue}]`;
       }
-      return `* ${issue.fields.summary}${publicIssueContent}`;
+      return `* ${issue.summary}${publicIssueContent}`;
     })
     .join('\n');
 

--- a/release/helpers/jira-helper.mjs
+++ b/release/helpers/jira-helper.mjs
@@ -29,12 +29,12 @@ export function getJiraVersion(versionName) {
 /**
  * Get all Jira issues associated to the given version id
  * @param versionId {string} The version id
- * @returns {Promise<Array<{id: string, key: string, fields: Record<string, any>}>>}
+ * @returns {Promise<Array<{id: string, key: string, githubIssue: string, summary: string, components: Array<string>, issueTypeName: string, statusName: string}>>}
  */
-export function getJiraIssuesOfVersion(versionId) {
+export async function getJiraIssuesOfVersion(versionId) {
   const token = process.env.JIRA_TOKEN;
 
-  return fetch(`https://gravitee.atlassian.net/rest/api/3/search?jql=project=AM AND fixVersion=${versionId}`, {
+  const issuesFromJira = await fetch(`https://gravitee.atlassian.net/rest/api/3/search?jql=project=AM AND fixVersion=${versionId}`, {
     method: 'GET',
     headers: {
       Authorization: `Basic ${token}`,
@@ -42,5 +42,33 @@ export function getJiraIssuesOfVersion(versionId) {
     },
   })
     .then((response) => response.json())
-    .then((issues) => issues.issues);
+    .then((body) => body.issues);
+
+  // Filter out issues that are not public bugs or public security issues
+  const issues = issuesFromJira.map((issue) => ({
+    key: issue.key,
+    githubIssue: issue.fields.customfield_10115,
+    summary: issue.fields.summary,
+    components: issue.fields.components,
+    issueTypeName: issue.fields.issuetype.name,
+    statusName: issue.fields.status.name,
+  }));
+
+  // For each issue with empty githubIssue field, get the remote link and extract the GitHub issue number
+  for (const issue of issues.filter((issue) => !issue.githubIssue)) {
+    const remoteLinks = await fetch(`https://gravitee.atlassian.net/rest/api/3/issue/${issue.key}/remotelink`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Basic ${token}`,
+        Accept: 'application/json',
+      },
+    }).then((response) => response.json());
+
+    const githubIssue = remoteLinks.find((remoteLink) => remoteLink.object.url.includes('https://github.com/gravitee-io/issues/issues/'));
+    if (githubIssue) {
+      issue.githubIssue = githubIssue.object.url.replace('https://github.com/gravitee-io/issues/issues/', '');
+    }
+  }
+
+  return issues;
 }


### PR DESCRIPTION
## :pencil2: A description of the changes proposed in the pull request

Update the script generating the changelog to match the new format and target the documentation website instead of the internal changelog.


-> To move further, we need to align filenames for APIM and AM first: https://github.com/gravitee-io/gravitee-platform-docs/pull/21

## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation

