### PR TITLE
fix: avoid infinite blocking call durint Indexes creation

### DIFF
--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
@@ -20,6 +20,7 @@ import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.model.Accumulators;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.WriteModel;
@@ -239,18 +240,17 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
                     });
 
             // create new indexes
-            Map<Document, IndexOptions> indexes = new HashMap<>();
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TIMESTAMP_NAME).background(true));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TYPE_TIMESTAMP_NAME).background(true));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_STATUS, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TYPE_STATUS_SUCCESS_TIMESTAMP_NAME).partialFilterExpression(new Document(FIELD_STATUS, new Document("$eq", "SUCCESS"))).background(true));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME).background(true));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TARGET, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TARGET_TIMESTAMP_NAME).background(true));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR, 1).append(FIELD_TARGET, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_TARGET_TIMESTAMP_NAME).background(true));
-            indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR_ID, 1).append(FIELD_TARGET_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_ID_TARGET_ID_TIMESTAMP_NAME).background(true));
-            Completable createNewIndexes = Observable.fromIterable(indexes.entrySet())
-                            .concatMapCompletable(index -> Completable.fromPublisher(reportableCollection.createIndex(index.getKey(), index.getValue()))
-                            .doOnComplete(() -> logger.debug("Created an index named: {}", index.getValue().getName()))
-                            .doOnError(throwable -> logger.error("An error has occurred during creation of index {}", index.getValue().getName(), throwable)));
+            List<IndexModel> indexes = new ArrayList<>();
+            indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TIMESTAMP_NAME).background(true)));
+            indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TYPE_TIMESTAMP_NAME).background(true)));
+            indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_STATUS, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TYPE_STATUS_SUCCESS_TIMESTAMP_NAME).partialFilterExpression(new Document(FIELD_STATUS, new Document("$eq", "SUCCESS"))).background(true)));
+            indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME).background(true)));
+            indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TARGET, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TARGET_TIMESTAMP_NAME).background(true)));
+            indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR, 1).append(FIELD_TARGET, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_TARGET_TIMESTAMP_NAME).background(true)));
+            indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR_ID, 1).append(FIELD_TARGET_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_ID_TARGET_ID_TIMESTAMP_NAME).background(true)));
+            Completable createNewIndexes = Completable.fromPublisher(reportableCollection.createIndexes(indexes))
+                            .doOnComplete(() -> logger.debug("{} Reporter indexes created", indexes.size()))
+                            .doOnError(throwable -> logger.error("An error has occurred during creation of indexes", throwable));
 
             // process indexes
             deleteOldIndexes

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/AbstractMongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/AbstractMongoRepository.java
@@ -15,12 +15,17 @@
  */
 package io.gravitee.am.repository.mongodb.common;
 
+import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.reactivestreams.client.MongoCollection;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -40,16 +45,20 @@ public abstract class AbstractMongoRepository {
     protected static final String FIELD_USER_ID = "userId";
 
     protected void init(MongoCollection<?> collection) {
-        this.createIndex(collection, new Document(FIELD_ID, 1), new IndexOptions(), true);
+        Single.fromPublisher(collection.createIndex(new Document(FIELD_ID, 1), new IndexOptions()))
+                .subscribe(
+                        ignore -> logger.debug("Index {} created", FIELD_ID),
+                        throwable -> logger.error("Error occurs during creation of index {}", FIELD_ID, throwable)
+                );
     }
 
-    protected void createIndex(MongoCollection<?> collection, Document document, IndexOptions indexOptions, boolean ensure) {
+    protected void createIndex(MongoCollection<?> collection, Map<Document, IndexOptions> indexes, boolean ensure) {
         if (ensure) {
-            Single.fromPublisher(collection.createIndex(document, indexOptions))
-                    .blockingSubscribe(
-                            s -> logger.debug("Created an index named: {}", s),
-                            throwable -> logger.error("Error occurs during creation of index", throwable)
-                    );
+            var indexesModel = indexes.entrySet().stream().map(entry -> new IndexModel(entry.getKey(), entry.getValue().background(true))).toList();
+            Completable.fromPublisher(collection.createIndexes(indexesModel))
+                    .doOnComplete(() -> logger.debug("{} indexes created", indexes.size()))
+                    .doOnError(throwable -> logger.error("An error has occurred during creation of indexes", throwable))
+                    .blockingAwait(1, TimeUnit.MINUTES);
         }
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractManagementMongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractManagementMongoRepository.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -59,8 +60,8 @@ public abstract class AbstractManagementMongoRepository extends AbstractMongoRep
     @Value("${management.mongodb.cursorMaxTime:60000}")
     private int cursorMaxTimeInMs;
 
-    protected void createIndex(MongoCollection<?> collection, Document document, IndexOptions indexOptions) {
-        super.createIndex(collection, document, indexOptions.background(true), ensureIndexOnStart);
+    protected void createIndex(MongoCollection<?> collection, Map<Document, IndexOptions> indexes) {
+        super.createIndex(collection, indexes, ensureIndexOnStart);
     }
 
     protected final <TResult> AggregatePublisher<TResult> withMaxTime(AggregatePublisher<TResult> query) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractUserRepository.java
@@ -46,8 +46,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -85,15 +87,20 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
     protected void initCollection(String collectionName) {
         usersCollection = mongoOperations.getCollection(collectionName, getMongoClass());
         super.init(usersCollection);
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EMAIL, 1), new IndexOptions().name("rt1ri1e1"));
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ADDITIONAL_INFO_EMAIL, 1), new IndexOptions().name("rt1ri1ae1"));
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1), new IndexOptions().name("rt1ri1u1"));
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_DISPLAY_NAME, 1), new IndexOptions().name("rt1ri1d1"));
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_FIRST_NAME, 1), new IndexOptions().name("rt1ri1f1"));
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_LAST_NAME, 1), new IndexOptions().name("rt1ri1l1"));
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EXTERNAL_ID, 1), new IndexOptions().name("rt1ri1ext1"));
-        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EXTERNAL_ID, 1).append(FIELD_SOURCE, 1), new IndexOptions().name("rt1ri1ext1s1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EMAIL, 1), new IndexOptions().name("rt1ri1e1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ADDITIONAL_INFO_EMAIL, 1), new IndexOptions().name("rt1ri1ae1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1), new IndexOptions().name("rt1ri1u1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_DISPLAY_NAME, 1), new IndexOptions().name("rt1ri1d1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_FIRST_NAME, 1), new IndexOptions().name("rt1ri1f1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_LAST_NAME, 1), new IndexOptions().name("rt1ri1l1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EXTERNAL_ID, 1), new IndexOptions().name("rt1ri1ext1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EXTERNAL_ID, 1).append(FIELD_SOURCE, 1), new IndexOptions().name("rt1ri1ext1s1"));
+
+        super.createIndex(usersCollection, indexes);
+
         createOrUpdateIndex();
     }
 
@@ -552,8 +559,8 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
             getDeletableIndex()
                     .doOnComplete(() -> {
                         try {
-                            super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1).append(FIELD_SOURCE, 1),
-                                    new IndexOptions().name(INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE).unique(true));
+                            super.createIndex(usersCollection, Map.of(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1).append(FIELD_SOURCE, 1),
+                                    new IndexOptions().name(INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE).unique(true)));
                         } catch (Exception e) {
                             logger.error("An error has occurred while creating index {} with unique constraints", INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE, e);
                         }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAccessPolicyRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAccessPolicyRepository.java
@@ -33,6 +33,7 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.List;
 
 import static com.mongodb.client.model.Filters.and;
@@ -54,10 +55,14 @@ public class MongoAccessPolicyRepository extends AbstractManagementMongoReposito
     public void init() {
         accessPoliciesCollection = mongoOperations.getCollection(COLLECTION_NAME, AccessPolicyMongo.class);
         super.init(accessPoliciesCollection);
-        super.createIndex(accessPoliciesCollection, new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
-        super.createIndex(accessPoliciesCollection, new Document(FIELD_RESOURCE, 1), new IndexOptions().name("r1"));
-        super.createIndex(accessPoliciesCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_RESOURCE, 1), new IndexOptions().name("d1r1"));
-        super.createIndex(accessPoliciesCollection, new Document(FIELD_UPDATED_AT, -1), new IndexOptions().name("u_1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
+        indexes.put(new Document(FIELD_RESOURCE, 1), new IndexOptions().name("r1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_RESOURCE, 1), new IndexOptions().name("d1r1"));
+        indexes.put(new Document(FIELD_UPDATED_AT, -1), new IndexOptions().name("u_1"));
+
+        super.createIndex(accessPoliciesCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAccountAccessTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAccountAccessTokenRepository.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 import static com.mongodb.client.model.Filters.and;
@@ -49,7 +50,7 @@ public class MongoAccountAccessTokenRepository extends AbstractManagementMongoRe
     public void init() {
         accountTokensCollection = mongoOperations.getCollection(COLLECTION_NAME, AccountAccessTokenMongo.class);
         super.init(accountTokensCollection);
-        createIndex(accountTokensCollection, new Document(FIELD_USER_ID, 1), new IndexOptions().name("u1"));
+        createIndex(accountTokensCollection, Map.of(new Document(FIELD_USER_ID, 1), new IndexOptions().name("u1")));
     }
 
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -75,6 +75,7 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -117,14 +118,18 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
     public void init() {
         applicationsCollection = mongoOperations.getCollection("applications", ApplicationMongo.class);
         super.init(applicationsCollection);
-        super.createIndex(applicationsCollection, new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
-        super.createIndex(applicationsCollection, new Document(FIELD_UPDATED_AT, -1), new IndexOptions().name("u_1"));
-        super.createIndex(applicationsCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1), new IndexOptions().name("d1soc1"));
-        super.createIndex(applicationsCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_NAME, 1), new IndexOptions().name("d1n1"));
-        super.createIndex(applicationsCollection, new Document(FIELD_IDENTITIES, 1), new IndexOptions().name("i1"));
-        super.createIndex(applicationsCollection, new Document(FIELD_APPLICATION_IDENTITY_PROVIDERS + "." + FIELD_IDENTITY, 1), new IndexOptions().name("aidp1"));
-        super.createIndex(applicationsCollection, new Document(FIELD_CERTIFICATE, 1), new IndexOptions().name("c1"));
-        super.createIndex(applicationsCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_GRANT_TYPES, 1), new IndexOptions().name("d1sog1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put( new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
+        indexes.put( new Document(FIELD_UPDATED_AT, -1), new IndexOptions().name("u_1"));
+        indexes.put( new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1), new IndexOptions().name("d1soc1"));
+        indexes.put( new Document(FIELD_DOMAIN, 1).append(FIELD_NAME, 1), new IndexOptions().name("d1n1"));
+        indexes.put( new Document(FIELD_IDENTITIES, 1), new IndexOptions().name("i1"));
+        indexes.put( new Document(FIELD_APPLICATION_IDENTITY_PROVIDERS + "." + FIELD_IDENTITY, 1), new IndexOptions().name("aidp1"));
+        indexes.put( new Document(FIELD_CERTIFICATE, 1), new IndexOptions().name("c1"));
+        indexes.put( new Document(FIELD_DOMAIN, 1).append(FIELD_GRANT_TYPES, 1), new IndexOptions().name("d1sog1"));
+
+        super.createIndex(applicationsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAuthenticationDeviceNotifierRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAuthenticationDeviceNotifierRepository.java
@@ -31,6 +31,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -48,7 +50,7 @@ public class MongoAuthenticationDeviceNotifierRepository extends AbstractManagem
     public void init() {
         authDeviceNotifierCollection = mongoOperations.getCollection(COLLECTION_NAME, AuthenticationDeviceNotifierMongo.class);
         super.init(authDeviceNotifierCollection);
-        super.createIndex(authDeviceNotifierCollection,new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
+        super.createIndex(authDeviceNotifierCollection, Map.of(new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAuthenticationFlowContextRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoAuthenticationFlowContextRepository.java
@@ -31,6 +31,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.client.model.Filters.and;
@@ -54,8 +55,12 @@ public class MongoAuthenticationFlowContextRepository extends AbstractManagement
     public void init() {
         authContextCollection = mongoOperations.getCollection("auth_flow_ctx", AuthenticationFlowContextMongo.class);
         super.init(authContextCollection);
-        super.createIndex(authContextCollection, new Document(FIELD_TRANSACTION_ID, 1).append(FIELD_VERSION, -1), new IndexOptions().name("t1v_1"));
-        super.createIndex(authContextCollection, new Document(FIELD_EXPIRES_AT, 1), new IndexOptions().name("e1").expireAfter(0l, TimeUnit.SECONDS));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_TRANSACTION_ID, 1).append(FIELD_VERSION, -1), new IndexOptions().name("t1v_1"));
+        indexes.put(new Document(FIELD_EXPIRES_AT, 1), new IndexOptions().name("e1").expireAfter(0l, TimeUnit.SECONDS));
+
+        super.createIndex(authContextCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoBotDetectionRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoBotDetectionRepository.java
@@ -31,6 +31,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -48,7 +50,7 @@ public class MongoBotDetectionRepository extends AbstractManagementMongoReposito
     public void init() {
         botDetectionMongoCollection = mongoOperations.getCollection(COLLECTION_NAME, BotDetectionMongo.class);
         super.init(botDetectionMongoCollection);
-        super.createIndex(botDetectionMongoCollection, new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
+        super.createIndex(botDetectionMongoCollection, Map.of(new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoCertificateRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoCertificateRepository.java
@@ -52,7 +52,7 @@ public class MongoCertificateRepository extends AbstractManagementMongoRepositor
     public void init() {
         certificatesCollection = mongoOperations.getCollection("certificates", CertificateMongo.class);
         super.init(certificatesCollection);
-        super.createIndex(certificatesCollection, new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
+        super.createIndex(certificatesCollection, Map.of(new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoCredentialRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoCredentialRepository.java
@@ -31,6 +31,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -53,11 +55,15 @@ public class MongoCredentialRepository extends AbstractManagementMongoRepository
     public void init() {
         credentialsCollection = mongoOperations.getCollection("webauthn_credentials", CredentialMongo.class);
         super.init(credentialsCollection);
-        super.createIndex(credentialsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(credentialsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("rt1ri1uid1"));
-        super.createIndex(credentialsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1), new IndexOptions().name("rt1ri1un1"));
-        super.createIndex(credentialsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_CREDENTIAL_ID, 1), new IndexOptions().name("rt1ri1cid1"));
-        super.createIndex(credentialsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_AAGUID, 1), new IndexOptions().name("rt1ri1a1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("rt1ri1uid1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1), new IndexOptions().name("rt1ri1un1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_CREDENTIAL_ID, 1), new IndexOptions().name("rt1ri1cid1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_AAGUID, 1), new IndexOptions().name("rt1ri1a1"));
+
+        super.createIndex(credentialsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDeviceIdentifierRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDeviceIdentifierRepository.java
@@ -31,6 +31,7 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.Objects;
 
 import static com.mongodb.client.model.Filters.and;
@@ -52,7 +53,7 @@ public class MongoDeviceIdentifierRepository extends AbstractManagementMongoRepo
     public void init() {
         deviceIdentifierMongoMongoCollection = mongoOperations.getCollection(COLLECTION_NAME, DeviceIdentifierMongo.class);
         super.init(deviceIdentifierMongoMongoCollection);
-        super.createIndex(deviceIdentifierMongoMongoCollection, new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
+        super.createIndex(deviceIdentifierMongoMongoCollection, Map.of(new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDeviceRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDeviceRepository.java
@@ -32,6 +32,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -60,8 +61,11 @@ public class MongoDeviceRepository extends AbstractManagementMongoRepository imp
         rememberDeviceMongoCollection = mongoOperations.getCollection(COLLECTION_NAME, DeviceMongo.class);
         super.init(rememberDeviceMongoCollection);
 
-        super.createIndex(rememberDeviceMongoCollection, new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
-        super.createIndex(rememberDeviceMongoCollection, new Document(FIELD_EXPIRES_AT, 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS).name("e1"));
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
+        indexes.put(new Document(FIELD_EXPIRES_AT, 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS).name("e1"));
+
+        super.createIndex(rememberDeviceMongoCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
@@ -65,6 +65,7 @@ import org.bson.conversions.Bson;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -87,8 +88,12 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
     public void init() {
         domainsCollection = mongoOperations.getCollection("domains", DomainMongo.class);
         super.init(domainsCollection);
-        super.createIndex(domainsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("ri1rt1"));
-        super.createIndex(domainsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_HRID, 1), new IndexOptions().name("ri1rt1h1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("ri1rt1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_HRID, 1), new IndexOptions().name("ri1rt1h1"));
+
+        super.createIndex(domainsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEmailRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEmailRepository.java
@@ -31,6 +31,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.exists;
@@ -49,9 +51,13 @@ public class MongoEmailRepository extends AbstractManagementMongoRepository impl
     public void init() {
         emailsCollection = mongoOperations.getCollection("emails", EmailMongo.class);
         super.init(emailsCollection);
-        super.createIndex(emailsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("ri1rt1"));
-        super.createIndex(emailsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TEMPLATE, 1), new IndexOptions().name("ri1rt1t1"));
-        super.createIndex(emailsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_CLIENT, 1).append(FIELD_TEMPLATE, 1), new IndexOptions().name("ri1rc1t1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("ri1rt1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TEMPLATE, 1), new IndexOptions().name("ri1rt1t1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_CLIENT, 1).append(FIELD_TEMPLATE, 1), new IndexOptions().name("ri1rc1t1"));
+
+        super.createIndex(emailsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEntrypointRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEntrypointRepository.java
@@ -30,6 +30,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -46,7 +48,7 @@ public class MongoEntrypointRepository extends AbstractManagementMongoRepository
     public void init() {
         collection = mongoOperations.getCollection("entrypoints", EntrypointMongo.class);
         super.init(collection);
-        super.createIndex(collection, new Document(FIELD_ORGANIZATION_ID, 1), new IndexOptions().name("o1"));
+        super.createIndex(collection, Map.of(new Document(FIELD_ORGANIZATION_ID, 1), new IndexOptions().name("o1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEnvironmentRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEnvironmentRepository.java
@@ -30,6 +30,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -46,7 +48,7 @@ public class MongoEnvironmentRepository extends AbstractManagementMongoRepositor
     public void init() {
         collection = mongoOperations.getCollection("environments", EnvironmentMongo.class);
         super.init(collection);
-        super.createIndex(collection, new Document(FIELD_ORGANIZATION_ID, 1),new IndexOptions().name("o1"));
+        super.createIndex(collection, Map.of(new Document(FIELD_ORGANIZATION_ID, 1),new IndexOptions().name("o1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEventRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEventRepository.java
@@ -61,7 +61,7 @@ public class MongoEventRepository extends AbstractManagementMongoRepository impl
     public void init() {
         eventsCollection = mongoOperations.getCollection("events", EventMongo.class);
         super.init(eventsCollection);
-        super.createIndex(eventsCollection, new Document(FIELD_UPDATED_AT, 1), new IndexOptions().name("u1"));
+        super.createIndex(eventsCollection, Map.of(new Document(FIELD_UPDATED_AT, 1), new IndexOptions().name("u1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoExtensionGrantRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoExtensionGrantRepository.java
@@ -30,6 +30,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -46,8 +48,12 @@ public class MongoExtensionGrantRepository extends AbstractManagementMongoReposi
     public void init() {
         extensionGrantsCollection = mongoOperations.getCollection("extension_grants", ExtensionGrantMongo.class);
         super.init(extensionGrantsCollection);
-        super.createIndex(extensionGrantsCollection, new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
-        super.createIndex(extensionGrantsCollection,new Document(FIELD_DOMAIN, 1).append(FIELD_NAME, 1), new IndexOptions().name("d1n1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_NAME, 1), new IndexOptions().name("d1n1"));
+
+        super.createIndex(extensionGrantsCollection,indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoFactorRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoFactorRepository.java
@@ -30,6 +30,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+
 import static com.mongodb.client.model.Filters.eq;
 
 /**
@@ -46,8 +48,12 @@ public class MongoFactorRepository extends AbstractManagementMongoRepository imp
     public void init() {
         factorsCollection = mongoOperations.getCollection("factors", FactorMongo.class);
         super.init(factorsCollection);
-        super.createIndex(factorsCollection,new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
-        super.createIndex(factorsCollection,new Document(FIELD_DOMAIN, 1).append(FIELD_FACTOR_TYPE, 1), new IndexOptions().name("d1f1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_FACTOR_TYPE, 1), new IndexOptions().name("d1f1"));
+
+        super.createIndex(factorsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoFlowRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoFlowRepository.java
@@ -32,6 +32,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -49,9 +51,13 @@ public class MongoFlowRepository extends AbstractManagementMongoRepository imple
     public void init() {
         flowsCollection = mongoOperations.getCollection("flows", FlowMongo.class);
         super.init(flowsCollection);
-        super.createIndex(flowsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(flowsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_APPLICATION, 1), new IndexOptions().name("rt1ri1a1"));
-        super.createIndex(flowsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ID, 1), new IndexOptions().name("rt1ri1id1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_APPLICATION, 1), new IndexOptions().name("rt1ri1a1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ID, 1), new IndexOptions().name("rt1ri1id1"));
+
+        super.createIndex(flowsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoFormRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoFormRepository.java
@@ -31,6 +31,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.exists;
@@ -49,9 +51,13 @@ public class MongoFormRepository extends AbstractManagementMongoRepository imple
     public void init() {
         formsCollection = mongoOperations.getCollection("forms", FormMongo.class);
         super.init(formsCollection);
-        super.createIndex(formsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(formsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TEMPLATE, 1), new IndexOptions().name("rt1ri1t1"));
-        super.createIndex(formsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_CLIENT, 1).append(FIELD_TEMPLATE, 1), new IndexOptions().name("rt1ri1c1t1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TEMPLATE, 1), new IndexOptions().name("rt1ri1t1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_CLIENT, 1).append(FIELD_TEMPLATE, 1), new IndexOptions().name("rt1ri1c1t1"));
+
+        super.createIndex(formsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoGroupRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoGroupRepository.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -62,8 +63,12 @@ public class MongoGroupRepository extends AbstractManagementMongoRepository impl
     public void init() {
         groupsCollection = mongoOperations.getCollection("groups", GroupMongo.class);
         super.init(groupsCollection);
-        super.createIndex(groupsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(groupsCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_NAME, 1), new IndexOptions().name("rt1ri1n1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_NAME, 1), new IndexOptions().name("rt1ri1n1"));
+
+        super.createIndex(groupsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoI18nDictionaryRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoI18nDictionaryRepository.java
@@ -30,6 +30,7 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.Objects;
 
 import static com.mongodb.client.model.Filters.and;
@@ -47,9 +48,13 @@ public class MongoI18nDictionaryRepository extends AbstractManagementMongoReposi
     public void init() {
         mongoCollection = mongoOperations.getCollection("i18n_dictionaries", I18nDictionaryMongo.class);
         super.init(mongoCollection);
-        super.createIndex(mongoCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(mongoCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1)
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1)
                                                                                 .append(FIELD_NAME, 1), new IndexOptions().name("rt1ri1n1"));
+
+        super.createIndex(mongoCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoIdentityProviderRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoIdentityProviderRepository.java
@@ -65,7 +65,7 @@ public class MongoIdentityProviderRepository extends AbstractManagementMongoRepo
     public void init() {
         identitiesCollection = mongoOperations.getCollection("identities", IdentityProviderMongo.class);
         super.init(identitiesCollection);
-        super.createIndex(identitiesCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        super.createIndex(identitiesCollection, Map.of(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoLoginAttemptRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoLoginAttemptRepository.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -57,10 +58,13 @@ public class MongoLoginAttemptRepository extends AbstractManagementMongoReposito
     public void init() {
         loginAttemptsCollection = mongoOperations.getCollection("login_attempts", LoginAttemptMongo.class);
         super.init(loginAttemptsCollection);
-        super.createIndex(loginAttemptsCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT, 1).append(FIELD_USERNAME, 1), new IndexOptions().name("d1c1u1"));
 
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT, 1).append(FIELD_USERNAME, 1), new IndexOptions().name("d1c1u1"));
         // expire after index
-        super.createIndex(loginAttemptsCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().name("e1").expireAfter(0L, TimeUnit.SECONDS));
+        indexes.put(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().name("e1").expireAfter(0L, TimeUnit.SECONDS));
+
+        super.createIndex(loginAttemptsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoMembershipRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoMembershipRepository.java
@@ -34,6 +34,8 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
@@ -54,9 +56,13 @@ public class MongoMembershipRepository extends AbstractManagementMongoRepository
     public void init() {
         membershipsCollection = mongoOperations.getCollection("memberships", MembershipMongo.class);
         super.init(membershipsCollection);
-        super.createIndex(membershipsCollection, new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
-        super.createIndex(membershipsCollection, new Document(FIELD_REFERENCE_ID, 1).append(FIELD_MEMBER_ID, 1), new IndexOptions().name("ri1mi1"));
-        super.createIndex(membershipsCollection, new Document(FIELD_MEMBER_ID, 1).append(FIELD_MEMBER_TYPE, 1), new IndexOptions().name("mi1mt1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
+        indexes.put(new Document(FIELD_REFERENCE_ID, 1).append(FIELD_MEMBER_ID, 1), new IndexOptions().name("ri1mi1"));
+        indexes.put(new Document(FIELD_MEMBER_ID, 1).append(FIELD_MEMBER_TYPE, 1), new IndexOptions().name("mi1mt1"));
+
+        super.createIndex(membershipsCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoNodeMonitoringRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoNodeMonitoringRepository.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
@@ -54,7 +55,7 @@ public class MongoNodeMonitoringRepository extends AbstractManagementMongoReposi
     public void init() {
         collection = mongoOperations.getCollection("node_monitoring", MonitoringMongo.class);
         super.init(collection);
-        super.createIndex(collection, new Document(FIELD_UPDATED_AT, 1), new IndexOptions().name("u1"));
+        super.createIndex(collection, Map.of(new Document(FIELD_UPDATED_AT, 1), new IndexOptions().name("u1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoNotificationAcknowledgeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoNotificationAcknowledgeRepository.java
@@ -29,6 +29,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -49,8 +51,8 @@ public class MongoNotificationAcknowledgeRepository extends AbstractManagementMo
     @PostConstruct
     public void init() {
         collection = mongoOperations.getCollection("notification_acknowledgements", NotificationAcknowledgeMongo.class);
-        super.createIndex(collection, new Document(FIELD_RESOURCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_AUDIENCE_ID, 1), new IndexOptions().name("ri1rt1a1"));
         super.init(collection);
+        super.createIndex(collection, Map.of(new Document(FIELD_RESOURCE_ID, 1).append(FIELD_TYPE, 1).append(FIELD_AUDIENCE_ID, 1), new IndexOptions().name("ri1rt1a1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoPasswordHistoryRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoPasswordHistoryRepository.java
@@ -30,6 +30,7 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.Objects;
 
 import static com.mongodb.client.model.Filters.and;
@@ -45,9 +46,12 @@ public class MongoPasswordHistoryRepository extends AbstractManagementMongoRepos
     public void init() {
         mongoCollection = mongoOperations.getCollection("password_histories", PasswordHistoryMongo.class);
         super.init(mongoCollection);
-        super.createIndex(mongoCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(mongoCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1)
-                .append(FIELD_USER_ID, 1), new IndexOptions().name("rt1ri1u1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put( new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put( new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("rt1ri1u1"));
+
+        super.createIndex(mongoCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoPasswordPolicyRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoPasswordPolicyRepository.java
@@ -31,6 +31,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Sorts.ascending;
@@ -51,7 +53,7 @@ public class MongoPasswordPolicyRepository extends AbstractManagementMongoReposi
         mongoCollection = mongoOperations.getCollection(COLLECTION_NAME, PasswordPolicyMongo.class);
         super.init(mongoCollection);
 
-        super.createIndex(mongoCollection, new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
+        super.createIndex(mongoCollection, Map.of(new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoPermissionTicketRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoPermissionTicketRepository.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -58,7 +59,7 @@ public class MongoPermissionTicketRepository extends AbstractManagementMongoRepo
         super.init(permissionTicketCollection);
 
         // expire after index
-        super.createIndex(permissionTicketCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0l, TimeUnit.SECONDS).name("e1"));
+        super.createIndex(permissionTicketCollection, Map.of(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0l, TimeUnit.SECONDS).name("e1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoRateLimitRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoRateLimitRepository.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
@@ -54,9 +55,9 @@ public class MongoRateLimitRepository extends AbstractManagementMongoRepository 
     public void init() {
         rateLimitCollection = mongoOperations.getCollection(RATE_LIMIT, RateLimitMongo.class);
         super.init(rateLimitCollection);
-        super.createIndex(rateLimitCollection, new Document(FIELD_USER_ID, 1)
+        super.createIndex(rateLimitCollection, Map.of(new Document(FIELD_USER_ID, 1)
                 .append(FIELD_CLIENT, 1)
-                .append(FIELD_FACTOR_ID,1), new IndexOptions().name("u1c1f1"));
+                .append(FIELD_FACTOR_ID,1), new IndexOptions().name("u1c1f1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoReporterRepository.java
@@ -30,6 +30,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.eq;
 
 /**
@@ -45,7 +47,7 @@ public class MongoReporterRepository extends AbstractManagementMongoRepository i
     public void init() {
         reportersCollection = mongoOperations.getCollection("reporters", ReporterMongo.class);
         super.init(reportersCollection);
-        super.createIndex(reportersCollection, new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
+        super.createIndex(reportersCollection, Map.of(new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoResourceRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoResourceRepository.java
@@ -32,6 +32,7 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -56,9 +57,13 @@ public class MongoResourceRepository extends AbstractManagementMongoRepository i
     public void init() {
         resourceCollection = mongoOperations.getCollection(COLLECTION_NAME, ResourceMongo.class);
         super.init(resourceCollection);
-        super.createIndex(resourceCollection, new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
-        super.createIndex(resourceCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1), new IndexOptions().name("d1c1"));
-        super.createIndex(resourceCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("d1c1u1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1), new IndexOptions().name("d1c1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("d1c1u1"));
+
+        super.createIndex(resourceCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoRoleRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoRoleRepository.java
@@ -63,8 +63,12 @@ public class MongoRoleRepository extends AbstractManagementMongoRepository imple
     public void init() {
         rolesCollection = mongoOperations.getCollection("roles", RoleMongo.class);
         super.init(rolesCollection);
-        super.createIndex(rolesCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(rolesCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_NAME, 1).append(FIELD_SCOPE, 1), new IndexOptions().name("rt1ri1n1s1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_NAME, 1).append(FIELD_SCOPE, 1), new IndexOptions().name("rt1ri1n1s1"));
+
+        super.createIndex(rolesCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoScopeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoScopeRepository.java
@@ -33,6 +33,7 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -55,8 +56,12 @@ public class MongoScopeRepository extends AbstractManagementMongoRepository impl
     public void init() {
         scopesCollection = mongoOperations.getCollection("scopes", ScopeMongo.class);
         super.init(scopesCollection);
-        super.createIndex(scopesCollection, new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
-        super.createIndex(scopesCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_KEY, 1), new IndexOptions().name("d1k1"));
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_DOMAIN, 1), new IndexOptions().name("d1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_KEY, 1), new IndexOptions().name("d1k1"));
+
+        super.createIndex(scopesCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoServiceResourceRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoServiceResourceRepository.java
@@ -31,6 +31,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -47,7 +49,7 @@ public class MongoServiceResourceRepository extends AbstractManagementMongoRepos
     public void init() {
         resourceCollection = mongoOperations.getCollection("service_resources", ServiceResourceMongo.class);
         super.init(resourceCollection);
-        super.createIndex(resourceCollection,new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1"));
+        super.createIndex(resourceCollection, Map.of(new Document(FIELD_REFERENCE_ID, 1).append(FIELD_REFERENCE_TYPE, 1), new IndexOptions().name("ri1rt1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoTagRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoTagRepository.java
@@ -30,6 +30,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -46,7 +48,7 @@ public class MongoTagRepository extends AbstractManagementMongoRepository implem
     public void init() {
         tagsCollection = mongoOperations.getCollection("tags", TagMongo.class);
         super.init(tagsCollection);
-        super.createIndex(tagsCollection, new Document(FIELD_ORGANIZATION_ID, 1), new IndexOptions().name("o1"));
+        super.createIndex(tagsCollection, Map.of(new Document(FIELD_ORGANIZATION_ID, 1), new IndexOptions().name("o1")));
     }
 
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoThemeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoThemeRepository.java
@@ -30,6 +30,8 @@ import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -46,7 +48,7 @@ public class MongoThemeRepository extends AbstractManagementMongoRepository impl
     public void init() {
         themesCollection = mongoOperations.getCollection("themes", ThemeMongo.class);
         super.init(themesCollection);
-        super.createIndex(themesCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        super.createIndex(themesCollection, Map.of(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoUserActivityRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoUserActivityRepository.java
@@ -34,6 +34,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Repository;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.client.model.Filters.and;
@@ -60,13 +61,17 @@ public class MongoUserActivityRepository extends AbstractManagementMongoReposito
     public void init() {
         userActivityCollection = mongoOperations.getCollection("user_activities", UserActivityMongo.class);
         super.init(userActivityCollection);
-        super.createIndex(userActivityCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
-        super.createIndex(userActivityCollection, new Document(FIELD_REFERENCE_TYPE, 1)
+
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1), new IndexOptions().name("rt1ri1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1)
                 .append(FIELD_REFERENCE_ID, 1)
                 .append(FIELD_USER_ACTIVITY_TYPE, 1)
                 .append(FIELD_USER_ACTIVITY_KEY, 1), new IndexOptions().name("rt1ri1uat1uak1"));
-        super.createIndex(userActivityCollection, new Document(FIELD_CREATED_AT, 1), new IndexOptions().name("c1"));
-        super.createIndex(userActivityCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS).name("e1"));
+        indexes.put(new Document(FIELD_CREATED_AT, 1), new IndexOptions().name("c1"));
+        indexes.put(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS).name("e1"));
+
+        super.createIndex(userActivityCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoUserNotificationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoUserNotificationRepository.java
@@ -32,6 +32,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.Map;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
@@ -57,7 +58,7 @@ public class MongoUserNotificationRepository extends AbstractManagementMongoRepo
     protected void init() {
         this.mongoCollection = mongoOperations.getCollection(COLLECTION_NAME, UserNotificationMongo.class);
         super.init(mongoCollection);
-        createIndex(this.mongoCollection, new Document(FIELD_AUDIENCE, 1).append(FIELD_TYPE, 1).append(FIELD_STATUS, 1), new IndexOptions().name("a1t1s1"));
+        createIndex(this.mongoCollection, Map.of(new Document(FIELD_AUDIENCE, 1).append(FIELD_TYPE, 1).append(FIELD_STATUS, 1), new IndexOptions().name("a1t1s1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoVerifyAttemptRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoVerifyAttemptRepository.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
@@ -54,9 +55,8 @@ public class MongoVerifyAttemptRepository extends AbstractManagementMongoReposit
     public void init(){
         verifyAttemptCollection = mongoOperations.getCollection(VERIFY_ATTEMPT, VerifyAttemptMongo.class);
         super.init(verifyAttemptCollection);
-        super.createIndex(verifyAttemptCollection, new Document(FIELD_USER_ID, 1)
-                .append(FIELD_CLIENT, 1)
-                .append(FIELD_FACTOR_ID,1), new IndexOptions().name("u1c1f1"));
+        super.createIndex(verifyAttemptCollection, Map.of(new Document(FIELD_USER_ID, 1).append(FIELD_CLIENT, 1).append(FIELD_FACTOR_ID,1),
+                new IndexOptions().name("u1c1f1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/AbstractOAuth2MongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/AbstractOAuth2MongoRepository.java
@@ -24,6 +24,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 
+import java.util.Map;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -37,7 +39,7 @@ public abstract class AbstractOAuth2MongoRepository extends AbstractMongoReposit
     @Value("${oauth2.mongodb.ensureIndexOnStart:true}")
     private boolean ensureIndexOnStart;
 
-    protected void createIndex(MongoCollection<?> collection, Document document, IndexOptions indexOptions) {
-        super.createIndex(collection, document, indexOptions.background(true), ensureIndexOnStart);
+    protected void createIndex(MongoCollection<?> collection, Map<Document, IndexOptions> indexes) {
+        super.createIndex(collection, indexes, ensureIndexOnStart);
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoAccessTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoAccessTokenRepository.java
@@ -29,6 +29,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.client.model.Filters.and;
@@ -54,14 +55,17 @@ public class MongoAccessTokenRepository extends AbstractOAuth2MongoRepository im
     public void init() {
         accessTokenCollection = mongoOperations.getCollection("access_tokens", AccessTokenMongo.class);
         super.init(accessTokenCollection);
-        super.createIndex(accessTokenCollection, new Document(FIELD_TOKEN, 1), new IndexOptions().name("t1"));
-        super.createIndex(accessTokenCollection, new Document(FIELD_CLIENT, 1), new IndexOptions().name("c1"));
-        super.createIndex(accessTokenCollection, new Document(FIELD_AUTHORIZATION_CODE, 1), new IndexOptions().name("ac1"));
-        super.createIndex(accessTokenCollection, new Document(FIELD_SUBJECT, 1), new IndexOptions().name("s1"));
-        super.createIndex(accessTokenCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT, 1).append(FIELD_SUBJECT, 1), new IndexOptions().name("d1c1s1"));
 
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_TOKEN, 1), new IndexOptions().name("t1"));
+        indexes.put(new Document(FIELD_CLIENT, 1), new IndexOptions().name("c1"));
+        indexes.put(new Document(FIELD_AUTHORIZATION_CODE, 1), new IndexOptions().name("ac1"));
+        indexes.put(new Document(FIELD_SUBJECT, 1), new IndexOptions().name("s1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT, 1).append(FIELD_SUBJECT, 1), new IndexOptions().name("d1c1s1"));
         // expire after index
-        super.createIndex(accessTokenCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().name("e1").expireAfter(0L, TimeUnit.SECONDS));
+        indexes.put(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().name("e1").expireAfter(0L, TimeUnit.SECONDS));
+
+        super.createIndex(accessTokenCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoAuthorizationCodeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoAuthorizationCodeRepository.java
@@ -32,6 +32,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -56,11 +57,14 @@ public class MongoAuthorizationCodeRepository extends AbstractOAuth2MongoReposit
     public void init() {
         authorizationCodeCollection = mongoOperations.getCollection("authorization_codes", AuthorizationCodeMongo.class);
         super.init(authorizationCodeCollection);
-        super.createIndex(authorizationCodeCollection, new Document(FIELD_CODE, 1), new IndexOptions().name("c1"));
-        super.createIndex(authorizationCodeCollection, new Document(FIELD_TRANSACTION_ID, 1), new IndexOptions().name("t1"));
 
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_CODE, 1), new IndexOptions().name("c1"));
+        indexes.put(new Document(FIELD_TRANSACTION_ID, 1), new IndexOptions().name("t1"));
         // expire after index
-        super.createIndex(authorizationCodeCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0l, TimeUnit.SECONDS).name("e1"));
+        indexes.put(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0l, TimeUnit.SECONDS).name("e1"));
+
+        super.createIndex(authorizationCodeCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoCibaAuthRequestRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoCibaAuthRequestRepository.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.client.model.Filters.and;
@@ -56,7 +57,7 @@ public class MongoCibaAuthRequestRepository extends AbstractOAuth2MongoRepositor
         super.init(cibaAuthRequestCollection);
 
         // expire after index
-        super.createIndex(cibaAuthRequestCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS).name("e1"));
+        super.createIndex(cibaAuthRequestCollection, Map.of(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS).name("e1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoPushedAuthorizationRequestRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoPushedAuthorizationRequestRepository.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.client.model.Filters.and;
@@ -57,7 +58,7 @@ public class MongoPushedAuthorizationRequestRepository extends AbstractOAuth2Mon
         super.init(parCollection);
 
         // expire after index
-        super.createIndex(parCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().name("e1").expireAfter(0L, TimeUnit.SECONDS));
+        super.createIndex(parCollection, Map.of(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().name("e1").expireAfter(0L, TimeUnit.SECONDS)));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoRefreshTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoRefreshTokenRepository.java
@@ -30,6 +30,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.client.model.Filters.and;
@@ -53,12 +54,13 @@ public class MongoRefreshTokenRepository extends AbstractOAuth2MongoRepository i
     public void init() {
         refreshTokenCollection = mongoOperations.getCollection("refresh_tokens", RefreshTokenMongo.class);
         super.init(refreshTokenCollection);
-        super.createIndex(refreshTokenCollection, new Document(FIELD_TOKEN, 1), new IndexOptions().name("t1"));
-        super.createIndex(refreshTokenCollection, new Document(FIELD_SUBJECT, 1), new IndexOptions().name("s1"));
-        super.createIndex(refreshTokenCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT, 1).append(FIELD_SUBJECT, 1), new IndexOptions().name("d1c1s1"));
-
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_TOKEN, 1), new IndexOptions().name("t1"));
+        indexes.put(new Document(FIELD_SUBJECT, 1), new IndexOptions().name("s1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT, 1).append(FIELD_SUBJECT, 1), new IndexOptions().name("d1c1s1"));
         // expire after index
-        super.createIndex(refreshTokenCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().name("e1").expireAfter(0L, TimeUnit.SECONDS));
+        indexes.put(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().name("e1").expireAfter(0L, TimeUnit.SECONDS));
+        super.createIndex(refreshTokenCollection, indexes);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoRequestObjectRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoRequestObjectRepository.java
@@ -29,6 +29,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.client.model.Filters.and;
@@ -52,7 +53,7 @@ public class MongoRequestObjectRepository extends AbstractOAuth2MongoRepository 
         super.init(requestObjectCollection);
 
         // expire after index
-        super.createIndex(requestObjectCollection, new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS).name("e1"));
+        super.createIndex(requestObjectCollection, Map.of(new Document(FIELD_EXPIRE_AT, 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS).name("e1")));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoScopeApprovalRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoScopeApprovalRepository.java
@@ -31,6 +31,7 @@ import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -57,13 +58,16 @@ public class MongoScopeApprovalRepository extends AbstractOAuth2MongoRepository 
     public void init() {
         scopeApprovalsCollection = mongoOperations.getCollection("scope_approvals", ScopeApprovalMongo.class);
         super.init(scopeApprovalsCollection);
-        super.createIndex(scopeApprovalsCollection, new Document(FIELD_TRANSACTION_ID, 1), new IndexOptions().name("t1"));
-        super.createIndex(scopeApprovalsCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("d1u1"));
-        super.createIndex(scopeApprovalsCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("d1c1u1"));
-        super.createIndex(scopeApprovalsCollection, new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1).append(FIELD_USER_ID, 1).append(FIELD_SCOPE, 1), new IndexOptions().name("d1c1u1s1"));
 
+        final var indexes = new HashMap<Document, IndexOptions>();
+        indexes.put(new Document(FIELD_TRANSACTION_ID, 1), new IndexOptions().name("t1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("d1u1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1).append(FIELD_USER_ID, 1), new IndexOptions().name("d1c1u1"));
+        indexes.put(new Document(FIELD_DOMAIN, 1).append(FIELD_CLIENT_ID, 1).append(FIELD_USER_ID, 1).append(FIELD_SCOPE, 1), new IndexOptions().name("d1c1u1s1"));
         // expire after index
-        super.createIndex(scopeApprovalsCollection, new Document(FIELD_EXPIRES_AT, 1),  new IndexOptions().name("e1").expireAfter(0l, TimeUnit.SECONDS));
+        indexes.put(new Document(FIELD_EXPIRES_AT, 1),  new IndexOptions().name("e1").expireAfter(0l, TimeUnit.SECONDS));
+
+        super.createIndex(scopeApprovalsCollection, indexes);
     }
 
     @Override


### PR DESCRIPTION
 in addition we are using the createdIndexes command to send the creation as a batch

 this is a rework of the PR#4232 as it was blocking infinitly the process under kube deployements

fix AM-831

