### PR TITLE
fix: provide role and permission in user profile

### DIFF
--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/RoleProperties.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/RoleProperties.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.model.safe;
+
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Role;
+import io.gravitee.am.model.permissions.Permission;
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.springframework.util.CollectionUtils.isEmpty;
+
+@Data
+public class RoleProperties {
+    private final String id;
+    private final String name;
+    private final String description;
+    private final Map<Permission, Set<Acl>> permissionAcls;
+    private final List<String> oauthScopes;
+    private final boolean system;
+    private final boolean defaultRole;
+
+    public static RoleProperties from(Role role) {
+        if (role == null) {
+            return null;
+        }
+        final Map<Permission, Set<Acl>> permissions = isEmpty(role.getPermissionAcls()) ? Map.of() : new HashMap<>(role.getPermissionAcls());
+        final List<String> scopes = isEmpty(role.getOauthScopes()) ? List.of() : List.copyOf(role.getOauthScopes());
+        return new RoleProperties(role.getId(), role.getName(), role.getDescription(), permissions, scopes, role.isSystem(), role.isDefaultRole());
+    }
+
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/UserProperties.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/UserProperties.java
@@ -24,6 +24,8 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.UserIdentity;
 import io.gravitee.am.model.scim.Address;
 import io.gravitee.am.model.scim.Attribute;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.*;
 import java.util.function.Function;
@@ -36,6 +38,8 @@ import static java.util.stream.Collectors.toList;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class UserProperties {
 
     private String id;
@@ -49,6 +53,7 @@ public class UserProperties {
     private String source;
     private String preferredLanguage;
     private Set<String> roles;
+    private Set<RoleProperties> rolesPermissions;
     private List<String> groups;
     private Map<String, Object> claims;
     private Map<String, Object> additionalInformation;
@@ -112,6 +117,10 @@ public class UserProperties {
                     removeSensitiveClaims(filteredIdentity.getAdditionalInformation());
                     return filteredIdentity;
                 }).collect(toList())).orElse(List.of());
+
+        this.rolesPermissions = ofNullable(user.getRolesPermissions())
+                .map(roles -> roles.stream().map(RoleProperties::from).collect(Collectors.toSet()))
+                .orElse(Set.of());
     }
 
     private void removeSensitiveClaims(Map claimsToClean) {
@@ -120,183 +129,7 @@ public class UserProperties {
         claimsToClean.remove(ConstantKeys.OIDC_PROVIDER_ID_ACCESS_TOKEN_KEY);
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getExternalId() {
-        return externalId;
-    }
-
-    public void setExternalId(String externalId) {
-        this.externalId = externalId;
-    }
-
-    public String getDomain() {
-        return domain;
-    }
-
-    public void setDomain(String domain) {
-        this.domain = domain;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getFirstName() {
-        return firstName;
-    }
-
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPhoneNumber() {
-        return phoneNumber;
-    }
-
-    public void setPhoneNumber(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
-
-    public Set<String> getRoles() {
-        return roles;
-    }
-
-    public void setRoles(Set<String> roles) {
-        this.roles = roles;
-    }
-
-    public List<String> getGroups() {
-        return groups;
-    }
-
-    public void setGroups(List<String> groups) {
-        this.groups = groups;
-    }
-
-    public Map<String, Object> getClaims() {
-        return claims;
-    }
-
-    public void setClaims(Map<String, Object> claims) {
-        this.claims = claims;
-    }
-
-    public String getSource() {
-        return source;
-    }
-
-    public void setSource(String source) {
-        this.source = source;
-    }
-
-    public String getPreferredLanguage() {
-        return preferredLanguage;
-    }
-
-    public void setPreferredLanguage(String preferredLanguage) {
-        this.preferredLanguage = preferredLanguage;
-    }
-
-    public Map<String, Object> getAdditionalInformation() {
-        return additionalInformation;
-    }
-
-    public void setAdditionalInformation(Map<String, Object> additionalInformation) {
-        this.additionalInformation = additionalInformation;
-    }
-
-    public List<Attribute> getEmails() {
-        return emails;
-    }
-
-    public void setEmails(List<Attribute> emails) {
-        this.emails = emails;
-    }
-
-    public List<Attribute> getPhoneNumbers() {
-        return phoneNumbers;
-    }
-
-    public void setPhoneNumbers(List<Attribute> phoneNumbers) {
-        this.phoneNumbers = phoneNumbers;
-    }
-
-    public List<Attribute> getIms() {
-        return ims;
-    }
-
-    public void setIms(List<Attribute> ims) {
-        this.ims = ims;
-    }
-
-    public List<Attribute> getPhotos() {
-        return photos;
-    }
-
-    public void setPhotos(List<Attribute> photos) {
-        this.photos = photos;
-    }
-
-    public List<String> getEntitlements() {
-        return entitlements;
-    }
-
-    public void setEntitlements(List<String> entitlements) {
-        this.entitlements = entitlements;
-    }
-
-    public List<Address> getAddresses() {
-        return addresses;
-    }
-
-    public void setAddresses(List<Address> addresses) {
-        this.addresses = addresses;
-    }
-
-    public List<UserIdentity> getIdentities() {
-        return identities;
-    }
-
-    public void setIdentities(List<UserIdentity> identities) {
-        this.identities = identities;
-    }
-
-    public String getLastIdentityUsed() {
-        return lastIdentityUsed;
-    }
-
-    public void setLastIdentityUsed(String lastIdentityUsed) {
-        this.lastIdentityUsed = lastIdentityUsed;
-    }
-
-
+    // do not remove this "unused" method, it has been developed to easy EL expressions
     public Map<String, Object> getLastIdentityInformation() {
         if (this.lastIdentityUsed != null && this.identities != null) {
             return this.identities.stream()
@@ -308,9 +141,18 @@ public class UserProperties {
         return getAdditionalInformation();
     }
 
+    // do not remove this "unused" method, it has been developed to easy EL expressions
     public Map<String, Object> getIdentitiesAsMap() {
         if (this.identities != null) {
             return this.identities.stream().collect(Collectors.toMap(UserIdentity::getProviderId, Function.identity()));
+        }
+        return Map.of();
+    }
+
+    // do not remove this "unused" method, it has been developed to easy EL expressions
+    public Map<String, List<String>> getScopesByRole() {
+        if (this.rolesPermissions != null) {
+            return this.rolesPermissions.stream().collect(Collectors.toMap(RoleProperties::getName, RoleProperties::getOauthScopes));
         }
         return Map.of();
     }

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/safe/RolePropertiesTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/safe/RolePropertiesTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.model.safe;
+
+
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.Role;
+import io.gravitee.am.model.permissions.Permission;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RolePropertiesTest {
+    @Test
+    public void should_return_null() {
+        Assertions.assertThat(RoleProperties.from(null)).isNull();
+    }
+
+    @Test
+    public void should_contains_data() {
+        final var role = new Role();
+        role.setId(UUID.randomUUID().toString());
+        role.setName(UUID.randomUUID().toString());
+        role.setDescription(UUID.randomUUID().toString());
+        role.setDefaultRole(true);
+        role.setSystem(false);
+        role.setAssignableType(ReferenceType.DOMAIN);
+        role.setOauthScopes(List.of(UUID.randomUUID().toString()));
+        role.setPermissionAcls(Map.of(Permission.APPLICATION, Set.of(Acl.READ)));
+
+        final var roleProperties = RoleProperties.from(role);
+        Assertions.assertThat(role)
+                .hasFieldOrPropertyWithValue("id", roleProperties.getId())
+                .hasFieldOrPropertyWithValue("name", roleProperties.getName())
+                .hasFieldOrPropertyWithValue("description", roleProperties.getDescription())
+                .hasFieldOrPropertyWithValue("defaultRole", roleProperties.isDefaultRole())
+                .hasFieldOrPropertyWithValue("system", roleProperties.isSystem());
+        Assertions.assertThat(roleProperties.getOauthScopes()).isEqualTo(role.getOauthScopes());
+        Assertions.assertThat(roleProperties.getPermissionAcls()).isEqualTo(role.getPermissionAcls());
+    }
+
+    @Test
+    public void should_accept_null_scopes_and_acls() {
+        final var role = new Role();
+        role.setId(UUID.randomUUID().toString());
+        role.setName(UUID.randomUUID().toString());
+        role.setDescription(UUID.randomUUID().toString());
+        role.setDefaultRole(true);
+        role.setSystem(false);
+        role.setAssignableType(ReferenceType.DOMAIN);
+        role.setOauthScopes(null);
+        role.setPermissionAcls(null);
+
+        final var roleProperties = RoleProperties.from(role);
+        Assertions.assertThat(role)
+                .hasFieldOrPropertyWithValue("id", roleProperties.getId())
+                .hasFieldOrPropertyWithValue("name", roleProperties.getName())
+                .hasFieldOrPropertyWithValue("description", roleProperties.getDescription())
+                .hasFieldOrPropertyWithValue("defaultRole", roleProperties.isDefaultRole())
+                .hasFieldOrPropertyWithValue("system", roleProperties.isSystem());
+        Assertions.assertThat(roleProperties.getOauthScopes()).isEqualTo(List.of());
+        Assertions.assertThat(roleProperties.getPermissionAcls()).isEqualTo(Map.of());
+    }
+}


### PR DESCRIPTION
fixes AM-3661

gravitee-io/issues#9918

# how to use it

![image](https://github.com/user-attachments/assets/6ab4bfaf-c99d-4e8d-8bbf-50d29d25d020)


the custom claims defined in the screenshot will produce this output

```
{
...
  "rolesPermissions": [
    {
      "id": "0b74d6f7-9d5b-488b-b4d6-f79d5b988b35",
      "name": "test",
      "description": "test desdc",
      "permissionAcls": {},
      "oauthScopes": [
        "address",
        "dcr",
        "scim"
      ]
    }
  ],
  "permissions": {
    "test": [
      "address",
      "dcr",
      "scim"
    ]
  },
...
}

```