### PR TITLE
AM-3377 fix: NoOpReporter is not searchable.

### DIFF
--- a/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/provider/NoOpReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/provider/NoOpReporter.java
@@ -76,7 +76,7 @@ public class NoOpReporter implements AuditReporter {
 
     @Override
     public boolean canSearch() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
fixes AM-3377; In Audit Logs explorer, ManagementAuditReporterManager.doGetReporter(ref) returns the first one from all canSearch=true and then, it is used to perform queries. It could happen, the NoOpReporter is used instead of running System reporter.