### PR TITLE
AM-3317 [4.1] fix - StackOverflowError on Kubernetes websocket connection issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <gravitee-bom.version>6.0.47</gravitee-bom.version>
         <gravitee-common.version>2.1.0</gravitee-common.version>
         <gravitee-plugin.version>2.0.2</gravitee-plugin.version>
-        <gravitee-node.version>4.3.3</gravitee-node.version>
+        <gravitee-node.version>4.3.4</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>


### PR DESCRIPTION
fixes AM-3317, stacktrace details in https://gravitee.atlassian.net/browse/AM-3317

StackOverflowError is thrown due to recursive loop on watchProperty().
As a remedy, the main Flowable is wrapped to Flowable.defer(Supplier) and chained with repeat()