### PR TITLE
AM-2887 fix: Added crucial MFA event logs

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
@@ -337,6 +337,7 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
                 updateStrongAuthStatus(routingContext);
                 redirectToAuthorize(routingContext, client);
             }
+            logger.debug("User {} strongly authenticated", endUser.getId());
         };
     }
 
@@ -355,6 +356,7 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
 
 
             updateStrongAuthStatus(routingContext);
+            logger.info("User {} strongly authenticated", endUser.getId());
             // set the credentialId in session
             routingContext.session().put(ConstantKeys.WEBAUTHN_CREDENTIAL_ID_CONTEXT_KEY, credentialId);
             final Credential credential = ch.result();
@@ -411,6 +413,7 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
                             }
                         },
                         error -> {
+                            logger.info("Challenge failed for user {}", factorContext.getUser().getId());
                             final EnrolledFactor enrolledFactor = (EnrolledFactor) factorContext.getData().get(FactorContext.KEY_ENROLLED_FACTOR);
                             verifyAttemptService.incrementAttempt(factorContext.getUser().getId(), enrolledFactor.getFactorId(),
                                     factorContext.getClient(), domain, verifyAttempt).subscribe(
@@ -468,6 +471,7 @@ public class MFAChallengeEndpoint extends AbstractEndpoint implements Handler<Ro
 
     private void sendChallenge(FactorProvider factorProvider, FactorContext factorContext, Handler<AsyncResult<Void>> handler){
         factorProvider.sendChallenge(factorContext)
+                .doOnComplete(() -> logger.debug("Challenge sent to user {}", factorContext.getUser().getId()))
                 .subscribeOn(Schedulers.io())
                 .subscribe(
                         () -> handler.handle(Future.succeededFuture()),

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpoint.java
@@ -224,6 +224,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
         if (provider.checkSecurityFactor(getSecurityFactor(params, optFactor.get().getKey()))) {
             // save enrolled factor for the current user and continue
             routingContext.session().put(ConstantKeys.ENROLLED_FACTOR_ID_KEY, factorId);
+            logger.debug("Factor {} selected for user {}", factorId, endUser.getId());
             if (sharedSecret != null) {
                 routingContext.session().put(ConstantKeys.ENROLLED_FACTOR_SECURITY_VALUE_KEY, sharedSecret);
             }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/UserServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/UserServiceImpl.java
@@ -276,6 +276,7 @@ public class UserServiceImpl extends AbstractUserService implements UserService 
                         }
                     }
                     return update(user)
+                            .doOnSuccess(user1 -> LOGGER.debug("Factor {} upserted for user {}", enrolledFactor.getFactorId(), user1.getId()))
                             .doOnSuccess(user1 -> {
                                 if (needToAuditUserFactorsOperation(user1, oldUser)) {
                                     // remove sensitive data about factors


### PR DESCRIPTION
`15:01:36.652 [Thread-28] [] INFO  i.g.a.g.h.r.r.e.m.MFAEnrollEndpoint - Factor 298f0de1-be4c-4c06-8f0d-e1be4c5c064a selected for user c11e7f61-ad3d-47c2-9e7f-61ad3d67c226`

`15:01:36.665 [RxCachedThreadScheduler-1] [] INFO  i.g.a.g.h.r.r.e.m.MFAChallengeEndpoint - Challenge sent to user c11e7f61-ad3d-47c2-9e7f-61ad3d67c226`

`15:02:15.184 [Thread-21] [] INFO  i.g.a.g.h.r.r.e.m.MFAChallengeEndpoint - User c11e7f61-ad3d-47c2-9e7f-61ad3d67c226 strongly authenticated`

`15:02:15.187 [Thread-15] [] INFO  i.g.am.service.impl.UserServiceImpl - Factor 298f0de1-be4c-4c06-8f0d-e1be4c5c064a upserted for user c11e7f61-ad3d-47c2-9e7f-61ad3d67c226`