### PR TITLE
feat: remember me option

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/oidc/Parameters.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/oidc/Parameters.java
@@ -61,6 +61,10 @@ public interface Parameters {
      */
     String LOGIN_HINT = "login_hint";
     /**
+     * Hint to know if the user checked "remember me".
+     */
+    String REMEMBER_ME_HINT = "remember_me_hint";
+    /**
      * Requested Authentication Context Class Reference values.
      */
     String ACR_VALUES = "acr_values";

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -53,6 +53,7 @@ public interface ConstantKeys {
     String TOKEN_TYPE_HINT_PARAM_KEY = "token_type_hint";
     String USERNAME_PARAM_KEY = "username";
     String PASSWORD_PARAM_KEY = "password";
+    String REMEMBER_ME_PARAM_KEY = "rememberMe";
     String PROVIDER_ID_PARAM_KEY = "providerId";
     String ACTION_KEY = "action";
     String LOGIN_ACTION_KEY = "loginAction";
@@ -197,6 +198,7 @@ public interface ConstantKeys {
     String TEMPLATE_KEY_REGISTER_ACTION_KEY = "registerAction";
     String TEMPLATE_KEY_WEBAUTHN_ACTION_KEY = "passwordlessAction";
     String TEMPLATE_KEY_BACK_LOGIN_IDENTIFIER_ACTION_KEY = "backToLoginIdentifierAction";
+    String TEMPLATE_KEY_REMEMBER_ME_KEY = "rememberMeEnabled";
     // MFA templates
     String TEMPLATE_KEY_RECOVERY_CODES_KEY = "recoveryCodes";
     String TEMPLATE_KEY_RECOVERY_CODES_URL_KEY = "recoveryCodeURL";
@@ -229,4 +231,7 @@ public interface ConstantKeys {
 
     String POLICY_CHAIN_ERROR_KEY_MFA_CHALLENGE_ERROR = "GATEWAY_POLICY_MFA_CHALLENGE_ERROR";
     String LINKED_ACCOUNT_ID_CONTEXT_KEY = "linkedAccountId";
+
+    String DEFAULT_REMEMBER_ME_COOKIE_NAME = "GRAVITEE_IO_REMEMBER_ME";
+    String USER_ID_KEY = "userId";
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/RememberMeStep.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/RememberMeStep.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal;
+
+import io.gravitee.am.gateway.handler.common.jwt.JWTService;
+import io.gravitee.am.gateway.handler.common.user.UserService;
+import io.gravitee.am.model.User;
+import io.gravitee.am.service.exception.UserNotFoundException;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.Handler;
+import io.vertx.rxjava3.core.http.Cookie;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.gravitee.am.common.utils.ConstantKeys.USER_ID_KEY;
+import static io.gravitee.am.gateway.handler.common.jwt.JWTService.TokenType.SESSION;
+
+/**
+ * @author Aurélien PACAUD (aurelien.pacaud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RememberMeStep extends AuthenticationFlowStep {
+
+    private static final Logger logger = LoggerFactory.getLogger(RememberMeStep.class);
+
+    private final JWTService jwtService;
+    private final UserService userService;
+    private final String cookieName;
+
+    public RememberMeStep(Handler<RoutingContext> handler, JWTService jwtService, UserService userService, String cookieName) {
+        super(handler);
+        this.jwtService = jwtService;
+        this.userService = userService;
+        this.cookieName = cookieName;
+    }
+
+    @Override
+    public void execute(RoutingContext routingContext, AuthenticationFlowChain flow) {
+
+        // If the user is present, a valid session exists
+        if (routingContext.user() != null) {
+            flow.doNext(routingContext);
+            return;
+        }
+
+        // If there is no remember-me cookie
+        if (routingContext.request().getCookie(cookieName) == null) {
+            flow.doNext(routingContext);
+            return;
+        }
+
+        // Extract current user form remember-me cookie
+        extractUserFormRememberMeCookie(routingContext.request().getCookie(cookieName))
+                .subscribe(
+                        user -> {
+                            routingContext.setUser(io.vertx.rxjava3.ext.auth.User.newInstance(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User((user))));
+                            flow.doNext(routingContext);
+                        },
+                        throwable -> {
+                            logger.error("An error has occurred when parsing RememberMe cookie", throwable);
+                            flow.exit(this);
+                        }
+                );
+    }
+
+    private Single<User> extractUserFormRememberMeCookie(final Cookie rememberMeCookie) {
+
+        final var rememberMeCookieValue = rememberMeCookie.getValue();
+
+        return jwtService.decode(rememberMeCookieValue, SESSION)
+                .flatMap(jwt -> {
+
+                    final var userId = (String) jwt.get(USER_ID_KEY);
+
+                    return userService.findById(userId)
+                            .switchIfEmpty(Single.error(new UserNotFoundException(userId)));
+                });
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/RememberMeStepTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/RememberMeStepTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.vertx.web.handler;
+
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.gateway.handler.common.jwt.JWTService;
+import io.gravitee.am.gateway.handler.common.user.UserService;
+import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.AuthenticationFlowChain;
+import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.RememberMeStep;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.Cookie;
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import io.vertx.rxjava3.ext.auth.User;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static io.gravitee.am.common.utils.ConstantKeys.DEFAULT_REMEMBER_ME_COOKIE_NAME;
+import static io.gravitee.am.common.utils.ConstantKeys.USER_ID_KEY;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Aurélien PACAUD (aurelien.pacaud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RememberMeStepTest {
+
+    private static final Handler<RoutingContext> redirectHandler = RedirectHandler.create("/login");
+
+    @Mock
+    private JWTService jwtService;
+
+    @Mock
+    private UserService gatewayUserService;
+
+    @Mock
+    private RoutingContext routingContext;
+
+    @Mock
+    private HttpServerRequest httpServerRequest;
+
+    private AuthenticationFlowChain authenticationFlowChain;
+
+    private RememberMeStep step;
+
+    @Before
+    public void setUp() {
+
+        step = new RememberMeStep(redirectHandler, jwtService, gatewayUserService, DEFAULT_REMEMBER_ME_COOKIE_NAME);
+        authenticationFlowChain = spy(new AuthenticationFlowChain(List.of(step)));
+
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        doNothing().when(authenticationFlowChain).exit(Mockito.any());
+        doNothing().when(authenticationFlowChain).doNext(Mockito.any());
+    }
+
+    @Test
+    public void mustDoNext_userAlreadyAuthenticated() {
+        when(routingContext.user()).thenReturn(User.create(new JsonObject()));
+
+        step.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(0)).exit(step);
+        verify(authenticationFlowChain, times(1)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustExit_userNotAuthenticatedAndRememberMeCookieNotFound() {
+        when(routingContext.user()).thenReturn(null);
+
+        step.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(0)).exit(step);
+        verify(authenticationFlowChain, times(1)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustExit_failedToDecodeRememberMeCookie() {
+        when(routingContext.user()).thenReturn(null);
+
+        when(httpServerRequest.getCookie(DEFAULT_REMEMBER_ME_COOKIE_NAME)).thenReturn(Cookie.cookie(DEFAULT_REMEMBER_ME_COOKIE_NAME, "value"));
+        when(jwtService.decode(anyString(), any(JWTService.TokenType.class))).thenReturn(Single.error(new IllegalArgumentException("Error during decoding")));
+
+        step.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(1)).exit(step);
+        verify(authenticationFlowChain, times(0)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustExit_userNotFound() {
+        when(routingContext.user()).thenReturn(null);
+
+        when(httpServerRequest.getCookie(DEFAULT_REMEMBER_ME_COOKIE_NAME)).thenReturn(Cookie.cookie(DEFAULT_REMEMBER_ME_COOKIE_NAME, "value"));
+
+        final var jwt = new JWT();
+        jwt.put(USER_ID_KEY, "12345");
+        when(jwtService.decode(anyString(), any(JWTService.TokenType.class))).thenReturn(Single.just(jwt));
+
+        when(gatewayUserService.findById("12345")).thenReturn(Maybe.error(new IllegalStateException("User not found")));
+
+        step.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(1)).exit(step);
+        verify(authenticationFlowChain, times(0)).doNext(routingContext);
+    }
+
+    @Test
+    public void mustDoNext_cookieCorrectlyDecodedAndRead() {
+
+        when(routingContext.user()).thenReturn(null);
+
+        when(httpServerRequest.getCookie(DEFAULT_REMEMBER_ME_COOKIE_NAME)).thenReturn(Cookie.cookie(DEFAULT_REMEMBER_ME_COOKIE_NAME, "value"));
+
+        final var jwt = new JWT();
+        jwt.put(USER_ID_KEY, "12345");
+        when(jwtService.decode(anyString(), any(JWTService.TokenType.class))).thenReturn(Single.just(jwt));
+
+        when(gatewayUserService.findById("12345")).thenReturn(Maybe.just(new io.gravitee.am.model.User()));
+
+        step.execute(routingContext, authenticationFlowChain);
+
+        verify(authenticationFlowChain, times(0)).exit(step);
+        verify(authenticationFlowChain, times(1)).doNext(routingContext);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginEndpoint.java
@@ -23,6 +23,7 @@ import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifier
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.Template;
+import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.UserActivityService;
 import io.vertx.core.Handler;
@@ -33,9 +34,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
+import static io.gravitee.am.common.utils.ConstantKeys.TEMPLATE_KEY_REMEMBER_ME_KEY;
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+import static java.util.Optional.ofNullable;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -78,6 +82,10 @@ public class WebAuthnLoginEndpoint extends AbstractEndpoint implements Handler<R
             routingContext.put(ConstantKeys.PARAM_CONTEXT_KEY, params);
             addUserActivityTemplateVariables(routingContext, userActivityService);
             addUserActivityConsentTemplateVariables(routingContext);
+
+            AccountSettings accountSettings = AccountSettings.getInstance(domain, client);
+            var accountSettingsOptionalSettings = ofNullable(accountSettings).filter(Objects::nonNull);
+            routingContext.put(TEMPLATE_KEY_REMEMBER_ME_KEY, accountSettingsOptionalSettings.map(AccountSettings::isRememberMe).orElse(false));
 
             // put error in context
             final String error = routingContext.request().getParam(ConstantKeys.ERROR_PARAM_KEY);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackParseHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackParseHandler.java
@@ -115,6 +115,7 @@ public class LoginCallbackParseHandler implements Handler<RoutingContext> {
                     final MultiMap initialQueryParams = RequestUtils.getQueryParams((String) stateJwt.getOrDefault("q", ""), false);
                     context.put(ConstantKeys.PARAM_CONTEXT_KEY, initialQueryParams);
                     context.put(ConstantKeys.PROVIDER_ID_PARAM_KEY, stateJwt.get("p"));
+                    context.put(ConstantKeys.REMEMBER_ME_PARAM_KEY, stateJwt.get("r"));
                 })
                 .subscribe(
                         stateJwt -> handler.handle(Future.succeededFuture(true)),

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandler.java
@@ -23,17 +23,14 @@ import io.gravitee.am.identityprovider.api.SimpleAuthenticationContext;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.oidc.Client;
 import io.vertx.rxjava3.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static io.gravitee.am.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.*;
 import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
-import static io.gravitee.am.common.utils.ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -72,6 +69,9 @@ public class LoginSelectionRuleHandler extends LoginAbstractHandler  {
                 if (fromIdentifierFirstLogin) {
                     // encode login_hint parameter for external provider (Azure AD replace the '+' sign by a space ' ')
                     uriBuilder.addParameter(Parameters.LOGIN_HINT, UriBuilder.encodeURIComponent(routingContext.request().getParam(USERNAME_PARAM_KEY)));
+                    if (routingContext.request().getParam(REMEMBER_ME_PARAM_KEY) != null){
+                        uriBuilder.addParameter(Parameters.REMEMBER_ME_HINT, UriBuilder.encodeURIComponent(routingContext.request().getParam(REMEMBER_ME_PARAM_KEY)));
+                    }
                 }
 
                 doRedirect(routingContext, uriBuilder.buildString());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSocialAuthenticationHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSocialAuthenticationHandler.java
@@ -40,9 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.gravitee.am.common.utils.ConstantKeys.ACTION_KEY;
-import static io.gravitee.am.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
-import static io.gravitee.am.common.utils.ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.*;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
 
 /**
@@ -55,6 +53,7 @@ public class LoginSocialAuthenticationHandler implements Handler<RoutingContext>
 
     private static final Logger logger = LoggerFactory.getLogger(LoginSocialAuthenticationHandler.class);
     private static final Map<String, String> socialProviders;
+    public static final String REMEMBER_ME_ON = "on";
 
     static {
         Map<String, String> sMap = new HashMap<>();
@@ -164,6 +163,7 @@ public class LoginSocialAuthenticationHandler implements Handler<RoutingContext>
                     final JWT stateJwt = new JWT();
                     stateJwt.put("p", identityProviderId);
                     stateJwt.put("q", context.request().query());
+                    stateJwt.put("r", REMEMBER_ME_ON.equalsIgnoreCase(context.request().formAttributes().get(REMEMBER_ME_PARAM_KEY)));
 
                     return jwtService.encode(stateJwt, certificateManager.defaultCertificateProvider())
                             .flatMapMaybe(state -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRememberMeRequestHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRememberMeRequestHandler.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.resources.handler.user;
+
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.jwt.JWTService;
+import io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.vertx.rxjava3.core.http.Cookie;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.gravitee.am.common.utils.ConstantKeys.*;
+import static io.vertx.rxjava3.ext.web.handler.SessionHandler.DEFAULT_SESSION_TIMEOUT;
+
+/**
+ * @author Aurélien PACAUD (aurelien.pacaud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UserRememberMeRequestHandler extends UserRequestHandler {
+    private static final Logger logger = LoggerFactory.getLogger(UserRememberMeRequestHandler.class);
+    private static final String REMEMBER_ME_ON = "on";
+
+    private final JWTService jwtService;
+    private final Domain domain;
+    private final String cookieName;
+
+    public UserRememberMeRequestHandler(JWTService jwtService, Domain domain, String cookieName) {
+        this.jwtService = jwtService;
+        this.domain = domain;
+        this.cookieName = cookieName;
+    }
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+
+        final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
+
+        final var req = routingContext.request();
+
+        // If the user checks "remember me" option in the form or if another handler added a parameter in the context
+        boolean rememberMe = REMEMBER_ME_ON.equalsIgnoreCase(req.formAttributes().get(REMEMBER_ME_PARAM_KEY));
+
+        if (routingContext.data().containsKey(REMEMBER_ME_PARAM_KEY)) {
+            rememberMe |= (Boolean) routingContext.get(REMEMBER_ME_PARAM_KEY);
+        }
+
+        // If the user wants to be remembered, create a dedicated cookie.
+        // Using domain or application remember-me duration to define the max-age of this cookie
+        if (rememberMe && routingContext.user() != null) {
+
+            final var jwt = new JWT();
+
+            jwt.setIat(System.currentTimeMillis() / 1000);
+            jwt.put(USER_ID_KEY, ((User) routingContext.user().getDelegate()).getUser().getId());
+
+            jwtService.encode(jwt, client).map(jwtEncoded -> {
+                        final var cookie = Cookie.cookie(cookieName, jwtEncoded);
+                        cookie.setMaxAge(getRememberMeDuration(client));
+                        return cookie;
+                    })
+                    .subscribe(
+                            cookie -> {
+                                routingContext.response().addCookie(cookie);
+                                routingContext.next();
+                            },
+                            throwable -> {
+                                logger.warn("Error during remember me cookie creation", throwable);
+                                routingContext.fail(500);
+                            }
+                    );
+        } else {
+            routingContext.next();
+        }
+    }
+
+    private long getRememberMeDuration(Client client) {
+
+        var accountSettings = AccountSettings.getInstance(domain, client);
+
+        if (accountSettings != null && accountSettings.isRememberMe()) {
+            return accountSettings.getRememberMeDuration();
+        }
+
+        return DEFAULT_SESSION_TIMEOUT;// Should be never used
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRememberMeResponseHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRememberMeResponseHandler.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.resources.handler.user;
+
+import io.vertx.rxjava3.ext.web.RoutingContext;
+
+/**
+ * @author Aurélien PACAUD (aurelien.pacaud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UserRememberMeResponseHandler extends UserRequestHandler {
+
+    private final String cookieName;
+
+    public UserRememberMeResponseHandler(String cookieName) {
+        this.cookieName = cookieName;
+    }
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+
+        // remove the remember me cookie
+        routingContext.response().removeCookie(cookieName);
+
+        routingContext.next();
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnLoginHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnLoginHandler.java
@@ -45,7 +45,7 @@ import org.thymeleaf.util.StringUtils;
 import java.time.Instant;
 import java.util.Date;
 
-import static io.gravitee.am.common.utils.ConstantKeys.WEBAUTHN_CREDENTIAL_ID_CONTEXT_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.*;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -78,6 +78,7 @@ public class WebAuthnLoginHandler extends WebAuthnHandler {
     }
 
     private void authenticate(RoutingContext ctx) {
+
         try {
             // support for potential cached javascript files
             // see https://github.com/gravitee-io/issues/issues/7158

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/identifier_first_login.html
@@ -38,6 +38,13 @@
                 <input type="text" id="username" name="username" th:value="${param.username}" autofocus="autofocus" th:placeholder="#{identifier_first.username.placeholder}" class="input-field" required />
             </div>
 
+            <div class="checkbox" th:if="${rememberMeEnabled}">
+                <label for="rememberMe">
+                    <input type="checkbox" id="rememberMe" name="rememberMe" />
+                    <span th:text="#{login.label.remember.me}"/>
+                </label>
+            </div>
+
             <div th:if="${error}" class="item error-text">
                 <span>
                     <span class="error" th:text="${error}"></span>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html
@@ -56,6 +56,13 @@
                 </button>
             </div>
 
+            <div class="checkbox" th:if="${rememberMeEnabled}">
+                <label for="rememberMe">
+                    <input type="checkbox" id="rememberMe" name="rememberMe" th:checked="${param.rememberMe}"/>
+                    <span th:text="#{login.label.remember.me}"/>
+                </label>
+            </div>
+
             <div class="section" th:if="${allowForgotPassword}">
                 <a th:href="${forgotPasswordAction}" th:text="#{login.forgot.password}" />
             </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_login.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/webauthn_login.html
@@ -37,6 +37,13 @@
                 />
             </div>
 
+            <div class="checkbox" th:if="${rememberMeEnabled}">
+                <label for="rememberMe">
+                    <input type="checkbox" id="rememberMe" name="rememberMe" />
+                    <span th:text="#{login.label.remember.me}"/>
+                </label>
+            </div>
+
             <div class="header-description">
                 <span th:text="#{webauthn.login.tips}"/>
             </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRememberMeRequestHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRememberMeRequestHandlerTest.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.resources.handler.user;
+
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
+import io.gravitee.am.gateway.handler.common.jwt.JWTService;
+import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.handler.root.resources.handler.login.LoginFailureHandler;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.service.AuthenticationFlowContextService;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.MultiMap;
+import io.vertx.rxjava3.ext.web.handler.BodyHandler;
+import io.vertx.rxjava3.ext.web.handler.SessionHandler;
+import io.vertx.rxjava3.ext.web.sstore.LocalSessionStore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static io.gravitee.am.common.utils.ConstantKeys.DEFAULT_REMEMBER_ME_COOKIE_NAME;
+import static io.gravitee.am.common.utils.ConstantKeys.REMEMBER_ME_PARAM_KEY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Aurélien PACAUD (aurelien.pacaud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UserRememberMeRequestHandlerTest extends RxWebTestBase {
+
+    @Mock
+    private JWTService jwtService;
+    @Mock
+    private Domain domain;
+    @Mock
+    private AuthenticationFlowContextService authenticationFlowContextService;
+
+    private UserRememberMeRequestHandler handler;
+
+    @Mock
+    private IdentityProviderManager identityProviderManager;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        handler = new UserRememberMeRequestHandler(jwtService, domain, DEFAULT_REMEMBER_ME_COOKIE_NAME);
+
+        router.route(HttpMethod.POST, "/login")
+                .handler(SessionHandler.create(LocalSessionStore.create(vertx)))
+                .handler(BodyHandler.create())
+                .failureHandler(new LoginFailureHandler(authenticationFlowContextService, domain, identityProviderManager));
+    }
+
+    @Test
+    public void userNotWantsToBeRemembered() throws Exception {
+
+        router.route(HttpMethod.POST, "/login")
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, new Client());
+                    rc.next();
+                })
+                .handler(handler)
+                .handler(rc -> rc.end());
+
+        testRequest(
+                HttpMethod.POST,
+                "/login",
+                null,
+                rep -> {
+                    assertNull(getCookieFromName(rep.cookies(), DEFAULT_REMEMBER_ME_COOKIE_NAME));
+                    assertNull(rep.getHeader("Location"));
+                },
+                200, "OK", null);
+    }
+
+    @Test
+    public void userWantsToBeRememberedConfigurationAtDomainLevel() throws Exception {
+        // init domain
+        final var accountSettings = new AccountSettings();
+        accountSettings.setRememberMe(true);
+        accountSettings.setRememberMeDuration(10);
+        when(domain.getAccountSettings()).thenReturn(accountSettings);
+
+        router.route(HttpMethod.POST, "/login")
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, new Client());
+                    io.gravitee.am.model.User endUser = new io.gravitee.am.model.User();
+                    endUser.setId("user-id");
+                    rc.getDelegate().setUser(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(endUser));
+                    rc.next();
+                })
+                .handler(handler)
+                .handler(rc -> rc.end());
+
+        when(jwtService.encode(any(JWT.class), any(Client.class))).thenReturn(Single.just("encodedCookie"));
+
+        testRequest(
+                HttpMethod.POST,
+                "/login",
+                httpClientRequest -> {
+                    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+                    form.set(REMEMBER_ME_PARAM_KEY, "on");
+                    httpClientRequest.putHeader("content-type", "multipart/form-data");
+                    httpClientRequest.send(form.toString());
+                },
+                rep -> {
+                    final var cookie = getCookieFromName(rep.cookies(), DEFAULT_REMEMBER_ME_COOKIE_NAME);
+                    assertNotNull(cookie);
+                    assertTrue(cookie.contains("Max-Age=10"));
+                    assertNull(rep.getHeader("Location"));
+                },
+                200, "OK", null);
+    }
+
+    @Test
+    public void userWantsToBeRememberedConfigurationAtApplicationLevel() throws Exception {
+
+        final var accountSettings = new AccountSettings();
+        accountSettings.setInherited(false);
+        accountSettings.setRememberMe(true);
+        accountSettings.setRememberMeDuration(30);
+
+        final var client = new Client();
+        client.setAccountSettings(accountSettings);
+
+        router.route(HttpMethod.POST, "/login")
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+                    io.gravitee.am.model.User endUser = new io.gravitee.am.model.User();
+                    endUser.setId("user-id");
+                    rc.getDelegate().setUser(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(endUser));
+                    rc.next();
+                })
+                .handler(handler)
+                .handler(rc -> rc.end());
+
+        when(jwtService.encode(any(JWT.class), any(Client.class))).thenReturn(Single.just("encodedCookie"));
+
+        testRequest(
+                HttpMethod.POST,
+                "/login",
+                httpClientRequest -> {
+                    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+                    form.set(REMEMBER_ME_PARAM_KEY, "on");
+                    httpClientRequest.putHeader("content-type", "multipart/form-data");
+                    httpClientRequest.send(form.toString());
+                },
+                rep -> {
+                    final var cookie = getCookieFromName(rep.cookies(), DEFAULT_REMEMBER_ME_COOKIE_NAME);
+                    assertNotNull(cookie);
+                    assertTrue(cookie.contains("Max-Age=30"));
+                    assertNull(rep.getHeader("Location"));
+                },
+                200, "OK", null);
+    }
+
+    @Test
+    public void userWantsToBeRememberedButNoUserInContext() throws Exception {
+
+        router.route(HttpMethod.POST, "/login")
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, new Client());
+                    rc.next();
+                })
+                .handler(handler)
+                .handler(rc -> rc.end());
+
+        testRequest(
+                HttpMethod.POST,
+                "/login",
+                httpClientRequest -> {
+                    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+                    form.set(REMEMBER_ME_PARAM_KEY, "on");
+                    httpClientRequest.putHeader("content-type", "multipart/form-data");
+                    httpClientRequest.send(form.toString());
+                },
+                rep -> {
+                    assertNull(getCookieFromName(rep.cookies(), DEFAULT_REMEMBER_ME_COOKIE_NAME));
+                    assertNull(rep.getHeader("Location"));
+                },
+                200, "OK", null);
+    }
+
+    @Test
+    public void userWantsToBeRememberedAndRememberMeFlagComesFromContext() throws Exception {
+        // init domain
+        final var accountSettings = new AccountSettings();
+        accountSettings.setRememberMe(true);
+        accountSettings.setRememberMeDuration(10);
+        when(domain.getAccountSettings()).thenReturn(accountSettings);
+
+        router.route(HttpMethod.POST, "/login")
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, new Client());
+                    io.gravitee.am.model.User endUser = new io.gravitee.am.model.User();
+                    endUser.setId("user-id");
+                    rc.getDelegate().setUser(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(endUser));
+                    rc.put(ConstantKeys.REMEMBER_ME_PARAM_KEY, true);
+                    rc.next();
+                })
+                .handler(handler)
+                .handler(rc -> rc.end());
+
+        when(jwtService.encode(any(JWT.class), any(Client.class))).thenReturn(Single.just("encodedCookie"));
+
+        testRequest(
+                HttpMethod.POST,
+                "/login",
+                null,
+                rep -> {
+                    final var cookie = getCookieFromName(rep.cookies(), DEFAULT_REMEMBER_ME_COOKIE_NAME);
+                    assertNotNull(cookie);
+                    assertTrue(cookie.contains("Max-Age=10"));
+                    assertNull(rep.getHeader("Location"));
+                },
+                200, "OK", null);
+    }
+
+    @Test
+    public void userNotWantsToBeRememberedAndRememberMeFlagComesFromContext() throws Exception {
+
+        router.route(HttpMethod.POST, "/login")
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, new Client());
+                    io.gravitee.am.model.User endUser = new io.gravitee.am.model.User();
+                    endUser.setId("user-id");
+                    rc.getDelegate().setUser(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(endUser));
+                    rc.put(ConstantKeys.REMEMBER_ME_PARAM_KEY, false);
+                    rc.next();
+                })
+                .handler(handler)
+                .handler(rc -> rc.end());
+
+        testRequest(
+                HttpMethod.POST,
+                "/login",
+                null,
+                rep -> {
+                    assertNull(getCookieFromName(rep.cookies(), DEFAULT_REMEMBER_ME_COOKIE_NAME));
+                    assertNull(rep.getHeader("Location"));
+                },
+                200, "OK", null);
+    }
+
+    private String getCookieFromName(List<String> cookies, String cookieName) {
+        for (String cookie : cookies) {
+            if (cookie.contains(cookieName)) {
+                return cookie;
+            }
+        }
+
+        return null;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -72,6 +72,8 @@
 #      name: session-name
 #      persistent: true
 #      timeout: 1800000 # (in milliseconds)
+#    rememberMe:
+#      name: remember-me
 #  csrf:
 #    secret: s3cR3t4grAv1t3310AMS1g1ingDftK3y
 #  cors:

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -3,6 +3,7 @@ login.description=Don't have an account yet?
 login.subtitle=to continue to
 login.label.username=Username
 login.label.password=Password
+login.label.remember.me=Remember me
 login.error.default.message=Wrong user or password
 login.button.submit=Sign in
 login.forgot.password=Forgot Password?

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
@@ -3,6 +3,7 @@ login.description=Vous n'avez pas encore de compte ?
 login.subtitle=pour continuer vers
 login.label.username=Identifiant
 login.label.password=Mot de passe
+login.label.remember.me=Se souvenir de moi
 login.error.default.message=Utilisateur inconnu ou invalide
 login.button.submit=Connexion
 login.forgot.password=Mot de passe oublié ?

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
@@ -188,6 +188,7 @@ public class PreviewBuilder {
                 variables.put(ConstantKeys.TEMPLATE_KEY_ALLOW_FORGOT_PASSWORD_CONTEXT_KEY, Boolean.TRUE.toString());
                 variables.put(ConstantKeys.TEMPLATE_KEY_IDENTIFIER_FIRST_LOGIN_CONTEXT_KEY, Boolean.FALSE.toString());
                 variables.put(ConstantKeys.TEMPLATE_KEY_BOT_DETECTION_CONFIGURATION, Map.of(SITE_KEY, EMPTY_STRING));
+                variables.put(ConstantKeys.TEMPLATE_KEY_REMEMBER_ME_KEY, Boolean.TRUE.toString());
                 break;
 
             case REGISTRATION:
@@ -247,6 +248,7 @@ public class PreviewBuilder {
 
             case WEBAUTHN_LOGIN:
                 variables.put(ConstantKeys.REMEMBER_DEVICE_IS_ACTIVE, Boolean.FALSE.toString());
+                variables.put(ConstantKeys.TEMPLATE_KEY_REMEMBER_ME_KEY, Boolean.TRUE.toString());
                 break;
 
             case ERROR:
@@ -259,13 +261,16 @@ public class PreviewBuilder {
                 variables.put(TEMPLATE_KEY_RECOVERY_CODES_URL_KEY, EMPTY_STRING);
                 break;
 
+            case IDENTIFIER_FIRST_LOGIN:
+                variables.put(ConstantKeys.TEMPLATE_KEY_REMEMBER_ME_KEY, Boolean.TRUE.toString());
+                break;
+
             // template without specific variables
             case RESET_PASSWORD:
             case OAUTH2_USER_CONSENT:
             case BLOCKED_ACCOUNT:
             case COMPLETE_PROFILE:
             case WEBAUTHN_REGISTER:
-            case IDENTIFIER_FIRST_LOGIN:
             case CERTIFICATE_EXPIRATION:
             default:
                 break;

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/identifier_first_login.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/identifier_first_login.html
@@ -38,6 +38,13 @@
                 <input type="text" id="username" name="username" th:value="${param.username}" autofocus="autofocus" th:placeholder="#{identifier_first.username.placeholder}" class="input-field" required />
             </div>
 
+            <div class="checkbox" th:if="${rememberMeEnabled}">
+                <label for="rememberMe">
+                    <input type="checkbox" id="rememberMe" name="rememberMe" />
+                    <span th:text="#{login.label.remember.me}"/>
+                </label>
+            </div>
+
             <div th:if="${error}" class="item error-text">
                 <span>
                     <span class="error" th:text="${error}"></span>

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/login.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/login.html
@@ -56,6 +56,13 @@
                 </button>
             </div>
 
+            <div class="checkbox" th:if="${rememberMeEnabled}">
+                <label for="rememberMe">
+                    <input type="checkbox" id="rememberMe" name="rememberMe" th:checked="${param.rememberMe}" />
+                    <span th:text="#{login.label.remember.me}"/>
+                </label>
+            </div>
+
             <div class="section" th:if="${allowForgotPassword}">
                 <a th:href="${forgotPasswordAction}" th:text="#{login.forgot.password}" />
             </div>

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/webauthn_login.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/webauthn_login.html
@@ -37,6 +37,13 @@
                 />
             </div>
 
+            <div class="checkbox" th:if="${rememberMeEnabled}">
+                <label for="rememberMe">
+                    <input type="checkbox" id="rememberMe" name="rememberMe" />
+                    <span th:text="#{login.label.remember.me}"/>
+                </label>
+            </div>
+
             <div class="header-description">
                 <span th:text="#{webauthn.login.tips}"/>
             </div>

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -3,6 +3,7 @@ login.description=Don't have an account yet?
 login.subtitle=to continue to
 login.label.username=Username
 login.label.password=Password
+login.label.remember.me=Remember me
 login.error.default.message=Wrong user or password
 login.button.submit=Sign in
 login.forgot.password=Forgot Password?

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
@@ -3,6 +3,7 @@ login.description=Vous n'avez pas encore de compte ?
 login.subtitle=pour continuer vers
 login.label.username=Identifiant
 login.label.password=Mot de passe
+login.label.remember.me=Se souvenir de moi
 login.error.default.message=Utilisateur inconnu ou invalide
 login.button.submit=Connexion
 login.forgot.password=Mot de passe oublié ?

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/account/AccountSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/account/AccountSettings.java
@@ -108,6 +108,16 @@ public class AccountSettings {
     private String botDetectionPlugin;
 
     /**
+     * Remember me option, to avoid to sign in again during a predefined amount of time
+     */
+    private boolean rememberMe;
+
+    /**
+     * Amount of time while the cookie session is stored
+     */
+    private Integer rememberMeDuration;
+
+    /**
      * Used a custom form to generate ForgotPassword page
      */
     private boolean resetPasswordCustomForm;
@@ -169,6 +179,8 @@ public class AccountSettings {
         this.autoLoginAfterResetPassword = other.autoLoginAfterResetPassword;
         this.redirectUriAfterResetPassword = other.redirectUriAfterResetPassword;
         this.deletePasswordlessDevicesAfterResetPassword = other.deletePasswordlessDevicesAfterResetPassword;
+        this.rememberMe = other.rememberMe;
+        this.rememberMeDuration = other.rememberMeDuration;
         this.resetPasswordConfirmIdentity = other.resetPasswordConfirmIdentity;
         this.resetPasswordCustomForm = other.resetPasswordCustomForm;
         this.resetPasswordCustomFormFields = other.resetPasswordCustomFormFields;
@@ -381,6 +393,22 @@ public class AccountSettings {
 
     public void setSendVerifyRegistrationAccountEmail(boolean sendVerifyRegistrationAccountEmail) {
         this.sendVerifyRegistrationAccountEmail = sendVerifyRegistrationAccountEmail;
+    }
+
+    public boolean isRememberMe() {
+        return rememberMe;
+    }
+
+    public void setRememberMe(boolean rememberMe) {
+        this.rememberMe = rememberMe;
+    }
+
+    public Integer getRememberMeDuration() {
+        return rememberMeDuration;
+    }
+
+    public void setRememberMeDuration(Integer rememberMeDuration) {
+        this.rememberMeDuration = rememberMeDuration;
     }
 
     public static Optional<AccountSettings> getInstance(Client client, Domain domain) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/AccountSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/AccountSettingsMongo.java
@@ -45,6 +45,8 @@ public class AccountSettingsMongo {
     private boolean deletePasswordlessDevicesAfterResetPassword;
     private boolean useBotDetection;
     private String botDetectionPlugin;
+    private boolean rememberMe;
+    private Integer rememberMeDuration;
     private boolean resetPasswordCustomForm;
     private List<FormFieldMongo> resetPasswordCustomFormFields;
     private boolean resetPasswordConfirmIdentity;
@@ -255,6 +257,22 @@ public class AccountSettingsMongo {
         this.sendVerifyRegistrationAccountEmail = sendVerifyRegistrationAccountEmail;
     }
 
+    public boolean isRememberMe() {
+        return rememberMe;
+    }
+
+    public void setRememberMe(boolean rememberMe) {
+        this.rememberMe = rememberMe;
+    }
+
+    public Integer getRememberMeDuration() {
+        return rememberMeDuration;
+    }
+
+    public void setRememberMeDuration(Integer rememberMeDuration) {
+        this.rememberMeDuration = rememberMeDuration;
+    }
+
     public AccountSettings convert() {
         AccountSettings accountSettings = new AccountSettings();
         accountSettings.setInherited(isInherited());
@@ -273,6 +291,8 @@ public class AccountSettingsMongo {
         accountSettings.setDeletePasswordlessDevicesAfterResetPassword(isDeletePasswordlessDevicesAfterResetPassword());
         accountSettings.setBotDetectionPlugin(getBotDetectionPlugin());
         accountSettings.setUseBotDetection(isUseBotDetection());
+        accountSettings.setRememberMe(isRememberMe());
+        accountSettings.setRememberMeDuration(getRememberMeDuration());
         accountSettings.setResetPasswordConfirmIdentity(isResetPasswordConfirmIdentity());
         accountSettings.setResetPasswordCustomForm(isResetPasswordCustomForm());
         ofNullable(getResetPasswordCustomFormFields())
@@ -308,6 +328,8 @@ public class AccountSettingsMongo {
         accountSettingsMongo.setDeletePasswordlessDevicesAfterResetPassword(accountSettings.isDeletePasswordlessDevicesAfterResetPassword());
         accountSettingsMongo.setBotDetectionPlugin(accountSettings.getBotDetectionPlugin());
         accountSettingsMongo.setUseBotDetection(accountSettings.isUseBotDetection());
+        accountSettingsMongo.setRememberMe(accountSettings.isRememberMe());
+        accountSettingsMongo.setRememberMeDuration(accountSettings.getRememberMeDuration());
         accountSettingsMongo.setResetPasswordConfirmIdentity(accountSettings.isResetPasswordConfirmIdentity());
         accountSettingsMongo.setResetPasswordCustomForm(accountSettings.isResetPasswordCustomForm());
         ofNullable(accountSettings.getResetPasswordCustomFormFields())

--- a/gravitee-am-test/api/commands/gateway/login-commands.ts
+++ b/gravitee-am-test/api/commands/gateway/login-commands.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {extractXsrfTokenAndActionResponse, performFormPost, performGet} from "@gateway-commands/oauth-oidc-commands";
+import {expect} from "@jest/globals";
+
+const cheerio = require('cheerio');
+
+export const initiateLoginFlow = async (clientId, openIdConfiguration, domain, responseType = 'code') => {
+    const params = `?response_type=${responseType}&client_id=${clientId}&redirect_uri=https://auth-nightly.gravitee.io/myApp/callback`;
+
+    const authResponse = await performGet(openIdConfiguration.authorization_endpoint, params).expect(302);
+    const loginLocation = authResponse.headers['location'];
+
+    expect(loginLocation).toBeDefined();
+    expect(loginLocation).toContain(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/login`);
+    expect(loginLocation).toContain(`client_id=${clientId}`);
+
+    return authResponse;
+};
+
+export const login = async (authResponse, userName, clientId, password = 'SomeP@ssw0rd', rememberMe = false) => {
+    const loginResult = await extractXsrfTokenAndActionResponse(authResponse);
+    return await performFormPost(
+        loginResult.action,
+        '',
+        {
+            'X-XSRF-TOKEN': loginResult.token,
+            username: userName,
+            password: password,
+            rememberMe: rememberMe ? 'on' : 'off',
+            client_id: clientId,
+        },
+        {
+            Cookie: loginResult.headers['set-cookie'],
+            'Content-type': 'application/x-www-form-urlencoded',
+        },
+    ).expect(302);
+};
+
+export const postLoginAuthentication = async (postLogin) => {
+    return await performGet(postLogin.headers['location'], '', {
+        Cookie: postLogin.headers['set-cookie'],
+    }).expect(302);
+};
+
+export const postConsent = async (consent) => {
+    const dom = cheerio.load(consent.text);
+    const xsrfToken = dom('[name=X-XSRF-TOKEN]').val();
+    return await performFormPost(
+        consent.request.url,
+        '',
+        {
+            'X-XSRF-TOKEN': xsrfToken,
+            'scope.openid': true,
+            user_oauth_approval: true,
+        },
+        {
+            Cookie: consent.headers['set-cookie'],
+            'Content-type': 'application/x-www-form-urlencoded',
+        },
+    ).expect(302);
+};
+
+export const loginUserNameAndPassword = async (clientId, user, userPassword, rememberMe, openIdConfiguration, domain) => {
+    return await loginUser(clientId, user.username, userPassword, rememberMe, openIdConfiguration, domain);
+};
+
+export const loginAdditionalInfoAndPassword = async (clientId, additionalInfo, userPassword, rememberMe, openIdConfiguration, domain) => {
+    return await loginUser(clientId, additionalInfo, userPassword, rememberMe, openIdConfiguration, domain);
+};
+
+export const loginUser = async (clientId, nameOrAdditionalInfo, userPassword, rememberMe, openIdConfiguration, domain) => {
+    const authResponse = await initiateLoginFlow(clientId, openIdConfiguration, domain);
+    const postLogin = await login(authResponse, nameOrAdditionalInfo, clientId, userPassword, rememberMe);
+    //log in failed with error
+    if (postLogin.headers['location'].includes('error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user')) {
+        return postLogin;
+    }
+    const authorize = await postLoginAuthentication(postLogin);
+    expect(authorize.headers['location']).toBeDefined();
+
+    //log in for the very first time
+    if (authorize.headers['location'].includes(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/oauth/consent`)) {
+        const consent = await performGet(authorize.headers['location'], '', {
+            Cookie: authorize.headers['set-cookie'],
+        }).expect(200);
+
+        const authorize2 = await postConsent(consent);
+        expect(authorize2.headers['location']).toBeDefined();
+        expect(authorize2.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/oauth/authorize`);
+
+        const tokenResponse = await performGet(authorize2.headers['location'], '', {
+            Cookie: authorize.headers['set-cookie'],
+        }).expect(302);
+
+        expect(tokenResponse.headers['location']).toBeDefined();
+        return tokenResponse;
+    } else {
+        return authorize;
+    }
+};

--- a/gravitee-am-test/api/commands/utils/application-commands.ts
+++ b/gravitee-am-test/api/commands/utils/application-commands.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createApplication, updateApplication} from "@management-commands/application-management-commands";
+import {expect} from "@jest/globals";
+
+export const createTestApp = async (name, domain, accessToken, applicationType = 'web', body= {}) => {
+    const application = await createApplication(domain.id, accessToken, {
+        name: name,
+        type: applicationType,
+        clientId: `${name}-id`,
+    }).then((app) =>
+        updateApplication(
+            domain.id,
+            accessToken,
+            body,
+            app.id,
+        ),
+    );
+
+    expect(application).toBeDefined();
+    expect(application.settings.oauth.clientId).toBeDefined();
+
+    return application;
+};

--- a/gravitee-am-test/api/commands/utils/idps-commands.ts
+++ b/gravitee-am-test/api/commands/utils/idps-commands.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createIdp} from "@management-commands/idp-management-commands";
+
+export const createMongoIdp = async (domainId, accessToken) => {
+    console.log('creating mongodb  idp');
+    return await createIdp(domainId, accessToken, {
+        external: false,
+        type: 'mongo-am-idp',
+        domainWhitelist: [],
+        configuration:
+            '{"uri":"mongodb://localhost:27017","host":"localhost","port":27017,"enableCredentials":false,"databaseCredentials":"gravitee-am","database":"gravitee-am","usersCollection":"idp-test-users","findUserByUsernameQuery":"{$or: [{username: ?}, {contract: ?}]}","findUserByEmailQuery":"{email: ?}","usernameField":"username","passwordField":"password","passwordEncoder":"None","useDedicatedSalt":false,"passwordSaltLength":32}',
+        name: 'another-idp',
+    });
+};
+
+export const createJdbcIdp = async (domainId, accessToken) => {
+    console.log('creating jdbc idp');
+    const password = process.env.GRAVITEE_OAUTH2_JDBC_PASSWORD ? process.env.GRAVITEE_OAUTH2_JDBC_PASSWORD : 'p@ssw0rd';
+    const database = process.env.GRAVITEE_OAUTH2_JDBC_DATABASE ? process.env.GRAVITEE_OAUTH2_JDBC_DATABASE : 'gravitee-am';
+
+    return await createIdp(domainId, accessToken, {
+        external: false,
+        type: 'jdbc-am-idp',
+        domainWhitelist: [],
+        configuration: `{\"host\":\"localhost\",\"port\":5432,\"protocol\":\"postgresql\",\"database\":\"${database}\",\"usersTable\":\"test_users\",\"user\":\"postgres\",\"password\":\"${password}\",\"autoProvisioning\":\"true\",\"selectUserByUsernameQuery\":\"SELECT * FROM test_users WHERE username = %s\",\"selectUserByMultipleFieldsQuery\":\"SELECT * FROM test_users WHERE username = %s or email = %s\",\"selectUserByEmailQuery\":\"SELECT * FROM test_users WHERE email = %s\",\"identifierAttribute\":\"id\",\"usernameAttribute\":\"username\",\"emailAttribute\":\"email\",\"passwordAttribute\":\"password\",\"passwordEncoder\":\"None\",\"useDedicatedSalt\":false,\"passwordSaltLength\":32}`,
+        name: 'other-jdbc-idp',
+    });
+};

--- a/gravitee-am-test/api/management/models/AccountSettings.ts
+++ b/gravitee-am-test/api/management/models/AccountSettings.ts
@@ -136,6 +136,18 @@ export interface AccountSettings {
    * @type {boolean}
    * @memberof AccountSettings
    */
+  rememberMe?: boolean;
+  /**
+   *
+   * @type {number}
+   * @memberof AccountSettings
+   */
+  rememberMeDuration?: number;
+  /**
+   *
+   * @type {boolean}
+   * @memberof AccountSettings
+   */
   resetPasswordCustomForm?: boolean;
   /**
    *
@@ -212,6 +224,8 @@ export function AccountSettingsFromJSONTyped(json: any, ignoreDiscriminator: boo
       : json['deletePasswordlessDevicesAfterResetPassword'],
     useBotDetection: !exists(json, 'useBotDetection') ? undefined : json['useBotDetection'],
     botDetectionPlugin: !exists(json, 'botDetectionPlugin') ? undefined : json['botDetectionPlugin'],
+    rememberMe: !exists(json, 'rememberMe') ? undefined : json['rememberMe'],
+    rememberMeDuration: !exists(json, 'rememberMeDuration') ? undefined : json['rememberMeDuration'],
     resetPasswordCustomForm: !exists(json, 'resetPasswordCustomForm') ? undefined : json['resetPasswordCustomForm'],
     resetPasswordCustomFormFields: !exists(json, 'resetPasswordCustomFormFields')
       ? undefined
@@ -253,6 +267,8 @@ export function AccountSettingsToJSON(value?: AccountSettings | null): any {
     deletePasswordlessDevicesAfterResetPassword: value.deletePasswordlessDevicesAfterResetPassword,
     useBotDetection: value.useBotDetection,
     botDetectionPlugin: value.botDetectionPlugin,
+    rememberMe: value.rememberMe,
+    rememberMeDuration: value.rememberMeDuration,
     resetPasswordCustomForm: value.resetPasswordCustomForm,
     resetPasswordCustomFormFields:
       value.resetPasswordCustomFormFields === undefined

--- a/gravitee-am-test/specs/gateway/login-flow.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/login-flow.jest.spec.ts
@@ -15,23 +15,17 @@
  */
 
 import fetch from 'cross-fetch';
-import { afterAll, beforeAll, expect, jest } from '@jest/globals';
-import { requestAdminAccessToken } from '@management-commands/token-management-commands';
-import { createDomain, deleteDomain, startDomain } from '@management-commands/domain-management-commands';
-import { createIdp } from '@management-commands/idp-management-commands';
-import { createUser, deleteUser, updateUsername } from '@management-commands/user-management-commands';
-import { createApplication, updateApplication } from '@management-commands/application-management-commands';
-import {
-  extractXsrfTokenAndActionResponse,
-  getWellKnownOpenIdConfiguration,
-  logoutUser,
-  performFormPost,
-  performGet,
-} from '@gateway-commands/oauth-oidc-commands';
+import {afterAll, beforeAll, expect, jest} from '@jest/globals';
+import {requestAdminAccessToken} from '@management-commands/token-management-commands';
+import {createDomain, deleteDomain, startDomain} from '@management-commands/domain-management-commands';
+import {createUser, deleteUser, updateUsername} from '@management-commands/user-management-commands';
+import {getWellKnownOpenIdConfiguration, logoutUser, performGet,} from '@gateway-commands/oauth-oidc-commands';
+import {loginAdditionalInfoAndPassword, loginUserNameAndPassword} from "@gateway-commands/login-commands";
+import {createJdbcIdp, createMongoIdp} from "@utils-commands/idps-commands";
+import {createTestApp} from "@utils-commands/application-commands";
 
 global.fetch = fetch;
 
-const cheerio = require('cheerio');
 const jdbc = process.env.GRAVITEE_MANAGEMENT_TYPE;
 
 let accessToken;
@@ -42,403 +36,269 @@ let openIdConfiguration;
 
 jest.setTimeout(200000);
 
+
 beforeAll(async () => {
-  const adminTokenResponse = await requestAdminAccessToken();
-  accessToken = adminTokenResponse.body.access_token;
-  domain = await createDomain(accessToken, 'login-flow-domain', 'test user login').then((domain) => startDomain(domain.id, accessToken));
+    const adminTokenResponse = await requestAdminAccessToken();
+    accessToken = adminTokenResponse.body.access_token;
+    domain = await createDomain(accessToken, 'login-flow-domain', 'test user login').then((domain) => startDomain(domain.id, accessToken));
 
-  customIdp = jdbc === 'jdbc' ? await createJdbcIdp(domain.id, accessToken) : await createMongoIdp(domain.id, accessToken);
-  multiUserLoginApp = await createTestApp('multi-user-login-app', customIdp.id, domain, accessToken);
+    customIdp = jdbc === 'jdbc' ? await createJdbcIdp(domain.id, accessToken) : await createMongoIdp(domain.id, accessToken);
+    multiUserLoginApp = await createTestApp(
+        'multi-user-login-app',
+        domain,
+        accessToken,
+        'WEB',
+        {
+            settings: {
+                oauth: {
+                    redirectUris: ['https://auth-nightly.gravitee.io/myApp/callback'],
+                    scopeSettings: [
+                        { scope: 'openid', defaultScope: true },
+                        {
+                            scope: 'openid',
+                            defaultScope: true,
+                        },
+                    ],
+                },
+            },
+            identityProviders: [{ identity: customIdp.id, priority: 0 }],
+        });
 
-  await new Promise((r) => setTimeout(r, 10000));
+    await new Promise((r) => setTimeout(r, 10000));
 
-  const result = await getWellKnownOpenIdConfiguration(domain.hrid).expect(200);
-  openIdConfiguration = result.body;
+    const result = await getWellKnownOpenIdConfiguration(domain.hrid).expect(200);
+    openIdConfiguration = result.body;
 });
 
 describe('multiple user', () => {
-  const contractValue = '1234';
-  let user1;
-  const user1Password = 'Zxc123!!';
-  let user2;
-  const commonPassword = 'Asd123!!';
-  const commonEmail = 'common@test.com';
-  let user3; //user3 has same password as user2
-  let user4;
-  const user4Password = 'Qwe123!!';
-  let user5;
-  let user6;
-  const secondCommonPassword = 'Phd123!!';
-  const secondCommonEmail = 'second.common@test.com';
+    const contractValue = '1234';
+    let user1;
+    const user1Password = 'Zxc123!!';
+    let user2;
+    const commonPassword = 'Asd123!!';
+    const commonEmail = 'common@test.com';
+    let user3; //user3 has same password as user2
+    let user4;
+    const user4Password = 'Qwe123!!';
+    let user5;
+    let user6;
+    const secondCommonPassword = 'Phd123!!';
+    const secondCommonEmail = 'second.common@test.com';
 
-  beforeAll(async () => {
-    user1 = await createUser(domain.id, accessToken, {
-      firstName: 'john',
-      lastName: 'doe',
-      email: 'john.doe@test.com',
-      username: 'john.doe',
-      password: user1Password,
-      client: multiUserLoginApp.id,
-      source: customIdp.id,
-      additionalInformation: {
-        contract: contractValue,
-      },
-      preRegistration: false,
+    beforeAll(async () => {
+        user1 = await createUser(domain.id, accessToken, {
+            firstName: 'john',
+            lastName: 'doe',
+            email: 'john.doe@test.com',
+            username: 'john.doe',
+            password: user1Password,
+            client: multiUserLoginApp.id,
+            source: customIdp.id,
+            additionalInformation: {
+                contract: contractValue,
+            },
+            preRegistration: false,
+        });
+
+        expect(user1).toBeDefined();
+
+        user2 = await createUser(domain.id, accessToken, {
+            firstName: 'jensen',
+            lastName: 'barbara',
+            username: 'jensen.barbara',
+            email: 'jensen.barbara@test.com',
+            password: commonPassword,
+            client: multiUserLoginApp.id,
+            source: customIdp.id,
+            additionalInformation: {
+                contract: contractValue,
+            },
+            preRegistration: false,
+        });
+
+        expect(user2).toBeDefined();
+
+        user3 = await createUser(domain.id, accessToken, {
+            firstName: 'flip',
+            lastName: 'flop',
+            username: 'flip.flop',
+            email: commonEmail,
+            password: commonPassword,
+            client: multiUserLoginApp.id,
+            source: customIdp.id,
+            additionalInformation: {
+                contract: contractValue,
+            },
+            preRegistration: false,
+        });
+
+        expect(user3).toBeDefined();
+
+        user4 = await createUser(domain.id, accessToken, {
+            firstName: 'some',
+            lastName: 'user',
+            username: 'some.user',
+            email: commonEmail,
+            password: user4Password,
+            client: multiUserLoginApp.id,
+            source: customIdp.id,
+            additionalInformation: {
+                contract: contractValue,
+            },
+            preRegistration: false,
+        });
+
+        expect(user4).toBeDefined();
+
+        user5 = await createUser(domain.id, accessToken, {
+            firstName: 'alan',
+            lastName: 'bull',
+            username: 'user.five',
+            email: secondCommonEmail,
+            password: secondCommonPassword,
+            client: multiUserLoginApp.id,
+            source: customIdp.id,
+            additionalInformation: {
+                contract: contractValue,
+            },
+            preRegistration: false,
+        });
+
+        expect(user5).toBeDefined();
+
+        user6 = await createUser(domain.id, accessToken, {
+            firstName: 'james',
+            lastName: 'hen',
+            username: 'user.six',
+            email: secondCommonEmail,
+            password: secondCommonPassword,
+            client: multiUserLoginApp.id,
+            source: customIdp.id,
+            additionalInformation: {
+                contract: contractValue,
+            },
+            preRegistration: false,
+        });
+
+        expect(user6).toBeDefined();
     });
 
-    expect(user1).toBeDefined();
+    it('all users should be able to login using username and password', async () => {
+        const clientId = multiUserLoginApp.settings.oauth.clientId;
+        const user1TokenResponse = await loginUserNameAndPassword(clientId, user1, user1Password, false, openIdConfiguration, domain);
+        expect(user1TokenResponse.headers['location']).toContain('callback?code=');
+        await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
 
-    user2 = await createUser(domain.id, accessToken, {
-      firstName: 'jensen',
-      lastName: 'barbara',
-      username: 'jensen.barbara',
-      email: 'jensen.barbara@test.com',
-      password: commonPassword,
-      client: multiUserLoginApp.id,
-      source: customIdp.id,
-      additionalInformation: {
-        contract: contractValue,
-      },
-      preRegistration: false,
+        const user2TokenResponse = await loginUserNameAndPassword(clientId, user2, commonPassword, false, openIdConfiguration, domain);
+        expect(user2TokenResponse.headers['location']).toContain('callback?code=');
+        await logoutUser(openIdConfiguration.end_session_endpoint, user2TokenResponse);
+
+        //user3 has same password as user2
+        const user3TokenResponse = await loginUserNameAndPassword(clientId, user3, commonPassword, false, openIdConfiguration, domain);
+        expect(user3TokenResponse.headers['location']).toContain('callback?code=');
+        await logoutUser(openIdConfiguration.end_session_endpoint, user3TokenResponse);
+
+        const user4TokenResponse = await loginUserNameAndPassword(clientId, user4, user4Password, false, openIdConfiguration, domain);
+        expect(user4TokenResponse.headers['location']).toContain('callback?code=');
+        await logoutUser(openIdConfiguration.end_session_endpoint, user4TokenResponse);
     });
 
-    expect(user2).toBeDefined();
+    if (jdbc === 'jdbc') {
+        console.log('executing jdbc specific test');
+        it('jdbc: both users should be able to login using additional information (email) and password', async () => {
+            const clientId = multiUserLoginApp.settings.oauth.clientId;
+            //log in user3
+            const user3TokenResponse = await loginAdditionalInfoAndPassword(clientId, commonEmail, commonPassword, false, openIdConfiguration, domain);
+            expect(user3TokenResponse.headers['location']).toContain('callback?code=');
+            await logoutUser(openIdConfiguration.end_session_endpoint, user3TokenResponse);
 
-    user3 = await createUser(domain.id, accessToken, {
-      firstName: 'flip',
-      lastName: 'flop',
-      username: 'flip.flop',
-      email: commonEmail,
-      password: commonPassword,
-      client: multiUserLoginApp.id,
-      source: customIdp.id,
-      additionalInformation: {
-        contract: contractValue,
-      },
-      preRegistration: false,
+            //log in user4
+            const user4TokenResponse = await loginAdditionalInfoAndPassword(clientId, commonEmail, user4Password, false, openIdConfiguration, domain);
+            await logoutUser(openIdConfiguration.end_session_endpoint, user4TokenResponse);
+        });
+
+        it('jdbc: should throw exception when more than one users have same password for login with additional information', async () => {
+            const clientId = multiUserLoginApp.settings.oauth.clientId;
+            const failedLoginResponse = await loginAdditionalInfoAndPassword(clientId, secondCommonEmail, secondCommonPassword, false, openIdConfiguration, domain);
+            expect(failedLoginResponse.headers['location']).toContain(
+                `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user`,
+            );
+        });
+    } else {
+        console.log('executing mongodb specific test');
+        it('mongo: both users should be able to login using additional information (contract) and password', async () => {
+            const clientId = multiUserLoginApp.settings.oauth.clientId;
+
+            //log in user1
+            const user1TokenResponse = await loginAdditionalInfoAndPassword(clientId, contractValue, user1Password, false, openIdConfiguration, domain);
+            expect(user1TokenResponse.headers['location']).toContain('callback?code=');
+            await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
+
+            //log in user4
+            const user4TokenResponse = await loginAdditionalInfoAndPassword(clientId, contractValue, user4Password, false, openIdConfiguration, domain);
+            await logoutUser(openIdConfiguration.end_session_endpoint, user4TokenResponse);
+        });
+
+        it('mongo: should throw exception when more than one users have same password for login with additional information', async () => {
+            const clientId = multiUserLoginApp.settings.oauth.clientId;
+            const failedLoginResponse = await loginAdditionalInfoAndPassword(clientId, contractValue, commonPassword, false, openIdConfiguration, domain);
+            expect(failedLoginResponse.headers['location']).toContain(
+                `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user`,
+            );
+        });
+    }
+
+    it('user should have their username changed and have their session/token canceled', async () => {
+        const clientId = multiUserLoginApp.settings.oauth.clientId;
+        let user1TokenResponse = await loginUserNameAndPassword(clientId, user1, user1Password, false, openIdConfiguration, domain);
+        expect(user1TokenResponse.headers['location']).toContain('callback?code=');
+        await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
+
+        user1 = await updateUsername(domain.id, accessToken, user1.id, user1.username + '-changed');
+        const params = `?response_type=code&client_id=${clientId}&redirect_uri=https://auth-nightly.gravitee.io/myApp/callback`;
+
+        const authResponse = await performGet(openIdConfiguration.authorization_endpoint, params).expect(302);
+        const loginLocation = authResponse.headers['location'];
+        expect(loginLocation).not.toContain(`callback?code=`);
+        await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
+
+        user1TokenResponse = await loginUserNameAndPassword(clientId, user1, user1Password, false, openIdConfiguration, domain);
+        expect(user1TokenResponse.headers['location']).toContain('callback?code=');
+        await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
     });
 
-    expect(user3).toBeDefined();
+    it('should throw exception user name and wrong password', async () => {
+        const wrongPassword = 'WrongPassword';
+        const clientId = multiUserLoginApp.settings.oauth.clientId;
 
-    user4 = await createUser(domain.id, accessToken, {
-      firstName: 'some',
-      lastName: 'user',
-      username: 'some.user',
-      email: commonEmail,
-      password: user4Password,
-      client: multiUserLoginApp.id,
-      source: customIdp.id,
-      additionalInformation: {
-        contract: contractValue,
-      },
-      preRegistration: false,
+        const failedLoginResponse1 = await loginUserNameAndPassword(clientId, user1, wrongPassword, false, openIdConfiguration, domain);
+        expect(failedLoginResponse1.headers['location']).toContain(
+            `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user`,
+        );
+
+        const failedLoginResponse2 = await loginUserNameAndPassword(clientId, user2, wrongPassword, false, openIdConfiguration, domain);
+        expect(failedLoginResponse2.headers['location']).toContain(
+            `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user`,
+        );
+
+        const failedLoginResponse3 = await loginUserNameAndPassword(clientId, user3, wrongPassword, false, openIdConfiguration, domain);
+        expect(failedLoginResponse3.headers['location']).toContain(
+            `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+us`,
+        );
     });
 
-    expect(user4).toBeDefined();
-
-    user5 = await createUser(domain.id, accessToken, {
-      firstName: 'alan',
-      lastName: 'bull',
-      username: 'user.five',
-      email: secondCommonEmail,
-      password: secondCommonPassword,
-      client: multiUserLoginApp.id,
-      source: customIdp.id,
-      additionalInformation: {
-        contract: contractValue,
-      },
-      preRegistration: false,
+    afterAll(async () => {
+        // await deleteUser(domain.id, accessToken, user1.id);
+        // await deleteUser(domain.id, accessToken, user2.id);
+        // await deleteUser(domain.id, accessToken, user3.id);
+        // await deleteUser(domain.id, accessToken, user4.id);
+        // await deleteUser(domain.id, accessToken, user5.id);
+        // await deleteUser(domain.id, accessToken, user6.id);
     });
-
-    expect(user5).toBeDefined();
-
-    user6 = await createUser(domain.id, accessToken, {
-      firstName: 'james',
-      lastName: 'hen',
-      username: 'user.six',
-      email: secondCommonEmail,
-      password: secondCommonPassword,
-      client: multiUserLoginApp.id,
-      source: customIdp.id,
-      additionalInformation: {
-        contract: contractValue,
-      },
-      preRegistration: false,
-    });
-
-    expect(user6).toBeDefined();
-  });
-
-  it('all users should be able to login using username and password', async () => {
-    const clientId = multiUserLoginApp.settings.oauth.clientId;
-    const user1TokenResponse = await loginUserNameAndPassword(clientId, user1, user1Password);
-    expect(user1TokenResponse.headers['location']).toContain('callback?code=');
-    await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
-
-    const user2TokenResponse = await loginUserNameAndPassword(clientId, user2, commonPassword);
-    expect(user2TokenResponse.headers['location']).toContain('callback?code=');
-    await logoutUser(openIdConfiguration.end_session_endpoint, user2TokenResponse);
-
-    //user3 has same password as user2
-    const user3TokenResponse = await loginUserNameAndPassword(clientId, user3, commonPassword);
-    expect(user3TokenResponse.headers['location']).toContain('callback?code=');
-    await logoutUser(openIdConfiguration.end_session_endpoint, user3TokenResponse);
-
-    const user4TokenResponse = await loginUserNameAndPassword(clientId, user4, user4Password);
-    expect(user4TokenResponse.headers['location']).toContain('callback?code=');
-    await logoutUser(openIdConfiguration.end_session_endpoint, user4TokenResponse);
-  });
-
-  if (jdbc === 'jdbc') {
-    console.log('executing jdbc specific test');
-    it('jdbc: both users should be able to login using additional information (email) and password', async () => {
-      const clientId = multiUserLoginApp.settings.oauth.clientId;
-      //log in user3
-      const user3TokenResponse = await loginAdditionalInfoAndPassword(clientId, commonEmail, commonPassword);
-      expect(user3TokenResponse.headers['location']).toContain('callback?code=');
-      await logoutUser(openIdConfiguration.end_session_endpoint, user3TokenResponse);
-
-      //log in user4
-      const user4TokenResponse = await loginAdditionalInfoAndPassword(clientId, commonEmail, user4Password);
-      await logoutUser(openIdConfiguration.end_session_endpoint, user4TokenResponse);
-    });
-
-    it('jdbc: should throw exception when more than one users have same password for login with additional information', async () => {
-      const clientId = multiUserLoginApp.settings.oauth.clientId;
-      const failedLoginResponse = await loginAdditionalInfoAndPassword(clientId, secondCommonEmail, secondCommonPassword);
-      expect(failedLoginResponse.headers['location']).toContain(
-        `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user`,
-      );
-    });
-  } else {
-    console.log('executing mongodb specific test');
-    it('mongo: both users should be able to login using additional information (contract) and password', async () => {
-      const clientId = multiUserLoginApp.settings.oauth.clientId;
-
-      //log in user1
-      const user1TokenResponse = await loginAdditionalInfoAndPassword(clientId, contractValue, user1Password);
-      expect(user1TokenResponse.headers['location']).toContain('callback?code=');
-      await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
-
-      //log in user4
-      const user4TokenResponse = await loginAdditionalInfoAndPassword(clientId, contractValue, user4Password);
-      await logoutUser(openIdConfiguration.end_session_endpoint, user4TokenResponse);
-    });
-
-    it('mongo: should throw exception when more than one users have same password for login with additional information', async () => {
-      const clientId = multiUserLoginApp.settings.oauth.clientId;
-      const failedLoginResponse = await loginAdditionalInfoAndPassword(clientId, contractValue, commonPassword);
-      expect(failedLoginResponse.headers['location']).toContain(
-        `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user`,
-      );
-    });
-  }
-
-  it('user should have their username changed and have their session/token canceled', async () => {
-    const clientId = multiUserLoginApp.settings.oauth.clientId;
-    let user1TokenResponse = await loginUserNameAndPassword(clientId, user1, user1Password);
-    expect(user1TokenResponse.headers['location']).toContain('callback?code=');
-    await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
-
-    user1 = await updateUsername(domain.id, accessToken, user1.id, user1.username + '-changed');
-    const params = `?response_type=code&client_id=${clientId}&redirect_uri=https://auth-nightly.gravitee.io/myApp/callback`;
-
-    const authResponse = await performGet(openIdConfiguration.authorization_endpoint, params).expect(302);
-    const loginLocation = authResponse.headers['location'];
-    expect(loginLocation).not.toContain(`callback?code=`);
-    await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
-
-    user1TokenResponse = await loginUserNameAndPassword(clientId, user1, user1Password);
-    expect(user1TokenResponse.headers['location']).toContain('callback?code=');
-    await logoutUser(openIdConfiguration.end_session_endpoint, user1TokenResponse);
-  });
-
-  it('should throw exception user name and wrong password', async () => {
-    const wrongPassword = 'WrongPassword';
-    const clientId = multiUserLoginApp.settings.oauth.clientId;
-
-    const failedLoginResponse1 = await loginUserNameAndPassword(clientId, user1, wrongPassword);
-    expect(failedLoginResponse1.headers['location']).toContain(
-      `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user`,
-    );
-
-    const failedLoginResponse2 = await loginUserNameAndPassword(clientId, user2, wrongPassword);
-    expect(failedLoginResponse2.headers['location']).toContain(
-      `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user`,
-    );
-
-    const failedLoginResponse3 = await loginUserNameAndPassword(clientId, user3, wrongPassword);
-    expect(failedLoginResponse3.headers['location']).toContain(
-      `error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+us`,
-    );
-  });
-
-  afterAll(async () => {
-    await deleteUser(domain.id, accessToken, user1.id);
-    await deleteUser(domain.id, accessToken, user2.id);
-    await deleteUser(domain.id, accessToken, user3.id);
-    await deleteUser(domain.id, accessToken, user4.id);
-    await deleteUser(domain.id, accessToken, user5.id);
-    await deleteUser(domain.id, accessToken, user6.id);
-  });
 });
 
 afterAll(async () => {
-  if (domain.id) {
-    await deleteDomain(domain.id, accessToken);
-  }
+    // if (domain.id) {
+    //     await deleteDomain(domain.id, accessToken);
+    // }
 });
-
-const createTestApp = async (name, idpId, domain, accessToken) => {
-  const application = await createApplication(domain.id, accessToken, {
-    name: name,
-    type: 'WEB',
-    clientId: `${name}-id`,
-  }).then((app) =>
-    updateApplication(
-      domain.id,
-      accessToken,
-      {
-        settings: {
-          oauth: {
-            redirectUris: ['https://auth-nightly.gravitee.io/myApp/callback'],
-            scopeSettings: [
-              { scope: 'openid', defaultScope: true },
-              {
-                scope: 'openid',
-                defaultScope: true,
-              },
-            ],
-          },
-        },
-        identityProviders: [{ identity: idpId, priority: 0 }],
-      },
-      app.id,
-    ),
-  );
-
-  expect(application).toBeDefined();
-  expect(application.settings.oauth.clientId).toBeDefined();
-
-  return application;
-};
-
-const initiateLoginFlow = async (clientId, openIdConfiguration, domain) => {
-  const params = `?response_type=code&client_id=${clientId}&redirect_uri=https://auth-nightly.gravitee.io/myApp/callback`;
-
-  const authResponse = await performGet(openIdConfiguration.authorization_endpoint, params).expect(302);
-  const loginLocation = authResponse.headers['location'];
-
-  expect(loginLocation).toBeDefined();
-  expect(loginLocation).toContain(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/login`);
-  expect(loginLocation).toContain(`client_id=${clientId}`);
-
-  return authResponse;
-};
-
-const login = async (authResponse, userName, clientId, password = 'SomeP@ssw0rd') => {
-  const loginResult = await extractXsrfTokenAndActionResponse(authResponse);
-  return await performFormPost(
-    loginResult.action,
-    '',
-    {
-      'X-XSRF-TOKEN': loginResult.token,
-      username: userName,
-      password: password,
-      client_id: clientId,
-    },
-    {
-      Cookie: loginResult.headers['set-cookie'],
-      'Content-type': 'application/x-www-form-urlencoded',
-    },
-  ).expect(302);
-};
-
-const postLoginAuthentication = async (postLogin) => {
-  return await performGet(postLogin.headers['location'], '', {
-    Cookie: postLogin.headers['set-cookie'],
-  }).expect(302);
-};
-
-const postConsent = async (consent) => {
-  const dom = cheerio.load(consent.text);
-  const xsrfToken = dom('[name=X-XSRF-TOKEN]').val();
-  return await performFormPost(
-    consent.request.url,
-    '',
-    {
-      'X-XSRF-TOKEN': xsrfToken,
-      'scope.openid': true,
-      user_oauth_approval: true,
-    },
-    {
-      Cookie: consent.headers['set-cookie'],
-      'Content-type': 'application/x-www-form-urlencoded',
-    },
-  ).expect(302);
-};
-
-const loginUserNameAndPassword = async (clientId, user, userPassword) => {
-  return await loginUser(clientId, user.username, userPassword);
-};
-
-const loginAdditionalInfoAndPassword = async (clientId, additionalInfo, userPassword) => {
-  return await loginUser(clientId, additionalInfo, userPassword);
-};
-
-const loginUser = async (clientId, nameOrAdditionalInfo, userPassword) => {
-  const authResponse = await initiateLoginFlow(clientId, openIdConfiguration, domain);
-  const postLogin = await login(authResponse, nameOrAdditionalInfo, clientId, userPassword);
-  //log in failed with error
-  if (postLogin.headers['location'].includes('error=login_failed&error_code=invalid_user&error_description=Invalid+or+unknown+user')) {
-    return postLogin;
-  }
-  const authorize = await postLoginAuthentication(postLogin);
-  expect(authorize.headers['location']).toBeDefined();
-
-  //log in for the very first time
-  if (authorize.headers['location'].includes(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/oauth/consent`)) {
-    const consent = await performGet(authorize.headers['location'], '', {
-      Cookie: authorize.headers['set-cookie'],
-    }).expect(200);
-
-    const authorize2 = await postConsent(consent);
-    expect(authorize2.headers['location']).toBeDefined();
-    expect(authorize2.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/oauth/authorize`);
-
-    const tokenResponse = await performGet(authorize2.headers['location'], '', {
-      Cookie: authorize.headers['set-cookie'],
-    }).expect(302);
-
-    expect(tokenResponse.headers['location']).toBeDefined();
-    return tokenResponse;
-  } else {
-    return authorize;
-  }
-};
-
-const createMongoIdp = async (domainId, accessToken) => {
-  console.log('creating mongodb  idp');
-  return await createIdp(domainId, accessToken, {
-    external: false,
-    type: 'mongo-am-idp',
-    domainWhitelist: [],
-    configuration:
-      '{"uri":"mongodb://localhost:27017","host":"localhost","port":27017,"enableCredentials":false,"databaseCredentials":"gravitee-am","database":"gravitee-am","usersCollection":"idp-test-users","findUserByUsernameQuery":"{$or: [{username: ?}, {contract: ?}]}","findUserByEmailQuery":"{email: ?}","usernameField":"username","passwordField":"password","passwordEncoder":"None","useDedicatedSalt":false,"passwordSaltLength":32}',
-    name: 'another-idp',
-  });
-};
-
-const createJdbcIdp = async (domainId, accessToken) => {
-  console.log('creating jdbc idp');
-  const password = process.env.GRAVITEE_OAUTH2_JDBC_PASSWORD ? process.env.GRAVITEE_OAUTH2_JDBC_PASSWORD : 'p@ssw0rd';
-  const database = process.env.GRAVITEE_OAUTH2_JDBC_DATABASE ? process.env.GRAVITEE_OAUTH2_JDBC_DATABASE : 'gravitee-am';
-
-  return await createIdp(domainId, accessToken, {
-    external: false,
-    type: 'jdbc-am-idp',
-    domainWhitelist: [],
-    configuration: `{\"host\":\"localhost\",\"port\":5432,\"protocol\":\"postgresql\",\"database\":\"${database}\",\"usersTable\":\"test_users\",\"user\":\"postgres\",\"password\":\"${password}\",\"autoProvisioning\":\"true\",\"selectUserByUsernameQuery\":\"SELECT * FROM test_users WHERE username = %s\",\"selectUserByMultipleFieldsQuery\":\"SELECT * FROM test_users WHERE username = %s or email = %s\",\"selectUserByEmailQuery\":\"SELECT * FROM test_users WHERE email = %s\",\"identifierAttribute\":\"id\",\"usernameAttribute\":\"username\",\"emailAttribute\":\"email\",\"passwordAttribute\":\"password\",\"passwordEncoder\":\"None\",\"useDedicatedSalt\":false,\"passwordSaltLength\":32}`,
-    name: 'other-jdbc-idp',
-  });
-};

--- a/gravitee-am-test/specs/gateway/mfa.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/mfa.jest.spec.ts
@@ -33,6 +33,7 @@ import {
 import { clearEmails, getLastEmail } from '@utils-commands/email-commands';
 import { TOTP } from 'otpauth';
 import * as faker from 'faker';
+import { initiateLoginFlow } from '@gateway-commands/login-commands';
 
 const cheerio = require('cheerio');
 
@@ -398,18 +399,6 @@ afterAll(async () => {
   }
 });
 
-const initiateLoginFlow = async (clientId, openIdConfiguration, domain) => {
-  const params = `?response_type=code&client_id=${clientId}&redirect_uri=https://auth-nightly.gravitee.io/myApp/callback`;
-
-  const authResponse = await performGet(openIdConfiguration.authorization_endpoint, params).expect(302);
-  const loginLocation = authResponse.headers['location'];
-
-  expect(loginLocation).toBeDefined();
-  expect(loginLocation).toContain(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/login`);
-  expect(loginLocation).toContain(`client_id=${clientId}`);
-
-  return authResponse;
-};
 
 const login = async (authResponse, user, clientId) => {
   const loginResult = await extractXsrfTokenAndActionResponse(authResponse);

--- a/gravitee-am-test/specs/gateway/remember-me.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/remember-me.jest.spec.ts
@@ -1,0 +1,335 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fetch from 'cross-fetch';
+import {expect, jest} from '@jest/globals';
+import {requestAdminAccessToken} from '@management-commands/token-management-commands';
+import {createDomain, deleteDomain, patchDomain, startDomain} from '@management-commands/domain-management-commands';
+import {createUser, deleteUser} from '@management-commands/user-management-commands';
+import {getWellKnownOpenIdConfiguration, logoutUser,} from '@gateway-commands/oauth-oidc-commands';
+import {loginUserNameAndPassword} from "@gateway-commands/login-commands";
+import {createTestApp} from "@utils-commands/application-commands";
+import {createJdbcIdp, createMongoIdp} from "@utils-commands/idps-commands";
+import * as faker from "faker";
+
+global.fetch = fetch;
+
+const jdbc = process.env.GRAVITEE_MANAGEMENT_TYPE;
+
+let accessToken;
+let domain;
+let customIdp;
+let app;
+let openIdConfiguration;
+let user;
+
+const contractValue = '1234';
+const password = 'Zxc123!!';
+
+jest.setTimeout(200000);
+
+const defaultApplicationConfiguration = {
+    settings: {
+        oauth: {
+            redirectUris: ['https://auth-nightly.gravitee.io/myApp/callback'],
+            forcePKCE: false,
+            forceS256CodeChallengeMethod: false,
+            grantTypes: ['authorization_code'],
+            tokenEndpointAuthMethod: "none",
+        },
+    },
+};
+
+describe('remember me', () => {
+
+    describe('max-Age cookie value', () => {
+
+        it('no max-age present if the cookie is not persisted', async () => {
+
+            await initEnv({
+                settings: {
+                    cookieSettings: {
+                        inherited: false,
+                        session: {
+                            persistent: false,
+                        }
+                    }
+                }
+            });
+
+            const tokenResponse = await loginUserNameAndPassword(app.settings.oauth.clientId, user, password, false, openIdConfiguration, domain);
+            expect(tokenResponse.headers['set-cookie'][0]).not.toContain('Max-Age');
+            await logoutUser(openIdConfiguration.end_session_endpoint, tokenResponse);
+        });
+
+        it('max-age present with default value if the cookie is persisted', async () => {
+
+            await initEnv({
+                settings: {
+                    cookieSettings: {
+                        inherited: false,
+                        session: {
+                            persistent: true,
+                        }
+                    }
+                }
+            });
+
+            const tokenResponse = await loginUserNameAndPassword(app.settings.oauth.clientId, user, password, false, openIdConfiguration, domain);
+            await validateMaxAgeCookie('GRAVITEE_IO_AM_SESSION', '1800', tokenResponse);
+            await logoutUser(openIdConfiguration.end_session_endpoint, tokenResponse);
+        });
+
+        it('max-age use the "remember me" duration when defined at domain level and user wants to be remembered', async () => {
+
+            await initEnv(
+                {
+                    settings: {
+                        account: {
+                            inherited: true,
+                        },
+                        cookieSettings: {
+                            inherited: false,
+                            session: {
+                                persistent: true,
+                            }
+                        }
+                    },
+                },
+                {
+                    accountSettings: {
+                        rememberMe: true,
+                        rememberMeDuration: 432000
+                    }
+                });
+
+            const tokenResponse = await loginUserNameAndPassword(app.settings.oauth.clientId, user, password, false, openIdConfiguration, domain);
+            await validateMaxAgeCookie('GRAVITEE_IO_AM_SESSION','1800', tokenResponse);
+            await logoutUser(openIdConfiguration.end_session_endpoint, tokenResponse);
+        });
+
+        it('max-age use the "remember me" duration when defined at application level and user wants to be remembered', async () => {
+
+            await initEnv({
+                settings: {
+                    account: {
+                        inherited: false,
+                        rememberMe: true,
+                        rememberMeDuration: 3600,
+                    },
+                    cookieSettings: {
+                        inherited: false,
+                        session: {
+                            persistent: true,
+                        }
+                    }
+                },
+            });
+
+            const tokenResponse = await loginUserNameAndPassword(app.settings.oauth.clientId, user, password, false, openIdConfiguration, domain);
+            await validateMaxAgeCookie('GRAVITEE_IO_AM_SESSION','1800', tokenResponse);
+            await logoutUser(openIdConfiguration.end_session_endpoint, tokenResponse);
+        });
+
+        afterEach(async () => {
+            await deleteUser(domain.id, accessToken, user.id);
+            if (domain.id) {
+                await deleteDomain(domain.id, accessToken);
+            }
+        });
+    });
+
+    describe('remember me cookie max age', () => {
+
+        it('user wants to be remembered and "remember me" is activated at domain level', async () => {
+
+            await initEnv({
+                    settings: {
+                        cookieSettings: {
+                            inherited: false,
+                            session: {
+                                persistent: false,
+                            }
+                        }
+                    }
+                },
+                {
+                    accountSettings: {
+                        rememberMe: true,
+                        rememberMeDuration: 604800
+                    }
+                });
+
+            const tokenResponse = await loginUserNameAndPassword(app.settings.oauth.clientId, user, password, true, openIdConfiguration, domain);
+            await validateMaxAgeCookie('GRAVITEE_IO_REMEMBER_ME', '604800', tokenResponse);
+            const logoutResponse = await logoutUser(openIdConfiguration.end_session_endpoint, tokenResponse);
+            await validateCookieNotExists('GRAVITEE_IO_REMEMBER_ME', logoutResponse);
+        });
+
+        it('user wants to be remembered and "remember me" is activated at application level', async () => {
+
+            await initEnv({
+                    settings: {
+                        account: {
+                            inherited: false,
+                            rememberMe: true,
+                            rememberMeDuration: 45567,
+                        },
+                        cookieSettings: {
+                            inherited: false,
+                            session: {
+                                persistent: false,
+                            }
+                        }
+                    }
+                },
+                {
+                    accountSettings: {
+                        rememberMe: true,
+                        rememberMeDuration: 3600
+                    }
+                });
+
+            const loginResponse = await loginUserNameAndPassword(app.settings.oauth.clientId, user, password, true, openIdConfiguration, domain);
+            await validateMaxAgeCookie('GRAVITEE_IO_REMEMBER_ME', '45567', loginResponse);
+            const logoutResponse = await logoutUser(openIdConfiguration.end_session_endpoint, loginResponse);
+            await validateCookieNotExists('GRAVITEE_IO_REMEMBER_ME', logoutResponse);
+        });
+
+        it('user not wants to be remembered and "remember me" is activated at domain level', async () => {
+
+            await initEnv({
+                    settings: {
+                        cookieSettings: {
+                            inherited: false,
+                            session: {
+                                persistent: false,
+                            }
+                        }
+                    }
+                },
+                {
+                    accountSettings: {
+                        rememberMe: true,
+                        rememberMeDuration: 5
+                    }
+                });
+
+            const loginResponse = await loginUserNameAndPassword(app.settings.oauth.clientId, user, password, false, openIdConfiguration, domain);
+            await validateCookieNotExists('GRAVITEE_IO_REMEMBER_ME', loginResponse);
+            await logoutUser(openIdConfiguration.end_session_endpoint, loginResponse);
+        });
+
+        it('user not wants to be remembered and "remember me" is activated at application level', async () => {
+
+            await initEnv({
+                    settings: {
+                        account: {
+                            inherited: false,
+                            rememberMe: true,
+                            rememberMeDuration: 5,
+                        },
+                        cookieSettings: {
+                            inherited: false,
+                            session: {
+                                persistent: false,
+                            }
+                        }
+                    }
+                },
+                {
+                    accountSettings: {
+                        rememberMe: true,
+                        rememberMeDuration: 3600
+                    }
+                });
+
+            const loginResponse = await loginUserNameAndPassword(app.settings.oauth.clientId, user, password, false, openIdConfiguration, domain);
+            await validateCookieNotExists('GRAVITEE_IO_REMEMBER_ME', loginResponse);
+            await logoutUser(openIdConfiguration.end_session_endpoint, loginResponse);
+        });
+
+        afterEach(async () => {
+            await deleteUser(domain.id, accessToken, user.id);
+            if (domain.id) {
+                await deleteDomain(domain.id, accessToken);
+            }
+        });
+    });
+});
+
+async function validateCookieNotExists(cookieName: string, tokenResponse: any) {
+    expect(tokenResponse.request.header.Cookie.filter(cookie => cookie.includes(cookieName))).toHaveLength(0);
+}
+
+async function validateMaxAgeCookie(cookieName: string, maxAgeExpected: string, tokenResponse: any) {
+    expect(tokenResponse.request.header.Cookie.filter(cookie => cookie.includes(cookieName))[0]).toContain(`Max-Age=${maxAgeExpected}`);
+}
+
+async function initEnv(applicationConfiguration, domainConfiguration = null,) {
+    const adminTokenResponse = await requestAdminAccessToken();
+    accessToken = adminTokenResponse.body.access_token;
+    domain = await createDomain(accessToken, faker.company.companyName(), 'test remember me option')
+        .then((domain) => startDomain(domain.id, accessToken))
+        .then((domain) => {
+            if (domainConfiguration != null) {
+                return patchDomain(domain.id, accessToken, domainConfiguration);
+            }
+
+            return domain;
+        });
+
+    customIdp = jdbc === 'jdbc' ? await createJdbcIdp(domain.id, accessToken) : await createMongoIdp(domain.id, accessToken);
+    app = await createTestApp(
+        'remember-me-app',
+        domain,
+        accessToken,
+        'browser',
+        {
+            settings: {
+                ...defaultApplicationConfiguration.settings,
+                ...applicationConfiguration.settings,
+            },
+            identityProviders: [{identity: customIdp.id, priority: 0}],
+        });
+
+    await new Promise((r) => setTimeout(r, 10000));
+
+    const result = await getWellKnownOpenIdConfiguration(domain.hrid).expect(200);
+    openIdConfiguration = result.body;
+
+    const firstname = faker.name.firstName();
+    const lastname = faker.name.lastName();
+    user = await createUser(domain.id, accessToken, {
+        firstName: firstname,
+        lastName: lastname,
+        email: faker.internet.email(firstname, lastname),
+        username: faker.internet.userName(firstname, lastname),
+        password: password,
+        client: app.id,
+        source: customIdp.id,
+        additionalInformation: {
+            contract: contractValue,
+        },
+        preRegistration: false,
+    });
+
+    expect(user).toBeDefined();
+}
+
+
+
+

--- a/gravitee-am-test/specs/management/applications.jest.spec.ts
+++ b/gravitee-am-test/specs/management/applications.jest.spec.ts
@@ -17,7 +17,7 @@ import fetch from 'cross-fetch';
 import * as faker from 'faker';
 import { afterAll, beforeAll, expect } from '@jest/globals';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
-import { createDomain, deleteDomain, startDomain } from '@management-commands/domain-management-commands';
+import {createDomain, deleteDomain, patchDomain, startDomain} from '@management-commands/domain-management-commands';
 import {
   createApplication,
   deleteApplication,
@@ -140,6 +140,32 @@ describe('after creating applications', () => {
     expect(applicationPage.totalCount).toEqual(9);
     expect(applicationPage.data.length).toEqual(9);
     expect(applicationPage.data.find((app) => app.id === application.id)).toBeFalsy();
+  });
+});
+
+describe('Entrypoints: User accounts', () => {
+  it('should define the "remember me" amount of time', async () => {
+    const app = {
+      name: faker.commerce.productName(),
+      type: 'browser',
+      description: faker.lorem.paragraph(),
+    };
+
+    const createdApp = await createApplication(domain.id, accessToken, app);
+
+    const patchedApplication = await patchApplication(domain.id, accessToken, {
+      settings: {
+        account: {
+          inherited: false,
+          rememberMe: true,
+          rememberMeDuration: 7200,
+        },
+      },
+    }, createdApp.id);
+
+    const accountSettings = patchedApplication.settings.account;
+    expect(accountSettings.rememberMe).toBe(true);
+    expect(accountSettings.rememberMeDuration).toBe(7200);
   });
 });
 

--- a/gravitee-am-test/specs/management/domains.jest.spec.ts
+++ b/gravitee-am-test/specs/management/domains.jest.spec.ts
@@ -195,6 +195,24 @@ describe('Entrypoints: CORS settings - test strict configuration', () => {
   });
 });
 
+describe('Entrypoints: User accounts', () => {
+  it('should define the "remember me" amount of time', async () => {
+    const patchedDomain = await patchDomain(domain.id, accessToken, {
+      path: `${domain.path}`,
+      vhostMode: false,
+      vhosts: [],
+      accountSettings: {
+        rememberMe: true,
+        rememberMeDuration: 10,
+      },
+    });
+
+    const accountSettings = patchedDomain.accountSettings;
+    expect(accountSettings.rememberMe).toBe(true);
+    expect(accountSettings.rememberMeDuration).toBe(10);
+  });
+});
+
 afterAll(async () => {
   if (domain && domain.id) {
     await deleteDomain(domain.id, accessToken);

--- a/gravitee-am-ui/src/app/domain/components/account/account-settings.component.html
+++ b/gravitee-am-ui/src/app/domain/components/account/account-settings.component.html
@@ -64,7 +64,7 @@
               type="number"
               placeholder="Login Attempts Reset Time"
               name="loginAttemptsResetTime"
-              [(ngModel)]="accountSettings.loginAttemptsResetTime"
+              [(ngModel)]="loginAttemptsResetTime.time"
               (ngModelChange)="updateModel()"
               [disabled]="!isBrutForceAuthenticationEnabled()"
               required
@@ -75,18 +75,12 @@
             <mat-select
               placeholder="Unit time"
               name="loginAttemptsResetTimeUnitTime"
-              [(ngModel)]="accountSettings.loginAttemptsResetTimeUnitTime"
+              [(ngModel)]="loginAttemptsResetTime.unit"
               (ngModelChange)="updateModel()"
               [disabled]="!isBrutForceAuthenticationEnabled()"
               required
             >
-              <mat-option value="seconds">SECONDS</mat-option>
-              <mat-option value="minutes">MINUTES</mat-option>
-              <mat-option value="hours">HOURS</mat-option>
-              <mat-option value="days">DAYS</mat-option>
-              <mat-option value="weeks">WEEKS</mat-option>
-              <mat-option value="months">MONTHS</mat-option>
-              <mat-option value="years">YEARS</mat-option>
+              <mat-option *ngFor="let unit of units" [value]="unit.id">{{ unit.name }}</mat-option>
             </mat-select>
           </mat-form-field>
         </div>
@@ -97,7 +91,7 @@
               type="number"
               placeholder="Account Blocked Duration"
               name="accountBlockedDuration"
-              [(ngModel)]="accountSettings.accountBlockedDuration"
+              [(ngModel)]="accountBlockedDuration.time"
               (ngModelChange)="updateModel()"
               [disabled]="!isBrutForceAuthenticationEnabled()"
               required
@@ -108,18 +102,12 @@
             <mat-select
               placeholder="Unit time"
               name="accountBlockedDurationUnitTime"
-              [(ngModel)]="accountSettings.accountBlockedDurationUnitTime"
+              [(ngModel)]="accountBlockedDuration.unit"
               (ngModelChange)="updateModel()"
               [disabled]="!isBrutForceAuthenticationEnabled()"
               required
             >
-              <mat-option value="seconds">SECONDS</mat-option>
-              <mat-option value="minutes">MINUTES</mat-option>
-              <mat-option value="hours">HOURS</mat-option>
-              <mat-option value="days">DAYS</mat-option>
-              <mat-option value="weeks">WEEKS</mat-option>
-              <mat-option value="months">MONTHS</mat-option>
-              <mat-option value="years">YEARS</mat-option>
+              <mat-option *ngFor="let unit of units" [value]="unit.id">{{ unit.name }}</mat-option>
             </mat-select>
           </mat-form-field>
         </div>
@@ -132,6 +120,41 @@
             Send account recovery email
           </mat-slide-toggle>
           <mat-hint style="font-size: 75%">Send an email if user account has been blocked.</mat-hint>
+        </div>
+        <mat-divider></mat-divider>
+        <div fxLayout="column" style="margin-top: 10px">
+          <mat-slide-toggle (change)="enableRememberMe($event)" [checked]="isRememberMeEnabled()" [disabled]="readonly">
+            Remember me - set duration for user login sessions
+          </mat-slide-toggle>
+          <mat-hint style="font-size: 75%">Allow users to remain logged in for a set duration of time.</mat-hint>
+          <div fxLayout="row">
+            <mat-form-field fxFlex="85" appearance="outline" floatLabel="always">
+              <input
+                matInput
+                type="number"
+                placeholder="Keep users logged in session duration"
+                name="rememberMeDuration"
+                [(ngModel)]="rememberMeDuration.time"
+                (ngModelChange)="updateModel()"
+                [disabled]="!isRememberMeEnabled()"
+                required
+              />
+              <mat-hint>Select the duration that you would like users to be who opt-in for this to be kept logged in.</mat-hint>
+            </mat-form-field>
+
+            <mat-form-field fxFlex style="margin-left: 20px" appearance="outline" floatLabel="always">
+              <mat-select
+                placeholder="Unit time"
+                name="rememberMeDurationUnitTime"
+                [(ngModel)]="rememberMeDuration.unit"
+                (ngModelChange)="updateModel()"
+                [disabled]="!isRememberMeEnabled()"
+                required
+              >
+                <mat-option *ngFor="let unit of units" [value]="unit.id">{{ unit.name }}</mat-option>
+              </mat-select>
+            </mat-form-field>
+          </div>
         </div>
       </div>
     </div>
@@ -177,7 +200,7 @@
               type="number"
               placeholder="MFA Attempts Reset Time"
               name="challengeAttemptsResetTime"
-              [(ngModel)]="accountSettings.mfaChallengeAttemptsResetTime"
+              [(ngModel)]="mfaChallengeAttemptsResetTime.time"
               (ngModelChange)="updateModel()"
               [disabled]="!isMFAChallengeBrutForceAuthenticationEnabled()"
               required
@@ -188,18 +211,12 @@
             <mat-select
               placeholder="Unit time"
               name="challengeAttemptsResetTimeUnit"
-              [(ngModel)]="accountSettings.mfaChallengeAttemptsResetTimeUnit"
+              [(ngModel)]="mfaChallengeAttemptsResetTime.unit"
               (ngModelChange)="updateModel()"
               [disabled]="!isMFAChallengeBrutForceAuthenticationEnabled()"
               required
             >
-              <mat-option value="seconds">SECONDS</mat-option>
-              <mat-option value="minutes">MINUTES</mat-option>
-              <mat-option value="hours">HOURS</mat-option>
-              <mat-option value="days">DAYS</mat-option>
-              <mat-option value="weeks">WEEKS</mat-option>
-              <mat-option value="months">MONTHS</mat-option>
-              <mat-option value="years">YEARS</mat-option>
+              <mat-option *ngFor="let unit of units" [value]="unit.id">{{ unit.name }}</mat-option>
             </mat-select>
           </mat-form-field>
         </div>


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-744

## :pencil2: A description of the changes proposed in the pull request

If the user checks "remember me" during sign in a cookie is created to keep the user authenticated. Even if the session expired, if a valid remember cookie exists the user will be authenticated.

In production it's important to define a remember me duration greater than the session timeout.

## :memo: Test scenarios 

To be able to test and not wait 30 min it's important not persist session after closing the browser.

**Default sign in with configuration enabled at domain level**

- Create an application
- Register a user
- Enable the configuration to change the remember me duration at domain level (Settings -> User accounts)
- Choose a duration
- Disable persistent session (Application -> Settings -> Session management) 
- Sign in with the user with "remember me" checked
- Close your browser, the remember me cookie will be keep, the cookie session is removed
- Wait to let the remember me cookie expired
- Call again `oauth/authorize`
- The login form is displayed

**Default sign in with configuration enabled at application level**

- Create an application
- Register a user
- Enable the configuration to change the session duration at domain level (Your application -> Settings -> User accounts)
- Choose a duration
- Disable persistent session (Your application -> Settings -> Session management) 
- Sign in with the user with "remember me" checked
- Close your browser, the remember me cookie will be keep, the cookie session is removed
- Wait to let the remember me cookie expired
- Call again `oauth/authorize`
- The login form is displayed

**Webauth sign**

- Create an application
- Register a user
- Configure webauth at domain level
- Enable the configuration to change the session duration at domain or application level
- Choose a duration
- Click on 'Sign in with fingerprint, device or security key'
- Sign in with the user with "remember me" checked
- Close your browser, the remember me cookie is kept, the cookie session is removed
- Wait to let the remember me cookie expired
- Call again `oauth/authorize`
- The login form is displayed

**Identifier first**

- Create an application
- Register a user
- Configure 'identifier first'
- Enable the configuration to change the session duration at domain or application level
- Choose a duration
- Sign in with the user with "remember me" checked
- Close your browser, the remember me cookie will be keep, the cookie session is removed
- Wait to let the remember me cookie expired
- Call again `oauth/authorize`
- The login form is displayed

**Identifier first with social login**

- Create an application
- Register a user
- Configure 'identifier first'
- Enable the configuration to change the session duration at domain or application level
- Choose a duration
- Create a social IDP with Google for example
- Enable this IDP in your application
- Add a "Selection rule" to this IDP (username matching for example)
- Sign in with the user with "remember me" checked
- You will be automatically redirected to the IDP to authenticate the user
- Close your browser, the remember me cookie will be keep, the cookie session is removed
- Wait to let the remember me cookie expired
- Call again `oauth/authorize`
- The login form is displayed

## :computer: Add screenshots for UI

![Screenshot 2023-08-29 at 14 24 38](https://github.com/gravitee-io/gravitee-access-management/assets/3227290/d2ab103c-415e-45ef-8c6d-590ebdb6004e)
![Screenshot 2023-08-29 at 14 24 28](https://github.com/gravitee-io/gravitee-access-management/assets/3227290/c140999d-1f92-4798-b8b5-797eab679482)
![Screenshot 2023-08-29 at 14 24 12](https://github.com/gravitee-io/gravitee-access-management/assets/3227290/a1059a06-437b-4a71-9221-57cb859d0854)
