### PR TITLE
Fixed not encode certificate header

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/CertificateUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/CertificateUtils.java
@@ -64,9 +64,10 @@ public class CertificateUtils {
                 certHeaderValue = certHeaderValue
                         .replaceAll("\\+","%2F")
                         .replaceAll("//","%2B")
-                        .replaceAll("=","%3D");
+                        .replaceAll("=","%3D")
+                        .replaceAll("\t", "\n");
 
-                certHeaderValue = URLDecoder.decode(certHeaderValue.replaceAll("\t", "\n"), Charset.defaultCharset());
+                certHeaderValue = URLDecoder.decode(certHeaderValue, Charset.defaultCharset());
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
                 certificate = Optional.ofNullable((X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(certHeaderValue.getBytes())));
             } catch (CertificateException e) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/CertificateUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/CertificateUtils.java
@@ -61,6 +61,11 @@ public class CertificateUtils {
 
         if (certHeaderValue != null) {
             try {
+                certHeaderValue = certHeaderValue
+                        .replaceAll("\\+","%2F")
+                        .replaceAll("//","%2B")
+                        .replaceAll("=","%3D");
+
                 certHeaderValue = URLDecoder.decode(certHeaderValue.replaceAll("\t", "\n"), Charset.defaultCharset());
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
                 certificate = Optional.ofNullable((X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(certHeaderValue.getBytes())));


### PR DESCRIPTION
## :id: Reference related issue. 
from AWS gateway to certificate header value add not encrypted chars like "", "/","="
as result certificate not valid.

## :pencil2: A description of the changes proposed in the pull request
add replaceAll
"\+" to "%2F"
"//" to "%2B"
"=" to "%3D"

## :memo: Test scenarios 
to certificate add not encrypted "" or "/" or "="
and try by class CertificateUtils#extractPeerCertificate
receive certificate

## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
