### PR TITLE
Relax OIDC provider config schema

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/resources/schemas/schema-form.json
@@ -27,7 +27,7 @@
     "wellKnownUri": {
       "type" : "string",
       "title": "Well-Known Endpoint",
-      "description": "OpenID Connect Well-Known Endpoint '/.well-known/openid-configuration' to get OpenID Provider Configuration.\nFor settings configured both in this form and received from the well-known endpoint, the value from the endpoint is used."
+      "description": "OpenID Connect Well-Known Endpoint '/.well-known/openid-configuration' to get OpenID Provider Configuration and autodiscover the endpoints.\nFor settings configured both in this form and received from the well-known endpoint, the auto discovered values are used."
 
     },
     "userAuthorizationUri" : {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/resources/schemas/schema-form.json
@@ -27,7 +27,8 @@
     "wellKnownUri": {
       "type" : "string",
       "title": "Well-Known Endpoint",
-      "description": "OpenID Connect Well-Known Endpoint '/.well-known/openid-configuration' to get OpenID Provider Configuration"
+      "description": "OpenID Connect Well-Known Endpoint '/.well-known/openid-configuration' to get OpenID Provider Configuration.\nFor settings configured both in this form and received from the well-known endpoint, the value from the endpoint is used."
+
     },
     "userAuthorizationUri" : {
       "type" : "string",
@@ -156,7 +157,7 @@
     "clientId",
     "responseType"
   ],
-  "oneOf":[
+  "anyOf":[
     {
       "required": [
         "wellKnownUri"


### PR DESCRIPTION
## :id: Reference related issue. 

AM-3549, #9879

## :pencil2: A description of the changes proposed in the pull request

This commit changes validation from `oneOf` (i.e. XOR) to `anyOf` (OR), allowing users to configure all 4 endpoints (.well-known, authorization, token, userInfo). In case of an endpoint being defined both in the provider configuration and in the form in AM, the backend code already handles that by giving priority to configuration obtained from the .well-known URI. 
This has been added to the field description so the users have a chance of seeing this information.
