### PR TITLE
fix: provide enrolled factor in the MFA challenge template

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -91,6 +91,8 @@ public interface ConstantKeys {
     String MFA_FACTOR_ID_CONTEXT_KEY = "mfaFactorId";
     String MFA_ENROLLING_FIDO2_FACTOR = "enrollingFido2Factor";
 
+    String ENROLLED_FACTOR_KEY = "enrolledFactor";
+
     String MFA_ALTERNATIVES_ACTION_KEY = "mfaAlternativesAction";
 
     String MFA_ALTERNATIVES_ENABLE_KEY = "mfaAlternativesEnabled";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
@@ -43,6 +43,7 @@ import io.gravitee.am.model.factor.EnrolledFactorChannel.Type;
 import io.gravitee.am.model.factor.EnrolledFactorSecurity;
 import io.gravitee.am.model.factor.FactorStatus;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.model.safe.EnrolledFactorProperties;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.CredentialService;
 import io.gravitee.am.service.DeviceService;
@@ -71,6 +72,8 @@ import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 import io.vertx.rxjava3.ext.web.common.template.TemplateEngine;
+
+import static io.gravitee.am.common.utils.ConstantKeys.ENROLLED_FACTOR_KEY;
 import static java.lang.Boolean.TRUE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -236,8 +239,12 @@ public class MFAChallengeEndpoint extends MFAEndpoint {
                     routingContext.fail(resChallenge.cause());
                     return;
                 }
-                // render the mfa challenge page
-                this.renderPage(routingContext, generateData(routingContext, domain, client), client, logger, "Unable to render MFA challenge page");
+
+                Map<String, Object> templateData = generateData(routingContext, domain, client);
+                if (resChallenge.result() != null) {
+                    templateData.put(ENROLLED_FACTOR_KEY, new EnrolledFactorProperties(resChallenge.result()));
+                }
+                this.renderPage(routingContext, templateData, client, logger, "Unable to render MFA challenge page");
             });
         } catch (Exception ex) {
             logger.error("An error has occurred when rendering MFA challenge page", ex);
@@ -456,23 +463,23 @@ public class MFAChallengeEndpoint extends MFAEndpoint {
                 );
     }
 
-    private void sendChallenge(FactorProvider factorProvider, RoutingContext routingContext, Factor factor, User endUser, Handler<AsyncResult<Void>> handler) {
-        if (!factorProvider.needChallengeSending() || routingContext.get(ConstantKeys.ERROR_PARAM_KEY) != null
-                || routingContext.get(RATE_LIMIT_ERROR_PARAM_KEY) != null || routingContext.get(VERIFY_ATTEMPT_ERROR_PARAM_KEY) != null) {
-            // do not send challenge in case of error param to avoid useless code generation
-            handler.handle(Future.succeededFuture());
-            return;
-        }
-
+    private void sendChallenge(FactorProvider factorProvider, RoutingContext routingContext, Factor factor, User endUser, Handler<AsyncResult<EnrolledFactor>> handler) {
         // create factor context
         final Client client = routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY);
         final FactorContext factorContext = new FactorContext(applicationContext, new HashMap<>());
-        final EnrolledFactor enrolledFactor = getEnrolledFactor(routingContext, factorProvider, factor, endUser, factorContext);
         factorContext.getData().putAll(getEvaluableAttributes(routingContext));
         factorContext.registerData(FactorContext.KEY_CLIENT, client);
         factorContext.registerData(KEY_USER, endUser);
         factorContext.registerData(FactorContext.KEY_REQUEST, new EvaluableRequest(new VertxHttpServerRequest(routingContext.request().getDelegate())));
+        final EnrolledFactor enrolledFactor = getEnrolledFactor(routingContext, factorProvider, factor, endUser, factorContext);
         factorContext.registerData(FactorContext.KEY_ENROLLED_FACTOR, enrolledFactor);
+
+        if (!factorProvider.needChallengeSending() || routingContext.get(ConstantKeys.ERROR_PARAM_KEY) != null
+                || routingContext.get(RATE_LIMIT_ERROR_PARAM_KEY) != null || routingContext.get(VERIFY_ATTEMPT_ERROR_PARAM_KEY) != null) {
+            // do not send challenge in case of error param to avoid useless code generation
+            handler.handle(Future.succeededFuture(enrolledFactor));
+            return;
+        }
 
         if (rateLimiterService.isRateLimitEnabled()) {
             rateLimiterService.tryConsume(endUser.getId(), factor.getId(), endUser.getClient(), client.getDomain())
@@ -491,14 +498,14 @@ public class MFAChallengeEndpoint extends MFAEndpoint {
         }
     }
 
-    private void sendChallenge(RoutingContext routingContext, FactorProvider factorProvider, FactorContext factorContext, User endUser, Client client, Factor factor, Handler<AsyncResult<Void>> handler) {
+    private void sendChallenge(RoutingContext routingContext, FactorProvider factorProvider, FactorContext factorContext, User endUser, Client client, Factor factor, Handler<AsyncResult<EnrolledFactor>> handler) {
         factorProvider.sendChallenge(factorContext)
                 .doOnComplete(() -> logger.debug("Challenge sent to user {}", factorContext.getUser().getId()))
                 .subscribeOn(Schedulers.io())
                 .subscribe(
                         () -> {
                             updateAuditLog(routingContext, MFA_CHALLENGE_SENT, endUser, client, factor, factorContext, null);
-                            handler.handle(Future.succeededFuture());
+                            handler.handle(Future.succeededFuture((EnrolledFactor)factorContext.getData().get(FactorContext.KEY_ENROLLED_FACTOR)));
                         },
                         error -> {
                             updateAuditLog(routingContext, MFA_CHALLENGE_SENT, endUser, client, factor, factorContext, error);

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/factor/EnrolledFactor.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/factor/EnrolledFactor.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model.factor;
 
+import io.gravitee.am.model.safe.EnrolledFactorProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Date;
@@ -124,4 +125,5 @@ public class EnrolledFactor {
     public void setUpdatedAt(Date updatedAt) {
         this.updatedAt = updatedAt;
     }
+
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/EnrolledFactorChannelProperties.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/EnrolledFactorChannelProperties.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.model.safe;
+
+
+import io.gravitee.am.model.factor.EnrolledFactorChannel;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class EnrolledFactorChannelProperties {
+    private EnrolledFactorChannel.Type type;
+    private String target;
+
+    public EnrolledFactorChannelProperties(EnrolledFactorChannel channel) {
+        this.type = channel.getType();
+        this.target = channel.getTarget();
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/EnrolledFactorProperties.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/EnrolledFactorProperties.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.model.safe;
+
+
+import io.gravitee.am.model.factor.EnrolledFactor;
+import io.gravitee.am.model.factor.FactorStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Optional;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class EnrolledFactorProperties {
+    private String factorId;
+
+    private String appId;
+
+    private FactorStatus status = FactorStatus.NULL;
+
+    private EnrolledFactorChannelProperties channel;
+
+    private Boolean primary;
+
+    public EnrolledFactorProperties(EnrolledFactor factor) {
+        this.factorId = factor.getFactorId();
+        this.appId = factor.getAppId();
+        this.status = factor.getStatus();
+        this.primary = factor.isPrimary();
+        this.channel = Optional.ofNullable(factor.getChannel()).map(EnrolledFactorChannelProperties::new).orElse(null);
+    }
+
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/UserProperties.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/UserProperties.java
@@ -65,6 +65,7 @@ public class UserProperties {
     private List<Address> addresses;
     private List<UserIdentity> identities;
     private String lastIdentityUsed;
+    private List<EnrolledFactorProperties> factors;
 
     public UserProperties() {
     }
@@ -121,6 +122,10 @@ public class UserProperties {
         this.rolesPermissions = ofNullable(user.getRolesPermissions())
                 .map(roles -> roles.stream().map(RoleProperties::from).collect(Collectors.toSet()))
                 .orElse(Set.of());
+
+        this.factors = ofNullable(user.getFactors())
+                .map(factors -> factors.stream().map(EnrolledFactorProperties::new).collect(Collectors.toList()))
+                .orElse(List.of());
     }
 
     private void removeSensitiveClaims(Map claimsToClean) {


### PR DESCRIPTION
  we also provide the list of enrolled factor in the user profile

fixes AM-3791

gravitee-io/issues#9990

# Example of Form template

```
          <span th:text="${enrolledFactor.factorId}"></span><br /> // ID of the factor 
          <span th:text="${enrolledFactor.status}"></span><br /> // Status of the enrollment (PENDING_ACTIVATION or ACTIVE)
          <span th:text="${enrolledFactor.channel.type}"></span><br /> // SMS, EMAIL...
	  <span th:text="${enrolledFactor.channel.target}"></span><br /> // phoneNumber, email...
```

The list of factor linked enrolled by the user is also available using the factors list

`user.factors[0].channel.target`