### PR TITLE
chore: Add changelog for new 3.21.25 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,14 @@
 # Change Log
 
+==  - 3.21.25 (2024-05-09)
+
+== What's new !
+
+=== Gateway
+
+* Addition of MFA logs https://github.com/gravitee-io/issues/issues/9629[#9629]
+
+
 ==  - 3.21.24 (2024-04-29)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.25 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.25/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.25 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.25%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
