### PR TITLE
fix: analytics timeout

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/AnalyticsParam.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/AnalyticsParam.java
@@ -24,6 +24,8 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
+import java.time.temporal.ChronoUnit;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -113,31 +115,31 @@ public class AnalyticsParam {
                     .build());
         }
 
-        if (from == -1) {
+        if (from == -1L) {
             throw new WebApplicationException(Response
                     .status(Response.Status.BAD_REQUEST)
                     .entity("Query parameter 'from' is not valid")
                     .build());
         }
 
-        if (to == -1) {
+        if (to == -1L) {
             throw new WebApplicationException(Response
                     .status(Response.Status.BAD_REQUEST)
                     .entity("Query parameter 'to' is not valid")
                     .build());
         }
 
-        if (interval == -1) {
+        if (interval == -1L) {
             throw new WebApplicationException(Response
                     .status(Response.Status.BAD_REQUEST)
                     .entity("Query parameter 'interval' is not valid")
                     .build());
         }
 
-        if (interval < 1_000 || interval > 1_000_000_000) {
+        if (interval <  ChronoUnit.MILLIS.getDuration().toMillis() || interval > ChronoUnit.YEARS.getDuration().toMillis()) {
             throw new WebApplicationException(Response
                     .status(Response.Status.BAD_REQUEST)
-                    .entity("Query parameter 'interval' is not valid. 'interval' must be >= 1000 and <= 1000000000")
+                    .entity("Query parameter 'interval' is not valid. 'interval' must be >= 1000000 (millis) and <= 31556952 (years)")
                     .build());
         }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AnalyticsServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AnalyticsServiceImpl.java
@@ -109,7 +109,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                         .flatMap(analyticsResponse -> fetchMetadata((AnalyticsGroupByResponse) analyticsResponse));
             case Field.USER_STATUS:
             case Field.USER_REGISTRATION:
-                return userService.statistics(query).map(value -> new AnalyticsGroupByResponse(value));
+                return userService.statistics(query).map(AnalyticsGroupByResponse::new);
             default :
                 return executeGroupBy(query.getDomain(), queryBuilder.build(), query.getType());
         }
@@ -117,7 +117,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
 
     private Single<AnalyticsResponse> fetchMetadata(AnalyticsGroupByResponse analyticsGroupByResponse) {
         Map<Object, Object> values = analyticsGroupByResponse.getValues();
-        if (values == null && values.isEmpty()) {
+        if (values == null || values.isEmpty()) {
             return Single.just(analyticsGroupByResponse);
         }
         return Observable.fromIterable(values.keySet())
@@ -150,17 +150,17 @@ public class AnalyticsServiceImpl implements AnalyticsService {
 
         switch (query.getField()) {
             case Field.APPLICATION:
-                return applicationService.countByDomain(query.getDomain()).map(value -> new AnalyticsCountResponse(value));
+                return applicationService.countByDomain(query.getDomain()).map(AnalyticsCountResponse::new);
             case Field.USER:
-                return userService.countByDomain(query.getDomain()).map(value -> new AnalyticsCountResponse(value));
+                return userService.countByDomain(query.getDomain()).map(AnalyticsCountResponse::new);
             default :
                 return auditService.aggregate(query.getDomain(), queryBuilder.build(), query.getType())
-                        .map(values -> values.values().isEmpty() ? new AnalyticsCountResponse(0l) : new AnalyticsCountResponse((Long) values.values().iterator().next()));
+                        .map(values -> values.values().isEmpty() ? new AnalyticsCountResponse(0L) : new AnalyticsCountResponse((Long) values.values().iterator().next()));
         }
     }
 
     private Single<AnalyticsResponse> executeGroupBy(String domain, AuditReportableCriteria criteria, Type type) {
-        return auditService.aggregate(domain, criteria, type).map(values -> new AnalyticsGroupByResponse(values));
+        return auditService.aggregate(domain, criteria, type).map(AnalyticsGroupByResponse::new);
     }
 
     private Map<String, Object> getGenericMetadata(String value, boolean deleted) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
@@ -55,7 +55,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -69,7 +68,7 @@ import static io.gravitee.am.service.utils.BackendConfigurationUtils.getMongoDat
  */
 @Component
 public class IdentityProviderManagerImpl extends AbstractService<IdentityProviderManager> implements IdentityProviderManager, EventListener<IdentityProviderEvent, Payload> {
-    private static final Set SUPPORTED_PASSWORD_ENCODER = Set.of("BCrypt", "SHA-256", "SHA-384", "SHA-512", "SHA-256+MD5");
+    private static final Set<String> SUPPORTED_PASSWORD_ENCODER = Set.of("BCrypt", "SHA-256", "SHA-384", "SHA-512", "SHA-256+MD5");
     public static final String IDP_GRAVITEE = "gravitee";
 
     private static final Logger logger = LoggerFactory.getLogger(IdentityProviderManagerImpl.class);
@@ -79,7 +78,7 @@ public class IdentityProviderManagerImpl extends AbstractService<IdentityProvide
     private static final String DEFAULT_JDBC_IDP_TYPE = "jdbc-am-idp";
     // For postgres table name length is 63 (MySQL : 64 / SQL Server : 128) but the domain is prefixed by 'idp_users_' of length 10
     // set to 50 in order to also check the length of the ID field (max 64 with prefix of 12)
-    public static final int TABLE_NAME_MAX_LENGTH = 50;
+    private static final int TABLE_NAME_MAX_LENGTH = 50;
 
     private final ConcurrentMap<String, UserProvider> userProviders = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, IdentityProvider> identityProviders = new ConcurrentHashMap<>();
@@ -254,13 +253,12 @@ public class IdentityProviderManagerImpl extends AbstractService<IdentityProvide
             throw new IllegalArgumentException("Invalid password encoder value '" + encoder + "'");
         }
 
-        String providerConfig = null;
         String lowerCaseId = referenceId.toLowerCase();
         if (useMongoRepositories()) {
             Optional<String> mongoServers = getMongoServers();
             String mongoHost = null;
             String mongoPort = null;
-            if (!mongoServers.isPresent()) {
+            if (mongoServers.isEmpty()) {
                 mongoHost = environment.getProperty("management.mongodb.host", "localhost");
                 mongoPort = environment.getProperty("management.mongodb.port", "27017");
             }
@@ -270,7 +268,7 @@ public class IdentityProviderManagerImpl extends AbstractService<IdentityProvide
             final String mongoDBName = getMongoDatabaseName(environment);
 
             String defaultMongoUri = "mongodb://";
-            if (!StringUtils.isEmpty(username) && !StringUtils.isEmpty(password)) {
+            if (StringUtils.hasLength(username) && StringUtils.hasLength(password)) {
                 defaultMongoUri += username + ":" + password + "@";
             }
             defaultMongoUri += addOptionsToURI(mongoServers.orElse(mongoHost + ":" + mongoPort));
@@ -293,7 +291,7 @@ public class IdentityProviderManagerImpl extends AbstractService<IdentityProvide
             }
 
         } else if (useJdbcRepositories()) {
-            String tableSuffix = lowerCaseId.replaceAll("-", "_");
+            String tableSuffix = lowerCaseId.replace("-", "_");
             if ((tableSuffix).length() > TABLE_NAME_MAX_LENGTH) {
                 try {
                     logger.info("Table name 'idp_users_{}' will be too long, compute shortest unique name", tableSuffix);

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/constants/MongoAuditReporterConstants.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/constants/MongoAuditReporterConstants.java
@@ -38,6 +38,7 @@ public class MongoAuditReporterConstants {
   public static final String FIELD_ACCESS_POINT_ID = "accessPoint.id";
   public static final String INDEX_REFERENCE_TIMESTAMP_NAME = "r1t_1";
   public static final String INDEX_REFERENCE_TYPE_TIMESTAMP_NAME = "r1ty1t_1";
+  public static final String INDEX_REFERENCE_TYPE_STATUS_SUCCESS_TIMESTAMP_NAME = "r1ty1s1t_1";
   public static final String INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME = "r1a1t_1";
   public static final String INDEX_REFERENCE_TARGET_TIMESTAMP_NAME = "r1ta1t_1";
   public static final String INDEX_REFERENCE_ACTOR_TARGET_TIMESTAMP_NAME = "r1a1ta1t_1";

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ReporterServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ReporterServiceTest.java
@@ -59,7 +59,7 @@ public class ReporterServiceTest {
         final var reporter = new NewReporter();
         reporter.setEnabled(true);
         reporter.setName("Test");
-        reporter.setType(ReporterServiceImpl.REPORTER_AM_FILE);
+        reporter.setType("reporter-am-file");
         reporter.setConfiguration("{\"filename\":\"9f4bdf97-5481-4420-8bdf-9754818420f3\"}");
 
         when(reporterRepository.findByDomain(any())).thenReturn(Flowable.empty());
@@ -78,7 +78,7 @@ public class ReporterServiceTest {
         final var reporter = new NewReporter();
         reporter.setEnabled(true);
         reporter.setName("Test");
-        reporter.setType(ReporterServiceImpl.REPORTER_AM_FILE);
+        reporter.setType("reporter-am-file");
         reporter.setConfiguration("{\"filename\":\"../9f4bdf97-5481-4420-8bdf-9754818420f3\"}");
 
         final TestObserver<Reporter> observer = reporterService.create("domain", reporter).test();

--- a/gravitee-am-ui/src/app/components/widget/widget.component.html
+++ b/gravitee-am-ui/src/app/components/widget/widget.component.html
@@ -20,7 +20,17 @@
     <mat-card-title>{{ widget.title }}</mat-card-title>
     <mat-card-subtitle>{{ widget.subhead }}</mat-card-subtitle>
   </mat-card-header>
-  <mat-card-content>
+  <mat-card-content
+    class="no-data-card"
+    *ngIf="!widget.chart.response"
+    matTooltip="The data for this category could not be fetched. This could be related to the amount of data to process. Try to change the Time Range filter to see results."
+  >
+    <div class="no-data-text-block">
+      <mat-icon style="margin-right: 5px">info_outline</mat-icon>
+      <span>Failed to fetch data</span>
+    </div>
+  </mat-card-content>
+  <mat-card-content *ngIf="widget.chart.response">
     <gv-widget-chart-line *ngIf="widget.chart.type === 'line'" [chart]="widget.chart" [Highcharts]="Highcharts"></gv-widget-chart-line>
     <gv-widget-chart-pie *ngIf="widget.chart.type === 'pie'" [chart]="widget.chart" [Highcharts]="Highcharts"></gv-widget-chart-pie>
     <gv-widget-chart-gauge *ngIf="widget.chart.type === 'gauge'" [chart]="widget.chart" [Highcharts]="Highcharts"></gv-widget-chart-gauge>

--- a/gravitee-am-ui/src/app/components/widget/widget.component.scss
+++ b/gravitee-am-ui/src/app/components/widget/widget.component.scss
@@ -1,9 +1,29 @@
 mat-card {
+  height: 100%;
+
   mat-card-title {
     font-size: 16px;
   }
 
   mat-card-subtitle {
     font-size: 12px;
+  }
+}
+
+.mat-mdc-card-content:last-child {
+  padding: 8px;
+}
+
+.no-data-card {
+  padding: 8px;
+  cursor: default;
+
+  .no-data-text-block {
+    display: flex;
+    height: 29px;
+    align-items: center;
+    justify-content: center;
+    color: rgb(0 0 0 / 54%);
+    font-size: 16px;
   }
 }

--- a/gravitee-am-ui/src/app/domain/components/dashboard/dashboard.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/dashboard/dashboard.component.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { Component, Input, OnInit } from '@angular/core';
-import { forkJoin, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import * as Highcharts from 'highcharts';
 import moment from 'moment';
 import { find, isNil, map as _map } from 'lodash';
@@ -69,9 +69,8 @@ export class DashboardComponent implements OnInit {
     this.fetch();
   }
 
-  private query(widget): Observable<Widget> {
+  private query(widget: Widget): Observable<Widget> {
     const selectedTimeRange = find(this.timeRanges, { id: this.selectedTimeRange });
-
     const analyticsQuery = {
       type: widget.chart.request.type,
       field: widget.chart.request.field,
@@ -90,11 +89,13 @@ export class DashboardComponent implements OnInit {
         widget.chart.response = response;
         return widget;
       }),
+      catchError(() => of(widget)),
     );
   }
 
   private fetch() {
     const dashboard: DashboardData = Object.assign({}, this.dashboard);
+    this.widgets?.forEach((w) => (w.chart.response = null));
     this.widgets = [];
     this.isLoading = true;
     forkJoin(_map(dashboard.widgets, (widget) => this.query(widget))).subscribe((widgets) => {

--- a/gravitee-am-ui/src/app/utils/time-range-utils.ts
+++ b/gravitee-am-ui/src/app/utils/time-range-utils.ts
@@ -31,8 +31,8 @@ export const availableTimeRanges: TimeRange[] = [
   {
     id: '1h',
     name: 'Last hour',
-    value: 1,
-    unit: 'hours',
+    value: 60,
+    unit: 'minutes',
     interval: 1000 * 60,
   },
   {
@@ -45,22 +45,22 @@ export const availableTimeRanges: TimeRange[] = [
   {
     id: '1d',
     name: 'Today',
-    value: 1,
-    unit: 'days',
+    value: 24,
+    unit: 'hours',
     interval: 1000 * 60 * 60,
   },
   {
     id: '7d',
     name: 'This week',
-    value: 1,
-    unit: 'weeks',
+    value: 7,
+    unit: 'days',
     interval: 1000 * 60 * 60 * 24,
   },
   {
     id: '30d',
     name: 'This month',
-    value: 1,
-    unit: 'months',
+    value: 4,
+    unit: 'weeks',
     interval: 1000 * 60 * 60 * 24,
   },
   {


### PR DESCRIPTION
fixes AM-1110

two things: 
on the backend added extended index with outcome.status == 'SUCCESS'  
on the frontend made dashboard resilient to single indicator crash. 

for count pipeline aggregate with old index () the 3 month request for 0.5M user logins took `executionTimeMillis: 1150`
with new index `executionTimeMillis: 154`
the proof the planner takes new index: 

> winningPlan: {
            stage: 'COUNT_SCAN',
            keyPattern: {
              referenceType: 1,
              referenceId: 1,
              type: 1,
              'outcome.status': 1,
              timestamp: -1
            },
            indexName: 'r1ty1s1t_1'  <-- NEW ONE


Mockups: 
https://www.figma.com/file/k7okoie28WAjDjsnnEAjFc/AM---Dashboard?type=design&node-id=119-3190&mode=design&t=IPYa2HjD9JFmxrc0-0

Dashboard after changes:
![image](https://github.com/gravitee-io/gravitee-access-management/assets/158267130/73e201ce-b63c-412e-9709-a82c0abb918f)

![image](https://github.com/gravitee-io/gravitee-access-management/assets/158267130/72ee7e4f-9c3a-435d-afd6-a70ffedcfbdf)

![image](https://github.com/gravitee-io/gravitee-access-management/assets/158267130/d9cf4dcb-0bd9-4590-8daa-e64f8771aa5a)

![image](https://github.com/gravitee-io/gravitee-access-management/assets/158267130/0e182c93-2acb-4581-8293-8d8f182f34c1)
