### PR TITLE
chore(ci): fix link generation for changelogs

### DIFF
--- a/release/helpers/changelog-helper.mjs
+++ b/release/helpers/changelog-helper.mjs
@@ -31,7 +31,7 @@ export function getChangelogFor(title, issues) {
       let publicIssueContent = '';
       if (githubIssue) {
         const githubLink = `https://github.com/gravitee-io/issues/issues/${githubIssue}`;
-        publicIssueContent = ` ${githubLink}[#${githubIssue}]`;
+        publicIssueContent = ` [#${githubIssue}](${githubLink})`;
       }
       return `* ${issue.summary}${publicIssueContent}`;
     })


### PR DESCRIPTION
the AM pipeline to use proper link syntax, i.e., [text](url) instead of url[text]