### PR TITLE
fix: typo on account registration configuration

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -209,7 +209,7 @@ public class CommonConfiguration {
         final String mfaChallengeSubject = environment.getProperty("user.mfaChallenge.email.subject", String.class, "Verification Code");
         final int mfaChallengeExpireAfter = environment.getProperty("user.mfaChallenge.token.expire-after", Integer.class, 300);
         final String mfaVerifyAttemptSubject = environment.getProperty("user.mfaVerifyAttempt.email.subject", String.class, "${msg('email.verify_attempt.subject')}");
-        final String registrationVerifySubject = environment.getProperty("user.registration.verify.email.subject", String.class, "${msg('email.registration_verify.subject')");
+        final String registrationVerifySubject = environment.getProperty("user.registration.verify.email.subject", String.class, "${msg('email.registration_verify.subject')}");
         final int userRegistrationVerifyTimeValue = environment.getProperty("user.registration.verify.time.value", Integer.class, 7);
         final TimeUnit userRegistrationVerifyTimeUnit = environment.getProperty("user.registration.verify.time.unit", TimeUnit.class, TimeUnit.DAYS);
 


### PR DESCRIPTION
## :id: Reference related issue. 

fixes: [AM-2942](https://gravitee.atlassian.net/browse/AM-2942)
public: https://github.com/gravitee-io/issues/issues/9659


## :pencil2: A description of the changes proposed in the pull request

This PR fixes a typo in the configuration of the verify template on the subject.
Causing the Email not to be sent because of the enclosing `{` not being closed

## :memo: Test scenarios 

- Configure your AM application with `Login > Registration` Form and  `User Accounts > User Registration > 
Account verification via email: true`
- Initiate the login flow and register
- You should receive an Email to verify your account

## :computer: Add screenshots for UI

![image](https://github.com/gravitee-io/gravitee-access-management/assets/8531515/e7414330-48c9-4769-b20e-e5231fd603f5)

[AM-2942]: https://gravitee.atlassian.net/browse/AM-2942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ