### PR TITLE
chore: upgrade gravitee-bom to 6.0.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
     <properties>
         <awaitility.version>4.2.0</awaitility.version>
-        <gravitee-bom.version>6.0.14</gravitee-bom.version>
+        <gravitee-bom.version>6.0.32</gravitee-bom.version>
         <gravitee-common.version>2.1.0</gravitee-common.version>
         <gravitee-plugin.version>2.0.2</gravitee-plugin.version>
         <gravitee-node.version>4.3.0</gravitee-node.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
-        <nimbus.version>9.31</nimbus.version>
+        <nimbus.version>9.37.3</nimbus.version>
         <logback.version>1.4.14</logback.version>
         <json-smart.version>2.5.0</json-smart.version>
         <tink.version>1.7.0</tink.version>


### PR DESCRIPTION
  this upgrade contains vertx, jetty & spring security upgrade

AM-2740
