### PR TITLE
AM-3318 fix: obsolete gv-expression-language quirks.

### DIFF
--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -445,6 +445,7 @@ import { AccountTokenDialogModule } from './domain/settings/users/user/profile/t
 import { PasswordPoliciesResolver } from './resolvers/password-policies-resolver.service';
 import { PasswordPolicyResolver } from './resolvers/password-policy-resolver';
 import { PasswordPolicyService } from './services/password-policy.service';
+import { GvExpressionLanguageStyleReapplyDirective } from './directives/gv-expression-language-style-reapply.directive';
 
 @NgModule({
   declarations: [
@@ -696,6 +697,7 @@ import { PasswordPolicyService } from './services/password-policy.service';
     MfaChallengeComponent,
     FactorsSelectDialogComponent,
     PasswordPoliciesComponent,
+    GvExpressionLanguageStyleReapplyDirective,
   ],
   imports: [
     BrowserModule,

--- a/gravitee-am-ui/src/app/directives/gv-expression-language-style-reapply.directive.ts
+++ b/gravitee-am-ui/src/app/directives/gv-expression-language-style-reapply.directive.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive, ElementRef, Renderer2, OnDestroy, AfterViewChecked } from '@angular/core';
+
+@Directive({
+  selector: '[styleReapply]',
+})
+export class GvExpressionLanguageStyleReapplyDirective implements OnDestroy, AfterViewChecked {
+  private observer: MutationObserver;
+  private style: string;
+  private init: boolean = false;
+  constructor(
+    private el: ElementRef,
+    private renderer: Renderer2,
+  ) {}
+
+  ngAfterViewChecked(): void {
+    if (!this.init) {
+      this.applyStyles();
+      this.observer = new MutationObserver(() => this.applyStyles());
+      this.observer.observe(this.el.nativeElement, { childList: true, subtree: true });
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  }
+
+  private applyStyles(): void {
+    const shadowRoot = this.el.nativeElement.shadowRoot;
+    if (shadowRoot) {
+      const styleElement = this.renderer.createElement('style');
+      styleElement.textContent = this.createGvExpressionLanguageStyle();
+      this.renderer.appendChild(shadowRoot, styleElement);
+      this.init = true;
+    }
+  }
+
+  private createGvExpressionLanguageStyle() {
+    return `
+      .cm-tooltip {
+        border: 1px solid rgb(187, 187, 187);
+        background-color: rgb(245, 245, 245);
+        z-index: 100
+      }
+
+      .cm-content {
+        outline: none;
+      }
+      
+      .cm-matchingBracket {
+        background-color: rgba(50, 140, 130, 0.32);
+      }
+      
+      .cm-nonmatchingBracket {
+        background-color: rgba(187, 85, 85, 0.267);
+      }
+
+      .cm-tooltip-autocomplete > ul {
+        font-family: monospace;
+        white-space: nowrap;
+        overflow: hidden auto;
+        max-width: min(700px, 95vw);
+        min-width: 250px;
+        max-height: 10em;
+        list-style: none;
+        margin: 0px;
+        padding: 0px;
+      }
+
+      .cm-tooltip-autocomplete > ul > li {
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+        cursor: pointer;
+        padding: 1px 3px;
+        line-height: 1.2;
+      }
+
+      .cm-tooltip-autocomplete ul li[aria-selected] {
+        background: rgb(17, 119, 204);
+        color: white;
+      }
+
+      .cm-completionIcon-variable::after {
+        content: "𝑥"
+      }
+      
+      .cm-completionIcon {
+        font-size: 90%;
+        width: 0.8em;
+        display: inline-block;
+        text-align: center;
+        padding-right: 0.6em;
+        opacity: 0.6;
+      }
+
+      .cm-scroller {
+        font-family: monospace;
+        line-height: 1.4;
+        height: 100%;
+        overflow-x: auto;
+        position: relative;
+        z-index: 0;
+        display: flex !important;
+        align-items: flex-start !important;
+      }
+
+      .cm-line {
+        display: block;
+        padding: 0px 2px 0px 4px;
+      }
+    `;
+  }
+}

--- a/gravitee-am-ui/src/app/domain/applications/application/idp/selection-rule/create/create.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/idp/selection-rule/create/create.component.html
@@ -31,6 +31,7 @@
         (keyup)="change($event)"
         inner-hint
         rows="1"
+        styleReapply
       ></gv-expression-language>
     </div>
   </form>

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/mappers/create/create.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/mappers/create/create.component.html
@@ -34,6 +34,7 @@
         required
         inner-hint
         rows="1"
+        styleReapply
       ></gv-expression-language>
     </div>
   </form>

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/mappers/mappers.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/mappers/mappers.component.html
@@ -56,6 +56,7 @@
               required
               autofocus
               rows="1"
+              styleReapply
             ></gv-expression-language>
           </div>
         </ng-template>

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/roles/create/create.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/roles/create/create.component.html
@@ -31,6 +31,7 @@
           required
           inner-hint
           rows="1"
+          styleReapply
         ></gv-expression-language>
       </div>
     </div>


### PR DESCRIPTION
fixes AM-3318; after revisit page with gv-exp-lan component some CSS are missing. The directive workarounds the shadowRoot and applies needed CSSes.

