### PR TITLE
fix: define passwordEncoder as required for HTTP Provider to force a …

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/main/resources/schemas/schema-form.json
@@ -734,5 +734,6 @@
       "title": "HTTP Client max pool size",
       "description": "Maximum pool of connections can grow to. (default 200)"
     }
-  }
+  },
+  "required": ["passwordEncoder"]
 }


### PR DESCRIPTION
…value into th e field when None is selected

 if field is no required, there is 2 None options, one to use the None enum value and another one to use the None/empty entry of the dropdown list (null string)

 as the default value is defined as BCrypt, using the None/empty entry of the dropdown list assign BCrypt

fixes AM-2883

gravitee-io/issues#9627

