### PR TITLE
fix(docker): prevent $uri replacement in nginx configuration

### DIFF
--- a/docker/management-ui/Dockerfile
+++ b/docker/management-ui/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx-noconfd:1.25
+FROM graviteeio/nginx-noconfd:1.25.1
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0

--- a/docker/management-ui/Dockerfile-dev
+++ b/docker/management-ui/Dockerfile-dev
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM graviteeio/nginx-noconfd:1.25
+FROM graviteeio/nginx-noconfd:1.25.1
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0

--- a/docker/management-ui/Dockerfile-nightly
+++ b/docker/management-ui/Dockerfile-nightly
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM graviteeio/nginx-noconfd:1.25
+FROM graviteeio/nginx-noconfd:1.25.1
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0

--- a/docker/management-ui/config/default.conf
+++ b/docker/management-ui/config/default.conf
@@ -7,7 +7,7 @@ server {
     charset utf-8;
 
     location / {
-        try_files ${DOLLAR}uri ${DOLLAR}uri/ /index.html =404;
+        try_files $uri $uri/ /index.html =404;
         root /usr/share/nginx/html;
         sub_filter '<base href="/"' '<base href="$MGMT_BASE_HREF"';
         sub_filter_once on;


### PR DESCRIPTION
Prevent $uri replacement in nginx configuration.
Environment variables that need to be replaced are now specified in the run.sh of the nginx-noconfd docker image