### PR TITLE
chore: Add changelog for new 3.20.14 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,6 +1,29 @@
 # Change Log
 
-==  - 3.21.9 (2023-10-16)
+== AM - 3.20.14 (2023-10-27)
+
+== What's new !
+
+=== Gateway
+
+* Application error when using a non defined translation https://github.com/gravitee-io/issues/issues/9237[#9237]
+* Registration confirmation Javascript error (anti-XSRF token) https://github.com/gravitee-io/issues/issues/9276[#9276]
+* Quotes are lost in Gravitee AM forms https://github.com/gravitee-io/issues/issues/9326[#9326]
+* When a resource plugin has been removed from the installation, other resources may not be loaded https://github.com/gravitee-io/issues/issues/9344[#9344]
+
+=== Management API
+
+* Management API hangs completely https://github.com/gravitee-io/issues/issues/9339[#9339]
+
+=== Console
+
+
+=== Other
+
+* EnrichProfile reset factor defined by EnrollMFA policy https://github.com/gravitee-io/issues/issues/9161[#9161]
+
+
+== AM - 3.21.9 (2023-10-16)
 
 == What's new !
 
@@ -20,7 +43,7 @@
 * Upgrade script of the 3.21.6 does not work as expected https://github.com/gravitee-io/issues/issues/9288[#9288]
 
 
-==  - 3.20.13 (2023-10-16)
+== AM - 3.20.13 (2023-10-16)
 
 == What's new !
 
@@ -40,7 +63,7 @@
 * Upgrade script of the 3.21.6 does not work as expected https://github.com/gravitee-io/issues/issues/9288[#9288]
 
 
-==  - 3.21.8 (2023-10-05)
+== AM - 3.21.8 (2023-10-05)
 
 == What's new !
 
@@ -389,7 +412,7 @@ If you use the community edition, for each enterprise feature you will have a de
 == What's new !
 
 * MFA - manage remember device with external IDP
-* MFA - support Orange Contact Everyone service to send SMS 
+* MFA - support Orange Contact Everyone service to send SMS
 * Passwordless - enforce webauthn devices control
 * Passwordless - enforce password usage
 * Manage MFA factors that use username as SEED
@@ -490,8 +513,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - SCIM - additionalInformation entries are lost when using PATCH method https://github.com/gravitee-io/issues/issues/8991[#8991]
 - The same DOM element can have a different ID from one template to another https://github.com/gravitee-io/issues/issues/8884[#8884]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/646?closed=1[AM - 3.19.10 (2023-04-11)]
 
@@ -504,8 +527,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - AM should audit USER_CREATED when using delegated OIDC authentication https://github.com/gravitee-io/issues/issues/8920[#8920]
 - Merge 3.18.7 into 3.19.x https://github.com/gravitee-io/issues/issues/8986[#8986]
 - The same DOM element can have a different ID from one template to another https://github.com/gravitee-io/issues/issues/8884[#8884]
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/640?closed=1[AM - 3.19.9 (2023-03-30)]
 
@@ -515,8 +538,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - AM console login fails when 'nbf' claim type is Date https://github.com/gravitee-io/issues/issues/8979[#8979]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/645?closed=1[AM - 3.18.17 (2023-03-30)]
 
@@ -541,8 +564,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Full exception raised as an ERROR in gateway logs when token is expired https://github.com/gravitee-io/issues/issues/8656[#8656]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/648?closed=1[AM - 3.20.3 (2023-03-22)]
 
@@ -553,8 +576,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge 3.19.7 to 3.20.x https://github.com/gravitee-io/issues/issues/8925[#8925]
 - Merge 3.19.8 to 3.20.x https://github.com/gravitee-io/issues/issues/8950[#8950]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/643?closed=1[AM - 3.19.8 (2023-03-17)]
 
@@ -571,8 +594,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Shouldn't be possible to create dictionary with invalid locale https://github.com/gravitee-io/issues/issues/8885[#8885]
 - Shouldn't be possible to create two dictionaries with same locale https://github.com/gravitee-io/issues/issues/8886[#8886]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/644?closed=1[AM - 3.20.2 (2023-03-09)]
 
@@ -582,8 +605,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.19.7 to 3.20.x https://github.com/gravitee-io/issues/issues/8908[#8908]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/638?closed=1[AM - 3.19.7 (2023-03-02)]
 
@@ -595,8 +618,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge 3.18.16 to 3.19.x https://github.com/gravitee-io/issues/issues/8906[#8906]
 - When using an internal API for AM no validation of the requests payload it provided. https://github.com/gravitee-io/issues/issues/8865[#8865]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/634?closed=1[AM - 3.18.16 (2023-02-23)]
 
@@ -644,8 +667,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Store orginal token for Github provider https://github.com/gravitee-io/issues/issues/8852[#8852]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/624?closed=1[AM - 3.18.15 (2023-01-31)]
 
@@ -665,8 +688,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [ui] Multifactor Auth section does not keep configuration when saving for the first time https://github.com/gravitee-io/issues/issues/8836[#8836]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/629?closed=1[AM - 3.15.17 (2023-01-19)]
 
@@ -689,8 +712,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Unable to update a user linked to removed application https://github.com/gravitee-io/issues/issues/8380[#8380]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/627?closed=1[AM - 3.19.5 (2023-01-16)]
 
@@ -708,8 +731,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Send Email policy requires the "From Name" attribute https://github.com/gravitee-io/issues/issues/8778[#8778]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/625?closed=1[AM - 3.18.14 (2023-01-06)]
 
@@ -728,8 +751,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - State parameter isn't URLEncoded when redirect_uri is called https://github.com/gravitee-io/issues/issues/8761[#8761]
 - X-Forward-Port impact the iss claim https://github.com/gravitee-io/issues/issues/8807[#8807]
 
- 
- 
+
+
 == AM - 3.20.0 (2023-01-04)
 
 === Bug fixes
@@ -808,8 +831,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Add requested redirect_uri in error page with code redirect_uri_mismatch https://github.com/gravitee-io/issues/issues/7728[#7728]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/619?closed=1[AM - 3.15.15 (2022-12-07)]
 
@@ -835,8 +858,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Prevent CRUD operation on Mongo and JDBC IDPS https://github.com/gravitee-io/issues/issues/8695[#8695]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/617?closed=1[AM - 3.19.3 (2022-12-01)]
 
@@ -862,8 +885,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - A disabled user can trigger reset password and successfully reset the password https://github.com/gravitee-io/issues/issues/8670[#8670]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/613?closed=1[AM - 3.18.11 (2022-11-18)]
 
@@ -875,8 +898,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - [self service account] add a MFA sendChallenge method https://github.com/gravitee-io/issues/issues/8648[#8648]
 - [self service account] factor with moving factor should be updated after the verify step https://github.com/gravitee-io/issues/issues/8650[#8650]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/612?closed=1[AM - 3.19.2 (2022-11-14)]
 
@@ -909,8 +932,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Provide SocialIDP for register templates https://github.com/gravitee-io/issues/issues/8627[#8627]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/608?closed=1[AM - 3.15.14 (2022-10-28)]
 
@@ -940,8 +963,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - AM request_uri implementation is vulnerable to Server Side Request Forgery (SSRF) https://github.com/gravitee-io/issues/issues/8532[#8532]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/606?closed=1[AM - 3.19.1 (2022-10-21)]
 
@@ -953,8 +976,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge AM 3.18.8 into 3.19.x https://github.com/gravitee-io/issues/issues/8586[#8586]
 - Upgrade apache commons-text https://github.com/gravitee-io/issues/issues/8588[#8588]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/605?closed=1[AM - 3.18.9 (2022-10-19)]
 
@@ -976,8 +999,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Make PAR values accessible https://github.com/gravitee-io/issues/issues/8422[#8422]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/557?closed=1[AM - 3.19.0 (2022-10-11)]
 
@@ -1033,8 +1056,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [emails] improve Help and Tips section https://github.com/gravitee-io/issues/issues/8051[#8051]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/602?closed=1[AM - 3.18.8 (2022-10-05)]
 
@@ -1044,8 +1067,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [gateway] add new option for the passwordless login flow https://github.com/gravitee-io/issues/issues/8506[#8506]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/601?closed=1[AM - 3.18.7 (2022-09-29)]
 
@@ -1055,8 +1078,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.15.13 into 3.18 https://github.com/gravitee-io/issues/issues/8542[#8542]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/589?closed=1[AM - 3.15.13 (2022-09-27)]
 
@@ -1094,8 +1117,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Fill the username field in idFirstLogin https://github.com/gravitee-io/issues/issues/8511[#8511]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/597?closed=1[AM - 3.18.6 (2022-09-16)]
 
@@ -1112,8 +1135,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Implicit consent for audit logs https://github.com/gravitee-io/issues/issues/8448[#8448]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/594?closed=1[AM - 3.18.5 (2022-09-08)]
 
@@ -1134,8 +1157,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Self account management - missing delete method for the webauthn credentials https://github.com/gravitee-io/issues/issues/8415[#8415]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/587?closed=1[AM - 3.18.4 (2022-09-01)]
 
@@ -1153,8 +1176,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [MongoDB] queries are not well parsed for the user management features https://github.com/gravitee-io/issues/issues/8379[#8379]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/593?closed=1[AM - 3.17.5 (2022-09-01)]
 
@@ -1164,13 +1187,13 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Do not expose data in the forgot password template https://github.com/gravitee-io/issues/issues/8391[#8391]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/584?closed=1[AM - 3.18.3 (2022-08-19)]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/583?closed=1[AM - 3.15.12 (2022-08-19)]
 
@@ -1180,8 +1203,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - User fails to log in after completing registration via confirmation link https://github.com/gravitee-io/issues/issues/8321[#8321]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/581?closed=1[AM - 3.18.2 (2022-08-18)]
 
@@ -1197,8 +1220,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Inject identity provider in the SPEL context during selection rule process https://github.com/gravitee-io/issues/issues/8312[#8312]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/570?closed=1[AM - 3.18.1 (2022-08-10)]
 
@@ -1220,8 +1243,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge SAML IdP 1.4.2 into 1.5.x https://github.com/gravitee-io/issues/issues/8231[#8231]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/576?closed=1[AM - 3.17.4 (2022-08-03)]
 
@@ -1239,8 +1262,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [policy] Enroll MFA policy allows RecoveryCode https://github.com/gravitee-io/issues/issues/8119[#8119]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/568?closed=1[AM - 3.15.11 (2022-07-29)]
 
@@ -1264,8 +1287,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - AdditionalInformation for SCIM search are limited using RDMS https://github.com/gravitee-io/issues/issues/8085[#8085]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/554?closed=1[AM - 3.17.3 (2022-07-15)]
 
@@ -1293,8 +1316,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Email policy requires FROM-NAME field https://github.com/gravitee-io/issues/issues/7933[#7933]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/552?closed=1[AM - 3.15.10 (2022-07-11)]
 
@@ -1326,8 +1349,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Add option to client to force S256 challenge method for PKCE https://github.com/gravitee-io/issues/issues/7965[#7965]
 - Update accountNonLocked on successful connection https://github.com/gravitee-io/issues/issues/7831[#7831]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/502?closed=1[AM - 3.18.0 (2022-07-06)]
 
@@ -1384,8 +1407,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [webauthn] Allow WebAuthn for Social Idp users https://github.com/gravitee-io/issues/issues/5363[#5363]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/548?closed=1[AM - 3.17.2 (2022-06-10)]
 
@@ -1461,8 +1484,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Better support for back channel logout with GET method https://github.com/gravitee-io/issues/issues/7679[#7679]
 - Redirect to RP after POST login error https://github.com/gravitee-io/issues/issues/7708[#7708]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/544?closed=1[AM - 3.15.8 (2022-05-13)]
 
@@ -1482,8 +1505,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Improve sensitive data masking https://github.com/gravitee-io/issues/issues/7482[#7482]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/538?closed=1[AM - 3.17.1 (2022-05-12)]
 
@@ -1508,8 +1531,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - User registration acknowledgment https://github.com/gravitee-io/issues/issues/7470[#7470]
 - User reset password acknowledgment https://github.com/gravitee-io/issues/issues/7471[#7471]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/537?closed=1[AM - 3.16.2 (2022-05-03)]
 
@@ -1521,8 +1544,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge AM 3.15.6 into 3.16.x https://github.com/gravitee-io/issues/issues/7582[#7582]
 - Merge AM 3.15.7 into 3.16.x https://github.com/gravitee-io/issues/issues/7583[#7583]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/539?closed=1[AM - 3.15.7 (2022-05-02)]
 
@@ -1533,8 +1556,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Connection leak on mongodb https://github.com/gravitee-io/issues/issues/7599[#7599]
 - Merge AM 3.10.18 into 3.15.x https://github.com/gravitee-io/issues/issues/7576[#7576]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/540?closed=1[AM - 3.10.18 (2022-04-26)]
 
@@ -1544,8 +1567,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Session persistent mode https://github.com/gravitee-io/issues/issues/7526[#7526]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/532?closed=1[AM - 3.15.6 (2022-04-19)]
 
@@ -1585,8 +1608,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Improve file reporter input validation https://github.com/gravitee-io/issues/issues/7464[#7464]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/527?closed=1[AM - 3.15.5 (2022-04-04)]
 
@@ -1611,8 +1634,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Add the id of the Identity Provider on GET /domains/:domaind/users/:userid https://github.com/gravitee-io/issues/issues/7108[#7108]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/503?closed=1[AM - 3.17.0 (2022-03-30)]
 
@@ -1653,8 +1676,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Improve UX for IdP priority order https://github.com/gravitee-io/issues/issues/7286[#7286]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/526?closed=1[AM - 3.16.1 (2022-03-16)]
 
@@ -1664,8 +1687,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.15.4 https://github.com/gravitee-io/issues/issues/7318[#7318]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/518?closed=1[AM - 3.15.4 (2022-03-16)]
 
@@ -1680,8 +1703,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.10.17 https://github.com/gravitee-io/issues/issues/7291[#7291]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/520?closed=1[AM - 3.10.17 (2022-03-14)]
 
@@ -1705,8 +1728,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Handle `allow-credentials` CORS configuration https://github.com/gravitee-io/issues/issues/7221[#7221]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/479?closed=1[AM - 3.16.0 (2022-02-28)]
 
@@ -1730,8 +1753,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Password expiration policy https://github.com/gravitee-io/issues/issues/6836[#6836]
 - [mfa] Skip enrollment options https://github.com/gravitee-io/issues/issues/6188[#6188]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/513?closed=1[AM - 3.15.3 (2022-02-26)]
 
@@ -1745,8 +1768,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [notifier] update notifier plugin version to include "hide sensitive data" feature https://github.com/gravitee-io/issues/issues/7166[#7166]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/514?closed=1[AM - 3.14.7 (2022-02-26)]
 
@@ -1761,8 +1784,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.10.16 https://github.com/gravitee-io/issues/issues/7186[#7186]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/510?closed=1[AM - 3.10.16 (2022-02-23)]
 
@@ -1785,8 +1808,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [mongodb] index name too long https://github.com/gravitee-io/issues/issues/7136[#7136]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/512?closed=1[AM - 3.15.2 (2022-02-16)]
 
@@ -1796,8 +1819,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Sub value invalid into user info https://github.com/gravitee-io/issues/issues/7118[#7118]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/501?closed=1[AM - 3.15.1 (2022-02-15)]
 
@@ -1825,8 +1848,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Do not expose default identity provider and audit reporter https://github.com/gravitee-io/issues/issues/6782[#6782]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/511?closed=1[AM - 3.14.6 (2022-02-10)]
 
@@ -1836,8 +1859,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.10.15 https://github.com/gravitee-io/issues/issues/7089[#7089]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/509?closed=1[AM - 3.10.15 (2022-02-10)]
 
@@ -1851,8 +1874,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - `onActivated` and `onDeactivated` not called when plugin loaded https://github.com/gravitee-io/issues/issues/6942[#6942]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/500?closed=1[AM - 3.14.5 (2022-02-08)]
 
@@ -1871,8 +1894,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Upgrade gravitee-node to 1.20 https://github.com/gravitee-io/issues/issues/7020[#7020]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/499?closed=1[AM - 3.10.14 (2022-02-07)]
 
@@ -1904,8 +1927,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Async load users page https://github.com/gravitee-io/issues/issues/7021[#7021]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/452?closed=1[AM - 3.15.0 (2022-01-26)]
 
@@ -1960,8 +1983,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Do not expose sensitive information from audit logs https://github.com/gravitee-io/issues/issues/6783[#6783]
 - Lock user account via HTTP call https://github.com/gravitee-io/issues/issues/6785[#6785]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/495?closed=1[AM - 3.14.4 (2022-01-14)]
 
@@ -1975,8 +1998,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Http provider configuration is not respected https://github.com/gravitee-io/issues/issues/6916[#6916]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/492?closed=1[AM - 3.14.3 (2022-01-05)]
 
@@ -2009,8 +2032,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - [mfa] unable to enroll user with Email or SMS factor https://github.com/gravitee-io/issues/issues/6830[#6830]
 - [mfa] unable to enroll user with OTP https://github.com/gravitee-io/issues/issues/6822[#6822]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/489?closed=1[AM - 3.14.2 (2021-12-28)]
 
@@ -2020,8 +2043,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.13.3 https://github.com/gravitee-io/issues/issues/6814[#6814]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/483?closed=1[AM - 3.13.3 (2021-12-27)]
 
@@ -2033,8 +2056,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge 3.10.11 https://github.com/gravitee-io/issues/issues/6748[#6748]
 - Merge 3.10.12 https://github.com/gravitee-io/issues/issues/6807[#6807]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/480?closed=1[AM - 3.10.12 (2021-12-23)]
 
@@ -2056,8 +2079,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Handle metadata when creating an application https://github.com/gravitee-io/issues/issues/6774[#6774]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/477?closed=1[AM - 3.14.1 (2021-12-15)]
 
@@ -2067,8 +2090,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Manage WebAuthn exception on startup https://github.com/gravitee-io/issues/issues/6744[#6744]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/478?closed=1[AM - 3.13.2 (2021-12-15)]
 
@@ -2078,8 +2101,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Manage WebAuthn exception on startup https://github.com/gravitee-io/issues/issues/6741[#6741]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/464?closed=1[AM - 3.12.6 (2021-12-15)]
 
@@ -2089,8 +2112,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Manage WebAuthn exception on startup https://github.com/gravitee-io/issues/issues/6745[#6745]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/470?closed=1[AM - 3.10.11 (2021-12-15)]
 
@@ -2118,8 +2141,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Users > Sort by column is broken https://github.com/gravitee-io/issues/issues/6726[#6726]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/481?closed=1[AM - 3.5.12 (2021-12-15)]
 
@@ -2129,8 +2152,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Manage WebAuthn exception on startup (backport #6737) https://github.com/gravitee-io/issues/issues/6739[#6739]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/456?closed=1[AM - 3.10.10 (2021-12-07)]
 
@@ -2168,13 +2191,13 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Select applications component is not very friendly https://github.com/gravitee-io/issues/issues/6644[#6644]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/468?closed=1[AM - 3.5.11 (2021-11-25)]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/439?closed=1[AM - 3.14.0 (2021-11-24)]
 
@@ -2204,8 +2227,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [oauth2] improve wildcard support for allowed redirect_uris https://github.com/gravitee-io/issues/issues/6397[#6397]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/462?closed=1[AM - 3.5.10 (2021-11-18)]
 
@@ -2215,8 +2238,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Some searchs on user resources are malformed https://github.com/gravitee-io/issues/issues/6584[#6584]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/455?closed=1[AM - 3.13.1 (2021-11-18)]
 
@@ -2227,8 +2250,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge 3.12.4 https://github.com/gravitee-io/issues/issues/6510[#6510]
 - Merge 3.12.5 https://github.com/gravitee-io/issues/issues/6588[#6588]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/460?closed=1[AM - 3.12.5 (2021-11-18)]
 
@@ -2242,8 +2265,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Unable to authenticate user with new consent https://github.com/gravitee-io/issues/issues/6562[#6562]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/454?closed=1[AM - 3.10.9 (2021-11-17)]
 
@@ -2258,8 +2281,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Yaml users are not loaded anymore https://github.com/gravitee-io/issues/issues/6513[#6513]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/451?closed=1[AM - 3.12.4 (2021-11-05)]
 
@@ -2274,8 +2297,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge 3.10.7 https://github.com/gravitee-io/issues/issues/6503[#6503]
 - Merge 3.10.8 https://github.com/gravitee-io/issues/issues/6505[#6505]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/450?closed=1[AM - 3.10.8 (2021-11-04)]
 
@@ -2285,8 +2308,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Major error - 3.10.7 distribution is broken https://github.com/gravitee-io/issues/issues/6504[#6504]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/443?closed=1[AM - 3.10.7 (2021-11-04)]
 
@@ -2298,8 +2321,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Handle prompt login parameter to the underlying OIDC IdP https://github.com/gravitee-io/issues/issues/6477[#6477]
 - [identity provider] Consider the userInfo type when testing a mapping condition https://github.com/gravitee-io/issues/issues/6445[#6445]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/428?closed=1[AM - 3.13.0 (2021-11-01)]
 
@@ -2337,8 +2360,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Improve request object management https://github.com/gravitee-io/issues/issues/6266[#6266]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/445?closed=1[AM - 3.12.3 (2021-10-20)]
 
@@ -2348,8 +2371,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - When creating inline user, I get "domainWhitelistmust not be null" https://github.com/gravitee-io/issues/issues/6416[#6416]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/444?closed=1[AM - 3.12.2 (2021-10-17)]
 
@@ -2359,8 +2382,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.11.2 https://github.com/gravitee-io/issues/issues/6409[#6409]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/441?closed=1[AM - 3.11.2 (2021-10-15)]
 
@@ -2371,8 +2394,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge 3.10.5 https://github.com/gravitee-io/issues/issues/6347[#6347]
 - Merge 3.10.6 https://github.com/gravitee-io/issues/issues/6405[#6405]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/440?closed=1[AM - 3.10.6 (2021-10-15)]
 
@@ -2398,8 +2421,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Wrong link on audit logs https://github.com/gravitee-io/issues/issues/6356[#6356]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/433?closed=1[AM - 3.10.5 (2021-10-08)]
 
@@ -2417,8 +2440,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - [scim] specify identity provider for user provisioning https://github.com/gravitee-io/issues/issues/6322[#6322]
 - [webauthn] upgrading certificates https://github.com/gravitee-io/issues/issues/6324[#6324]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/436?closed=1[AM - 3.12.1 (2021-10-04)]
 
@@ -2435,8 +2458,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - [oidc] get client SSL certificate from HTTP proxy https://github.com/gravitee-io/issues/issues/6296[#6296]
 - [oidc] override mtls_endpoint_aliases https://github.com/gravitee-io/issues/issues/6297[#6297]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/418?closed=1[AM - 3.12.0 (2021-09-29)]
 
@@ -2472,8 +2495,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [gateway] add request timeout configuration option on IdP https://github.com/gravitee-io/issues/issues/3505[#3505]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/434?closed=1[AM - 3.11.1 (2021-09-28)]
 
@@ -2484,8 +2507,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Merge 3.10.3 https://github.com/gravitee-io/issues/issues/6261[#6261]
 - Merge 3.10.4 https://github.com/gravitee-io/issues/issues/6263[#6263]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/431?closed=1[AM - 3.10.4 (2021-09-28)]
 
@@ -2513,8 +2536,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [oidc] unknown (use) is currently not supported. https://github.com/gravitee-io/issues/issues/6184[#6184]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/425?closed=1[AM - 3.5.9 (2021-09-27)]
 
@@ -2530,8 +2553,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [jwt] add type header parameter https://github.com/gravitee-io/issues/issues/6239[#6239]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/424?closed=1[AM - 3.10.3 (2021-09-19)]
 
@@ -2557,8 +2580,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Manage http proxy for Twilio provider https://github.com/gravitee-io/issues/issues/5905[#5905]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/397?closed=1[AM - 3.11.0 (2021-09-05)]
 
@@ -2618,8 +2641,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Manage TLS Cipher Suites https://github.com/gravitee-io/issues/issues/5929[#5929]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/423?closed=1[AM - 3.10.2 (2021-09-03)]
 
@@ -2639,8 +2662,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - [jdbc] id column name it's hard encoded when updating a user https://github.com/gravitee-io/issues/issues/6083[#6083]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/420?closed=1[AM - 3.10.1 (2021-08-04)]
 
@@ -2650,8 +2673,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Loss of data when migrating on 3.10.0 for jdbc users https://github.com/gravitee-io/issues/issues/5957[#5957]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/252?closed=1[AM - 3.10.0 (2021-08-03)]
 
@@ -2744,8 +2767,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Do not start AuditReporter if diseabled https://github.com/gravitee-io/issues/issues/5813[#5813]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/415?closed=1[AM - 3.9.3 (2021-07-22)]
 
@@ -2763,8 +2786,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Backport #5675 https://github.com/gravitee-io/issues/issues/5868[#5868]
 - Merge 3.8.7 https://github.com/gravitee-io/issues/issues/5879[#5879]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/411?closed=1[AM - 3.8.7 (2021-07-19)]
 
@@ -2774,8 +2797,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.5.8 https://github.com/gravitee-io/issues/issues/5878[#5878]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/412?closed=1[AM - 3.5.8 (2021-07-19)]
 
@@ -2790,8 +2813,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Manage properly dbname for mongo backend https://github.com/gravitee-io/issues/issues/5836[#5836]
 - Use mongodb.uri in MongoIDP https://github.com/gravitee-io/issues/issues/5830[#5830]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/407?closed=1[AM - 3.9.2 (2021-06-27)]
 
@@ -2801,8 +2824,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.8.6 https://github.com/gravitee-io/issues/issues/5792[#5792]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/406?closed=1[AM - 3.8.6 (2021-06-26)]
 
@@ -2816,8 +2839,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Page not found when deleting organization user https://github.com/gravitee-io/issues/issues/5772[#5772]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/405?closed=1[AM - 3.5.7 (2021-06-25)]
 
@@ -2835,8 +2858,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Backport #5759 https://github.com/gravitee-io/issues/issues/5760[#5760]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/403?closed=1[AM - 3.9.1 (2021-06-19)]
 
@@ -2855,8 +2878,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Cannot collapse custom claims https://github.com/gravitee-io/issues/issues/5750[#5750]
 - Update an application change its type https://github.com/gravitee-io/issues/issues/5749[#5749]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/382?closed=1[AM - 3.5.6 (2021-06-10)]
 
@@ -2876,8 +2899,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - [idp] default idp configuration must handle MongoDB cluster configuration https://github.com/gravitee-io/issues/issues/2528[#2528]
 - [reporters] default reporter configuration must handle MongoDB cluster configuration https://github.com/gravitee-io/issues/issues/2527[#2527]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/390?closed=1[AM - 3.8.4 (2021-05-26)]
 
@@ -2891,8 +2914,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - The username filter (while adding users in group) is not working in Access Management https://github.com/gravitee-io/issues/issues/5612[#5612]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/251?closed=1[AM - 3.9.0 (2021-05-19)]
 
@@ -2935,8 +2958,8 @@ If you use the community edition, for each enterprise feature you will have a de
 - Scopes pagination https://github.com/gravitee-io/issues/issues/5213[#5213]
 - Security domains pagination https://github.com/gravitee-io/issues/issues/5212[#5212]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/385?closed=1[AM - 3.8.3 (2021-05-19)]
 
@@ -2946,8 +2969,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Missing application field for flows with JDBC https://github.com/gravitee-io/issues/issues/5566[#5566]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/380?closed=1[AM - 3.8.2 (2021-05-06)]
 
@@ -2971,8 +2994,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Allow to configure the size of form attributes (SAMLResponse) https://github.com/gravitee-io/issues/issues/5506[#5506]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/379?closed=1[AM - 3.7.3 (2021-04-23)]
 
@@ -2982,8 +3005,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Merge 3.5.5 https://github.com/gravitee-io/issues/issues/5474[#5474]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/367?closed=1[AM - 3.5.5 (2021-04-22)]
 
@@ -2999,8 +3022,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Add proxy exclusion in the system proxy configuration of gravitee.yml https://github.com/gravitee-io/issues/issues/5337[#5337]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/377?closed=1[AM - 3.8.1 (2021-04-21)]
 
@@ -3010,8 +3033,8 @@ If you use the community edition, for each enterprise feature you will have a de
 
 - Domain is undefined for organization resources https://github.com/gravitee-io/issues/issues/5465[#5465]
 
- 
- 
+
+
 
 == https://github.com/gravitee-io/issues/milestone/250?closed=1[AM - 3.8.0 (2021-04-20)]
 


### PR DESCRIPTION

# New version 3.20.14 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.20.14/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.20.14 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.20.14%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
