### PR TITLE
fix: avoid error when unknown text key is used into a template

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/FreemarkerMessageResolver.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/FreemarkerMessageResolver.java
@@ -24,6 +24,7 @@ import freemarker.template.TemplateModelException;
 import java.util.List;
 import java.util.Properties;
 
+import static io.gravitee.am.service.i18n.MessageFormatSanitizer.sanitizeSingleQuote;
 import static java.text.MessageFormat.format;
 import static java.util.Optional.ofNullable;
 
@@ -46,7 +47,7 @@ public class FreemarkerMessageResolver implements TemplateMethodModelEx {
             try {
                 return ofNullable(messages.getProperty(key))
                         // double the single quote to avoid erasure by MessageFormatter.format
-                        .map(msg -> msg.replace("'", "''"))
+                        .map(MessageFormatSanitizer::sanitizeSingleQuote)
                         .map(msg -> format(msg, toArguments(list)))
                         .orElse(key);
             } catch (Exception e) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/GraviteeMessageResolver.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/GraviteeMessageResolver.java
@@ -60,12 +60,16 @@ public class GraviteeMessageResolver extends AbstractMessageResolver {
         final String domainMessage = domainBasedDictionaryProvider.getDictionaryFor(locale).getProperty(key);
         final String message = Optional.ofNullable(domainMessage).orElse(dictionaryProvider.getDictionaryFor(locale).getProperty(key));
 
-        if (!isFormatCandidate(message)) {
-            return message;
-        }
+        String resolvedMessage = null;
+        if (message != null) {
+            if (!isFormatCandidate(message)) {
+                return message;
+            }
 
-        final MessageFormat messageFormat = new MessageFormat(message, locale);
-        return messageFormat.format(Optional.ofNullable(messageParameters).orElse(new Object[0]));
+            final MessageFormat messageFormat = new MessageFormat(message, locale);
+            resolvedMessage = messageFormat.format(Optional.ofNullable(messageParameters).orElse(new Object[0]));
+        }
+        return resolvedMessage;
     }
 
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/GraviteeMessageResolver.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/GraviteeMessageResolver.java
@@ -24,6 +24,8 @@ import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.Optional;
 
+import static io.gravitee.am.service.i18n.MessageFormatSanitizer.sanitizeSingleQuote;
+
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -66,7 +68,7 @@ public class GraviteeMessageResolver extends AbstractMessageResolver {
                 return message;
             }
 
-            final MessageFormat messageFormat = new MessageFormat(message, locale);
+            final MessageFormat messageFormat = new MessageFormat(sanitizeSingleQuote(message), locale);
             resolvedMessage = messageFormat.format(Optional.ofNullable(messageParameters).orElse(new Object[0]));
         }
         return resolvedMessage;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/MessageFormatSanitizer.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/MessageFormatSanitizer.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.i18n;
+
+import java.util.regex.Pattern;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class MessageFormatSanitizer {
+
+    private static final Pattern singleQuote = Pattern.compile("'");
+    private static final Pattern openBracket = Pattern.compile("''\\{");
+    private static final Pattern closeBracket = Pattern.compile("\\}''");
+
+    public static String sanitizeSingleQuote(String message) {
+        String sanitizedMsg = null;
+        if (message != null) {
+            // single quote needs to be double otherwise the MessageFormatter will remove it
+            String escapedQuotes = singleQuote.matcher(message).replaceAll("''");
+            // if  left curly brace is preceded by doubled single quote or right curly brace is followed by doubled single
+            // we deduplicate the single quote as the curly brace is trying to be escaped
+            sanitizedMsg = closeBracket.matcher(openBracket.matcher(escapedQuotes).replaceAll("'{")).replaceAll("}'");
+        }
+        return sanitizedMsg;
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/GraviteeMessageResolverTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/GraviteeMessageResolverTest.java
@@ -24,8 +24,10 @@ import org.thymeleaf.context.ITemplateContext;
 
 import java.util.Locale;
 import java.util.Properties;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +49,7 @@ public class GraviteeMessageResolverTest {
     private static final String MSG_WITHOUT_PARAM = "message-without-param";
     private static final String MSG_WITH_PARAM = "message-wit-param";
     private static final String MSG_WITH_MULTI_PARAM = "message-with-multi-param";
+    private static final String UNKNOWN_KEY = UUID.randomUUID().toString();
 
     private GraviteeMessageResolver messageResolver;
 
@@ -96,5 +99,11 @@ public class GraviteeMessageResolverTest {
         String message = messageResolver.resolveMessage(context, null, MSG_WITH_MULTI_PARAM, msgParams);
 
         assertEquals("Don't have an account user: Alice ? Use temporary name: Bob.",message);
+    }
+
+    @Test
+    public void shouldNoResolveMessage_with_Unknown_key() {
+        String message = messageResolver.resolveMessage(context, null, UNKNOWN_KEY, null);
+        assertNull(message);
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/GraviteeMessageResolverTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/GraviteeMessageResolverTest.java
@@ -61,8 +61,9 @@ public class GraviteeMessageResolverTest {
         /*
           apostrophe should be added twice in message properties. For more info check:
           https://stackoverflow.com/questions/4449639/apostrophe-doesnt-get-translated-properly-when-placed-in-a-resource-bundle
+          The GraviteeMessageResolver will manage this case (see gravitee-io/issues#9326)
          */
-        properties.setProperty(MSG_WITH_MULTI_PARAM, "Don''t have an account user: {0} ? Use temporary name: {1}.");
+        properties.setProperty(MSG_WITH_MULTI_PARAM, "Don't have an account user: {0} ? Use temporary name: {1}.");
 
         messageResolver = new GraviteeMessageResolver(dictionaryProvider, domainBasedDictionaryProvider);
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/MessageFormatSanitizerTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/MessageFormatSanitizerTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.i18n;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class MessageFormatSanitizerTest {
+
+    @ParameterizedTest
+    @MethodSource("dataSet")
+    public void checkSingleQuote(String msg, String exptedMsg) {
+        Assertions.assertEquals(exptedMsg, MessageFormatSanitizer.sanitizeSingleQuote(msg));
+    }
+
+    static Stream<Arguments> dataSet() {
+        return Stream.of(
+                Arguments.arguments("Hello without single quote", "Hello without single quote"),
+                Arguments.arguments("Single quote (') need to be double to avoid erasure by MessageFormatter", "Single quote ('') need to be double to avoid erasure by MessageFormatter"),
+                Arguments.arguments("Single quote surrounded by spaces ( ')/( ' )/(' ) need to be double to avoid erasure by MessageFormatter", "Single quote surrounded by spaces ( '')/( '' )/('' ) need to be double to avoid erasure by MessageFormatter"),
+                Arguments.arguments("Single quote (') need to be double to avoid erasure by MessageFormatter but not these ones '{0}'", "Single quote ('') need to be double to avoid erasure by MessageFormatter but not these ones '{0}'")
+        );
+    }
+}


### PR DESCRIPTION
fixes AM-836

fixes gravitee-io/issues#9237

And also fixes AM-1003 (single quote management)

## How to test

Edit a template (login page for example) with an unknown dictionnary key.
When the page is previewed on the Management Theme editor or when the page is loaded by the GW, the key should be displayed surrounded by question mark.


![image](https://github.com/gravitee-io/gravitee-access-management/assets/3110552/8fdbb0cc-7299-44c8-82dd-f8f88073927c)

![image](https://github.com/gravitee-io/gravitee-access-management/assets/3110552/beefbf7d-c688-41d1-bf14-67ffc996a164)

![image](https://github.com/gravitee-io/gravitee-access-management/assets/3110552/292b3f92-2d3b-4d19-b370-e772c043236c)

To test AM-1003, add single quote in the text message you want to display on the form, you should see it in the preview and in the page rendered by the Gateway
