### PR TITLE
fix: max consecutive letters in password policy

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchPasswordSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchPasswordSettings.java
@@ -148,7 +148,11 @@ public class PatchPasswordSettings {
         SetterUtils.safeSet(toPatch::setIncludeNumbers, this.includeNumbers);
         SetterUtils.safeSet(toPatch::setIncludeSpecialCharacters, this.includeSpecialCharacters);
         SetterUtils.safeSet(toPatch::setLettersInMixedCase, this.lettersInMixedCase);
-        SetterUtils.safeSet(toPatch::setMaxConsecutiveLetters, this.maxConsecutiveLetters);
+        if (this.maxConsecutiveLetters == null) { // There must be option to set null.
+            toPatch.setMaxConsecutiveLetters(null);
+        } else {
+            SetterUtils.safeSet(toPatch::setMaxConsecutiveLetters, this.maxConsecutiveLetters);
+        }
         SetterUtils.safeSet(toPatch::setExcludePasswordsInDictionary, this.excludePasswordsInDictionary);
         SetterUtils.safeSet(toPatch::setExcludeUserProfileInfoInPassword, this.excludeUserProfileInfoInPassword);
         SetterUtils.safeSet(toPatch::setExpiryDuration, this.expiryDuration);
@@ -158,11 +162,11 @@ public class PatchPasswordSettings {
             getPasswordHistoryEnabled().ifPresent(toPatch::setPasswordHistoryEnabled);
         }
         if (toPatch.isPasswordHistoryEnabled() && (toPatch.getOldPasswords() == null || toPatch.getOldPasswords() > MAX_PASSWORD_HISTORY || toPatch.getOldPasswords() < MIN_PASSWORD_HISTORY)) {
-            throw new InvalidParameterException("Number of old passwords must be within the range  ["+MIN_PASSWORD_HISTORY+", "+MAX_PASSWORD_HISTORY+"]");
+            throw new InvalidParameterException("Number of old passwords must be within the range  [" + MIN_PASSWORD_HISTORY + ", " + MAX_PASSWORD_HISTORY + "]");
         }
 
         if (toPatch.getMinLength() != null) {
-            if (toPatch.getMinLength() <=0) {
+            if (toPatch.getMinLength() <= 0) {
                 throw new InvalidParameterException("Min password length must be greater than zero");
             }
 

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/password-policy/password-policy.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/password-policy/password-policy.component.html
@@ -68,7 +68,7 @@
             <mat-form-field appearance="outline" floatLabel="always" style="margin-top: 5px">
               <mat-label>Max consecutive letters</mat-label>
               <mat-select [(value)]="maxConsecutiveLetters" (selectionChange)="formChange()" [disabled]="!editMode">
-                <mat-option [value]="null">Unlimited</mat-option>
+                <mat-option [value]="0">Unlimited</mat-option>
                 <mat-option *ngFor="let p of [1, 2, 3, 4, 5]" [value]="p">{{ p }}</mat-option>
               </mat-select>
               <mat-hint>Max number of consecutive letters.</mat-hint>

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/password-policy/password-policy.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/password-policy/password-policy.component.ts
@@ -40,7 +40,7 @@ export class PasswordPolicyComponent implements OnInit {
   includeSpecialCharacters: boolean;
   lettersInMixedCase: boolean;
   inherited: boolean;
-  maxConsecutiveLetters: number;
+  maxConsecutiveLetters = 0;
   excludePasswordsInDictionary: boolean;
   excludeUserProfileInfoInPassword: boolean;
   expiryDuration: number;
@@ -70,7 +70,9 @@ export class PasswordPolicyComponent implements OnInit {
       this.includeNumbers = this.passwordSettings.includeNumbers;
       this.includeSpecialCharacters = this.passwordSettings.includeSpecialCharacters;
       this.lettersInMixedCase = this.passwordSettings.lettersInMixedCase;
-      this.maxConsecutiveLetters = this.passwordSettings.maxConsecutiveLetters;
+      if (this.passwordSettings.maxConsecutiveLetters) {
+        this.maxConsecutiveLetters = this.passwordSettings.maxConsecutiveLetters;
+      }
       this.excludePasswordsInDictionary = this.passwordSettings.excludePasswordsInDictionary;
       this.excludeUserProfileInfoInPassword = this.passwordSettings.excludeUserProfileInfoInPassword;
       this.expiryDuration = this.passwordSettings.expiryDuration;
@@ -138,7 +140,7 @@ export class PasswordPolicyComponent implements OnInit {
       includeNumbers: this.includeNumbers,
       includeSpecialCharacters: this.includeSpecialCharacters,
       lettersInMixedCase: this.lettersInMixedCase,
-      maxConsecutiveLetters: this.maxConsecutiveLetters,
+      maxConsecutiveLetters: this.maxConsecutiveLetters > 0 ? this.maxConsecutiveLetters : undefined,
       excludePasswordsInDictionary: this.excludePasswordsInDictionary,
       excludeUserProfileInfoInPassword: this.excludeUserProfileInfoInPassword,
       expiryDuration: this.expiryDuration,

--- a/gravitee-am-ui/src/app/domain/settings/password-policy/domain-password-policy.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/password-policy/domain-password-policy.component.html
@@ -83,12 +83,12 @@
               <mat-form-field appearance="outline" class="large-input">
                 <mat-label>Maximum Consecutive Letters</mat-label>
                 <mat-select
-                  [(value)]="passwordPolicy.maxConsecutiveLetters"
+                  [(value)]="maxConsecutiveLetters"
                   (selectionChange)="formChange()"
                   [disabled]="!editMode"
                   placeholder="Maximum Consecutive Letters"
                 >
-                  <mat-option [value]="null">Unlimited</mat-option>
+                  <mat-option [value]="0">Unlimited</mat-option>
                   <mat-option *ngFor="let p of [1, 2, 3, 4, 5]" [value]="p">{{ p }}</mat-option>
                 </mat-select>
               </mat-form-field>

--- a/gravitee-am-ui/src/app/domain/settings/password-policy/domain-password-policy.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/password-policy/domain-password-policy.component.ts
@@ -46,6 +46,7 @@ export class DomainPasswordPolicyComponent implements OnInit {
   providers = [];
   linkedProviders = [];
   displayLinkedProviders = false;
+  maxConsecutiveLetters = 0;
 
   @Input() passwordPolicy: DomainPasswordPolicy;
 
@@ -69,6 +70,9 @@ export class DomainPasswordPolicyComponent implements OnInit {
     }
     this.buildLinkedIdentityProviders(false);
     this.editMode = this.authService.hasPermissions(['domain_settings_update']);
+    if (this.passwordPolicy?.maxConsecutiveLetters > 0) {
+      this.maxConsecutiveLetters = this.passwordPolicy.maxConsecutiveLetters;
+    }
   }
 
   formChange(): void {
@@ -115,6 +119,12 @@ export class DomainPasswordPolicyComponent implements OnInit {
     if (this.passwordPolicy.maxLength && this.passwordPolicy.maxLength <= 0) {
       this.snackbarService.open('Max length must be greater than zero');
       return;
+    }
+
+    if (this.maxConsecutiveLetters > 0) {
+      this.passwordPolicy.maxConsecutiveLetters = this.maxConsecutiveLetters;
+    } else {
+      this.passwordPolicy.maxConsecutiveLetters = undefined;
     }
 
     let request: Observable<any>;


### PR DESCRIPTION


## :id: Reference related issue. 
fixes: AM-36

## :pencil2: A description of the changes proposed in the pull request

The problem was with setting value in mat-option to null. We cannot use null or undefined if value is number. I changed it to 0.
We can set also maxConsecutiveLetters in password policy for an application settings. But there is PATCH and undefined value was ignored (couldn't set maxConsecutiveLetters from for example 2 to unlimited). It required small change in backend.
