### PR TITLE
fix: hide sensitive additional properties from api

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UserEntity.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UserEntity.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.am.management.handlers.management.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.am.model.User;
 import lombok.Getter;
 import lombok.Setter;
@@ -75,30 +73,12 @@ public class UserEntity extends User {
     }
 
     private Map<String, Object> filterSensitiveInfo(Map<String, Object> additionalInformation) {
+        if (additionalInformation == null) {
+            return null;
+        }
         return additionalInformation.entrySet()
                 .stream()
                 .map(e -> SENSITIVE_ADDITIONAL_PROPERTIES.contains(e.getKey()) ? Map.entry(e.getKey(), SENSITIVE_PROPERTY_PLACEHOLDER) : e)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
-
-
-    public record AdditionalProperty(@JsonIgnore Object value, boolean sensitive, boolean isNewValue) {
-
-        @JsonProperty("value")
-        public Object getValue() {
-            return sensitive ? null : value;
-        }
-
-        static Map<String, Object> wrap(Map<String, Object> properties) {
-            return properties.entrySet()
-                    .stream()
-                    .map(AdditionalProperty::wrap)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        }
-
-        private static Map.Entry<String, AdditionalProperty> wrap(Map.Entry<String, Object> e) {
-            return Map.entry(e.getKey(), new AdditionalProperty(e.getValue(), SENSITIVE_ADDITIONAL_PROPERTIES.contains(e.getKey()), false));
-        }
-    }
-
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UserEntity.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UserEntity.java
@@ -15,15 +15,23 @@
  */
 package io.gravitee.am.management.handlers.management.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.am.model.User;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class UserEntity extends User {
-
     private ApplicationEntity applicationEntity;
 
     private String sourceId;
@@ -58,7 +66,7 @@ public class UserEntity extends User {
         setRoles(user.getRoles());
         setDynamicRoles(user.getDynamicRoles());
         setRolesPermissions(user.getRolesPermissions());
-        setAdditionalInformation(user.getAdditionalInformation());
+        setAdditionalInformation(filterSensitiveInfo(user.getAdditionalInformation()));
         setCreatedAt(user.getCreatedAt());
         setUpdatedAt(user.getUpdatedAt());
         setLastPasswordReset(user.getLastPasswordReset());
@@ -66,19 +74,31 @@ public class UserEntity extends User {
         this.sourceId = user.getSource();
     }
 
-    public ApplicationEntity getApplicationEntity() {
-        return applicationEntity;
+    private Map<String, Object> filterSensitiveInfo(Map<String, Object> additionalInformation) {
+        return additionalInformation.entrySet()
+                .stream()
+                .map(e -> SENSITIVE_ADDITIONAL_PROPERTIES.contains(e.getKey()) ? Map.entry(e.getKey(), SENSITIVE_PROPERTY_PLACEHOLDER) : e)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    public void setApplicationEntity(ApplicationEntity applicationEntity) {
-        this.applicationEntity = applicationEntity;
+
+    public record AdditionalProperty(@JsonIgnore Object value, boolean sensitive, boolean isNewValue) {
+
+        @JsonProperty("value")
+        public Object getValue() {
+            return sensitive ? null : value;
+        }
+
+        static Map<String, Object> wrap(Map<String, Object> properties) {
+            return properties.entrySet()
+                    .stream()
+                    .map(AdditionalProperty::wrap)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        private static Map.Entry<String, AdditionalProperty> wrap(Map.Entry<String, Object> e) {
+            return Map.entry(e.getKey(), new AdditionalProperty(e.getValue(), SENSITIVE_ADDITIONAL_PROPERTIES.contains(e.getKey()), false));
+        }
     }
 
-    public String getSourceId() {
-        return sourceId;
-    }
-
-    public void setSourceId(String sourceId) {
-        this.sourceId = sourceId;
-    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserResource.java
@@ -37,6 +37,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.ResourceContext;
@@ -44,9 +46,6 @@ import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -138,7 +137,8 @@ public class UserResource extends AbstractResource {
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_USER, Acl.UPDATE)
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
-                        .flatMapSingle(irrelevant -> userService.update(ReferenceType.DOMAIN, domain, user, updateUser, authenticatedUser)))
+                        .flatMapSingle(irrelevant -> userService.update(ReferenceType.DOMAIN, domain, user, updateUser, authenticatedUser))
+                        .map(UserEntity::new))
                 .subscribe(response::resume, response::resume);
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/UserResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/UserResourceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources;
 
+import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
 import io.gravitee.am.management.handlers.management.api.model.PasswordValue;
 import io.gravitee.am.management.handlers.management.api.model.StatusEntity;
@@ -28,10 +29,12 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
-import org.junit.Test;
-
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,6 +56,7 @@ public class UserResourceTest extends JerseySpringTest {
     @Test
     public void shouldGetUser() {
         final String domainId = "domain-id";
+        final String someSensitiveProperty = ConstantKeys.OIDC_PROVIDER_ID_TOKEN_KEY;
         final Domain mockDomain = new Domain();
         mockDomain.setId(domainId);
 
@@ -63,6 +67,7 @@ public class UserResourceTest extends JerseySpringTest {
         mockUser.setReferenceType(ReferenceType.DOMAIN);
         mockUser.setReferenceId(domainId);
         mockUser.setSource("source");
+        mockUser.putAdditionalInformation(someSensitiveProperty, "example of sensitive property value");
         doReturn(Maybe.empty()).when(identityProviderService).findById(any());
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
         doReturn(Maybe.just(mockUser)).when(userService).findById(userId);
@@ -70,11 +75,16 @@ public class UserResourceTest extends JerseySpringTest {
         final Response response = target("domains").path(domainId).path("users").path(userId).request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
-        final Map user = readEntity(response, HashMap.class);
+        final Map<?, ?> user = readEntity(response, HashMap.class);
         assertEquals(domainId, user.get("referenceId"));
         assertEquals(mockUser.getUsername(), user.get("username"));
         assertEquals(mockUser.getSource(), user.get("sourceId"));
-     }
+        Assertions.assertThat(user.get("additionalInformation"))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class))
+                .hasEntrySatisfying(someSensitiveProperty, actual -> Assertions.assertThat(actual)
+                        .as("Sensitive property should be censored")
+                        .isEqualTo(User.SENSITIVE_PROPERTY_PLACEHOLDER));
+    }
 
     @Test
     public void shouldGetUser_notFound() {
@@ -264,8 +274,8 @@ public class UserResourceTest extends JerseySpringTest {
         doReturn(Single.just(userToUpdate)).when(userService).updateUsername(eq(ReferenceType.DOMAIN), eq(domainId), eq(userId), eq(usernameEntity.getUsername()), any());
 
         final var response = target("domains").path(domainId).path("users").path(userId).path("username").request()
-                                              .property(SET_METHOD_WORKAROUND, true)
-                                              .method(PATCH, Entity.json(usernameEntity));
+                .property(SET_METHOD_WORKAROUND, true)
+                .method(PATCH, Entity.json(usernameEntity));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final var updatedUser = readEntity(response, User.class);
         assertEquals(usernameEntity.getUsername(), updatedUser.getUsername());
@@ -277,8 +287,8 @@ public class UserResourceTest extends JerseySpringTest {
         var usernameEntity = new UsernameEntity();
         usernameEntity.setUsername("username");
         var response = target("domains").path("domainId").path("users").path("userId").path("username").request()
-                                        .property(SET_METHOD_WORKAROUND, true)
-                                        .method(PATCH, Entity.json(usernameEntity));
+                .property(SET_METHOD_WORKAROUND, true)
+                .method(PATCH, Entity.json(usernameEntity));
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
     }
 
@@ -324,7 +334,7 @@ public class UserResourceTest extends JerseySpringTest {
         var statusEntity = new StatusEntity();
         statusEntity.setEnabled(false);
         doReturn(Single.just(mockUser)).when(organizationUserService)
-            .updateStatus(eq(ReferenceType.ORGANIZATION), eq(referenceId), eq(userId), eq(statusEntity.isEnabled()), any());
+                .updateStatus(eq(ReferenceType.ORGANIZATION), eq(referenceId), eq(userId), eq(statusEntity.isEnabled()), any());
 
         final Response response = target("organizations").path(referenceId).path("users").path(userId).path("status").request().put(Entity.json(statusEntity));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -368,6 +378,8 @@ public class UserResourceTest extends JerseySpringTest {
         mockDomain.setId(domainId);
 
         final String userId = "userId";
+        final String sensitivePropertyLeftAsIs = ConstantKeys.OIDC_PROVIDER_ID_TOKEN_KEY;
+        final String sensitivePropertyToUpdate = ConstantKeys.OIDC_PROVIDER_ID_ACCESS_TOKEN_KEY;
         final User mockUser = new User();
         mockUser.setId(userId);
         mockUser.setUsername("username");
@@ -375,10 +387,18 @@ public class UserResourceTest extends JerseySpringTest {
         mockUser.setReferenceType(ReferenceType.DOMAIN);
         mockUser.setReferenceId(domainId);
         mockUser.setEnabled(false);
+        mockUser.putAdditionalInformation(sensitivePropertyLeftAsIs, "sensitive value");
+        mockUser.putAdditionalInformation(sensitivePropertyToUpdate, "sensitive value");
+        mockUser.putAdditionalInformation("not-sensitive", "lorem ipsum");
 
         final UpdateUser updateUser = new UpdateUser();
         updateUser.setEmail("email@email.com");
         updateUser.setFirstName("firstname");
+        updateUser.setAdditionalInformation(Map.of(
+                sensitivePropertyLeftAsIs, User.SENSITIVE_PROPERTY_PLACEHOLDER,
+                sensitivePropertyToUpdate, "updated sensitive value",
+                "not-sensitive", "lorem ipsum"
+        ));
 
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
         doReturn(Single.just(mockUser)).when(userService).update(eq(ReferenceType.DOMAIN), eq(domainId), eq(userId), any(), any());
@@ -388,6 +408,8 @@ public class UserResourceTest extends JerseySpringTest {
         final User user = readEntity(response, User.class);
         assertEquals(domainId, user.getReferenceId());
         assertEquals("firstname", user.getFirstName());
+        assertEquals(User.SENSITIVE_PROPERTY_PLACEHOLDER, user.getAdditionalInformation().get(sensitivePropertyLeftAsIs));
+        assertEquals(User.SENSITIVE_PROPERTY_PLACEHOLDER, user.getAdditionalInformation().get(sensitivePropertyToUpdate));
     }
 
     @Test
@@ -412,11 +434,11 @@ public class UserResourceTest extends JerseySpringTest {
         doReturn(Single.just(mockUser)).when(organizationUserService).update(eq(ReferenceType.ORGANIZATION), eq(organization), eq(userId), any(), any());
 
         final Response response = target("organizations")
-            .path(organization)
-            .path("users")
-            .path(userId)
-            .request()
-            .put(Entity.json(updateUser));
+                .path(organization)
+                .path("users")
+                .path(userId)
+                .request()
+                .put(Entity.json(updateUser));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         final User user = readEntity(response, User.class);

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
@@ -34,11 +34,11 @@ import java.util.stream.Collectors;
  */
 public class User implements IUser {
 
-    protected static final Set<String> SENSITIVE_ADDITIONAL_PROPERTIES = Set.of(
+    public static final Set<String> SENSITIVE_ADDITIONAL_PROPERTIES = Set.of(
             ConstantKeys.OIDC_PROVIDER_ID_TOKEN_KEY,
             ConstantKeys.OIDC_PROVIDER_ID_ACCESS_TOKEN_KEY
     );
-    protected static final String SENSITIVE_PROPERTY_PLACEHOLDER = "●●●●●●●●";
+    public static final String SENSITIVE_PROPERTY_PLACEHOLDER = "●●●●●●●●";
     private String id;
 
     private String externalId;
@@ -705,7 +705,11 @@ public class User implements IUser {
     }
 
     public void setAdditionalInformation(Map<String, Object> additionalInformation) {
-        var newAdditionalInformation = additionalInformation
+        if (additionalInformation == null) {
+            this.additionalInformation = null;
+            return;
+        }
+        this.additionalInformation = additionalInformation
                 .entrySet()
                 .stream()
                 .map(e -> {
@@ -720,7 +724,7 @@ public class User implements IUser {
                 })
                 // Collectors.toMap() doesn't work if there's any null values, and we don't have a guarantee there aren't any
                 .collect(HashMap<String, Object>::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll);
-        this.additionalInformation = newAdditionalInformation;
+        ;
     }
 
     public Date getLastPasswordReset() {

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/User.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.model;
 
 import io.gravitee.am.common.oidc.StandardClaims;
+import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.model.factor.EnrolledFactor;
 import io.gravitee.am.model.scim.Address;
 import io.gravitee.am.model.scim.Attribute;
@@ -33,6 +34,11 @@ import java.util.stream.Collectors;
  */
 public class User implements IUser {
 
+    protected static final Set<String> SENSITIVE_ADDITIONAL_PROPERTIES = Set.of(
+            ConstantKeys.OIDC_PROVIDER_ID_TOKEN_KEY,
+            ConstantKeys.OIDC_PROVIDER_ID_ACCESS_TOKEN_KEY
+    );
+    protected static final String SENSITIVE_PROPERTY_PLACEHOLDER = "●●●●●●●●";
     private String id;
 
     private String externalId;
@@ -699,7 +705,22 @@ public class User implements IUser {
     }
 
     public void setAdditionalInformation(Map<String, Object> additionalInformation) {
-        this.additionalInformation = additionalInformation;
+        var newAdditionalInformation = additionalInformation
+                .entrySet()
+                .stream()
+                .map(e -> {
+                    var isHiddenSensitiveValue = SENSITIVE_ADDITIONAL_PROPERTIES.contains(e.getKey()) && SENSITIVE_PROPERTY_PLACEHOLDER.equals(e.getValue());
+                    var propertyExistedBefore = this.additionalInformation != null && this.additionalInformation.containsKey(e.getKey());
+                    if (isHiddenSensitiveValue && propertyExistedBefore) {
+                        // the value existed before and is not being updated right now - keep old value
+                        return Map.entry(e.getKey(), this.additionalInformation.get(e.getKey()));
+                    } else {
+                        return e;
+                    }
+                })
+                // Collectors.toMap() doesn't work if there's any null values, and we don't have a guarantee there aren't any
+                .collect(HashMap<String, Object>::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll);
+        this.additionalInformation = newAdditionalInformation;
     }
 
     public Date getLastPasswordReset() {

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/UserTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/UserTest.java
@@ -16,6 +16,7 @@
 
 package io.gravitee.am.model;
 
+import io.gravitee.am.common.utils.ConstantKeys;
 import org.junit.Test;
 
 import java.util.List;
@@ -64,6 +65,7 @@ public class UserTest {
 
         assertThat(user.getLastIdentityInformation()).containsExactlyEntriesOf(additionalInfo);
     }
+
     @Test
     public void should_LastIdentity_AdditionalInfo_Return_IdentityAdditionInfo() {
         var user = new User();
@@ -119,6 +121,28 @@ public class UserTest {
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("additionalInformation", identityInfo2)
                 .hasFieldOrPropertyWithValue("providerId", identity2.getProviderId());
+    }
+
+    @Test
+    public void shouldNotUpdateSensitivePropertyToPlaceholder() {
+        var user = new User();
+        final String theSensitiveProperty = ConstantKeys.OIDC_PROVIDER_ID_TOKEN_KEY;
+        user.putAdditionalInformation(theSensitiveProperty, "sensitive value");
+
+        user.setAdditionalInformation(Map.of(theSensitiveProperty, User.SENSITIVE_PROPERTY_PLACEHOLDER));
+
+        assertThat(user.getAdditionalInformation().get(theSensitiveProperty)).isEqualTo("sensitive value");
+    }
+
+    @Test
+    public void shouldUpdateSensitiveProperty() {
+        var user = new User();
+        final String theSensitiveProperty = ConstantKeys.OIDC_PROVIDER_ID_TOKEN_KEY;
+        user.putAdditionalInformation(theSensitiveProperty, "original value");
+
+        user.setAdditionalInformation(Map.of(theSensitiveProperty, "updated value"));
+
+        assertThat(user.getAdditionalInformation().get(theSensitiveProperty)).isEqualTo("updated value");
     }
 
 }


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3453

## :pencil2: A description of the changes proposed in the pull request
This PR hides "sensitive" user properties from being viewed.
These properties will still be readable in policies, EL, etc, but the REST API and consequently the UI will see a placeholder (`●●●●●●●●`) instead of the real value.
The sensitive properties can still be deleted/updated normally.

Currently the only properties marked sensitive are the properties used for storing original tokens from OIDC providers:
`op_access_token` and `op_id_token`.
