### PR TITLE
fix: remember me default duration and hint text

### DIFF
--- a/gravitee-am-ui/src/app/domain/components/account/account-settings.component.html
+++ b/gravitee-am-ui/src/app/domain/components/account/account-settings.component.html
@@ -139,7 +139,7 @@
                 [disabled]="!isRememberMeEnabled()"
                 required
               />
-              <mat-hint>Select the duration that you would like users to be who opt-in for this to be kept logged in.</mat-hint>
+              <mat-hint>Select the duration that you would like users to remain logged in.</mat-hint>
             </mat-form-field>
 
             <mat-form-field fxFlex style="margin-left: 20px" appearance="outline" floatLabel="always">

--- a/gravitee-am-ui/src/app/domain/components/account/account-settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/account/account-settings.component.ts
@@ -46,7 +46,7 @@ export class AccountSettingsComponent implements OnInit, OnChanges {
   private defaultLoginAttemptsResetTimeInSecond = 43200; // 12 hours
   private defaultAccountBlockedDurationInSecond = 7200; // 2 hours
   private defaultMFAChallengeAttemptsResetTimeInSecond = 60; // 1 minutes
-  private defaultRememberMeDurationInSecond = 604800; // 7 days
+  private defaultRememberMeDurationInSecond = 1209600; // 14 days
   private defaultMFAChallengeMaxAttempts = 3;
 
   loginAttemptsResetTime: Duration = { time: null, unit: null };


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-818
https://gravitee.atlassian.net/browse/AM-819

## :pencil2: A description of the changes proposed in the pull request
Fix hint text and default duration of remember me option at domain and application level
![Screenshot 2023-09-12 at 13 18 37](https://github.com/gravitee-io/gravitee-access-management/assets/3227290/9878951c-58d7-48c4-8655-0d336cbfd6f5)

