### PR TITLE
fix: update scim Operation class to manage multi valued elements usin…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/model/MultiValuedAttributes.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/model/MultiValuedAttributes.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.scim.model;
+
+import java.util.List;
+
+import static org.springframework.util.StringUtils.hasLength;
+
+/**
+ * Helper to identify User & Group attributes which should be managed as list.
+ * This has been introduced to manage https://github.com/gravitee-io/issues/issues/9674
+ */
+class MultiValuedAttributes {
+    private static final List<String> listOfSingularValue = List.of("roles", "entitlements");
+    private static final List<String> listOfMultiAttributeValue = List.of("emails", "phoneNumbers", "ims", "photos", "addresses", "groups", "x509Certificates", "members");
+
+    private MultiValuedAttributes() {}
+
+    static boolean isListOfObjects(String path) {
+        return hasLength(path) && listOfMultiAttributeValue.contains(path);
+    }
+
+    static boolean isListOfSingular(String path) {
+        return hasLength(path) && listOfSingularValue.contains(path);
+    }
+}

--- a/postman/collections/graviteeio-am-scim-collection-app-version.json
+++ b/postman/collections/graviteeio-am-scim-collection-app-version.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "8c2b7d54-677a-48cb-b5d8-acad2688e63f",
+		"_postman_id": "712ac904-a213-4d52-ab81-5f7a75652929",
 		"name": "Gravitee.io - AM - SCIM - app version",
 		"description": "Test System for Cross-domain Identity Management\nSCIM 2.0 is released as RFC7642, RFC7643 and RFC7644",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "31343100"
 	},
 	"item": [
 		{
@@ -2203,9 +2204,13 @@
 													"    pm.expect(jsonData.schemas).to.eql(['urn:ietf:params:scim:schemas:core:2.0:User']);",
 													"    pm.expect(jsonData).to.have.property('emails');",
 													"    pm.expect(jsonData.emails[0].value).to.eql('bjensen@example.com');",
+													"    pm.expect(jsonData).to.have.property('phoneNumbers');",
+													"    pm.expect(jsonData.phoneNumbers[0].value).to.eql('0606060606');",
+													"    pm.expect(jsonData.phoneNumbers[0].type).to.eql('work');",
 													"});"
 												],
-												"type": "text/javascript"
+												"type": "text/javascript",
+												"packages": {}
 											}
 										}
 									],
@@ -2226,7 +2231,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n     \"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"],\n     \"Operations\": [{\n        \"op\":\"Add\",\n        \"value\" : {\n            \"emails\": [\n                {\n                    \"value\": \"bjensen@example.com\",\n                    \"type\": \"work\",\n                    \"primary\": true\n                }\n            ]\n        }\n     }]\n\n}"
+											"raw": "{\n     \"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"],\n     \"Operations\": [{\n        \"op\":\"Add\",\n        \"value\" : {\n            \"emails\": [\n                {\n                    \"value\": \"bjensen@example.com\",\n                    \"type\": \"work\",\n                    \"primary\": true\n                }\n            ]\n        }\n     },{\n        \"op\":\"Add\",\n        \"path\" : \"phoneNumbers[type eq \\\"work\\\"].value\",\n        \"value\" : \"0606060606\"\n     }]\n\n}"
 										},
 										"url": {
 											"raw": "{{gateway_url}}/{{domainHrid}}/scim/Users/{{userSCIM}}",


### PR DESCRIPTION
…g Azure AD syntaxe

 the syntax is not consistent with the RFC 7644 as it is using filter 'emails[type eq "work"].value'

 instead of a path with an array

fixes AM-3041

gravitee-io/issues#9674
