### PR TITLE
chore: Add changelog for new 3.21.22 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,29 @@
 # Change Log
 
+==  - 3.21.22 (2024-04-05)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Disable Application https://github.com/gravitee-io/issues/issues/9584[#9584]
+
+=== Management API
+
+
+
+=== Console
+
+
+
+=== Other
+
+* Expired records present in table ciba_auth_requests. Cron is not taken into acoount. https://github.com/gravitee-io/issues/issues/9499[#9499]
+* Logs too verbose in AM when GeoIP plugin is not available https://github.com/gravitee-io/issues/issues/9633[#9633]
+
+
 ==  - 3.21.21 (2024-03-28)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.22 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.22/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.22 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.22%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
