### PR TITLE
chore: Add changelog for new 3.21.20 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,16 @@
 # Change Log
 
+==  - 3.21.20 (2024-03-15)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Redirect executed with jwt-bearer grant_type https://github.com/gravitee-io/issues/issues/9505[#9505]
+
+
 ==  - 3.21.19 (2024-02-29)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.20 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.20/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.20 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.20%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
