### PR TITLE
chore: Add changelog for new 3.21.9 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,25 @@
 # Change Log
 
+==  - 3.21.9 (2023-10-16)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Align XSRF token ttl to the user session ttl https://github.com/gravitee-io/issues/issues/9282[#9282]
+
+=== Management API
+
+* Wrong values returned by Gravitee AM management API https://github.com/gravitee-io/issues/issues/9141[#9141]
+* AM Management API should start even with missing or unknown Identity Provider plugins https://github.com/gravitee-io/issues/issues/9230[#9230]
+
+=== Other
+
+* Upgrade script of the 3.21.6 does not work as expected https://github.com/gravitee-io/issues/issues/9288[#9288]
+
+
 ==  - 3.20.13 (2023-10-16)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.9 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.9/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.9 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.9%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
