### PR TITLE
chore: add 4.1.x to mergify config and remove the 3.18.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -94,13 +94,13 @@ pull_request_rules:
           ----
           {{ cherry_pick_error }}
         title: "[3.19.x] {{ title }}"
-  - name: Apply commits on `3.18.x`
+  - name: Apply commits on `4.1.x`
     conditions:
-      - label=apply-on-3-18-x
+      - label=apply-on-4-1-x
     actions:
       backport:
         branches:
-          - 3.18.x
+          - 4.1.x
         assignees:
           - "{{ author }}"
         body: |
@@ -112,4 +112,4 @@ pull_request_rules:
 
           ----
           {{ cherry_pick_error }}
-        title: "[3.18.x] {{ title }}"
+        title: "[4.1.x] {{ title }}"


### PR DESCRIPTION
Thsi PR updates mergify configuration to be able to apply cherrypick on the 4.1.x branch
The config for the 3.18.x has been removed as this version is EOL