### PR TITLE
chore: update release note generation script

### DIFF
--- a/release/helpers/changelog-helper.mjs
+++ b/release/helpers/changelog-helper.mjs
@@ -2,17 +2,17 @@
  * Get the MarkDown doc formatted changelog for input issues
  *
  * @param title {string}
- * @param issues {Array<{id: string, key: string, githubIssue: string, summary: string, components: Array<string>, issueTypeName: string, statusName: string}>}
+ * @param issues {Array<{id: string, key: string, githubIssue: string, summary: string, components: Array<string>, issueTypeName: string, statusKey: string}>}
  */
 export function getChangelogFor(title, issues) {
-  const authorizedIssueTypes = ['Public Bug', 'Public Security', 'Story'];
+  const authorizedIssueTypes = ['Public Bug', 'Public Security', 'Public Improvement', 'Story'];
 
   const filteredIssues = issues
     .filter((issue) => {
       return !!issue.issueTypeName && authorizedIssueTypes.includes(issue.issueTypeName);
     })
     .filter((issue) => {
-      return issue.statusName === 'Done';
+      return issue.statusKey === 'done';
     })
     .sort((issue1, issue2) => {
       // if null or undefined, put it at the end

--- a/release/helpers/jira-helper.mjs
+++ b/release/helpers/jira-helper.mjs
@@ -29,7 +29,7 @@ export function getJiraVersion(versionName) {
 /**
  * Get all Jira issues associated to the given version id
  * @param versionId {string} The version id
- * @returns {Promise<Array<{id: string, key: string, githubIssue: string, summary: string, components: Array<string>, issueTypeName: string, statusName: string}>>}
+ * @returns {Promise<Array<{id: string, key: string, githubIssue: string, summary: string, components: Array<string>, issueTypeName: string, statusKey: string}>>}
  */
 export async function getJiraIssuesOfVersion(versionId) {
   const token = process.env.JIRA_TOKEN;
@@ -51,7 +51,7 @@ export async function getJiraIssuesOfVersion(versionId) {
     summary: issue.fields.summary,
     components: issue.fields.components,
     issueTypeName: issue.fields.issuetype.name,
-    statusName: issue.fields.status.name,
+    statusKey: issue.fields.status.statusCategory.key,
   }));
 
   // For each issue with empty githubIssue field, get the remote link and extract the GitHub issue number


### PR DESCRIPTION
Improve Release Note generation script:

* avoid filtering on JIRA issue status (the value depend of the language preferences of the account used to generate the token, so it may not be Done but for example Terminé(e) in french)
* addition of "Public Improvement" as issue to include into the release note