### PR TITLE
fix: introduce legacy settings to filter out the custom prompt values

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/oidc/Prompt.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/oidc/Prompt.java
@@ -62,7 +62,7 @@ public interface Prompt {
      */
     String MFA_ENROLL = "mfa_enroll";
 
-    static List<String> supportedValues() {
-        return Arrays.asList(NONE, LOGIN, CONSENT, MFA_ENROLL);
+    static List<String> supportedValues(boolean filterCustomValues) {
+        return filterCustomValues ? Arrays.asList(NONE, LOGIN, CONSENT) : Arrays.asList(NONE, LOGIN, CONSENT, MFA_ENROLL);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
@@ -123,7 +123,8 @@ public class OpenIDDiscoveryServiceImpl implements OpenIDDiscoveryService, Initi
         openIDProviderMetadata.setGrantTypesSupported(GrantTypeUtils.getSupportedGrantTypes());
         openIDProviderMetadata.setClaimTypesSupported(ClaimType.supportedValues());
         openIDProviderMetadata.setSubjectTypesSupported(SubjectTypeUtils.getSupportedSubjectTypes());
-        openIDProviderMetadata.setPromptValuesSupported(Prompt.supportedValues());
+        final Boolean filterCustomValues = env.getProperty("legacy.openid.filterCustomPrompt", Boolean.class, false);
+        openIDProviderMetadata.setPromptValuesSupported(Prompt.supportedValues(filterCustomValues));
 
         // id_token
         openIDProviderMetadata.setIdTokenSigningAlgValuesSupported(JWAlgorithmUtils.getSupportedIdTokenSigningAlg());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
@@ -37,6 +37,10 @@ import java.util.List;
 
 import java.util.Arrays;
 
+import static io.gravitee.am.common.oidc.Prompt.CONSENT;
+import static io.gravitee.am.common.oidc.Prompt.LOGIN;
+import static io.gravitee.am.common.oidc.Prompt.MFA_ENROLL;
+import static io.gravitee.am.common.oidc.Prompt.NONE;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,6 +70,7 @@ public class OpenIDDiscoveryServiceTest {
     public void prepare() {
         when(environment.getProperty("http.secured", Boolean.class, false)).thenReturn(false);
         when(environment.getProperty("http.ssl.clientAuth", String.class, "none")).thenReturn("none");
+        when(environment.getProperty("legacy.openid.filterCustomPrompt", Boolean.class, false)).thenReturn(false);
     }
 
     private void enableMtls() {
@@ -73,6 +78,24 @@ public class OpenIDDiscoveryServiceTest {
         when(environment.getProperty("http.secured", Boolean.class, false)).thenReturn(true);
         when(environment.getProperty("http.ssl.clientAuth", String.class, "none")).thenReturn("required");
         when(environment.getProperty(ConstantKeys.HTTP_SSL_ALIASES_BASE_URL, String.class, "/")).thenReturn("/");
+        when(environment.getProperty("legacy.openid.filterCustomPrompt", Boolean.class, false)).thenReturn(false);
+    }
+
+    private void filterPromptValues() {
+        when(environment.getProperty("legacy.openid.filterCustomPrompt", Boolean.class, false)).thenReturn(true);
+    }
+
+    @Test
+    public void shouldContain_all_prompt_values() {
+        OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
+        assertEquals(List.of(NONE, LOGIN, CONSENT, MFA_ENROLL), openIDProviderMetadata.getPromptValuesSupported());
+    }
+
+    @Test
+    public void shouldContain_standard_prompt_values() {
+        filterPromptValues();
+        OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
+        assertEquals(List.of(NONE, LOGIN, CONSENT), openIDProviderMetadata.getPromptValuesSupported());
     }
 
     @Test


### PR DESCRIPTION
  by default custom prompt are exposed, to remove them legacy.openid.filterCustomPrompt has to be set to true in gravitee.yml

fixes AM-2987

gravitee-io/issues#9667
