### PR TITLE
fix: manage to use the destroySession boolean introduced by PR#4185

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/error/ErrorHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/error/ErrorHandler.java
@@ -118,7 +118,7 @@ public class ErrorHandler extends AbstractErrorHandler {
     }
 
     private void doRedirect(RoutingContext context, String url) {
-        if (context.session() != null) {
+        if (destroySession && context.session() != null) {
             context.session().destroy();
         }
         doRedirect(context.response(), url);


### PR DESCRIPTION
https://github.com/gravitee-io/gravitee-access-management/pull/4185

related-to AM-3139
