### PR TITLE
fix(helm): license deleted after helm upgrade

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -23,8 +23,7 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/am?modal=changelog
   artifacthub.io/changes: |
-    - Make optional HTTP2 request processing via `gateway.http.alpn` set at `true` by default.
     - Manage consent setting to log IP & User-Agent into the audits.
     - Allow users to define extra manifests
     - refactoring of email configuration now `smtp.email` and `api.notifiers.email` transpose helm values to `gravitee.yml` with some process to be backward compatible.
-
+    - 'fix: license deleted after helm upgrade'

--- a/helm/templates/common/licenses-secrets.yaml
+++ b/helm/templates/common/licenses-secrets.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "v1" "Secret" .Release.Namespace .Values.license.name) }}
 {{- with .Values.license }}
 {{- if .key }}
 apiVersion: v1
@@ -8,6 +7,5 @@ metadata:
 type: Opaque
 data:
   licensekey: {{ .key }}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/tests/api-configmap_test.yaml
+++ b/helm/tests/api-configmap_test.yaml
@@ -583,7 +583,10 @@ tests:
 
   - it: should set allowed from
     set:
-      smtp.enabled: true
+      smtp:
+        allowedfrom:
+          - email@from
+        enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -591,17 +594,18 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: "[ ]{2}allowedfrom:"
-      - matchRegex:
-          path: data.[gravitee.yml]
-          pattern: "[ ]{3}- \\$\\{email\\.from\\}"
+          pattern: " *email:\n
+                     *  allowedfrom:\n
+                     *  - email@from\n
+                     *  enabled: true"
 
   - it: should set allowed from with custom values
     set:
-      smtp.enabled: true
-      smtp.allowedfrom:
-        - "*@company.com"
-        - "specific@email.com"
+      smtp:
+        allowedfrom:
+          - '*@company.com'
+          - specific@email.com
+        enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -609,11 +613,9 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: "[ ]{2}allowedfrom:"
-      - matchRegex:
-          path: data.[gravitee.yml]
-          pattern: "[ ]{3}- '\\*@company\\.com'"
-      - matchRegex:
-          path: data.[gravitee.yml]
-          pattern: "[ ]{3}- specific@email\\.com"
+          pattern: " *email:\n
+                     *  allowedfrom:\n
+                     *  - '\\*@company\\.com'\n
+                     *  - specific@email\\.com\n
+                     *  enabled: true"
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -958,5 +958,5 @@ initContainers:
 
 # For enterprise plugin only, you will need a license
 license:
-  name: licensekey
+  name: licensekey-am
 #  key: <put here your license.key file encoded in base64>


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/DV-331

## :pencil2: A description of the changes proposed in the pull request

During an helm upgrade, the secret with gravitee license created
from `values.yml` entry: `license.key` is deleted.

It seems that the lookup implies that the ressource is not re-created,
however during the helm upgrade rotation it is deleted.

The fix consist on removing this lookup and by default name the secret
with component suffix. We set this suffix to allow specific use case
with multiple gravitee component on the same namespace (eg: AM+AE).

## :memo: Test scenarios 

1. Do an helm install on a new fresh namespace
2. proceed the upgrade
2.1 the secret is now named licensekey-am
2.2 the secret still exist after the upgrade

Bonus: this PR include a fix about previous failling test 😅.

