### PR TITLE
chore: bump france-connect idp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <gravitee-am-idp-saml2.version>3.0.0</gravitee-am-idp-saml2.version>
         <gravitee-am-idp-ldap.version>1.0.1</gravitee-am-idp-ldap.version>
         <gravitee-am-idp-azure-ad.version>1.0.0</gravitee-am-idp-azure-ad.version>
-        <gravitee-am-idp-franceconnect.version>1.1.0</gravitee-am-idp-franceconnect.version>
+        <gravitee-am-idp-franceconnect.version>1.1.1</gravitee-am-idp-franceconnect.version>
         <gravitee-am-idp-salesforce.version>1.0.0</gravitee-am-idp-salesforce.version>
         <gravitee-am-factor-call.version>1.0.0</gravitee-am-factor-call.version>
         <gravitee-am-factor-sms.version>1.0.0</gravitee-am-factor-sms.version>


### PR DESCRIPTION
related AM-1056

gravitee-io/issues#9381


## How to test

In FranceConnect IDP, add this additional parameter to get the AMR claims. This claims is present only into the id_token not in the UserInfo endpoint

![image](https://github.com/gravitee-io/gravitee-access-management/assets/3110552/e83b21bb-9f31-4836-a98b-8d21cf057301)

In the User Mapper linked to FranceConnect, add these entries. Note the amr_el one that will provide in the User profile the amr claims coming from the id_token.

![image](https://github.com/gravitee-io/gravitee-access-management/assets/3110552/fa3e1844-05ad-40ac-bbcb-783f1dc548d8)

in the user profile, you should see something like this

![image](https://github.com/gravitee-io/gravitee-access-management/assets/3110552/3e1b8e66-f626-4a67-8a0d-897153677c94)
