### PR TITLE
[4.3.x+] fix: copy all RememberDeviceSettings fields when updating an application

### DIFF
--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/RememberDeviceSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/RememberDeviceSettings.java
@@ -42,5 +42,6 @@ public class RememberDeviceSettings {
         this.active = other.active;
         this.expirationTimeSeconds = other.expirationTimeSeconds;
         this.deviceIdentifierId = other.deviceIdentifierId;
+        this.isSkipChallengeWhenRememberDevice = other.isSkipChallengeWhenRememberDevice;
     }
 }

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/RememberDeviceSettingsTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/RememberDeviceSettingsTest.java
@@ -46,6 +46,13 @@ class RememberDeviceSettingsTest {
         };
     }
 
+    @ParameterizedTest
+    @MethodSource("examples")
+    void copyConstructorCopiesProperly(TestCase testCase) {
+        var source = testCase.expectedSettings();
+        assertThat(new RememberDeviceSettings(source)).isEqualTo(source);
+    }
+
     // github: #9734
     @ParameterizedTest
     @MethodSource("examples")


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3451, #9857

## :pencil2: A description of the changes proposed in the pull request

Ensure all fields of RememberDeviceSettings get copied.

Fixed separately for 4.2 by #4458 