### PR TITLE
fix: remove tokens on user delete

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserResource.java
@@ -225,8 +225,8 @@ public class UserResource extends AbstractResource {
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_USER, Acl.DELETE)
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
-                        .flatMapCompletable(irrelevant -> userService.delete(ReferenceType.DOMAIN, domain, user, authenticatedUser)))
-                .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
+                        .flatMapSingle(irrelevant -> userService.delete(ReferenceType.DOMAIN, domain, user, authenticatedUser)))
+                .subscribe((u) -> response.resume(Response.noContent().build()), response::resume);
     }
 
     @POST

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UserResource.java
@@ -261,7 +261,7 @@ public class UserResource extends AbstractResource {
 
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_USER, Acl.DELETE)
                 .andThen(organizationUserService.delete(ReferenceType.ORGANIZATION, organizationId, user, authenticatedUser))
-                .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
+                .subscribe((u) -> response.resume(Response.noContent().build()), response::resume);
     }
 
     @POST

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/CommonUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/CommonUserService.java
@@ -43,10 +43,10 @@ public interface CommonUserService {
 
     Single<User> updateUsername(ReferenceType referenceType, String referenceId, String id, String username, io.gravitee.am.identityprovider.api.User principal);
 
-    default Completable delete(ReferenceType referenceType, String referenceId, String userId) {
+    default Single<User> delete(ReferenceType referenceType, String referenceId, String userId) {
         return delete(referenceType, referenceId, userId, null);
     }
 
-    Completable delete(ReferenceType referenceType, String referenceId, String userId, io.gravitee.am.identityprovider.api.User principal);
+    Single<User> delete(ReferenceType referenceType, String referenceId, String userId, io.gravitee.am.identityprovider.api.User principal);
 
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
@@ -251,4 +251,10 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
                         .throwable(x)))
                 .ignoreElement();
     }
+
+    @Override
+    public Single<User> delete(ReferenceType referenceType, String referenceId, String userId, io.gravitee.am.identityprovider.api.User principal) {
+        return super.delete(referenceType, referenceId, userId, principal)
+                .flatMap(user -> getUserService().revokeUserAccessTokens(user.getReferenceType(), user.getReferenceId(), user.getId()).toSingleDefault(user));
+    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/UserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/UserServiceImpl.java
@@ -283,6 +283,12 @@ public class UserServiceImpl extends AbstractUserService<io.gravitee.am.service.
     }
 
     @Override
+    public Single<User> delete(ReferenceType referenceType, String referenceId, String userId, io.gravitee.am.identityprovider.api.User principal) {
+        return super.delete(referenceType, referenceId, userId, principal)
+                .flatMap(user -> tokenService.deleteByUser(user).toSingleDefault(user));
+    }
+
+    @Override
     public Single<User> updateStatus(String domain, String id, boolean status, io.gravitee.am.identityprovider.api.User principal) {
         return updateStatus(DOMAIN, domain, id, status, principal);
     }

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/AccountAccessTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/AccountAccessTokenRepository.java
@@ -18,9 +18,12 @@ package io.gravitee.am.repository.management.api;
 import io.gravitee.am.model.AccountAccessToken;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.repository.common.CrudRepository;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 
 public interface AccountAccessTokenRepository extends CrudRepository<AccountAccessToken, String> {
 
     Flowable<AccountAccessToken> findByUserId(ReferenceType referenceType, String referenceId, String userId);
+
+    Completable deleteByUserId(ReferenceType referenceType, String referenceId, String userId);
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcAccountAccessTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcAccountAccessTokenRepository.java
@@ -52,6 +52,11 @@ public class JdbcAccountAccessTokenRepository extends AbstractJdbcRepository imp
     }
 
     @Override
+    public Completable deleteByUserId(ReferenceType referenceType, String referenceId, String userId) {
+        return accessTokenRepository.deleteByUserId(referenceType.name(), referenceId, userId).ignoreElement();
+    }
+
+    @Override
     public Single<AccountAccessToken> create(AccountAccessToken item) {
         var entity = toEntity(item);
         if (entity.getId() == null) {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringAccountAccessTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringAccountAccessTokenRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.am.repository.jdbc.management.api.spring;
 
 import io.gravitee.am.repository.jdbc.management.api.model.JdbcAccountAccessToken;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.reactive.RxJava3CrudRepository;
@@ -25,4 +26,7 @@ public interface SpringAccountAccessTokenRepository extends RxJava3CrudRepositor
 
     @Query("select * from account_access_tokens a where a.user_id = :userId and a.reference_id = :refId and a.reference_type = :refType")
     Flowable<JdbcAccountAccessToken> findByUserId(@Param("refType") String refType, @Param("refId") String refId, @Param("userId") String userId);
+
+    @Query("delete from account_access_tokens a where a.user_id = :userId and a.reference_id = :refId and a.reference_type = :refType")
+    Maybe<Long> deleteByUserId(@Param("refType") String refType, @Param("refId") String refId, @Param("userId") String userId);
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAccountAccessTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAccountAccessTokenRepository.java
@@ -72,6 +72,15 @@ public class MongoAccountAccessTokenRepository extends AbstractManagementMongoRe
     }
 
     @Override
+    public Completable deleteByUserId(ReferenceType referenceType, String referenceId, String userId) {
+        return Completable.fromPublisher(accountTokensCollection.deleteMany(and(
+                eq(FIELD_USER_ID, userId),
+                eq(FIELD_REFERENCE_ID, referenceId),
+                eq(FIELD_REFERENCE_TYPE, referenceType.name())
+        )));
+    }
+
+    @Override
     public Single<AccountAccessToken> create(AccountAccessToken item) {
         var document = convert(item);
         return Single.fromPublisher(accountTokensCollection.insertOne(document))

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/CommonUserService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/CommonUserService.java
@@ -58,7 +58,7 @@ public interface CommonUserService {
 
     Single<User> update(User user);
 
-    Completable delete(String userId);
+    Single<User> delete(String userId);
 
     Single<User> enhance(User user);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/OrganizationUserService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/OrganizationUserService.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.service;
 
 import io.gravitee.am.model.AccountAccessToken;
+import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
 import io.gravitee.am.service.model.NewAccountAccessToken;
 import io.reactivex.rxjava3.core.Completable;
@@ -46,6 +47,8 @@ public interface OrganizationUserService extends CommonUserService {
     Flowable<AccountAccessToken> findUserAccessTokens(String organisationId, String userId);
 
     Single<AccountAccessToken> generateAccountAccessToken(User user, NewAccountAccessToken newAccountToken, String issuer);
+
+    Completable revokeUserAccessTokens(ReferenceType referenceType, String organizationId, String userId);
 
     Single<User> findByAccessToken(String token, String tokenValue);
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
@@ -247,7 +247,7 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
         LOGGER.debug("Assigning Password Policy {} to IdentityProvider {} for domain {}", assignPasswordPolicy.getPasswordPolicy(), id, domain);
 
         return identityProviderRepository.findById(ReferenceType.DOMAIN, domain, id)
-                .switchIfEmpty(Single.error(new IdentityProviderNotFoundException(id)))
+                .switchIfEmpty(Single.error(() -> new IdentityProviderNotFoundException(id)))
                 .flatMap(oldIdentity -> {
                     IdentityProvider identityToUpdate = new IdentityProvider(oldIdentity);
                     identityToUpdate.setUpdatedAt(new Date());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/OrganizationUserServiceImpl.java
@@ -187,6 +187,11 @@ public class OrganizationUserServiceImpl extends AbstractUserService<Organizatio
                 .flatMap(token -> prepareTokenToGet(token).toFlowable());
     }
 
+    @Override
+    public Completable revokeUserAccessTokens(ReferenceType referenceType, String referenceId, String userId) {
+        return accessTokenRepository.deleteByUserId(referenceType, referenceId, userId);
+    }
+
     private Single<AccountAccessToken> prepareTokenToGet(AccountAccessToken token) {
         return prepareTokenToGet(token, false);
     }
@@ -214,5 +219,11 @@ public class OrganizationUserServiceImpl extends AbstractUserService<Organizatio
                 .flatMapSingle(token -> accessTokenRepository.delete(token.tokenId())
                         .andThen(Single.just(token)))
                 .toSingle();
+    }
+
+    @Override
+    public Single<User> delete(String userId) {
+        return super.delete(userId)
+                .flatMap(user -> accessTokenRepository.deleteByUserId(user.getReferenceType(), user.getReferenceId(), user.getId()).toSingleDefault(user));
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/UserServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/UserServiceImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.am.model.scim.Attribute;
 import io.gravitee.am.repository.management.api.CommonUserRepository.UpdateActions;
 import io.gravitee.am.repository.management.api.UserRepository;
 import io.gravitee.am.service.AuditService;
+import io.gravitee.am.service.TokenService;
 import io.gravitee.am.service.UserService;
 import io.gravitee.am.service.exception.AbstractManagementException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
@@ -68,6 +69,9 @@ public class UserServiceImpl extends AbstractUserService implements UserService 
 
     @Autowired
     private AuditService auditService;
+
+    @Autowired
+    protected TokenService tokenService;
 
     @Override
     protected UserRepository getUserRepository() {
@@ -145,6 +149,12 @@ public class UserServiceImpl extends AbstractUserService implements UserService 
                     LOGGER.error("An error occurs while trying to update a user", ex);
                     return Single.error(new TechnicalManagementException("An error occurs while trying to update a user", ex));
                 }));
+    }
+
+    @Override
+    public Single<User> delete(String userId) {
+        return super.delete(userId)
+                .flatMap(user -> tokenService.deleteByUser((User) user).toSingleDefault(user));
     }
 
     @Override

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/OrganizationUserServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/OrganizationUserServiceTest.java
@@ -24,6 +24,7 @@ import io.gravitee.am.reporter.api.audit.model.Audit;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.repository.management.api.AccountAccessTokenRepository;
 import io.gravitee.am.repository.management.api.OrganizationUserRepository;
+import io.gravitee.am.repository.oauth2.api.AccessTokenRepository;
 import io.gravitee.am.service.authentication.crypto.password.PasswordEncoder;
 import io.gravitee.am.service.exception.EmailFormatInvalidException;
 import io.gravitee.am.service.exception.InvalidUserException;
@@ -96,8 +97,10 @@ public class OrganizationUserServiceTest {
 
     @Mock
     private OrganizationUserRepository userRepository;
+
     @Mock
     private AccountAccessTokenRepository accessTokenRepository;
+
     @Mock
     private CredentialService credentialService;
 
@@ -287,6 +290,7 @@ public class OrganizationUserServiceTest {
         when(userRepository.findById("my-user")).thenReturn(Maybe.just(user));
         when(userRepository.delete("my-user")).thenReturn(Completable.complete());
         when(credentialService.findByUserId(user.getReferenceType(), user.getReferenceId(), user.getId())).thenReturn(Flowable.empty());
+        when(accessTokenRepository.deleteByUserId(any(), any(), any())).thenReturn(Completable.complete());
 
         TestObserver testObserver = userService.delete("my-user").test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
@@ -312,6 +316,7 @@ public class OrganizationUserServiceTest {
         when(userRepository.delete("my-user")).thenReturn(Completable.complete());
         when(credentialService.findByUserId(user.getReferenceType(), user.getReferenceId(), user.getId())).thenReturn(Flowable.just(credential));
         when(credentialService.delete(credential.getId(), false)).thenReturn(Completable.complete());
+        when(accessTokenRepository.deleteByUserId(any(), any(), any())).thenReturn(Completable.complete());
 
         TestObserver testObserver = userService.delete("my-user").test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/UserServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/UserServiceTest.java
@@ -99,6 +99,9 @@ public class UserServiceTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private TokenService tokenService;
+
     private final static String DOMAIN = "domain1";
 
     @Test
@@ -469,6 +472,7 @@ public class UserServiceTest {
         when(userRepository.findById("my-user")).thenReturn(Maybe.just(user));
         when(userRepository.delete("my-user")).thenReturn(Completable.complete());
         when(credentialService.findByUserId(user.getReferenceType(), user.getReferenceId(), user.getId())).thenReturn(Flowable.empty());
+        when(tokenService.deleteByUser(any())).thenReturn(Completable.complete());
 
         TestObserver testObserver = userService.delete("my-user").test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
@@ -494,6 +498,7 @@ public class UserServiceTest {
         when(userRepository.delete("my-user")).thenReturn(Completable.complete());
         when(credentialService.findByUserId(user.getReferenceType(), user.getReferenceId(), user.getId())).thenReturn(Flowable.just(credential));
         when(credentialService.delete(credential.getId(), false)).thenReturn(Completable.complete());
+        when(tokenService.deleteByUser(any())).thenReturn(Completable.complete());
 
         TestObserver testObserver = userService.delete("my-user").test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);


### PR DESCRIPTION
fixes AM-3093

## :id: Reference related issue. 


## :pencil2: A description of the changes proposed in the pull request

- Remove tokens from access_tokens when a user is removed
- Remove tokens from account_access_tokens when an organization user is removed

## :memo: Test scenarios 


## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
