### PR TITLE
fix: provide UUID generated based on the internal sub for Domain in v2

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/subject/SubjectManagerV2.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/subject/SubjectManagerV2.java
@@ -29,9 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
+import java.util.UUID;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -41,7 +39,6 @@ import java.util.HexFormat;
 @AllArgsConstructor
 public class SubjectManagerV2 implements SubjectManager {
 
-    private static final String SUB_PREFIX = "h_";
     private static final String SEPARATOR = ":";
 
     private UserService userService;
@@ -50,14 +47,7 @@ public class SubjectManagerV2 implements SubjectManager {
 
     @Override
     public String generateSubFrom(User user) {
-        final var gisub = generateInternalSubFrom(user);
-        try {
-            var rawhash = MessageDigest.getInstance("SHA-256").digest(gisub.getBytes(StandardCharsets.UTF_8));
-            return SUB_PREFIX + HexFormat.of().formatHex(rawhash);
-        } catch (NoSuchAlgorithmException e) {
-            log.warn("Error while generating subject from user", e);
-            return gisub;
-        }
+        return UUID.nameUUIDFromBytes(generateInternalSubFrom(user).getBytes(StandardCharsets.UTF_8)).toString();
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/subject/SubjectManagerV2Test.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/subject/SubjectManagerV2Test.java
@@ -69,7 +69,7 @@ public class SubjectManagerV2Test {
         user.setSource(UUID.randomUUID().toString());
 
         Assertions.assertEquals(user.getSource() + ":" + user.getExternalId(), cut.generateInternalSubFrom(user));
-        Assertions.assertTrue(cut.generateSubFrom(user).startsWith("h_"));
+        Assertions.assertEquals(3, UUID.fromString(cut.generateSubFrom(user)).version());
     }
 
     @Test


### PR DESCRIPTION
the reason is some user expect such format to not exceed a 32 characters value

fixes AM-3662
