### PR TITLE
fix: provide null as default value for email.from placeholder

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailManagerImpl.java
@@ -69,7 +69,7 @@ public class EmailManagerImpl extends AbstractService implements EmailManager, I
     @Value("${email.subject:[Gravitee.io] %s}")
     private String subject;
 
-    @Value("${email.from}")
+    @Value("${email.from:#{null}}")
     private String defaultFrom;
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/EmailManagerImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/EmailManagerImpl.java
@@ -54,7 +54,7 @@ public class EmailManagerImpl extends AbstractService<EmailManager> implements E
     private static final String TEMPLATE_SUFFIX = ".html";
     private ConcurrentMap<String, Email> emailTemplates = new ConcurrentHashMap<>();
 
-    @Value("${email.from}")
+    @Value("${email.from:#{null}}")
     private String defaultFrom;
 
     @Value("${email.subject:[Gravitee.io] %s}")


### PR DESCRIPTION
 to avoid initialization error if the value is not defined which prevent the domain to load on the GW

fixes AM-3723

gravitee-io/issues#9951
