### PR TITLE
Changes needed by RO filesystem support in base nonconfd image

### DIFF
--- a/docker/management-ui/Dockerfile
+++ b/docker/management-ui/Dockerfile
@@ -19,9 +19,6 @@ LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0
 
-# Update to get support for Zip/Unzip, Bash
-RUN apk --update add zip unzip bash wget
-
 ENV WWW_TARGET /usr/share/nginx/html
 ENV MGMT_BASE_HREF "/"
 ENV MGMT_API_URL "http://localhost:8093"
@@ -38,7 +35,7 @@ RUN apk update \
 ADD config/constants.json /usr/share/nginx/html/constants.json
 ADD config/default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/conf.d/
+RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 
 CMD ["sh", "/run.sh"]
 

--- a/docker/management-ui/Dockerfile-nightly
+++ b/docker/management-ui/Dockerfile-nightly
@@ -18,9 +18,6 @@ LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEAM_VERSION=0
 
-# Update to get support for Zip/Unzip, Bash
-RUN apk --update add zip unzip bash wget
-
 ENV WWW_TARGET /usr/share/nginx/html
 ENV MGMT_BASE_HREF "/"
 ENV MGMT_API_URL "http://localhost:8093"

--- a/docker/management-ui/config/default.conf
+++ b/docker/management-ui/config/default.conf
@@ -8,7 +8,7 @@ server {
 
     location / {
         try_files $uri $uri/ /index.html =404;
-        root /usr/share/nginx/html;
+        root /rw.mount/www;
         sub_filter '<base href="/"' '<base href="$MGMT_BASE_HREF"';
         sub_filter_once on;
     }
@@ -16,6 +16,6 @@ server {
     # redirect server error pages to the static page /50x.html
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
-        root   /usr/share/nginx/html;
+        root   /rw.mount/www;
     }
 }


### PR DESCRIPTION
## :id: [TT-4930.](https://gravitee.atlassian.net/browse/TT-4930) 


## :pencil2: This allows to start the containers with RO filesystem enabled. Requested by BY but can be used everywhere for better security.
