### PR TITLE
AM-838: replaced User and Client with respective property object

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -370,10 +370,7 @@ public class TokenServiceImpl implements TokenService {
     private ExecutionContext createExecutionContext(OAuth2Request request, Client client, User user) {
         ExecutionContext simpleExecutionContext = new SimpleExecutionContext(request, null);
         ExecutionContext executionContext = executionContextFactory.create(simpleExecutionContext);
-        executionContext.setAttribute(ConstantKeys.CLIENT_CONTEXT_KEY, new ClientProperties(client));
-        if (user != null) {
-            executionContext.setAttribute(ConstantKeys.USER_CONTEXT_KEY, new UserProperties(user));
-        }
+
         // put authorization request in context
         if (request.getResponseType() != null && !request.getResponseType().isEmpty()) {
             executionContext.setAttribute("authorizationRequest", request);
@@ -388,6 +385,11 @@ public class TokenServiceImpl implements TokenService {
         }
         // put oauth2 request execution context attributes in context
         executionContext.getAttributes().putAll(request.getExecutionContext());
+        executionContext.setAttribute(ConstantKeys.CLIENT_CONTEXT_KEY, new ClientProperties(client));
+        if (user != null) {
+            executionContext.setAttribute(ConstantKeys.USER_CONTEXT_KEY, new UserProperties(user));
+        }
+
         return executionContext;
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/impl/IDTokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/impl/IDTokenServiceImpl.java
@@ -327,11 +327,6 @@ public class IDTokenServiceImpl implements IDTokenService {
         ExecutionContext simpleExecutionContext = new SimpleExecutionContext(request, null);
         ExecutionContext executionContext = executionContextFactory.create(simpleExecutionContext);
 
-        executionContext.setAttribute(ConstantKeys.CLIENT_CONTEXT_KEY, new ClientProperties(client));
-        if (user != null) {
-            executionContext.setAttribute(ConstantKeys.USER_CONTEXT_KEY, new UserProperties(user));
-        }
-
         // put auth flow policy context attributes in context
         Object authFlowAttributes = request.getContext().get(ConstantKeys.AUTH_FLOW_CONTEXT_ATTRIBUTES_KEY);
         if (authFlowAttributes != null) {
@@ -340,6 +335,11 @@ public class IDTokenServiceImpl implements IDTokenService {
         }
         // put oauth2 request execution context attributes in context
         executionContext.getAttributes().putAll(request.getExecutionContext());
+        executionContext.setAttribute(ConstantKeys.CLIENT_CONTEXT_KEY, new ClientProperties(client));
+        if (user != null) {
+            executionContext.setAttribute(ConstantKeys.USER_CONTEXT_KEY, new UserProperties(user));
+        }
+
         return executionContext;
     }
 }


### PR DESCRIPTION
## How to Test

1. Create a domain and application as usual.
2. Add a custom claim in the application such ash `{#context.attributes['user']['claims']['email']}`. This claim access `claims` property which was missing before this fix.
3. Save and generate access token for a user by sending request to token endpoint such as `http://localhost:8092/self-account-management-test/oauth/token`
4. The generated token should have the email claim 