### PR TITLE
chore: Add changelog for new 3.21.24 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,29 @@
 # Change Log
 
+==  - 3.21.24 (2024-04-29)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Issue with MFA and silent refresh token https://github.com/gravitee-io/issues/issues/9622[#9622]
+* [WebAuthn] Problèmatique Authenticator "SecurityError : The operation is insecure." https://github.com/gravitee-io/issues/issues/9686[#9686]
+
+=== Management API
+
+* AM - Application Analytics Timeout https://github.com/gravitee-io/issues/issues/9405[#9405]
+
+=== Console
+
+
+
+=== Other
+
+
+
+
 ==  - 3.21.23 (2024-04-12)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.24 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.24/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.24 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.24%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
