### PR TITLE
AM-1091: License notification in UI

### DIFF
--- a/docs/upgrades/3.x/3.20.0/1-licence-notification-permission.js
+++ b/docs/upgrades/3.x/3.20.0/1-licence-notification-permission.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+db.getCollection("roles").updateMany(
+    {
+        name: {$in: ["ORGANIZATION_PRIMARY_ONWER", "ORGANIZATION_OWNER"]},
+        "permissionAcls.LICENSE_NOTIFICATION": {$exists: false},
+    },
+    {
+        $set: {"permissionAcls.LICENSE_NOTIFICATION": ["READ"]},
+    }
+);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/platform/LicenseResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/platform/LicenseResource.java
@@ -16,7 +16,6 @@
 package io.gravitee.am.management.handlers.management.api.resources.platform;
 
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
-import io.gravitee.am.management.service.PermissionService;
 import io.gravitee.am.service.model.GraviteeLicense;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.node.api.license.License;

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/platform/LicenseResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/platform/LicenseResource.java
@@ -39,7 +39,7 @@ public class LicenseResource extends AbstractResource {
     @Autowired
     private LicenseManager licenseManager;
 
-    @Value("${notifiers.licenseExpiration.enabled:true}")
+    @Value("${license.expire-notification.enabled:true}")
     private boolean isLicenseExpirationNotifierEnabled = true;
 
     @GET

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -211,6 +211,10 @@ services:
     # Subject of the email send by the email notifier
     expiryEmailSubject: Certificate will expire soon
 
+license:
+  expire-notification:
+    enabled: true
+
 notifiers:
   email:
     enabled: false
@@ -223,8 +227,6 @@ notifiers:
     sslTrustAll: false
     #sslKeyStore: /path/to/keystore
     #sslKeyStorePassword: changeme
-  licenseExpiration:
-    enabled: true
   ui:
     enabled: false
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -223,6 +223,8 @@ notifiers:
     sslTrustAll: false
     #sslKeyStore: /path/to/keystore
     #sslKeyStorePassword: changeme
+  licenseExpiration:
+    enabled: true
   ui:
     enabled: false
 

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
@@ -90,8 +90,9 @@ public enum Permission {
     APPLICATION_RESOURCE(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN, ReferenceType.APPLICATION),
     APPLICATION_ANALYTICS(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN, ReferenceType.APPLICATION),
     APPLICATION_FLOW(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN, ReferenceType.APPLICATION),
+    LICENSE_NOTIFICATION(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN, ReferenceType.APPLICATION),
+    INSTALLATION(ReferenceType.ORGANIZATION);
 
-    INSTALLATION(ReferenceType.PLATFORM);
 
     List<ReferenceType> relevantTypes;
 

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
@@ -91,7 +91,7 @@ public enum Permission {
     APPLICATION_ANALYTICS(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN, ReferenceType.APPLICATION),
     APPLICATION_FLOW(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN, ReferenceType.APPLICATION),
     LICENSE_NOTIFICATION(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN, ReferenceType.APPLICATION),
-    INSTALLATION(ReferenceType.ORGANIZATION);
+    INSTALLATION(ReferenceType.PLATFORM);
 
 
     List<ReferenceType> relevantTypes;

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_3_0/4.3.0-license-notification-permission.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_3_0/4.3.0-license-notification-permission.yml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.3.0-license-notification-permission
+      author: GraviteeSource Team
+      changes:
+        # Add licence notification permission
+        ##############
+        - sql:
+            dbms: postgresql
+            sql: "UPDATE roles SET permission_acls = jsonb_set(cast(permission_acls as jsonb), '{LICENSE_NOTIFICATION}', '[\"READ\"]', true)  WHERE name in ('ORGANIZATION_PRIMARY_OWNER', 'ORGANIZATION_OWNER');"
+
+        - sql:
+            dbms: mysql, mariadb
+            sql: "UPDATE roles SET permission_acls = JSON_SET(permission_acls, '$.LICENSE_NOTIFICATION', JSON_ARRAY('READ')) WHERE name in ('ORGANIZATION_PRIMARY_OWNER', 'ORGANIZATION_OWNER');"
+
+        - sql:
+            dbms: mssql
+            sql: "UPDATE roles SET permission_acls = JSON_MODIFY(permission_acls, '$.LICENSE_NOTIFICATION', JSON_QUERY('[\"READ\"]', '$')) WHERE name in ('ORGANIZATION_PRIMARY_OWNER', 'ORGANIZATION_OWNER');"

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -117,3 +117,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_1_0/4.1.0-update-users-table.yml
   - include:
       - file: liquibase/changelogs/v4_2_0/4.2.0-update-applications-table.yml
+  - include:
+      - file: liquibase/changelogs/v4_3_0/4.3.0-license-notification-permission.yml

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RoleServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RoleServiceImpl.java
@@ -408,6 +408,7 @@ public class RoleServiceImpl implements RoleService {
         organizationPrimaryOwnerPermissions.put(Permission.ORGANIZATION_SETTINGS, Acl.of(READ, UPDATE));
         organizationPrimaryOwnerPermissions.put(Permission.ORGANIZATION_AUDIT, Acl.of(READ, LIST));
         organizationPrimaryOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ, LIST));
+        organizationPrimaryOwnerPermissions.put(Permission.LICENSE_NOTIFICATION, Acl.of(READ));
 
         environmentPrimaryOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ));
 
@@ -441,6 +442,7 @@ public class RoleServiceImpl implements RoleService {
         organizationOwnerPermissions.put(Permission.ORGANIZATION_SETTINGS, Acl.of(READ, UPDATE));
         organizationOwnerPermissions.put(Permission.ORGANIZATION_AUDIT, Acl.of(READ, LIST));
         organizationOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ, LIST));
+        organizationOwnerPermissions.put(Permission.LICENSE_NOTIFICATION, Acl.of(READ));
 
         environmentOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ));
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/GraviteeLicense.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/GraviteeLicense.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service.model;
 
+import java.util.Date;
 import java.util.Set;
 import lombok.*;
 
@@ -38,4 +39,6 @@ public class GraviteeLicense {
 
     @Builder.Default
     private Set<String> features = Set.of();
+
+    private Date expirationDate;
 }

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.html
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="gio-side-nav mat mat-typography mat-app-background">
   <gio-menu>
-    <gio-menu-header style="padding: 0 16px">
+    <gio-menu-header class="header">
       <gio-menu-selector
         *ngIf="canDisplayEnvironments()"
         [selectedItemValue]="currentEnvironment.id"
@@ -39,18 +39,18 @@
         <gio-menu-item [icon]="item.icon" [active]="rla.isActive" [iconRight]="item?.iconRight$ | async">{{ item.label }}</gio-menu-item>
       </a>
     </gio-menu-list>
-    <gio-menu-footer *ngIf="showExpirationMessage() && canDisplayOrganizationSettings()">
+    <gio-menu-footer *ngIf="canDisplayLicence() && showExpirationMessage()">
       <gio-menu-header>
         <div class="license" fxLayout="column" fxLayoutAlign="center" fxLayoutGap="10px">
           <div [style]="getLicenseColor()" class="license-message">
             {{ licenseExpirationMessage }}
           </div>
-          <div style="padding: 1px 10px 10px">
-            <div fxFlex="50%" style="color: #767676">Learn more</div>
+          <div class="license-bottom">
+            <div fxFlex="50%" class="license-learn-more">Learn more</div>
             <span class="material-icons"></span>
             <div fxFlex="50%" fxLayoutAlign="end start">
               <a href="https://www.gravitee.io/pricing" target="_blank">
-                <mat-icon style="border: 1px solid #767676; border-radius: 12px; color: #767676">navigate_next </mat-icon>
+                <mat-icon class="license-learn-more-icon">navigate_next</mat-icon>
               </a>
             </div>
           </div>

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.html
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="gio-side-nav mat mat-typography mat-app-background">
   <gio-menu>
-    <gio-menu-header>
+    <gio-menu-header style="padding: 0 16px">
       <gio-menu-selector
         *ngIf="canDisplayEnvironments()"
         [selectedItemValue]="currentEnvironment.id"
@@ -39,6 +39,29 @@
         <gio-menu-item [icon]="item.icon" [active]="rla.isActive" [iconRight]="item?.iconRight$ | async">{{ item.label }}</gio-menu-item>
       </a>
     </gio-menu-list>
+    <gio-menu-footer *ngIf="showExpirationMessage() && canDisplayOrganizationSettings()">
+      <gio-menu-header>
+        <div
+          style="background-color: white; border-radius: 10px; align-self: flex-end"
+          fxLayout="column"
+          fxLayoutAlign="center"
+          fxLayoutGap="10px"
+        >
+          <div [style]="getLicenseColor() + 'padding: 10px; border-top-left-radius: 9px; border-top-right-radius: 9px;'">
+            {{ licenseExpirationMessage }}
+          </div>
+          <div style="padding: 1px 10px 10px">
+            <div fxFlex="50%" style="color: #767676">Learn more</div>
+            <span class="material-icons"></span>
+            <div fxFlex="50%" fxLayoutAlign="end start">
+              <a href="https://www.gravitee.io/pricing" target="_blank">
+                <mat-icon style="border: 1px solid #767676; border-radius: 12px; color: #767676">navigate_next </mat-icon>
+              </a>
+            </div>
+          </div>
+        </div>
+      </gio-menu-header>
+    </gio-menu-footer>
     <gio-menu-footer *ngIf="canDisplayOrganizationSettings()">
       <a *ngFor="let item of footerMenuItems" [routerLink]="item.path" [matTooltip]="item.tooltip" [matTooltipPosition]="'right'">
         <gio-menu-item [icon]="item.icon">{{ item.label }}</gio-menu-item>

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.html
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.html
@@ -41,13 +41,8 @@
     </gio-menu-list>
     <gio-menu-footer *ngIf="showExpirationMessage() && canDisplayOrganizationSettings()">
       <gio-menu-header>
-        <div
-          style="background-color: white; border-radius: 10px; align-self: flex-end"
-          fxLayout="column"
-          fxLayoutAlign="center"
-          fxLayoutGap="10px"
-        >
-          <div [style]="getLicenseColor() + 'padding: 10px; border-top-left-radius: 9px; border-top-right-radius: 9px;'">
+        <div class="license" fxLayout="column" fxLayoutAlign="center" fxLayoutGap="10px">
+          <div [style]="getLicenseColor()" class="license-message">
             {{ licenseExpirationMessage }}
           </div>
           <div style="padding: 1px 10px 10px">

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.scss
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.scss
@@ -6,3 +6,7 @@
 a {
   text-decoration: none;
 }
+
+:host ::ng-deep.gio-menu-header {
+  padding: 0 !important;
+}

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.scss
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.scss
@@ -7,6 +7,10 @@ a {
   text-decoration: none;
 }
 
+.header {
+  padding: 0 16px;
+}
+
 .license {
   background-color: white;
   border-radius: 10px;
@@ -16,6 +20,20 @@ a {
   padding: 10px;
   border-top-left-radius: 9px;
   border-top-right-radius: 9px;
+}
+
+.license-bottom {
+  padding: 1px 10px 10px;
+}
+
+.license-learn-more {
+  color: #767676;
+}
+
+.license-learn-more-icon {
+  border: 1px solid #767676;
+  border-radius: 12px;
+  color: #767676;
 }
 
 :host ::ng-deep.gio-menu-header {

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.scss
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.scss
@@ -27,13 +27,13 @@ a {
 }
 
 .license-learn-more {
-  color: #767676;
+  color: #44435a;
 }
 
 .license-learn-more-icon {
   border: 1px solid #767676;
   border-radius: 12px;
-  color: #767676;
+  color: #44435a;
 }
 
 :host ::ng-deep.gio-menu-header {

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.scss
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.scss
@@ -7,6 +7,17 @@ a {
   text-decoration: none;
 }
 
+.license {
+  background-color: white;
+  border-radius: 10px;
+}
+
+.license-message {
+  padding: 10px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+}
+
 :host ::ng-deep.gio-menu-header {
   padding: 0 !important;
 }

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.ts
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.ts
@@ -128,6 +128,10 @@ export class SidenavComponent implements OnInit, OnDestroy {
     return this.environments && this.environments.length > 0 && !this.router.url.startsWith('/settings');
   }
 
+  canDisplayLicence(): boolean {
+    return !this.router.url.startsWith('/settings') && this.authService.hasPermissions(['license_notification_read']);
+  }
+
   canDisplayOrganizationSettings(): boolean {
     return !this.router.url.startsWith('/settings') && this.authService.hasPermissions(['organization_settings_read']);
   }

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.ts
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.ts
@@ -97,7 +97,7 @@ export class SidenavComponent implements OnInit, OnDestroy {
   }
 
   getLicenseColor(): string {
-    if (this.expirationDays === undefined || this.expirationDays > 30) {
+    if (this.expirationDays === undefined) {
       return '';
     } else if (this.expirationDays > 15) {
       return 'color: #0482c7; background-color: #E7F8FF;';

--- a/gravitee-am-ui/src/app/components/sidenav/sidenav.component.ts
+++ b/gravitee-am-ui/src/app/components/sidenav/sidenav.component.ts
@@ -87,7 +87,7 @@ export class SidenavComponent implements OnInit, OnDestroy {
       if (this.expirationDays > 0) {
         this.licenseExpirationMessage = `Your license will expire in ${this.expirationDays} days`;
       } else {
-        this.licenseExpirationMessage = `Your license is expired`;
+        this.licenseExpirationMessage = `Your license has expired`;
       }
     }
   }
@@ -102,9 +102,9 @@ export class SidenavComponent implements OnInit, OnDestroy {
     } else if (this.expirationDays > 15) {
       return 'color: #0482c7; background-color: #E7F8FF;';
     } else if (this.expirationDays > 0) {
-      return 'color: #ebe175; background-color: #8f8301;';
+      return 'color: #9C4626; background-color: #FDEDE5;';
     } else {
-      return 'color: red; background-color: black;';
+      return 'color: #9E2C64; background-color: #FDE9F4;';
     }
   }
 
@@ -129,7 +129,7 @@ export class SidenavComponent implements OnInit, OnDestroy {
   }
 
   canDisplayLicence(): boolean {
-    return !this.router.url.startsWith('/settings') && this.authService.hasPermissions(['license_notification_read']);
+    return this.authService.hasPermissions(['license_notification_read']);
   }
 
   canDisplayOrganizationSettings(): boolean {


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-1091

## :pencil2: A description of the changes proposed in the pull request
The information is present when the license expires in 30 days and the user has "license_notification_read". Frontend mocks are not ready at the moment. 


## :computer: Add screenshots for UI
29 days
![Screenshot from 2024-01-05 09-21-53](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/e0492347-e3bc-4eb5-8e9c-3a93df9b7a5b)

12 days
![Screenshot from 2024-01-05 09-21-46](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/f9a822b6-64cf-4fbf-838d-204401da52b3)

expired
![Screenshot from 2024-01-05 09-21-34](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/6c46036c-32c7-4bb9-ba86-4590a0d45012)

when the menu is collapsed
![Screenshot from 2024-01-02 09-41-40](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/50d1201c-fad6-4bef-abe7-e3c464888c28)

permission to see the license 
![image](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/8f309774-d359-4813-a5be-607ee12f5512)



