### PR TITLE
change cache key to bypass malformed node archive

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1157,7 +1157,7 @@ jobs:
     steps:
       - checkout
       - restore-maven-job-cache:
-          jobName: releaseV2
+          jobName: release
       - attach_workspace:
           at: /tmp
       - prepare-gpg
@@ -1210,7 +1210,7 @@ jobs:
                 command: |
                   mvn -s /tmp/.gravitee.settings.xml -B -U -P gio-artifactory-release,gio-release clean install
       - save-maven-job-cache:
-          jobName: releaseV2
+          jobName: release
 
       # ---
       # Package Bundle Must succeed, before nexus staging is done : Package bundle is idempotnent and non immutable, whereas NExus staging and Git release are immutable
@@ -1358,7 +1358,7 @@ jobs:
     steps:
       - checkout
       - restore-maven-job-cache:
-          jobName: releaseV2
+          jobName: release
       - attach_workspace:
           at: /tmp
       - prepare-gpg


### PR DESCRIPTION
```
Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.6:install-node-and-npm (install node 
and npm) on project gravitee-am-webui: Could not extract the Node archive: Could not extract archive: 
'/home/circleci/.m2/repository/com/github/eirslett/node/18.13.0/node-18.13.0-linux-x64.tar.gz'
```

This PR fchanges the cache key to force a fresh donwload of the broken archive