### PR TITLE
AM-3306 fix: Limit on webauthn credentials sending back in a response

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/store/RepositoryCredentialStore.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/store/RepositoryCredentialStore.java
@@ -30,6 +30,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.vertx.ext.auth.webauthn.Authenticator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -53,13 +54,11 @@ public class RepositoryCredentialStore {
     @Autowired
     private Domain domain;
 
+    @Value("${user.webAuthn.maxAllowCredentials:-1}")
+    protected int maxAllowCredentials;
+
     public Single<List<Authenticator>> fetch(Authenticator query) {
-
-        Single<List<Credential>> fetchCredentials = query.getUserName() != null ?
-                credentialService.findByUsername(ReferenceType.DOMAIN, domain.getId(), query.getUserName()).toList() :
-                credentialService.findByCredentialId(ReferenceType.DOMAIN, domain.getId(), query.getCredID()).toList();
-
-        return fetchCredentials
+        return fetchCredentials(query)
                 .flatMap(credentials -> {
                     if (credentials.isEmpty() && query.getUserName() != null) {
                         // If, when initiating an authentication ceremony, there is no account matching the provided username,
@@ -112,6 +111,18 @@ public class RepositoryCredentialStore {
                                 .collect(Collectors.toList()));
                     }
                 });
+    }
+
+    private Single<List<Credential>> fetchCredentials(Authenticator query){
+        if (query.getUserName() != null) {
+            if (maxAllowCredentials > 0) {
+                return credentialService.findByUsername(ReferenceType.DOMAIN, domain.getId(), query.getUserName(), maxAllowCredentials).toList();
+            } else {
+                return credentialService.findByUsername(ReferenceType.DOMAIN, domain.getId(), query.getUserName()).toList();
+            }
+        } else {
+            return credentialService.findByCredentialId(ReferenceType.DOMAIN, domain.getId(), query.getCredID()).toList();
+        }
     }
 
     public Completable store(Authenticator authenticator) {

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -304,6 +304,8 @@ user:
   mfaVerifyAttempt:
     email:
       #subject: Multiple verification attempt detected
+  webAuthn:
+    #maxAllowCredentials: 20 # number of credentials sent back to perform passwordless authentication. Keep in mind, Firefox handles max 20
 
 handlers:
   request:

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/CredentialRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/CredentialRepository.java
@@ -34,6 +34,8 @@ public interface CredentialRepository extends CrudRepository<Credential, String>
 
     Flowable<Credential> findByUsername(ReferenceType referenceType, String referenceId, String username);
 
+    Flowable<Credential> findByUsername(ReferenceType referenceType, String referenceId, String username, int limit);
+
     Flowable<Credential> findByCredentialId(ReferenceType referenceType, String referenceId, String credentialId);
 
     Completable deleteByUserId(ReferenceType referenceType, String referenceId, String userId);

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcCredentialRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcCredentialRepository.java
@@ -66,6 +66,14 @@ public class JdbcCredentialRepository extends AbstractJdbcRepository implements 
     }
 
     @Override
+    public Flowable<Credential> findByUsername(ReferenceType referenceType, String referenceId, String username, int limit) {
+        LOGGER.debug("findByUsername({},{},{},{})", referenceType, referenceId, username, limit);
+        return credentialRepository.findByUsernameOrderByCreatedAt(referenceType.name(), referenceId, username)
+                .take(limit)
+                .map(this::toEntity);
+    }
+
+    @Override
     public Flowable<Credential> findByCredentialId(ReferenceType referenceType, String referenceId, String credentialId) {
         LOGGER.debug("findByCredentialId({},{},{})", referenceType, referenceId, credentialId);
         return credentialRepository.findByCredentialId(referenceType.name(), referenceId, credentialId)

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringCredentialRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringCredentialRepository.java
@@ -34,6 +34,9 @@ public interface SpringCredentialRepository extends RxJava3CrudRepository<JdbcCr
     @Query("Select * from webauthn_credentials c where c.reference_id = :refId and c.reference_type = :refType and username = :username")
     Flowable<JdbcCredential> findByUsername(@Param("refType") String referenceType, @Param("refId")String referenceId, @Param("username") String username);
 
+    @Query("Select * from webauthn_credentials c where c.reference_id = :refId and c.reference_type = :refType and username = :username ORDER BY c.created_at DESC")
+    Flowable<JdbcCredential> findByUsernameOrderByCreatedAt(@Param("refType") String referenceType, @Param("refId")String referenceId, @Param("username") String username);
+
     @Query("Select * from webauthn_credentials c where c.reference_id = :refId and c.reference_type = :refType and credential_id = :credId")
     Flowable<JdbcCredential> findByCredentialId(@Param("refType") String referenceType, @Param("refId")String referenceId, @Param("credId")String credentialId);
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoCredentialRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoCredentialRepository.java
@@ -40,6 +40,7 @@ public class MongoCredentialRepository extends AbstractManagementMongoRepository
     private static final String FIELD_USER_ID = "userId";
     private static final String FIELD_USERNAME = "username";
     private static final String FIELD_CREDENTIAL_ID = "credentialId";
+    private static final String FIELD_CREATED_AT = "createdAt";
     private MongoCollection<CredentialMongo> credentialsCollection;
 
     @PostConstruct
@@ -75,6 +76,20 @@ public class MongoCredentialRepository extends AbstractManagementMongoRepository
                                 eq(FIELD_USERNAME, username)
                         )
                 ))
+                .map(this::convert);
+    }
+
+    @Override
+    public Flowable<Credential> findByUsername(ReferenceType referenceType, String referenceId, String username, int limit) {
+        return Flowable.fromPublisher(
+                        credentialsCollection.find(
+                                and(
+                                        eq(FIELD_REFERENCE_TYPE, referenceType.name()),
+                                        eq(FIELD_REFERENCE_ID, referenceId),
+                                        eq(FIELD_USERNAME, username)
+                                )).sort(
+                                    new Document(FIELD_CREATED_AT, -1))
+                                .limit(limit))
                 .map(this::convert);
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/CredentialRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/CredentialRepositoryTest.java
@@ -70,6 +70,25 @@ public class CredentialRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
+    public void findByUsernameWithLimit() throws TechnicalException {
+        // create credential
+        Credential credential1 = buildCredential();
+        Credential credential2 = buildCredential();
+
+        credentialRepository.create(credential1).blockingGet();
+        credentialRepository.create(credential2).blockingGet();
+
+        // fetch credentials
+        TestSubscriber<Credential> testSubscriber = credentialRepository
+                .findByUsername(credential1.getReferenceType(), credential1.getReferenceId(), credential1.getUsername(), 1).test();
+        testSubscriber.awaitDone(10, TimeUnit.SECONDS);
+
+        testSubscriber.assertComplete();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertValueCount(1);
+    }
+
+    @Test
     public void findByCredentialId() throws TechnicalException {
         // create credential
         Credential credential = buildCredential();

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/CredentialService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/CredentialService.java
@@ -34,6 +34,8 @@ public interface CredentialService {
 
     Flowable<Credential> findByUsername(ReferenceType referenceType, String referenceId, String username);
 
+    Flowable<Credential> findByUsername(ReferenceType referenceType, String referenceId, String username, int limit);
+
     Flowable<Credential> findByCredentialId(ReferenceType referenceType, String referenceId, String credentialId);
 
     Single<Credential> create(Credential credential);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CredentialServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CredentialServiceImpl.java
@@ -91,6 +91,17 @@ public class CredentialServiceImpl implements CredentialService {
     }
 
     @Override
+    public Flowable<Credential> findByUsername(ReferenceType referenceType, String referenceId, String username, int limit) {
+        LOGGER.debug("Find credentials by {} {} and username: {}, returning {}", referenceType, referenceId, username, limit);
+        return credentialRepository.findByUsername(referenceType, referenceId, username, limit)
+                .onErrorResumeNext(ex -> {
+                    LOGGER.error("An error occurs while trying to find a credential using {} {} and username: {} and limit: {}", referenceType, referenceId, username, limit, ex);
+                    return Flowable.error(new TechnicalManagementException(
+                            String.format("An error occurs while trying to find a credential using %s %s and username: %s", referenceType, referenceId, username), ex));
+                });
+    }
+
+    @Override
     public Flowable<Credential> findByCredentialId(ReferenceType referenceType, String referenceId, String credentialId) {
         LOGGER.debug("Find credentials by {} {} and credential ID: {}", referenceType, referenceId, credentialId);
         return credentialRepository.findByCredentialId(referenceType, referenceId, credentialId)

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/CredentialServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/CredentialServiceTest.java
@@ -127,6 +127,17 @@ public class CredentialServiceTest {
     }
 
     @Test
+    public void shouldFindLatestElementsByUsername() {
+        when(credentialRepository.findByUsername(ReferenceType.DOMAIN, DOMAIN, "username", 15)).thenReturn(Flowable.just(new Credential()));
+        TestSubscriber<Credential> testObserver = credentialService.findByUsername(ReferenceType.DOMAIN, DOMAIN, "username", 15).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValueCount(1);
+    }
+
+    @Test
     public void shouldFindByUsername_technicalException() {
         when(credentialRepository.findByUsername(ReferenceType.DOMAIN, DOMAIN, "username")).thenReturn(Flowable.error(TechnicalException::new));
 


### PR DESCRIPTION
Added gravitee.yaml property which limits number of credentials sent back to browser on password-less authentication.
It is due to different behaviour on different browsers. Firefox accepts max 20, Chrome max 64.   