### PR TITLE
feature: AM-2892 - add common resolver component to get IDP for regisration

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/password/PasswordPolicyManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/password/PasswordPolicyManager.java
@@ -27,7 +27,6 @@ public interface PasswordPolicyManager extends Service {
 
     Optional<PasswordPolicy> getPolicy(String policyId);
     Optional<PasswordPolicy> getDefaultPolicy();
-
     Optional<PasswordPolicy> getPolicy(Client client, IdentityProvider identityProvider);
 
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserRegistrationIdpResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserRegistrationIdpResolver.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.service.user;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.model.oidc.Client;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class UserRegistrationIdpResolver {
+    private static final String DEFAULT_IDP_PREFIX = "default-idp-";
+
+
+    public static String getRegistrationIdpForUser(Domain domain, Client client, User user) {
+        var accountSettings = AccountSettings.getInstance(client, domain);
+        return accountSettings
+                .map(AccountSettings::getDefaultIdentityProviderForRegistration)
+                .orElseGet(() -> user.getSource() == null ? DEFAULT_IDP_PREFIX + domain.getId() : user.getSource());
+    }
+
+    public static String getRegistrationIdp(Domain domain, Client client) {
+        var accountSettings = AccountSettings.getInstance(client, domain);
+        return accountSettings
+                .map(AccountSettings::getDefaultIdentityProviderForRegistration)
+                .orElseGet(() -> DEFAULT_IDP_PREFIX + domain.getId());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
@@ -29,6 +29,7 @@ import io.gravitee.am.gateway.handler.common.jwt.JWTService;
 import io.gravitee.am.gateway.handler.common.password.PasswordPolicyManager;
 import io.gravitee.am.gateway.handler.root.service.response.RegistrationResponse;
 import io.gravitee.am.gateway.handler.root.service.response.ResetPasswordResponse;
+import io.gravitee.am.gateway.handler.root.service.user.UserRegistrationIdpResolver;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.gateway.handler.root.service.user.model.ForgotPasswordParameters;
 import io.gravitee.am.gateway.handler.root.service.user.model.UserToken;
@@ -226,8 +227,7 @@ public class UserServiceImpl implements UserService {
     public Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams) {
         // set user idp source
         var accountSettings = AccountSettings.getInstance(client, domain);
-        final String source = accountSettings.map(AccountSettings::getDefaultIdentityProviderForRegistration)
-                .orElse(user.getSource() == null ? DEFAULT_IDP_PREFIX + domain.getId() : user.getSource());
+        final String source = UserRegistrationIdpResolver.getRegistrationIdpForUser(domain, client, user);
         final var rawPassword = user.getPassword();
         // validate user and then check user uniqueness
         return userValidator.validate(user)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/PasswordPolicyRequestParseHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/PasswordPolicyRequestParseHandlerTest.java
@@ -20,6 +20,7 @@ import io.gravitee.am.gateway.handler.common.password.PasswordPolicyManager;
 import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.service.PasswordService;
 import io.gravitee.am.service.exception.InvalidPasswordException;
 import io.vertx.core.http.HttpMethod;
@@ -32,9 +33,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -70,7 +71,8 @@ public class PasswordPolicyRequestParseHandlerTest extends RxWebTestBase {
                 .handler(passwordPolicyRequestParseHandler)
                 .handler(rc -> rc.response().end());
 
-        doThrow(InvalidPasswordException.class).when(passwordValidator).validate(anyString(), eq(null), any());
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        doThrow(InvalidPasswordException.class).when(passwordValidator).validate(anyString(), any(), any());
 
         testRequest(HttpMethod.POST, "/", req -> {
             Buffer buffer = Buffer.buffer();
@@ -91,8 +93,8 @@ public class PasswordPolicyRequestParseHandlerTest extends RxWebTestBase {
                 .handler(passwordPolicyRequestParseHandler)
                 .handler(rc -> rc.response().end());
 
-
-        doNothing().when(passwordValidator).validate(anyString(), eq(null), any());
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        doNothing().when(passwordValidator).validate(anyString(), any(), any());
 
         testRequest(HttpMethod.POST, "/", req -> {
             Buffer buffer = Buffer.buffer();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserRegistrationIdpResolverTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserRegistrationIdpResolverTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.service.user;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.model.oidc.Client;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class UserRegistrationIdpResolverTest {
+
+    @Test
+    public void shouldReturnRegistrationIdpFromDomainWhenClientsIsNull() {
+        // given
+        Domain domain = new Domain();
+        domain.setAccountSettings(accountSettings("DEFAULT_DOMAIN_IDP"));
+
+        User user = new User();
+
+        // when
+        String idpByUser = UserRegistrationIdpResolver.getRegistrationIdpForUser(domain, null, user);
+        String idpByClient = UserRegistrationIdpResolver.getRegistrationIdp(domain, null);
+
+        // then
+        Assertions.assertEquals("DEFAULT_DOMAIN_IDP", idpByUser);
+        Assertions.assertEquals("DEFAULT_DOMAIN_IDP", idpByClient);
+    }
+
+    @Test
+    public void shouldReturnRegistrationIdpFromDomainWhenClientsSettingIsEmpty() {
+        // given
+        Domain domain = new Domain();
+        domain.setAccountSettings(accountSettings("DEFAULT_DOMAIN_IDP"));
+
+        Client client = new Client();
+
+        User user = new User();
+
+        // when
+        String idpByUser = UserRegistrationIdpResolver.getRegistrationIdpForUser(domain, client, user);
+        String idpByClient = UserRegistrationIdpResolver.getRegistrationIdp(domain, client);
+
+        // then
+        Assertions.assertEquals("DEFAULT_DOMAIN_IDP", idpByUser);
+        Assertions.assertEquals("DEFAULT_DOMAIN_IDP", idpByClient);
+    }
+
+    @Test
+    public void shouldReturnRegistrationIdpFromClientAccountSettingsWhenItsNotInherited() {
+        // given
+        Domain domain = new Domain();
+        domain.setAccountSettings(accountSettings("DEFAULT_DOMAIN_IDP"));
+
+        Client client = new Client();
+        client.setAccountSettings(accountSettings("DEFAULT_CLIENT_IDP", false));
+
+        User user = new User();
+
+        // when
+        String idpByUser = UserRegistrationIdpResolver.getRegistrationIdpForUser(domain, client, user);
+        String idpByClient = UserRegistrationIdpResolver.getRegistrationIdp(domain, client);
+
+        // then
+        Assertions.assertEquals("DEFAULT_CLIENT_IDP", idpByUser);
+        Assertions.assertEquals("DEFAULT_CLIENT_IDP", idpByClient);
+    }
+
+    @Test
+    public void shouldReturnRegistrationIdpFromDomainAccountSettingsWhenClientSettingsIsInherited() {
+        // given
+        Domain domain = new Domain();
+        domain.setAccountSettings(accountSettings("DEFAULT_DOMAIN_IDP"));
+
+        Client client = new Client();
+        client.setAccountSettings(accountSettings("DEFAULT_CLIENT_IDP", true));
+
+        User user = new User();
+
+        // when
+        String idpByUser = UserRegistrationIdpResolver.getRegistrationIdpForUser(domain, client, user);
+        String idpByClient = UserRegistrationIdpResolver.getRegistrationIdp(domain, client);
+
+        // then
+        Assertions.assertEquals("DEFAULT_DOMAIN_IDP", idpByUser);
+        Assertions.assertEquals("DEFAULT_DOMAIN_IDP", idpByClient);
+    }
+
+    @Test
+    public void shouldReturnRegistrationIdpFromUserSourceIfNorDomainAndClientHasSuchSettings() {
+        // given
+        Domain domain = new Domain();
+        domain.setId("ID");
+        Client client = new Client();
+        User user = new User();
+        user.setSource("USER_IDP");
+
+        // when
+        String idpByUser = UserRegistrationIdpResolver.getRegistrationIdpForUser(domain, client, user);
+
+        // then
+        Assertions.assertEquals("USER_IDP", idpByUser);
+    }
+
+    @Test
+    public void should_return_default_registration_idp_when_such_not_found_for_domain_nor_client_nor_user() {
+        // given
+        Domain domain = new Domain();
+        domain.setId("ID");
+        Client client = new Client();
+        User user = new User();
+
+        // when
+        String idpByUser = UserRegistrationIdpResolver.getRegistrationIdpForUser(domain, client, user);
+        String idpByClient = UserRegistrationIdpResolver.getRegistrationIdp(domain, client);
+
+        // then
+        Assertions.assertEquals("default-idp-ID", idpByUser);
+        Assertions.assertEquals("default-idp-ID", idpByClient);
+    }
+
+    private AccountSettings accountSettings(String idpForRegistration) {
+        return accountSettings(idpForRegistration, true);
+    }
+
+    private AccountSettings accountSettings(String idpForRegistration, boolean inherited) {
+        AccountSettings accountSettings = new AccountSettings();
+        accountSettings.setDefaultIdentityProviderForRegistration(idpForRegistration);
+        accountSettings.setInherited(inherited);
+        return accountSettings;
+    }
+}


### PR DESCRIPTION
added common resolver component to get IDP for registration. Reuse it, on password policy stages: presentation and validation
