### PR TITLE
fix: AM-3455 check credential count on WebAuthnLoginStep

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/AuthenticationFlowHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/AuthenticationFlowHandlerImpl.java
@@ -30,6 +30,7 @@ import io.gravitee.am.gateway.handler.common.webauthn.WebAuthnCookieService;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.service.CredentialService;
 import io.vertx.core.Handler;
+import io.vertx.rxjava3.ext.auth.webauthn.WebAuthn;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -78,7 +79,7 @@ public class AuthenticationFlowHandlerImpl implements AuthenticationFlowHandler 
         steps.add(new RememberMeStep(RedirectHandler.create("/login"), jwtService, userService, rememberMeCookieName));
         steps.add(new SPNEGOStep(RedirectHandler.create("/login/SSO/SPNEGO"), identityProviderManager));
         steps.add(new FormIdentifierFirstLoginStep(RedirectHandler.create("/login/identifier"), domain));
-        steps.add(new WebAuthnLoginStep(RedirectHandler.create("/webauthn/login"), domain, webAuthnCookieService));
+        steps.add(new WebAuthnLoginStep(RedirectHandler.create("/webauthn/login"), domain, credentialService, webAuthnCookieService));
         steps.add(new FormLoginStep(RedirectHandler.create("/login")));
         steps.add(new WebAuthnRegisterStep(domain, RedirectHandler.create("/webauthn/register"), factorManager, credentialService));
         steps.add(new MFAEnrollStep(RedirectHandler.create("/mfa/enroll"), ruleEngine, factorManager));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/webauthn/WebAuthnCookieService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/webauthn/WebAuthnCookieService.java
@@ -44,7 +44,7 @@ public class WebAuthnCookieService implements InitializingBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(WebAuthnCookieService.class);
     private static final String DEFAULT_COOKIE_NAME = "GRAVITEE_AM_DEVICE_RECOGNITION";
     private static final long DEFAULT_SESSION_TIMEOUT = (long) 365 * 24 * 60 * 60 * 1000; // a year
-    private static final String USER_ID = "userId";
+    static final String USER_ID = "userId";
 
     @Value("${passwordless.rememberDevice.cookie.name:" + DEFAULT_COOKIE_NAME + "}")
     private String rememberDeviceCookieName;
@@ -84,12 +84,11 @@ public class WebAuthnCookieService implements InitializingBean {
         return jwtService.encode(jwt, certificateProvider);
     }
 
-    public Completable verifyRememberDeviceCookieValue(String cookieValue) {
+    public Single<String> extractUserIdFromRememberDeviceCookieValue(String cookieValue) {
         return decodeAndVerify(cookieValue)
-                .ignoreElement()
-                .onErrorResumeNext(throwable -> {
+                .map(jwt -> (String) jwt.get(USER_ID))
+                .doOnError(throwable -> {
                     LOGGER.error("An error has occurred when parsing WebAuthn cookie {}", cookieValue, throwable);
-                    return Completable.error(throwable);
                 });
     }
 


### PR DESCRIPTION
fixes: when WebAuthN remember device is ON and no credential exists, user shouldn't land on /webauth/login page
