### PR TITLE
feat(helm): backport HTTP 2 configuration from gravitee.yml to helm values

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -23,4 +23,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/am?modal=changelog
   artifacthub.io/changes: |
-    - Allow users to define extra manifests
+    - Make optional HTTP2 request processing via `gateway.http.alpn` set at `true` by default.

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -51,7 +51,7 @@ data:
       maxChunkSize: {{ .Values.gateway.http.maxChunkSize }}
       maxInitialLineLength: {{ .Values.gateway.http.maxInitialLineLength }}
       maxFormAttributeSize: {{ .Values.gateway.http.maxFormAttributeSize }}
-      alpn: true
+      alpn: {{ .Values.gateway.http.alpn | default "true" }}
       {{- if .Values.gateway.ssl.enabled }}
       secured: true
       ssl:

--- a/helm/tests/gateway/configmap_http_test.yaml
+++ b/helm/tests/gateway/configmap_http_test.yaml
@@ -1,0 +1,47 @@
+suite: Test Gateway configmap section alpn
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Default ALPN value (true)
+    template: gateway/gateway-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            alpn: true
+
+  - it: Enable ALPN
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        http:
+          alpn: "true"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            alpn: true
+
+  - it: Disable ALPN
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        http:
+          alpn: "false"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            alpn: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -488,6 +488,7 @@ gateway:
     maxChunkSize: 8192
     maxInitialLineLength: 4096
     maxFormAttributeSize: 2048
+    alpn: "true"
 
   logging:
     debug: false


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/DEVOPS-283

## :pencil2: A description of the changes proposed in the pull request

Previously the `http.alpn` option was hardcoded as `true` in `gravitee.yml`.
Now we add the option `gateway.http.alpn` to configure it in helm `values.yml`
which is set to `true` by default for backward compatibility.

## :memo: Test scenarios 

See unit test

