### PR TITLE
fix: add missing statement to index creation script

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/resources/scripts/create-index.js
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/resources/scripts/create-index.js
@@ -359,7 +359,7 @@ db.alert_notifiers.reIndex();
 db.request_objects.dropIndexes();
 db.request_objects.createIndex( { "_id": 1 }, {"name": "_id1"} );
 db.request_objects.createIndex( { "expire_at" : 1 }, {"name": "e1", "expireAfterSeconds": 0});
-db.request_objects
+db.request_objects.reIndex();
 
 // "pushed_authorization_requests" collection
 db.pushed_authorization_requests.dropIndexes();


### PR DESCRIPTION
## :id: Reference related issue. 

Support issue make us notice the missing part

## :pencil2: A description of the changes proposed in the pull request

It seems that some tools are less forgiving when running the script and the execution was failing.

