### PR TITLE
chore: Add changelog for new 3.21.28 release

### DIFF
--- a/CHANGELOG-v3.adoc
+++ b/CHANGELOG-v3.adoc
@@ -1,5 +1,28 @@
 # Change Log
 
+==  - 3.21.28 (2024-07-19)
+
+== What's new !
+
+
+
+=== Gateway
+
+* Error Azure SCIM user update  https://github.com/gravitee-io/issues/issues/9674[#9674]
+
+=== Management API
+
+
+
+=== Console
+
+
+
+=== Other
+
+
+
+
 ==  - 3.21.27 (2024-06-06)
 
 == What's new !


### PR DESCRIPTION

# New version 3.21.28 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-access-management/edit/changelog-AM-3.21.28/CHANGELOG-v3.adoc)

## Jira issues

[See all Jira issues for 3.21.28 version](https://gravitee.atlassian.net/jira/software/c/projects/AM/issues/?jql=project%20%3D%20%22AM%22%20and%20fixVersion%20%3D%203.21.28%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
