### PR TITLE
chore: Add changelog for new 3.20.19 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,15 @@
 # Change Log
 
+==  - 3.20.19 (2024-02-09)
+
+== What's new !
+
+=== Gateway
+
+* SCIM search operator PR doesn't work as expected https://github.com/gravitee-io/issues/issues/9265[#9265]
+* Authentication flow rejected due to redirect_uri when PAR is used https://github.com/gravitee-io/issues/issues/9478[#9478]
+
+
 == AM - 3.21.16 (2024-01-22)
 
 == What's new !


### PR DESCRIPTION

# New version 3.20.19 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.20.19/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.20.19 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.20.19%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
