### PR TITLE
feat(CI): release helm chart without PR creation

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1613,7 +1613,6 @@ jobs:
     steps:
       - checkout
       - git_config
-      - gh/setup
       - helm/install-helm-client
       - run:
           name: Update Chart and App versions
@@ -1636,7 +1635,7 @@ jobs:
             not: << pipeline.parameters.dry_run>>
           steps:
             - run:
-                name: "Open a PR to publish helm chart release into helm-charts repository"
+                name: "Publish helm chart release into helm-charts repository"
                 working_directory: "./release"
                 command: npm run zx -- ci-steps/release-helm.mjs --version=${VERSION}
       - when:

--- a/release/ci-steps/release-helm.mjs
+++ b/release/ci-steps/release-helm.mjs
@@ -1,18 +1,16 @@
 import { extractVersion } from '../helpers/version-helper.mjs';
 
-console.log(chalk.magenta(`#############################################`));
-console.log(chalk.magenta(`#  Open AM Helm chart PR for new Release  #`));
-console.log(chalk.magenta(`#############################################`));
+console.log(chalk.magenta(`##################################`));
+console.log(chalk.magenta(`#  Do the AM Helm chart release  #`));
+console.log(chalk.magenta(`##################################`));
 
 const releasingVersion = await extractVersion();
 const helmRepository = 'https://github.com/gravitee-io/helm-charts';
-const gitBranch = `release-am-chart-${releasingVersion}`;
 
 echo(chalk.blue(`# Clone helm-charts repository`));
 cd('/home/circleci');
 await $`git clone --depth 1  ${helmRepository} --single-branch --branch=gh-pages`;
 cd('/home/circleci/helm-charts');
-await $`git checkout -b ${gitBranch}`;
 
 await $`cp /home/circleci/project/helm/charts/am-${releasingVersion}.tgz /home/circleci/helm-charts/helm/am/am-${releasingVersion}.tgz`;
 
@@ -21,13 +19,4 @@ await $`helm repo index --url https://helm.gravitee.io/helm helm`;
 await $`mv helm/index.yaml .`;
 
 await $`git add . && git commit -m "chore: Release AM Chart ${releasingVersion}"`;
-await $`git push --set-upstream origin ${gitBranch}`;
-
-const prBody = `
-# New APIM Helm Chart version ${releasingVersion} has been released
-`;
-echo(chalk.blue('# Create PR on Github helm-charts repository'));
-echo(prBody);
-process.env.PR_BODY = prBody;
-
-await $`gh pr create --title "[AM] Helm charts ${releasingVersion} release" --body "$PR_BODY" --base gh-pages --head ${gitBranch}`;
+await $`git push --set-upstream origin gh-pages`;


### PR DESCRIPTION
## :id: Reference related issue. 

DEVOPS-216

## :pencil2: A description of the changes proposed in the pull request

Previously we opened a PR on helm-chart repository
which need to be merged manually during release process.

The goal here is to remove the PR step and directly release it.

