### PR TITLE
fix: do not perform blockingGet when we create indexes in repository …

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTest.java
@@ -27,6 +27,7 @@ import io.gravitee.am.service.exception.UserNotFoundException;
 import io.gravitee.common.http.HttpHeaders;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,8 +56,8 @@ public class HttpUserProviderTest {
     @Autowired
     private DefaultIdentityProviderMapper mapper;
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(19998));
+    @ClassRule
+    public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(19998));
 
     @Before
     public void init() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/AbstractMongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/AbstractMongoRepository.java
@@ -51,8 +51,9 @@ public abstract class AbstractMongoRepository {
     protected void createIndex(MongoCollection<?> collection, Document document, IndexOptions indexOptions, boolean ensure) {
         if (ensure) {
             Single.fromPublisher(collection.createIndex(document, indexOptions))
-                    .doOnSuccess(s -> logger.debug("Created an index named: {}", s))
-                    .doOnError(throwable -> logger.error("Error occurs during creation of index", throwable)).blockingGet();
+                    .subscribe(
+                            s -> logger.debug("Created an index named: {}", s),
+                            throwable -> logger.error("Error occurs during creation of index", throwable));
         }
     }
 }


### PR DESCRIPTION
…layer

fix: AM-680

## Context

Due to the blokingGet, the process doesn't start as gravitee-node thread is waiting indefinitly.

```
"graviteeio-node" #1 prio=5 os_prio=0 cpu=3781.41ms elapsed=110.19s tid=0x00007f1dc5c9d040 nid=0xf waiting on condition  [0x00007f1dcae23000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.5/Native Method)
	- parking to wait for  <0x00000000e96e7f18> (a java.util.concurrent.CountDownLatch$Sync)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.5/Unknown Source)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.5/Unknown Source)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@17.0.5/Unknown Source)
	at java.util.concurrent.CountDownLatch.await(java.base@17.0.5/Unknown Source)
	at io.reactivex.rxjava3.internal.observers.BlockingMultiObserver.blockingGet(BlockingMultiObserver.java:86)
	at io.reactivex.rxjava3.core.Single.blockingGet(Single.java:3645)
	at io.gravitee.am.repository.mongodb.common.AbstractMongoRepository.createIndex(AbstractMongoRepository.java:55)
	at io.gravitee.am.repository.mongodb.common.AbstractMongoRepository.init(AbstractMongoRepository.java:44)
	at io.gravitee.am.repository.mongodb.management.MongoFormRepository.init(MongoFormRepository.java:46)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@17.0.5/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@17.0.5/Unknown Source)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.5/Unknown Source)
	at java.lang.reflect.Method.invoke(java.base@17.0.5/Unknown Source)
	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor$LifecycleMethod.invoke(InitDestroyAnnotationBeanPostProcessor.java:457)
	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor$LifecycleMetadata.invokeInitMethods(InitDestroyAnnotationBeanPostProcessor.java:401)
	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.postProcessBeforeInitialization(InitDestroyAnnotationBeanPostProcessor.java:219)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:419)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1762)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:598)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:520)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:326)
	at org.springframework.beans.factory.support.AbstractBeanFactory$$Lambda$162/0x0000000800d22de0.getObject(Unknown Source)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)

```


