### PR TITLE
fix: introduce option to not force redirectUris during app creation

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -82,6 +82,7 @@ import io.reactivex.rxjava3.core.Single;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -155,6 +156,9 @@ public class ApplicationServiceImpl implements ApplicationService {
 
     @Autowired
     private CertificateService certificateService;
+
+    @Value("${legacy.openid.application.redirectUrisOptional:false}")
+    private boolean redirectUrisOptional;
 
     @Override
     public Single<Page<Application>> findAll(int page, int size) {
@@ -770,7 +774,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                                 return Single.error(new InvalidRedirectUriException("redirect_uri : " + redirectUri + " is malformed"));
                             }
                         }
-                    } else if (application.getType() != ApplicationType.SERVICE && !updateTypeOnly) {
+                    } else if (application.getType() != ApplicationType.SERVICE && !updateTypeOnly && !redirectUrisOptional) {
                         return Single.error(new InvalidRedirectUriException("At least one redirect_uri is required"));
                     }
                     return Single.just(application);

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ApplicationServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ApplicationServiceTest.java
@@ -41,6 +41,7 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -48,7 +49,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.ReflectionUtils;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
@@ -114,6 +118,11 @@ public class ApplicationServiceTest {
     private TokenService tokenService;
 
     private final static String DOMAIN = "domain1";
+
+    @Before
+    public void init() {
+        ReflectionTestUtils.setField(applicationService, "redirectUrisOptional", false);
+    }
 
     @Test
     public void shouldFindById() {
@@ -428,6 +437,32 @@ public class ApplicationServiceTest {
         verify(applicationRepository, times(1)).findByDomainAndClientId(DOMAIN, null);
         verify(applicationRepository, never()).create(any(Application.class));
         verify(membershipService, never()).addOrUpdate(eq(ORGANIZATION_ID), any());
+    }
+
+    @Test
+    public void shouldCreate_AppWithoutRedirectUri_legacyOptionActivate() {
+        NewApplication newClient = prepareCreateApp(false);
+        ReflectionTestUtils.setField(applicationService, "redirectUrisOptional", true);
+        DefaultUser user = new DefaultUser("username");
+        user.setAdditionalInformation(Collections.singletonMap(Claims.organization, ORGANIZATION_ID));
+
+        final Certificate defaultCert = new Certificate();
+        defaultCert.setId("default");
+        defaultCert.setSystem(true);
+        defaultCert.setName("Default");
+        defaultCert.setCreatedAt(new Date());
+
+        when(certificateService.findByDomain(DOMAIN)).thenReturn(Flowable.just(defaultCert));
+
+        TestObserver<Application> testObserver = applicationService.create(DOMAIN, newClient, user).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(applicationRepository, times(1)).findByDomainAndClientId(DOMAIN, null);
+        verify(applicationRepository, times(1)).create(any(Application.class));
+        verify(membershipService).addOrUpdate(eq(ORGANIZATION_ID), any());
     }
 
     @Test


### PR DESCRIPTION
fixes AM-3961

gravitee-io/issues#10024

# description

This PR allowes to ignore a change introduced by gravitee-io/issues#9987 in order to not block users which are creating app witout redirectUris. This fix will be applied on 4.1.x up to 4.4.x but in 4.5.0, the application creation will require redirectUris without options to bypass it.