### PR TITLE
fix: block deleting the last default entrypoint on api level

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/LastDefaultEntrypointException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/LastDefaultEntrypointException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.exception;
+
+import io.gravitee.common.http.HttpStatusCode;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LastDefaultEntrypointException extends AbstractManagementException {
+
+    private final String msg;
+
+    public LastDefaultEntrypointException(String msg) {
+        this.msg = msg;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return msg;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
@@ -167,17 +167,20 @@ public class EntrypointServiceImpl implements EntrypointService {
         LOGGER.debug("Delete entrypoint by id {} and organizationId {}", id, organizationId);
 
         return findById(id, organizationId)
-                .flatMap(e -> {
-                    if (e.isDefaultEntrypoint()) {
-                        return isNotTheLastDefaultEntryPoint(e)
-                                .flatMap(notLast -> notLast ? Single.just(e) : Single.error(new LastDefaultEntrypointException("You cannot remove the last default entrypoint")));
-                    } else {
-                        return Single.just(e);
-                    }
-                })
-                .flatMapCompletable(entrypoint -> entrypointRepository.delete(id)
-                        .doOnComplete(() -> auditService.report(AuditBuilder.builder(EntrypointAuditBuilder.class).principal(principal).type(EventType.ENTRYPOINT_DELETED).entrypoint(entrypoint)))
-                        .doOnError(throwable -> auditService.report(AuditBuilder.builder(EntrypointAuditBuilder.class).principal(principal).type(EventType.ENTRYPOINT_DELETED).throwable(throwable))));
+                .flatMapCompletable(e -> deleteEntrypoint(e)
+                        .flatMapCompletable(entrypoint -> entrypointRepository.delete(id))
+                        .doOnComplete(() -> auditService.report(AuditBuilder.builder(EntrypointAuditBuilder.class).principal(principal).type(EventType.ENTRYPOINT_DELETED).entrypoint(e)))
+                        .doOnError(throwable -> auditService.report(AuditBuilder.builder(EntrypointAuditBuilder.class).principal(principal).entrypoint(e).type(EventType.ENTRYPOINT_DELETED).throwable(throwable)))
+                );
+    }
+
+    private Single<Entrypoint> deleteEntrypoint(Entrypoint e) {
+        if (e.isDefaultEntrypoint()) {
+            return isNotTheLastDefaultEntryPoint(e)
+                    .flatMap(notLast -> notLast ? Single.just(e) : Single.error(new LastDefaultEntrypointException("You cannot remove the last default entrypoint")));
+        } else {
+            return Single.just(e);
+        }
     }
 
     private Single<Boolean> isNotTheLastDefaultEntryPoint(Entrypoint entrypoint) {

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.html
@@ -22,7 +22,13 @@
     <div fxLayout="column" fxFlex="70">
       <form (ngSubmit)="update()" #domainForm="ngForm" fxLayout="column">
         <div *ngIf="!domain.vhostMode">
-          <div class="gv-form-section">
+          <div *ngIf="!domain.entrypoint" class="gv-form-section warning" fxLayout="row space-between">
+            <mat-icon>warning</mat-icon>
+            <p>
+              Default entrypoint is missing. Please make sure there is at least one default entrypoint configured in the organization settings.
+            </p>
+          </div>
+          <div *ngIf="domain.entrypoint" class="gv-form-section">
             <mat-form-field appearance="outline" floatLabel="always">
               <mat-label>Domain entrypoint url</mat-label>
               <input matInput type="text" name="url" [value]="entrypoint.url" disabled />

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.html
@@ -25,7 +25,8 @@
           <div *ngIf="!domain.entrypoint" class="gv-form-section warning" fxLayout="row space-between">
             <mat-icon>warning</mat-icon>
             <p>
-              Default entrypoint is missing. Please make sure there is at least one default entrypoint configured in the organization settings.
+              Default entrypoint is missing. Please make sure there is at least one default entrypoint configured in the organization
+              settings.
             </p>
           </div>
           <div *ngIf="domain.entrypoint" class="gv-form-section">

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.scss
@@ -54,4 +54,3 @@ a {
 #cors-settings > .mat-mdc-form-field {
   margin-bottom: 15px;
 }
-

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.scss
@@ -27,6 +27,10 @@
   font-size: 75%;
 }
 
+mat-icon {
+  color: grey;
+}
+
 .warning {
   mat-icon {
     margin-right: 20px;
@@ -35,10 +39,6 @@
   p {
     margin-block-end: 0;
   }
-}
-
-mat-icon {
-  color: grey;
 }
 
 a {

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.scss
@@ -27,6 +27,16 @@
   font-size: 75%;
 }
 
+.warning {
+  mat-icon {
+    margin-right: 20px;
+  }
+
+  p {
+    margin-block-end: 0;
+  }
+}
+
 mat-icon {
   color: grey;
 }
@@ -44,3 +54,4 @@ a {
 #cors-settings > .mat-mdc-form-field {
   margin-bottom: 15px;
 }
+


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3597, #9888

## :pencil2: A description of the changes proposed in the pull request
This PR does 2 things:
1. adds a check to block deleting the (last) default entrypoint via the API to reflect the restriction already present in UI.
2. adds a bit more graceful error handling for the case when somehow there's no default entrypoint configured
