### PR TITLE
fix: add default error handler on path that are managing HTML rendering

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -780,5 +780,11 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
         router.route(PATH_WEBAUTHN_LOGIN).failureHandler(errorHandler);
         router.route(PATH_WEBAUTHN_REGISTER).failureHandler(errorHandler);
         router.route(PATH_WEBAUTHN_RESPONSE).failureHandler(errorHandler);
+
+        router.route(PATH_MFA_ENROLL).failureHandler(errorHandler);
+        router.route(PATH_MFA_CHALLENGE_ALTERNATIVES).failureHandler(errorHandler);
+        router.route(PATH_MFA_RECOVERY_CODE).failureHandler(errorHandler);
+
+        router.route(PATH_CONFIRM_REGISTRATION).failureHandler(errorHandler);
     }
 }


### PR DESCRIPTION
fixe AM-671

## Description

When a HTML template is invlid, some endpoint ends with `Internal Server Error` blank page.
This fix redirect page that have no specific error handleing to the default Error page.

Pages : 
* CONFIRM_REGISTRATION
* MFA_ENROLL
* MFA_CHALLENGE_ALTERNATIVE
* MFA_RECOVERY_CODE

