### PR TITLE
chore: Add changelog for new 3.21.11 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,10 +1,8 @@
 # Change Log
 
-==  - 3.20.15 (2023-11-10)
+== AM - 3.21.11 (2023-11-10)
 
 == What's new !
-
-
 
 === Gateway
 
@@ -12,11 +10,25 @@
 
 === Management API
 
-
-
 === Console
 
+=== Other
 
+* Upgrade Groovy policy https://github.com/gravitee-io/issues/issues/9229[#9229]
+* EnrollmentMFA policy doesn't manage the useVariableFactorSecurity setting https://github.com/gravitee-io/issues/issues/9365[#9365]
+
+
+== AM - 3.20.15 (2023-11-10)
+
+== What's new !
+
+=== Gateway
+
+* Deadlock during generate AccessToken https://github.com/gravitee-io/issues/issues/9238[#9238]
+
+=== Management API
+
+=== Console
 
 === Other
 


### PR DESCRIPTION

# New version 3.21.11 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.11/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.11 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.11%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
