### PR TITLE
chore: Add changelog for new 3.20.15 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,28 @@
 # Change Log
 
+==  - 3.20.15 (2023-11-10)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Deadlock during generate AccessToken https://github.com/gravitee-io/issues/issues/9238[#9238]
+
+=== Management API
+
+
+
+=== Console
+
+
+
+=== Other
+
+* Upgrade Groovy policy https://github.com/gravitee-io/issues/issues/9229[#9229]
+
+
 == AM - 3.21.10 (2023-10-27)
 
 == What's new !


### PR DESCRIPTION

# New version 3.20.15 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.20.15/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.20.15 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.20.15%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
