### PR TITLE
chore: Add changelog for new 3.21.18 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,24 @@
 # Change Log
 
+==  - 3.21.18 (2024-02-20)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Unable to finalize SAML authentication using HTTP-POST binding https://github.com/gravitee-io/issues/issues/9485[#9485]
+
+=== Console
+
+* Missing read password policy role https://github.com/gravitee-io/issues/issues/8924[#8924]
+
+=== Other
+
+* SAML 2.0 Identity Provider requires AM dependency update https://github.com/gravitee-io/issues/issues/9515[#9515]
+
+
 ==  - 3.20.20 (2024-02-19)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.18 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.18/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.18 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.18%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
