### PR TITLE
fix: align XSRF token duration with the session cookie one

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSRFHandlerFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSRFHandlerFactory.java
@@ -22,6 +22,8 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
+import static io.vertx.ext.web.handler.SessionHandler.DEFAULT_SESSION_TIMEOUT;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -34,9 +36,12 @@ public class CSRFHandlerFactory implements FactoryBean<CSRFHandler> {
     @Autowired
     private Vertx vertx;
 
+    @Value("${http.cookie.session.timeout:" + DEFAULT_SESSION_TIMEOUT + "}")
+    private long timeout;
+
     @Override
     public CSRFHandler getObject() {
-        return CSRFHandler.newInstance(new CSRFHandlerImpl(vertx, csrfSecret));
+        return CSRFHandler.newInstance(new CSRFHandlerImpl(vertx, csrfSecret, timeout));
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CSRFHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CSRFHandlerImpl.java
@@ -59,12 +59,13 @@ public class CSRFHandlerImpl implements CSRFHandler {
     private String cookieName = DEFAULT_COOKIE_NAME;
     private String cookiePath = DEFAULT_COOKIE_PATH;
     private String headerName = DEFAULT_HEADER_NAME;
-    private long timeout = SessionHandler.DEFAULT_SESSION_TIMEOUT;
+    private long timeout;
     private String origin;
     private boolean httpOnly;
 
-    public CSRFHandlerImpl(Vertx vertx, final String secret) {
+    public CSRFHandlerImpl(Vertx vertx, final String secret, final long timeout) {
         this.RAND = VertxContextPRNG.current(vertx);
+        this.timeout = timeout;
         try {
             mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(secret.getBytes(), "HmacSHA256"));


### PR DESCRIPTION
fixes AM-875

fixes gravitee-io/issues#9282
