### PR TITLE
fix: unique constraints added for username

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/database/mariadb.schema
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/database/mariadb.schema
@@ -3,5 +3,4 @@
 -- Table & index names are suffixed by 3 underscores to define a
 -- pattern to replace with the domain name
 --
-CREATE TABLE IF NOT EXISTS idp_users___ (id VARCHAR(64) NOT NULL, username VARCHAR(320) NOT NULL, password VARCHAR(255), email VARCHAR(320), metadata LONGTEXT, PRIMARY KEY (id))
-CREATE INDEX IF NOT EXISTS idp_users____username_idx ON idp_users___(username)
+CREATE TABLE IF NOT EXISTS idp_users___ (id VARCHAR(64) NOT NULL, username VARCHAR(320) NOT NULL UNIQUE, password VARCHAR(255), email VARCHAR(320), metadata LONGTEXT, PRIMARY KEY (id))

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/database/mysql.schema
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/database/mysql.schema
@@ -3,4 +3,4 @@
 -- Table & index names are suffixed by 3 underscores to define a
 -- pattern to replace with the domain name
 --
-CREATE TABLE IF NOT EXISTS idp_users___ (id NVARCHAR(64) NOT NULL, username NVARCHAR(320) NOT NULL, password NVARCHAR(255) NULL, email NVARCHAR(320) NULL, metadata LONGTEXT NULL, PRIMARY KEY (id), INDEX (username))
+CREATE TABLE IF NOT EXISTS idp_users___ (id NVARCHAR(64) NOT NULL, username NVARCHAR(320) NOT NULL, password NVARCHAR(255) NULL, email NVARCHAR(320) NULL, metadata LONGTEXT NULL, PRIMARY KEY (id), UNIQUE KEY (username))

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/database/sqlserver.schema
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/database/sqlserver.schema
@@ -3,4 +3,4 @@
 -- Table & index names are suffixed by 3 underscores to define a
 -- pattern to replace with the domain name
 --
-IF NOT EXISTS( SELECT 1 FROM sysobjects WHERE name = 'idp_users___' AND xtype = 'U' ) CREATE TABLE idp_users___ (id NVARCHAR(64) NOT NULL, username NVARCHAR(320) NOT NULL, password NVARCHAR(255) NULL, email NVARCHAR(320) NULL, metadata NVARCHAR(MAX) NULL, PRIMARY KEY (id), INDEX idp_users____username_idx NONCLUSTERED (username))
+IF NOT EXISTS( SELECT 1 FROM sysobjects WHERE name = 'idp_users___' AND xtype = 'U' ) CREATE TABLE idp_users___ (id NVARCHAR(64) NOT NULL, username NVARCHAR(320) NOT NULL UNIQUE, password NVARCHAR(255) NULL, email NVARCHAR(320) NULL, metadata NVARCHAR(MAX) NULL, PRIMARY KEY (id), INDEX idp_users____username_idx NONCLUSTERED (username))

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.identityprovider.mongo.user;
 
 import com.google.common.base.Strings;
+import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Updates;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import io.gravitee.am.common.oidc.StandardClaims;
@@ -38,6 +39,7 @@ import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
 
 import java.security.SecureRandom;
@@ -53,22 +55,27 @@ import static com.mongodb.client.model.Filters.eq;
  */
 @Import({MongoAuthenticationProviderConfiguration.class})
 public class MongoUserProvider extends MongoAbstractProvider implements UserProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoUserProvider.class);
     private static final String FIELD_ID = "_id";
     private static final String FIELD_CREATED_AT = "createdAt";
     private static final String FIELD_UPDATED_AT = "updatedAt";
+    private static final String INDEX_USERNAME = "username_1";
 
     @Autowired
     private BinaryToTextEncoder binaryToTextEncoder;
 
     private MongoCollection<Document> usersCollection;
 
+    @Value("${management.mongodb.ensureIndexOnStart:true}")
+    private boolean ensureIndexOnStart;
+
     @Override
     public void afterPropertiesSet() {
         super.afterPropertiesSet();
         // init users collection
         usersCollection = this.mongoClient.getDatabase(this.configuration.getDatabase()).getCollection(this.configuration.getUsersCollection());
-        // create index on username field
-        Observable.fromPublisher(usersCollection.createIndex(new Document(configuration.getUsernameField(), 1))).subscribe();
+
+        createOrUpdateIndex();
     }
 
     public UserProvider stop() throws Exception {
@@ -257,5 +264,30 @@ public class MongoUserProvider extends MongoAbstractProvider implements UserProv
         byte[] salt = new byte[configuration.getPasswordSaltLength()];
         random.nextBytes(salt);
         return salt;
+    }
+
+    /**
+     * Create or update index on username field
+     */
+    private void createOrUpdateIndex() {
+        if (ensureIndexOnStart) {
+            getUserNameIndex()
+                    .andThen(Completable.fromPublisher(usersCollection.createIndex(new Document(configuration.getUsernameField(), 1), new IndexOptions().unique(true))))
+                    .subscribe(
+                            () -> LOGGER.debug("Unique index on username created"),
+                            err -> LOGGER.error("An error occurred while creating index {} with unique constraints", INDEX_USERNAME, err));
+        }
+    }
+
+    private Completable getUserNameIndex() {
+        return Observable.fromPublisher(usersCollection.listIndexes())
+                .map(document -> document.getString("name"))
+                .flatMapCompletable(indexName -> {
+                    if (indexName.equals(INDEX_USERNAME)) {
+                        return Completable.fromPublisher(usersCollection.dropIndex(indexName));
+                    } else {
+                        return Completable.complete();
+                    }
+                });
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_19_21/3.19.21-alter-users_username_unique.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v3_19_21/3.19.21-alter-users_username_unique.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.19.21-users-add-username-unique-constraints
+      author: GraviteeSource Team
+      changes:
+        #############################
+        # users Table, add unique constraints to the username field
+        ############################
+        - addUniqueConstraint:
+            tableName: users
+            columnNames: username, source
+            constraintName: users_username_source_unique

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -83,3 +83,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_19_0/3.19.0-add-theme-table.yml
   - include:
       - file: liquibase/changelogs/v3_19_13/3.19.13-alter-i18n_dictionary_entries-column-length.yml
+  - include:
+      - file: liquibase/changelogs/v3_19_21/3.19.21-alter-users_username_unique.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/resources/scripts/create-index.js
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/resources/scripts/create-index.js
@@ -146,7 +146,7 @@ db.users.createIndex( { "referenceType" : 1, "referenceId": 1, "displayName": 1 
 db.users.createIndex( { "referenceType" : 1, "referenceId": 1, "firstName": 1 } );
 db.users.createIndex( { "referenceType" : 1, "referenceId": 1, "lastName": 1 } );
 db.users.createIndex( { "referenceType" : 1, "referenceId": 1, "externalId": 1 } );
-db.users.createIndex( { "referenceType" : 1, "referenceId": 1, "username": 1, "source": 1 } );
+db.users.createIndex( { "referenceType" : 1, "referenceId": 1, "username": 1, "source": 1 }, { unique: true } );
 db.users.createIndex( { "referenceType" : 1, "referenceId": 1, "externalId": 1, "source": 1 } );
 db.users.reIndex();
 

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/UserRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/UserRepositoryTest.java
@@ -851,13 +851,13 @@ public class UserRepositoryTest extends AbstractManagementTest {
     public void testFindByDomainAndEmail() throws TechnicalException {
         final String domain = "domain";
         // create user
-        User user = new User();
+        User user = createUserWithRandomName();
         user.setReferenceType(ReferenceType.DOMAIN);
         user.setReferenceId(domain);
         user.setEmail("test@test.com");
         userRepository.create(user).blockingGet();
 
-        User user2 = new User();
+        User user2 = createUserWithRandomName();
         user2.setReferenceType(ReferenceType.DOMAIN);
         user2.setReferenceId(domain);
         user2.setEmail("test@Test.com");
@@ -876,13 +876,13 @@ public class UserRepositoryTest extends AbstractManagementTest {
     public void testFindByDomainAndEmailWithStandardClaim() throws TechnicalException {
         final String domain = "domain";
         // create user
-        User user = new User();
+        User user = createUserWithRandomName();
         user.setReferenceType(ReferenceType.DOMAIN);
         user.setReferenceId(domain);
         user.setEmail("test@test.com");
         userRepository.create(user).blockingGet();
 
-        User user2 = new User();
+        User user2 = createUserWithRandomName();
         user2.setReferenceType(ReferenceType.DOMAIN);
         user2.setReferenceId(domain);
         user2.setAdditionalInformation(Collections.singletonMap(StandardClaims.EMAIL, "test@Test.com"));// one UPPER case letter
@@ -968,21 +968,21 @@ public class UserRepositoryTest extends AbstractManagementTest {
     public void testStat_UserRegistration() throws TechnicalException {
         final String domain = "domain";
         // create user
-        User user = new User();
+        User user = createUserWithRandomName();
         user.setReferenceType(ReferenceType.DOMAIN);
         user.setReferenceId(domain);
         user.setPreRegistration(true);
         user.setRegistrationCompleted(true);
         userRepository.create(user).blockingGet();
 
-        User user2 = new User();
+        User user2 = createUserWithRandomName();
         user2.setReferenceType(ReferenceType.DOMAIN);
         user2.setReferenceId(domain);
         user2.setPreRegistration(true);
         user2.setRegistrationCompleted(false);
         userRepository.create(user2).blockingGet();
 
-        User user3 = new User();
+        User user3 = createUserWithRandomName();
         user3.setReferenceType(ReferenceType.DOMAIN);
         user3.setReferenceId(domain);
         user3.setPreRegistration(false);
@@ -1007,7 +1007,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
     public void testStat_StatusRepartition() throws TechnicalException {
         final String domain = "domain_status";
         // enabled used
-        User user = new User();
+        User user = createUserWithRandomName();
         user.setReferenceType(ReferenceType.DOMAIN);
         user.setReferenceId(domain);
         user.setEnabled(true);
@@ -1015,7 +1015,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         userRepository.create(user).blockingGet();
 
         // disabled used
-        User user2 = new User();
+        User user2 = createUserWithRandomName();
         user2.setReferenceType(ReferenceType.DOMAIN);
         user2.setReferenceId(domain);
         user2.setEnabled(false);
@@ -1023,7 +1023,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         userRepository.create(user2).blockingGet();
 
         // locked used
-        User user3 = new User();
+        User user3 = createUserWithRandomName();
         user3.setReferenceType(ReferenceType.DOMAIN);
         user3.setReferenceId(domain);
         user3.setAccountNonLocked(false);
@@ -1032,7 +1032,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         userRepository.create(user3).blockingGet();
 
         // expired locked user ==> so active one
-        User user4 = new User();
+        User user4 = createUserWithRandomName();
         user4.setReferenceType(ReferenceType.DOMAIN);
         user4.setReferenceId(domain);
         user4.setAccountNonLocked(false);
@@ -1041,7 +1041,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         userRepository.create(user4).blockingGet();
 
         // inactive user
-        User user5 = new User();
+        User user5 =createUserWithRandomName();
         user5.setReferenceType(ReferenceType.DOMAIN);
         user5.setReferenceId(domain);
         user5.setLoggedAt(new Date(Instant.now().minus(91, ChronoUnit.DAYS).toEpochMilli()));
@@ -1070,7 +1070,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         final String clientId2 = UUID.randomUUID().toString();;
 
         // enabled used
-        User user = new User();
+        User user = createUserWithRandomName();
         user.setClient(clientId1);
         user.setReferenceType(ReferenceType.DOMAIN);
         user.setReferenceId(domain);
@@ -1079,7 +1079,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         userRepository.create(user).blockingGet();
 
         // disabled used
-        User user2 = new User();
+        User user2 = createUserWithRandomName();
         user2.setClient(clientId1);
         user2.setReferenceType(ReferenceType.DOMAIN);
         user2.setReferenceId(domain);
@@ -1088,7 +1088,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         userRepository.create(user2).blockingGet();
 
         // locked used
-        User user3 = new User();
+        User user3 = createUserWithRandomName();
         user3.setClient(clientId1);
         user3.setReferenceType(ReferenceType.DOMAIN);
         user3.setReferenceId(domain);
@@ -1098,7 +1098,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         userRepository.create(user3).blockingGet();
 
         // expired locked user ==> so active one
-        User user4 = new User();
+        User user4 = createUserWithRandomName();
         user4.setClient(clientId2);
         user4.setReferenceType(ReferenceType.DOMAIN);
         user4.setReferenceId(domain);
@@ -1108,7 +1108,7 @@ public class UserRepositoryTest extends AbstractManagementTest {
         userRepository.create(user4).blockingGet();
 
         // inactive user
-        User user5 = new User();
+        User user5 = createUserWithRandomName();
         user5.setClient(clientId2);
         user5.setReferenceType(ReferenceType.DOMAIN);
         user5.setReferenceId(domain);
@@ -1146,5 +1146,12 @@ public class UserRepositoryTest extends AbstractManagementTest {
         testObserver2.assertValue(users -> ((Number)users.get("inactive")).intValue() == 1);
         testObserver2.assertValue(users -> ((Number)users.get("disabled")).intValue() == 0);
         testObserver2.assertValue(users -> ((Number)users.get("locked")).intValue() == 0);
+    }
+
+    private User createUserWithRandomName(){
+        User user = new User();
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        user.setUsername("testUser" + uuid);
+        return user;
     }
 }


### PR DESCRIPTION
Brief summary:

Unique constraints are added in:
Users table and newly created idp_xxx tables as necessary.
As a result there won't be any duplicate username in the users table. 

What to check:
Postgresql already had unique constraints and had no issue. For rest of the JDBC or mongodb the easiest way to test would be running the "CreateUsers" gatling test under "gravitee-am-performance" package. 

- Run "CrateDomain" gatling test
- Change "SimulationSettigns.scala" such as

1. val NUMBER_OF_USERS = Integer.getInteger("number_of_users", 12)
2. val AGENTS = Integer.getInteger("agents", 3)
3. Remove "${index}" from username around line number 87.
The goal here to create a duplicate user. These changes allow 3 threads to try to create user with same username in total 4 times. Feel free to change the variable value as necessary.

- Run "CreateUsers" gatling test
- The expectation is there will be no duplicate user with same username

Testing mongoDB and at least one JDBC should be sufficient.
I have written few queries to delete duplicate username entries from the exiting tables (if requres), I will add them in a slab page. The reason is; exception will be thrown during startup due to unique constraints if table already has duplicate data.