### PR TITLE
chore: Add changelog for new 3.21.12 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,28 @@
 # Change Log
 
+==  - 3.21.12 (2023-12-11)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Excessive number of ExpiredJWTException errors in Gravitee logs https://github.com/gravitee-io/issues/issues/9261[#9261]
+* Original Parameters lost during redirect using SAML Handler https://github.com/gravitee-io/issues/issues/9393[#9393]
+* Avoid to log GeoIP error stackstrace  https://github.com/gravitee-io/issues/issues/9401[#9401]
+
+=== Management API
+
+
+=== Console
+
+
+=== Other
+
+* Invalid value in Issuer for Response https://github.com/gravitee-io/issues/issues/9409[#9409]
+* Configuration files are beeing overwritten during yum update https://github.com/gravitee-io/issues/issues/9368[#9368]
+
 ==  - 3.20.16 (2023-12-11)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.12 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.12/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.12 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.12%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
