### PR TITLE
fix: break redirect loop when redirected to a hidden login form with …

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
@@ -219,6 +219,17 @@ public class UriBuilder {
         return this;
     }
 
+    /**
+     * Add a query param if the value isn't null, otherwise return this builder unmodified
+     */
+    public UriBuilder addParameterIfHasValue(String paremeter, String value) {
+        if (value != null) {
+            return addParameter(paremeter, value);
+        } else {
+            return this;
+        }
+    }
+
     public UriBuilder addFragmentParameter(String parameter, String value) {
         if (fragment == null) {
             fragment = "";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginHideFormHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginHideFormHandler.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.am.gateway.handler.root.resources.handler.login;
 
-import io.gravitee.am.common.exception.oauth2.OAuth2Exception;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.common.web.UriBuilder;
@@ -30,7 +29,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static io.gravitee.am.common.utils.ConstantKeys.*;
 import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
@@ -93,7 +91,7 @@ public class LoginHideFormHandler implements Handler<RoutingContext> {
         var errorDescription = context.queryParam(ERROR_DESCRIPTION_PARAM_KEY).stream().findFirst().orElse("");
 
         var redirectUri = context.request().getParam(Parameters.REDIRECT_URI);
-        if  (StringUtils.isBlank(redirectUri)) {
+        if (StringUtils.isBlank(redirectUri)) {
             context.fail(500, new IllegalStateException("Received an error but there's nowhere to redirect to. error=%s, error_code=%s, error_description=%s".formatted(error, errorCode, errorDescription)));
             return;
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginHideFormHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginHideFormHandler.java
@@ -15,20 +15,25 @@
  */
 package io.gravitee.am.gateway.handler.root.resources.handler.login;
 
+import io.gravitee.am.common.exception.oauth2.OAuth2Exception;
+import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static io.gravitee.am.common.utils.ConstantKeys.*;
 import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
-import static io.gravitee.am.common.utils.ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -37,7 +42,7 @@ import static java.util.Optional.ofNullable;
  */
 public class LoginHideFormHandler implements Handler<RoutingContext> {
 
-    private Domain domain;
+    private final Domain domain;
 
     public LoginHideFormHandler(Domain domain) {
         this.domain = domain;
@@ -47,36 +52,58 @@ public class LoginHideFormHandler implements Handler<RoutingContext> {
     public void handle(RoutingContext routingContext) {
         final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
         final List<IdentityProvider> socialProviders = routingContext.get(SOCIAL_PROVIDER_CONTEXT_KEY);
-        final LoginSettings loginSettings = LoginSettings.getInstance(domain, client);
-        var optionalSettings = ofNullable(loginSettings).filter(Objects::nonNull);
-        boolean isHideForm = optionalSettings.map(LoginSettings::isHideForm).orElse(false);
+        boolean isHideFormEnabled = ofNullable(LoginSettings.getInstance(domain, client))
+                .map(LoginSettings::isHideForm)
+                .orElse(false);
+        boolean hasExactlyOneSocialProvider = socialProviders != null && socialProviders.size() == 1;
+
+        boolean shouldSkipLoginForm = isHideFormEnabled && hasExactlyOneSocialProvider;
+        boolean hasError = !routingContext.queryParam(ConstantKeys.ERROR_PARAM_KEY).isEmpty();
+
 
         // hide form option disabled, continue
-        if (!isHideForm) {
+        if (!shouldSkipLoginForm) {
             routingContext.next();
             return;
         }
 
-        // no external provider, continue
-        if (socialProviders == null) {
-            routingContext.next();
-            return;
+        if (hasError) {
+            redirectWithError(routingContext);
+        } else {
+            redirectToProvider(routingContext, socialProviders.get(0));
         }
-
-        // more than one external provider, continue
-        if (socialProviders.size() != 1) {
-            routingContext.next();
-            return;
-        }
-
-        doRedirect(routingContext, socialProviders.get(0));
     }
 
-    private void doRedirect(RoutingContext routingContext, IdentityProvider identityProvider) {
+    private void redirectToProvider(RoutingContext routingContext, IdentityProvider identityProvider) {
         Map<String, String> urls = routingContext.get(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY);
         String redirectUrl = urls.get(identityProvider.getId());
         routingContext.response()
                 .putHeader(io.vertx.core.http.HttpHeaders.LOCATION, redirectUrl)
+                .setStatusCode(302)
+                .end();
+    }
+
+    private void redirectWithError(RoutingContext context) {
+        /* AM-3381: normally if we're at /login with an error, the form displays it.
+               However, when the login form is hidden, we don't have a place to display it, and redirecting to the provider
+               may cause a redirect loop. */
+
+        var error = context.queryParam(ERROR_PARAM_KEY).stream().findFirst().orElse("");
+        var errorCode = context.queryParam(ERROR_CODE_PARAM_KEY).stream().findFirst().orElse("");
+        var errorDescription = context.queryParam(ERROR_DESCRIPTION_PARAM_KEY).stream().findFirst().orElse("");
+
+        var redirectUri = context.request().getParam(Parameters.REDIRECT_URI);
+        if  (StringUtils.isBlank(redirectUri)) {
+            context.fail(500, new IllegalStateException("Received an error but there's nowhere to redirect to. error=%s, error_code=%s, error_description=%s".formatted(error, errorCode, errorDescription)));
+            return;
+        }
+        var targetUri = UriBuilder.fromURIString(redirectUri)
+                .addParameter(ConstantKeys.ERROR_PARAM_KEY, error)
+                .addParameter(ERROR_CODE_PARAM_KEY, errorCode)
+                .addParameter(ERROR_DESCRIPTION_PARAM_KEY, UriBuilder.encodeURIComponent(errorDescription))
+                .buildString();
+        context.response()
+                .putHeader(HttpHeaders.LOCATION, targetUri)
                 .setStatusCode(302)
                 .end();
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginHideFormHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginHideFormHandlerTest.java
@@ -1,0 +1,131 @@
+package io.gravitee.am.gateway.handler.root.resources.handler.login;
+
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.handler.root.RootProvider;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.vertx.core.http.HttpMethod;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class LoginHideFormHandlerTest extends RxWebTestBase {
+
+    public static final int CONTEXT_SETUP = -1;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        router.get(RootProvider.PATH_LOGIN)
+                .handler(new LoginHideFormHandler(new Domain()))
+                .handler(rc -> rc.response().setStatusCode(200).send("completed"))
+                .failureHandler(c -> c.response()
+                        .setStatusCode(500)
+                        .send(c.failure().getClass().getSimpleName() + ": " + c.failure().getMessage()));
+    }
+
+    @Test
+    public void shouldDoNothingWhenHideFormDisabled() throws Exception {
+        router.route(HttpMethod.GET, RootProvider.PATH_LOGIN)
+                .order(CONTEXT_SETUP)
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, minimalClient(false));
+                    rc.next();
+                });
+        testRequest(HttpMethod.GET, RootProvider.PATH_LOGIN, 200, "OK", "completed");
+    }
+
+    @Test
+    public void shouldDoNothingWhenHideFormEnabledButMultipleProviders() throws Exception {
+        router.route(HttpMethod.GET, RootProvider.PATH_LOGIN)
+                .order(CONTEXT_SETUP)
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, minimalClient(true));
+                    rc.put(ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY, List.of(minimalProvider("idp-a"), minimalProvider("idp-b")));
+                    rc.next();
+                });
+        testRequest(HttpMethod.GET, RootProvider.PATH_LOGIN, 200, "OK", "completed");
+    }
+
+    @Test
+    public void shouldRedirectToProviderWhenHideFormEnabledAndOneProvider() throws Exception {
+        final String idpId = "idp-a";
+        final String idpUrl = "http://localhost/test-idp";
+        router.route(HttpMethod.GET, RootProvider.PATH_LOGIN)
+                .order(CONTEXT_SETUP)
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, minimalClient(true));
+                    rc.put(ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY, List.of(minimalProvider(idpId)));
+                    rc.put(LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idpId, idpUrl));
+                    rc.next();
+                });
+        testRequest(HttpMethod.GET, RootProvider.PATH_LOGIN, req -> {}, res -> Assertions.assertThat(res.getHeader("Location")).isEqualTo(idpUrl),302, "Found", null);
+    }
+
+    @Test
+    public void shouldRedirectToRedirectUriWithError() throws Exception {
+        final String idpId = "idp-a";
+        final String idpUrl = "http://localhost/test-idp";
+        router.route(HttpMethod.GET, RootProvider.PATH_LOGIN)
+                .order(CONTEXT_SETUP)
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, minimalClient(true));
+                    rc.put(ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY, List.of(minimalProvider(idpId)));
+                    rc.put(LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idpId, idpUrl));
+                    rc.next();
+                });
+
+        final var errorQueryParams = "error=test-error&error_code=test-error-code&error_description=test-error-from-test";
+        testRequest(HttpMethod.GET,
+                RootProvider.PATH_LOGIN+"?redirect_uri=some-redirect&" + errorQueryParams,
+                req -> {},
+                res -> Assertions.assertThat(res.getHeader("Location"))
+                        .isEqualTo("some-redirect?" + errorQueryParams),
+                302,
+                "Found",
+                null);
+    }
+
+    @Test
+    public void shouldFailWithErrorIfNoRedirectUri() throws Exception {
+        final String idpId = "idp-a";
+        final String idpUrl = "http://localhost/test-idp";
+        router.route(HttpMethod.GET, RootProvider.PATH_LOGIN)
+                .order(CONTEXT_SETUP)
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, minimalClient(true));
+                    rc.put(ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY, List.of(minimalProvider(idpId)));
+                    rc.put(LoginSocialAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idpId, idpUrl));
+                    rc.next();
+                });
+
+        final var errorQueryParams = "error=test-error&error_code=test-error-code&error_description=test-error-from-test";
+        testRequest(HttpMethod.GET,
+                RootProvider.PATH_LOGIN + "?" + errorQueryParams,
+                req -> {},
+                res -> res.bodyHandler(buf -> Assertions.assertThat(buf.toString()).startsWith("IllegalStateException")),
+                500,
+                "Internal Server Error",
+                null);
+    }
+
+    private IdentityProvider minimalProvider(String id) {
+        var idp = new IdentityProvider();
+        idp.setId(id);
+        return idp;
+    }
+
+    private Client minimalClient(boolean hideForm) {
+        var client = new Client();
+        client.setLoginSettings(new LoginSettings());
+        client.getLoginSettings().setInherited(false);
+        client.getLoginSettings().setHideForm(hideForm);
+        return client;
+
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginHideFormHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginHideFormHandlerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.am.gateway.handler.root.resources.handler.login;
 
 import io.gravitee.am.common.utils.ConstantKeys;


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3628, #9898


## :pencil2: A description of the changes proposed in the pull request
Adds error handling to HideLoginFormHandler to avoid login -> idp -> login redirect loop when a policy exits with an error in between these steps

