### PR TITLE
chore: remove time window for sync process

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -474,6 +474,8 @@ jobs:
             
             # Reduce the sync frequency to avoid flaky test due to synchronization delay
             export gravitee_services_sync_cron="*/2 * * * * *"
+            export gravitee_services_sync_timeframeBeforeDelay=5000
+            export gravitee_services_sync_timeframeAfterDelay=5000
             export GIO_MAX_MEM=512m
             
             # Start AM Management
@@ -485,8 +487,8 @@ jobs:
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
             
             echo "Wait for AM to be up and running..."
-            timeout 120s bash -c 'until nc -z localhost 8093; do sleep 2; done'
-            timeout 120s bash -c 'until nc -z localhost 8092; do sleep 2; done'
+            timeout 180s bash -c 'until nc -z localhost 8093; do sleep 2; done'
+            timeout 180s bash -c 'until nc -z localhost 8092; do sleep 2; done'
             
             retVal=$?
             if [ $retVal -ne 0 ]; then
@@ -597,6 +599,8 @@ jobs:
             
             # Reduce the sync frequency to avoid flaky test due to synchronization delay  
             export gravitee_services_sync_cron="*/2 * * * * *"
+            export gravitee_services_sync_timeframeBeforeDelay=5000
+            export gravitee_services_sync_timeframeAfterDelay=5000
             export GIO_MAX_MEM=512m
             
             # Start AM Management
@@ -617,7 +621,7 @@ jobs:
             mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -P cicd -f gravitee-am-ciba-delegated-service/pom.xml package
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
             echo "Wait for AM to be up and running..."
-            timeout 120s bash -c 'until nc -z localhost 8092; do sleep 2; done'
+            timeout 180s bash -c 'until nc -z localhost 8092; do sleep 2; done'
             retVal=$?
             if [ $retVal -ne 0 ]; then
               echo "Gateway not started"
@@ -673,6 +677,8 @@ jobs:
             
             # Reduce the sync frequency to avoid flaky test due to synchronization delay
             export gravitee_services_sync_cron="*/2 * * * * *"
+            export gravitee_services_sync_timeframeBeforeDelay=5000
+            export gravitee_services_sync_timeframeAfterDelay=5000
             export GIO_MAX_MEM=512m
             
             # Start AM Management
@@ -684,8 +690,9 @@ jobs:
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
             
             echo "Wait for AM to be up and running..."
-            timeout 120s bash -c 'until nc -z localhost 8093; do sleep 2; done'
-            timeout 120s bash -c 'until nc -z localhost 8092; do sleep 2; done'
+            timeout 180s bash -c 'until nc -z localhost 8093; do sleep 2; done'
+            timeout 180s bash -c 'until nc -z localhost 8092; do sleep 2; done'
+            
             retVal=$?
             if [ $retVal -ne 0 ]; then
               echo "AM not started"
@@ -772,6 +779,8 @@ jobs:
             
             # Reduce the sync frequency to avoid flaky test due to synchronization delay
             export gravitee_services_sync_cron="*/2 * * * * *"
+            export gravitee_services_sync_timeframeBeforeDelay=5000
+            export gravitee_services_sync_timeframeAfterDelay=5000
             export GIO_MAX_MEM=512m
 
             # Start AM Management
@@ -791,7 +800,8 @@ jobs:
             java -jar gravitee-am-ciba-delegated-service/target/gravitee-am-ciba-delegated-service-${AM_VERSION}.jar &
            
             echo "Wait for AM to be up and running..."
-            timeout 120s bash -c 'until nc -z localhost 8092; do sleep 2; done'
+            timeout 180s bash -c 'until nc -z localhost 8092; do sleep 2; done'
+            
             retVal=$?
             if [ $retVal -ne 0 ]; then
               echo "Gateway not started"

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
@@ -240,15 +240,15 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
 
             // create new indexes
             Map<Document, IndexOptions> indexes = new HashMap<>();
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TIMESTAMP_NAME));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TYPE_TIMESTAMP_NAME));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_STATUS, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TYPE_STATUS_SUCCESS_TIMESTAMP_NAME).partialFilterExpression(new Document(FIELD_STATUS, new Document("$eq", "SUCCESS"))));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TARGET, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TARGET_TIMESTAMP_NAME));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR, 1).append(FIELD_TARGET, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_TARGET_TIMESTAMP_NAME));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR_ID, 1).append(FIELD_TARGET_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_ID_TARGET_ID_TIMESTAMP_NAME));
+            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TIMESTAMP_NAME).background(true));
+            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TYPE_TIMESTAMP_NAME).background(true));
+            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_STATUS, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TYPE_STATUS_SUCCESS_TIMESTAMP_NAME).partialFilterExpression(new Document(FIELD_STATUS, new Document("$eq", "SUCCESS"))).background(true));
+            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME).background(true));
+            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TARGET, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TARGET_TIMESTAMP_NAME).background(true));
+            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR, 1).append(FIELD_TARGET, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_TARGET_TIMESTAMP_NAME).background(true));
+            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR_ID, 1).append(FIELD_TARGET_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_ID_TARGET_ID_TIMESTAMP_NAME).background(true));
             Completable createNewIndexes = Observable.fromIterable(indexes.entrySet())
-                    .flatMapCompletable(index -> Completable.fromPublisher(reportableCollection.createIndex(index.getKey(), index.getValue()))
+                            .concatMapCompletable(index -> Completable.fromPublisher(reportableCollection.createIndex(index.getKey(), index.getValue()))
                             .doOnComplete(() -> logger.debug("Created an index named: {}", index.getValue().getName()))
                             .doOnError(throwable -> logger.error("An error has occurred during creation of index {}", index.getValue().getName(), throwable)));
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/AbstractMongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/AbstractMongoRepository.java
@@ -39,7 +39,6 @@ public abstract class AbstractMongoRepository {
     protected static final String FIELD_NAME = "name";
     protected static final String FIELD_USER_ID = "userId";
 
-
     protected void init(MongoCollection<?> collection) {
         this.createIndex(collection, new Document(FIELD_ID, 1), new IndexOptions(), true);
     }
@@ -47,9 +46,10 @@ public abstract class AbstractMongoRepository {
     protected void createIndex(MongoCollection<?> collection, Document document, IndexOptions indexOptions, boolean ensure) {
         if (ensure) {
             Single.fromPublisher(collection.createIndex(document, indexOptions))
-                    .subscribe(
+                    .blockingSubscribe(
                             s -> logger.debug("Created an index named: {}", s),
-                            throwable -> logger.error("Error occurs during creation of index", throwable));
+                            throwable -> logger.error("Error occurs during creation of index", throwable)
+                    );
         }
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractManagementMongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractManagementMongoRepository.java
@@ -59,12 +59,8 @@ public abstract class AbstractManagementMongoRepository extends AbstractMongoRep
     @Value("${management.mongodb.cursorMaxTime:60000}")
     private int cursorMaxTimeInMs;
 
-    protected void createIndex(MongoCollection<?> collection, Document document) {
-        super.createIndex(collection, document, new IndexOptions(), ensureIndexOnStart);
-    }
-
     protected void createIndex(MongoCollection<?> collection, Document document, IndexOptions indexOptions) {
-        super.createIndex(collection, document, indexOptions, ensureIndexOnStart);
+        super.createIndex(collection, document, indexOptions.background(true), ensureIndexOnStart);
     }
 
     protected final <TResult> AggregatePublisher<TResult> withMaxTime(AggregatePublisher<TResult> query) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/AbstractOAuth2MongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/AbstractOAuth2MongoRepository.java
@@ -37,11 +37,7 @@ public abstract class AbstractOAuth2MongoRepository extends AbstractMongoReposit
     @Value("${oauth2.mongodb.ensureIndexOnStart:true}")
     private boolean ensureIndexOnStart;
 
-    protected void createIndex(MongoCollection<?> collection, Document document) {
-        super.createIndex(collection, document, new IndexOptions(), ensureIndexOnStart);
-    }
-
     protected void createIndex(MongoCollection<?> collection, Document document, IndexOptions indexOptions) {
-        super.createIndex(collection, document, indexOptions, ensureIndexOnStart);
+        super.createIndex(collection, document, indexOptions.background(true), ensureIndexOnStart);
     }
 }


### PR DESCRIPTION
 this time window is used when mAPI and GW have a time drift

 this is not the case in IT env

related-to AM-3078
