### PR TITLE
fix: http redirection to https

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Access Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/am/) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.0.21
+
+- BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect)
+
 ### 4.0.20
 
 - 'fix' remove default value for `smtp.allowedfrom` to use the default value (*@*.*) defined into the service source code.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -704,10 +704,10 @@ gateway:
       - am.example.com
     annotations:
       kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
       nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
       kubernetes.io/app-root: /auth
       kubernetes.io/rewrite-target: /auth
+      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
       # ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
       # kubernetes.io/tls-acme: "true"
     #tls:


### PR DESCRIPTION
## :id: 
https://gravitee.atlassian.net/browse/AM-3084

## :pencil2: A description of the changes proposed in the pull request

Previously, our default configuration say that even if you enable TLS, we don't redirect HTTP to HTTPS.
By default (without our overwrite config) nginx says:

```
By default the controller redirects (308) to HTTPS if TLS is enabled for that ingress.
```
https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect

So both case:

- customer keep default and use HTTP
- customer only enable TLS

will be handled correctly with default nginx configuration.

As we add nginx.ingress.kubernetes.io/ssl-redirect: "false" which is ok by default without TLS.
This mean that even if we enable TLS, the redirection is still disabled.

My proposal is to remove our default setting and keep the nginx default one to make both case (TLS or not) work properly:
enable redirection only if TLS is used.


