### PR TITLE
Add missing Gateway SSL settings to the helm chart

### DIFF
--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -55,6 +55,9 @@ data:
       {{- if .Values.gateway.ssl.enabled }}
       secured: true
       ssl:
+        {{- if .Values.gateway.ssl.certificateHeader }}
+        certificateHeader: {{- .Values.gateway.ssl.certificateHeader }}
+        {{- end }}
         keystore:
           {{- if .Values.gateway.ssl.keystore.type }}
           type: {{ .Values.gateway.ssl.keystore.type }}
@@ -63,6 +66,9 @@ data:
           password: {{ .Values.gateway.ssl.keystore.password | quote }}
         clientAuth: {{ .Values.gateway.ssl.clientAuth }}
         tlsProtocols: {{ .Values.gateway.ssl.tlsProtocols }}
+        {{- if .Values.gateway.ssl.ciphers }}
+        ciphers: {{.Values.gateway.ssl.ciphers}}
+        {{- end}}
         {{- if .Values.gateway.ssl.truststore }}
         truststore:
           {{- if .Values.gateway.ssl.truststore.type }}
@@ -71,6 +77,11 @@ data:
           path: {{ .Values.gateway.ssl.truststore.path }}
           password: {{ .Values.gateway.ssl.truststore.password | quote }}
         {{- end }}
+        {{- if .Values.gateway.ssl.mtls_aliases }}
+        mtls_aliases:
+          {{- .Values.gateway.ssl.mtls_aliases | toYaml | nindent 10}}
+        {{- end }}
+
       {{- end }}
 
     liquibase:

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -56,7 +56,7 @@ data:
       secured: true
       ssl:
         {{- if .Values.gateway.ssl.certificateHeader }}
-        certificateHeader: {{- .Values.gateway.ssl.certificateHeader }}
+        certificateHeader: {{ .Values.gateway.ssl.certificateHeader }}
         {{- end }}
         keystore:
           {{- if .Values.gateway.ssl.keystore.type }}

--- a/helm/tests/gateway/configmap_http_test.yaml
+++ b/helm/tests/gateway/configmap_http_test.yaml
@@ -45,3 +45,156 @@ tests:
           path: data.[gravitee.yml]
           pattern: |
             alpn: false
+  - it: Should ignore ssl config if ssl disabled
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        ssl:
+          enabled: false
+          tlsProtocols: TLSv1.2, TLSv1.3
+          ciphers: TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+          certificateHeader: X-Test-CertHeader # header where the peer certificate is read if there are no sslSession (default is null)
+          keystore:
+            type: jks # Supports jks, pem, pkcs12
+            path: ${gravitee.home}/security/keystore.jks
+            password: t0pS3cre7
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            secured
+  - it: Should have ssl config if ssl enabled
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        ssl:
+          enabled: true
+          tlsProtocols: TLSv1.2, TLSv1.3
+          ciphers: TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+          certificateHeader: X-Test-CertHeader
+          keystore:
+            type: jks
+            path: ${gravitee.home}/security/keystore.jks
+            password: t0pS3cre7
+          truststore:
+            type: pkcs12
+            path: /etc/security/my_awesome_pkcs12_truststore
+            password: t0pS3cre7
+          mtls_aliases:
+            baseUrl: https://baseurl.example.com
+            endpoints:
+              - userinfo_endpoint
+              - pushed_authorization_request_endpoint
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            http:
+              [a-zA-Z0-9:.# \n]*
+              secured: true
+              ssl:
+                certificateHeader: X-Test-CertHeader
+                keystore:
+                  type: jks
+                  path: \$\{gravitee\.home\}/security/keystore\.jks
+                  password: "t0pS3cre7"
+                clientAuth: false
+                tlsProtocols: TLSv1.2, TLSv1.3
+                ciphers: TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                truststore:
+                  type: pkcs12
+                  path: /etc/security/my_awesome_pkcs12_truststore
+                  password: "t0pS3cre7"
+                mtls_aliases:
+                  baseUrl: https://baseurl.example.com
+                  endpoints:
+                  - userinfo_endpoint
+                  - pushed_authorization_request_endpoint
+  - it: should skip truststore if not provieded
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        ssl:
+          enabled: true
+          tlsProtocols: TLSv1.2, TLSv1.3
+          ciphers: TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+          certificateHeader: X-Test-CertHeader
+          keystore:
+            type: jks
+            path: ${gravitee.home}/security/keystore.jks
+            password: t0pS3cre7
+          mtls_aliases:
+            baseUrl: https://baseurl.example.com
+            endpoints:
+              - userinfo_endpoint
+              - pushed_authorization_request_endpoint
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: "truststore:"
+  - it: Should skip mtls_section config if not provided
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        ssl:
+          enabled: true
+          tlsProtocols: TLSv1.2, TLSv1.3
+          ciphers: TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+          certificateHeader: X-Test-CertHeader
+          keystore:
+            type: jks
+            path: ${gravitee.home}/security/keystore.jks
+            password: t0pS3cre7
+          truststore:
+            type: pkcs12
+            path: /etc/security/my_awesome_pkcs12_truststore
+            password: t0pS3cre7
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: "mtls_aliases:"
+  - it: Should not configure custom cert header if not provided
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        ssl:
+          enabled: true
+          tlsProtocols: TLSv1.2, TLSv1.3
+          ciphers: TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+          keystore:
+            type: jks
+            path: ${gravitee.home}/security/keystore.jks
+            password: t0pS3cre7
+          truststore:
+            type: pkcs12
+            path: /etc/security/my_awesome_pkcs12_truststore
+            password: t0pS3cre7
+          mtls_aliases:
+            baseUrl: https://baseurl.example.com
+            endpoints:
+              - userinfo_endpoint
+              - pushed_authorization_request_endpoint
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: "certificateHeader:"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -603,6 +603,8 @@ gateway:
   ssl:
     enabled: false
     tlsProtocols: TLSv1.2, TLSv1.3
+  #  ciphers: TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  #  certificateHeader: X-ClientCert # header where the peer certificate is read if there are no sslSession (default is null)
   #  keystore:
   #    type: jks # Supports jks, pem, pkcs12
   #    path: ${gravitee.home}/security/keystore.jks
@@ -612,6 +614,13 @@ gateway:
   #    type: jks # Supports jks, pem, pkcs12
   #    path: ${gravitee.home}/security/truststore.jks
   #    password: secret
+  #  mtls_aliases: # base URL for mtls_endpoint_aliases (default is null and the standard endpoints will be used)
+  #    base_url: https://gravitee.mlts.com
+  #    endpoints:
+  #      - token_endpoint
+  #      - registration_endpoint
+  #      - userinfo_endpoint
+  #      - pushed_authorization_request_endpoint
   services:
     core:
       http:


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3531

## :pencil2: A description of the changes proposed in the pull request

Add missing gateway SSL settings to the helm chart so they can be configured.
This PR only exposes new settings, no values are changed from the current config.