### PR TITLE
fix: audits present twice during user creation

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/service/impl/AuthenticationServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/service/impl/AuthenticationServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.authentication.service.impl;
 
+import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.oidc.CustomClaims;
 import io.gravitee.am.common.oidc.StandardClaims;
@@ -34,6 +35,7 @@ import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.exception.UserNotFoundException;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.AuthenticationAuditBuilder;
+import io.gravitee.am.service.reporter.builder.management.UserAuditBuilder;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -121,6 +123,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                             newUser.setLoginsCount(1L);
                             newUser.setAdditionalInformation(principal.getAdditionalInformation());
                             return userService.create(newUser)
+                                    .doOnSuccess(user1 -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).type(EventType.USER_CREATED).user(user1)))
+                                    .doOnError(err -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).type(EventType.USER_CREATED).throwable(err)))
                                     .flatMap(user -> userService.setRoles(principal, user).andThen(Single.just(user)));
                         }
                         return Single.error(ex);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
@@ -102,7 +102,9 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
                         return Single.error(() -> new UserInvalidException("Field [username] is required"));
                     }
                     User user = transform(newUser, referenceType, referenceId);
-                    return userService.create(user);
+                    return userService.create(user)
+                            .doOnSuccess(user1 -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).type(EventType.USER_CREATED).user(user1)))
+                            .doOnError(err -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class).type(EventType.USER_CREATED).throwable(err)));
                 }));
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DefaultOrganizationUpgraderTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DefaultOrganizationUpgraderTest.java
@@ -26,6 +26,7 @@ import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.permissions.DefaultRole;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.OrganizationService;
 import io.gravitee.am.service.OrganizationUserService;
@@ -90,12 +91,15 @@ public class DefaultOrganizationUpgraderTest {
     @Mock
     private Environment environment;
 
+    @Mock
+    private AuditService auditService;
+
     private DefaultOrganizationUpgrader cut;
 
     @BeforeEach
     public void before() {
         when(environment.getProperty("security.defaultAdmin", boolean.class, true)).thenReturn(true);
-        cut = new DefaultOrganizationUpgrader(organizationService, identityProviderService, userService, membershipHelper, roleService, domainService, environment, null);
+        cut = new DefaultOrganizationUpgrader(organizationService, identityProviderService, userService, membershipHelper, roleService, domainService, environment, null, auditService);
     }
 
     @Test


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-3386


## :pencil2: A description of the changes proposed in the pull request


## :memo: Test scenarios 


## :computer: Add screenshots for UI
Create organization user 
![Screenshot from 2024-08-02 08-59-09](https://github.com/user-attachments/assets/493c14d8-4359-4bb9-99c1-85d50a8b03f8)

Create app user
![Screenshot from 2024-08-02 09-00-04](https://github.com/user-attachments/assets/98aa6bb8-dacc-4a31-90f7-8a081fdfff48)



## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
