### PR TITLE
Feat/am 3268 inheritable reporters

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -17,7 +17,7 @@ package io.gravitee.am.gateway.handler.common.spring;
 
 import io.gravitee.am.gateway.handler.common.alert.AlertEventProcessor;
 import io.gravitee.am.gateway.handler.common.audit.AuditReporterManager;
-import io.gravitee.am.gateway.handler.common.audit.impl.AuditReporterManagerImpl;
+import io.gravitee.am.gateway.handler.common.audit.impl.GatewayAuditReporterManager;
 import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
 import io.gravitee.am.gateway.handler.common.auth.idp.impl.IdentityProviderManagerImpl;
 import io.gravitee.am.gateway.handler.common.auth.listener.AuthenticationEventListener;
@@ -132,7 +132,7 @@ public class CommonConfiguration {
 
     @Bean
     public AuditReporterManager auditReporterManager() {
-        return new AuditReporterManagerImpl();
+        return new GatewayAuditReporterManager();
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/resources/groups/GroupEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/resources/groups/GroupEndpoint.java
@@ -229,7 +229,7 @@ public class GroupEndpoint extends AbstractGroupEndpoint {
      * In response to a successful DELETE, the server SHALL return a
      *    successful HTTP status code 204 (No Content).
      *
-     * See <a href="https://tools.ietf.org/html/rfc7644#section-3.6>3.6. Deleting Resources</a>
+     * See <a href="https://tools.ietf.org/html/rfc7644#section-3.6">3.6. Deleting Resources</a>
      */
     public void delete(RoutingContext context) {
         final String groupId = context.request().getParam("id");

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/ReporterResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/ReporterResource.java
@@ -114,7 +114,6 @@ public class ReporterResource extends AbstractResource {
             @Parameter(name = "reporter", required = true) @Valid @NotNull UpdateReporter updateReporter,
             @Suspended final AsyncResponse response) {
         final User authenticatedUser = getAuthenticatedUser();
-
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_REPORTER, Acl.UPDATE)
                 .andThen(organizationService.findById(organizationId)
                         .onErrorResumeWith(Single.error(new OrganizationNotFoundException(organizationId)))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/ReportersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/ReportersResource.java
@@ -113,7 +113,6 @@ public class ReportersResource extends AbstractResource {
             @Suspended final AsyncResponse response) {
 
         User authenticatedUser = getAuthenticatedUser();
-
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_REPORTER, Acl.CREATE)
                 .andThen(reporterPluginService.checkPluginDeployment(newReporter.getType()))
                 .andThen(organizationService.findById(organizationId)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ReporterServiceProxyImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ReporterServiceProxyImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.common.audit.EventType;
+import io.gravitee.am.common.event.Action;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.service.AbstractSensitiveProxy;
 import io.gravitee.am.management.service.ReporterPluginService;
@@ -112,6 +113,11 @@ public class ReporterServiceProxyImpl extends AbstractSensitiveProxy implements 
     @Override
     public String createReporterConfig(Reference reference){
         return reporterService.createReporterConfig(reference);
+    }
+
+    @Override
+    public Completable notifyInheritedReporters(Reference parentReference, Reference affectedReference, Action action) {
+        return reporterService.notifyInheritedReporters(parentReference, affectedReference, action);
     }
 
     private Single<Reporter> filterSensitiveData(Reporter reporter) {

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Reporter.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Reporter.java
@@ -43,6 +43,11 @@ public class Reporter {
     private Date createdAt;
     @Schema(type = "java.lang.Long")
     private Date updatedAt;
+    /**
+     * If an organization level is inherited, it will automatically report events from all domains in this organization.
+     * This has no effect on domain reporters.
+     */
+    private boolean inherited;
 
     public Reporter() {
     }
@@ -58,6 +63,7 @@ public class Reporter {
         this.configuration = other.configuration;
         this.createdAt = other.createdAt;
         this.updatedAt = other.updatedAt;
+        this.inherited = other.inherited;
     }
 
     /**

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/common/event/Payload.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/common/event/Payload.java
@@ -36,7 +36,7 @@ public class Payload extends HashMap<String, Object> {
     public Payload(String id, Reference reference, Action action) {
         this(id, reference.type(), reference.id(), action);
     }
-    @Deprecated(since = "4.5")
+
     public Payload(String id, ReferenceType referenceType, String referenceId, Action action) {
         put(ID, id);
         if(referenceType != null) {

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-reporter/src/main/java/io/gravitee/am/plugins/reporter/core/ReporterPluginManager.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-reporter/src/main/java/io/gravitee/am/plugins/reporter/core/ReporterPluginManager.java
@@ -26,6 +26,9 @@ import io.gravitee.am.reporter.api.audit.AuditReporter;
 import io.gravitee.plugin.core.api.PluginContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 
 import java.util.List;
 

--- a/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/Reportable.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/Reportable.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.reporter.api;
 
+import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
 
 /**
@@ -26,4 +27,8 @@ public interface Reportable extends io.gravitee.reporter.api.Reportable {
     String getReferenceId();
 
     ReferenceType getReferenceType();
+
+    default Reference getReference() {
+        return new Reference(getReferenceType(), getReferenceId());
+    }
 }

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/ReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/ReporterRepository.java
@@ -29,4 +29,5 @@ public interface ReporterRepository extends CrudRepository<Reporter, String> {
     Flowable<Reporter> findAll();
 
     Flowable<Reporter> findByReference(Reference reference);
+    Flowable<Reporter> findInheritedFrom(Reference parentReference);
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcReporter.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcReporter.java
@@ -53,5 +53,6 @@ public class JdbcReporter  {
     private LocalDateTime updatedAt;
     @Column("system")
     private boolean system;
+    private boolean inherited;
 
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringReporterRepository.java
@@ -28,4 +28,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SpringReporterRepository extends RxJava3CrudRepository<JdbcReporter, String> {
     Flowable<JdbcReporter> findByReferenceTypeAndReferenceId(ReferenceType referenceType, String referenceId);
+    Flowable<JdbcReporter> findByReferenceTypeAndReferenceIdAndInheritedTrue(ReferenceType referenceType, String referenceId);
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/4.5.0-reporters-inherited.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/4.5.0-reporters-inherited.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.5.0-reporters-reference-type
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+      changes:
+        - addColumn:
+            tableName: reporters
+            columns:
+              - column:
+                  name: inherited
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -137,3 +137,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_5_0/4.5.0-add-upgraders-table.yml
   - include:
       - file: liquibase/changelogs/v4_5_0/4.5.0-reporters-reference-type.yml
+  - include:
+      - file: liquibase/changelogs/v4_5_0/4.5.0-reporters-inherited.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ReporterMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ReporterMongo.java
@@ -36,7 +36,6 @@ public class ReporterMongo extends Auditable {
     /**
      * @deprecated use referenceType & referenceId instead
      */
-
     // Lombok copies @deprecated to the generated accessors; mongo codec loses its mind when it sees @Deprecated both
     // on a field and an accessor. So we define them manually.
     @Getter(AccessLevel.NONE)
@@ -68,6 +67,6 @@ public class ReporterMongo extends Auditable {
 
     private String configuration;
 
-
+    private boolean inherited;
 
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/ReporterService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/ReporterService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service;
 
+import io.gravitee.am.common.event.Action;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Platform;
 import io.gravitee.am.model.Reference;
@@ -69,4 +70,5 @@ public interface ReporterService {
         return delete(reporterId, null);
     }
 
+    Completable notifyInheritedReporters(Reference parentReference, Reference affectedReference, Action action);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -202,6 +202,7 @@ public class ReporterServiceImpl implements ReporterService {
                 .flatMap(oldReporter -> {
                     Reporter reporterToUpdate = new Reporter(oldReporter);
                     reporterToUpdate.setEnabled(updateReporter.isEnabled());
+
                     reporterToUpdate.setName(updateReporter.getName());
                     if (!oldReporter.isSystem() || isUpgrader) {
                         reporterToUpdate.setConfiguration(updateReporter.getConfiguration());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewReporter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewReporter.java
@@ -16,11 +16,13 @@
 package io.gravitee.am.service.model;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Data;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Data
 public class NewReporter {
 
     private String id;
@@ -36,45 +38,7 @@ public class NewReporter {
     @NotNull
     private String configuration;
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getConfiguration() {
-        return configuration;
-    }
-
-    public void setConfiguration(String configuration) {
-        this.configuration = configuration;
-    }
+    private boolean inherited;
 
     @Override
     public String toString() {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateReporter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateReporter.java
@@ -16,11 +16,13 @@
 package io.gravitee.am.service.model;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Data;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Data
 public class UpdateReporter {
 
     private boolean enabled;
@@ -31,29 +33,8 @@ public class UpdateReporter {
     @NotNull
     private String configuration;
 
-    public boolean isEnabled() {
-        return enabled;
-    }
+    private boolean inherited;
 
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getConfiguration() {
-        return configuration;
-    }
-
-    public void setConfiguration(String configuration) {
-        this.configuration = configuration;
-    }
 
     @Override
     public String toString() {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainServiceTest.java
@@ -69,6 +69,7 @@ import io.gravitee.am.service.model.PatchDomain;
 import io.gravitee.am.service.validators.accountsettings.AccountSettingsValidator;
 import io.gravitee.am.service.validators.domain.DomainValidator;
 import io.gravitee.am.service.validators.virtualhost.VirtualHostValidator;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -369,6 +370,7 @@ public class DomainServiceTest {
         when(eventService.create(any())).thenReturn(Single.just(new Event()));
         when(membershipService.addOrUpdate(eq(ORGANIZATION_ID), any())).thenReturn(Single.just(new Membership()));
         when(roleService.findSystemRole(SystemRole.DOMAIN_PRIMARY_OWNER, DOMAIN)).thenReturn(Maybe.just(new Role()));
+        when(reporterService.notifyInheritedReporters(any(),any(),any())).thenReturn(Completable.complete());
         doReturn(Single.just(List.of()).ignoreElement()).when(domainValidator).validate(any(), any());
         doReturn(Single.just(List.of()).ignoreElement()).when(virtualHostValidator).validateDomainVhosts(any(), any());
 
@@ -818,6 +820,7 @@ public class DomainServiceTest {
         when(rateLimiterService.deleteByDomain(any(), any())).thenReturn(complete());
         when(verifyAttemptService.deleteByDomain(any(), any())).thenReturn(complete());
         when(passwordPolicyService.deleteByReference(any(), any())).thenReturn(complete());
+        when(reporterService.notifyInheritedReporters(any(),any(),any())).thenReturn(Completable.complete());
 
         final var graviteeContext = GraviteeContext.defaultContext(DOMAIN_ID);
         final var testObserver = domainService.delete(graviteeContext, DOMAIN_ID, null).test();
@@ -878,6 +881,7 @@ public class DomainServiceTest {
         when(passwordHistoryService.deleteByReference(DOMAIN, DOMAIN_ID)).thenReturn(complete());
         when(verifyAttemptService.deleteByDomain(any(), any())).thenReturn(complete());
         when(passwordPolicyService.deleteByReference(any(), any())).thenReturn(complete());
+        when(reporterService.notifyInheritedReporters(any(),any(),any())).thenReturn(Completable.complete());
 
         var testObserver = domainService.delete(GraviteeContext.defaultContext(DOMAIN_ID), DOMAIN_ID, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ReporterServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ReporterServiceTest.java
@@ -55,11 +55,11 @@ class ReporterServiceTest {
                     new char[]{'_', '_'})
             .usingRandom(rng::nextInt).build();
 
-    private ReporterRepository reporterRepository = new MemoryReporterRepository();
+    private final ReporterRepository reporterRepository = new MemoryReporterRepository();
 
     @Mock
     private EventService eventService;
-    private MockEnvironment environment = new MockEnvironment();
+    private final MockEnvironment environment = new MockEnvironment();
 
     @InjectMocks
     private ReporterService reporterService = new ReporterServiceImpl(environment, reporterRepository, null, null);
@@ -197,7 +197,7 @@ class ReporterServiceTest {
         when(eventService.create(any())).thenReturn(Single.just(new Event()));
         var reference = Reference.organization("test-org");
         var newReporter = randomTestFileReporter("test");
-        var createdReporter = reporterService.create(reference, newReporter)
+        var createdReporter = reporterService.create(reference, newReporter, null, false)
                 .test()
                 .awaitDone(1, TimeUnit.SECONDS)
                 .assertComplete()

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/repository/MemoryReporterRepository.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/repository/MemoryReporterRepository.java
@@ -34,6 +34,12 @@ public class MemoryReporterRepository extends MemoryRepository<Reporter,String> 
     }
 
     @Override
+    public Flowable<Reporter> findInheritedFrom(Reference parentReference) {
+        return findByReference(parentReference)
+                .filter(Reporter::isInherited);
+    }
+
+    @Override
     protected String getId(Reporter item) {
         return item.getId();
     }

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.html
@@ -29,7 +29,9 @@
             matTooltip="{{ reporter.enabled ? 'Disable reporter ?' : 'Enable reporter ?' }}"
             (change)="enableReporter($event)"
             [checked]="reporter.enabled"
-          ></mat-slide-toggle>
+            labelPosition="before"
+            >Enabled
+          </mat-slide-toggle>
         </div>
         <div *ngIf="createMode">
           <mat-form-field appearance="outline" floatLabel="always">
@@ -48,6 +50,13 @@
             <input matInput type="text" placeholder="Name" name="name" [(ngModel)]="reporter.name" (input)="validateName()" required />
             <mat-hint>A name for your reporter.</mat-hint>
           </mat-form-field>
+          <mat-slide-toggle
+            *ngIf="isOrganizationContext() && !reporter.system"
+            matTooltip=""
+            [checked]="reporter.inherited"
+            (change)="setInherited($event)"
+            >Log events from all domains in this organization
+          </mat-slide-toggle>
         </div>
       </div>
 

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.ts
@@ -103,7 +103,8 @@ export class ReporterComponent implements OnInit {
 
       // for File reporter fill the filename entry with the domain
       if (this.reporter.type === 'reporter-am-file') {
-        this.reporterSchema['properties']['filename'].default = this.domainId;
+        const defaultFilename = this.organizationContext ? '' : this.domainId;
+        this.reporterSchema['properties']['filename'].default = defaultFilename;
       }
     });
   }

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.ts
@@ -175,11 +175,19 @@ export class ReporterComponent implements OnInit {
     this.formChanged = true;
   }
 
+  setInherited(event): void {
+    this.reporter.inherited = event.checked;
+    this.formChanged = true;
+  }
+
   validateName() {
     this.hasName = this.reporter.name !== '' && this.reporter.name.trim() !== '';
   }
 
   isDefaultReporter() {
     return this.reporter.type === 'mongodb' || this.reporter.type === 'reporter-am-jdbc';
+  }
+  isOrganizationContext() {
+    return this.organizationContext;
   }
 }

--- a/gravitee-am-ui/src/app/services/organization.service.ts
+++ b/gravitee-am-ui/src/app/services/organization.service.ts
@@ -349,6 +349,7 @@ export class OrganizationService {
     return this.http.put<any>(this.organizationURL + '/reporters/' + reporterId, {
       name: reporter.name,
       enabled: reporter.enabled,
+      inherited: reporter.inherited,
       configuration: reporter.configuration,
     });
   }
@@ -363,6 +364,7 @@ export class OrganizationService {
       type: reporter.type,
       enabled: reporter.enabled,
       configuration: reporter.configuration,
+      inherited: reporter.inherited,
     });
   }
 


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3268
AM-3346

## :pencil2: A description of the changes proposed in the pull request
This PR allows setting **non-system**, **org-level** reporters as "inherited". Inherited reporters are automatically added to all existing & future domain within the organization and pick up all events from these domains.

In management API, the org-level reporter's instance is re-used for all domains. Adding/deleting a domain doesn't trigger a re-deployment of the reporter, this part of configuration is updated in-place on the running reporter.
In the gateway, each domain gets a copy of this domains' reporters and inherited org's reporters.

All these instances are linked to a single configuration object (entry in `reporters` table/collection), so updating it in the org's settings updates all relevant instances.
There's no limit on the number of inherited reporters in the domain.
