### PR TITLE
chore: Add changelog for new 3.21.8 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,23 @@
 # Change Log
 
+==  - 3.21.8 (2023-10-05)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Upgrade thymeleaf to 3.1.2
+
+=== Management API
+
+* Theme Preview Does Not Load https://github.com/gravitee-io/issues/issues/9160[#9160]
+
+=== Other
+
+* MS SqlServer 10.2 onwards driver support https://github.com/gravitee-io/issues/issues/9178[#9178]
+
 == AM - 3.21.7 (2023-09-29)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.8 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.8/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.8 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.8%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
