### PR TITLE
fix: restore the default contructor for WebClientBuilder as it is used by EE plugins

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/http/WebClientBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/http/WebClientBuilder.java
@@ -22,6 +22,7 @@ import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.ext.web.client.WebClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
@@ -98,11 +99,15 @@ public class WebClientBuilder {
     @Value("${httpClient.ssl.keystore.type:#{null}}")
     private String sslKeyStoreType;
 
-    private final Environment environment;
+    @Autowired
+    private Environment environment;
+
+    public WebClientBuilder() {}
 
     public WebClientBuilder(Environment environment) {
         this.environment = environment;
     }
+
     public WebClient createWebClient(Vertx vertx, URL url) {
 
         final int port = url.getPort() != -1 ? url.getPort() : (HTTPS_SCHEME.equals(url.getProtocol()) ? 443 : 80);


### PR DESCRIPTION
fixes AM-3873

fixes AM-3845

fixes AM-3790

fixes AM-3897

gravitee-io/issues#10000

gravitee-io/issues#9997

gravitee-io/issues#9988

gravitee-io/issues#10006