### PR TITLE
AM-2154: add retries in pipeline

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -482,11 +482,9 @@ jobs:
             # build & start CIBA Delegated Service
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
-            sleep 50
             # Wait for AM to be up and running
-            timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
-            timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
-            sleep 50
+            timeout 120s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
+            timeout 120s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
             # Run Jest tests
             npm --prefix gravitee-am-test run ci
       - keeper/env-export:
@@ -598,11 +596,9 @@ jobs:
             # build & start CIBA Delegated Service
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
-            sleep 50
             # Wait for AM to be up and running
-            timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
-            timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
-            sleep 50
+            timeout 120s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
+            timeout 120s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
             # Run Jest tests
             npm --prefix gravitee-am-test run ci
       - keeper/env-export:
@@ -660,11 +656,9 @@ jobs:
             # build & start CIBA Delegated Service
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
-            sleep 50
             # Wait for AM to be up and running
-            timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
-            timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
-            sleep 50
+            timeout 120s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
+            timeout 120s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
             # Run Postman tests with retry
             N=2
             while [ $N -gt 0 ]
@@ -765,11 +759,9 @@ jobs:
             # build & start CIBA Delegated Service
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
-            sleep 50
             # Wait for AM to be up and running
-            timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
-            timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
-            sleep 50
+            timeout 120s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
+            timeout 120s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
             # Run Postman tests with retry
             N=2
             while [ $N -gt 0 ]

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -482,13 +482,25 @@ jobs:
             # build & start CIBA Delegated Service
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
-            sleep 30
+            sleep 50
             # Wait for AM to be up and running
             timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
             timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
-            sleep 30
-            # Run Jest tests
-            npm --prefix gravitee-am-test run ci
+            sleep 50
+            # Run Jest tests with retry
+            N=2
+            while [ $N -gt 0 ]
+            do
+              if $(npm --prefix gravitee-am-test run ci); then 
+                echo "Completed"
+                exit 0
+              fi
+
+              echo "Retrying postman tests"
+              N=$(( $N - 1 ))
+              sleep 10
+            done
+            exit 1
       - keeper/env-export:
           secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
           var-name: SLACK_ACCESS_TOKEN
@@ -598,13 +610,25 @@ jobs:
             # build & start CIBA Delegated Service
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
-            sleep 30
+            sleep 50
             # Wait for AM to be up and running
             timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
             timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
-            sleep 30
-            # Run Jest tests
-            npm --prefix gravitee-am-test run ci
+            sleep 50
+            # Run Jest tests with retry
+            N=2
+            while [ $N -gt 0 ]
+            do
+              if $(npm --prefix gravitee-am-test run ci); then 
+                echo "Completed"
+                exit 0
+              fi
+
+              echo "Retrying postman tests"
+              N=$(( $N - 1 ))
+              sleep 10
+            done
+            exit 1
       - keeper/env-export:
           secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
           var-name: SLACK_ACCESS_TOKEN
@@ -660,11 +684,11 @@ jobs:
             # build & start CIBA Delegated Service
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
-            sleep 30
+            sleep 50
             # Wait for AM to be up and running
             timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
             timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
-            sleep 30
+            sleep 50
             # Run Postman tests with retry
             N=2
             while [ $N -gt 0 ]
@@ -765,11 +789,11 @@ jobs:
             # build & start CIBA Delegated Service
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
-            sleep 30
+            sleep 50
             # Wait for AM to be up and running
             timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
             timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
-            sleep 30
+            sleep 50
             # Run Postman tests with retry
             N=2
             while [ $N -gt 0 ]

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -496,7 +496,7 @@ jobs:
                 exit 0
               fi
 
-              echo "Retrying postman tests"
+              echo "Retrying Jest tests"
               N=$(( $N - 1 ))
               sleep 10
             done
@@ -624,7 +624,7 @@ jobs:
                 exit 0
               fi
 
-              echo "Retrying postman tests"
+              echo "Retrying Jest tests"
               N=$(( $N - 1 ))
               sleep 10
             done
@@ -698,7 +698,7 @@ jobs:
                 exit 0
               fi
 
-              echo "Retrying postman tests"
+              echo "Retrying Postman tests"
               N=$(( $N - 1 ))
               sleep 10
             done
@@ -803,7 +803,7 @@ jobs:
                 exit 0
               fi
 
-              echo "Retrying postman tests"
+              echo "Retrying Postman tests"
               N=$(( $N - 1 ))
               sleep 10
             done

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -487,20 +487,8 @@ jobs:
             timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
             timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
             sleep 50
-            # Run Jest tests with retry
-            N=2
-            while [ $N -gt 0 ]
-            do
-              if $(npm --prefix gravitee-am-test run ci); then 
-                echo "Completed"
-                exit 0
-              fi
-
-              echo "Retrying postman tests"
-              N=$(( $N - 1 ))
-              sleep 10
-            done
-            exit 1
+            # Run Jest tests
+            npm --prefix gravitee-am-test run ci
       - keeper/env-export:
           secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
           var-name: SLACK_ACCESS_TOKEN
@@ -615,20 +603,8 @@ jobs:
             timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
             timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
             sleep 50
-            # Run Jest tests with retry
-            N=2
-            while [ $N -gt 0 ]
-            do
-              if $(npm --prefix gravitee-am-test run ci); then 
-                echo "Completed"
-                exit 0
-              fi
-
-              echo "Retrying postman tests"
-              N=$(( $N - 1 ))
-              sleep 10
-            done
-            exit 1
+            # Run Jest tests
+            npm --prefix gravitee-am-test run ci
       - keeper/env-export:
           secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
           var-name: SLACK_ACCESS_TOKEN

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -246,7 +246,7 @@ commands:
             sha1sum gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip > gravitee-am-webui-${RELEASE_VERSION_NUMBER}.zip.sha1
             mkdir -p ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/graviteeio-am-management-ui-${RELEASE_VERSION_NUMBER}/
             cp -R ~/project/gravitee-am-ui/dist/* ~/release/graviteeio-am/distributions/graviteeio-am-full-${RELEASE_VERSION_NUMBER}/graviteeio-am-management-ui-${RELEASE_VERSION_NUMBER}/
- 
+            
             cd ~/release/graviteeio-am/distributions/
             zip -rm graviteeio-am-full-${RELEASE_VERSION_NUMBER}.zip graviteeio-am-full-${RELEASE_VERSION_NUMBER}
             md5sum graviteeio-am-full-${RELEASE_VERSION_NUMBER}.zip > graviteeio-am-full-${RELEASE_VERSION_NUMBER}.zip.md5
@@ -665,8 +665,20 @@ jobs:
             timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
             timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
             sleep 30
-            # Run Postman tests
-            make postman
+            # Run Postman tests with retry
+            N=2
+            while [ $N -gt 0 ]
+            do
+              if $(make postman); then 
+                echo "Completed"
+                exit 0
+              fi
+
+              echo "Retrying postman tests"
+              N=$(( $N - 1 ))
+              sleep 10
+            done
+            exit 1
       - keeper/env-export:
           secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
           var-name: SLACK_ACCESS_TOKEN
@@ -758,8 +770,20 @@ jobs:
             timeout 30s bash -c 'until nc -vz localhost 8093; do sleep 2; done'
             timeout 30s bash -c 'until nc -vz localhost 8092; do sleep 2; done'
             sleep 30
-            # Run Postman tests
-            make postman
+            # Run Postman tests with retry
+            N=2
+            while [ $N -gt 0 ]
+            do
+              if $(make postman); then 
+                echo "Completed"
+                exit 0
+              fi
+
+              echo "Retrying postman tests"
+              N=$(( $N - 1 ))
+              sleep 10
+            done
+            exit 1
       - keeper/env-export:
           secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
           var-name: SLACK_ACCESS_TOKEN
@@ -936,7 +960,7 @@ jobs:
                           --set "gateway.image.tag=${TAG}" \
                           --set "ui.image.repository=graviteeio.azurecr.io/am-management-ui" \
                           --set "ui.image.tag=${TAG}"
-              
+            
               helm upgrade --repo https://helm.gravitee.io \
                           --install am-master-ce \
                           -n am-master-ce-dev \
@@ -947,7 +971,7 @@ jobs:
                           --set "gateway.image.tag=${TAG}" \
                           --set "ui.image.repository=graviteeio.azurecr.io/am-management-ui" \
                           --set "ui.image.tag=${TAG}"
-              
+            
               helm upgrade --repo https://helm.gravitee.io \
                           --install am-psql \
                           -n am-master-postgres-dev \
@@ -973,7 +997,7 @@ jobs:
                                       --set "gateway.image.tag=${TAG}" \
                                       --set "ui.image.repository=graviteeio.azurecr.io/am-management-ui" \
                                       --set "ui.image.tag=${TAG}"
-              
+            
               # same with ce version
               kubectl create namespace am-${CIRCLE_BRANCH//./-}-ce-dev --dry-run=client -o yaml | kubectl apply -f -
               sed -i 's#__BRANCH_NAME_SANITIZED__#'${CIRCLE_BRANCH//./-}'#g' ./cloud-am/devs-preprod/values-ce-maint.yaml

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -453,7 +453,7 @@ jobs:
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
             export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-            curl https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
+            curl --retry 2 --retry-delay 10 https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
@@ -538,7 +538,7 @@ jobs:
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
             export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-            curl https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
+            curl --retry 2 --retry-delay 10000 https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
@@ -547,8 +547,8 @@ jobs:
             cp /tmp/workspace/gravitee-am-factor-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
             
             # copy r2dbc & jdbc drivers
-            curl https://jdbc.postgresql.org/download/postgresql-42.6.0.jar -o postgresql-jdbc.jar
-            curl https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar -o r2dbc-postgresql.jar
+            curl --retry 2 --retry-delay 10000 https://jdbc.postgresql.org/download/postgresql-42.6.0.jar -o postgresql-jdbc.jar
+            curl --retry 2 --retry-delay 10000 https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar -o r2dbc-postgresql.jar
 
             mkdir -p gravitee-am-gateway-standalone-${AM_VERSION}/plugins/ext/reporter-am-jdbc gravitee-am-gateway-standalone-${AM_VERSION}/plugins/ext/repository-am-jdbc
             mkdir -p gravitee-am-management-api-standalone-${AM_VERSION}/plugins/ext/reporter-am-jdbc gravitee-am-management-api-standalone-${AM_VERSION}/plugins/ext/repository-am-jdbc
@@ -641,7 +641,7 @@ jobs:
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
             export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-            curl https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
+            curl --retry 2 --retry-delay 10000 https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
@@ -717,7 +717,7 @@ jobs:
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
             export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-            curl https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
+            curl --retry 2 --retry-delay 10000 https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
@@ -726,8 +726,8 @@ jobs:
             cp /tmp/workspace/gravitee-am-factor-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
             
             # copy r2dbc & jdbc drivers
-            curl https://jdbc.postgresql.org/download/postgresql-42.6.0.jar -o postgresql-jdbc.jar
-            curl https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar -o r2dbc-postgresql.jar
+            curl --retry 2 --retry-delay 10000 https://jdbc.postgresql.org/download/postgresql-42.6.0.jar -o postgresql-jdbc.jar
+            curl --retry 2 --retry-delay 10000 https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar -o r2dbc-postgresql.jar
 
             mkdir -p gravitee-am-gateway-standalone-${AM_VERSION}/plugins/ext/reporter-am-jdbc gravitee-am-gateway-standalone-${AM_VERSION}/plugins/ext/repository-am-jdbc
             mkdir -p gravitee-am-management-api-standalone-${AM_VERSION}/plugins/ext/reporter-am-jdbc gravitee-am-management-api-standalone-${AM_VERSION}/plugins/ext/repository-am-jdbc

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -453,7 +453,7 @@ jobs:
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
             export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-            curl --retry 2 --retry-delay 10 https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
+            curl --retry 4 --retry-delay 10 --retry-all-errors https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
@@ -538,7 +538,7 @@ jobs:
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
             export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-            curl --retry 2 --retry-delay 10000 https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
+            curl --retry 4 --retry-delay 10 --retry-all-errors https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
@@ -547,8 +547,8 @@ jobs:
             cp /tmp/workspace/gravitee-am-factor-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
             
             # copy r2dbc & jdbc drivers
-            curl --retry 2 --retry-delay 10000 https://jdbc.postgresql.org/download/postgresql-42.6.0.jar -o postgresql-jdbc.jar
-            curl --retry 2 --retry-delay 10000 https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar -o r2dbc-postgresql.jar
+            curl --retry 4 --retry-delay 10 --retry-all-errors https://jdbc.postgresql.org/download/postgresql-42.6.0.jar -o postgresql-jdbc.jar
+            curl --retry 4 --retry-delay 10 --retry-all-errors https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar -o r2dbc-postgresql.jar
 
             mkdir -p gravitee-am-gateway-standalone-${AM_VERSION}/plugins/ext/reporter-am-jdbc gravitee-am-gateway-standalone-${AM_VERSION}/plugins/ext/repository-am-jdbc
             mkdir -p gravitee-am-management-api-standalone-${AM_VERSION}/plugins/ext/reporter-am-jdbc gravitee-am-management-api-standalone-${AM_VERSION}/plugins/ext/repository-am-jdbc
@@ -641,7 +641,7 @@ jobs:
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
             export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-            curl --retry 2 --retry-delay 10000 https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
+            curl --retry 4 --retry-delay 10 --retry-all-errors https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
@@ -717,7 +717,7 @@ jobs:
             unzip /tmp/workspace/gravitee-am-gateway-standalone-*.zip
             unzip /tmp/workspace/gravitee-am-management-api-standalone-*.zip
             export AM_VERSION=$(mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-            curl --retry 2 --retry-delay 10000 https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
+            curl --retry 4 --retry-delay 10 --retry-all-errors https://download.gravitee.io/plugins/services/gravitee-service-geoip/gravitee-service-geoip-2.1.0.zip -o gravitee-am-gateway-standalone-${AM_VERSION}/plugins/gravitee-service-geoip-2.1.0.zip
             
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-management-api-standalone-${AM_VERSION}/plugins/
             cp /tmp/workspace/gravitee-am-resource-mfa-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
@@ -726,8 +726,8 @@ jobs:
             cp /tmp/workspace/gravitee-am-factor-mock-*.zip gravitee-am-gateway-standalone-${AM_VERSION}/plugins/
             
             # copy r2dbc & jdbc drivers
-            curl --retry 2 --retry-delay 10000 https://jdbc.postgresql.org/download/postgresql-42.6.0.jar -o postgresql-jdbc.jar
-            curl --retry 2 --retry-delay 10000 https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar -o r2dbc-postgresql.jar
+            curl --retry 4 --retry-delay 10 --retry-all-errors https://jdbc.postgresql.org/download/postgresql-42.6.0.jar -o postgresql-jdbc.jar
+            curl --retry 4 --retry-delay 10 --retry-all-errors https://repo1.maven.org/maven2/org/postgresql/r2dbc-postgresql/1.0.2.RELEASE/r2dbc-postgresql-1.0.2.RELEASE.jar -o r2dbc-postgresql.jar
 
             mkdir -p gravitee-am-gateway-standalone-${AM_VERSION}/plugins/ext/reporter-am-jdbc gravitee-am-gateway-standalone-${AM_VERSION}/plugins/ext/repository-am-jdbc
             mkdir -p gravitee-am-management-api-standalone-${AM_VERSION}/plugins/ext/reporter-am-jdbc gravitee-am-management-api-standalone-${AM_VERSION}/plugins/ext/repository-am-jdbc

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -496,7 +496,7 @@ jobs:
                 exit 0
               fi
 
-              echo "Retrying Jest tests"
+              echo "Retrying postman tests"
               N=$(( $N - 1 ))
               sleep 10
             done
@@ -624,7 +624,7 @@ jobs:
                 exit 0
               fi
 
-              echo "Retrying Jest tests"
+              echo "Retrying postman tests"
               N=$(( $N - 1 ))
               sleep 10
             done
@@ -698,7 +698,7 @@ jobs:
                 exit 0
               fi
 
-              echo "Retrying Postman tests"
+              echo "Retrying postman tests"
               N=$(( $N - 1 ))
               sleep 10
             done
@@ -803,7 +803,7 @@ jobs:
                 exit 0
               fi
 
-              echo "Retrying Postman tests"
+              echo "Retrying postman tests"
               N=$(( $N - 1 ))
               sleep 10
             done


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-2154

## :pencil2: A description of the changes proposed in the pull request
Added:
- retry download packages from "download.gravitee.io" domain which often does not respond correctly 
- retry postman tests
- increase waiting time for application to start
- remove sleeps

Result: 
- save developers time by removing the need for manual pipeline retry
- save costs by retiring tests/downloads instead of a whole pipeline step

## :computer: Add screenshots for UI
![image](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/fe21692e-1ba3-4a9e-818e-c7fca3cef61f)

![image](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/4efe5d09-cab3-4ad7-a2f9-a2e3c06feac1)

![image](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/1f844d5f-28f3-4ea8-8754-7096b993d739)


[AM-2154]: https://gravitee.atlassian.net/browse/AM-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ