### PR TITLE
fix: "skip remember device" not being saved when using JDBC storage

### DIFF
--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/RememberDeviceSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/RememberDeviceSettings.java
@@ -15,14 +15,23 @@
  */
 package io.gravitee.am.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Data
 public class RememberDeviceSettings {
 
     private boolean active;
-    private boolean skipRememberDevice;
+
+    /**
+     * Only used with conditional MFA challenge. If true, remember device will not be applied when MFA condition evaluates to no risk
+     */
+    @JsonProperty("skipRememberDevice")
+    private boolean isSkipChallengeWhenRememberDevice;
     private Long expirationTimeSeconds;
     private String deviceIdentifierId;
 
@@ -33,37 +42,5 @@ public class RememberDeviceSettings {
         this.active = other.active;
         this.expirationTimeSeconds = other.expirationTimeSeconds;
         this.deviceIdentifierId = other.deviceIdentifierId;
-    }
-
-    public boolean isActive() {
-        return active;
-    }
-
-    public boolean isSkipChallengeWhenRememberDevice() {
-        return skipRememberDevice;
-    }
-
-    public Long getExpirationTimeSeconds() {
-        return expirationTimeSeconds;
-    }
-
-    public String getDeviceIdentifierId() {
-        return deviceIdentifierId;
-    }
-
-    public void setActive(boolean active) {
-        this.active = active;
-    }
-
-    public void setExpirationTimeSeconds(Long expirationTimeSeconds) {
-        this.expirationTimeSeconds = expirationTimeSeconds;
-    }
-
-    public void setDeviceIdentifierId(String deviceIdentifierId) {
-        this.deviceIdentifierId = deviceIdentifierId;
-    }
-
-    public void setSkipRememberDevice(boolean skipRememberDevice) {
-        this.skipRememberDevice = skipRememberDevice;
     }
 }

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/RememberDeviceSettingsTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/RememberDeviceSettingsTest.java
@@ -1,0 +1,92 @@
+
+package io.gravitee.am.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class RememberDeviceSettingsTest {
+
+
+    public static TestCase[] examples() {
+        return new TestCase[]{
+                // null simulate field being unset in the incoming JSON payload
+                settings(null, null, null, null),
+
+                settings(false, null, null, null),
+                settings(true, null, null, null),
+
+                settings(null, false, null, null),
+                settings(null, true, null, null),
+
+                settings(null, null, 123456L, null),
+
+                settings(null, null, 123456L, "test-device-identifier"),
+
+                settings(true, true, 123456L, "test-device-identifier"),
+        };
+    }
+
+    // github: #9734
+    @ParameterizedTest
+    @MethodSource("examples")
+    void jsonMapper_readsCorrectly(TestCase testCase) throws Exception {
+        var expectedSettings = testCase.expectedSettings;
+        var read = getMapper().treeToValue(testCase.json(), RememberDeviceSettings.class);
+        assertThat(read)
+                .as("json is read correctly")
+                .usingRecursiveComparison()
+                .isEqualTo(expectedSettings);
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("examples")
+    void jsonMapperSerialization_roundTrips(TestCase testCase) throws Exception {
+        var mapper = getMapper();
+        var expectedSettings = testCase.expectedSettings;
+        var readBack = mapper.readValue(mapper.writeValueAsBytes(expectedSettings), RememberDeviceSettings.class);
+        assertThat(readBack)
+                .as("serialization round-trips")
+                .usingRecursiveComparison()
+                .isEqualTo(expectedSettings);
+    }
+
+    private static JsonMapper getMapper() {
+        var mapper = new JsonMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return mapper;
+    }
+
+    static TestCase settings(Boolean active,
+                                           Boolean skipRememberDevice,
+                                           Long expirationTimeSeconds,
+                                           String deviceIdentifierId) {
+        var json = getMapper().createObjectNode();
+        var expectedSettings = new RememberDeviceSettings();
+
+        if (active != null) {
+            expectedSettings.setActive(active);
+            json.put("active", active);
+        }
+        if (skipRememberDevice != null) {
+            expectedSettings.setSkipChallengeWhenRememberDevice(skipRememberDevice);
+            json.put("skipRememberDevice", skipRememberDevice);
+        }
+        expectedSettings.setExpirationTimeSeconds(expirationTimeSeconds);
+        json.put("expirationTimeSeconds", expirationTimeSeconds);
+
+        expectedSettings.setDeviceIdentifierId(deviceIdentifierId);
+        json.put("deviceIdentifierId", deviceIdentifierId);
+        return new TestCase(json, expectedSettings);
+    }
+
+    record TestCase(ObjectNode json, RememberDeviceSettings expectedSettings) {}
+
+}

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/RememberDeviceSettingsTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/RememberDeviceSettingsTest.java
@@ -1,4 +1,18 @@
-
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.am.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/RememberDeviceSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/RememberDeviceSettingsMongo.java
@@ -75,7 +75,7 @@ public class RememberDeviceSettingsMongo {
     public RememberDeviceSettings convert() {
         var rememberDeviceSettings = new RememberDeviceSettings();
         rememberDeviceSettings.setActive(TRUE.equals(isActive()));
-        rememberDeviceSettings.setSkipRememberDevice(TRUE.equals(isSkipRememberDevice()));
+        rememberDeviceSettings.setSkipChallengeWhenRememberDevice(TRUE.equals(isSkipRememberDevice()));
         rememberDeviceSettings.setDeviceIdentifierId(deviceIdentifierId);
         rememberDeviceSettings.setExpirationTimeSeconds(expirationTimeSeconds);
         return rememberDeviceSettings;

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryTest.java
@@ -41,7 +41,15 @@ import org.junit.Test;
 import org.mockito.internal.util.collections.Sets;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -444,7 +452,7 @@ public class ApplicationRepositoryTest extends AbstractManagementTest {
         var rememberDeviceSettings = new RememberDeviceSettings();
         rememberDeviceSettings.setActive(true);
         rememberDeviceSettings.setDeviceIdentifierId("device-id");
-        rememberDeviceSettings.setSkipRememberDevice(true);
+        rememberDeviceSettings.setSkipChallengeWhenRememberDevice(true);
         rememberDeviceSettings.setExpirationTimeSeconds(100000L);
 
         var mfaSettings = new MFASettings();

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchRememberDeviceSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchRememberDeviceSettings.java
@@ -80,7 +80,7 @@ public class PatchRememberDeviceSettings {
         RememberDeviceSettings toPatch = _toPatch == null ? new RememberDeviceSettings() : new RememberDeviceSettings(_toPatch);
         SetterUtils.safeSet(toPatch::setDeviceIdentifierId, this.getDeviceIdentifierId());
         SetterUtils.safeSet(toPatch::setActive, this.getActive());
-        SetterUtils.safeSet(toPatch::setSkipRememberDevice, this.getSkipRememberDevice());
+        SetterUtils.safeSet(toPatch::setSkipChallengeWhenRememberDevice, this.getSkipRememberDevice());
         final Optional<Long> expirationTimeSeconds = isNull(this.getExpirationTimeSeconds()) ? Optional.empty() : this.getExpirationTimeSeconds();
         SetterUtils.safeSet(toPatch::setExpirationTimeSeconds, expirationTimeSeconds.filter(Objects::nonNull).map(Math::abs));
         return toPatch;


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3186,  #9734

## :pencil2: A description of the changes proposed in the pull request

This PR ensure property names used for JSON serialization & deserialization of Remember Device settings match and therefore will be properly persisted.


