### PR TITLE
fix: don't require a redirect_uri param in the reset password flow

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/TokenPurpose.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/TokenPurpose.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.jwt;
+
+import java.util.Arrays;
+
+public enum TokenPurpose {
+    UNSPECIFIED,
+    RESET_PASSWORD,
+    REGISTRATION_VERIFY;
+
+    public static TokenPurpose of(String string) {
+        return Arrays.stream(values())
+                .filter(x -> x.name().equalsIgnoreCase(string))
+                .findFirst()
+                .orElse(UNSPECIFIED);
+    }
+}

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -247,6 +247,7 @@ public interface ConstantKeys {
     String CLAIM_REMEMBER_ME = "r";
     String CLAIM_TARGET = "t";
     String CLAIM_STATUS = "s";
+    String CLAIM_TOKEN_PURPOSE = "tp";
     String STATUS_SIGNED_IN = "signed-in";
     String STATUS_FAILURE = "failure";
     String CLAIM_ISSUING_REASON = "ir";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
@@ -265,12 +265,12 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
     }
 
     private Optional<TokenPurpose> getTokenPurpose(io.gravitee.am.model.Template template) {
-        var purpose = switch (template) {
-            case RESET_PASSWORD -> TokenPurpose.RESET_PASSWORD;
-            case REGISTRATION_VERIFY -> TokenPurpose.REGISTRATION_VERIFY;
-            default -> null;
+        return switch (template) {
+            case RESET_PASSWORD -> Optional.of(TokenPurpose.RESET_PASSWORD);
+            case REGISTRATION_VERIFY -> Optional.of(TokenPurpose.REGISTRATION_VERIFY);
+            // not UNSPECIFIED, because if the token has no particular purpose, we don't want it to contain this claim
+            default -> Optional.empty();
         };
-        return Optional.ofNullable(purpose);
 
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.am.common.email.Email;
 import io.gravitee.am.common.email.EmailBuilder;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.jwt.TokenPurpose;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.email.EmailManager;
 import io.gravitee.am.gateway.handler.common.email.EmailService;
@@ -41,8 +42,6 @@ import io.gravitee.am.service.i18n.GraviteeMessageResolver;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.EmailAuditBuilder;
 import io.vertx.rxjava3.core.MultiMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -57,6 +56,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.gravitee.am.common.oauth2.Parameters.CLIENT_ID;
 import static io.gravitee.am.common.web.UriBuilder.encodeURIComponent;
@@ -217,7 +217,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
     }
 
     private Email prepareEmail(io.gravitee.am.model.Template template, io.gravitee.am.model.Email emailTemplate, User user, Client client, MultiMap queryParams) {
-        Map<String, Object> params = prepareEmailParams(user, client, emailTemplate.getExpiresAfter(), template.redirectUri(), queryParams);
+        Map<String, Object> params = prepareEmailParams(user, client, emailTemplate.getExpiresAfter(), template, queryParams);
         return new EmailBuilder()
                 .to(user.getEmail())
                 .from(emailTemplate.getFrom())
@@ -228,7 +228,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
                 .build();
     }
 
-    private Map<String, Object> prepareEmailParams(User user, Client client, Integer expiresAfter, String path, MultiMap queryParams) {
+    private Map<String, Object> prepareEmailParams(User user, Client client, Integer expiresAfter, io.gravitee.am.model.Template template, MultiMap queryParams) {
         // generate a JWT to store user's information and for security purpose
         final Map<String, Object> claims = new HashMap<>();
         Instant now = Instant.now();
@@ -243,6 +243,9 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
             queryParams.add(CLIENT_ID, encodeURIComponent(client.getClientId()));
         }
 
+        getTokenPurpose(template)
+                .ifPresent(purpose -> claims.put(ConstantKeys.CLAIM_TOKEN_PURPOSE, purpose));
+
         String token = jwtBuilder.sign(new JWT(claims));
         queryParams.add("token", token);
 
@@ -256,9 +259,19 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
             params.put("client", new ClientProperties(client));
         }
 
-        params.put("url", domainService.buildUrl(domain, path, queryParams));
+        params.put("url", domainService.buildUrl(domain, template.redirectUri(), queryParams));
 
         return params;
+    }
+
+    private Optional<TokenPurpose> getTokenPurpose(io.gravitee.am.model.Template template) {
+        var purpose = switch (template) {
+            case RESET_PASSWORD -> TokenPurpose.RESET_PASSWORD;
+            case REGISTRATION_VERIFY -> TokenPurpose.REGISTRATION_VERIFY;
+            default -> null;
+        };
+        return Optional.ofNullable(purpose);
+
     }
 
     protected io.gravitee.am.model.Email getEmailTemplate(io.gravitee.am.model.Template template, Client client) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -356,7 +356,7 @@ public class RootProvider extends AbstractProtocolProvider {
         Handler<RoutingContext> localeHandler = new LocaleHandler(messageResolver);
         Handler<RoutingContext> loginPostWebAuthnHandler = new LoginPostWebAuthnHandler(webAuthnCookieService);
         Handler<RoutingContext> userRememberMeHandler = new UserRememberMeRequestHandler(jwtService, domain, rememberMeCookieName);
-        Handler<RoutingContext> redirectUriValidationHandler = new RedirectUriValidationHandler(domain);
+        Handler<RoutingContext> redirectUriValidationHandler = new RedirectUriValidationHandler(domain, userService);
 
         // Root policy chain handler
         rootRouter.route()

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandler.java
@@ -16,14 +16,22 @@
 package io.gravitee.am.gateway.handler.root.resources.handler.common;
 
 import io.gravitee.am.common.exception.oauth2.RedirectMismatchException;
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.jwt.TokenPurpose;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.root.service.RedirectUriValidator;
+import io.gravitee.am.gateway.handler.root.service.user.UserService;
+import io.gravitee.am.gateway.handler.root.service.user.model.UserToken;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.Client;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.Handler;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 import static io.gravitee.am.gateway.handler.root.resources.endpoint.ParamUtils.getOAuthParameter;
 import static io.gravitee.am.gateway.handler.root.resources.endpoint.ParamUtils.redirectMatches;
@@ -32,9 +40,9 @@ import static io.gravitee.am.gateway.handler.root.resources.endpoint.ParamUtils.
  * The authorization server validates the request to ensure that all parameters are valid.
  * If the request is valid, the authorization server authenticates the resource owner and obtains
  * an authorization decision (by asking the resource owner or by establishing approval via other means).
- *
+ * <p>
  * See <a href="https://tools.ietf.org/html/rfc6749#section-4.1.1">4.1.1. Authorization Request</a>
- *
+ * <p>
  * This specific handler is checking the validity of the redirect_uri
  *
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -44,25 +52,58 @@ public class RedirectUriValidationHandler implements Handler<RoutingContext> {
 
     private final Domain domain;
     private final RedirectUriValidator redirectUriValidator;
+    private Function<String, Maybe<JWT>> tokenVerifier;
 
     public RedirectUriValidationHandler(Domain domain) {
         this.domain = domain;
         this.redirectUriValidator = new RedirectUriValidator();
+        this.tokenVerifier = t -> Maybe.empty();
+    }
+
+    public RedirectUriValidationHandler(Domain domain, UserService userService) {
+        this.domain = domain;
+        this.redirectUriValidator = new RedirectUriValidator();
+        this.tokenVerifier = t -> userService.verifyToken(t)
+                .map(UserToken::getToken);
     }
 
     @Override
     public void handle(RoutingContext context) {
         final Client client = context.get(ConstantKeys.CLIENT_CONTEXT_KEY);
-
-        // proceed redirect_uri parameter
-        parseRedirectUriParameter(context, client);
-
-        context.next();
+        getOperation(context)
+                .subscribe(operation -> {
+                            // proceed redirect_uri parameter
+                            parseRedirectUriParameter(context, client, operation);
+                            context.next();
+                        },
+                        context::fail);
     }
 
-    private void parseRedirectUriParameter(RoutingContext context, Client client) {
+    private Single<TokenPurpose> getOperation(RoutingContext context) {
+        return getAndVerifyToken(context)
+                .mapOptional(verified -> {
+                    var tokenPurpose = (String) verified.get(ConstantKeys.CLAIM_TOKEN_PURPOSE);
+                    return Optional.ofNullable(tokenPurpose)
+                            .map(TokenPurpose::of);
+                })
+                .defaultIfEmpty(TokenPurpose.UNSPECIFIED);
+    }
+
+    private Maybe<JWT> getAndVerifyToken(RoutingContext context) {
+        if (tokenVerifier == null) {
+            return Maybe.empty();
+        }
+        final String token = context.request().getParam(ConstantKeys.TOKEN_PARAM_KEY);
+        if (token == null) {
+            return Maybe.empty();
+        }
+        return tokenVerifier.apply(token);
+    }
+
+    private void parseRedirectUriParameter(RoutingContext context, Client client, TokenPurpose operation) {
         String requestedRedirectUri = getOAuthParameter(context, io.gravitee.am.common.oauth2.Parameters.REDIRECT_URI);
-        redirectUriValidator.validate(client, requestedRedirectUri, this::checkMatchingRedirectUri);
+
+        redirectUriValidator.validate(client, requestedRedirectUri, operation, this::checkMatchingRedirectUri);
     }
 
     private void checkMatchingRedirectUri(String requestedRedirect, List<String> registeredClientRedirectUris) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandler.java
@@ -52,7 +52,7 @@ public class RedirectUriValidationHandler implements Handler<RoutingContext> {
 
     private final Domain domain;
     private final RedirectUriValidator redirectUriValidator;
-    private Function<String, Maybe<JWT>> tokenVerifier;
+    private final Function<String, Maybe<JWT>> tokenVerifier;
 
     public RedirectUriValidationHandler(Domain domain) {
         this.domain = domain;
@@ -71,12 +71,8 @@ public class RedirectUriValidationHandler implements Handler<RoutingContext> {
     public void handle(RoutingContext context) {
         final Client client = context.get(ConstantKeys.CLIENT_CONTEXT_KEY);
         getOperation(context)
-                .subscribe(operation -> {
-                            // proceed redirect_uri parameter
-                            parseRedirectUriParameter(context, client, operation);
-                            context.next();
-                        },
-                        context::fail);
+                .doOnSuccess(op -> parseRedirectUriParameter(context, client, op))
+                .subscribe(x -> context.next(), context::fail);
     }
 
     private Single<TokenPurpose> getOperation(RoutingContext context) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/RedirectUriValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/RedirectUriValidator.java
@@ -60,6 +60,9 @@ public class RedirectUriValidator {
     }
 
     private boolean requiresRedirectUri(TokenPurpose operation) {
+        /* In the forgotten password flow, the "reset password" link user receives doesn't contain a redirect_uri,
+           because unlike other in flows - it's not used. If the uri is provided for any reason we still should
+           validate it - but we can't require it to be present. */
         return operation != TokenPurpose.RESET_PASSWORD;
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/RedirectUriValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/RedirectUriValidator.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.root.service;
 
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
+import io.gravitee.am.common.jwt.TokenPurpose;
 import io.gravitee.am.model.oidc.Client;
 
 import java.util.List;
@@ -26,20 +27,28 @@ import java.util.function.BiConsumer;
  * @author GraviteeSource Team
  */
 public class RedirectUriValidator {
+
     public void validate(Client client, String requestedRedirectUri, BiConsumer<String, List<String>> checkMethod) {
+        validate(client, requestedRedirectUri, null, checkMethod);
+    }
+
+    public void validate(Client client, String requestedRedirectUri, TokenPurpose operation, BiConsumer<String, List<String>> checkMethod) {
+
+        final boolean redirectUriRequired = requiresRedirectUri(operation);
+
         final List<String> registeredClientRedirectUris = client.getRedirectUris();
         final boolean hasRegisteredClientRedirectUris = registeredClientRedirectUris != null && !registeredClientRedirectUris.isEmpty();
         final boolean hasRequestedRedirectUri = requestedRedirectUri != null && !requestedRedirectUri.isEmpty();
 
         // if no requested redirect_uri and no registered client redirect_uris
         // throw invalid request exception
-        if (!hasRegisteredClientRedirectUris && !hasRequestedRedirectUri) {
+        if (redirectUriRequired && !hasRegisteredClientRedirectUris && !hasRequestedRedirectUri) {
             throw new InvalidRequestException("A redirect_uri must be supplied");
         }
 
         // if no requested redirect_uri and more than one registered client redirect_uris
         // throw invalid request exception
-        if (!hasRequestedRedirectUri && (registeredClientRedirectUris != null && registeredClientRedirectUris.size() > 1)) {
+        if (redirectUriRequired && !hasRequestedRedirectUri && (registeredClientRedirectUris != null && registeredClientRedirectUris.size() > 1)) {
             throw new InvalidRequestException("Unable to find suitable redirect_uri, a redirect_uri must be supplied");
         }
 
@@ -48,5 +57,9 @@ public class RedirectUriValidator {
         if (hasRequestedRedirectUri && hasRegisteredClientRedirectUris) {
             checkMethod.accept(requestedRedirectUri, registeredClientRedirectUris);
         }
+    }
+
+    private boolean requiresRedirectUri(TokenPurpose operation) {
+        return operation != TokenPurpose.RESET_PASSWORD;
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/RedirectUriValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/RedirectUriValidatorTest.java
@@ -1,0 +1,105 @@
+package io.gravitee.am.gateway.handler.root.service;
+
+import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
+import io.gravitee.am.common.jwt.TokenPurpose;
+import io.gravitee.am.model.oidc.Client;
+import lombok.Getter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class RedirectUriValidatorTest {
+
+    private final RedirectUriValidator validator = new RedirectUriValidator();
+
+    private final static String REGISTERED_URI_1 = "http://a.localhost";
+    private final static String REGISTERED_URI_2 = "http://b.localhost";
+    private final static String UNREGISTERED_URI = "http://example.com";
+
+
+    private final BiConsumer<String, List<String>> strictUriChecker = (uri, registeredUris) -> {
+        if (!registeredUris.contains(uri)) {
+            throw new ExceptionFromUriChecker();
+        }
+    };
+
+    // allows asserting that it's not the validator throwing, but the checker delegate
+    static class ExceptionFromUriChecker extends RuntimeException {}
+
+
+    abstract class SharedCases {
+        abstract Client getClient();
+
+
+        @Test
+        void noOperation_redirectUriNotRegistered_shouldFail() {
+            assertThatThrownBy(()->validator.validate(getClient(), UNREGISTERED_URI, strictUriChecker))
+                    .isInstanceOf(ExceptionFromUriChecker.class);
+        }
+
+        @Test
+        void operationOptionalRedirect_redirectUriNotRegistered_shouldFail() {
+            assertThatThrownBy(()->validator.validate(getClient(), UNREGISTERED_URI, TokenPurpose.RESET_PASSWORD, strictUriChecker))
+                    .isInstanceOf(ExceptionFromUriChecker.class);
+        }
+
+        @Test
+        void operationOptionalRedirect_redirectUriRegistered_ok() {
+            assertThatCode(()->validator.validate(getClient(), REGISTERED_URI_1, TokenPurpose.RESET_PASSWORD, strictUriChecker))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void operationOptionalRedirect_noRedirectGiven_ok() {
+            assertThatCode(()->validator.validate(getClient(), null, TokenPurpose.RESET_PASSWORD, strictUriChecker))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void operationRequiredRedirect_redirectUriNotRegistered_shouldFail() {
+            assertThatThrownBy(()->validator.validate(getClient(), UNREGISTERED_URI, TokenPurpose.UNSPECIFIED, strictUriChecker))
+                    .isInstanceOf(ExceptionFromUriChecker.class);
+        }
+
+    }
+
+    @Nested
+    class ClientWithSingleRedirect extends SharedCases {
+        @Getter
+        private Client client;
+
+        @BeforeEach
+        public void setup() {
+            client = new Client();
+            client.setRedirectUris(List.of(REGISTERED_URI_1));
+        }
+        @Test
+        void noOperation_noRedirectGiven_ok() {
+            assertThatCode(()->validator.validate(client, null, strictUriChecker))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class ClientWithMultipleRedirects extends SharedCases {
+        @Getter
+        private Client client;
+        @BeforeEach
+        public void setup() {
+            client = new Client();
+            client.setRedirectUris(List.of(REGISTERED_URI_1, REGISTERED_URI_2));
+        }
+        @Test
+        void noOperation_noRedirectGiven_fail() {
+            assertThatThrownBy(()->validator.validate(client, null, strictUriChecker))
+                    .isInstanceOf(InvalidRequestException.class);
+        }
+    }
+
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/RedirectUriValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/RedirectUriValidatorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.am.gateway.handler.root.service;
 
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3187, #9735

## :pencil2: A description of the changes proposed in the pull request
Keep track of what flow the MFA challenge is invoked in, and allow redirect_uri to not be provided where it's not used (i.e. in the password reset flow)

