### PR TITLE
chore: Add changelog for new 3.21.14 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,19 @@
 # Change Log
 
+== AM - 3.21.14 (2024-01-19)
+
+== What's new !
+
+=== Gateway
+
+* Avoid BodyHandler processing for GET request https://github.com/gravitee-io/issues/issues/9352[#9352]
+
+=== Management API
+
+=== Console
+
+=== Other
+
 == AM - 3.21.13 (2023-12-22)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.14 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.14/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.14 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.14%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
