### PR TITLE
chore: Add changelog for new 3.21.21 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,24 @@
 # Change Log
 
+==  - 3.21.21 (2024-03-28)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Revert: Passwordless authentication doesn't take the IDP status into account (#9494) https://github.com/gravitee-io/issues/issues/9615[#9615]
+* Addition of WebAuthn Credentials info into the context https://github.com/gravitee-io/issues/issues/9620[#9620]
+
+
+=== Console
+
+* User-agent showing 'undefined' in audit logs https://github.com/gravitee-io/issues/issues/9459[#9459]
+* Fetch user group doesn't persist https://github.com/gravitee-io/issues/issues/9609[#9609]
+
+
+
 ==  - 3.20.21 (2024-03-28)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.21 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.21/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.21 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.21%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
