### PR TITLE
bugfix - missing serviceAccountName in UI deployment template

### DIFF
--- a/helm/templates/ui/ui-deployment.yaml
+++ b/helm/templates/ui/ui-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ui.enabled -}}
+{{- $serviceAccount := include "am.serviceAccount" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,6 +65,8 @@ spec:
       {{- if .Values.ui.deployment.podSecurityContext }}
       securityContext: {{ toYaml .Values.ui.deployment.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- if $serviceAccount }}
+      serviceAccountName: {{ $serviceAccount }}{{ end }}
       affinity: {{ toYaml .Values.ui.deployment.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.ui.deployment.nodeSelector | nindent 8 }}
       topologySpreadConstraints: {{ toYaml .Values.ui.deployment.topologySpreadConstraints | nindent 8 }}


### PR DESCRIPTION
## :pencil2: A description of the changes proposed in the pull request
Missing the serviceAccountName in UI deployment template.
This resulted in "unable to validate against any security context constraint" errors in OpenShift unless the SA was included.