### PR TITLE
chore: Add changelog for new 3.20.20 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,25 @@
 # Change Log
 
+==  - 3.20.20 (2024-02-19)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Unable to finalize SAML authentication using HTTP-POST binding https://github.com/gravitee-io/issues/issues/9485[#9485]
+
+=== Management API
+
+
+
+=== Console
+
+* Missing read password policy role https://github.com/gravitee-io/issues/issues/8924[#8924]
+
+
+
 ==  - 3.21.17 (2024-02-09)
 
 == What's new !


### PR DESCRIPTION

# New version 3.20.20 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.20.20/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.20.20 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.20.20%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
