### PR TITLE
refactor(helm): rework email configuration to use ident

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -25,3 +25,6 @@ annotations:
   artifacthub.io/changes: |
     - Make optional HTTP2 request processing via `gateway.http.alpn` set at `true` by default.
     - Manage consent setting to log IP & User-Agent into the audits.
+    - Allow users to define extra manifests
+    - refactoring of email configuration now `smtp.email` and `api.notifiers.email` transpose helm values to `gravitee.yml` with some process to be backward compatible.
+

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -246,65 +246,18 @@ data:
   {{- end }}
 
     notifiers:
-      email: 
-        enabled: {{ .Values.api.notifiers.email.enabled }}
-        {{- if or .Values.api.notifiers.email.enabled .Values.smtp.enabled }}
-        host: {{ .Values.api.notifiers.email.host | default .Values.smtp.host }}
-        subject: {{ .Values.api.notifiers.email.subject | default .Values.smtp.subject | quote }}
-        port: {{ .Values.api.notifiers.email.port | default .Values.smtp.port }}
-        from: {{ .Values.api.notifiers.email.from | default .Values.smtp.from }}
-        {{- if or .Values.api.notifiers.email.username .Values.api.notifiers.email.password }}
-        username: {{ .Values.api.notifiers.email.username }}
-        password: {{ .Values.api.notifiers.email.password }}
-        {{- else if or .Values.smtp.username .Values.smtp.password }}
-        username: {{ .Values.smtp.username }}
-        password: {{ .Values.smtp.password }}
-        {{- end }}
-        startTLSEnabled: {{ .Values.api.notifiers.email.startTLSEnabled | default .Values.smtp.properties.starttlsEnable }}
-        {{- if .Values.api.notifiers.email.sslTrustAll }}
-        sslTrustAll: {{ .Values.api.notifiers.email.sslTrustAll }}
-        {{- else if eq (.Values.smtp.properties.sslTrust | default "") "*" }}
-        sslTrustAll: true
-        {{- else }}
-        sslTrustAll: false
-        {{- end }}
-        {{- if .Values.api.notifiers.email.sslKeyStore }}
-        sslKeyStore: {{ .Values.api.notifiers.email.sslKeyStore }}
-        {{- end }}
-        {{- if .Values.api.notifiers.email.sslKeyStorePassword }}
-        sslKeyStorePassword: {{ .Values.api.notifiers.email.sslKeyStorePassword }}
-        {{- end }}
-        {{- end }}
+      {{- if .Values.api.notifiers.email.enabled }}
+      email:
+        {{- .Values.api.notifiers.email | toYaml | nindent 8 }}
+      {{- end }}
       ui:
         enabled: {{ .Values.api.notifiers.ui.enabled }}
-    
+
+    {{- if .Values.smtp }}
     # SMTP configuration used to send mails
     email:
-      enabled: {{ .Values.smtp.enabled }}
-      {{- if .Values.smtp.enabled }}
-      host: {{ .Values.smtp.host }}
-      subject: {{ .Values.smtp.subject | quote }}
-      port: {{ .Values.smtp.port }}
-      from: {{ .Values.smtp.from }}
-      allowedfrom:
-        {{ toYaml .Values.smtp.allowedfrom | nindent 8 | trim -}}
-      {{- if or .Values.smtp.username .Values.smtp.password }}
-      username: {{ .Values.smtp.username }}
-      password: {{ .Values.smtp.password }}
-      {{- end }}
-      properties:
-        auth: {{ .Values.smtp.properties.auth }}
-        starttls.enable: {{ .Values.smtp.properties.starttlsEnable }}
-        {{- if .Values.smtp.properties.localhost }}
-        localhost: {{ .Values.smtp.properties.localhost }}
-        {{- end }}
-        {{- if .Values.smtp.properties.sslTrust }}
-        ssl.trust: {{ .Values.smtp.properties.sslTrust }}
-        {{- end }}
-        {{- if .Values.smtp.properties.sslProtocols }}
-        ssl.protocols: {{ .Values.smtp.properties.sslProtocols }}
-        {{- end }}
-      {{- end }}
+      {{- .Values.smtp | toYaml | nindent 6 | replace "starttlsEnable" "starttls.enable" | replace "sslTrust" "ssl.trust" | replace "sslProtocols" "ssl.protocols" }}
+    {{- end }}
 
     domains:
       certificates:
@@ -435,7 +388,7 @@ data:
         enabled: false
     {{- end }}
   {{- end }}
-  {{- if .Values.api.logging.debug }}
+    {{- if .Values.api.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>
 

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -248,7 +248,16 @@ data:
     notifiers:
       {{- if .Values.api.notifiers.email.enabled }}
       email:
+        {{- if .Values.smtp.enabled }}
+          {{- $rootEmail := omit .Values.smtp "properties" "allowedfrom" }}
+          {{- if .Values.smtp.properties }}
+          {{- $wantedProperties := omit .Values.smtp.properties "auth" "sslProtocols" "localhost" }}
+          {{- $rootEmail := merge $rootEmail $wantedProperties }}
+          {{- end }}
+        {{- .Values.api.notifiers.email | mergeOverwrite $rootEmail | toYaml | nindent 8 | replace "starttlsEnable:" "startTLSEnabled:" | replace "sslTrust:" "sslTrustAll:" }}
+        {{- else }}
         {{- .Values.api.notifiers.email | toYaml | nindent 8 }}
+        {{- end }}
       {{- end }}
       ui:
         enabled: {{ .Values.api.notifiers.ui.enabled }}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -273,32 +273,12 @@ data:
       # Allows to define if cookie secure only (default false)
       cookie-secure: {{ .Values.gateway.jwt.cookie.secure | default false }}
 
+    {{- if .Values.smtp }}
     # SMTP configuration used to send mails
     email:
-      enabled: {{ .Values.smtp.enabled }}
-      {{- if .Values.smtp.enabled }}
-      host: {{ .Values.smtp.host }}
-      subject: {{ .Values.smtp.subject | quote }}
-      port: {{ .Values.smtp.port }}
-      from: {{ .Values.smtp.from }}
-      {{- if or .Values.smtp.username .Values.smtp.password }}
-      username: {{ .Values.smtp.username }}
-      password: {{ .Values.smtp.password }}
-      {{- end }}
-      properties:
-        auth: {{ .Values.smtp.properties.auth }}
-        starttls.enable: {{ .Values.smtp.properties.starttlsEnable }}
-        {{- if .Values.smtp.properties.localhost }}
-        localhost: {{ .Values.smtp.properties.localhost }}
-        {{- end }}
-        {{- if .Values.smtp.properties.sslTrust }}
-        ssl.trust: {{ .Values.smtp.properties.sslTrust }}
-        {{- end }}
-        {{- if .Values.smtp.properties.sslProtocols }}
-        ssl.protocols: {{ .Values.smtp.properties.sslProtocols }}
-        {{- end }}
-      {{- end }}
-    
+      {{- .Values.smtp | toYaml | nindent 6 | replace "starttlsEnable" "starttls.enable" | replace "sslTrust" "ssl.trust" | replace "sslProtocols" "ssl.protocols" }}
+    {{- end }}
+
     {{- if .Values.userManagement }}
     user:
 {{ toYaml .Values.userManagement | indent 6 }}

--- a/helm/tests/api/configmap_email_test.yaml
+++ b/helm/tests/api/configmap_email_test.yaml
@@ -185,3 +185,134 @@ tests:
                 sslTrustAll: false
                 startTLSEnabled: false
                 username: info@example.com
+
+  - it: Define notifiers with merged attributes from smtp.email
+    template: api/api-configmap.yaml
+    set:
+      api:
+        notifiers:
+          email:
+            enabled: true
+            host: smtp2.example.com
+            sslKeyStore: /path/to/keystore
+            sslKeyStorePassword: changeme
+      smtp:
+        enabled: true
+        host: smtp.example.com
+        port: 25
+        from: info@example.com
+        username: info@example.com
+        password: example.com
+        subject: "gravitee"
+        properties:
+          starttlsEnable: false
+          sslTrust: smtp.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *notifiers:\n
+                     * email:\n
+                     *   enabled: true\n
+                     *   from: info@example.com\n
+                     *   host: smtp2.example.com\n
+                     *   password: example.com\n
+                     *   port: 25\n
+                     *   sslKeyStore: /path/to/keystore\n
+                     *   sslKeyStorePassword: changeme\n
+                     *   sslTrustAll: smtp.example.com\n
+                     *   startTLSEnabled: false\n
+                     *   subject: gravitee\n
+                     *   username: info@example.com"
+
+  - it: Define notifiers with merged attributes from smtp.email without unneeded smtp values
+    template: api/api-configmap.yaml
+    set:
+      api:
+        notifiers:
+          email:
+            enabled: true
+            host: smtp2.example.com
+            sslKeyStore: /path/to/keystore
+            sslKeyStorePassword: changeme
+      smtp:
+        enabled: true
+        host: smtp.example.com
+        port: 25
+        from: info@example.com
+        username: info@example.com
+        password: example.com
+        subject: "gravitee"
+        allowedfrom:
+          - email@from
+        properties:
+          auth: true
+          starttlsEnable: false
+          sslTrust: smtp.example.com
+          sslProtocols: TLSv1.2
+          localhost: am.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *notifiers:\n
+                     * email:\n
+                     *   enabled: true\n
+                     *   from: info@example.com\n
+                     *   host: smtp2.example.com\n
+                     *   password: example.com\n
+                     *   port: 25\n
+                     *   sslKeyStore: /path/to/keystore\n
+                     *   sslKeyStorePassword: changeme\n
+                     *   sslTrustAll: smtp.example.com\n
+                     *   startTLSEnabled: false\n
+                     *   subject: gravitee\n
+                     *   username: info@example.com"
+
+  - it: Define notifiers with merged attributes from smtp.email in case of no smtp.properties
+    template: api/api-configmap.yaml
+    set:
+      api:
+        notifiers:
+          email:
+            enabled: true
+            startTLSEnabled: false
+            sslTrustAll: false
+            sslKeyStore: /path/to/keystore
+            sslKeyStorePassword: changeme
+      smtp:
+        enabled: true
+        host: smtp.example.com
+        port: 25
+        from: info@example.com
+        username: info@example.com
+        password: example.com
+        subject: "gravitee"
+        allowedfrom:
+          - email@from
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *notifiers:\n
+                     * email:\n
+                     *   enabled: true\n
+                     *   from: info@example.com\n
+                     *   host: smtp.example.com\n
+                     *   password: example.com\n
+                     *   port: 25\n
+                     *   sslKeyStore: /path/to/keystore\n
+                     *   sslKeyStorePassword: changeme\n
+                     *   sslTrustAll: false\n
+                     *   startTLSEnabled: false\n
+                     *   subject: gravitee\n
+                     *   username: info@example.com"

--- a/helm/tests/api/configmap_email_test.yaml
+++ b/helm/tests/api/configmap_email_test.yaml
@@ -1,0 +1,187 @@
+suite: Test Gateway configmap section email and notifiers
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: Define email host
+    template: api/api-configmap.yaml
+    set:
+      smtp:
+        enabled: true
+        host: smtp.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            email:
+              enabled: true
+              host: smtp.example.com
+
+  - it: Define all email attribute
+    template: api/api-configmap.yaml
+    set:
+      smtp:
+        enabled: true
+        host: smtp.example.com
+        port: 25
+        from: info@example.com
+        username: info@example.com
+        password: example.com
+        subject: "gravitee"
+        allowedfrom:
+          - email@from
+        properties:
+          auth: true
+          starttls.enable: false
+          ssl.trust: smtp.example.com
+          ssl.protocols: TLSv1.2
+          localhost: am.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *email:\n
+                     *  allowedfrom:\n
+                     *  - email@from\n
+                     *  enabled: true\n
+                     *  from: info@example.com\n
+                     *  host: smtp.example.com\n
+                     *  password: example.com\n
+                     *  port: 25\n
+                     *  properties:\n
+                     *    auth: true\n
+                     *    localhost: am.example.com\n
+                     *    ssl.protocols: TLSv1.2\n
+                     *    ssl.trust: smtp.example.com\n
+                     *    starttls.enable: false\n
+                     *  subject: gravitee\n
+                     *  username: info@example.com"
+
+  - it: Check backward compatibility with attribute startTLSEnabled, sslTrust, sslProtocols
+    template: api/api-configmap.yaml
+    set:
+      smtp:
+        enabled: true
+        host: smtp.example.com
+        port: 25
+        from: info@example.com
+        username: info@example.com
+        password: example.com
+        subject: "gravitee"
+        allowedfrom:
+          - email@from
+        properties:
+          auth: true
+          starttlsEnable: false
+          sslTrust: smtp.example.com
+          sslProtocols: TLSv1.2
+          localhost: am.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *email:\n
+                     *  allowedfrom:\n
+                     *  - email@from\n
+                     *  enabled: true\n
+                     *  from: info@example.com\n
+                     *  host: smtp.example.com\n
+                     *  password: example.com\n
+                     *  port: 25\n
+                     *  properties:\n
+                     *    auth: true\n
+                     *    localhost: am.example.com\n
+                     *    ssl.protocols: TLSv1.2\n
+                     *    ssl.trust: smtp.example.com\n
+                     *    starttls.enable: false\n
+                     *  subject: gravitee\n
+                     *  username: info@example.com"
+
+  - it: Disable notifiers email
+    template: api/api-configmap.yaml
+    set:
+      api:
+        notifiers:
+          email:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            notifiers:
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            notifiers:
+              email:
+
+  - it: Define notifiers email host
+    template: api/api-configmap.yaml
+    set:
+      api:
+        notifiers:
+          email:
+            enabled: true
+            host: smtp.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            notifiers:
+              email:
+                enabled: true
+                host: smtp.example.com
+
+  - it: Define notifiers all email attribute
+    template: api/api-configmap.yaml
+    set:
+      api:
+        notifiers:
+          email:
+            enabled: true
+            host: smtp.example.com
+            port: 25
+            from: info@example.com
+            username: info@example.com
+            password: example.com
+            startTLSEnabled: false
+            sslTrustAll: false
+            sslKeyStore: /path/to/keystore
+            sslKeyStorePassword: changeme
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            notifiers:
+              email:
+                enabled: true
+                from: info@example.com
+                host: smtp.example.com
+                password: example.com
+                port: 25
+                sslKeyStore: /path/to/keystore
+                sslKeyStorePassword: changeme
+                sslTrustAll: false
+                startTLSEnabled: false
+                username: info@example.com

--- a/helm/tests/gateway/configmap_email_test.yaml
+++ b/helm/tests/gateway/configmap_email_test.yaml
@@ -1,0 +1,107 @@
+suite: Test Gateway configmap section email and notifiers
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Define email host
+    template: gateway/gateway-configmap.yaml
+    set:
+      smtp:
+        enabled: true
+        host: smtp.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            email:
+              enabled: true
+              host: smtp.example.com
+
+  - it: Define all email attribute
+    template: gateway/gateway-configmap.yaml
+    set:
+      smtp:
+        enabled: true
+        host: smtp.example.com
+        port: 25
+        from: info@example.com
+        username: info@example.com
+        password: example.com
+        subject: "gravitee"
+        allowedfrom:
+          - email@from
+        properties:
+          auth: true
+          starttls.enable: false
+          ssl.trust: smtp.example.com
+          ssl.protocols: TLSv1.2
+          localhost: am.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *email:\n
+                     *  allowedfrom:\n
+                     *  - email@from\n
+                     *  enabled: true\n
+                     *  from: info@example.com\n
+                     *  host: smtp.example.com\n
+                     *  password: example.com\n
+                     *  port: 25\n
+                     *  properties:\n
+                     *    auth: true\n
+                     *    localhost: am.example.com\n
+                     *    ssl.protocols: TLSv1.2\n
+                     *    ssl.trust: smtp.example.com\n
+                     *    starttls.enable: false\n
+                     *  subject: gravitee\n
+                     *  username: info@example.com"
+
+  - it: Check backward compatibility with attribute startTLSEnabled, sslTrust, sslProtocols
+    template: gateway/gateway-configmap.yaml
+    set:
+      smtp:
+        enabled: true
+        host: smtp.example.com
+        port: 25
+        from: info@example.com
+        username: info@example.com
+        password: example.com
+        subject: "gravitee"
+        allowedfrom:
+          - email@from
+        properties:
+          auth: true
+          starttlsEnable: false
+          sslTrust: smtp.example.com
+          sslProtocols: TLSv1.2
+          localhost: am.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *email:\n
+                     *  allowedfrom:\n
+                     *  - email@from\n
+                     *  enabled: true\n
+                     *  from: info@example.com\n
+                     *  host: smtp.example.com\n
+                     *  password: example.com\n
+                     *  port: 25\n
+                     *  properties:\n
+                     *    auth: true\n
+                     *    localhost: am.example.com\n
+                     *    ssl.protocols: TLSv1.2\n
+                     *    ssl.trust: smtp.example.com\n
+                     *    starttls.enable: false\n
+                     *  subject: gravitee\n
+                     *  username: info@example.com"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -60,20 +60,20 @@ chaos:
 
 smtp:
   enabled: true
-  host: smtp.example.com
-  port: 25
-  from: info@example.com
-  username: info@example.com
-  password: example.com
-  subject: "[gravitee] %s"
-  allowedfrom:
-    - ${email.from}
-  properties:
-    auth: true
-    starttlsEnable: false
-    #sslTrust: smtp.example.com
-    #sslProtocols: TLSv1.2
-    #localhost: am.example.com
+#  host: smtp.example.com
+#  port: 25
+#  from: info@example.com
+#  username: info@example.com
+#  password: example.com
+#  subject: "[gravitee] %s"
+#  allowedfrom:
+#    - ${email.from}
+#  properties:
+#    auth: true
+#    starttls.enable: false
+#    ssl.trust: smtp.example.com
+#    ssl.protocols: TLSv1.2
+#    localhost: am.example.com
 
 mongo:
   # uri: mongodb://mongo-mongodb-replicaset:27017/gravitee?connectTimeoutMS=30000
@@ -453,15 +453,15 @@ api:
   notifiers:
     email:
       enabled: false
-      #host: smtp.example.com
-      #port: 25
-      #from: info@example.com
-      #username: info@example.com
-      #password: example.com
-      #startTLSEnabled: false
-      #sslTrustAll: false
-      #sslKeyStore: /path/to/keystore
-      #sslKeyStorePassword: changeme
+#      host: smtp.example.com
+#      port: 25
+#      from: info@example.com
+#      username: info@example.com
+#      password: example.com
+#      startTLSEnabled: false
+#      sslTrustAll: false
+#      sslKeyStore: /path/to/keystore
+#      sslKeyStorePassword: changeme
     ui:
       enabled: true
 


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/DEVOPS-180

## :pencil2: A description of the changes proposed in the pull request

* rework email configuration in helm `values.yml` in `smtp.email`
* rework also the `notifiers.email`

Note: previously, some properties was different between helm values and
`gravitee.yml` file:

* `starttlsEnable` to `starttls.enable`
* `sslTrust` to `ssl.trust`
* `sslProtocols` to `ssl.protocols`

And on another side, the `notifiers` email configuration in
`gravitee.yml` use these camelcase properties...

This refactoring take care to be backward compatible with old and new
configuration. (see unit test)

* fix also the conversion from `starttlsEnable` to `startTLSEnabled`
* remove unwanted properties from `smtp` when include to `notifiers`
* flatten the `.smtp.properties` into `api.notifiers.email` directly

## :memo: Test scenarios 

see unittest
