### PR TITLE
fix(helm): remove nonexistant existingClaim attribute

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -423,7 +423,6 @@ api:
     # - name: extra-volume
     #   mountPath: /mnt/volume
     #   readOnly: true
-    #   existingClaim: volume-claim
   # If you want to use your own gravitee.yml you have to provide your configmap or secret in extraVolume part.
   # the name of the volume MUST be "config".
   # In this case, values configuration related to gravitee.yml defined in this file will be ignored
@@ -717,7 +716,6 @@ gateway:
     # - name: extra-volume
     #   mountPath: /mnt/volume
     #   readOnly: true
-    #   existingClaim: volume-claim
   # If you want to use your own gravitee.yml you have to provide your configmap or secret in extraVolume part.
   # the name of the volume MUST be "config".
   # In this case, values configuration related to gravitee.yml defined in this file will be ignored


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/DEVOPS-265

## :pencil2: A description of the changes proposed in the pull request

The chart is putting the whole extraVolumeMounts verbatim (i.e. as is)
in the deployment spec, and existingClaim is not a kubernetes attribute.

