### PR TITLE
chore: include thymeleaf dep in depManagement to override the version used by vertx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,11 @@
                 <version>${thymeleaf.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.thymeleaf</groupId>
+                <artifactId>thymeleaf</artifactId>
+                <version>${thymeleaf.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${javax.servlet-api.version}</version>


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-833

## :pencil2: A description of the changes proposed in the pull request

Added a dependency management on the version of the library Thymeleaf so we avoid pulling an old version from another dependency (vertx). 
