### PR TITLE
AM-3292 mtls openid delete cert

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/oidc/OpenIDConnectConfigurationUtils.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/oidc/OpenIDConnectConfigurationUtils.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.identityprovider.api.oidc;
 
 import com.nimbusds.jose.util.JSONObjectUtils;
+import io.gravitee.am.common.oidc.ClientAuthenticationMethod;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,6 +39,23 @@ public final class OpenIDConnectConfigurationUtils {
         } catch (ParseException e) {
             log.warn("Problem at parsing certificate configuration, msg={}", e.getMessage());
             return Optional.empty();
+        }
+    }
+
+    public static String sanitizeClientAuthMethod(String configuration) {
+        if (configuration == null) {
+            return configuration;
+        }
+        try {
+            Map<String, Object> cfg = JSONObjectUtils.parse(configuration);
+            String authMethod = JSONObjectUtils.getString(cfg, "clientAuthenticationMethod");
+            if (!ClientAuthenticationMethod.TLS_CLIENT_AUTH.equals(authMethod)) {
+                cfg.remove("clientAuthenticationCertificate");
+            }
+            return JSONObjectUtils.toJSONString(cfg);
+        } catch (ParseException e) {
+            log.warn("Problem at parsing OpenId configuration, msg={}", e.getMessage());
+            return configuration;
         }
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/test/java/io/gravitee/am/identityprovider/api/oidc/OpenIDConnectConfigurationUtilsTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/test/java/io/gravitee/am/identityprovider/api/oidc/OpenIDConnectConfigurationUtilsTest.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.am.identityprovider.api.oidc;
 
+import com.nimbusds.jose.util.JSONObjectUtils;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
+import java.util.Map;
 import java.util.Optional;
 
 public class OpenIDConnectConfigurationUtilsTest {
@@ -50,4 +52,23 @@ public class OpenIDConnectConfigurationUtilsTest {
         Optional<String> certId = OpenIDConnectConfigurationUtils.extractCertificateId(cfg);
         Assertions.assertTrue(certId.isEmpty());
     }
+
+    @Test
+    public void shouldNotRemoveCertificateIfClientAuthMethodIsTls () {
+        String cfg = "{\"clientId\":\"aaa\",\"clientSecret\":\"aaa\",\"clientAuthenticationMethod\":\"tls_client_auth\",\"clientAuthenticationCertificate\":\"32d89a07-c7a9-48c4-989a-07c7a9b8c4ef\",\"wellKnownUri\":\"https://localhost:9092/test/oidc/.well-known/openid-configuration\",\"responseType\":\"code\",\"encodeRedirectUri\":false,\"useIdTokenForUserInfo\":false,\"signature\":\"RSA_RS256\",\"publicKeyResolver\":\"GIVEN_KEY\",\"connectTimeout\":10000,\"idleTimeout\":10000,\"maxPoolSize\":200,\"storeOriginalTokens\":false}";
+        String validated = OpenIDConnectConfigurationUtils.sanitizeClientAuthMethod(cfg);
+        Assertions.assertEquals(validated, cfg);
+    }
+
+    @Test
+    public void shouldRemoveCertificateIfClientAuthMethodIsNotTls () throws Exception{
+        String cfg = "{\"clientId\":\"aaa\",\"clientSecret\":\"aaa\",\"clientAuthenticationMethod\":\"client_secret_post\",\"clientAuthenticationCertificate\":\"32d89a07-c7a9-48c4-989a-07c7a9b8c4ef\",\"wellKnownUri\":\"https://localhost:9092/test/oidc/.well-known/openid-configuration\",\"responseType\":\"code\",\"encodeRedirectUri\":false,\"useIdTokenForUserInfo\":false,\"signature\":\"RSA_RS256\",\"publicKeyResolver\":\"GIVEN_KEY\",\"connectTimeout\":10000,\"idleTimeout\":10000,\"maxPoolSize\":200,\"storeOriginalTokens\":false}";
+        String validated = OpenIDConnectConfigurationUtils.sanitizeClientAuthMethod(cfg);
+        Assertions.assertNotEquals(validated, cfg);
+
+        Map<String, Object> map = JSONObjectUtils.parse(validated);
+        Assertions.assertFalse(map.containsKey("clientAuthenticationCertificate"));
+    }
+
+
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
@@ -52,6 +52,7 @@ import org.springframework.stereotype.Component;
 import java.util.Date;
 import java.util.List;
 
+import static io.gravitee.am.identityprovider.api.oidc.OpenIDConnectConfigurationUtils.sanitizeClientAuthMethod;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -146,7 +147,7 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
         identityProvider.setName(newIdentityProvider.getName());
         identityProvider.setType(newIdentityProvider.getType());
         identityProvider.setSystem(system);
-        identityProvider.setConfiguration(newIdentityProvider.getConfiguration());
+        identityProvider.setConfiguration(sanitizeClientAuthMethod(newIdentityProvider.getConfiguration()));
         identityProvider.setExternal(newIdentityProvider.isExternal());
         identityProvider.setDomainWhitelist(ofNullable(newIdentityProvider.getDomainWhitelist()).orElse(List.of()));
         identityProvider.setCreatedAt(new Date());
@@ -180,6 +181,7 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
                     identityToUpdate.setRoleMapper(updateIdentityProvider.getRoleMapper());
                     identityToUpdate.setDomainWhitelist(ofNullable(updateIdentityProvider.getDomainWhitelist()).orElse(List.of()));
                     identityToUpdate.setUpdatedAt(new Date());
+                    identityToUpdate.setConfiguration(sanitizeClientAuthMethod(identityToUpdate.getConfiguration()));
 
                     return identityProviderRepository.update(identityToUpdate)
                             .flatMap(identityProvider1 -> {


### PR DESCRIPTION
If client auth method equals to client_secret_basic or  client_secret_post there is no use of certificate.
By removing it on create/update for configurtion, the certificate would be able to be deleted as its won't be associated with any IDP.