### PR TITLE
chore: reduce to sync delay to avoid flaky integration test

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -456,6 +456,8 @@ jobs:
             export GRAVITEE_MFA_RATE_TIMEPERIOD=1
             export GRAVITEE_MFA_RATE_TIMEUNIT=Minutes
             
+            # Reduce the sync frequency to avoid flaky test due to synchronization delay
+            export gravitee_services_sync_cron="*/2 * * * * *"
             
             # Start AM Management
             gravitee-am-management-api-standalone-${AM_VERSION}/bin/gravitee &
@@ -571,6 +573,9 @@ jobs:
             export GRAVITEE_OAUTH2_JDBC_USERNAME=postgres
             export GRAVITEE_OAUTH2_JDBC_PASSWORD=T0pS3cr3t
             
+            # Reduce the sync frequency to avoid flaky test due to synchronization delay
+            export gravitee_services_sync_cron="*/2 * * * * *"
+            
             # Start AM Management
             gravitee-am-management-api-standalone-${AM_VERSION}/bin/gravitee &
             # Start AM Gateway
@@ -631,6 +636,9 @@ jobs:
             
             # Environment Variables
             export GRAVITEE_EMAIL_ALLOWEDFROM_0="*@*.*"
+            
+            # Reduce the sync frequency to avoid flaky test due to synchronization delay
+            export gravitee_services_sync_cron="*/2 * * * * *"
             
             # Start AM Management
             gravitee-am-management-api-standalone-${AM_VERSION}/bin/gravitee &
@@ -723,6 +731,9 @@ jobs:
             export GRAVITEE_OAUTH2_JDBC_PASSWORD=T0pS3cr3t
             
             export GRAVITEE_EMAIL_ALLOWEDFROM_0="*@*.*"
+            
+            # Reduce the sync frequency to avoid flaky test due to synchronization delay
+            export gravitee_services_sync_cron="*/2 * * * * *"
             
             # Start AM Management
             gravitee-am-management-api-standalone-${AM_VERSION}/bin/gravitee &


### PR DESCRIPTION
fixe AM-820

## Description

This PR increases the synchronization rate of the GW.

During the OOM error analyze (AM-797), I saw that the Spring Context were more huge than previously.
My assumption is the spring context takes more time to be initialized. As the test timeout to have a domain synchronized was set to 6 second we may be to slow of few millisec to have a domain up and running against the default sync period of 5 second.
