### PR TITLE
feat: publish some domain event to the Organization Audit logs

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/GraviteeContext.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/GraviteeContext.java
@@ -15,32 +15,19 @@
  */
 package io.gravitee.am.common.utils;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
+@AllArgsConstructor
+@Getter
 public class GraviteeContext {
     private final String organizationId;
     private final String environmentId;
     private final String domainId;
-
-    public GraviteeContext(String organizationId, String environmentId, String domainId) {
-        this.organizationId = organizationId;
-        this.environmentId = environmentId;
-        this.domainId = domainId;
-    }
-
-    public String getOrganizationId() {
-        return organizationId;
-    }
-
-    public String getEnvironmentId() {
-        return environmentId;
-    }
-
-    public String getDomainId() {
-        return domainId;
-    }
 
     public static GraviteeContext defaultContext(String domain) {
      return new GraviteeContext("DEFAULT", "DEFAULT", domain);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources.organizations.environments.domains;
 
+import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Domain;
@@ -158,7 +159,7 @@ public class DomainResource extends AbstractDomainResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN, Acl.DELETE)
-                .andThen(domainService.delete(domain, authenticatedUser))
+                .andThen(domainService.delete(new GraviteeContext(organizationId, environmentId, domain), domain, authenticatedUser))
                 .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
     }
 
@@ -322,7 +323,7 @@ public class DomainResource extends AbstractDomainResource {
         } else {
             Completable.merge(requiredPermissions.stream()
                     .map(permission -> checkAnyPermission(organizationId, environmentId, domainId, permission, Acl.UPDATE)).collect(Collectors.toList()))
-                    .andThen(domainService.patch(domainId, patchDomain, authenticatedUser)
+                    .andThen(domainService.patch(new GraviteeContext(organizationId, environmentId, domainId), domainId, patchDomain, authenticatedUser)
                             .flatMap(domain -> findAllPermissions(authenticatedUser, organizationId, environmentId, domainId)
                                     .map(userPermissions -> filterDomainInfos(domain, userPermissions))))
                     .subscribe(response::resume, response::resume);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources;
 
+import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
 import io.gravitee.am.management.service.permissions.PermissionAcls;
@@ -166,7 +167,7 @@ public class DomainResourceTest extends JerseySpringTest {
 
         doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
         doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
-        doReturn(Single.just(mockDomain)).when(domainService).patch(eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
+        doReturn(Single.just(mockDomain)).when(domainService).patch(any(GraviteeContext.class), eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
 
         final Response response = put(target("domains").path(mockDomain.getId()), patchDomain);
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -207,7 +208,7 @@ public class DomainResourceTest extends JerseySpringTest {
 
         doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
         doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
-        doReturn(Single.just(mockDomain)).when(domainService).patch(eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
+        doReturn(Single.just(mockDomain)).when(domainService).patch(any(GraviteeContext.class), eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
 
         final Response response = put(target("domains").path(mockDomain.getId()), patchDomain);
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -241,7 +242,7 @@ public class DomainResourceTest extends JerseySpringTest {
 
         doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
         doReturn(Single.just(Permission.of(Permission.DOMAIN, Acl.READ))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString()); // only domain read permission
-        doReturn(Single.just(mockDomain)).when(domainService).patch(eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
+        doReturn(Single.just(mockDomain)).when(domainService).patch(any(GraviteeContext.class), eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
 
         final Response response = put(target("domains").path(mockDomain.getId()), patchDomain);
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -271,7 +272,7 @@ public class DomainResourceTest extends JerseySpringTest {
         patchDomain.setDescription(Optional.of("New description"));
 
         doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
-        doReturn(Single.just(new Domain())).when(domainService).patch(anyString(), any(PatchDomain.class), any(User.class));
+        doReturn(Single.just(new Domain())).when(domainService).patch(any(GraviteeContext.class), anyString(), any(PatchDomain.class), any(User.class));
 
         final Response response = put(target("domains").path(domainId), patchDomain);
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DefaultOrganizationUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DefaultOrganizationUpgrader.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.service.impl.upgrades;
 
+import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.management.service.IdentityProviderManager;
 import io.gravitee.am.management.service.impl.upgrades.helpers.MembershipHelper;
 import io.gravitee.am.model.Domain;
@@ -154,7 +155,7 @@ public class DefaultOrganizationUpgrader implements Upgrader {
             } while (userPage.getData().size() == PAGE_SIZE);
 
             // then delete the domain
-            domainService.delete(ADMIN_DOMAIN).blockingAwait();
+            domainService.delete(GraviteeContext.defaultContext(ADMIN_DOMAIN), ADMIN_DOMAIN, null).blockingAwait();
         } else if (useDefaultAdmin) {
             // Need to create an inline provider and an admin user for this newly created default organization.
             IdentityProvider inlineProvider = createInlineProvider();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainUpgrader.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.service.impl.upgrades;
 
+import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.service.DomainService;
 import io.gravitee.am.service.model.PatchDomain;
@@ -72,7 +73,7 @@ public class DomainUpgrader extends AsyncUpgrader {
         PatchDomain patchDomain = new PatchDomain();
         patchDomain.setOidc(Optional.of(oidcPatch));
 
-        return domainService.patch(domain.getId(),patchDomain);
+        return domainService.patch(GraviteeContext.defaultContext(domain.getId()), domain.getId(), patchDomain, null);
     }
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DefaultOrganizationUpgraderTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DefaultOrganizationUpgraderTest.java
@@ -276,7 +276,7 @@ public class DefaultOrganizationUpgraderTest {
         when(organizationService.createDefault()).thenReturn(Maybe.just(organization));
         when(organizationService.update(any(), any(), any())).thenReturn(Single.just(organization));
         when(domainService.findById("admin")).thenReturn(Maybe.just(new Domain()));
-        when(domainService.delete("admin")).thenReturn(Completable.complete());
+        when(domainService.delete(any(), eq("admin"), any())).thenReturn(Completable.complete());
 
         when(roleService.findDefaultRole(Organization.DEFAULT, DefaultRole.ORGANIZATION_OWNER, ReferenceType.ORGANIZATION))
                 .thenReturn(Maybe.just(adminRole)); // Role has been created.

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service;
 
+import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.repository.management.api.search.DomainCriteria;
@@ -61,20 +62,12 @@ public interface DomainService {
 
     Single<Domain> update(String domainId, Domain domain);
 
-    Single<Domain> patch(String domainId, PatchDomain domain, User principal);
+    Single<Domain> patch(GraviteeContext graviteeContext, String domainId, PatchDomain domain, User principal);
 
-    Completable delete(String domain, User principal);
+    Completable delete(GraviteeContext graviteeContext, String domain, User principal);
 
     default Single<Domain> create(String organizationId, String environmentId, NewDomain domain) {
         return create(organizationId, environmentId, domain, null);
-    }
-
-    default Single<Domain> patch(String domainId, PatchDomain domain) {
-        return patch(domainId, domain, null);
-    }
-
-    default Completable delete(String domain) {
-        return delete(domain, null);
     }
 
     String buildUrl(Domain domain, String path, MultiMap queryParams);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/MembershipServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/MembershipServiceImpl.java
@@ -305,7 +305,7 @@ public class MembershipServiceImpl implements MembershipService {
                     return Single.error(new TechnicalManagementException(String.format("An error occurs while trying to create membership %s", membership), ex));
                 })
                 .doOnSuccess(membership1 -> auditService.report(AuditBuilder.builder(MembershipAuditBuilder.class).principal(principal).type(EventType.MEMBERSHIP_CREATED).membership(membership1)))
-                .doOnError(throwable -> auditService.report(AuditBuilder.builder(DomainAuditBuilder.class).principal(principal).type(EventType.MEMBERSHIP_CREATED).throwable(throwable)));
+                .doOnError(throwable -> auditService.report(AuditBuilder.builder(MembershipAuditBuilder.class).principal(principal).type(EventType.MEMBERSHIP_CREATED).throwable(throwable)));
     }
 
     private Member convert(io.gravitee.am.model.User user) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/TagServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/TagServiceImpl.java
@@ -146,9 +146,9 @@ public class TagServiceImpl implements TagService {
     }
 
     @Override
-    public Completable delete(String tagId, String orgaizationId, User principal) {
+    public Completable delete(String tagId, String organizationId, User principal) {
         LOGGER.debug("Delete tag {}", tagId);
-        return tagRepository.findById(tagId, orgaizationId)
+        return tagRepository.findById(tagId, organizationId)
                 .switchIfEmpty(Maybe.error(new TagNotFoundException(tagId)))
                 .flatMapCompletable(tag -> tagRepository.delete(tagId)
                         .andThen(domainService.listAll()

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/management/DomainAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/management/DomainAuditBuilder.java
@@ -36,7 +36,7 @@ public class DomainAuditBuilder extends ManagementAuditBuilder<DomainAuditBuilde
             if (EventType.DOMAIN_CREATED.equals(getType()) || EventType.DOMAIN_UPDATED.equals(getType())) {
                 setNewValue(domain);
             }
-            setTarget(domain.getId(), EntityType.DOMAIN, null, domain.getName(), ReferenceType.DOMAIN, domain.getId());
+            setTarget(domain.getId(), EntityType.DOMAIN, null, domain.getName(), domain.getReferenceType(), domain.getReferenceId());
         }
         return this;
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/impl/AuditReporterVerticle.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/impl/AuditReporterVerticle.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class AuditReporterVerticle extends AbstractVerticle implements AuditReporterService {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(AuditReporterVerticle.class);
-    private static final String EVENT_BUS_ADDRESS = "node:audits";
+    public static final String EVENT_BUS_ADDRESS = "node:audits";
     private MessageProducer<Reportable> producer;
 
     private static AtomicInteger activeReporter = new AtomicInteger(0);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/vertx/EventBusReporterWrapper.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/vertx/EventBusReporterWrapper.java
@@ -34,6 +34,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
+import static io.gravitee.am.service.reporter.impl.AuditReporterVerticle.EVENT_BUS_ADDRESS;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -41,7 +43,6 @@ import java.util.Map;
 public class EventBusReporterWrapper implements Reporter, Handler<Message<Reportable>> {
 
     public static final Logger logger = LoggerFactory.getLogger(EventBusReporterWrapper.class);
-    public static final String EVENT_BUS_ADDRESS = "node:audits";
     private Vertx vertx;
     private ReferenceType referenceType;
     private String referenceId;
@@ -114,7 +115,7 @@ public class EventBusReporterWrapper implements Reporter, Handler<Message<Report
     }
 
     @Override
-    public Object start() throws Exception {
+    public Reporter start() throws Exception {
         // start the delegate reporter
         vertx.rxExecuteBlocking(event -> {
                     try {
@@ -132,11 +133,11 @@ public class EventBusReporterWrapper implements Reporter, Handler<Message<Report
     }
 
     @Override
-    public Object stop() throws Exception {
+    public Reporter stop() throws Exception {
         if (messageConsumer != null) {
             messageConsumer.unregister();
         }
-        return reporter.stop();
+        return (Reporter) reporter.stop();
     }
 
     public void unregister() {

--- a/gravitee-am-ui/src/app/domain/settings/audits/audits.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/audits/audits.component.html
@@ -169,12 +169,20 @@
       </ngx-datatable-column>
       <ngx-datatable-column [sortable]="true" name="Target" [flexGrow]="2" prop="target.sortDisplayName">
         <ng-template let-row="row" ngx-datatable-cell-template>
-          <a *ngIf="row.target" [routerLink]="getTargetUrl(row)" [queryParams]="getTargetParams(row)"
-            >{{ row.target?.displayName
-            }}<span *ngIf="row.target.alternativeId">
-              | <small>{{ row.target?.alternativeId }}</small></span
-            ></a
-          >
+          <div *ngIf="row.target">
+            <a *ngIf="!isDomainAuditOnOrganizationLevel(row)" [routerLink]="getTargetUrl(row)" [queryParams]="getTargetParams(row)"
+              >{{ row.target?.displayName
+              }}<span *ngIf="row.target.alternativeId">
+                | <small>{{ row.target?.alternativeId }}</small></span
+              ></a
+            >
+            <span *ngIf="isDomainAuditOnOrganizationLevel(row)">
+              {{ row.target?.displayName
+              }}<span *ngIf="row.target.alternativeId">
+                | <small>{{ row.target?.alternativeId }}</small></span
+              >
+            </span>
+          </div>
         </ng-template>
       </ngx-datatable-column>
       <ngx-datatable-column [sortable]="true" name="Status" [flexGrow]="1" prop="outcome.status">

--- a/gravitee-am-ui/src/app/domain/settings/audits/audits.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/audits.component.ts
@@ -26,6 +26,7 @@ import { OrganizationService } from '../../../services/organization.service';
 import { UserService } from '../../../services/user.service';
 import { AuthService } from '../../../services/auth.service';
 import { availableTimeRanges, defaultTimeRangeId } from '../../../utils/time-range-utils';
+import { EnvironmentService } from '../../../services/environment.service';
 
 @Component({
   selector: 'app-audits',
@@ -61,6 +62,7 @@ export class AuditsComponent implements OnInit {
     private router: Router,
     private auditService: AuditService,
     private organizationService: OrganizationService,
+    private environmentService: EnvironmentService,
     private userService: UserService,
     private authService: AuthService,
   ) {
@@ -138,6 +140,12 @@ export class AuditsComponent implements OnInit {
 
   private buildNotOrganizationLink(row) {
     const routerLink = [];
+    if (this.isDomainAuditOnOrganizationLevel(row)) {
+      // For now, we do not provide a link to the domain when it comes from the organization audits
+      // as for doing so we need the env and the domain HRID. To get these information we have to manage
+      // backend requests based on the env & domain internal ids.
+      return routerLink;
+    }
     routerLink.push('/environments');
     routerLink.push(this.route.snapshot.paramMap.get('envHrid'));
     routerLink.push('domains');
@@ -147,6 +155,10 @@ export class AuditsComponent implements OnInit {
       routerLink.push('settings');
     }
     return routerLink;
+  }
+
+  isDomainAuditOnOrganizationLevel(row): boolean {
+    return row.referenceType === 'organization' && row.target.referenceType === 'environment' && row.target.type === 'DOMAIN';
   }
 
   private buildNotDomainLink(row) {


### PR DESCRIPTION
 Only DOMAIN_CREATED, DOMAIN_DELETED are sent in addition of DOMAIN_UPDATED when the name or the enabled attributes change

 This commit changes the referenceType and refenceId of the target entry for domain event (previously it was referencing the domain but it is more relevant to have the env

 DOMAIN_CREATED & DOMAIN_DELETED are only sent on the Org level reporters not on the domain reporters anymore

fixes AM-3269
