### PR TITLE
chore: Add changelog for new 3.21.6 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,18 @@
 # Change Log
 
+==  - 3.21.6 (2023-09-14)
+
+== What's new !
+
+* The fix about duplicated user could need a cleanup of the database.
+More info into https://docs.gravitee.io/am/current/am_breaking_changes_3.21.6.html
+
+=== Other
+
+* Multiple concurrent requests creates users with duplicated usernames https://github.com/gravitee-io/issues/issues/9117[#9117]
+* fix potential bug in IDTokenServiceImpl
+
+
 ==  - 3.20.11 (2023-09-15)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.6 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.6/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.6 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.6%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
