### PR TITLE
chore: Add changelog for new 3.21.23 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,30 @@
 # Change Log
 
+==  - 3.21.23 (2024-04-12)
+
+== What's new !
+
+
+
+=== Gateway
+
+
+
+=== Management API
+
+
+
+=== Console
+
+
+
+=== Other
+
+* Enrollment Flow Logic Bug https://github.com/gravitee-io/issues/issues/9518[#9518]
+* Improve CORS Domain settings and replace default value https://github.com/gravitee-io/issues/issues/9531[#9531]
+* Support SAML mixing response binding protocol https://github.com/gravitee-io/issues/issues/9648[#9648]
+
+
 ==  - 3.21.22 (2024-04-05)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.23 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.23/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.23 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.23%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
