### PR TITLE
chore: Add changelog for new 3.21.10 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,27 @@
 # Change Log
 
+== AM - 3.21.10 (2023-10-27)
+
+== What's new !
+
+=== Gateway
+
+* Application error when using a non defined translation https://github.com/gravitee-io/issues/issues/9237[#9237]
+* Registration confirmation Javascript error (anti-XSRF token) https://github.com/gravitee-io/issues/issues/9276[#9276]
+* Quotes are lost in Gravitee AM forms https://github.com/gravitee-io/issues/issues/9326[#9326]
+* When a resource plugin has been removed from the installation, other resources may not be loaded https://github.com/gravitee-io/issues/issues/9344[#9344]
+
+=== Management API
+
+* Management API hangs completely https://github.com/gravitee-io/issues/issues/9339[#9339]
+
+=== Console
+
+=== Other
+
+* EnrichProfile reset factor defined by EnrollMFA policy https://github.com/gravitee-io/issues/issues/9161[#9161]
+
+
 == AM - 3.20.14 (2023-10-27)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.10 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.10/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.10 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.10%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
