### PR TITLE
AM-1116: added license log notifier

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/LogNotificationService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/LogNotificationService.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl;
+
+import io.gravitee.am.model.safe.CertificateProperties;
+import io.gravitee.am.model.safe.DomainProperties;
+import io.gravitee.notifier.api.Notification;
+import io.gravitee.notifier.api.Notifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class LogNotificationService implements Notifier {
+    public static final String CERTIFICATE = "certificate";
+    public static final String DOMAIN = "domain";
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    public CompletableFuture<Void> send(Notification notification, Map<String, Object> map) {
+        final CertificateProperties certificate = (CertificateProperties) map.get(CERTIFICATE);
+        final String domainName = ((DomainProperties) map.get(DOMAIN)).getName();
+        final Date expiredDate = certificate.getExpiresAt();
+        final Instant now = Instant.now();
+
+        if (now.isAfter(expiredDate.toInstant())) {
+            logger.warn("Certificate '{}' of domain '{}' expired on '{}'.", certificate.getName(), domainName, expiredDate);
+        } else {
+            logger.warn("Certificate '{}' of domain '{}' is expiring on '{}'.", certificate.getName(), domainName, expiredDate);
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/notifications/LogNotifierFactoryImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/notifications/LogNotifierFactoryImpl.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.am.management.service.impl.notifications;
 
-import io.gravitee.am.management.service.UserNotificationService;
 import io.gravitee.am.management.service.impl.LogNotificationService;
 import io.gravitee.node.api.notifier.NotificationDefinition;
 import io.gravitee.node.notifier.plugin.impl.NotifierPluginFactoryImpl;
@@ -25,27 +24,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Optional;
 
 /**
- * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class PlatformNotifierPluginFactoryImpl extends NotifierPluginFactoryImpl {
-
-    @Autowired
-    private UserNotificationService userNotificationService;
+public class LogNotifierFactoryImpl extends NotifierPluginFactoryImpl {
 
     @Autowired
     private LogNotificationService logNotificationService;
 
     @Override
     public Optional<Notifier> create(NotificationDefinition notification) {
-        if (notification.getType().equals(NotificationDefinitionUtils.TYPE_UI_NOTIFIER)) {
-            return Optional.of(this.userNotificationService);
-        }
-
         if (notification.getType().equals(NotificationDefinitionUtils.TYPE_LOG_NOTIFIER)) {
             return Optional.of(logNotificationService);
         }
-
         return super.create(notification);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/notifications/NotificationDefinitionUtils.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/notifications/NotificationDefinitionUtils.java
@@ -34,6 +34,7 @@ import java.util.Map;
 public class NotificationDefinitionUtils {
     public static final String TYPE_UI_NOTIFIER = "ui-notifier";
     public static final String TYPE_EMAIL_NOTIFIER = "email-notifier";
+    public static final String TYPE_LOG_NOTIFIER = "log-notifier";
     public static final String RESOURCE_TYPE_CERTIFICATE = "certificate";
     public static final String NOTIFIER_DATA_USER = "user";
     public static final String NOTIFIER_DATA_DOMAIN = "domain";

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/LogNotificationServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/LogNotificationServiceTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl;
+
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.gravitee.am.model.Certificate;
+import io.gravitee.am.model.safe.CertificateProperties;
+import io.gravitee.am.model.safe.DomainProperties;
+import io.gravitee.notifier.api.Notification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class LogNotificationServiceTest {
+
+    @Mock
+    Certificate certificate;
+
+    @Mock
+    DomainProperties domainProperties;
+
+    private LogNotificationService service;
+    private ListAppender<ILoggingEvent> listAppender;
+    private Notification notification;
+    private Map<String, Object> map;
+
+    @BeforeEach
+    public void setUp() {
+        when(certificate.getId()).thenReturn("any-id");
+        when(certificate.getName()).thenReturn("TestCertificate");
+        when(certificate.getType()).thenReturn("Domain");
+        when(domainProperties.getName()).thenReturn("TestDomain");
+
+        Logger logger = (Logger) LoggerFactory.getLogger(LogNotificationService.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger .addAppender(listAppender);
+
+        notification = new Notification();
+        map = new HashMap<>();
+        map.put("domain", domainProperties);
+
+        service = new LogNotificationService();
+    }
+
+    @Test
+    void log_expired_certificate() {
+        when(certificate.getExpiresAt()).thenReturn(new Date());
+        final CertificateProperties certificateProperties = new CertificateProperties(certificate);
+        map.put("certificate", certificateProperties);
+
+        service.send(notification, map);
+
+        final ILoggingEvent event = listAppender.list.get(0);
+        assertEquals(Level.WARN, event.getLevel());
+        assertEquals("Certificate '{}' of domain '{}' expired on '{}'.", event.getMessage());
+        assertEquals(3, event.getArgumentArray().length);
+    }
+
+    @Test
+    void log_expiring_certificate() {
+        final Instant instant = Instant.now().plus(1, ChronoUnit.DAYS);
+        Date future = new Date(instant.toEpochMilli());
+        when(certificate.getExpiresAt()).thenReturn(future);
+        CertificateProperties certificateProperties = new CertificateProperties(certificate);
+        map.put("certificate", certificateProperties);
+
+        service.send(notification, map);
+
+        ILoggingEvent event = listAppender.list.get(0);
+        assertEquals(Level.WARN, event.getLevel());
+        assertEquals("Certificate '{}' of domain '{}' is expiring on '{}'.", event.getMessage());
+        assertEquals(3, event.getArgumentArray().length);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -224,7 +224,11 @@ notifiers:
     #sslKeyStore: /path/to/keystore
     #sslKeyStorePassword: changeme
   ui:
+    enabled: false
+
+  log:
     enabled: true
+
 
 domains:
   certificates:


### PR DESCRIPTION
### How to test

1. Change the cron expression for the certificate to `0 */1 * ? * *` to generate log per minute
2. Upload one expired and another about to expired certificate [please let me know if you need those certs]
3. Should be able to see AM console log entires such as below:

<img width="1529" alt="Screenshot 2023-12-18 at 12 35 20" src="https://github.com/gravitee-io/gravitee-access-management/assets/10583111/9cdfe226-cd91-4ead-a5e6-a58299bc7c4a">

4. There should be entry in the `notification_acknowledgements` collection for each certificate
