### PR TITLE
fix: AM-2950 - badge number centralized.

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/password-policies/domain-password-policies.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/password-policies/domain-password-policies.component.scss
@@ -4,3 +4,7 @@
   color: #000;
   font-weight: normal;
 }
+
+.mat-badge-medium.mat-badge-overlap .mat-badge-content {
+  margin: unset;
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/AM-2950

![image](https://github.com/gravitee-io/gravitee-access-management/assets/158267130/9e6e3190-2690-4767-a973-d6717a5749a0)
