### PR TITLE
fix: allow to set a String array as aud custom value

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/JWT.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/JWT.java
@@ -17,6 +17,7 @@ package io.gravitee.am.common.jwt;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -52,7 +53,16 @@ public class JWT extends HashMap<String, Object> {
     }
 
     public String getAud() {
-        return containsKey(Claims.aud) ? (String) get(Claims.aud) : null;
+        if (containsKey(Claims.aud)) {
+            Object aud = get(Claims.aud);
+            if (aud instanceof List && !((List<?>) aud).isEmpty()) {
+                return ((List<String>) aud).get(0);
+            } else {
+                return (String) aud;
+            }
+        } else {
+            return null;
+        }
     }
 
     public void setAud(String aud) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -50,6 +50,7 @@ import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
+import net.minidev.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,6 +58,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -352,7 +354,16 @@ public class TokenServiceImpl implements TokenService {
                             String claimExpression = tokenClaim.getClaimValue();
                             Object extValue = (claimExpression != null) ? executionContext.getTemplateEngine().getValue(claimExpression, Object.class) : null;
                             if (extValue != null) {
-                                jwt.put(claimName, extValue);
+                                if (Claims.aud.equals(claimName) && (extValue instanceof String[] || extValue instanceof List)) {
+                                    var audiences = new LinkedHashSet<>();
+                                    audiences.add(jwt.getAud()); // make sure the client_id is the first entry of the aud array
+                                    audiences.addAll(extValue instanceof List ? (List)extValue : List.of((String[]) extValue)); // Set will remove duplicate client_id if any
+                                    var jsonArray = new JSONArray();
+                                    jsonArray.addAll(audiences);
+                                    jwt.put(claimName, jsonArray);
+                                } else {
+                                    jwt.put(claimName, extValue);
+                                }
                             }
                         } catch (Exception ex) {
                             logger.debug("An error occurs while parsing expression language : {}", tokenClaim.getClaimValue(), ex);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/impl/IDTokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/impl/IDTokenServiceImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.oidc.service.idtoken.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.certificate.api.CertificateMetadata;
+import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.oauth2.TokenTypeHint;
 import io.gravitee.am.common.oidc.Parameters;
@@ -44,6 +45,7 @@ import io.gravitee.am.service.exception.UserNotFoundException;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.reactivex.Single;
+import net.minidev.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +53,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -313,7 +316,16 @@ public class IDTokenServiceImpl implements IDTokenService {
                             String claimExpression = tokenClaim.getClaimValue();
                             Object extValue = (claimExpression != null) ? executionContext.getTemplateEngine().getValue(claimExpression, Object.class) : null;
                             if (extValue != null) {
-                                jwt.put(claimName, extValue);
+                                if (Claims.aud.equals(claimName) && (extValue instanceof String[] || extValue instanceof List)) {
+                                    var audiences = new LinkedHashSet<>();
+                                    audiences.add(jwt.getAud()); // make sure the client_id is the first entry of the aud array
+                                    audiences.addAll(extValue instanceof List ? (List)extValue : List.of((String[]) extValue)); // Set will remove duplicate client_id if any
+                                    var jsonArray = new JSONArray();
+                                    jsonArray.addAll(audiences);
+                                    jwt.put(claimName, jsonArray);
+                                } else {
+                                    jwt.put(claimName, extValue);
+                                }
                             }
                         } catch (Exception ex) {
                             logger.debug("An error occurs while parsing expression language : {}", tokenClaim.getClaimValue(), ex);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/IDTokenServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/IDTokenServiceTest.java
@@ -192,17 +192,24 @@ public class IDTokenServiceTest {
 
         TokenClaim customClaim = new TokenClaim();
         customClaim.setTokenType(TokenTypeHint.ID_TOKEN);
-        customClaim.setClaimName("iss");
+        customClaim.setClaimName(Claims.iss);
         customClaim.setClaimValue("https://custom-iss");
+
+        TokenClaim customAudClaim = new TokenClaim();
+        customAudClaim.setTokenType(TokenTypeHint.ID_TOKEN);
+        customAudClaim.setClaimName(io.gravitee.am.common.jwt.Claims.aud);
+        String customClaimExpression = "{T(java.lang.String).valueOf(\"client_id_value,other_value,client-id\").split(\",\")}";
+        customAudClaim.setClaimValue(customClaimExpression);
 
         Client client = new Client();
         client.setCertificate("certificate-client");
         client.setClientId("my-client-id");
-        client.setTokenCustomClaims(Arrays.asList(customClaim));
+        client.setTokenCustomClaims(Arrays.asList(customClaim, customAudClaim));
 
         ExecutionContext executionContext = mock(ExecutionContext.class);
         TemplateEngine templateEngine = mock(TemplateEngine.class);
         when(templateEngine.getValue("https://custom-iss", Object.class)).thenReturn("https://custom-iss");
+        when(templateEngine.getValue(customClaimExpression, Object.class)).thenReturn(new String[]{"client_id_value","other_value","client-id"});
         when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
 
         String idTokenPayload = "payload";
@@ -220,7 +227,11 @@ public class IDTokenServiceTest {
 
         JWT jwt = jwtCaptor.getValue();
         assertNotNull(jwt);
-        assertTrue(jwt.get("iss") != null && "https://custom-iss".equals(jwt.get("iss")));
+        assertTrue(jwt.get(Claims.iss) != null && "https://custom-iss".equals(jwt.get(Claims.iss)));
+        assertTrue("client-id".equals(jwt.getAud()));
+        assertTrue(jwt.get(Claims.aud) != null
+                && jwt.get(Claims.aud) instanceof List
+                && ((List)jwt.get(Claims.aud)).size() == 3);
 
         verify(certificateManager, times(1)).findByAlgorithm(any());
         verify(certificateManager, times(1)).get(anyString());


### PR DESCRIPTION
  this claims can be a list according to the spec

  WARN: to make this array usable by introspection endpoint and don't break anything, the client_id need to be the first entry

fixes AM-2865

gravitee-io/issues#9614
