### PR TITLE
feat: load boot plugins

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -452,7 +452,7 @@ jobs:
             # Prepare AM
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
-            export AM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
             curl https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
@@ -480,7 +480,7 @@ jobs:
             # Start AM Gateway
             gravitee-am-gateway-standalone-${AM_VERSION}/bin/gravitee &
             # build & start CIBA Delegated Service
-            mvn -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
+            mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
             sleep 30
             # Wait for AM to be up and running
@@ -537,7 +537,7 @@ jobs:
             # Prepare AM
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
-            export AM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
             curl https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
@@ -596,7 +596,7 @@ jobs:
             # Start AM Gateway
             gravitee-am-gateway-standalone-${AM_VERSION}/bin/gravitee &
             # build & start CIBA Delegated Service
-            mvn -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
+            mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
             sleep 30
             # Wait for AM to be up and running
@@ -640,7 +640,7 @@ jobs:
             # Prepare AM
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
-            export AM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
             curl https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
@@ -658,7 +658,7 @@ jobs:
             # Start AM Gateway
             gravitee-am-gateway-standalone-${AM_VERSION}/bin/gravitee &
             # build & start CIBA Delegated Service
-            mvn -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
+            mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
             sleep 30
             # Wait for AM to be up and running
@@ -704,7 +704,7 @@ jobs:
             # Prepare AM
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
-            export AM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
             curl https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
@@ -751,7 +751,7 @@ jobs:
             # Start AM Gateway
             gravitee-am-gateway-standalone-${AM_VERSION}/bin/gravitee &
             # build & start CIBA Delegated Service
-            mvn -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
+            mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
             sleep 30
             # Wait for AM to be up and running
@@ -781,7 +781,7 @@ jobs:
       - run:
           name: Build
           command: |
-            mvn install -pl \!gravitee-am-ui -Pcicd -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
+            mvn install -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
       - save-maven-job-cache:
           jobName: run_testcontainer_tests
   publish-images-azure-registry:
@@ -1023,7 +1023,7 @@ jobs:
       - run:
           name: Maven Package
           command: |
-            export AM_VERSION=$(mvn -U -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            export AM_VERSION=$(mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot -U -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
             echo $AM_VERSION > am.version
             echo $AM_VERSION
             mvn -s /tmp/.gravitee.settings.xml verify -pl \!gravitee-am-ui
@@ -1048,7 +1048,7 @@ jobs:
       - run:
           name: Maven Package
           command: |
-            export AM_VERSION=$(mvn -U -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+            export AM_VERSION=$(mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot -U -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
             echo $AM_VERSION > gravitee-am-ui/am.version
             echo $AM_VERSION
       - persist_to_workspace:

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
@@ -38,15 +38,11 @@ import io.gravitee.am.plugins.protocol.spring.ProtocolSpringConfiguration;
 import io.gravitee.am.plugins.reporter.spring.ReporterSpringConfiguration;
 import io.gravitee.am.plugins.resource.spring.ResourceSpringConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.api.cluster.ClusterManager;
-import io.gravitee.node.certificates.spring.NodeCertificatesConfiguration;
-import io.gravitee.node.container.NodeFactory;
 import io.gravitee.node.plugin.cluster.standalone.StandaloneClusterManager;
-import io.gravitee.node.vertx.spring.VertxConfiguration;
 import io.gravitee.platform.repository.api.RepositoryScopeProvider;
-import io.gravitee.plugin.alert.spring.AlertPluginConfiguration;
-import io.gravitee.plugin.core.spring.PluginConfiguration;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.jackson.DatabindCodec;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,30 +56,26 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @Import({
-        VertxConfiguration.class,
         ReactorConfiguration.class,
         VertxServerConfiguration.class,
-        PluginConfiguration.class,
         IdentityProviderSpringConfiguration.class,
         CertificateSpringConfiguration.class,
         ExtensionGrantSpringConfiguration.class,
         ReporterSpringConfiguration.class,
         ProtocolSpringConfiguration.class,
         PolicySpringConfiguration.class,
-        AlertPluginConfiguration.class,
         FactorSpringConfiguration.class,
         ResourceSpringConfiguration.class,
         BotDetectionSpringConfiguration.class,
         DeviceIdentifierSpringConfiguration.class,
         PasswordDictionaryConfiguration.class,
         AuthenticationDeviceNotifierSpringConfiguration.class,
-        NodeCertificatesConfiguration.class
 })
 public class StandaloneConfiguration {
 
     @Bean
-    public NodeFactory node() {
-        return new NodeFactory(GatewayNode.class);
+    public Node node() {
+        return new GatewayNode();
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/GraviteeVerticle.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/GraviteeVerticle.java
@@ -16,9 +16,7 @@
 package io.gravitee.am.gateway.vertx;
 
 import io.gravitee.am.gateway.reactor.Reactor;
-import io.gravitee.node.management.http.vertx.configuration.HttpServerConfiguration;
 import io.gravitee.node.vertx.server.http.VertxHttpServer;
-import io.gravitee.node.vertx.server.http.VertxHttpServerOptions;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.rxjava3.core.http.HttpServer;
@@ -36,13 +34,11 @@ public class GraviteeVerticle extends AbstractVerticle {
 
     private final VertxHttpServer vertxHttpServer;
     private final Reactor reactor;
-    private final VertxHttpServerOptions httpServerConfiguration;
     private HttpServer httpServer;
 
-    public GraviteeVerticle(VertxHttpServer vertxHttpServer, Reactor reactor, VertxHttpServerOptions httpServerConfiguration) {
+    public GraviteeVerticle(VertxHttpServer vertxHttpServer, Reactor reactor) {
         this.vertxHttpServer = vertxHttpServer;
         this.reactor = reactor;
-        this.httpServerConfiguration = httpServerConfiguration;
     }
 
     @Override
@@ -53,8 +49,7 @@ public class GraviteeVerticle extends AbstractVerticle {
         httpServer.rxListen()
                 .subscribe(
                         httpServer1 -> {
-                            logger.info("HTTP Server is now listening for requests on port {}",
-                                    httpServerConfiguration.getPort());
+                            logger.info("HTTP Server is now listening for requests on port {}", vertxHttpServer.options().getPort());
                             startPromise.complete();
                         },
                         throwable -> {

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/node/ManagementNode.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/node/ManagementNode.java
@@ -56,7 +56,7 @@ public class ManagementNode extends JettyNode {
 
     @Override
     public Map<String, Object> metadata() {
-        if(metadata == null) {
+        if (metadata == null) {
             metadata = nodeMetadataResolver.resolve();
         }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/spring/StandaloneConfiguration.java
@@ -35,14 +35,13 @@ import io.gravitee.am.plugins.resource.spring.ResourceSpringConfiguration;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.event.impl.EventManagerImpl;
 import io.gravitee.el.ExpressionLanguageInitializer;
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.node.certificates.spring.NodeCertificatesConfiguration;
-import io.gravitee.node.container.NodeFactory;
 import io.gravitee.node.plugin.cluster.standalone.StandaloneClusterManager;
 import io.gravitee.node.vertx.spring.VertxConfiguration;
 import io.gravitee.platform.repository.api.RepositoryScopeProvider;
-import io.gravitee.plugin.alert.spring.AlertPluginConfiguration;
 import io.gravitee.plugin.core.spring.PluginConfiguration;
 import io.vertx.rxjava3.core.Vertx;
 import org.springframework.context.annotation.Bean;
@@ -70,7 +69,6 @@ import org.springframework.context.annotation.Import;
         NotifierConfiguration.class,
         FactorSpringConfiguration.class,
         ResourceSpringConfiguration.class,
-        AlertPluginConfiguration.class,
         BotDetectionSpringConfiguration.class,
         DeviceIdentifierSpringConfiguration.class,
         PasswordDictionaryConfiguration.class,
@@ -85,8 +83,8 @@ public class StandaloneConfiguration {
     }
 
     @Bean
-    public NodeFactory node() {
-        return new NodeFactory(ManagementNode.class);
+    public Node node() {
+        return new ManagementNode();
     }
 
     @Bean

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-notifier/src/main/java/io/gravitee/am/plugins/notifier/spring/NotifierConfiguration.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-notifier/src/main/java/io/gravitee/am/plugins/notifier/spring/NotifierConfiguration.java
@@ -16,17 +16,14 @@
 package io.gravitee.am.plugins.notifier.spring;
 
 import io.gravitee.am.plugins.notifier.core.NotifierPluginManager;
-import io.gravitee.plugin.notifier.spring.NotifierPluginConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Configuration
-@Import(NotifierPluginConfiguration.class)
 public class NotifierConfiguration {
 
     @Bean

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-policy/src/main/java/io/gravitee/am/plugins/policy/spring/PolicySpringConfiguration.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-policy/src/main/java/io/gravitee/am/plugins/policy/spring/PolicySpringConfiguration.java
@@ -19,17 +19,14 @@ import io.gravitee.am.plugins.handlers.api.core.ConfigurationFactory;
 import io.gravitee.am.plugins.handlers.api.core.impl.ConfigurationFactoryImpl;
 import io.gravitee.am.plugins.policy.core.PolicyPluginManager;
 import io.gravitee.am.plugins.policy.core.impl.PolicyPluginManagerImpl;
-import io.gravitee.plugin.policy.spring.PolicyPluginConfiguration;
 import io.gravitee.policy.api.PolicyConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Import(PolicyPluginConfiguration.class)
 @Configuration
 public class PolicySpringConfiguration {
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,14 +75,14 @@
         <awaitility.version>4.2.0</awaitility.version>
         <gravitee-bom.version>6.0.14</gravitee-bom.version>
         <gravitee-common.version>2.1.0</gravitee-common.version>
-        <gravitee-plugin.version>2.2.0</gravitee-plugin.version>
-        <gravitee-node.version>5.0.0</gravitee-node.version>
+        <gravitee-plugin.version>3.0.0</gravitee-plugin.version>
+        <gravitee-node.version>5.3.1</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
-        <gravitee-kubernetes-client-version>3.0.2</gravitee-kubernetes-client-version>
+        <gravitee-kubernetes-client-version>3.1.0</gravitee-kubernetes-client-version>
         <nimbus.version>9.31</nimbus.version>
         <logback.version>1.4.14</logback.version>
         <json-smart.version>2.5.0</json-smart.version>


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/ARCHI-297

## :pencil2: A description of the changes proposed in the pull request

This PR upgrades `gravitee-node` and `gravitee-plugin` and brings the required adaptations to allow for loading plugins in 2 steps, first, the boot plugins such as the secret provider plugins, and second, the rest of the plugins. This allows for a wider support of secret resolution during startup.

## :memo: Test scenarios 

This PR can be tested by enabling and configuring a Kubernetes secret provider. It can be achieved by specifying the following environment variables on both management and gateway:

```properties
gravitee_secrets_kubernetes_enabled=true
gravitee_secrets_kubernetes_namespace=graviteeio
```

You can create a Kubernetes secret with several entries representing some "sensitive" information such as jwt secret, keystore password, ..., ex:

```bash
kubectl create secret -n graviteeio generic am \
     --from-literal=jwt.secret=A_Very_Sensitive_JWT_Secret \
     --from-literal=services.core.http.auth.basic.password=A_Very_Sensitive_Password \
     --from-literal=jetty.ssl.keystore.password=secret \
     --from-literal=http.ssl.keystore.password=secret \
     --dry-run=client -o yaml | k apply -f -
```

⚠️ This is not an exhaustive list, further tests can be made (ex: recaptcha, csrf secret, MongoDB password, ...)

Then for the management rest API, a couple of secrets can be configured via environment variables:

```properties
# Protect the jwt secret using a k8s secret.
gravitee_jwt_secret=secret://kubernetes/am:jwt.secret

# Configure SSL on jetty and protect the password in a secret.
gravitee_jetty_secured=true
gravitee_jetty_ssl_keystore_password=secret://kubernetes/am:jetty.ssl.keystore.password
gravitee_jetty_ssl_keystore_path=localhost.p12
gravitee_jetty_ssl_keystore_type=PKCS12
```

A similar configuration can be made for the gateway:

```properties
# Configure SSL on Vertx and protect the password in a secret.
gravitee_http_secured=true
gravitee_http_ssl_keystore_password=secret://kubernetes/am:http.ssl.keystore.password
gravitee_http_ssl_keystore_path=localhost.p12
gravitee_http_ssl_keystore_type=PKCS12
```

You can use the following command to generate a localhost.p12 keystore:

```bash
openssl genrsa -out localhost.key 4096
openssl req -new -key localhost.key -out localhost.csr -sha256 -subj "/emailAddress=unit.tests@graviteesource.com/CN=localhost/OU=GraviteeSource/O=GraviteeSource/L=Lille/ST=France/C=FR"
openssl x509 -req -in localhost.csr -CA ca.pem -CAkey ca.key -set_serial 100 -extensions server -days 36500 -outform PEM -out localhost.cer -sha256 -passin pass:ca-secret
openssl pkcs12 -export -inkey localhost.key -in localhost.cer -out localhost.p12 -passout pass:secret -name localhost
```

## :computer: Add screenshots for UI

N/A

## :books: Any other comments that will help with documentation

N/A

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

N/A