### PR TITLE
fix: add toggle to disable parameter encoding

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/AccountProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/AccountProvider.java
@@ -69,6 +69,8 @@ public class AccountProvider extends AbstractService<ProtocolProvider> implement
     @Autowired
     private RateLimiterService rateLimiterService;
 
+    private boolean sanitizeParametersEncoding;
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -87,7 +89,7 @@ public class AccountProvider extends AbstractService<ProtocolProvider> implement
             accountRouter.route().handler(oAuth2AuthHandler);
 
             // Account profile routes
-            final AccountEndpointHandler accountHandler = new AccountEndpointHandler(accountService, domain);
+            final AccountEndpointHandler accountHandler = new AccountEndpointHandler(accountService, domain, sanitizeParametersEncoding);
             accountRouter.get(AccountRoutes.PROFILE.getRoute()).handler(accountHandler::getUser).handler(accountHandler::getProfile);
             accountRouter.put(AccountRoutes.PROFILE.getRoute()).handler(BodyHandler.create()).handler(accountHandler::getUser).handler(accountHandler::updateProfile);
             accountRouter.get(AccountRoutes.ACTIVITIES.getRoute()).handler(accountHandler::getUser).handler(accountHandler::getActivity);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/resources/AccountEndpointHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/resources/AccountEndpointHandler.java
@@ -69,10 +69,12 @@ public class AccountEndpointHandler {
     public static final String ERROR_MSG_ACCESS_TOKEN_TOO_OLD = "Access token does not conform with expiration period. Please generate a new token.";
     private final AccountService accountService;
     private final Domain domain;
+    private final boolean sanitizeParametersEncoding;
 
-    public AccountEndpointHandler(AccountService accountService, Domain domain) {
+    public AccountEndpointHandler(AccountService accountService, Domain domain, boolean sanitizeParametersEncoding) {
         this.accountService = accountService;
         this.domain = domain;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     public void getUser(RoutingContext routingContext) {
@@ -193,7 +195,7 @@ public class AccountEndpointHandler {
 
         final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
         final String path = AccountRoutes.CHANGE_PASSWORD_REDIRECT.getRoute() + "?client_id=" + client.getClientId();
-        RedirectHandler.create(path).handle(routingContext);
+        RedirectHandler.create(path, sanitizeParametersEncoding).handle(routingContext);
     }
 
     public void updateProfile(RoutingContext routingContext) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/test/java/io/gravitee/am/gateway/handler/account/resources/AccountEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/test/java/io/gravitee/am/gateway/handler/account/resources/AccountEndpointHandlerTest.java
@@ -31,10 +31,6 @@ import io.reactivex.Single;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.core.http.HttpClientRequest;
-import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.User;
-import io.reactivex.Single;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.ext.web.handler.BodyHandler;
@@ -63,8 +59,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -93,7 +87,7 @@ public class AccountEndpointHandlerTest extends RxWebTestBase {
 
     private AccountEndpointHandler accountEndpointHandler;
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Override
     public void setUp() throws Exception {
@@ -105,7 +99,7 @@ public class AccountEndpointHandlerTest extends RxWebTestBase {
         this.domain.setSelfServiceAccountManagementSettings(selfAccountSettings);
 
         when(user.getUsername()).thenReturn("user1");
-        accountEndpointHandler = new AccountEndpointHandler(accountService, domain);
+        accountEndpointHandler = new AccountEndpointHandler(accountService, domain, true);
 
         router.route()
                 .handler(ctx -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSRFHandlerFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSRFHandlerFactory.java
@@ -34,9 +34,12 @@ public class CSRFHandlerFactory implements FactoryBean<CSRFHandler> {
     @Autowired
     private Vertx vertx;
 
+    @Value("${legacy.openid.sanitizeParametersEncoding:true}")
+    private boolean sanitizeParametersEncoding;
+
     @Override
     public CSRFHandler getObject() {
-        return CSRFHandler.newInstance(new CSRFHandlerImpl(vertx, csrfSecret));
+        return CSRFHandler.newInstance(new CSRFHandlerImpl(vertx, csrfSecret, sanitizeParametersEncoding));
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/RedirectHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/RedirectHandler.java
@@ -25,7 +25,7 @@ import io.vertx.reactivex.ext.web.RoutingContext;
  */
 public interface RedirectHandler {
 
-    static Handler<RoutingContext> create(String path) {
-        return new RedirectHandlerImpl(path);
+    static Handler<RoutingContext> create(String path, boolean sanitizeParametersEncoding) {
+        return new RedirectHandlerImpl(path, sanitizeParametersEncoding);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CSRFHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CSRFHandlerImpl.java
@@ -53,6 +53,7 @@ public class CSRFHandlerImpl implements CSRFHandler {
     private static final Base64.Encoder BASE64 = Base64.getMimeEncoder();
 
     private final VertxContextPRNG RAND;
+    private final boolean sanitizeParametersEncoding;
     private final Mac mac;
 
     private boolean nagHttps;
@@ -63,8 +64,9 @@ public class CSRFHandlerImpl implements CSRFHandler {
     private String origin;
     private boolean httpOnly;
 
-    public CSRFHandlerImpl(Vertx vertx, final String secret) {
+    public CSRFHandlerImpl(Vertx vertx, final String secret, boolean sanitizeParametersEncoding) {
         this.RAND = VertxContextPRNG.current(vertx);
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
         try {
             mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(secret.getBytes(), "HmacSHA256"));
@@ -166,7 +168,7 @@ public class CSRFHandlerImpl implements CSRFHandler {
         queryParams.set("error", "session_expired");
         queryParams.set("error_description", "Your session expired, please try again.");
 
-        final String uri = UriBuilderRequest.resolveProxyRequest(httpServerRequest, ctx.request().path(), queryParams, true);
+        final String uri = UriBuilderRequest.resolveProxyRequest(httpServerRequest, ctx.request().path(), queryParams, true, sanitizeParametersEncoding);
 
         ctx.response()
                 .putHeader(HttpHeaders.LOCATION, uri)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/RedirectHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/RedirectHandlerImpl.java
@@ -38,9 +38,11 @@ public class RedirectHandlerImpl implements Handler<RoutingContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(RedirectHandlerImpl.class);
     private final String path;
+    private final boolean sanitizeParametersEncoding;
 
-    public RedirectHandlerImpl(String path) {
+    public RedirectHandlerImpl(String path, boolean sanitizeParametersEncoding) {
         this.path = path;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -61,7 +63,7 @@ public class RedirectHandlerImpl implements Handler<RoutingContext> {
                 if (!UriBuilder.decodeURIComponent(login_hint).equals(login_hint)
                         && login_hint.contains("@")
                         && login_hint.contains("+")) {
-                    queryParams.set(LOGIN_HINT, UriBuilder.encodeURIComponent(login_hint));
+                    queryParams.set(LOGIN_HINT, sanitizeParametersEncoding? UriBuilder.encodeURIComponent(login_hint) : login_hint);
                 }
             }
 
@@ -71,7 +73,7 @@ public class RedirectHandlerImpl implements Handler<RoutingContext> {
             }
 
             // Now redirect the user.
-            String uri = UriBuilderRequest.resolveProxyRequest(request, redirectUrl, queryParams, true);
+            String uri = UriBuilderRequest.resolveProxyRequest(request, redirectUrl, queryParams, true, sanitizeParametersEncoding);
             context.response()
                     .putHeader(HttpHeaders.LOCATION, uri)
                     .setStatusCode(302)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequestTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequestTest.java
@@ -40,7 +40,7 @@ public class UriBuilderRequestTest {
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("myhost");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PORT))).thenReturn("8888");
 
-        final var generatedUri = UriBuilderRequest.resolveProxyRequest(request, path, params, true);
+        final var generatedUri = UriBuilderRequest.resolveProxyRequest(request, path, params, true, true);
         assertEquals("https://myhost:8888/my/path?param1=value1", generatedUri);
     }
 
@@ -50,7 +50,7 @@ public class UriBuilderRequestTest {
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("myhost:9999");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PORT))).thenReturn("8888");
 
-        final var generatedUri = UriBuilderRequest.resolveProxyRequest(request, path, params, true);
+        final var generatedUri = UriBuilderRequest.resolveProxyRequest(request, path, params, true, true);
         assertEquals("https://myhost:8888/my/path?param1=value1", generatedUri);
     }
 
@@ -60,13 +60,13 @@ public class UriBuilderRequestTest {
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("myhost");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PORT))).thenReturn("80");
 
-        assertEquals("http://myhost/my/path?param1=value1", UriBuilderRequest.resolveProxyRequest(request, path, params, true));
+        assertEquals("http://myhost/my/path?param1=value1", UriBuilderRequest.resolveProxyRequest(request, path, params, true, true));
 
         // default https port with http scheme should keep the forwarded port
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PROTO))).thenReturn("http");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("myhost");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PORT))).thenReturn("443");
-        assertEquals("http://myhost:443/my/path?param1=value1", UriBuilderRequest.resolveProxyRequest(request, path, params, true));
+        assertEquals("http://myhost:443/my/path?param1=value1", UriBuilderRequest.resolveProxyRequest(request, path, params, true, true));
     }
 
 
@@ -76,13 +76,13 @@ public class UriBuilderRequestTest {
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("myhost");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PORT))).thenReturn("443");
 
-        assertEquals("https://myhost/my/path?param1=value1", UriBuilderRequest.resolveProxyRequest(request, path, params, true));
+        assertEquals("https://myhost/my/path?param1=value1", UriBuilderRequest.resolveProxyRequest(request, path, params, true, true));
 
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PROTO))).thenReturn("https");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("myhost");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PORT))).thenReturn("80");
         // default http port with https scheme should keep the forwarded port
-        assertEquals("https://myhost:80/my/path?param1=value1", UriBuilderRequest.resolveProxyRequest(request, path, params, true));
+        assertEquals("https://myhost:80/my/path?param1=value1", UriBuilderRequest.resolveProxyRequest(request, path, params, true, true));
     }
 
     @Test
@@ -90,7 +90,7 @@ public class UriBuilderRequestTest {
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PROTO))).thenReturn("https");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("myhost:9999");
 
-        final var generatedUri = UriBuilderRequest.resolveProxyRequest(request, path, params, true);
+        final var generatedUri = UriBuilderRequest.resolveProxyRequest(request, path, params, true, true);
         assertEquals("https://myhost:9999/my/path?param1=value1", generatedUri);
     }
     @Test
@@ -98,7 +98,7 @@ public class UriBuilderRequestTest {
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PROTO))).thenReturn("https");
         when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("myhost");
 
-        final var generatedUri = UriBuilderRequest.resolveProxyRequest(request, path, params, true);
+        final var generatedUri = UriBuilderRequest.resolveProxyRequest(request, path, params, true, true);
         assertEquals("https://myhost/my/path?param1=value1", generatedUri);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/AuthenticationFlowHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/AuthenticationFlowHandlerTest.java
@@ -91,9 +91,9 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
         super.setUp();
 
         List<AuthenticationFlowStep> steps = new LinkedList<>();
-        steps.add(new MFAEnrollStep(RedirectHandler.create("/mfa/enroll"), ruleEngine, factorManager));
-        steps.add(new MFAChallengeStep(RedirectHandler.create("/mfa/challenge"), ruleEngine, factorManager));
-        steps.add(new MFARecoveryCodeStep(RedirectHandler.create("/mfa/recovery_code"), ruleEngine, factorManager));
+        steps.add(new MFAEnrollStep(RedirectHandler.create("/mfa/enroll", true), ruleEngine, factorManager));
+        steps.add(new MFAChallengeStep(RedirectHandler.create("/mfa/challenge", true), ruleEngine, factorManager));
+        steps.add(new MFARecoveryCodeStep(RedirectHandler.create("/mfa/recovery_code", true), ruleEngine, factorManager));
         AuthenticationFlowChainHandler authenticationFlowChainHandler = new AuthenticationFlowChainHandler(steps);
 
         when(jwtService.encode(any(JWT.class), (CertificateProvider) eq(null))).thenReturn(Single.just("token"));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/FormIdentifierFirstLoginStepTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/FormIdentifierFirstLoginStepTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class FormIdentifierFirstLoginStepTest {
 
-    private static final Handler<RoutingContext> redirectHandler = RedirectHandler.create("/login/identifier");
+    private static final Handler<RoutingContext> redirectHandler = RedirectHandler.create("/login/identifier", true);
 
     @Mock
     private RoutingContext routingContext;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/WebAuthnLoginStepTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/WebAuthnLoginStepTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class WebAuthnLoginStepTest {
 
-    private static final Handler<RoutingContext> redirectHandler = RedirectHandler.create("/webauthn/login");
+    private static final Handler<RoutingContext> redirectHandler = RedirectHandler.create("/webauthn/login", true);
 
     @Mock
     private RoutingContext routingContext;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/AbstractEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/AbstractEndpoint.java
@@ -87,10 +87,10 @@ public abstract class AbstractEndpoint {
         templateEngine.render(data, getTemplateFileName(client), handler);
     }
 
-    protected final String getReturnUrl(RoutingContext context, MultiMap queryParams) {
+    protected final String getReturnUrl(RoutingContext context, MultiMap queryParams, boolean sanitizeParametersEncoding) {
         return context.session().get(ConstantKeys.RETURN_URL_KEY) != null ?
                 context.session().get(ConstantKeys.RETURN_URL_KEY) :
-                UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/oauth/authorize", queryParams, true);
+                UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/oauth/authorize", queryParams, true, sanitizeParametersEncoding);
     }
 
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginCallbackEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginCallbackEndpoint.java
@@ -17,10 +17,8 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.login;
 
 import com.google.common.net.HttpHeaders;
 import io.gravitee.am.common.utils.ConstantKeys;
-import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
 import io.vertx.core.Handler;
-import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.http.HttpServerResponse;
 import io.vertx.reactivex.ext.web.RoutingContext;
 import io.vertx.reactivex.ext.web.Session;
@@ -34,10 +32,16 @@ import static io.gravitee.am.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
  */
 public class LoginCallbackEndpoint extends AbstractEndpoint implements Handler<RoutingContext> {
 
+    private final boolean sanitizeParametersEncoding;
+
+    public LoginCallbackEndpoint(boolean sanitizeParametersEncoding) {
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
+    }
+
     @Override
     public void handle(RoutingContext routingContext) {
         final Session session = routingContext.session();
-        final String returnURL = getReturnUrl(routingContext, routingContext.get(PARAM_CONTEXT_KEY));
+        final String returnURL = getReturnUrl(routingContext, routingContext.get(PARAM_CONTEXT_KEY), sanitizeParametersEncoding);
 
         // if we have an id_token, put in the session context for post step (mainly the user consent step)
         if (session != null) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpoint.java
@@ -68,18 +68,21 @@ public class LoginEndpoint extends AbstractEndpoint implements Handler<RoutingCo
     private final BotDetectionManager botDetectionManager;
     private final DeviceIdentifierManager deviceIdentifierManager;
     private final UserActivityService userActivityService;
+    private final boolean sanitizeParametersEncoding;
 
     public LoginEndpoint(
             TemplateEngine templateEngine,
             Domain domain,
             BotDetectionManager botDetectionManager,
             DeviceIdentifierManager deviceIdentifierManager,
-            UserActivityService userActivityService) {
+            UserActivityService userActivityService,
+            boolean sanitizeParametersEncoding) {
         super(templateEngine);
         this.domain = domain;
         this.botDetectionManager = botDetectionManager;
         this.deviceIdentifierManager = deviceIdentifierManager;
         this.userActivityService = userActivityService;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -128,17 +131,17 @@ public class LoginEndpoint extends AbstractEndpoint implements Handler<RoutingCo
 
         // put action urls in context
         final MultiMap queryParams = getCleanedQueryParams(routingContext.request());
-        routingContext.put(ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true));
-        routingContext.put(TEMPLATE_KEY_FORGOT_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true));
-        routingContext.put(TEMPLATE_KEY_REGISTER_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true));
-        routingContext.put(TEMPLATE_KEY_WEBAUTHN_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true));
+        routingContext.put(ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true, sanitizeParametersEncoding));
+        routingContext.put(TEMPLATE_KEY_FORGOT_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true, sanitizeParametersEncoding));
+        routingContext.put(TEMPLATE_KEY_REGISTER_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true, sanitizeParametersEncoding));
+        routingContext.put(TEMPLATE_KEY_WEBAUTHN_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true, sanitizeParametersEncoding));
         if (isIdentifierFirstLoginEnabled) {
             // we remove the login_hint in the backToIdFirst login action to avoid
             // * infinite loop (if the idFirst login page submit the form if these parameter is provided)
             // * prevent the user from changing the username in the idFirst login page
             // https://github.com/gravitee-io/issues/issues/8236
             queryParams.remove(Parameters.LOGIN_HINT);
-            routingContext.put(TEMPLATE_KEY_BACK_LOGIN_IDENTIFIER_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParams, true));
+            routingContext.put(TEMPLATE_KEY_BACK_LOGIN_IDENTIFIER_ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParams, true, sanitizeParametersEncoding));
         }
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginPostEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginPostEndpoint.java
@@ -31,11 +31,17 @@ import io.vertx.reactivex.ext.web.Session;
  */
 public class LoginPostEndpoint extends AbstractEndpoint implements Handler<RoutingContext> {
 
+    private final boolean sanitizeParametersEncoding;
+
+    public LoginPostEndpoint(boolean sanitizeParametersEncoding) {
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
+    }
+
     @Override
     public void handle(RoutingContext context) {
         final Session session = context.session();
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(context.request());
-        final String redirectUri = getReturnUrl(context, queryParams);
+        final String redirectUri = getReturnUrl(context, queryParams, sanitizeParametersEncoding);
 
         // save that the user has just been signed in
         session.put(ConstantKeys.USER_LOGIN_COMPLETED_KEY, true);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeAlternativesEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeAlternativesEndpoint.java
@@ -53,12 +53,15 @@ public class MFAChallengeAlternativesEndpoint extends AbstractEndpoint implement
     private static final Logger logger = LoggerFactory.getLogger(MFAChallengeAlternativesEndpoint.class);
     private final FactorManager factorManager;
     private final Domain domain;
+    private final boolean sanitizeParametersEncoding;
 
     public MFAChallengeAlternativesEndpoint(TemplateEngine templateEngine,
-                                            FactorManager factorManager, Domain domain) {
+                                            FactorManager factorManager, Domain domain,
+                                            boolean sanitizeParametersEncoding) {
         super(templateEngine);
         this.factorManager = factorManager;
         this.domain = domain;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -99,7 +102,7 @@ public class MFAChallengeAlternativesEndpoint extends AbstractEndpoint implement
         final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
         final List<Factor> factors = getEnabledFactors(client, endUser);
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-        final String action = UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true);
+        final String action = UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true, sanitizeParametersEncoding);
         routingContext.put(ConstantKeys.FACTORS_KEY, factors);
         routingContext.put(ConstantKeys.ACTION_KEY, action);
 
@@ -129,7 +132,7 @@ public class MFAChallengeAlternativesEndpoint extends AbstractEndpoint implement
 
         // redirect to MFA challenge step
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-        final String returnURL = UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/mfa/challenge", queryParams, true);
+        final String returnURL = UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/mfa/challenge", queryParams, true, sanitizeParametersEncoding);
         doRedirect(routingContext.response(), returnURL);
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeFailureHandler.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.am.gateway.handler.root.resources.endpoint.mfa;
 
-import com.google.common.net.HttpHeaders;
 import io.gravitee.am.common.exception.mfa.SendChallengeException;
 import io.gravitee.am.common.oidc.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
@@ -25,9 +24,7 @@ import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.root.RootProvider;
 import io.gravitee.am.gateway.handler.root.resources.handler.error.AbstractErrorHandler;
 import io.gravitee.am.service.AuthenticationFlowContextService;
-import io.vertx.core.Handler;
 import io.vertx.reactivex.core.MultiMap;
-import io.vertx.reactivex.core.http.HttpServerResponse;
 import io.vertx.reactivex.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +41,12 @@ public class MFAChallengeFailureHandler extends AbstractErrorHandler {
     private static final String ERROR_CODE_VALUE = "send_challenge_failed";
 
     private final AuthenticationFlowContextService authenticationFlowContextService;
+    private final boolean sanitizeParametersEncoding;
 
-    public MFAChallengeFailureHandler(AuthenticationFlowContextService authenticationFlowContextService) {
-        super(RootProvider.PATH_ERROR);
+    public MFAChallengeFailureHandler(AuthenticationFlowContextService authenticationFlowContextService, boolean sanitizeParametersEncoding) {
+        super(RootProvider.PATH_ERROR, sanitizeParametersEncoding);
         this.authenticationFlowContextService = authenticationFlowContextService;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -60,10 +59,10 @@ public class MFAChallengeFailureHandler extends AbstractErrorHandler {
         final MultiMap queryParams = updateQueryParams(context, errorDescription);
         String uri;
         if (throwable instanceof SendChallengeException) {
-            uri =  UriBuilderRequest.resolveProxyRequest(context.request(), context.request().uri(), queryParams, true);
+            uri =  UriBuilderRequest.resolveProxyRequest(context.request(), context.request().uri(), queryParams, true, sanitizeParametersEncoding);
         } else {
             logoutUser(context);
-            uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true);
+            uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true, sanitizeParametersEncoding);
         }
 
         doRedirect(context.response(), uri);
@@ -77,7 +76,7 @@ public class MFAChallengeFailureHandler extends AbstractErrorHandler {
 
         if (context.request().getParam(Parameters.LOGIN_HINT) != null) {
             // encode login_hint parameter (to not replace '+' sign by a space ' ')
-            queryParams.set(Parameters.LOGIN_HINT, UriBuilder.encodeURIComponent(context.request().getParam(Parameters.LOGIN_HINT)));
+            queryParams.set(Parameters.LOGIN_HINT, sanitizeParametersEncoding? UriBuilder.encodeURIComponent(context.request().getParam(Parameters.LOGIN_HINT)) : context.request().getParam(Parameters.LOGIN_HINT));
         }
 
         return queryParams;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpoint.java
@@ -62,12 +62,14 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
     private final FactorManager factorManager;
     private final UserService userService;
     private final Domain domain;
+    private final boolean sanitizeParametersEncoding;
 
-    public MFAEnrollEndpoint(FactorManager factorManager, TemplateEngine engine, UserService userService, Domain domain) {
+    public MFAEnrollEndpoint(FactorManager factorManager, TemplateEngine engine, UserService userService, Domain domain, boolean sanitizeParametersEncoding) {
         super(engine);
         this.factorManager = factorManager;
         this.userService = userService;
         this.domain = domain;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -99,7 +101,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
 
             // Create post action url.
             final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-            final String action = UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true);
+            final String action = UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true, sanitizeParametersEncoding);
 
             // load factor providers
             load(factors, endUser, h -> {
@@ -204,7 +206,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
 
     private void redirectToAuthorize(RoutingContext routingContext) {
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-        final String returnURL = getReturnUrl(routingContext, queryParams);
+        final String returnURL = getReturnUrl(routingContext, queryParams, sanitizeParametersEncoding);
         doRedirect(routingContext.response(), returnURL);
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFARecoveryCodeEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFARecoveryCodeEndpoint.java
@@ -67,14 +67,17 @@ public class MFARecoveryCodeEndpoint extends AbstractEndpoint implements Handler
     private final UserService userService;
     private final FactorManager factorManager;
     private final ApplicationContext applicationContext;
+    private final boolean sanitizeParametersEncoding;
 
     public MFARecoveryCodeEndpoint(TemplateEngine templateEngine, Domain domain, UserService userService,
-                                   FactorManager factorManager, ApplicationContext applicationContext) {
+                                   FactorManager factorManager, ApplicationContext applicationContext,
+                                   boolean sanitizeParametersEncoding) {
         super(templateEngine);
         this.domain = domain;
         this.userService = userService;
         this.factorManager = factorManager;
         this.applicationContext = applicationContext;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -171,7 +174,7 @@ public class MFARecoveryCodeEndpoint extends AbstractEndpoint implements Handler
 
     private void doRedirect(RoutingContext routingContext) {
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-        final String returnUrl = getReturnUrl(routingContext, queryParams);
+        final String returnUrl = getReturnUrl(routingContext, queryParams, sanitizeParametersEncoding);
         routingContext.response()
                 .putHeader(io.vertx.core.http.HttpHeaders.LOCATION, returnUrl)
                 .setStatusCode(302)
@@ -226,7 +229,7 @@ public class MFARecoveryCodeEndpoint extends AbstractEndpoint implements Handler
         routingContext.put(recoveryCodes, codes);
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
         final String recoveryCodeUrl = UriBuilderRequest.resolveProxyRequest(routingContext.request(),
-                routingContext.get(CONTEXT_PATH) + "/mfa/recovery_code", queryParams, true);
+                routingContext.get(CONTEXT_PATH) + "/mfa/recovery_code", queryParams, true, sanitizeParametersEncoding);
 
         routingContext.put("recoveryCodeURL", recoveryCodeUrl);
         // render the mfa recovery code page

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordEndpoint.java
@@ -51,11 +51,13 @@ public class ForgotPasswordEndpoint extends AbstractEndpoint implements Handler<
     private static final Logger logger = LoggerFactory.getLogger(ForgotPasswordEndpoint.class);
     private final Domain domain;
     private final BotDetectionManager botDetectionManager;
+    private boolean sanitizeParametersEncoding;
 
-    public ForgotPasswordEndpoint(TemplateEngine engine, Domain domain, BotDetectionManager botDetectionManager) {
+    public ForgotPasswordEndpoint(TemplateEngine engine, Domain domain, BotDetectionManager botDetectionManager, boolean sanitizeParametersEncoding) {
         super(engine);
         this.domain = domain;
         this.botDetectionManager = botDetectionManager;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -82,8 +84,8 @@ public class ForgotPasswordEndpoint extends AbstractEndpoint implements Handler<
         routingContext.put(ConstantKeys.PARAM_CONTEXT_KEY, params);
 
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-        routingContext.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true));
-        routingContext.put(ConstantKeys.LOGIN_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login", queryParams, true));
+        routingContext.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true, sanitizeParametersEncoding));
+        routingContext.put(ConstantKeys.LOGIN_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login", queryParams, true, sanitizeParametersEncoding));
 
         AccountSettings settings = AccountSettings.getInstance(domain, client);
         if (settings != null && settings.isResetPasswordCustomForm()) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordEndpoint.java
@@ -47,10 +47,12 @@ public class ResetPasswordEndpoint extends AbstractEndpoint implements Handler<R
     private static final Logger logger = LoggerFactory.getLogger(ResetPasswordEndpoint.class);
 
     private final Domain domain;
+    private final boolean sanitizeParametersEncoding;
 
-    public ResetPasswordEndpoint(TemplateEngine engine, Domain domain) {
+    public ResetPasswordEndpoint(TemplateEngine engine, Domain domain, boolean sanitizeParametersEncoding) {
         super(engine);
         this.domain = domain;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -79,7 +81,7 @@ public class ResetPasswordEndpoint extends AbstractEndpoint implements Handler<R
 
         final Map<String, String> actionParams = (client != null) ? Map.of(Parameters.CLIENT_ID, encodeURIComponent(client.getClientId())) : Map.of();
         routingContext.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), actionParams));
-        routingContext.put(PASSWORD_HISTORY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/passwordHistory", actionParams, true));
+        routingContext.put(PASSWORD_HISTORY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/passwordHistory", actionParams, true, sanitizeParametersEncoding));
 
         // render the reset password page
         this.renderPage(routingContext, generateData(routingContext, domain, client), client, logger, "Unable to render reset password page");

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterEndpoint.java
@@ -53,11 +53,13 @@ public class RegisterEndpoint extends AbstractEndpoint implements Handler<Routin
 
     private final Domain domain;
     private final BotDetectionManager botDetectionManager;
+    private final boolean sanitizeParametersEncoding;
 
-    public RegisterEndpoint(TemplateEngine engine, Domain domain, BotDetectionManager botDetectionManager) {
+    public RegisterEndpoint(TemplateEngine engine, Domain domain, BotDetectionManager botDetectionManager, boolean sanitizeParametersEncoding) {
         super(engine);
         this.domain = domain;
         this.botDetectionManager = botDetectionManager;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -88,8 +90,8 @@ public class RegisterEndpoint extends AbstractEndpoint implements Handler<Routin
 
         MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
         final String loginActionKey = routingContext.get(CONTEXT_PATH) + (isIdentifierFirstEnabled ? IDENTIFIER_FIRST_LOGIN.redirectUri() : LOGIN.redirectUri());
-        routingContext.put(ConstantKeys.ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true));
-        routingContext.put(ConstantKeys.LOGIN_ACTION_KEY, resolveProxyRequest(routingContext.request(), loginActionKey, queryParams, true));
+        routingContext.put(ConstantKeys.ACTION_KEY, resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true, sanitizeParametersEncoding));
+        routingContext.put(ConstantKeys.LOGIN_ACTION_KEY, resolveProxyRequest(routingContext.request(), loginActionKey, queryParams, true, sanitizeParametersEncoding));
 
         final Map<String, Object> data = generateData(routingContext, domain, client);
         data.putAll(botDetectionManager.getTemplateVariables(domain, client));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpoint.java
@@ -39,9 +39,11 @@ public class RegisterSubmissionEndpoint implements Handler<RoutingContext> {
     public static final String GATEWAY_ENDPOINT_REGISTRATION_KEEP_PARAMS = "legacy.registration.keepParams";
 
     private final boolean keepParams;
+    private final boolean sanitizeParametersEncoding;
 
-    public RegisterSubmissionEndpoint(Environment environment) {
+    public RegisterSubmissionEndpoint(Environment environment, boolean sanitizeParametersEncoding) {
         this.keepParams = environment.getProperty(GATEWAY_ENDPOINT_REGISTRATION_KEEP_PARAMS, boolean.class, true);
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -53,7 +55,7 @@ public class RegisterSubmissionEndpoint implements Handler<RoutingContext> {
         // no redirect uri has been set, redirect to the default page
         if (registrationResponse.getRedirectUri() == null || registrationResponse.getRedirectUri().isEmpty()) {
             queryParams.set(ConstantKeys.SUCCESS_PARAM_KEY, "registration_succeed");
-            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.request().path(), queryParams, true);
+            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.request().path(), queryParams, true, sanitizeParametersEncoding);
             doRedirect(context.response(), uri);
             return;
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginEndpoint.java
@@ -48,15 +48,18 @@ public class WebAuthnLoginEndpoint extends AbstractEndpoint implements Handler<R
     private final Domain domain;
     private final DeviceIdentifierManager deviceIdentifierManager;
     private final UserActivityService userActivityService;
+    private final boolean sanitizeParametersEncoding;
 
     public WebAuthnLoginEndpoint(ThymeleafTemplateEngine engine,
                                  Domain domain,
                                  DeviceIdentifierManager deviceIdentifierManager,
-                                 UserActivityService userActivityService) {
+                                 UserActivityService userActivityService,
+                                 boolean sanitizeParametersEncoding) {
         super(engine);
         this.domain = domain;
         this.deviceIdentifierManager = deviceIdentifierManager;
         this.userActivityService = userActivityService;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -70,10 +73,10 @@ public class WebAuthnLoginEndpoint extends AbstractEndpoint implements Handler<R
             final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
 
             final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-            routingContext.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true));
+            routingContext.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.request().path(), queryParams, true, sanitizeParametersEncoding));
 
             final String loginActionKey = routingContext.get(CONTEXT_PATH) + "/login";
-            routingContext.put(ConstantKeys.LOGIN_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), loginActionKey, queryParams, true));
+            routingContext.put(ConstantKeys.LOGIN_ACTION_KEY, UriBuilderRequest.resolveProxyRequest(routingContext.request(), loginActionKey, queryParams, true, sanitizeParametersEncoding));
             var params = new HashMap<>();
             params.put(Parameters.CLIENT_ID, client.getClientId());
             routingContext.put(ConstantKeys.PARAM_CONTEXT_KEY, params);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginPostEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginPostEndpoint.java
@@ -31,6 +31,12 @@ import io.vertx.reactivex.ext.web.RoutingContext;
  */
 public class WebAuthnLoginPostEndpoint extends AbstractEndpoint implements Handler<RoutingContext>  {
 
+    private final boolean sanitizeParametersEncoding;
+
+    public WebAuthnLoginPostEndpoint(boolean sanitizeParametersEncoding) {
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
+    }
+
     @Override
     public void handle(RoutingContext ctx) {
         // support for potential cached javascript files
@@ -56,7 +62,7 @@ public class WebAuthnLoginPostEndpoint extends AbstractEndpoint implements Handl
         // at this stage the user has been authenticated
         // redirect the user to the original request
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(ctx.request());
-        final String redirectUri = getReturnUrl(ctx, queryParams);
+        final String redirectUri = getReturnUrl(ctx, queryParams, sanitizeParametersEncoding);
 
         ctx.response().putHeader(io.vertx.core.http.HttpHeaders.LOCATION, redirectUri)
                 .setStatusCode(302)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterPostEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterPostEndpoint.java
@@ -31,6 +31,12 @@ import io.vertx.reactivex.ext.web.RoutingContext;
  */
 public class WebAuthnRegisterPostEndpoint extends AbstractEndpoint implements Handler<RoutingContext>  {
 
+    private final boolean sanitizeParametersEncoding;
+
+    public WebAuthnRegisterPostEndpoint(boolean sanitizeParametersEncoding) {
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
+    }
+
     @Override
     public void handle(RoutingContext ctx) {
         // support for potential cached javascript files
@@ -56,7 +62,7 @@ public class WebAuthnRegisterPostEndpoint extends AbstractEndpoint implements Ha
         // at this stage the registration has been done
         // redirect the user to the original request
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(ctx.request());
-        final String redirectUri = getReturnUrl(ctx, queryParams);
+        final String redirectUri = getReturnUrl(ctx, queryParams, sanitizeParametersEncoding);
 
         ctx.response().putHeader(io.vertx.core.http.HttpHeaders.LOCATION, redirectUri)
                 .setStatusCode(302)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnResponseEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnResponseEndpoint.java
@@ -32,12 +32,18 @@ import io.vertx.reactivex.ext.web.RoutingContext;
  */
 public class WebAuthnResponseEndpoint extends AbstractEndpoint implements Handler<RoutingContext>  {
 
+    private final boolean sanitizeParametersEncoding;
+
+    public WebAuthnResponseEndpoint(boolean sanitizeParametersEncoding) {
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
+    }
+
     @Override
     public void handle(RoutingContext ctx) {
         // at this stage the user has been authenticated
         // redirect the user to the original request
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(ctx.request());
-        final String redirectUri = getReturnUrl(ctx, queryParams);
+        final String redirectUri = getReturnUrl(ctx, queryParams, sanitizeParametersEncoding);
 
         ctx.response().putHeader(io.vertx.core.http.HttpHeaders.LOCATION, redirectUri)
                 .setStatusCode(302)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/error/AbstractErrorHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/error/AbstractErrorHandler.java
@@ -47,9 +47,11 @@ public abstract class AbstractErrorHandler implements Handler<RoutingContext> {
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
     protected final String errorPage;
+    private final boolean sanitizeParametersEncoding;
 
-    public AbstractErrorHandler(String errorPage) {
+    public AbstractErrorHandler(String errorPage, boolean sanitizeParametersEncoding) {
         this.errorPage = errorPage;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -77,7 +79,7 @@ public abstract class AbstractErrorHandler implements Handler<RoutingContext> {
                 parameters.set(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, "Unexpected error occurred");
 
                 // redirect
-                String proxiedErrorPage = UriBuilderRequest.resolveProxyRequest(request, errorPageURL, parameters, true);
+                String proxiedErrorPage = UriBuilderRequest.resolveProxyRequest(request, errorPageURL, parameters, true, sanitizeParametersEncoding);
                 doRedirect(routingContext.response(), proxiedErrorPage);
             }
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/error/ErrorHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/error/ErrorHandler.java
@@ -40,8 +40,11 @@ import static java.util.Objects.isNull;
  */
 public class ErrorHandler extends AbstractErrorHandler {
 
-    public ErrorHandler(String errorPage) {
-        super(errorPage);
+    private final boolean sanitizeParametersEncoding;
+
+    public ErrorHandler(String errorPage, boolean sanitizeParametersEncoding) {
+        super(errorPage, sanitizeParametersEncoding);
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -98,7 +101,7 @@ public class ErrorHandler extends AbstractErrorHandler {
             }
 
             // redirect
-            String proxiedErrorPage = UriBuilderRequest.resolveProxyRequest(request, errorPageURL, parameters, true);
+            String proxiedErrorPage = UriBuilderRequest.resolveProxyRequest(request, errorPageURL, parameters, true, sanitizeParametersEncoding);
             doRedirect(routingContext.response(), proxiedErrorPage);
         } catch (Exception e) {
             logger.error("Unable to handle root error response", e);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandler.java
@@ -55,12 +55,15 @@ public class LoginFailureHandler extends LoginAbstractHandler {
     private final AuthenticationFlowContextService authenticationFlowContextService;
     private final Domain domain;
     private final IdentityProviderManager identityProviderManager;
+    private final boolean sanitizeParametersEncoding;
 
     public LoginFailureHandler(AuthenticationFlowContextService authenticationFlowContextService,
-                               Domain domain, IdentityProviderManager identityProviderManager) {
+                               Domain domain, IdentityProviderManager identityProviderManager,
+                               boolean sanitizeParametersEncoding) {
         this.authenticationFlowContextService = authenticationFlowContextService;
         this.domain = domain;
         this.identityProviderManager = identityProviderManager;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -168,9 +171,10 @@ public class LoginFailureHandler extends LoginAbstractHandler {
         }
         if (nonNull(context.request().getParam(Parameters.LOGIN_HINT)) && nonNull(context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY))) {
             // encode login_hint parameter (to not replace '+' sign by a space ' ')
-            queryParams.set(Parameters.LOGIN_HINT, UriBuilder.encodeURIComponent(context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY)));
+            queryParams.set(Parameters.LOGIN_HINT, sanitizeParametersEncoding? UriBuilder.encodeURIComponent(context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY))
+                    :context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY));
         }
-        String uri = UriBuilderRequest.resolveProxyRequest(req, req.path(), queryParams, true);
+        String uri = UriBuilderRequest.resolveProxyRequest(req, req.path(), queryParams, true, sanitizeParametersEncoding);
         doRedirect(resp, uri);
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginNegotiateAuthenticationHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginNegotiateAuthenticationHandler.java
@@ -48,10 +48,12 @@ public class LoginNegotiateAuthenticationHandler implements Handler<RoutingConte
 
     private final UserAuthProvider authProvider;
     private final ThymeleafTemplateEngine engine;
+    private final boolean sanitizeParametersEncoding;
 
-    public LoginNegotiateAuthenticationHandler(UserAuthProvider authProvider, ThymeleafTemplateEngine engine) {
+    public LoginNegotiateAuthenticationHandler(UserAuthProvider authProvider, ThymeleafTemplateEngine engine, boolean sanitizeParametersEncoding) {
         this.authProvider = authProvider;
         this.engine = engine;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -93,7 +95,7 @@ public class LoginNegotiateAuthenticationHandler implements Handler<RoutingConte
                         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(context.request())
                                 .add(ASK_FOR_NEGOTIATE_KEY, "true")
                                 .add(NEGOTIATE_CONTINUE_TOKEN_KEY, ((NegotiateContinueException) res.cause()).getToken());
-                        final String redirectUri = UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true);
+                        final String redirectUri = UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true, sanitizeParametersEncoding);
                         context.response().putHeader(HttpHeaders.LOCATION, redirectUri)
                                 .setStatusCode(302)
                                 .end();
@@ -117,7 +119,7 @@ public class LoginNegotiateAuthenticationHandler implements Handler<RoutingConte
 
             // create post action url.
             final MultiMap queryParams = RequestUtils.getCleanedQueryParams(context.request()).add(ASK_FOR_NEGOTIATE_KEY, "true");
-            context.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true));
+            context.put(ConstantKeys.ACTION_KEY, UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true, sanitizeParametersEncoding));
 
             // Render login SSO SPNEGO form.
             // Responds with an 401 response with the "WWW-Authenticate: Negotiate" HTTP Response Header.

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRequestHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/UserRequestHandler.java
@@ -54,7 +54,7 @@ public abstract class UserRequestHandler implements Handler<RoutingContext> {
             if (exceptions != null && exceptions.length > 0) {
                 logger.debug("Error user actions : " + queryParams.get(ERROR_PARAM_KEY), exceptions[0]);
             }
-            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.request().path(), queryParams, true);
+            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.request().path(), queryParams, true, false);
             doRedirect(context.response(), uri);
         } catch (Exception ex) {
             logger.error("An error occurs while redirecting to {}", context.request().absoluteURI(), ex);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterFailureHandler.java
@@ -38,8 +38,11 @@ import static io.gravitee.am.common.utils.ConstantKeys.ERROR_PARAM_KEY;
  */
 public class RegisterFailureHandler extends AbstractErrorHandler {
 
-    public RegisterFailureHandler() {
-        super(RootProvider.PATH_ERROR);
+    private final boolean sanitizeParametersEncoding;
+
+    public RegisterFailureHandler(boolean sanitizeParametersEncoding) {
+        super(RootProvider.PATH_ERROR, sanitizeParametersEncoding);
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -64,7 +67,7 @@ public class RegisterFailureHandler extends AbstractErrorHandler {
             if (exceptions != null && exceptions.length > 0) {
                 logger.debug("Error user actions : " + queryParams.get(ERROR_PARAM_KEY), exceptions[0]);
             }
-            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.request().path(), queryParams, true);
+            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.request().path(), queryParams, true, sanitizeParametersEncoding);
             doRedirect(context.response(), uri);
         } catch (Exception ex) {
             logger.error("An error occurs while redirecting to {}", context.request().absoluteURI(), ex);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/ResetPasswordEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/ResetPasswordEndpointTest.java
@@ -44,7 +44,7 @@ public class ResetPasswordEndpointTest {
         domain.setId("domain-id");
 
         final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
-        var registrationConfirmation = new ResetPasswordEndpoint(engine, domain);
+        var registrationConfirmation = new ResetPasswordEndpoint(engine, domain, true);
 
         final SpyRoutingContext ctx = new SpyRoutingContext();
         ctx.setMethod(HttpMethod.GET);
@@ -66,7 +66,7 @@ public class ResetPasswordEndpointTest {
         domain.setId("domain-id");
 
         final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
-        var resetPassword = new ResetPasswordEndpoint(engine, domain);
+        var resetPassword = new ResetPasswordEndpoint(engine, domain, true);
 
         final SpyRoutingContext ctx = new SpyRoutingContext();
         ctx.setMethod(HttpMethod.GET);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpointTest.java
@@ -97,7 +97,7 @@ public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
         appClient.setDomain(domain.getId());
         when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
 
-        identifierFirstLoginEndpoint = new IdentifierFirstLoginEndpoint(templateEngine, domain, botDetectionManager);
+        identifierFirstLoginEndpoint = new IdentifierFirstLoginEndpoint(templateEngine, domain, botDetectionManager, true);
 
         router.route("/login/identifier")
                 .handler(clientRequestParseHandler)
@@ -346,7 +346,7 @@ public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
                     assertNotNull(routingContext.get(PARAM_CONTEXT_KEY));
                     final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
                     assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(),
-                            routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParams, true));
+                            routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParams, true, true));
                 } catch (Exception e) {
                     e.printStackTrace();
                 } finally {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpointHandlerTest.java
@@ -118,7 +118,7 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
         domain.setPath("/login-domain");
         domain.setLoginSettings(loginSettings);
         appClient.setDomain(domain.getId());
-        loginEndpoint = new LoginEndpoint(templateEngine, domain, botDetectionManager, deviceIdentifierManager, userActivityService);
+        loginEndpoint = new LoginEndpoint(templateEngine, domain, botDetectionManager, deviceIdentifierManager, userActivityService, true);
         appClient.setLoginSettings(loginSettings);
         doReturn(Map.of()).when(deviceIdentifierManager).getTemplateVariables(any());
         doReturn(true).when(userActivityService).canSaveUserActivity();
@@ -175,7 +175,7 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
         appIdp.setSelectionRule("true");
         appIdp.setIdentity("provider-id");
 
-        final TreeSet treeSet = new TreeSet();
+        final TreeSet<ApplicationIdentityProvider> treeSet = new TreeSet<>();
         treeSet.add(appIdp);
         appClient.setIdentityProviders(treeSet);
 
@@ -250,7 +250,7 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
             loginEndpoint.handle(context);
             context.next();
         });
-        ;
+
         when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
         testRequest(
                 HttpMethod.GET, "/login?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com&username=",
@@ -300,21 +300,18 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
                     var queryParamsNoUsername = MultiMap.caseInsensitiveMultiMap();
                     queryParamsNoUsername.addAll(queryParams);
                     queryParamsNoUsername.remove(USERNAME_PARAM_KEY);
-                    assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login", queryParams, true));
-                    assertEquals(routingContext.get(FORGOT_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true));
-                    assertEquals(routingContext.get(REGISTER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true));
-                    assertEquals(routingContext.get(WEBAUTHN_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true));
+                    assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login", queryParams, true, true));
+                    assertEquals(routingContext.get(FORGOT_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true, true));
+                    assertEquals(routingContext.get(REGISTER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true, true));
+                    assertEquals(routingContext.get(WEBAUTHN_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true, true));
                     if (expectedFirstIdentifier) {
-                        assertEquals(routingContext.get(BACK_TO_LOGIN_IDENTIFIER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParamsNoUsername, true));
+                        assertEquals(routingContext.get(BACK_TO_LOGIN_IDENTIFIER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login/identifier", queryParamsNoUsername, true, true));
                     }
                     assertFalse(TRUE.equals(routingContext.get(ALLOW_FORGOT_PASSWORD_CONTEXT_KEY)));
                     assertFalse(TRUE.equals(routingContext.get(ALLOW_REGISTER_CONTEXT_KEY)));
                     assertFalse(TRUE.equals(routingContext.get(ALLOW_PASSWORDLESS_CONTEXT_KEY)));
                     assertEquals(TRUE.equals(routingContext.get(HIDE_FORM_CONTEXT_KEY)), expectedHide);
                     assertEquals(TRUE.equals(routingContext.get(IDENTIFIER_FIRST_LOGIN_ENABLED)), expectedFirstIdentifier);
-
-                } catch (Exception e) {
-                    e.printStackTrace();
                 } finally {
                     routingContext.end();
                 }
@@ -337,18 +334,16 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
                 queryParamsNoUsername.addAll(queryParams);
                 queryParamsNoUsername.remove(USERNAME_PARAM_KEY);
 
-                assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login", queryParams, true));
-                assertEquals(routingContext.get(FORGOT_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true));
-                assertEquals(routingContext.get(REGISTER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true));
-                assertEquals(routingContext.get(WEBAUTHN_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true));
+                assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/login", queryParams, true, true));
+                assertEquals(routingContext.get(FORGOT_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/forgotPassword", queryParams, true, true));
+                assertEquals(routingContext.get(REGISTER_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/register", queryParams, true, true));
+                assertEquals(routingContext.get(WEBAUTHN_ACTION_KEY), resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/webauthn/login", queryParams, true, true));
 
                 assertFalse(TRUE.equals(routingContext.get(ALLOW_FORGOT_PASSWORD_CONTEXT_KEY)));
                 assertFalse(TRUE.equals(routingContext.get(ALLOW_REGISTER_CONTEXT_KEY)));
                 assertFalse(TRUE.equals(routingContext.get(ALLOW_PASSWORDLESS_CONTEXT_KEY)));
                 assertEquals(TRUE.equals(routingContext.get(HIDE_FORM_CONTEXT_KEY)), expectedHide);
                 assertEquals(TRUE.equals(routingContext.get(IDENTIFIER_FIRST_LOGIN_ENABLED)), expectedFirstIdentifier);
-            } catch (Exception e) {
-                e.printStackTrace();
             } finally {
                 routingContext.end();
             }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/logout/LogoutCallbackEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/logout/LogoutCallbackEndpointHandlerTest.java
@@ -70,7 +70,7 @@ public class LogoutCallbackEndpointHandlerTest extends RxWebTestBase {
 
         router.route(HttpMethod.GET, "/logout/callback")
                 .handler(new LogoutCallbackEndpoint(domain, clientSyncService, jwtService, userService, authenticationFlowContextService, certificateManager))
-                .failureHandler(new ErrorHandler("/error"));
+                .failureHandler(new ErrorHandler("/error", true));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/logout/LogoutEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/logout/LogoutEndpointHandlerTest.java
@@ -87,7 +87,7 @@ public class LogoutEndpointHandlerTest extends RxWebTestBase {
 
         router.route(HttpMethod.GET, "/logout")
                 .handler(new LogoutEndpoint(domain, clientSyncService, jwtService, userService, authenticationFlowContextService, identityProviderManager, certificateManager, webClient))
-                .failureHandler(new ErrorHandler("/error"));
+                .failureHandler(new ErrorHandler("/error", true));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeAlternativesEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeAlternativesEndpointTest.java
@@ -94,7 +94,7 @@ public class MFAChallengeAlternativesEndpointTest extends RxWebTestBase {
     @Test
     public void mustNotInvokeMFAChallengeAlternativesEndpoint_noUser() throws Exception {
         router.route(HttpMethod.GET, "/mfa/challenge/alternatives")
-                .handler(new MFAChallengeAlternativesEndpoint(templateEngine, factorManager, domain));
+                .handler(new MFAChallengeAlternativesEndpoint(templateEngine, factorManager, domain, true));
 
         testRequest(
                 HttpMethod.GET, "/mfa/challenge/alternatives?client_id=test",
@@ -110,7 +110,7 @@ public class MFAChallengeAlternativesEndpointTest extends RxWebTestBase {
         });
 
         router.route(HttpMethod.GET, "/mfa/challenge/alternatives")
-                .handler(new MFAChallengeAlternativesEndpoint(templateEngine, factorManager, domain));
+                .handler(new MFAChallengeAlternativesEndpoint(templateEngine, factorManager, domain, true));
 
         testRequest(
                 HttpMethod.GET, "/mfa/challenge/alternatives?client_id=test",
@@ -127,7 +127,7 @@ public class MFAChallengeAlternativesEndpointTest extends RxWebTestBase {
         });
 
         router.route(HttpMethod.GET, "/mfa/challenge/alternatives")
-                .handler(new MFAChallengeAlternativesEndpoint(templateEngine, factorManager, domain));
+                .handler(new MFAChallengeAlternativesEndpoint(templateEngine, factorManager, domain, true));
 
         testRequest(
                 HttpMethod.GET, "/mfa/challenge/alternatives?client_id=test",
@@ -149,7 +149,7 @@ public class MFAChallengeAlternativesEndpointTest extends RxWebTestBase {
         });
 
         router.route(HttpMethod.GET, "/mfa/challenge/alternatives")
-                .handler(get200AssertMockRoutingContextHandler(new MFAChallengeAlternativesEndpoint(templateEngine, factorManager, domain)));
+                .handler(get200AssertMockRoutingContextHandler(new MFAChallengeAlternativesEndpoint(templateEngine, factorManager, domain, true)));
 
         testRequest(
                 HttpMethod.GET, "/mfa/challenge/alternatives?client_id=test",
@@ -162,9 +162,7 @@ public class MFAChallengeAlternativesEndpointTest extends RxWebTestBase {
                 try {
                     assertNotNull(routingContext.get(CLIENT_CONTEXT_KEY));
                     final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-                    assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(),"/mfa/challenge/alternatives", queryParams, true));
-                } catch (Exception e) {
-                    e.printStackTrace();
+                    assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(),"/mfa/challenge/alternatives", queryParams, true, true));
                 } finally {
                     routingContext.end();
                 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpointTest.java
@@ -142,7 +142,7 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
                     ctx.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
                     ctx.next();
                 })
-                .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService, factorService, rateLimiterService, verifyAttemptService, emailService));
+                .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService, factorService, rateLimiterService, verifyAttemptService, emailService, true));
 
         testRequest(
                 HttpMethod.POST,
@@ -188,8 +188,8 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
                     ctx.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
                     ctx.next();
                 })
-                .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService, factorService, rateLimiterService, verifyAttemptService, emailService))
-                .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService));
+                .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService, factorService, rateLimiterService, verifyAttemptService, emailService, true))
+                .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService, true));
 
         testRequest(
                 HttpMethod.POST,
@@ -230,8 +230,8 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
               ctx.next();
           })
           .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService,
-                  factorService, rateLimiterService, verifyAttemptService, emailService))
-          .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService));
+                  factorService, rateLimiterService, verifyAttemptService, emailService, true))
+          .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService, true));
 
       testRequest(
           HttpMethod.GET,
@@ -266,8 +266,8 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
           ctx.next();
         })
         .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService,
-                factorService, rateLimiterService, verifyAttemptService, emailService))
-        .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService));
+                factorService, rateLimiterService, verifyAttemptService, emailService, true))
+        .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService, true));
 
     testRequest(
         HttpMethod.GET,
@@ -291,8 +291,8 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
           ctx.next();
         })
         .handler(new MFAChallengeEndpoint(factorManager, userService, engine, deviceService, applicationContext, domain, credentialService,
-                factorService, rateLimiterService, verifyAttemptService, emailService))
-        .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService));
+                factorService, rateLimiterService, verifyAttemptService, emailService, true))
+        .failureHandler(new MFAChallengeFailureHandler(authenticationFlowContextService, true));
 
     testRequest(
         HttpMethod.GET,

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFARecoveryCodeEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFARecoveryCodeEndpointTest.java
@@ -79,7 +79,7 @@ public class MFARecoveryCodeEndpointTest extends RxWebTestBase {
         client.setClientId(UUID.randomUUID().toString());
         final User user = new User();
         setFactorsFor(user);
-        mfaRecoveryCodeEndpoint = new MFARecoveryCodeEndpoint(templateEngine, domain, userService, factorManager, applicationContext);
+        mfaRecoveryCodeEndpoint = new MFARecoveryCodeEndpoint(templateEngine, domain, userService, factorManager, applicationContext, true);
 
         router.route()
                 .handler(ctx -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpointTest.java
@@ -64,8 +64,8 @@ public class RegisterSubmissionEndpointTest extends RxWebTestBase {
         router.route(HttpMethod.POST, "/register")
                 .handler(BodyHandler.create())
                 .handler(new RegisterProcessHandler(userService, domain))
-                .handler(new RegisterSubmissionEndpoint(environment))
-                .failureHandler(new RegisterFailureHandler());
+                .handler(new RegisterSubmissionEndpoint(environment, true))
+                .failureHandler(new RegisterFailureHandler(true));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandlerTest.java
@@ -62,7 +62,7 @@ public class LoginFailureHandlerTest extends RxWebTestBase {
 
         router.route(HttpMethod.GET, "/login")
                 .handler(rc -> rc.fail(policyChainException))
-                .failureHandler(new LoginFailureHandler(authenticationFlowContextService, domain, identityProviderManager));
+                .failureHandler(new LoginFailureHandler(authenticationFlowContextService, domain, identityProviderManager, true));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/UserConsentPostEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/UserConsentPostEndpoint.java
@@ -37,13 +37,18 @@ import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderReques
 public class UserConsentPostEndpoint implements Handler<RoutingContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(UserConsentPostEndpoint.class);
+    private final boolean sanitizeParametersEncoding;
+
+    public UserConsentPostEndpoint(boolean sanitizeParametersEncoding) {
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
+    }
 
     @Override
     public void handle(RoutingContext routingContext) {
         // consent has been processed, replay authorization request
         try {
             final String authorizationRequestUrl = UriBuilderRequest.resolveProxyRequest(routingContext.request(),
-                    routingContext.get(CONTEXT_PATH) + "/oauth/authorize", RequestUtils.getCleanedQueryParams(routingContext.request()), true);
+                    routingContext.get(CONTEXT_PATH) + "/oauth/authorize", RequestUtils.getCleanedQueryParams(routingContext.request()), true, sanitizeParametersEncoding);
             doRedirect(routingContext.response(), authorizationRequestUrl);
         } catch (Exception e) {
             logger.error("An error occurs while handling authorization approval request", e);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestEndUserConsentHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestEndUserConsentHandler.java
@@ -61,9 +61,11 @@ public class AuthorizationRequestEndUserConsentHandler implements Handler<Routin
     private static final String CONSENT_PAGE_PATH = "/oauth/consent";
 
     private final UserConsentService userConsentService;
+    private final boolean sanitizeParametersEncoding;
 
-    public AuthorizationRequestEndUserConsentHandler(UserConsentService userConsentService) {
+    public AuthorizationRequestEndUserConsentHandler(UserConsentService userConsentService, boolean sanitizeParametersEncoding) {
         this.userConsentService = userConsentService;
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
     }
 
     @Override
@@ -156,7 +158,7 @@ public class AuthorizationRequestEndUserConsentHandler implements Handler<Routin
 
         try {
             final MultiMap queryParams = RequestUtils.getCleanedQueryParams(request);
-            String proxiedRedirectURI = UriBuilderRequest.resolveProxyRequest(request, consentPageURL, queryParams, true);
+            String proxiedRedirectURI = UriBuilderRequest.resolveProxyRequest(request, consentPageURL, queryParams, true, sanitizeParametersEncoding);
             request.response()
                     .putHeader(HttpHeaders.LOCATION, proxiedRedirectURI)
                     .setStatusCode(302)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/consent/UserConsentFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/consent/UserConsentFailureHandler.java
@@ -35,6 +35,11 @@ import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderReques
  */
 public class UserConsentFailureHandler implements Handler<RoutingContext> {
     private static final Logger logger = LoggerFactory.getLogger(UserConsentFailureHandler.class);
+    private final boolean sanitizeParametersEncoding;
+
+    public UserConsentFailureHandler(boolean sanitizeParametersEncoding) {
+        this.sanitizeParametersEncoding = sanitizeParametersEncoding;
+    }
 
     @Override
     public void handle(RoutingContext context) {
@@ -68,7 +73,7 @@ public class UserConsentFailureHandler implements Handler<RoutingContext> {
             }
 
             // go back to login page
-            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true);
+            String uri = UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/login", queryParams, true, sanitizeParametersEncoding);
             doRedirect(context.response(), uri);
         } catch (Exception ex) {
             logger.error("An error occurs while redirecting to {}", context.request().absoluteURI(), ex);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/AuthorizationRequestEndUserConsentHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/AuthorizationRequestEndUserConsentHandlerTest.java
@@ -63,7 +63,7 @@ public class AuthorizationRequestEndUserConsentHandlerTest extends RxWebTestBase
                     context.setSession(new io.vertx.reactivex.ext.web.Session(session));
                     context.next();
                 })
-                .handler(new AuthorizationRequestEndUserConsentHandler(userConsentService))
+                .handler(new AuthorizationRequestEndUserConsentHandler(userConsentService, true))
                 .handler(rc -> rc.response().end())
                 .failureHandler(rc -> rc.response().setStatusCode(403).end());
     }


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-737

## :pencil2: A description of the changes proposed in the pull request

This PR introduces a hack 😞. Please be as harsh as possible with reviews. I don't like this code and I'm open to any suggestion 🙏 .

So far, when computing redirect URLs in AM, the `static` class `UriBuilderRequest` decodes and encodes all parameters.

When parameters aren't url-encoded, this is not a big deal. But when parameters are already url-encoded, we introduce a few issues.

Since the method is `UriBuilderRequest.resolveProxyRequest(...)` is used all around AM, it's hard to tell if removing the extra decoding will not break stuff.

This PR introduces the parameter `legacy.openid.sanitizeParametersEncoding` that, when set to `false`, disables the extra decoding.

For the future, we should remove the hack and any extra handling of parameters, only decoding parameters when they are received and encoding them when they leave AM Handlers.


## :memo: Test scenarios 

The issue contains a reproduction scenario.

I manually tested the fix in the following flows:
- Normal login flow
- Wrong password on normal login flow
- Login flow with `Identifier-first` enabled.
- Wrong password on ID first flow
- Navigation to Password reset page and back.
- Navigation to Register page and back.
- MFA with an SMS mock factor
- Wrong code with MFA mock factor.

## :books: Any other comments that will help with documentation

I'm not even sure where this should be documented
