### PR TITLE
chore: Add changelog for new 3.21.27 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,21 +1,18 @@
 # Change Log
 
-==  - 3.21.26 (2024-05-24)
+==  - 3.21.27 (2024-06-06)
 
 == What's new !
 
 
-
 === Gateway
 
+* [AM] [3.21.18] User don't receive the email to recover his password with an uppercase email https://github.com/gravitee-io/issues/issues/9624[#9624]
 
 
-=== Management API
+==  - 3.21.26 (2024-05-24)
 
-
-
-=== Console
-
+== What's new !
 
 
 === Other


### PR DESCRIPTION

# New version 3.21.27 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.27/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.27 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.27%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
