### PR TITLE
avoid testcontainers tests hanging

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -808,7 +808,7 @@ jobs:
           event: fail
           mentions: "@am_team"
           template: basic_fail_1
-  run_testcontainer_tests:
+  run_testcontainer_tests_mongo:
     executor:
       name: ubuntu
       class: "xlarge"
@@ -817,13 +817,33 @@ jobs:
           at: /tmp
       - checkout
       - restore-maven-job-cache:
-          jobName: run_testcontainer_tests
+          jobName: run_testcontainer_tests_mongo
       - run:
           name: Build
           command: |
             mvn install -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
       - save-maven-job-cache:
-          jobName: run_testcontainer_tests
+          jobName: run_testcontainer_tests_mongo
+  run_testcontainer_tests_jdbc:
+    executor:
+      name: ubuntu
+      class: "xlarge"
+    parameters:
+      jdbcType:
+        type: enum
+        enum: [ "postgres", "mysql", "mariadb", "mssql" ]
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - checkout
+      - restore-maven-job-cache:
+          jobName: run_testcontainer_tests_jdbc
+      - run:
+          name: Build
+          command: |
+            mvn install -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd-jdbc -P << parameters.jdbcType >> -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
+      - save-maven-job-cache:
+          jobName: run_testcontainer_tests_jdbc
   publish-images-azure-registry:
     docker:
       - image: cimg/openjdk:17.0.11
@@ -1883,7 +1903,7 @@ workflows:
               ignore:
                 - master
                 - /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.x$/
-      - run_testcontainer_tests:
+      - run_testcontainer_tests_mongo:
           context: cicd-orchestrator
           requires:
             - setup
@@ -1892,6 +1912,18 @@ workflows:
               ignore:
                 - master
                 - /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.x$/
+      - run_testcontainer_tests_jdbc:
+          context: cicd-orchestrator
+          requires:
+            - setup
+          filters:
+            branches:
+              ignore:
+                - master
+                - /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.x$/
+          matrix:
+            parameters:
+              jdbcType: ["postgres", "mysql", "mariadb", "mssql"]
 
   build_branch:
     when:

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/pom.xml
@@ -40,6 +40,7 @@
 
         <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
         <dozer-jaxb-runtime.version>2.4.0-b180830.0438</dozer-jaxb-runtime.version>
+        <jdbcType>postgresql-tc~15.1</jdbcType>
     </properties>
 
     <dependencyManagement>
@@ -304,11 +305,11 @@
             <version>${test-container.version}</version>
             <scope>test</scope>
             <exclusions>
-            <exclusion>
-                <artifactId>r2dbc-spi</artifactId>
-                <groupId>io.r2dbc</groupId>
-            </exclusion>
-        </exclusions>
+                <exclusion>
+                    <artifactId>r2dbc-spi</artifactId>
+                    <groupId>io.r2dbc</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -357,18 +358,59 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <profiles>
         <profile>
-            <id>cicd</id>
+            <id>postgres</id>
+            <properties>
+                <jdbcType>postgresql-tc~15.1</jdbcType>
+            </properties>
+        </profile>
+        <profile>
+            <id>mysql</id>
+            <properties>
+                <jdbcType>mysql-tc~8.0.27</jdbcType>
+            </properties>
+        </profile>
+        <profile>
+            <id>mariadb</id>
+            <properties>
+                <jdbcType>mariadb-tc~10.6.5</jdbcType>
+            </properties>
+        </profile>
+        <profile>
+            <id>mssql</id>
+            <properties>
+                <jdbcType>mssql-tc~2019-latest</jdbcType>
+            </properties>
+        </profile>
+        <profile>
+            <id>cicd-jdbc</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xmx1024m</argLine>
                             <skipTests>false</skipTests>
+                            <argLine>-Xmx1024m</argLine>
+                            <systemPropertyVariables>
+                                <jdbcType>${jdbcType}</jdbcType>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>cicd-full</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <argLine>-Xmx1024m</argLine>
                             <systemPropertyVariables>
                                 <jdbcType>postgresql-tc~15.1</jdbcType>
                             </systemPropertyVariables>

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/JdbcRepositoriesTestInitializer.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/JdbcRepositoriesTestInitializer.java
@@ -17,137 +17,181 @@ package io.gravitee.am.repository.jdbc.common;
 
 import io.gravitee.am.repository.RepositoriesTestInitializer;
 import io.gravitee.am.repository.jdbc.common.dialect.DatabaseDialectHelper;
+import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.schedulers.Schedulers;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.reactivex.rxjava3.core.Single;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Service
+@Slf4j
+@RequiredArgsConstructor
 public class JdbcRepositoriesTestInitializer implements RepositoriesTestInitializer {
 
-    @Autowired
-    protected ConnectionFactory connectionFactory;
 
-    @Autowired
-    protected DatabaseDialectHelper dialect;
+    private static final int MAX_ATTEMPTS = 5;
+    protected final ConnectionFactory connectionFactory;
+    protected final DatabaseDialectHelper dialect;
 
-    public JdbcRepositoriesTestInitializer(ConnectionFactory connectionFactory, DatabaseDialectHelper dialect) {
-        this.connectionFactory = connectionFactory;
-        this.dialect = dialect;
+    public void removeAllData() {
+
+        var tables = List.of(
+                "access_tokens",
+                "authorization_codes",
+                "refresh_tokens",
+                "scope_approvals",
+                "request_objects",
+
+                "users",
+                "user_entitlements",
+                "user_roles",
+                "user_attributes",
+                "user_addresses",
+                "application_factors",
+                "application_identities",
+                "application_scope_settings",
+                "application_client_secrets",
+                "applications",
+                "tags",
+                "scope_claims",
+                "scopes",
+                "role_oauth_scopes",
+                "roles",
+                "uma_resource_scopes",
+                "uma_resource_set",
+                "reporters",
+                "memberships",
+                "login_attempts",
+                "identities",
+                dialect.toSql(SqlIdentifier.quoted("groups")),
+                "group_members",
+                "group_roles",
+                "forms",
+                "factors",
+                "extension_grants",
+                "events",
+                "entrypoints",
+                "emails",
+                "webauthn_credentials",
+                "certificates",
+                "uma_access_policies",
+                "domains",
+                "domain_identities",
+                "domain_tags",
+                "domain_vhosts",
+                "environments",
+                "environment_domain_restrictions",
+                "environment_hrids",
+                "organizations",
+                "organization_identities",
+                "organization_domain_restrictions",
+                "organization_hrids",
+                "installations",
+                "alert_triggers_alert_notifiers",
+                "alert_triggers",
+                "alert_notifiers",
+                "service_resources",
+                "node_monitoring",
+                "bot_detections",
+
+                "organization_users",
+                "organization_user_entitlements",
+                "organization_user_roles",
+                "organization_user_attributes",
+                "organization_user_addresses",
+
+                "pushed_authorization_requests",
+
+                "system_tasks",
+
+                "ciba_auth_requests",
+                "authentication_device_notifiers",
+
+                "notification_acknowledgements",
+                "user_notifications",
+
+                "i18n_dictionaries",
+                "i18n_dictionary_entries",
+
+                "themes",
+                "password_histories",
+                "rate_limit",
+                "verify_attempt",
+
+                "password_policies",
+                "account_access_tokens"
+        );
+
+        // in seconds
+        var timeoutPerTable = 2;
+        var timeoutTechnical = 1;
+        var timeoutTotal = 30;
+
+        var retryCounterTotal = new AtomicInteger(0);
+        Single.fromPublisher(connectionFactory.create())
+                .flatMapCompletable(connection -> Completable.fromPublisher(connection.beginTransaction())
+                        .andThen(Flowable.fromIterable(tables)
+                                .concatMapCompletable(table -> deleteAll(table, connection, timeoutPerTable))
+                                .andThen(Completable.fromPublisher(connection.commitTransaction())
+                                        .timeout(timeoutTechnical, TimeUnit.SECONDS, Completable.error(new TimeoutException("timeout: commit [%ds]".formatted(timeoutTechnical)))))
+                                .onErrorResumeNext(err -> {
+                                    log.error("Got an error while clearing database - rolling back", err);
+                                    return Completable.fromPublisher(connection.rollbackTransaction());
+                                })
+                        )
+                        .doFinally(() -> Completable.fromPublisher(connection.close()).subscribe()))
+                .timeout(timeoutTotal, TimeUnit.SECONDS,
+                        Completable.fromAction(() -> {
+                            throw new TimeoutException("[attempt #%d/%d] timeout: clearing database didn't finish within %ds".formatted(retryCounterTotal.incrementAndGet(), MAX_ATTEMPTS, timeoutTotal));
+                        }))
+                .doOnError(ex -> log.error("Error clearing database", ex))
+                .doOnComplete(() -> log.debug("DB cleared on attempt {}", retryCounterTotal.get()))
+                .retry(MAX_ATTEMPTS - 1, ex -> ex instanceof TimeoutException)
+                .blockingAwait();
+
+
     }
 
-    public void truncateTables() {
-        Set<String> tables = new HashSet<>();
-        tables.add("access_tokens");
-        tables.add("authorization_codes");
-        tables.add("refresh_tokens");
-        tables.add("scope_approvals");
-        tables.add("request_objects");
-
-        tables.add("users");
-        tables.add("user_entitlements");
-        tables.add("user_roles");
-        tables.add("user_attributes");
-        tables.add("user_addresses");
-        tables.add("application_factors");
-        tables.add("application_identities");
-        tables.add("application_scope_settings");
-        tables.add("application_client_secrets");
-        tables.add("applications");
-        tables.add("tags");
-        tables.add("scope_claims");
-        tables.add("scopes");
-        tables.add("role_oauth_scopes");
-        tables.add("roles");
-        tables.add("uma_resource_scopes");
-        tables.add("uma_resource_set");
-        tables.add("reporters");
-        tables.add("memberships");
-        tables.add("login_attempts");
-        tables.add("identities");
-        tables.add(dialect.toSql(SqlIdentifier.quoted("groups")));
-        tables.add("group_members");
-        tables.add("group_roles");
-        tables.add("forms");
-        tables.add("factors");
-        tables.add("extension_grants");
-        tables.add("events");
-        tables.add("entrypoints");
-        tables.add("emails");
-        tables.add("webauthn_credentials");
-        tables.add("certificates");
-        tables.add("uma_access_policies");
-        tables.add("domains");
-        tables.add("domain_identities");
-        tables.add("domain_tags");
-        tables.add("domain_vhosts");
-        tables.add("environments");
-        tables.add("environment_domain_restrictions");
-        tables.add("environment_hrids");
-        tables.add("organizations");
-        tables.add("organization_identities");
-        tables.add("organization_domain_restrictions");
-        tables.add("organization_hrids");
-        tables.add("installations");
-        tables.add("alert_triggers_alert_notifiers");
-        tables.add("alert_triggers");
-        tables.add("alert_notifiers");
-        tables.add("service_resources");
-        tables.add("node_monitoring");
-        tables.add("bot_detections");
-
-        tables.add("organization_users");
-        tables.add("organization_user_entitlements");
-        tables.add("organization_user_roles");
-        tables.add("organization_user_attributes");
-        tables.add("organization_user_addresses");
-
-        tables.add("pushed_authorization_requests");
-
-        tables.add("system_tasks");
-
-        tables.add("ciba_auth_requests");
-        tables.add("authentication_device_notifiers");
-
-        tables.add("notification_acknowledgements");
-        tables.add("user_notifications");
-
-        tables.add("i18n_dictionaries");
-        tables.add("i18n_dictionary_entries");
-
-        tables.add("themes");
-        tables.add("password_histories");
-        tables.add("rate_limit");
-        tables.add("verify_attempt");
-
-        tables.add("password_policies");
-        tables.add("account_access_tokens");
-
-        io.r2dbc.spi.Connection connection = Flowable.fromPublisher(connectionFactory.create()).blockingFirst();
-        connection.beginTransaction();
-        tables.stream().forEach(table -> {
-            Flowable.fromPublisher(connection.createStatement("delete from " + table).execute()).subscribeOn(Schedulers.single()).blockingSubscribe();
-        });
-        connection.commitTransaction();
-        connection.close();
+    private Completable deleteAll(String table, Connection connection, int timeoutSeconds) {
+        AtomicInteger retryCounter = new AtomicInteger(0);
+        return Single.fromPublisher(connection.createStatement("delete from " + table)
+                        .execute())
+                .flatMap(result -> Single.fromPublisher(result.getRowsUpdated()))
+                .ignoreElement()
+                .timeout(timeoutSeconds, TimeUnit.SECONDS,
+                        Completable.fromAction(() -> {
+                            throw new TimeoutException("[attempt #%d/%d] timeout: 'delete from %s' didn't finish within %ds".formatted(retryCounter.incrementAndGet(), MAX_ATTEMPTS, table, timeoutSeconds));
+                        }))
+                .doOnError(ex -> {
+                    if (!(ex instanceof TimeoutException)) {
+                        log.error("Error clearing table '{}'", table, ex);
+                    }
+                })
+                .doOnComplete(() -> log.debug("Table '{}' cleared on attempt {}", table, retryCounter.get()))
+                .retry(MAX_ATTEMPTS - 1, x -> x instanceof TimeoutException);
     }
+
 
     @Override
     public void before(Class testClass) {
-        truncateTables();
+        removeAllData();
     }
 
     @Override
     public void after(Class testClass) {
-        truncateTables();
+        // nothing to do
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-tests/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-tests/pom.xml
@@ -71,12 +71,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
## :id: Reference related issue. 
AM-2995

## :pencil2: A description of the changes proposed in the pull request
1. Tests: Add timeouts + retries to testcontainers tests' db cleaning code to prevent them from crashing the pipeline
2. CI :Run testcontainers tests for each db separately and in parallel to avoid having to rerun all of them

