### PR TITLE
fix: use the additional information coming from the lastest Identity …

### DIFF
--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
@@ -23,6 +23,8 @@ import io.gravitee.am.model.scim.Certificate;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -654,6 +656,24 @@ public class User implements IUser {
 
     public Map<String, Object> getAdditionalInformation() {
         return additionalInformation;
+    }
+
+    public Map<String, Object> getLastIdentityInformation() {
+        if (this.lastIdentityUsed != null && this.identities != null) {
+            return this.identities.stream()
+                    .filter(userIdentity -> this.lastIdentityUsed.equals(userIdentity.getProviderId()))
+                    .findFirst()
+                    .map(UserIdentity::getAdditionalInformation)
+                    .orElse(getAdditionalInformation());
+        }
+        return getAdditionalInformation();
+    }
+
+    public Map<String, Object> getIdentitiesAsMap() {
+        if (this.identities != null) {
+            return this.identities.stream().collect(Collectors.toMap(UserIdentity::getProviderId, Function.identity()));
+        }
+        return Map.of();
     }
 
     public User putAdditionalInformation(String key, Object value) {

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/UserTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/UserTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.model;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UserTest {
+
+    @Test
+    public void should_LastIdentity_AdditionalInfo_Return_ProfileAdditionInfo_noLastIdentityUsed() {
+        var user = new User();
+        user.setLastIdentityUsed(null);
+        Map<String, Object> additionalInfo = Map.of("profile", "value");
+        user.setAdditionalInformation(additionalInfo);
+
+        assertThat(user.getLastIdentityInformation()).containsExactlyEntriesOf(additionalInfo);
+    }
+
+    @Test
+    public void should_LastIdentity_AdditionalInfo_Return_ProfileAdditionInfo_noIdentityEntry() {
+        var user = new User();
+        user.setLastIdentityUsed(UUID.randomUUID().toString());
+        Map<String, Object> additionalInfo = Map.of("profile", "value");
+        user.setAdditionalInformation(additionalInfo);
+
+        assertThat(user.getLastIdentityInformation()).containsExactlyEntriesOf(additionalInfo);
+    }
+
+    @Test
+    public void should_LastIdentity_AdditionalInfo_Return_ProfileAdditionInfo_IdentityEntry_notFound() {
+        var user = new User();
+        user.setLastIdentityUsed(UUID.randomUUID().toString());
+        Map<String, Object> additionalInfo = Map.of("profile", "value");
+        user.setAdditionalInformation(additionalInfo);
+        UserIdentity identity = new UserIdentity();
+        identity.setProviderId(UUID.randomUUID().toString());
+        Map<String, Object> identityInfo = Map.of("identity", "value");
+        identity.setAdditionalInformation(identityInfo);
+        user.setIdentities(List.of(identity));
+
+        assertThat(user.getLastIdentityInformation()).containsExactlyEntriesOf(additionalInfo);
+    }
+    @Test
+    public void should_LastIdentity_AdditionalInfo_Return_IdentityAdditionInfo() {
+        var user = new User();
+        user.setLastIdentityUsed(UUID.randomUUID().toString());
+        Map<String, Object> additionalInfo = Map.of("profile", "value");
+        user.setAdditionalInformation(additionalInfo);
+        UserIdentity identity = new UserIdentity();
+        identity.setProviderId(user.getLastIdentityUsed());
+        Map<String, Object> identityInfo = Map.of("identity", "value");
+        identity.setAdditionalInformation(identityInfo);
+        user.setIdentities(List.of(identity));
+
+        assertThat(user.getLastIdentityInformation()).containsExactlyEntriesOf(identityInfo);
+    }
+
+    @Test
+    public void should_not_have_identitiesMap() {
+        var user = new User();
+        user.setLastIdentityUsed(UUID.randomUUID().toString());
+        Map<String, Object> additionalInfo = Map.of("profile", "value");
+        user.setAdditionalInformation(additionalInfo);
+
+        assertThat(user.getIdentitiesAsMap()).isEmpty();
+    }
+
+    @Test
+    public void should_provide_identitiesMap() {
+        var user = new User();
+        user.setLastIdentityUsed(UUID.randomUUID().toString());
+        Map<String, Object> additionalInfo = Map.of("profile", "value");
+        user.setAdditionalInformation(additionalInfo);
+        UserIdentity identity = new UserIdentity();
+        identity.setProviderId(user.getLastIdentityUsed());
+        Map<String, Object> identityInfo = Map.of("identity", "value");
+        identity.setAdditionalInformation(identityInfo);
+        UserIdentity identity2 = new UserIdentity();
+        identity2.setProviderId(UUID.randomUUID().toString());
+        Map<String, Object> identityInfo2 = Map.of("identity2", "value");
+        identity2.setAdditionalInformation(identityInfo2);
+
+        user.setIdentities(List.of(identity, identity2));
+
+        assertThat(user.getIdentitiesAsMap())
+                .hasSize(2)
+                .containsKeys(identity.getProviderId(), identity2.getProviderId());
+
+        assertThat(user.getIdentitiesAsMap().get(identity.getProviderId()))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("additionalInformation", identityInfo)
+                .hasFieldOrPropertyWithValue("providerId", identity.getProviderId());
+
+        assertThat(user.getIdentitiesAsMap().get(identity2.getProviderId()))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("additionalInformation", identityInfo2)
+                .hasFieldOrPropertyWithValue("providerId", identity2.getProviderId());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -618,6 +618,11 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
…profile for single sign out

we also add utility methods to access to UserIdentity in EL
    
fixes AM-1024
    
gravitee-io/issues#9358

# Description

In addition of the bug described into the issue, I introduce two method to User and UserProperties object to ease access to the information coming from the "linked" profile.

`getLastIdentityInformation` to directly have access to the additionalInformaiton of the UserIdentity linked to the lastIdentityUsed  (ex  `{#context.attributes['user']['lastIdentityInformation']['test-key']}`)

`getIdentitiesAsMap` to convert the list of identities to a map with the providerId as key (ex `{#context.attributes['user']['identitiesAsMap']['a826b06e-9f55-42eb-a6b0-6e9f5502eb99']['additionalInformation']['test-key']}` )


