### PR TITLE
Point to latest documentation website

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Gravitee.io AM also supports the following protocols to help our customers to co
 
 ## 📚 Documentation
 
-You can find Gravitee.io Access Management's documentation on the [dedicated website](https://docs.gravitee.io/).
+You can find Gravitee.io Access Management's documentation on the [dedicated website](https://documentation.gravitee.io/).
 
 ## 👥 Community
 


### PR DESCRIPTION
The Github readme was pointing to the old (<4.0) documentation website.

This PR updates the link to point to the new documentation website.