### PR TITLE
fix: add sanitizeParametersEncoding toggle

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -46,6 +46,7 @@ import io.gravitee.am.gateway.handler.common.ruleengine.SpELRuleEngine;
 import io.gravitee.am.gateway.handler.common.spring.web.WebConfiguration;
 import io.gravitee.am.gateway.handler.common.user.UserService;
 import io.gravitee.am.gateway.handler.common.user.impl.UserServiceImpl;
+import io.gravitee.am.gateway.handler.common.utils.StaticEnvironmentProvider;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.UserAuthProvider;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.impl.OAuth2AuthProviderImpl;
@@ -67,6 +68,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
+import javax.annotation.PostConstruct;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -86,6 +89,11 @@ public class CommonConfiguration {
 
     @Autowired
     private Vertx vertx;
+
+    @PostConstruct
+    public void initStaticEnvironmentProvider() {
+        StaticEnvironmentProvider.setEnvironment(environment);
+    }
 
     @Bean
     @Qualifier("oidcWebClient")

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.utils;
+
+import org.springframework.core.env.Environment;
+
+public class StaticEnvironmentProvider {
+
+    private static Environment env = null;
+    private static Boolean sanitizeParametersEncoding = null;
+
+    public static void setEnvironment(Environment environment) {
+        env = environment;
+        // reset cached values
+        sanitizeParametersEncoding = null;
+    }
+
+    public static boolean sanitizeParametersEncoding() {
+        if (sanitizeParametersEncoding != null) {
+            return sanitizeParametersEncoding;
+        }
+        sanitizeParametersEncoding = getEnvironmentProperty("legacy.openid.sanitizeParametersEncoding", boolean.class, true);
+        return sanitizeParametersEncoding;
+    }
+
+    private static <T> T getEnvironmentProperty(String property, Class<T> type, T defaultValue) {
+        return env != null ? env.getProperty(property, type, defaultValue) : defaultValue;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProvider.java
@@ -29,10 +29,9 @@ public class StaticEnvironmentProvider {
     }
 
     public static boolean sanitizeParametersEncoding() {
-        if (sanitizeParametersEncoding != null) {
-            return sanitizeParametersEncoding;
+        if (sanitizeParametersEncoding == null) {
+            sanitizeParametersEncoding = getEnvironmentProperty("legacy.openid.sanitizeParametersEncoding", boolean.class, true);
         }
-        sanitizeParametersEncoding = getEnvironmentProperty("legacy.openid.sanitizeParametersEncoding", boolean.class, true);
         return sanitizeParametersEncoding;
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.common.vertx.utils;
 
 import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.gateway.handler.common.utils.StaticEnvironmentProvider;
 import io.gravitee.common.http.HttpHeaders;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.http.HttpServerRequest;
@@ -134,8 +135,12 @@ public class UriBuilderRequest {
         } else {
             if (parameters != null) {
                 parameters.forEach(entry -> {
-                    // some parameters can be already URL encoded, decode first
-                    builder.addParameter(entry.getKey(), UriBuilder.encodeURIComponent(UriBuilder.decodeURIComponent(entry.getValue())));
+                    var parameter = entry.getValue();
+                    if (StaticEnvironmentProvider.sanitizeParametersEncoding()) {
+                        // some parameters can be already URL encoded, decode first
+                        parameter = UriBuilder.decodeURIComponent(parameter);
+                    }
+                    builder.addParameter(entry.getKey(), UriBuilder.encodeURIComponent(parameter));
                 });
             }
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/RedirectHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/RedirectHandlerImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl;
 
 import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.gateway.handler.common.utils.StaticEnvironmentProvider;
 import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.vertx.core.Handler;
@@ -61,7 +62,7 @@ public class RedirectHandlerImpl implements Handler<RoutingContext> {
                 if (!UriBuilder.decodeURIComponent(login_hint).equals(login_hint)
                         && login_hint.contains("@")
                         && login_hint.contains("+")) {
-                    queryParams.set(LOGIN_HINT, UriBuilder.encodeURIComponent(login_hint));
+                    queryParams.set(LOGIN_HINT, StaticEnvironmentProvider.sanitizeParametersEncoding() ? UriBuilder.encodeURIComponent(login_hint) : login_hint);
                 }
             }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProviderTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProviderTest.java
@@ -36,7 +36,7 @@ public class StaticEnvironmentProviderTest {
     }
 
     @Test
-    public void sanitizeParametersEncoding_environment_returns_value() {
+    public void sanitizeParametersEncoding_environment_returns_cached_value() {
         assertFalse(StaticEnvironmentProvider.sanitizeParametersEncoding());
 
         // Call method twice to test cached value is used

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProviderTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProviderTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.utils;
+
+import org.junit.BeforeClass;
+import org.springframework.core.env.Environment;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.*;
+
+public class StaticEnvironmentProviderTest {
+
+    static Environment env = mock(Environment.class);
+
+    @BeforeClass
+    public static void setup() {
+        when(env.getProperty("legacy.openid.sanitizeParametersEncoding", boolean.class, true))
+                .thenReturn(false)
+                .thenReturn(true);
+        StaticEnvironmentProvider.setEnvironment(env);
+    }
+
+    @Test
+    public void sanitizeParametersEncoding_environment_returns_value() {
+        assertFalse(StaticEnvironmentProvider.sanitizeParametersEncoding());
+
+        // Call method twice to test cached value is used
+        assertFalse(StaticEnvironmentProvider.sanitizeParametersEncoding());
+        verify(env).getProperty("legacy.openid.sanitizeParametersEncoding", boolean.class, true);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpoint.java
@@ -20,6 +20,7 @@ import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
 import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
+import io.gravitee.am.gateway.handler.common.utils.StaticEnvironmentProvider;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.context.EvaluableRequest;
 import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
@@ -145,8 +146,9 @@ public class IdentifierFirstLoginEndpoint extends AbstractEndpoint implements Ha
         final MultiMap queryParams = RequestUtils.getCleanedQueryParams(request);
         // login_hint parameter can be duplicated from a previous step, remove it
         queryParams.remove(Parameters.LOGIN_HINT);
-        queryParams.add(Parameters.LOGIN_HINT, UriBuilder.encodeURIComponent(request.getParam(USERNAME_PARAM_KEY)));
-        final String url = UriBuilderRequest.resolveProxyRequest(request, redirectUrl, queryParams, true);
+        // If parameters is sanitized when generating the redirect URL, then the login-hint requires an extra encoding
+        queryParams.add(Parameters.LOGIN_HINT, StaticEnvironmentProvider.sanitizeParametersEncoding() ? UriBuilder.encodeURIComponent(request.getParam(USERNAME_PARAM_KEY)) : request.getParam(USERNAME_PARAM_KEY));
+        final String url = resolveProxyRequest(request, redirectUrl, queryParams, true);
         doRedirect0(routingContext, url);
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginCallbackEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginCallbackEndpoint.java
@@ -17,10 +17,8 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.login;
 
 import com.google.common.net.HttpHeaders;
 import io.gravitee.am.common.utils.ConstantKeys;
-import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
 import io.vertx.core.Handler;
-import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.http.HttpServerResponse;
 import io.vertx.reactivex.ext.web.RoutingContext;
 import io.vertx.reactivex.ext.web.Session;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeFailureHandler.java
@@ -15,19 +15,17 @@
  */
 package io.gravitee.am.gateway.handler.root.resources.endpoint.mfa;
 
-import com.google.common.net.HttpHeaders;
 import io.gravitee.am.common.exception.mfa.SendChallengeException;
 import io.gravitee.am.common.oidc.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
+import io.gravitee.am.gateway.handler.common.utils.StaticEnvironmentProvider;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.root.RootProvider;
 import io.gravitee.am.gateway.handler.root.resources.handler.error.AbstractErrorHandler;
 import io.gravitee.am.service.AuthenticationFlowContextService;
-import io.vertx.core.Handler;
 import io.vertx.reactivex.core.MultiMap;
-import io.vertx.reactivex.core.http.HttpServerResponse;
 import io.vertx.reactivex.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +75,8 @@ public class MFAChallengeFailureHandler extends AbstractErrorHandler {
 
         if (context.request().getParam(Parameters.LOGIN_HINT) != null) {
             // encode login_hint parameter (to not replace '+' sign by a space ' ')
-            queryParams.set(Parameters.LOGIN_HINT, UriBuilder.encodeURIComponent(context.request().getParam(Parameters.LOGIN_HINT)));
+            queryParams.set(Parameters.LOGIN_HINT, StaticEnvironmentProvider.sanitizeParametersEncoding() ?
+                    UriBuilder.encodeURIComponent(context.request().getParam(Parameters.LOGIN_HINT)) : context.request().getParam(Parameters.LOGIN_HINT));
         }
 
         return queryParams;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginFailureHandler.java
@@ -23,6 +23,7 @@ import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
 import io.gravitee.am.gateway.handler.common.vertx.utils.RequestUtils;
+import io.gravitee.am.gateway.handler.common.utils.StaticEnvironmentProvider;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.policy.PolicyChainException;
 import io.gravitee.am.model.Domain;
@@ -168,7 +169,8 @@ public class LoginFailureHandler extends LoginAbstractHandler {
         }
         if (nonNull(context.request().getParam(Parameters.LOGIN_HINT)) && nonNull(context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY))) {
             // encode login_hint parameter (to not replace '+' sign by a space ' ')
-            queryParams.set(Parameters.LOGIN_HINT, UriBuilder.encodeURIComponent(context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY)));
+            queryParams.set(Parameters.LOGIN_HINT, StaticEnvironmentProvider.sanitizeParametersEncoding() ?
+                    UriBuilder.encodeURIComponent(context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY)) : context.request().getParam(ConstantKeys.USERNAME_PARAM_KEY));
         }
         String uri = UriBuilderRequest.resolveProxyRequest(req, req.path(), queryParams, true);
         doRedirect(resp, uri);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandler.java
@@ -23,17 +23,15 @@ import io.gravitee.am.identityprovider.api.SimpleAuthenticationContext;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.oidc.Client;
 import io.vertx.reactivex.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static io.gravitee.am.common.utils.ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
 import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
-import static io.gravitee.am.common.utils.ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -71,7 +69,11 @@ public class LoginSelectionRuleHandler extends LoginAbstractHandler  {
 
                 if (fromIdentifierFirstLogin) {
                     // encode login_hint parameter for external provider (Azure AD replace the '+' sign by a space ' ')
-                    uriBuilder.addParameter(Parameters.LOGIN_HINT, UriBuilder.encodeURIComponent(routingContext.request().getParam(USERNAME_PARAM_KEY)));
+                    // we do not need to test the StaticEnvironmentProvider.sanitizeParametersEncoding() here as
+                    // we are not relying on the UriBuilderRequest.resolveProxyRequest method...
+                    uriBuilder.addParameter(Parameters.LOGIN_HINT,
+                            UriBuilder.encodeURIComponent(routingContext.request().getParam(USERNAME_PARAM_KEY))
+                    );
                 }
 
                 doRedirect(routingContext, uriBuilder.buildString());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpointHandlerTest.java
@@ -175,7 +175,7 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
         appIdp.setSelectionRule("true");
         appIdp.setIdentity("provider-id");
 
-        final TreeSet treeSet = new TreeSet();
+        final TreeSet<ApplicationIdentityProvider> treeSet = new TreeSet<>();
         treeSet.add(appIdp);
         appClient.setIdentityProviders(treeSet);
 
@@ -250,7 +250,7 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
             loginEndpoint.handle(context);
             context.next();
         });
-        ;
+
         when(clientSyncService.findByClientId(appClient.getClientId())).thenReturn(Maybe.just(appClient));
         testRequest(
                 HttpMethod.GET, "/login?client_id=" + appClient.getClientId() + "&response_type=code&redirect_uri=somewhere.com&username=",
@@ -312,9 +312,6 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
                     assertFalse(TRUE.equals(routingContext.get(ALLOW_PASSWORDLESS_CONTEXT_KEY)));
                     assertEquals(TRUE.equals(routingContext.get(HIDE_FORM_CONTEXT_KEY)), expectedHide);
                     assertEquals(TRUE.equals(routingContext.get(IDENTIFIER_FIRST_LOGIN_ENABLED)), expectedFirstIdentifier);
-
-                } catch (Exception e) {
-                    e.printStackTrace();
                 } finally {
                     routingContext.end();
                 }
@@ -347,8 +344,6 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
                 assertFalse(TRUE.equals(routingContext.get(ALLOW_PASSWORDLESS_CONTEXT_KEY)));
                 assertEquals(TRUE.equals(routingContext.get(HIDE_FORM_CONTEXT_KEY)), expectedHide);
                 assertEquals(TRUE.equals(routingContext.get(IDENTIFIER_FIRST_LOGIN_ENABLED)), expectedFirstIdentifier);
-            } catch (Exception e) {
-                e.printStackTrace();
             } finally {
                 routingContext.end();
             }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeAlternativesEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeAlternativesEndpointTest.java
@@ -163,8 +163,6 @@ public class MFAChallengeAlternativesEndpointTest extends RxWebTestBase {
                     assertNotNull(routingContext.get(CLIENT_CONTEXT_KEY));
                     final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
                     assertEquals(routingContext.get(ACTION_KEY), resolveProxyRequest(routingContext.request(),"/mfa/challenge/alternatives", queryParams, true));
-                } catch (Exception e) {
-                    e.printStackTrace();
                 } finally {
                     routingContext.end();
                 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/EmailServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/EmailServiceImpl.java
@@ -15,11 +15,7 @@
  */
 package io.gravitee.am.management.service.impl;
 
-import freemarker.template.Configuration;
-import freemarker.template.DefaultObjectWrapperBuilder;
-import freemarker.template.SimpleHash;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
+import freemarker.template.*;
 import io.gravitee.am.common.email.Email;
 import io.gravitee.am.common.email.EmailBuilder;
 import io.gravitee.am.common.jwt.Claims;
@@ -59,7 +55,6 @@ import java.util.Map;
 
 import static io.gravitee.am.common.web.UriBuilder.encodeURIComponent;
 import static io.gravitee.am.service.utils.UserProfileUtils.preferredLanguage;
-import static org.springframework.ui.freemarker.FreeMarkerTemplateUtils.processTemplateIntoString;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-737

## :pencil2: A description of the changes proposed in the pull request

This PR introduces a hack 😞.

So far, when computing redirect URLs in AM, the `static` class `UriBuilderRequest` decodes and encodes all parameters.

When parameters aren't url-encoded, this is not a big deal. But when parameters are already url-encoded, we introduce a few issues.

Since the method is `UriBuilderRequest.resolveProxyRequest(...)` is used all around AM, it's hard to tell if removing the extra decoding will not break stuff.

This PR introduces the parameter `legacy.openid.sanitizeParametersEncoding` that, when set to `false`, disables the extra decoding.

For the future, we should remove the hack and any extra handling of parameters, only decoding parameters when they are received and encoding them when they leave AM Handlers.


## :memo: Test scenarios 

The issue contains a reproduction scenario.

I manually tested the fix in the following flows:
- Normal login flow
- Wrong password on normal login flow
- Login flow with `Identifier-first` enabled.
- Wrong password on ID first flow
- Navigation to Password reset page and back.
- Navigation to Register page and back.
- MFA with an SMS mock factor
- Wrong code with MFA mock factor.

## :books: Any other comments that will help with documentation

I'm not even sure where this should be documented
