### PR TITLE
feat: allow get certificate content from different sources than a file

### DIFF
--- a/gravitee-am-certificate/gravitee-am-certificate-api/src/main/java/io/gravitee/am/certificate/api/AbstractCertificateProvider.java
+++ b/gravitee-am-certificate/gravitee-am-certificate-api/src/main/java/io/gravitee/am/certificate/api/AbstractCertificateProvider.java
@@ -66,7 +66,7 @@ public abstract class AbstractCertificateProvider implements CertificateProvider
     private List<CertificateKey> certificateKeys;
 
     public void createCertificateKeys(CertificateMetadata certificateMetadata) throws Exception {
-        Object file = certificateMetadata.getMetadata().get(CertificateMetadata.FILE);
+        Object file = getCertificateContent(certificateMetadata);
         Objects.requireNonNull(file, invalidCertificateFileMessage());
 
         try (InputStream is = new ByteArrayInputStream((byte[]) file)) {
@@ -106,6 +106,10 @@ public abstract class AbstractCertificateProvider implements CertificateProvider
                 throw new IllegalArgumentException("An ECSDA or RSA Signer must be supplied");
             }
         }
+    }
+
+    protected Object getCertificateContent(CertificateMetadata certificateMetadata) {
+        return certificateMetadata.getMetadata().get(CertificateMetadata.FILE);
     }
 
     protected abstract String getStorepass();


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-3308

## :pencil2: A description of the changes proposed in the pull request
allow get certificate content from different sources than a file for plugin gravitee-am-certificate-aws

## :memo: Test scenarios 


## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
