### PR TITLE
feat(helm): Add podSecurityContext at deployment spec level

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -23,5 +23,6 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/am?modal=changelog
   artifacthub.io/changes: |
+    - Add podSecurityContext
     - [BREAKING CHANGE]: AM 4.1.0 upgrade to R2DBC 1.0, now the r2dbc drivers need to be in 1.x. Drivers in 0.x will not work anymore.
     - Default values for RDBMS connection pool have changed (warning: timeout duration set to 0 doesn't mean infinite anymore, you have to define negative value)

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -66,6 +66,9 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- if .Values.api.deployment.podSecurityContext }}
+      securityContext: {{ toYaml .Values.api.deployment.podSecurityContext | nindent 8 }}
+      {{ end }}
       {{- if $serviceAccount }}
       serviceAccountName: {{ $serviceAccount }}
       {{ end }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -66,6 +66,9 @@ spec:
         {{- end }}
         {{- end }}  
     spec:
+      {{- if .Values.gateway.deployment.podSecurityContext }}
+      securityContext: {{ toYaml .Values.gateway.deployment.podSecurityContext | nindent 8 }}
+      {{ end }}
       {{- if $serviceAccount }}
       serviceAccountName: {{ $serviceAccount }}
       {{ end }}

--- a/helm/templates/ui/ui-deployment.yaml
+++ b/helm/templates/ui/ui-deployment.yaml
@@ -61,6 +61,9 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- if .Values.ui.deployment.podSecurityContext }}
+      securityContext: {{ toYaml .Values.ui.deployment.podSecurityContext | nindent 8 }}
+      {{- end }}
       affinity: {{ toYaml .Values.ui.deployment.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.ui.deployment.nodeSelector | nindent 8 }}
       topologySpreadConstraints: {{ toYaml .Values.ui.deployment.topologySpreadConstraints | nindent 8 }}

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -112,3 +112,19 @@ tests:
               items:
                 - key: licensekey
                   path: license.key
+
+  - it: Deploy with podSecurityContext
+    template: api/api-deployment.yaml
+    set:
+      api:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001

--- a/helm/tests/gateway/deployment_test.yaml
+++ b/helm/tests/gateway/deployment_test.yaml
@@ -112,3 +112,19 @@ tests:
               items:
                 - key: licensekey
                   path: license.key
+
+  - it: Deploy with podSecurityContext
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001

--- a/helm/tests/ui/deployment_test.yaml
+++ b/helm/tests/ui/deployment_test.yaml
@@ -1,0 +1,20 @@
+suite: Test ui deployment
+templates:
+  - "ui/ui-deployment.yaml"
+  - "ui/ui-configmap.yaml"
+tests:
+  - it: Deploy with podSecurityContext
+    template: ui/ui-deployment.yaml
+    set:
+      ui:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -233,6 +233,12 @@ api:
     envFrom: []
     # - configMapRef:
     #     name: config-secret
+    # SecurityContext holds pod-level security attributes and common container settings.
+    # Field values of container.securityContext take precedence over field values of PodSecurityContext.
+    podSecurityContext:
+      #fsGroup: 1001
+      #runAsUser: 1001
+      #runAsNonRoot: true
     securityContext:
       runAsUser: 1001
       runAsNonRoot: true
@@ -515,6 +521,12 @@ gateway:
     envFrom: []
     # - configMapRef:
     #     name: config-secret
+    # SecurityContext holds pod-level security attributes and common container settings.
+    # Field values of container.securityContext take precedence over field values of PodSecurityContext.
+    podSecurityContext:
+      #fsGroup: 1001
+      #runAsUser: 1001
+      #runAsNonRoot: true
     securityContext:
       runAsUser: 1001
       runAsNonRoot: true
@@ -797,6 +809,12 @@ ui:
     envFrom: []
     # - configMapRef:
     #     name: config-secret
+    # SecurityContext holds pod-level security attributes and common container settings.
+    # Field values of container.securityContext take precedence over field values of PodSecurityContext.
+    podSecurityContext:
+      #fsGroup: 1001
+      #runAsUser: 1001
+      #runAsNonRoot: true
     securityContext:
       runAsUser: 101
       runAsGroup: 101


### PR DESCRIPTION
## :id: Reference related issue. 

Issue [#9209](https://github.com/gravitee-io/issues/issues/9209) on APIM replicated to AM.
[https://gravitee.atlassian.net/browse/DEVOPS-179](DEVOPS-179)

## :pencil2: A description of the changes proposed in the pull request

In addition of the container level, you can now define a security
context at pod level.

## :memo: Test scenarios 

Edit the `values.yml` with:

* the tag 4.0.1 of docker AM images
* the right mongo uri
* set a podSecurityContext

And then:

```
kubectl create namespace my-namespace
helm install graviteeio-am . --namespace my-namespace
kubectl --namespace my-namespace get deploy graviteeio-am-management-api -o yaml | grep -A 4 'securityContext:'
```

You should see the security context defined.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/devops @gravitee-io/am 