### PR TITLE
fix: upgrade groovy policy to allow request headers usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <protobuf-java.version>3.23.3</protobuf-java.version>
         <!-- External plugins versions -->
         <gravitee-policy-callout-http.version>1.15.1</gravitee-policy-callout-http.version>
-        <gravitee-policy-groovy.version>2.0.0</gravitee-policy-groovy.version>
+        <gravitee-policy-groovy.version>2.3.0</gravitee-policy-groovy.version>
         <gravitee-policy-ipfiltering.version>1.8.0</gravitee-policy-ipfiltering.version>
         <gravitee-policy-request-validation.version>1.12.0</gravitee-policy-request-validation.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>


### PR DESCRIPTION
fixes AM-828

gravitee-io/issues#9229

# Test

Create groovy policy in flow ALL

```
import io.gravitee.policy.groovy.PolicyResult.State

result.state = State.FAILURE
result.code = 400
result.error = '{"data":' + [request.method, request.parameters, request.headers['Host'] + '}'
result.contentType = 'application/json'
```

With this script, a request on the GW to initiate a login flow should return a JSON with an array. Lastest element of the array should contains the value of the Host header 