### PR TITLE
AM-1085: bug fixed by implementing same behaviour in different scenarios

### DIFF
--- a/gravitee-am-ui/src/app/domain/applications/application/overview/overview.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/overview/overview.component.html
@@ -264,10 +264,8 @@ curl -X GET \
           <h2>Call your APIs</h2>
           <p>Use your access_token in your request via the Authorization HTTP header to obtain authorized access to the APIs.</p>
           <div class="code">
-            <pre class="multiline">
-curl -X GET \
-  https://api.gravitee.io/api/v1/data \
->>>>>>> 12c6efa872 (AM-688: Do not refer to company.com (#3275))
+            <pre class="multiline">curl -X GET \
+  https://api.mycompany.com/api/v1/data \
   -H 'Authorization: Bearer access_token'
             </pre>
           </div>


### PR DESCRIPTION
### How to test

1. Create a B2B application and send a request to the authorize endpoint with a redirect uri such as [http://localhost:8092/domain/oauth/authorize?client_id=XXXredirect_uri=https%3A%2F%2Fgoogle.co.uk]
2. The response shouldn't redirect to the site mentioned in the redirect_uri
3. Now create a Web application with a redirect uri. 
4. Change the Web application to a B2B application.
5. Send a request to the authorize endpoint.
6. The outcome should be exactly as mentioned in 2. The response won't redirect and error msg should be same.