### PR TITLE
AM-2745: remember device mfa

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -76,7 +76,8 @@ public interface ConstantKeys {
 
     // MFA keys.
     String MFA_STOP = "mfaStop";
-    String MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY = "mfaEnrollmentCanBeSkipped";
+    String MFA_ENROLL_CONDITIONAL_SKIPPED_KEY = "mfaEnrollmentCanBeSkipped";
+    String MFA_CHALLENGE_CONDITIONAL_SKIPPED_KEY = "mfaChallengeCanBeSkipped";
     String MFA_ENROLLMENT_COMPLETED_KEY = "mfaEnrollmentCompleted";
     String MFA_CHALLENGE_COMPLETED_KEY = "mfaChallengeCompleted";
     String STRONG_AUTH_COMPLETED_KEY = "strongAuthCompleted";

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -155,6 +155,7 @@ public interface ConstantKeys {
 
     //remember device
     String DEVICE_ALREADY_EXISTS_KEY = "deviceAlreadyExists";
+    String REMEMBER_DEVICE_SKIP_UNTIL = "deviceSkipUntil";
     String REMEMBER_DEVICE_CONSENT_TIME_SECONDS = "rememberDeviceConsentTimeSeconds";
     long DEFAULT_REMEMBER_DEVICE_CONSENT_TIME = 10 * 60 * 60; // 10 hours
     String REMEMBER_DEVICE_IS_ACTIVE = "rememberDeviceIsActive";

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -66,7 +66,6 @@ public interface ConstantKeys {
     String DEVICE_ID = "deviceId";
     String X_XSRF_TOKEN = "X-XSRF-TOKEN";
     String _CSRF = "_csrf";
-    String __BODY_HANDLED = "__body-handled";
     String SOCIAL_PROVIDER_CONTEXT_KEY = "socialProviders";
 
     // enrich authentication flow keys
@@ -76,8 +75,7 @@ public interface ConstantKeys {
 
     // MFA keys.
     String MFA_STOP = "mfaStop";
-    String MFA_ENROLL_CONDITIONAL_SKIPPED_KEY = "mfaEnrollmentCanBeSkipped";
-    String MFA_CHALLENGE_CONDITIONAL_SKIPPED_KEY = "mfaChallengeCanBeSkipped";
+    String MFA_ENROLL_CONDITIONAL_SKIPPED_KEY = "mfaEnrollmentCanBeSkippedConditionally";
     String MFA_ENROLLMENT_COMPLETED_KEY = "mfaEnrollmentCompleted";
     String MFA_CHALLENGE_COMPLETED_KEY = "mfaChallengeCompleted";
     String STRONG_AUTH_COMPLETED_KEY = "strongAuthCompleted";
@@ -155,9 +153,9 @@ public interface ConstantKeys {
 
     //remember device
     String DEVICE_ALREADY_EXISTS_KEY = "deviceAlreadyExists";
-    String REMEMBER_DEVICE_SKIP_UNTIL = "deviceSkipUntil";
+    String REMEMBER_DEVICE_OR_SKIP_UNTIL = "deviceDeviceOrSkipUntil";
     String REMEMBER_DEVICE_CONSENT_TIME_SECONDS = "rememberDeviceConsentTimeSeconds";
-    long DEFAULT_REMEMBER_DEVICE_CONSENT_TIME = 10 * 60 * 60; // 10 hours
+    long DEFAULT_REMEMBER_DEVICE_CONSENT_TIME = 36000; // 10 hours
     String REMEMBER_DEVICE_IS_ACTIVE = "rememberDeviceIsActive";
     String DEVICE_IDENTIFIER_PROVIDER_KEY = "deviceIdentifierProvider";
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStep.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStep.java
@@ -16,7 +16,7 @@
 package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa;
 
 import io.gravitee.am.common.utils.ConstantKeys;
-import static io.gravitee.am.common.utils.ConstantKeys.MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.ruleengine.RuleEngine;
@@ -86,7 +86,7 @@ public class MFAEnrollStep extends MFAStep {
         } else if (userHasFactor(context)) {
             continueFlow(routingContext, flow);
         } else if (canUserSkip(client, context)) {
-            routingContext.session().put(MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY, true);
+            routingContext.session().put(MFA_ENROLL_CONDITIONAL_SKIPPED_KEY, true);
             if (context.isEnrollSkipped()) {
                 stopMfaFlow(routingContext, flow);
             } else {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStep.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStep.java
@@ -16,8 +16,8 @@
 package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mfa;
 
 import io.gravitee.am.common.utils.ConstantKeys;
-import static io.gravitee.am.common.utils.ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.ruleengine.RuleEngine;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.AuthenticationFlowChain;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MfaFilterContext.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MfaFilterContext.java
@@ -42,11 +42,9 @@ import io.vertx.rxjava3.ext.web.RoutingContext;
 import io.vertx.rxjava3.ext.web.Session;
 import static java.lang.Boolean.TRUE;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import java.util.Optional;
 import static java.util.Optional.ofNullable;
 import java.util.stream.Collectors;
 import static org.springframework.util.StringUtils.hasText;
@@ -74,7 +72,7 @@ public class MfaFilterContext {
     }
 
     public boolean isEnrollSkipped() {
-        final boolean canSkip = MfaUtils.isCanSkip(client, routingContext);
+        final boolean canSkip = MfaUtils.isCanSkip(routingContext, client);
         if (canSkip && nonNull(endUser.getMfaEnrollmentSkippedAt())) {
             Date now = new Date();
             long skipTime = ofNullable(MfaUtils.getEnrollSettings(client).getSkipTimeSeconds()).orElse(DEFAULT_ENROLLMENT_SKIP_TIME_SECONDS) * 1000L;
@@ -93,6 +91,13 @@ public class MfaFilterContext {
 
     public boolean deviceAlreadyExists() {
         return MfaUtils.deviceAlreadyExists(session);
+    }
+    public RoutingContext routingContext() {
+        return routingContext;
+    }
+
+    public Session session() {
+        return session;
     }
 
     public Object getLoginAttempt() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MfaFilterContext.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MfaFilterContext.java
@@ -72,8 +72,7 @@ public class MfaFilterContext {
     }
 
     public boolean isEnrollSkipped() {
-        final boolean canSkip = MfaUtils.isCanSkip(routingContext, client);
-        if (canSkip && nonNull(endUser.getMfaEnrollmentSkippedAt())) {
+        if (nonNull(endUser.getMfaEnrollmentSkippedAt())) {
             Date now = new Date();
             long skipTime = ofNullable(MfaUtils.getEnrollSettings(client).getSkipTimeSeconds()).orElse(DEFAULT_ENROLLMENT_SKIP_TIME_SECONDS) * 1000L;
             return endUser.getMfaEnrollmentSkippedAt().getTime() + skipTime > now.getTime();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/utils/MfaUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/utils/MfaUtils.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import io.gravitee.am.common.factor.FactorType;
 import io.gravitee.am.common.utils.ConstantKeys;
 import static io.gravitee.am.common.utils.ConstantKeys.DEVICE_ALREADY_EXISTS_KEY;
-import static io.gravitee.am.common.utils.ConstantKeys.MFA_CHALLENGE_CONDITIONAL_SKIPPED_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.MFA_STOP;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.ruleengine.RuleEngine;
@@ -31,7 +30,6 @@ import io.gravitee.am.model.ChallengeSettings;
 import io.gravitee.am.model.EnrollSettings;
 import io.gravitee.am.model.FactorSettings;
 import io.gravitee.am.model.MFASettings;
-import io.gravitee.am.model.MfaChallengeType;
 import io.gravitee.am.model.MfaEnrollType;
 import io.gravitee.am.model.RememberDeviceSettings;
 import io.gravitee.am.model.StepUpAuthenticationSettings;
@@ -66,7 +64,7 @@ public class MfaUtils {
     }
 
     public static String getAdaptiveMfaStepUpRule(Client client) {
-        return ofNullable(client.getMfaSettings()).orElse(new MFASettings()).getAdaptiveAuthenticationRule();
+        return ofNullable(client.getMfaSettings()).map(MFASettings::getChallenge).map(ChallengeSettings::getChallengeRule).orElse("");
     }
 
     public static RememberDeviceSettings getRememberDeviceSettings(Client client) {
@@ -150,11 +148,5 @@ public class MfaUtils {
         var enrollSettings = MfaUtils.getEnrollSettings(client);
         return (enrollSettings.getForceEnrollment() != null && !enrollSettings.getForceEnrollment())
                 || (MfaEnrollType.CONDITIONAL.equals(enrollSettings.getType()) && Boolean.TRUE.equals(routingContext.session().get(ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY)));
-    }
-
-    public static boolean isSkipRememberDevice(RoutingContext routingContext, Client client) {
-        return MfaUtils.getChallengeSettings(client).getType().equals(MfaChallengeType.CONDITIONAL)
-                && MfaUtils.getRememberDeviceSettings(client).isSkipRememberDevice()
-                && TRUE.equals(routingContext.session().get(MFA_CHALLENGE_CONDITIONAL_SKIPPED_KEY));
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/utils/MfaUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/utils/MfaUtils.java
@@ -147,6 +147,6 @@ public class MfaUtils {
     public static boolean isCanSkip(Client client, RoutingContext routingContext) {
         var enrollSettings = MfaUtils.getEnrollSettings(client);
         return (enrollSettings.getForceEnrollment() != null && !enrollSettings.getForceEnrollment())
-                || (MfaEnrollType.CONDITIONAL.equals(enrollSettings.getType()) && Boolean.TRUE.equals(routingContext.session().get(ConstantKeys.MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY)));
+                || (MfaEnrollType.CONDITIONAL.equals(enrollSettings.getType()) && Boolean.TRUE.equals(routingContext.session().get(ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY)));
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/AuthenticationFlowHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/AuthenticationFlowHandlerTest.java
@@ -161,15 +161,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAEnrollmentPage_adaptiveMFA() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String rule = "{context.attributes['geoip']['country_iso_code'] == 'FR'";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, rule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
-
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{context.attributes['geoip']['country_iso_code'] == 'FR'");
+            mfaSettings.setAdaptiveAuthenticationRule(rule);
             client.setMfaSettings(mfaSettings);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "US").getMap());
             // set user
@@ -192,14 +192,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAEnrollmentPage_adaptiveMFA_no_enroll() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String rule = "{context.attributes['geoip']['country_iso_code'] == 'FR'";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, rule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{context.attributes['geoip']['country_iso_code'] == 'FR'");
+            mfaSettings.setAdaptiveAuthenticationRule(rule);
             client.setMfaSettings(mfaSettings);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "FR").getMap());
             // set user
@@ -222,14 +223,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldNoRedirectToMFAChallengePage_adaptiveMFA_no_active_enroll_and_endUser_not_enrolled() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String rule = "{context.attributes['geoip']['country_iso_code'] == 'FR'";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, rule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{context.attributes['geoip']['country_iso_code'] == 'FR'");
+            mfaSettings.setAdaptiveAuthenticationRule(rule);
             client.setMfaSettings(mfaSettings);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "FR").getMap());
 
@@ -257,14 +259,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAChallengePage_adaptiveMFA_no_active_enroll_and_endUser_is_enrolling() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String rule = "{context.attributes['geoip']['country_iso_code'] == 'FR'";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, rule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{context.attributes['geoip']['country_iso_code'] == 'FR'");
+            mfaSettings.setAdaptiveAuthenticationRule(rule);
             client.setMfaSettings(mfaSettings);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "FR").getMap());
 
@@ -643,14 +646,9 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
         });
 
         testRequest(
-                HttpMethod.GET, "/login?scope=write",
-                null,
-                resp -> {
-                    String location = resp.headers().get("location");
-                    assertNotNull(location);
-                    assertTrue(location.endsWith("/mfa/challenge?scope=write"));
-                },
-                HttpStatusCode.FOUND_302, "Found", null);
+                HttpMethod.GET,
+                "/login",
+                HttpStatusCode.OK_200, "OK");
     }
 
 
@@ -806,14 +804,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAChallengePage_adaptiveMFA() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String challengeRule = "{#context.attributes['geoip']['country_iso_code'] == 'FR'}";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.RISK_BASED, challengeRule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{#context.attributes['geoip']['country_iso_code'] == 'FR'}");
+            mfaSettings.setAdaptiveAuthenticationRule(challengeRule);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "US").getMap());
             client.setMfaSettings(mfaSettings);
             // set user
@@ -841,8 +840,9 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAChallengePage_adaptiveMFA_with_step_up_true_strong_auth_true() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String challengeRule = "{#context.attributes['geoip']['country_iso_code'] == 'FR'}";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.RISK_BASED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.RISK_BASED, challengeRule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
@@ -859,7 +859,7 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
             stepUpAuthentication.setStepUpAuthenticationRule(stepUpAuthenticationRule);
             mfaSettings.setStepUpAuthentication(stepUpAuthentication);
 
-            mfaSettings.setAdaptiveAuthenticationRule("{#context.attributes['geoip']['country_iso_code'] == 'FR'}");
+            mfaSettings.setAdaptiveAuthenticationRule(challengeRule);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "FR").getMap());
             client.setMfaSettings(mfaSettings);
             // set user
@@ -874,21 +874,16 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
         });
 
         testRequest(
-                HttpMethod.GET, "/login?scope=write",
-                null,
-                resp -> {
-                    String location = resp.headers().get("location");
-                    assertNotNull(location);
-                    assertTrue(location.endsWith("/mfa/challenge?scope=write"));
-                },
-                HttpStatusCode.FOUND_302, "Found", null);
+                HttpMethod.GET, "/login?scope=read",
+                HttpStatusCode.OK_200, "OK");
     }
 
     @Test
     public void shouldContinue_adaptiveMFA_with_step_up_false_strong_auth_true_device_known() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String rule = "{#context.attributes['geoip']['country_iso_code'] == 'FR'}";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.RISK_BASED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.RISK_BASED, rule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
@@ -905,7 +900,7 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
             stepUpAuthentication.setStepUpAuthenticationRule(stepUpAuthenticationRule);
             mfaSettings.setStepUpAuthentication(stepUpAuthentication);
 
-            mfaSettings.setAdaptiveAuthenticationRule("{#context.attributes['geoip']['country_iso_code'] == 'FR'}");
+            mfaSettings.setAdaptiveAuthenticationRule(rule);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "FR").getMap());
             client.setMfaSettings(mfaSettings);
             // set user
@@ -1082,14 +1077,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAChallengePage_adaptiveMFA_2() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String challengeRule = "{#context.attributes['geoip']['country_iso_code'] == 'FR'}";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.RISK_BASED, challengeRule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{#context.attributes['geoip']['country_iso_code'] == 'FR'}");
+            mfaSettings.setAdaptiveAuthenticationRule(challengeRule);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "US").getMap());
             client.setMfaSettings(mfaSettings);
             // set user
@@ -1117,14 +1113,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAChallengePage_adaptiveMFA_2_user_auth() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String challenge = "{#context.attributes['geoip']['country_iso_code'] == 'FR'}";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.RISK_BASED, challenge);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{#context.attributes['geoip']['country_iso_code'] == 'FR'}");
+            mfaSettings.setAdaptiveAuthenticationRule(challenge);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "US").getMap());
             client.setMfaSettings(mfaSettings);
             // set user
@@ -1152,14 +1149,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAChallengePage_adaptiveMFA_3_factor_is_pending() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String rule = "{#context.attributes['geoip']['country_iso_code'] == 'FR'}";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, rule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{#context.attributes['geoip']['country_iso_code'] == 'FR'}");
+            mfaSettings.setAdaptiveAuthenticationRule(rule);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "FR").getMap());
             client.setMfaSettings(mfaSettings);
             rc.session().put(ENROLLED_FACTOR_ID_KEY, FACTOR_ID);
@@ -1219,14 +1217,15 @@ public class AuthenticationFlowHandlerTest extends RxWebTestBase {
     @Test
     public void shouldRedirectToMFAChallengePage_adaptiveMFA_3_alternate_factor_id() throws Exception {
         router.route().order(-1).handler(rc -> {
+            String rule = "{#context.attributes['geoip']['country_iso_code'] == 'FR'}";
             EnrollSettings enrollSettings = createEnrollSettings(true, false, MfaEnrollType.REQUIRED, 0, "");
-            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, "");
+            ChallengeSettings challengeSettings = createChallengeSettings(true, MfaChallengeType.REQUIRED, rule);
             MFASettings mfaSettings = createMFASettings(enrollSettings, challengeSettings);
             // set client
             Client client = new Client();
             setFactors(client);
             rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
-            mfaSettings.setAdaptiveAuthenticationRule("{#context.attributes['geoip']['country_iso_code'] == 'FR'}");
+            mfaSettings.setAdaptiveAuthenticationRule(rule);
             rc.put(ConstantKeys.GEOIP_KEY, new JsonObject().put("country_iso_code", "FR").getMap());
             client.setMfaSettings(mfaSettings);
             rc.session().put(ENROLLED_FACTOR_ID_KEY, FACTOR_ID);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAChallengeStepTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAChallengeStepTest.java
@@ -285,9 +285,28 @@ class MFAChallengeStepTest {
         verifyChallenge();
     }
 
+    @Test
+    void shouldChallengeWhenRiskBasedRuleFalse() {
+        mockContextRequest();
+        mockAuthUser(false);
+        when(client.getMfaSettings()).thenReturn(mfa);
+        when(mfa.getChallenge()).thenReturn(challenge);
+        when(challenge.isActive()).thenReturn(true);
+        when(challenge.getType()).thenReturn(MfaChallengeType.RISK_BASED);
+
+        when(routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY)).thenReturn(client);
+        when(routingContext.session()).thenReturn(session);
+        when(session.get(MFA_STOP)).thenReturn(false);
+
+        mockRiskBasedSatisfied(false);
+
+        mfaChallengeStep.execute(routingContext, flow);
+
+        verifyContinue();
+    }
 
     @Test
-    void shouldChallengeWhenRiskBasedRuleTrueAndNoAuth() {
+    void shouldChallengeWhenRiskBasedRuleTrueNoAuth() {
         mockContextRequest();
         mockAuthUser(false);
         when(client.getMfaSettings()).thenReturn(mfa);
@@ -307,7 +326,7 @@ class MFAChallengeStepTest {
     }
 
     @Test
-    void shouldChallengeWhenRiskBasedRuleTrueAndAuth() {
+    void shouldContinueWhenRiskBasedRuleTrueAndAuth() {
         mockContextRequest();
         mockAuthUser(false);
         when(client.getMfaSettings()).thenReturn(mfa);
@@ -317,13 +336,14 @@ class MFAChallengeStepTest {
         when(routingContext.session()).thenReturn(session);
 
         when(routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY)).thenReturn(client);
+        when(session.get(MFA_CHALLENGE_COMPLETED_KEY)).thenReturn(true);
         when(session.get(MFA_STOP)).thenReturn(false);
 
         mockRiskBasedSatisfied(true);
 
         mfaChallengeStep.execute(routingContext, flow);
 
-        verifyChallenge();
+        verifyContinue();
     }
 
     @Test
@@ -337,6 +357,7 @@ class MFAChallengeStepTest {
         when(routingContext.session()).thenReturn(session);
 
         when(routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY)).thenReturn(client);
+        when(session.get(MFA_CHALLENGE_COMPLETED_KEY)).thenReturn(true);
         when(session.get(MFA_STOP)).thenReturn(false);
 
         mockRiskBasedSatisfied(false);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStepTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStepTest.java
@@ -314,7 +314,6 @@ class MFAEnrollStepTest {
         when(mfa.getEnroll()).thenReturn(enroll);
         when(client.getMfaSettings()).thenReturn(mfa);
         when(enroll.isActive()).thenReturn(true);
-        when(enroll.getForceEnrollment()).thenReturn(false);
         when(enroll.getSkipTimeSeconds()).thenReturn(1000L);
         when(enroll.getType()).thenReturn(MfaEnrollType.OPTIONAL);
         when(factor.getFactorType()).thenReturn(FactorType.SMS);
@@ -331,7 +330,6 @@ class MFAEnrollStepTest {
         when(client.getMfaSettings()).thenReturn(mfa);
         when(enroll.isActive()).thenReturn(true);
         when(enroll.getType()).thenReturn(MfaEnrollType.OPTIONAL);
-        when(enroll.getForceEnrollment()).thenReturn(false);
         when(mfa.getEnroll()).thenReturn(enroll);
         when(factor.getFactorType()).thenReturn(FactorType.SMS);
         when(factorManager.getFactor(DEFAULT_FACTOR.getId())).thenReturn(factor);
@@ -588,10 +586,8 @@ class MFAEnrollStepTest {
         when(enroll.isActive()).thenReturn(true);
         when(enroll.getSkipTimeSeconds()).thenReturn(1000L);
         when(enroll.getType()).thenReturn(MfaEnrollType.CONDITIONAL);
-        when(enroll.getForceEnrollment()).thenReturn(true);
         when(factor.getFactorType()).thenReturn(FactorType.SMS);
         when(factorManager.getFactor(DEFAULT_FACTOR.getId())).thenReturn(factor);
-        when(session.get(MFA_ENROLL_CONDITIONAL_SKIPPED_KEY)).thenReturn(true);
 
         mockConditionalEnrollmentRuleSatisfied(false);
         mockEnrollmentCanSkipRuleSatisfied(true);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStepTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/mfa/MFAEnrollStepTest.java
@@ -18,7 +18,7 @@ package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal.mf
 import io.gravitee.am.common.factor.FactorType;
 import io.gravitee.am.common.utils.ConstantKeys;
 import static io.gravitee.am.common.utils.ConstantKeys.ENROLLED_FACTOR_ID_KEY;
-import static io.gravitee.am.common.utils.ConstantKeys.MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.MFA_STOP;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.ruleengine.SpELRuleEngine;
@@ -591,7 +591,7 @@ class MFAEnrollStepTest {
         when(enroll.getForceEnrollment()).thenReturn(true);
         when(factor.getFactorType()).thenReturn(FactorType.SMS);
         when(factorManager.getFactor(DEFAULT_FACTOR.getId())).thenReturn(factor);
-        when(session.get(MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY)).thenReturn(true);
+        when(session.get(MFA_ENROLL_CONDITIONAL_SKIPPED_KEY)).thenReturn(true);
 
         mockConditionalEnrollmentRuleSatisfied(false);
         mockEnrollmentCanSkipRuleSatisfied(true);
@@ -599,7 +599,7 @@ class MFAEnrollStepTest {
         mfaEnrollStep.execute(routingContext, flow);
 
         verifyStop();
-        verify(session).put(MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY, true);
+        verify(session).put(MFA_ENROLL_CONDITIONAL_SKIPPED_KEY, true);
     }
 
     private void mockEnrollmentCanSkipRuleSatisfied(boolean isSatisfied) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpoint.java
@@ -151,7 +151,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
                     routingContext.put("emailAddress", endUser.getEmail());
                 }
 
-                routingContext.put(ConstantKeys.MFA_FORCE_ENROLLMENT, !MfaUtils.isCanSkip(client, routingContext));
+                routingContext.put(ConstantKeys.MFA_FORCE_ENROLLMENT, !MfaUtils.isCanSkip(routingContext, client));
                 routingContext.put(ConstantKeys.ACTION_KEY, action);
                 // render the mfa enroll page
                 this.renderPage(routingContext, generateData(routingContext, domain, client), client, logger, "Unable to render MFA enroll page");
@@ -200,7 +200,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
     }
     private boolean isSkipped(RoutingContext routingContext, boolean acceptEnrollment, Client client) {
         // if user has skipped the enrollment process, continue
-        if (!acceptEnrollment && MfaUtils.isCanSkip(client, routingContext)) {
+        if (!acceptEnrollment && MfaUtils.isCanSkip(routingContext, client)) {
             final User endUser = ((io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User) routingContext.user().getDelegate()).getUser();
             // set the last skipped time
             // and update the session

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
@@ -67,6 +67,11 @@
             <input th:if="${factor.factorType.type == 'FIDO2'}" type="hidden" id="webAuthnLoginPath" th:value="${webAuthnLoginPath}"/>
             <input th:if="${factor.factorType.type == 'FIDO2'}" type="hidden" id="userName" th:value="${userName}"/>
 
+            <div class="checkbox" th:if="${rememberDeviceIsActive && rememberDeviceConsentTimeSeconds != null && deviceId != null && !deviceAlreadyExists && !mfaChallengeCanBeSkipped}">
+                <input type="checkbox" id="rememberDeviceConsent" name="rememberDeviceConsent">
+                <span><span th:text="#{mfa_challenge.remember.device}"/> [[${rememberDeviceConsentTimeSeconds >= 2629746 ? (rememberDeviceConsentTimeSeconds / 2629746) + " month(s)" : (rememberDeviceConsentTimeSeconds >= 86400 ? (rememberDeviceConsentTimeSeconds / 86400) + " day(s)" : (rememberDeviceConsentTimeSeconds >= 3600 ? (rememberDeviceConsentTimeSeconds / 3600) + " hour(s)" : (rememberDeviceConsentTimeSeconds >= 60 ? (rememberDeviceConsentTimeSeconds / 60) + " minute(s)" : (rememberDeviceConsentTimeSeconds + " second(s)"))))}]]</span>
+            </div>
+
             <div>
                 <button type="submit" id="verify" class="button primary" th:text="#{mfa_challenge.button.submit}"></button>
             </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
@@ -67,11 +67,6 @@
             <input th:if="${factor.factorType.type == 'FIDO2'}" type="hidden" id="webAuthnLoginPath" th:value="${webAuthnLoginPath}"/>
             <input th:if="${factor.factorType.type == 'FIDO2'}" type="hidden" id="userName" th:value="${userName}"/>
 
-            <div class="checkbox" th:if="${rememberDeviceIsActive && rememberDeviceConsentTimeSeconds != null && deviceId != null && !deviceAlreadyExists}">
-                <input type="checkbox" id="rememberDeviceConsent" name="rememberDeviceConsent">
-                <span><span th:text="#{mfa_challenge.remember.device}"/> [[${rememberDeviceConsentTimeSeconds >= 2629746 ? (rememberDeviceConsentTimeSeconds / 2629746) + " month(s)" : (rememberDeviceConsentTimeSeconds >= 86400 ? (rememberDeviceConsentTimeSeconds / 86400) + " day(s)" : (rememberDeviceConsentTimeSeconds >= 3600 ? (rememberDeviceConsentTimeSeconds / 3600) + " hour(s)" : (rememberDeviceConsentTimeSeconds >= 60 ? (rememberDeviceConsentTimeSeconds / 60) + " minute(s)" : (rememberDeviceConsentTimeSeconds + " second(s)"))))}]]</span>
-            </div>
-
             <div>
                 <button type="submit" id="verify" class="button primary" th:text="#{mfa_challenge.button.submit}"></button>
             </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/mfa_challenge.html
@@ -67,7 +67,7 @@
             <input th:if="${factor.factorType.type == 'FIDO2'}" type="hidden" id="webAuthnLoginPath" th:value="${webAuthnLoginPath}"/>
             <input th:if="${factor.factorType.type == 'FIDO2'}" type="hidden" id="userName" th:value="${userName}"/>
 
-            <div class="checkbox" th:if="${rememberDeviceIsActive && rememberDeviceConsentTimeSeconds != null && deviceId != null && !deviceAlreadyExists && !mfaChallengeCanBeSkipped}">
+            <div class="checkbox" th:if="${rememberDeviceIsActive && rememberDeviceConsentTimeSeconds != null && deviceId != null && !deviceAlreadyExists}">
                 <input type="checkbox" id="rememberDeviceConsent" name="rememberDeviceConsent">
                 <span><span th:text="#{mfa_challenge.remember.device}"/> [[${rememberDeviceConsentTimeSeconds >= 2629746 ? (rememberDeviceConsentTimeSeconds / 2629746) + " month(s)" : (rememberDeviceConsentTimeSeconds >= 86400 ? (rememberDeviceConsentTimeSeconds / 86400) + " day(s)" : (rememberDeviceConsentTimeSeconds >= 3600 ? (rememberDeviceConsentTimeSeconds / 3600) + " hour(s)" : (rememberDeviceConsentTimeSeconds >= 60 ? (rememberDeviceConsentTimeSeconds / 60) + " minute(s)" : (rememberDeviceConsentTimeSeconds + " second(s)"))))}]]</span>
             </div>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpointTest.java
@@ -748,7 +748,7 @@ public class MFAEnrollEndpointTest extends RxWebTestBase {
                     ctx.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
 
                     ctx.session().put(ConstantKeys.MFA_FORCE_ENROLLMENT, true);
-                    ctx.session().put(ConstantKeys.MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY, false);
+                    ctx.session().put(ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY, false);
 
                     ctx.next();
                 })
@@ -817,7 +817,7 @@ public class MFAEnrollEndpointTest extends RxWebTestBase {
                     ctx.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
 
                     ctx.session().put(ConstantKeys.MFA_FORCE_ENROLLMENT, true);
-                    ctx.session().put(ConstantKeys.MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY, true);
+                    ctx.session().put(ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY, true);
 
                     ctx.next();
                 })

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/AuthorizationEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/AuthorizationEndpoint.java
@@ -151,6 +151,6 @@ public class AuthorizationEndpoint implements Handler<RoutingContext> {
         context.session().remove(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY);
         context.session().remove(ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY);
         context.session().remove(ConstantKeys.USER_LOGIN_COMPLETED_KEY);
-        context.session().remove(ConstantKeys.MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY);
+        context.session().remove(ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestFailureHandler.java
@@ -283,7 +283,7 @@ public class AuthorizationRequestFailureHandler implements Handler<RoutingContex
             context.session().remove(ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY);
             context.session().remove(ConstantKeys.MFA_CHALLENGE_COMPLETED_KEY);
             context.session().remove(ConstantKeys.USER_LOGIN_COMPLETED_KEY);
-            context.session().remove(ConstantKeys.MFA_CAN_BE_CONDITIONAL_SKIPPED_KEY);
+            context.session().remove(ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY);
         }
     }
 

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/RememberDeviceSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/RememberDeviceSettings.java
@@ -39,7 +39,7 @@ public class RememberDeviceSettings {
         return active;
     }
 
-    public boolean isSkipRememberDevice() {
+    public boolean isSkipChallengeWhenRememberDevice() {
         return skipRememberDevice;
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/RememberDeviceSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/RememberDeviceSettingsMongo.java
@@ -84,7 +84,7 @@ public class RememberDeviceSettingsMongo {
     public static RememberDeviceSettingsMongo convert(RememberDeviceSettings rememberDevice) {
         var rememberDeviceSettingsMongo = new RememberDeviceSettingsMongo();
         rememberDeviceSettingsMongo.setActive(TRUE.equals(rememberDevice.isActive()));
-        rememberDeviceSettingsMongo.setSkipRememberDevice(TRUE.equals(rememberDevice.isSkipRememberDevice()));
+        rememberDeviceSettingsMongo.setSkipRememberDevice(TRUE.equals(rememberDevice.isSkipChallengeWhenRememberDevice()));
         rememberDeviceSettingsMongo.setDeviceIdentifierId(rememberDevice.getDeviceIdentifierId());
         rememberDeviceSettingsMongo.setExpirationTimeSeconds(rememberDevice.getExpirationTimeSeconds());
         return rememberDeviceSettingsMongo;


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-2745
https://gravitee.atlassian.net/browse/AM-2746

## :pencil2: A description of the changes proposed in the pull request
- When the Remember device is active it is remembered for all challenge types except conditional when skipRemember is set.

updated diagram:
![image](https://github.com/gravitee-io/gravitee-access-management/assets/152597515/7fa6c0ec-6e7f-4e42-976e-ef33d01eae6e)


## :memo: Test scenarios 


## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
