### PR TITLE
chore: Add changelog for new 3.21.26 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,30 @@
 # Change Log
 
+==  - 3.21.26 (2024-05-24)
+
+== What's new !
+
+
+
+=== Gateway
+
+
+
+=== Management API
+
+
+
+=== Console
+
+
+
+=== Other
+
+* Application - Forms - Page not found error when enabling custom form again after being 'cleared' https://github.com/gravitee-io/issues/issues/9492[#9492]
+* Unable to remove a FORM at orgnazation level
+* Password Policy Blank value in dropbox when selecting value Unlimited
+
+
 ==  - 3.21.25 (2024-05-09)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.26 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.26/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.26 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.26%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
