### PR TITLE
fix: execute session handler on forgot password

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -576,6 +576,9 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
                 .handler(botDetectionHandler)
                 .handler(forgotPasswordAccessHandler)
                 .handler(new ForgotPasswordSubmissionEndpoint(userService, domain));
+
+        router.route(PATH_FORGOT_PASSWORD).failureHandler(new ErrorHandler(PATH_ERROR, true));
+
         rootRouter.route(HttpMethod.GET, PATH_RESET_PASSWORD)
                 .handler(new ResetPasswordRequestParseHandler(userService))
                 .handler(clientRequestParseHandlerOptional)
@@ -669,6 +672,10 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
         // Reset password endpoint
         router
                 .route(PATH_RESET_PASSWORD)
+                .handler(sessionHandler);
+
+        router
+                .route(PATH_FORGOT_PASSWORD)
                 .handler(sessionHandler);
 
         // WebAuthn endpoint
@@ -832,7 +839,6 @@ public class RootProvider extends AbstractService<ProtocolProvider> implements P
 
     private void errorHandler(Router router) {
         Handler<RoutingContext> errorHandler = new ErrorHandler(PATH_ERROR);
-        router.route(PATH_FORGOT_PASSWORD).failureHandler(errorHandler);
         router.route(PATH_LOGOUT).failureHandler(errorHandler);
         router.route(PATH_LOGOUT_CALLBACK).failureHandler(errorHandler);
         router.route(PATH_LOGIN).failureHandler(errorHandler);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordSubmissionEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordSubmissionEndpoint.java
@@ -67,9 +67,11 @@ public class ForgotPasswordSubmissionEndpoint extends UserRequestHandler {
                 .subscribe(
                         () -> {
                             queryParams.set(ConstantKeys.SUCCESS_PARAM_KEY, "forgot_password_completed");
+                            resetCookieSession(context);
                             redirectToPage(context, queryParams);
                         },
                         error -> {
+                            resetCookieSession(context);
                             // we don't want to expose potential security leaks such as guessing existing users
                             // the actual error continue to be stored in the audit logs
                             if (error instanceof UserNotFoundException || error instanceof AccountStatusException) {
@@ -87,6 +89,12 @@ public class ForgotPasswordSubmissionEndpoint extends UserRequestHandler {
                                 redirectToPage(context, queryParams, error);
                             }
                         });
+    }
+
+    private void resetCookieSession(RoutingContext context) {
+        if (context.session() != null) {
+            context.session().destroy();
+        }
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/error/ErrorHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/error/ErrorHandler.java
@@ -40,8 +40,15 @@ import static java.util.Objects.isNull;
  */
 public class ErrorHandler extends AbstractErrorHandler {
 
+    private final boolean destroySession;
+
     public ErrorHandler(String errorPage) {
+        this(errorPage, false);
+    }
+
+    public ErrorHandler(String errorPage, boolean destroySession) {
         super(errorPage);
+        this.destroySession = destroySession;
     }
 
     @Override
@@ -103,11 +110,17 @@ public class ErrorHandler extends AbstractErrorHandler {
 
             // redirect
             String proxiedErrorPage = UriBuilderRequest.resolveProxyRequest(request, errorPageURL, parameters, true);
-            doRedirect(routingContext.response(), proxiedErrorPage);
+            doRedirect(routingContext, proxiedErrorPage);
         } catch (Exception e) {
             logger.error("Unable to handle root error response", e);
-            doRedirect(routingContext.response(), errorPageURL);
+            doRedirect(routingContext, errorPageURL);
         }
     }
 
+    private void doRedirect(RoutingContext context, String url) {
+        if (context.session() != null) {
+            context.session().destroy();
+        }
+        doRedirect(context.response(), url);
+    }
 }


### PR DESCRIPTION
 this is useful to give access to the IP & UserAgent if the consent is given automatically through the gravitee config

 to be align with the previous behaviour, cookie session is destroyed at the end of the forgot password request

fixes AM-3139

gravitee-io/issues#9724
