### PR TITLE
fix: CORS allow origin issue with comma into regex

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/cors/CorsHandlerFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/cors/CorsHandlerFactory.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -44,7 +45,7 @@ public class CorsHandlerFactory implements FactoryBean<CorsHandler> {
     protected static final String DEFAULT_MAX_AGE_KEY = "http.cors.max-age";
     protected static final String DEFAULT_ALLOW_CREDENTIAL_KEY = "http.cors.allow-credentials";
 
-    protected static final String DEFAULT_ORIGIN_VALUE = "*";
+    protected static final String DEFAULT_ORIGIN_VALUE = ".*";
     protected static final String DEFAULT_ALLOWED_HEADERS_VALUE = "Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, x-xsrf-token";
     protected static final String DEFAULT_HTTP_METHODS_VALUE = "GET, POST, PUT, PATCH, DELETE";
     protected static final int DEFAULT_MAX_AGE_VALUE = 86400;
@@ -100,7 +101,7 @@ public class CorsHandlerFactory implements FactoryBean<CorsHandler> {
 
     private CorsSettings createDefaultCorsSettings() {
         final CorsSettings settings = new CorsSettings();
-        settings.setAllowedOrigins(getProperties(DEFAULT_ORIGIN_KEY, DEFAULT_ORIGIN_VALUE));
+        settings.setAllowedOrigins(Set.of(environment.getProperty(DEFAULT_ORIGIN_KEY, DEFAULT_ORIGIN_VALUE)));
         settings.setAllowedHeaders(getProperties(DEFAULT_ALLOWED_HEADERS_KEY, DEFAULT_ALLOWED_HEADERS_VALUE));
         settings.setAllowedMethods(getProperties(DEFAULT_HTTP_METHODS_KEY, DEFAULT_HTTP_METHODS_VALUE));
         settings.setMaxAge(environment.getProperty(DEFAULT_MAX_AGE_KEY, Integer.class, DEFAULT_MAX_AGE_VALUE));
@@ -111,10 +112,11 @@ public class CorsHandlerFactory implements FactoryBean<CorsHandler> {
     private CorsHandler createCorsHandler(CorsSettings settings) {
         return CorsHandler
                 .newInstance(io.vertx.ext.web.handler.CorsHandler
-                        .create(String.join(",", settings.getAllowedOrigins()))
+                        .create()
                         .allowedHeaders(settings.getAllowedHeaders())
                         .allowedMethods(getHttpMethods(settings.getAllowedMethods()))
-                        .maxAgeSeconds(settings.getMaxAge()))
+                        .maxAgeSeconds(settings.getMaxAge())
+                        .addRelativeOrigins(List.copyOf(settings.getAllowedOrigins())))
                 .allowCredentials(settings.isAllowCredentials());
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/cors/CorsHandlerFactoryTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/cors/CorsHandlerFactoryTest.java
@@ -19,8 +19,6 @@ import io.gravitee.am.model.CorsSettings;
 import io.gravitee.am.model.Domain;
 import io.vertx.ext.web.handler.impl.CorsHandlerImpl;
 import io.vertx.rxjava3.ext.web.handler.CorsHandler;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,19 +28,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.Environment;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static io.gravitee.am.gateway.handler.vertx.cors.CorsHandlerFactory.DEFAULT_ALLOWED_HEADERS_VALUE;
-import static io.gravitee.am.gateway.handler.vertx.cors.CorsHandlerFactory.DEFAULT_ALLOW_CREDENTIAL_KEY;
-import static io.gravitee.am.gateway.handler.vertx.cors.CorsHandlerFactory.DEFAULT_ALLOW_CREDENTIAL_VALUE;
-import static io.gravitee.am.gateway.handler.vertx.cors.CorsHandlerFactory.DEFAULT_HTTP_METHODS_VALUE;
-import static io.gravitee.am.gateway.handler.vertx.cors.CorsHandlerFactory.DEFAULT_MAX_AGE_KEY;
-import static io.gravitee.am.gateway.handler.vertx.cors.CorsHandlerFactory.DEFAULT_MAX_AGE_VALUE;
-import static io.gravitee.am.gateway.handler.vertx.cors.CorsHandlerFactory.DEFAULT_ORIGIN_VALUE;
-import static java.util.Arrays.asList;
+import static io.gravitee.am.gateway.handler.vertx.cors.CorsHandlerFactory.*;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
@@ -66,6 +55,7 @@ public class CorsHandlerFactoryTest {
 
     @Before
     public void setUp() throws Exception {
+        when(environment.getProperty(DEFAULT_ORIGIN_KEY, DEFAULT_ORIGIN_VALUE)).thenReturn(DEFAULT_ORIGIN_VALUE);
         when(environment.getProperty(DEFAULT_MAX_AGE_KEY, Integer.class, DEFAULT_MAX_AGE_VALUE)).thenReturn(DEFAULT_MAX_AGE_VALUE);
         when(environment.getProperty(DEFAULT_ALLOW_CREDENTIAL_KEY, Boolean.class, DEFAULT_ALLOW_CREDENTIAL_VALUE)).thenReturn(DEFAULT_ALLOW_CREDENTIAL_VALUE);
     }
@@ -134,10 +124,11 @@ public class CorsHandlerFactoryTest {
         assertEquals(corsSettings.getAllowedHeaders(), allowedHeaders);
 
         final Set<Pattern> relativeOrigins = (Set<Pattern>) ReflectionTestUtils.getField(corsHandler, "relativeOrigins");
+        // Note that regarding:
+        // io/vertx/vertx-web/4.4.4/vertx-web-4.4.4-sources.jar!/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java:104
+        // default relative origin ".*" is like null (allow everything).
         if (relativeOrigins != null) {
-            LinkedHashSet<Pattern> originPattern = new LinkedHashSet<>();
-            originPattern.add(Pattern.compile(String.join(",", corsSettings.getAllowedOrigins())));
-            assertEquals(originPattern.toString(), relativeOrigins.toString());
+            assertEquals(corsSettings.getAllowedOrigins().toString(), relativeOrigins.toString());
         }
 
         return true;


### PR DESCRIPTION
## :id: Reference related issue. 

Linked jira issue: AM-824

## :pencil2: A description of the changes proposed in the pull request

The issue happen if you use a regex for allowed origin that contain a comma.

As example:

```
 - name: GRAVITEE_HTTP_CORS_ALLOWORIGIN
   value: "https:\/\/((.*)\.)?(mydomain|(mydomain-(\d){1,5}))\.company.cloud"
 - name: GRAVITEE_HTTP_CORS_ALLOWCREDENTIALS
   value: "true"
```

On another side, if you set the same regex but as domain level in
Management UI, the attribute will be badly saved and failed when
we test a CORS call.

## :memo: Test scenarios 

1. On startup:
    * start AM with environment variable as describe before
    * check error in startup logs
2. From UI:
    * start AM
    * create a domain
    * in domain > settings > entrypoint : setup CORS with a regex which contain comma
    * save the configuration and wait that the gateway will be updated.
    * do a cors call on gateway like:

```
curl -v -X OPTIONS \
        -H 'Authorization: Bearer eyJraW--oauth2-token-here-IG7ig' \
        -H 'Origin: https://blabla.company.cloud' \
        -H "Access-Control-Request-Method: GET" \
        -H "Access-Control-Request-Headers: Authorization" \
        http://localhost:8092/my-domain/oauth/authorize
```

In case of error you shoud have a 403, on succes a 204 HTTP code.

## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation

Also I update the `DEFAULT_ORIGIN_VALUE` to `.*` as a regex is expected.
When we create a `CorsHandler` instance, we used a deprecated method
`create(String ..)`. We use now the `.addRelativeOrigins()` function.
Finally, I updated the unit test to make them green again 😊.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@leleueri @ashraf706 

