### PR TITLE
feat: allow users from external idp to have new attributes

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/UserServiceTest.java
@@ -32,6 +32,7 @@ import io.gravitee.am.service.*;
 import io.gravitee.am.service.exception.*;
 import io.gravitee.am.service.impl.PasswordHistoryService;
 import io.gravitee.am.service.model.NewUser;
+import io.gravitee.am.service.model.UpdateUser;
 import io.gravitee.am.service.validators.email.EmailValidatorImpl;
 import io.gravitee.am.service.validators.user.UserValidator;
 import io.gravitee.am.service.validators.user.UserValidatorImpl;
@@ -39,6 +40,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import java.io.IOException;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -943,6 +945,147 @@ public class UserServiceTest {
                 MovingFactorUtils.generateInitialMovingFactor(user.getId()),
                 user.getFactors().get(0).getSecurity().getAdditionalData().get(FactorDataKeys.KEY_MOVING_FACTOR)
         );
+    }
+
+    @Test
+    public void must_update_user_with_user_provider() {
+        var domain = new Domain();
+        domain.setId("domain");
+
+
+        var user = new User();
+        user.setId("user-id");
+        user.setSource("idp-id");
+        user.setUsername(USERNAME);
+
+        var updatedUser = new UpdateUser();
+        updatedUser.setFirstName("New firstName");
+        updatedUser.setLastName("New lastName");
+        updatedUser.setEmail("john@doe.com");
+
+        var additionalInformation = new HashMap<String, Object>();
+        additionalInformation.put("customClaim", "claim");
+        updatedUser.setAdditionalInformation(additionalInformation);
+
+        when(commonUserService.findById(DOMAIN, domain.getId(), user.getId()))
+                .thenReturn(Single.just(user));
+        when(commonUserService.update(DOMAIN, domain.getId(), user.getId(), updatedUser)).thenReturn(Single.just(user));
+
+        final UserProvider userProvider = mock(UserProvider.class);
+
+        final var defaultUser = new DefaultUser(user.getUsername());
+        defaultUser.setId("idp-user-id");
+
+        final var idpUserUpdated = new DefaultUser(NEW_USERNAME);
+        defaultUser.setId("idp-user-id");
+
+        when(userProvider.findByUsername(anyString())).thenReturn(Maybe.just(defaultUser));
+        when(userProvider.update(any(), any())).thenReturn(Single.just(idpUserUpdated));
+
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+        var observer = userService.update(domain.getId(), user.getId(), updatedUser).test();
+
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertComplete();
+
+        verify(commonUserService, times(1)).update(DOMAIN, domain.getId(), user.getId(), updatedUser);
+        verify(userProvider, times(1)).update(any(), any());
+    }
+
+    @Test
+    public void must_update_user_with_user_provider_even_if_user_absent() {
+        var domain = new Domain();
+        domain.setId("domain");
+
+        var user = new User();
+        user.setId("user-id");
+        user.setSource("idp-id");
+        user.setUsername(USERNAME);
+
+        var updatedUser = new UpdateUser();
+        updatedUser.setSource("idp-user-id");
+
+        when(commonUserService.findById(DOMAIN, domain.getId(), user.getId()))
+                .thenReturn(Single.just(user));
+        when(commonUserService.update(DOMAIN, domain.getId(), user.getId(), updatedUser)).thenReturn(Single.just(user));
+
+        final UserProvider userProvider = mock(UserProvider.class);
+
+        final var defaultUser = new DefaultUser(user.getUsername());
+        defaultUser.setId("idp-user-id");
+
+        when(userProvider.findByUsername(anyString())).thenReturn(Maybe.error(new UserNotFoundException("User not found in idp")));
+
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+        var observer = userService.update(domain.getId(), user.getId(), updatedUser).test();
+
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertComplete();
+
+        verify(commonUserService, times(1)).update(DOMAIN, domain.getId(), user.getId(), updatedUser);
+    }
+
+    @Test
+    public void must_update_user_without_provider() {
+        var domain = new Domain();
+        domain.setId("domain");
+
+        var user = new User();
+        user.setId("user-id");
+        user.setSource("idp-user-id");
+
+
+        var updatedUser = new UpdateUser();
+        updatedUser.setSource("idp-user-id");
+
+        when(commonUserService.findById(DOMAIN, domain.getId(), user.getId()))
+                .thenReturn(Single.just(user));
+        when(commonUserService.update(DOMAIN, domain.getId(), user.getId(), updatedUser))
+                .thenReturn(Single.just(user));
+
+        final UserProvider userProvider = mock(UserProvider.class);
+
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.empty());
+        var observer = userService.update(domain.getId(), user.getId(), updatedUser).test();
+
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertComplete();
+
+        verify(commonUserService, times(1)).update(DOMAIN, domain.getId(), user.getId(), updatedUser);
+        verify(userProvider, times(0)).update(any(), any());
+    }
+
+    @Test
+    public void must_not_update_user_with_user_with_unexpected_error() {
+        var domain = new Domain();
+        domain.setId("domain");
+
+        var user = new User();
+        user.setId("user-id");
+        user.setSource("idp-id");
+        user.setUsername(USERNAME);
+
+        var updatedUser = new UpdateUser();
+        user.setId("user-id");
+        user.setSource("idp-user-id");
+        user.setUsername(USERNAME);
+
+        when(commonUserService.findById(DOMAIN, domain.getId(), user.getId()))
+                .thenReturn(Single.just(user));
+
+        final UserProvider userProvider = mock(UserProvider.class);
+
+        final var defaultUser = new DefaultUser(user.getUsername());
+        defaultUser.setId("idp-user-id");
+
+        when(userProvider.findByUsername(anyString()))
+                .thenReturn(Maybe.error(new IOException("Other issue")));
+
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+        var observer = userService.update(domain.getId(), user.getId(), updatedUser).test();
+
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertError(IOException.class);
     }
 
     @Test

--- a/gravitee-am-ui/package-lock.json
+++ b/gravitee-am-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gravitee-am-webui",
-  "version": "4.0.15",
+  "version": "4.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gravitee-am-webui",
-      "version": "4.0.15",
+      "version": "4.0.16",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.html
@@ -73,28 +73,28 @@
                 matInput
                 type="text"
                 placeholder="First name"
-                [disabled]="!editMode() || !canEdit"
+                [disabled]="!canEdit"
                 #firstName="ngModel"
                 name="firstName"
                 [(ngModel)]="user.firstName"
                 required
               />
-              <mat-hint *ngIf="editMode()">The first name of the User.</mat-hint>
+              <mat-hint>The first name of the User.</mat-hint>
               <mat-error *ngIf="firstName.errors?.required">Enter first name</mat-error>
             </mat-form-field>
-            <mat-form-field *ngIf="user.lastName || user.internal" appearance="outline" floatLabel="always">
+            <mat-form-field *ngIf="user.lastName" appearance="outline" floatLabel="always">
               <mat-label>Last name</mat-label>
               <input
                 matInput
                 type="text"
                 placeholder="Last name"
-                [disabled]="!editMode() || !canEdit"
+                [disabled]="!canEdit"
                 #lastName="ngModel"
                 name="lastName"
                 [(ngModel)]="user.lastName"
                 required
               />
-              <mat-hint *ngIf="editMode()">The last name of the User.</mat-hint>
+              <mat-hint>The last name of the User.</mat-hint>
               <mat-error *ngIf="lastName.errors?.required">Enter last name</mat-error>
             </mat-form-field>
           </div>
@@ -104,19 +104,19 @@
               <input
                 matInput
                 placeholder="Email"
-                [disabled]="!editMode() || !canEdit"
+                [disabled]="!canEdit"
                 #email="ngModel"
                 name="email"
                 [(ngModel)]="user.email"
                 [email]="user.email !== ''"
                 required
               />
-              <mat-hint *ngIf="editMode()">Email address for the User.</mat-hint>
+              <mat-hint>Email address for the User.</mat-hint>
               <mat-error *ngIf="email.errors?.required">Enter email</mat-error>
               <mat-error *ngIf="user.email && email.errors?.email">Not a valid email</mat-error>
             </mat-form-field>
           </div>
-          <div *ngIf="!isOrganizationUserAction() && editMode() && canEdit">
+          <div *ngIf="!isOrganizationUserAction() && canEdit">
             <app-select-applications
               [selectedApp]="user.applicationEntity"
               (onSelectApp)="onAppSelectionChanged($event)"
@@ -124,14 +124,14 @@
             ></app-select-applications>
           </div>
         </div>
-        <div class="gv-form-section" *ngIf="!isEmptyObject(user.additionalInformation) || editMode()">
+        <div class="gv-form-section" *ngIf="!isEmptyObject(user.additionalInformation)">
           <div class="gv-form-section-title">
             <h5>Additional information</h5>
             <small>Custom information about the user. These details are available in the user's profile.</small>
             <mat-divider></mat-divider>
           </div>
           <div>
-            <a (click)="addDynamicComponent()" class="gv-accent-link" *ngIf="editMode() && canEdit">(+) add user attribute</a>
+            <a (click)="addDynamicComponent()" class="gv-accent-link" *ngIf="canEdit">(+) add user attribute</a>
             <template #dynamic></template>
             <div *ngFor="let keyValuePair of user.additionalInformation | mapToIterable">
               <div *ngIf="keyValuePair.value && !asObject(keyValuePair.value)" fxLayout="row">
@@ -145,10 +145,9 @@
                     [name]="'claimValue' + keyValuePair.key"
                     [(ngModel)]="user.additionalInformation[keyValuePair.key]"
                     (change)="formChanged = true"
-                    [disabled]="!editMode()"
                   />
                 </mat-form-field>
-                <button mat-icon-button *ngIf="editMode()" (click)="removeExistingClaim(keyValuePair.key, $event)">
+                <button mat-icon-button (click)="removeExistingClaim(keyValuePair.key, $event)">
                   <mat-icon>clear</mat-icon>
                 </button>
               </div>
@@ -166,7 +165,7 @@
                     disabled
                   />
                 </mat-form-field>
-                <button mat-icon-button *ngIf="editMode()" (click)="removeExistingClaim(keyValuePair.key, $event)">
+                <button mat-icon-button (click)="removeExistingClaim(keyValuePair.key, $event)">
                   <mat-icon>clear</mat-icon>
                 </button>
               </div>
@@ -264,7 +263,7 @@
             </div>
           </div>
         </div>
-        <div fxLayout="row" *ngIf="editMode() && canEdit">
+        <div fxLayout="row" *ngIf="canEdit">
           <button mat-raised-button color="primary" [disabled]="(!userForm.valid || userForm.pristine) && !formChanged" type="submit">
             SAVE
           </button>


### PR DESCRIPTION
## :id: Reference related issue. 

Relates to: https://gravitee.atlassian.net/browse/AM-475
Public bug: https://github.com/gravitee-io/issues/issues/8434

## :pencil2: A description of the changes proposed in the pull request

This PR allows to edit the user profile even with an external IDP.
Note that the changes will only happen in AM and not to this external IDP.

## :memo: Test scenarios 

- Create an external IDP (Google, Github, Facebook, LinkedIn ...)
- Associate it to your application
- Login with your User using the IDP
- Go to the User Profile
- Add / Remove additionalInformation
- Logout and LogIn with the user 

The custom attributes you have added should remain while the one default to your IDP should come back
This should also work with organization users

Internal users should still be able to have fields updated and removed as well

## :computer: Add screenshots for UI

<img width="1552" alt="image" src="https://github.com/gravitee-io/gravitee-access-management/assets/8531515/efc58cb3-f190-4f70-92a6-3aa47e2383ce">

<img width="1538" alt="image" src="https://github.com/gravitee-io/gravitee-access-management/assets/8531515/a5407910-21fa-4351-abfc-9b1fd3036e68">