### PR TITLE
fix: defer some @Value resolution and bean instantiation

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -156,6 +156,11 @@ public interface ConstantKeys {
     String DEVICE_IDENTIFIER_PROVIDER_KEY = "deviceIdentifierProvider";
 
     // ------
+    // Default secret value used in gravitee.yaml
+    // ------
+    String DEFAULT_JWT_OR_CSRF_SECRET = "s3cR3t4grAv1t3310AMS1g1ingDftK3y";
+
+    // ------
     // Values used to find key into gravitee.yaml
     // ------
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/certificate/impl/CertificateManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/certificate/impl/CertificateManagerImpl.java
@@ -52,6 +52,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+import static io.gravitee.am.common.utils.ConstantKeys.DEFAULT_JWT_OR_CSRF_SECRET;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -317,7 +319,7 @@ public class CertificateManagerImpl extends AbstractService implements Certifica
     }
 
     private String signingKeySecret() {
-        return configuration.getProperty("jwt.secret", "s3cR3t4grAv1t3310AMS1g1ingDftK3y");
+        return configuration.getProperty("jwt.secret", DEFAULT_JWT_OR_CSRF_SECRET);
     }
 
     private String signingKeyId() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/certificate/impl/CertificateManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/certificate/impl/CertificateManagerImpl.java
@@ -33,15 +33,14 @@ import io.gravitee.am.repository.management.api.CertificateRepository;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.configuration.Configuration;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -57,15 +56,12 @@ import java.util.stream.Collectors;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class CertificateManagerImpl extends AbstractService implements CertificateManager, EventListener<CertificateEvent, Payload>, InitializingBean {
+public class CertificateManagerImpl extends AbstractService implements CertificateManager, EventListener<CertificateEvent, Payload> {
 
     private static final Logger logger = LoggerFactory.getLogger(CertificateManagerImpl.class);
 
-    @Value("${jwt.secret:s3cR3t4grAv1t3310AMS1g1ingDftK3y}")
-    private String signingKeySecret;
-
-    @Value("${jwt.kid:default-gravitee-AM-key}")
-    private String signingKeyId;
+    @Autowired
+    private Configuration configuration;
 
     @Autowired
     private Domain domain;
@@ -84,29 +80,6 @@ public class CertificateManagerImpl extends AbstractService implements Certifica
     private CertificateProvider noneAlgorithmCertificateProvider;
 
     private final ConcurrentMap<String, Certificate> certificates = new ConcurrentHashMap<>();
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        logger.info("Initializing default certificate provider for domain {}", domain.getName());
-        initDefaultCertificateProvider();
-        logger.info("Default certificate loaded for domain {}", domain.getName());
-
-        logger.info("Initializing none algorithm certificate provider for domain {}", domain.getName());
-        initNoneAlgorithmCertificateProvider();
-        logger.info("None algorithm certificate loaded for domain {}", domain.getName());
-
-        logger.info("Initializing certificates for domain {}", domain.getName());
-        certificateRepository.findByDomain(domain.getId())
-                .subscribeOn(Schedulers.io())
-                .subscribe(
-                        certificate -> {
-                            certificateProviderManager.create(certificate);
-                            certificates.put(certificate.getId(), certificate);
-                            logger.info("Certificate {} loaded for domain {}", certificate.getName(), domain.getName());
-                        },
-                        error -> logger.error("An error has occurred when loading certificates for domain {}", domain.getName(), error)
-                );
-    }
 
     @Override
     public void onEvent(Event<CertificateEvent, Payload> event) {
@@ -128,8 +101,32 @@ public class CertificateManagerImpl extends AbstractService implements Certifica
     protected void doStart() throws Exception {
         super.doStart();
 
+        initialize();
+
         logger.info("Register event listener for certificate events for domain {}", domain.getName());
         eventManager.subscribeForEvents(this, CertificateEvent.class, domain.getId());
+    }
+
+    private void initialize() throws Exception {
+        logger.info("Initializing default certificate provider for domain {}", domain.getName());
+        initDefaultCertificateProvider();
+        logger.info("Default certificate loaded for domain {}", domain.getName());
+
+        logger.info("Initializing none algorithm certificate provider for domain {}", domain.getName());
+        initNoneAlgorithmCertificateProvider();
+        logger.info("None algorithm certificate loaded for domain {}", domain.getName());
+
+        logger.info("Initializing certificates for domain {}", domain.getName());
+        certificateRepository.findByDomain(domain.getId())
+                .subscribeOn(Schedulers.io())
+                .subscribe(
+                        certificate -> {
+                            certificateProviderManager.create(certificate);
+                            certificates.put(certificate.getId(), certificate);
+                            logger.info("Certificate {} loaded for domain {}", certificate.getName(), domain.getName());
+                        },
+                        error -> logger.error("An error has occurred when loading certificates for domain {}", domain.getName(), error)
+                );
     }
 
     @Override
@@ -228,10 +225,10 @@ public class CertificateManagerImpl extends AbstractService implements Certifica
 
     private void initDefaultCertificateProvider() throws InvalidKeyException {
         // create default signing HMAC key
-        byte[] keySecretBytes = signingKeySecret.getBytes();
+        byte[] keySecretBytes = signingKeySecret().getBytes();
         Key key = Keys.hmacShaKeyFor(keySecretBytes);
         SignatureAlgorithm signatureAlgorithm = Keys.hmacShaSignatureAlgorithmFor(keySecretBytes);
-        io.gravitee.am.certificate.api.Key certificateKey = new DefaultKey(signingKeyId, key);
+        io.gravitee.am.certificate.api.Key certificateKey = new DefaultKey(signingKeyId(), key);
 
         // create default certificate provider
         CertificateMetadata certificateMetadata = new CertificateMetadata();
@@ -317,5 +314,13 @@ public class CertificateManagerImpl extends AbstractService implements Certifica
             }
         };
         this.noneAlgorithmCertificateProvider = certificateProviderManager.create(noneProvider);
+    }
+
+    private String signingKeySecret() {
+        return configuration.getProperty("jwt.secret", "s3cR3t4grAv1t3310AMS1g1ingDftK3y");
+    }
+
+    private String signingKeyId() {
+        return configuration.getProperty("jwt.kid", "default-gravitee-AM-key");
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -93,6 +94,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
     @Autowired
     private AuditService auditService;
 
+    @Lazy // Need to be lazy loaded to ensure jwt buider is instantiated with all resolved configuration included eventual secrets.
     @Autowired
     @Qualifier("managementJwtBuilder")
     private JWTBuilder jwtBuilder;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSRFHandlerFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSRFHandlerFactory.java
@@ -16,11 +16,11 @@
 package io.gravitee.am.gateway.handler.common.vertx.web.handler;
 
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.CSRFHandlerImpl;
+import io.gravitee.node.api.configuration.Configuration;
 import io.vertx.core.Vertx;
 import io.vertx.rxjava3.ext.web.handler.CSRFHandler;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 import static io.vertx.ext.web.handler.SessionHandler.DEFAULT_SESSION_TIMEOUT;
 
@@ -30,22 +30,27 @@ import static io.vertx.ext.web.handler.SessionHandler.DEFAULT_SESSION_TIMEOUT;
  */
 public class CSRFHandlerFactory implements FactoryBean<CSRFHandler> {
 
-    @Value("${http.csrf.secret:s3cR3t4grAv1t3310AMS1g1ingDftK3y}")
-    private String csrfSecret;
+    @Autowired
+    private Configuration configuration;
 
     @Autowired
     private Vertx vertx;
 
-    @Value("${http.cookie.session.timeout:" + DEFAULT_SESSION_TIMEOUT + "}")
-    private long timeout;
-
     @Override
     public CSRFHandler getObject() {
-        return CSRFHandler.newInstance(new CSRFHandlerImpl(vertx, csrfSecret, timeout));
+        return CSRFHandler.newInstance(new CSRFHandlerImpl(vertx, csrfSecret(), timeout()));
     }
 
     @Override
     public Class<?> getObjectType() {
         return CSRFHandler.class;
+    }
+
+    private String csrfSecret() {
+        return configuration.getProperty("http.csrf.secret", "s3cR3t4grAv1t3310AMS1g1ingDftK3y");
+    }
+
+    private long timeout() {
+        return configuration.getProperty("http.cookie.session.timeout", Long.class, DEFAULT_SESSION_TIMEOUT);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSRFHandlerFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSRFHandlerFactory.java
@@ -22,6 +22,7 @@ import io.vertx.rxjava3.ext.web.handler.CSRFHandler;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static io.gravitee.am.common.utils.ConstantKeys.DEFAULT_JWT_OR_CSRF_SECRET;
 import static io.vertx.ext.web.handler.SessionHandler.DEFAULT_SESSION_TIMEOUT;
 
 /**
@@ -47,7 +48,7 @@ public class CSRFHandlerFactory implements FactoryBean<CSRFHandler> {
     }
 
     private String csrfSecret() {
-        return configuration.getProperty("http.csrf.secret", "s3cR3t4grAv1t3310AMS1g1ingDftK3y");
+        return configuration.getProperty("http.csrf.secret", DEFAULT_JWT_OR_CSRF_SECRET);
     }
 
     private long timeout() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/store/RepositoryCredentialStore.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/store/RepositoryCredentialStore.java
@@ -30,6 +30,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.vertx.ext.auth.webauthn.Authenticator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -46,6 +47,7 @@ public class RepositoryCredentialStore {
     @Autowired
     private CredentialService credentialService;
 
+    @Lazy // Need to be lazy loaded to ensure jwt builder is instantiated with all resolved configuration included eventual secrets.
     @Autowired
     @Qualifier("managementJwtBuilder")
     private JWTBuilder jwtBuilder;

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/configuration/ConfigurationChecker.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/configuration/ConfigurationChecker.java
@@ -20,7 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+
+import static io.gravitee.am.common.utils.ConstantKeys.DEFAULT_JWT_OR_CSRF_SECRET;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -35,7 +36,7 @@ public class ConfigurationChecker implements InitializingBean {
 
     void check() {
         //Warning if the secret is still the default one
-        if ("s3cR3t4grAv1t3310AMS1g1ingDftK3y".equals(csrfSecret())) {
+        if (DEFAULT_JWT_OR_CSRF_SECRET.equals(csrfSecret())) {
             LOGGER.warn("");
             LOGGER.warn("##############################################################");
             LOGGER.warn("#                      SECURITY WARNING                      #");
@@ -56,6 +57,6 @@ public class ConfigurationChecker implements InitializingBean {
     }
 
     private String csrfSecret() {
-        return configuration.getProperty("http.csrf.secret", "s3cR3t4grAv1t3310AMS1g1ingDftK3y");
+        return configuration.getProperty("http.csrf.secret", DEFAULT_JWT_OR_CSRF_SECRET);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/configuration/ConfigurationChecker.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/configuration/ConfigurationChecker.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.am.gateway.configuration;
 
+import io.gravitee.node.api.configuration.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 /**
@@ -28,12 +30,12 @@ public class ConfigurationChecker implements InitializingBean {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationChecker.class);
 
-    @Value("${http.csrf.secret:s3cR3t4grAv1t3310AMS1g1ingDftK3y}")
-    private String csrfSecret;
+    @Autowired
+    private Configuration configuration;
 
     void check() {
         //Warning if the secret is still the default one
-        if ("s3cR3t4grAv1t3310AMS1g1ingDftK3y".equals(csrfSecret)) {
+        if ("s3cR3t4grAv1t3310AMS1g1ingDftK3y".equals(csrfSecret())) {
             LOGGER.warn("");
             LOGGER.warn("##############################################################");
             LOGGER.warn("#                      SECURITY WARNING                      #");
@@ -51,5 +53,9 @@ public class ConfigurationChecker implements InitializingBean {
     @Override
     public void afterPropertiesSet() {
         check();
+    }
+
+    private String csrfSecret() {
+        return configuration.getProperty("http.csrf.secret", "s3cR3t4grAv1t3310AMS1g1ingDftK3y");
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxServerConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxServerConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
 
@@ -37,6 +38,7 @@ public class VertxServerConfiguration {
 
     private static final String HTTP_PREFIX = "http";
 
+    @Lazy
     @Bean
     public VertxHttpServerOptions httpServerConfiguration(
             Environment environment,

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/filter/CockpitAuthenticationFilter.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/filter/CockpitAuthenticationFilter.java
@@ -26,19 +26,19 @@ import io.gravitee.am.management.handlers.management.api.authentication.provider
 import io.gravitee.am.management.handlers.management.api.authentication.service.AuthenticationService;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.service.EnvironmentService;
+import io.gravitee.node.api.configuration.Configuration;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,32 +52,8 @@ public class CockpitAuthenticationFilter extends GenericFilterBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(CockpitAuthenticationFilter.class);
     private static final String COCKPIT_SOURCE = "cockpit";
 
-    @Value("${cockpit.enabled:false}")
-    private boolean enabled;
-
-    /**
-     * Cockpit keystore type for client certificate (mtls) and jwt signature verification.
-     */
-    @Value("${cockpit.keystore.type:#{null}}")
-    private String keyStoreType;
-
-    /**
-     * Cockpit keystore path for client mtls and jwt.
-     */
-    @Value("${cockpit.keystore.path:#{null}}")
-    private String keyStorePath;
-
-    /**
-     * Cockpit keystore password.
-     */
-    @Value("${cockpit.keystore.password:#{null}}")
-    private String keyStorePassword;
-
-    /**
-     * Cockpit key alias.
-     */
-    @Value("${cockpit.keystore.key.alias:cockpit-client}")
-    private String keyAlias;
+    @Autowired
+    private Configuration configuration;
 
     @Autowired
     @Lazy
@@ -91,10 +67,8 @@ public class CockpitAuthenticationFilter extends GenericFilterBean {
 
     private JWTParser jwtParser;
 
-    @Override
-    public void afterPropertiesSet() {
-
-        if (enabled) {
+    private void initialize() {
+        if (enabled() && jwtParser == null) {
             try {
                 this.jwtParser = new DefaultJWTParser(this.getPublicKey());
             } catch (Exception e) {
@@ -125,17 +99,17 @@ public class CockpitAuthenticationFilter extends GenericFilterBean {
     private Key getPublicKey() throws Exception {
 
         final KeyStore trustStore = loadKeyStore();
-        final Certificate cert = trustStore.getCertificate(keyAlias);
+        final Certificate cert = trustStore.getCertificate(keyAlias());
 
         return cert.getPublicKey();
     }
 
     private KeyStore loadKeyStore() throws Exception {
 
-        final KeyStore keystore = KeyStore.getInstance(keyStoreType);
+        final KeyStore keystore = KeyStore.getInstance(keyStoreType());
 
-        try (InputStream is = new File(keyStorePath).toURI().toURL().openStream()) {
-            keystore.load(is, null == keyStorePassword ? null : keyStorePassword.toCharArray());
+        try (InputStream is = new File(keyStorePath()).toURI().toURL().openStream()) {
+            keystore.load(is, null == keyStorePassword() ? null : keyStorePassword().toCharArray());
         }
 
         return keystore;
@@ -143,11 +117,11 @@ public class CockpitAuthenticationFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(jakarta.servlet.ServletRequest request, jakarta.servlet.ServletResponse response, jakarta.servlet.FilterChain filterChain) throws IOException, jakarta.servlet.ServletException {
-
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-        if (enabled && httpRequest.getPathInfo().equals("/cockpit")) {
+        if (enabled() && httpRequest.getPathInfo().equals("/cockpit")) {
+            initialize();
 
             String token = request.getParameter("token");
 
@@ -162,8 +136,8 @@ public class CockpitAuthenticationFilter extends GenericFilterBean {
                     final Environment environment = environmentService.findById((String) jwt.get(Claims.environment), (String) jwt.get(Claims.organization)).blockingGet();
                     String redirectPath = "";
 
-                    if(environment != null) {
-                        redirectPath = "/environments/"+ environment.getHrids().get(0);
+                    if (environment != null) {
+                        redirectPath = "/environments/" + environment.getHrids().get(0);
                     }
 
                     Cookie jwtAuthenticationCookie = jwtGenerator.generateCookie(principal);
@@ -177,5 +151,37 @@ public class CockpitAuthenticationFilter extends GenericFilterBean {
         } else {
             filterChain.doFilter(request, response);
         }
+    }
+
+    private boolean enabled() {
+        return configuration.getProperty("cockpit.enabled", Boolean.class, false);
+    }
+
+    /**
+     * Cockpit keystore type for client certificate (mtls) and jwt signature verification.
+     */
+    private String keyStoreType() {
+        return configuration.getProperty("cockpit.keystore.type");
+    }
+
+    /**
+     * Cockpit keystore path for client mtls and jwt.
+     */
+    private String keyStorePath() {
+        return configuration.getProperty("cockpit.keystore.path");
+    }
+
+    /**
+     * Cockpit keystore password.
+     */
+    private String keyStorePassword() {
+        return configuration.getProperty("cockpit.keystore.password");
+    }
+
+    /**
+     * Cockpit key alias.
+     */
+    private String keyAlias() {
+        return configuration.getProperty("cockpit.keystore.key.alias", "cockpit-client");
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/provider/generator/JWTGenerator.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/provider/generator/JWTGenerator.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static io.gravitee.am.common.utils.ConstantKeys.DEFAULT_JWT_OR_CSRF_SECRET;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -44,6 +46,7 @@ public class JWTGenerator implements InitializingBean {
 
     public static final String AM_CLAIMS_ORG = "org";
     public static final String AM_CLAIMS_LOGINS = "login_count";
+    public static final String JWT_EXPIRE_AFTER_KEY = "jwt.expire-after";
 
     private final Logger LOGGER = LoggerFactory.getLogger(JWTGenerator.class);
 
@@ -81,13 +84,13 @@ public class JWTGenerator implements InitializingBean {
         cookie.setSecure(configuration.getProperty("jwt.cookie-secure", Boolean.class, DEFAULT_JWT_COOKIE_SECURE));
         cookie.setPath(configuration.getProperty("jwt.cookie-path", DEFAULT_JWT_COOKIE_PATH));
         cookie.setDomain(configuration.getProperty("jwt.cookie-domain", DEFAULT_JWT_COOKIE_DOMAIN));
-        cookie.setMaxAge(value == null ? 0 : configuration.getProperty("jwt.expire-after", Integer.class, DEFAULT_JWT_EXPIRE_AFTER));
+        cookie.setMaxAge(value == null ? 0 : configuration.getProperty(JWT_EXPIRE_AFTER_KEY, Integer.class, DEFAULT_JWT_EXPIRE_AFTER));
 
         return cookie;
     }
 
     public Cookie generateCookie(final User user) {
-        int expiresAfter = configuration.getProperty("jwt.expire-after", Integer.class, DEFAULT_JWT_EXPIRE_AFTER);
+        int expiresAfter = configuration.getProperty(JWT_EXPIRE_AFTER_KEY, Integer.class, DEFAULT_JWT_EXPIRE_AFTER);
         Date expirationDate = new Date(System.currentTimeMillis() + expiresAfter * 1000);
         String jwtToken  = generateToken(user, expirationDate);
 
@@ -98,7 +101,7 @@ public class JWTGenerator implements InitializingBean {
     }
 
     public Map<String, Object> generateToken(final User user) {
-        int expiresAfter = configuration.getProperty("jwt.expire-after", Integer.class, DEFAULT_JWT_EXPIRE_AFTER);
+        int expiresAfter = configuration.getProperty(JWT_EXPIRE_AFTER_KEY, Integer.class, DEFAULT_JWT_EXPIRE_AFTER);
         Date expirationDate = new Date(System.currentTimeMillis() + expiresAfter * 1000);
         String jwtToken  = generateToken(user, expirationDate);
 
@@ -144,7 +147,7 @@ public class JWTGenerator implements InitializingBean {
     @Override
     public void afterPropertiesSet() {
         //Warning if the secret is still the default one
-        if ("s3cR3t4grAv1t3310AMS1g1ingDftK3y".equals(signingKeySecret())) {
+        if (DEFAULT_JWT_OR_CSRF_SECRET.equals(signingKeySecret())) {
             LOGGER.warn("");
             LOGGER.warn("##############################################################");
             LOGGER.warn("#                      SECURITY WARNING                      #");
@@ -160,6 +163,6 @@ public class JWTGenerator implements InitializingBean {
     }
 
     private String signingKeySecret() {
-        return configuration.getProperty("jwt.secret", "s3cR3t4grAv1t3310AMS1g1ingDftK3y");
+        return configuration.getProperty("jwt.secret", DEFAULT_JWT_OR_CSRF_SECRET);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/EmailServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/EmailServiceImpl.java
@@ -47,6 +47,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -97,7 +98,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
             io.gravitee.am.service.EmailService emailService,
             Configuration freemarkerConfiguration,
             AuditService auditService,
-            @Qualifier("managementJwtBuilder") JWTBuilder jwtBuilder,
+            @Lazy @Qualifier("managementJwtBuilder") JWTBuilder jwtBuilder, // Need to be lazy loaded to ensure jwt builder is instantiated with all resolved configuration included eventual secrets.
             DomainService domainService,
             I18nDictionaryService i18nDictionaryService,
             @Value("${email.enabled:false}") boolean enabled,

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/NewsletterServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/NewsletterServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -54,6 +55,7 @@ public class NewsletterServiceImpl implements NewsletterService, InitializingBea
     @Autowired
     private ObjectMapper mapper;
 
+    @Lazy // Need to be lazy loaded to ensure webclient is instantiated with all resolved configuration included eventual secrets.
     @Autowired
     @Qualifier("newsletterWebClient")
     private WebClient client;

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/notifications/EmailNotifierConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/notifications/EmailNotifierConfiguration.java
@@ -52,7 +52,7 @@ public class EmailNotifierConfiguration {
         this.to = other.getTo();
         this.subject = other.getSubject();
         this.body = other.getBody();
-        this.startTLSEnabled = other.startTLSEnabled;
+        this.startTLSEnabled = other.isStartTLSEnabled();
         this.sslTrustAll = other.isSslTrustAll();
         this.sslKeyStore = other.getSslKeyStore();
         this.sslKeyStorePassword = other.getSslKeyStorePassword();
@@ -116,7 +116,7 @@ public class EmailNotifierConfiguration {
 
     public boolean isStartTLSEnabled() {
         if (configuration == null) {
-            return isStartTLSEnabled();
+            return startTLSEnabled;
         }
         return configuration.getProperty("notifiers.email.startTLSEnabled", Boolean.class, false);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/notifications/EmailNotifierConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/notifications/EmailNotifierConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.am.management.service.impl.notifications;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -24,34 +24,21 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class EmailNotifierConfiguration {
+    @Autowired
+    private io.gravitee.node.api.configuration.Configuration configuration;
 
-    @Value("${notifiers.email.host:#{null}}")
     private String host;
-    @Value("${notifiers.email.port:587}")
     private int port;
-    @Value("${notifiers.email.username:#{null}}")
     private String username;
-    @Value("${notifiers.email.password:#{null}}")
     private String password;
-
-    @Value("${notifiers.email.from:#{null}}")
     private String from;
-    @Value("${notifiers.email.to:#{null}}")
     private String to;
-    @Value("${notifiers.email.subject:#{null}}")
     private String subject;
-    @Value("${notifiers.email.body:#{null}}")
     private String body;
-
-    @Value("${notifiers.email.startTLSEnabled:false}")
     private boolean startTLSEnabled;
-    @Value("${notifiers.email.sslTrustAll:false}")
     private boolean sslTrustAll;
-    @Value("${notifiers.email.sslKeyStore:#{null}}")
     private String sslKeyStore;
-    @Value("${notifiers.email.sslKeyStorePassword:#{null}}")
     private String sslKeyStorePassword;
-
 
     public EmailNotifierConfiguration() {
     }
@@ -72,98 +59,118 @@ public class EmailNotifierConfiguration {
     }
 
     public String getHost() {
-        return host;
+        if (configuration == null) {
+            return host;
+        }
+        return configuration.getProperty("notifiers.email.host");
+    }
+
+    public int getPort() {
+        if (configuration == null) {
+            return port;
+        }
+        return configuration.getProperty("notifiers.email.port", Integer.class, 587);
+    }
+
+    public String getUsername() {
+        if (configuration == null) {
+            return username;
+        }
+        return configuration.getProperty("notifiers.email.username");
+    }
+
+    public String getPassword() {
+        if (configuration == null) {
+            return password;
+        }
+        return configuration.getProperty("notifiers.email.password");
+    }
+
+    public String getFrom() {
+        if (configuration == null) {
+            return from;
+        }
+        return configuration.getProperty("notifiers.email.from");
+    }
+
+    public String getTo() {
+        if (configuration == null) {
+            return to;
+        }
+        return configuration.getProperty("notifiers.email.to");
+    }
+
+    public String getSubject() {
+        if (configuration == null) {
+            return subject;
+        }
+        return configuration.getProperty("notifiers.email.subject");
+    }
+
+    public String getBody() {
+        if (configuration == null) {
+            return body;
+        }
+        return configuration.getProperty("notifiers.email.body");
+    }
+
+    public boolean isStartTLSEnabled() {
+        if (configuration == null) {
+            return isStartTLSEnabled();
+        }
+        return configuration.getProperty("notifiers.email.startTLSEnabled", Boolean.class, false);
+    }
+
+    public boolean isSslTrustAll() {
+        if (configuration == null) {
+            return sslTrustAll;
+        }
+        return configuration.getProperty("notifiers.email.sslTrustAll", Boolean.class, false);
+    }
+
+    public String getSslKeyStore() {
+        if (configuration == null) {
+            return sslKeyStore;
+        }
+        return configuration.getProperty("notifiers.email.sslKeyStore");
+    }
+
+    public String getSslKeyStorePassword() {
+        if (configuration == null) {
+            return sslKeyStorePassword;
+        }
+        return configuration.getProperty("notifiers.email.sslKeyStorePassword");
     }
 
     public void setHost(String host) {
         this.host = host;
     }
 
-    public int getPort() {
-        return port;
-    }
-
     public void setPort(int port) {
         this.port = port;
-    }
-
-    public String getUsername() {
-        return username;
     }
 
     public void setUsername(String username) {
         this.username = username;
     }
 
-    public String getPassword() {
-        return password;
-    }
-
     public void setPassword(String password) {
         this.password = password;
-    }
-
-    public String getFrom() {
-        return from;
     }
 
     public void setFrom(String from) {
         this.from = from;
     }
 
-    public String getTo() {
-        return to;
-    }
-
     public void setTo(String to) {
         this.to = to;
-    }
-
-    public String getSubject() {
-        return subject;
     }
 
     public void setSubject(String subject) {
         this.subject = subject;
     }
 
-    public String getBody() {
-        return body;
-    }
-
     public void setBody(String body) {
         this.body = body;
-    }
-
-    public boolean isStartTLSEnabled() {
-        return startTLSEnabled;
-    }
-
-    public void setStartTLSEnabled(boolean startTLSEnabled) {
-        this.startTLSEnabled = startTLSEnabled;
-    }
-
-    public boolean isSslTrustAll() {
-        return sslTrustAll;
-    }
-
-    public void setSslTrustAll(boolean sslTrustAll) {
-        this.sslTrustAll = sslTrustAll;
-    }
-
-    public String getSslKeyStore() {
-        return sslKeyStore;
-    }
-
-    public void setSslKeyStore(String sslKeyStore) {
-        this.sslKeyStore = sslKeyStore;
-    }
-
-    public String getSslKeyStorePassword() {
-        return sslKeyStorePassword;
-    }
-
-    public void setSslKeyStorePassword(String sslKeyStorePassword) {
-        this.sslKeyStorePassword = sslKeyStorePassword;
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/http/WebClientBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/http/WebClientBuilder.java
@@ -244,14 +244,14 @@ public class WebClientBuilder {
         return environment.getProperty("httpClient.proxy.https.password");
     }
 
-    private Boolean isProxyConfigured() {
+    private boolean isProxyConfigured() {
         return environment.getProperty(
                 "httpClient.proxy.enabled",
                 Boolean.class,
                 false);
     }
 
-    private Boolean isSSLEnabled() {
+    private boolean isSSLEnabled() {
         return environment.getProperty(
                 "httpClient.ssl.enabled",
                 Boolean.class,

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EmailServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EmailServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.am.service.i18n.FileSystemDictionaryProvider;
 import io.gravitee.am.service.utils.EmailSender;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +45,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
     private DictionaryProvider defaultDictionaryProvider;
     private DictionaryProvider dictionaryProvider;
 
-    public EmailServiceImpl(JavaMailSender mailSender, @Value("${templates.path:${gravitee.home}/templates}") String templatesPath) {
+    public EmailServiceImpl(@Lazy JavaMailSender mailSender, @Value("${templates.path:${gravitee.home}/templates}") String templatesPath) {
         this.mailSender = mailSender;
         this.templatesPath = templatesPath;
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/spring/JWTConfiguration.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/spring/JWTConfiguration.java
@@ -22,14 +22,13 @@ import io.gravitee.am.jwt.DefaultJWTParser;
 import io.gravitee.am.jwt.JWTBuilder;
 import io.gravitee.am.jwt.JWTParser;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 
-import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.Key;
+
+import static io.gravitee.am.common.utils.ConstantKeys.DEFAULT_JWT_OR_CSRF_SECRET;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -54,7 +53,7 @@ public class JWTConfiguration {
     }
 
     private String signingKeySecret(io.gravitee.node.api.configuration.Configuration configuration) {
-        return configuration.getProperty("jwt.secret", "s3cR3t4grAv1t3310AMS1g1ingDftK3y");
+        return configuration.getProperty("jwt.secret", DEFAULT_JWT_OR_CSRF_SECRET);
     }
 
     private String issuer(io.gravitee.node.api.configuration.Configuration configuration) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/spring/WebClientsConfiguration.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/spring/WebClientsConfiguration.java
@@ -21,6 +21,7 @@ import io.vertx.rxjava3.ext.web.client.WebClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -29,14 +30,9 @@ import java.net.URI;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Lazy
 @Configuration
 public class WebClientsConfiguration {
-
-    @Value("${reCaptcha.serviceUrl:https://www.google.com/recaptcha/api/siteverify}")
-    private String recaptchaServiceUrl;
-
-    @Value("${newsletter.url:https://newsletter.gravitee.io}")
-    private String newsletterURL;
 
     @Bean
     protected WebClientBuilder webClientBuilder() {
@@ -44,12 +40,14 @@ public class WebClientsConfiguration {
     }
 
     @Bean("recaptchaWebClient")
-    protected WebClient recaptchaWebClient(Vertx vertx, WebClientBuilder webClientBuilder) throws MalformedURLException {
+    protected WebClient recaptchaWebClient(Vertx vertx, WebClientBuilder webClientBuilder, io.gravitee.node.api.configuration.Configuration configuration) throws MalformedURLException {
+        final String recaptchaServiceUrl = configuration.getProperty("reCaptcha.serviceUrl", "https://www.google.com/recaptcha/api/siteverify");
         return webClientBuilder.createWebClient(vertx, URI.create(recaptchaServiceUrl).toURL());
     }
 
     @Bean("newsletterWebClient")
-    protected WebClient newsletterWebClient(Vertx vertx, WebClientBuilder webClientBuilder) throws MalformedURLException {
+    protected WebClient newsletterWebClient(Vertx vertx, WebClientBuilder webClientBuilder, io.gravitee.node.api.configuration.Configuration configuration) throws MalformedURLException {
+        final String newsletterURL =  configuration.getProperty("newsletter.url", "https://newsletter.gravitee.io");
         return webClientBuilder.createWebClient(vertx, URI.create(newsletterURL).toURL());
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/spring/email/EmailConfiguration.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/spring/email/EmailConfiguration.java
@@ -16,10 +16,6 @@
 package io.gravitee.am.service.spring.email;
 
 import io.gravitee.common.util.EnvironmentUtils;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -27,6 +23,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -58,14 +56,14 @@ public class EmailConfiguration {
     public JavaMailSender mailSender(io.gravitee.node.api.configuration.Configuration configuration) {
         this.configuration = configuration;
         final JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
-        javaMailSender.setHost(host());
+        javaMailSender.setHost(getHost());
         try {
-            javaMailSender.setPort(Integer.valueOf(this.port()));
+            javaMailSender.setPort(Integer.valueOf(getPort()));
         } catch (Exception e) {
         }
-        javaMailSender.setUsername(username());
-        javaMailSender.setPassword(password());
-        javaMailSender.setProtocol(protocol());
+        javaMailSender.setUsername(getUsername());
+        javaMailSender.setPassword(getPassword());
+        javaMailSender.setProtocol(getProtocol());
         javaMailSender.setJavaMailProperties(loadProperties());
         return javaMailSender;
     }
@@ -82,31 +80,31 @@ public class EmailConfiguration {
     }
 
     public String getHost() {
-        return host();
+        return configuration.getProperty("email.host" );
     }
 
     public String getPort() {
-        return port();
+        return configuration.getProperty("email.port");
     }
 
     public String getUsername() {
-        return username();
+        return configuration.getProperty("email.username");
     }
 
     public String getPassword() {
-        return password();
+        return configuration.getProperty("email.password");
     }
 
     public String getProtocol() {
-        return protocol();
+        return configuration.getProperty("email.protocol:smtp");
     }
 
     public String getFrom() {
-        return from();
+        return configuration.getProperty("email.from");
     }
 
     public boolean isEnabled() {
-        return enabled();
+        return Boolean.valueOf(configuration.getProperty("email.enabled", "false"));
     }
 
     public List<String> getAllowedFrom() {
@@ -147,31 +145,4 @@ public class EmailConfiguration {
 
     }
 
-    private Boolean enabled(){
-        return Boolean.valueOf(configuration.getProperty("email.enabled", "false"));
-    }
-
-    private String host(){
-        return configuration.getProperty("email.host" );
-    }
-
-    private String port(){
-        return configuration.getProperty("email.port");
-    }
-
-    private String username(){
-        return configuration.getProperty("email.username", "#{null}");
-    }
-
-    private String password(){
-        return configuration.getProperty("email.password", "#{null}");
-    }
-
-    private String protocol() {
-        return configuration.getProperty("email.protocol:smtp");
-    }
-
-    private String from(){
-        return configuration.getProperty("email.from");
-    }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/http/WebClientBuilderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/http/WebClientBuilderTest.java
@@ -24,7 +24,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -48,14 +47,16 @@ public class WebClientBuilderTest {
         io.vertx.core.Vertx vertDelegate = mock(io.vertx.core.Vertx.class);
         vertx = mock(Vertx.class);
         when(vertx.getDelegate()).thenReturn(vertDelegate);
-
+        lenient().when(environment.getProperty(anyString(), eq(Boolean.class), anyBoolean())).thenReturn(false);
+        lenient().when(environment.getProperty("httpClient.ssl.truststore.type")).thenReturn(null);
     }
 
     @Test
     public void shouldApplySSLOptions_trustAll() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", true);
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(true);
+
         webClientBuilder.createWebClient(vertx, webClientOptions);
 
         assertTrue(webClientOptions.isTrustAll());
@@ -64,9 +65,10 @@ public class WebClientBuilderTest {
     @Test
     public void shouldApplySSLOptions_invalidTrustStoreType() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", false);
-        ReflectionTestUtils.setField(webClientBuilder, "sslTrustStoreType", "unknown");
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(false);
+        when(environment.getProperty("httpClient.ssl.truststore.type")).thenReturn("unknown");
+
         webClientBuilder.createWebClient(vertx, webClientOptions);
 
         assertFalse(webClientOptions.isTrustAll());
@@ -78,9 +80,9 @@ public class WebClientBuilderTest {
     @Test
     public void shouldApplySSLOptions_jksTrustStore() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", false);
-        ReflectionTestUtils.setField(webClientBuilder, "sslTrustStoreType", "jks");
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(false);
+        when(environment.getProperty("httpClient.ssl.truststore.type")).thenReturn("jks");
         when(environment.getProperty("httpClient.ssl.truststore.path")).thenReturn("/truststore.jks");
         when(environment.getProperty("httpClient.ssl.truststore.password")).thenReturn("password");
         webClientBuilder.createWebClient(vertx, webClientOptions);
@@ -94,9 +96,9 @@ public class WebClientBuilderTest {
     @Test
     public void shouldApplySSLOptions_pfxTrustStore() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", false);
-        ReflectionTestUtils.setField(webClientBuilder, "sslTrustStoreType", "pkcs12");
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(false);
+        when(environment.getProperty("httpClient.ssl.truststore.type")).thenReturn("pkcs12");
         when(environment.getProperty("httpClient.ssl.truststore.path")).thenReturn("/truststore.p12");
         when(environment.getProperty("httpClient.ssl.truststore.password")).thenReturn("password");
         webClientBuilder.createWebClient(vertx, webClientOptions);
@@ -110,9 +112,9 @@ public class WebClientBuilderTest {
     @Test
     public void shouldApplySSLOptions_pemTrustStore() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", false);
-        ReflectionTestUtils.setField(webClientBuilder, "sslTrustStoreType", "pem");
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(false);
+        when(environment.getProperty("httpClient.ssl.truststore.type")).thenReturn("pem");
         when(environment.getProperty("httpClient.ssl.truststore.path")).thenReturn("/truststore.pem");
         webClientBuilder.createWebClient(vertx, webClientOptions);
 
@@ -125,9 +127,9 @@ public class WebClientBuilderTest {
     @Test
     public void shouldApplySSLOptions_invalidKeyStoreType() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", false);
-        ReflectionTestUtils.setField(webClientBuilder, "sslKeyStoreType", "unknown");
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(false);
+        when(environment.getProperty("httpClient.ssl.keystore.type")).thenReturn("unknown");
         webClientBuilder.createWebClient(vertx, webClientOptions);
 
         assertFalse(webClientOptions.isTrustAll());
@@ -139,9 +141,9 @@ public class WebClientBuilderTest {
     @Test
     public void shouldApplySSLOptions_jksKeyStore() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", false);
-        ReflectionTestUtils.setField(webClientBuilder, "sslKeyStoreType", "jks");
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(false);
+        when(environment.getProperty("httpClient.ssl.keystore.type")).thenReturn("jks");
         when(environment.getProperty("httpClient.ssl.keystore.path")).thenReturn("/keystore.jks");
         when(environment.getProperty("httpClient.ssl.keystore.password")).thenReturn("password");
         webClientBuilder.createWebClient(vertx, webClientOptions);
@@ -155,9 +157,9 @@ public class WebClientBuilderTest {
     @Test
     public void shouldApplySSLOptions_pfxKeyStore() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", false);
-        ReflectionTestUtils.setField(webClientBuilder, "sslKeyStoreType", "pkcs12");
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(false);
+        when(environment.getProperty("httpClient.ssl.keystore.type")).thenReturn("pkcs12");
         when(environment.getProperty("httpClient.ssl.keystore.path")).thenReturn("/keystore.p12");
         when(environment.getProperty("httpClient.ssl.keystore.password")).thenReturn("password");
         webClientBuilder.createWebClient(vertx, webClientOptions);
@@ -171,9 +173,9 @@ public class WebClientBuilderTest {
     @Test
     public void shouldApplySSLOptions_pemKeyStore() {
         WebClientOptions webClientOptions = new WebClientOptions();
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLEnabled", true);
-        ReflectionTestUtils.setField(webClientBuilder, "isSSLTrustAllEnabled", false);
-        ReflectionTestUtils.setField(webClientBuilder, "sslKeyStoreType", "pem");
+        when(environment.getProperty("httpClient.ssl.enabled", Boolean.class, false)).thenReturn(true);
+        when(environment.getProperty("httpClient.ssl.trustAll", Boolean.class, false)).thenReturn(false);
+        when(environment.getProperty("httpClient.ssl.keystore.type")).thenReturn("pem");
         when(environment.getProperty("httpClient.ssl.keystore.path")).thenReturn("/certificate.key");
         when(environment.getProperty("httpClient.ssl.keystore.keyPath")).thenReturn("/private.key");
         webClientBuilder.createWebClient(vertx, webClientOptions);

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/EmailDomainValidatorTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/EmailDomainValidatorTest.java
@@ -81,15 +81,6 @@ public class EmailDomainValidatorTest {
     }
 
     private EmailConfiguration getEmailConfiguration() {
-        return new EmailConfiguration(
-                true,
-                "localhost",
-                "12345",
-                "username",
-                "password",
-                "smtp",
-                "test@example.com",
-                environment
-        );
+        return new EmailConfiguration(environment);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
         <awaitility.version>4.2.0</awaitility.version>
         <gravitee-bom.version>6.0.14</gravitee-bom.version>
         <gravitee-common.version>2.1.0</gravitee-common.version>
-        <gravitee-plugin.version>2.0.2</gravitee-plugin.version>
-        <gravitee-node.version>4.2.0</gravitee-node.version>
+        <gravitee-plugin.version>2.2.0</gravitee-plugin.version>
+        <gravitee-node.version>4.6.1-archi-299-defer-resolve-values-SNAPSHOT</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <gravitee-bom.version>6.0.14</gravitee-bom.version>
         <gravitee-common.version>2.1.0</gravitee-common.version>
         <gravitee-plugin.version>2.2.0</gravitee-plugin.version>
-        <gravitee-node.version>4.6.1-archi-299-defer-resolve-values-SNAPSHOT</gravitee-node.version>
+        <gravitee-node.version>4.6.1</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
@@ -131,6 +131,7 @@
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-risk-assessment-api.version>2.0.0</gravitee-risk-assessment-api.version>
+        <gravitee-secretprovider-kubernetes.version>1.0.0-alpha.4</gravitee-secretprovider-kubernetes.version>
 
         <!-- EE plugin included in default bundle -->
         <gravitee-am-idp-saml2.version>3.0.0</gravitee-am-idp-saml2.version>


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/ARCHI-299

## :pencil2: A description of the changes proposed in the pull request

This PR defers some `@Value` resolutions that are susceptible to holding sensitive data and are eligible for secret injection. It also defers some bean instantiations for the same purpose (waiting for a proper global solution).

## :memo: Test scenarios 

This PR can be tested by enabling and configuring a Kubernetes secret provider. It can be achieved by specifying the following environment variables on both management and gateway:

```properties
gravitee_secrets_kubernetes_enabled=true
gravitee_secrets_kubernetes_namespace=graviteeio
```

You can create a Kubernetes secret with several entries representing some "sensitive" information such as jwt secret, keystore password, ..., ex:

```bash
kubectl create secret -n graviteeio generic am \
     --from-literal=jwt.secret=A_Very_Sensitive_JWT_Secret \
     --from-literal=services.core.http.auth.basic.password=A_Very_Sensitive_Password \
     --from-literal=jetty.ssl.keystore.password=secret \
     --from-literal=http.ssl.keystore.password=secret \
     --dry-run=client -o yaml | k apply -f -
```

⚠️ This is not an exhaustive list, further tests can be made (ex: recaptcha, csrf secret, MongoDB password, ...)

Then for the management rest API, a couple of secrets can be configured via environment variables:

```properties
# Protect the jwt secret using a k8s secret.
gravitee_jwt_secret=secret://kubernetes/am:jwt.secret

# Configure SSL on jetty and protect the password in a secret.
gravitee_jetty_secured=true
gravitee_jetty_ssl_keystore_password=secret://kubernetes/am:jetty.ssl.keystore.password
gravitee_jetty_ssl_keystore_path=localhost.p12
gravitee_jetty_ssl_keystore_type=PKCS12
```

A similar configuration can be made for the gateway:

```properties
# Configure SSL on Vertx and protect the password in a secret.
gravitee_http_secured=true
gravitee_http_ssl_keystore_password=secret://kubernetes/am:http.ssl.keystore.password
gravitee_http_ssl_keystore_path=localhost.p12
gravitee_http_ssl_keystore_type=PKCS12
```

You can use the following command to generate a localhost.p12 keystore:

```bash
openssl genrsa -out localhost.key 4096
openssl req -new -key localhost.key -out localhost.csr -sha256 -subj "/emailAddress=unit.tests@graviteesource.com/CN=localhost/OU=GraviteeSource/O=GraviteeSource/L=Lille/ST=France/C=FR"
openssl x509 -req -in localhost.csr -CA ca.pem -CAkey ca.key -set_serial 100 -extensions server -days 36500 -outform PEM -out localhost.cer -sha256 -passin pass:ca-secret
openssl pkcs12 -export -inkey localhost.key -in localhost.cer -out localhost.p12 -passout pass:secret -name localhost
```

## :computer: Add screenshots for UI

N/A

## :books: Any other comments that will help with documentation

It is necessary to educate people to use secrets only for sensitive configurations as resolving secrets may add extra cost during the startup phase.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

N/A