### PR TITLE
fix: load rememberDevice JS during resetPassword and registration

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -555,7 +555,7 @@ public class RootProvider extends AbstractProtocolProvider {
                 .handler(new LoginSocialAuthenticationHandler(identityProviderManager, jwtService, certificateManager))
                 .handler(policyChainHandler.create(ExtensionPoint.PRE_REGISTER))
                 .handler(localeHandler)
-                .handler(new RegisterEndpoint(thymeleafTemplateEngine, domain, botDetectionManager));
+                .handler(new RegisterEndpoint(thymeleafTemplateEngine, domain, botDetectionManager, deviceIdentifierManager));
         rootRouter.route(HttpMethod.POST, PATH_REGISTER)
                 .handler(new RegisterSubmissionRequestParseHandler())
                 .handler(clientRequestParseHandlerOptional)
@@ -563,6 +563,7 @@ public class RootProvider extends AbstractProtocolProvider {
                 .handler(registerAccessHandler)
                 .handler(passwordPolicyRequestParseHandler)
                 .handler(new RegisterProcessHandler(userService, domain))
+                .handler(deviceIdentifierHandler)
                 .handler(policyChainHandler.create(ExtensionPoint.POST_REGISTER))
                 .handler(new RegisterSubmissionEndpoint(environment));
         rootRouter.route(PATH_REGISTER)
@@ -573,11 +574,12 @@ public class RootProvider extends AbstractProtocolProvider {
                 .handler(clientRequestParseHandlerOptional)
                 .handler(policyChainHandler.create(ExtensionPoint.PRE_REGISTRATION_CONFIRMATION))
                 .handler(localeHandler)
-                .handler(new RegisterConfirmationEndpoint(thymeleafTemplateEngine, domain));
+                .handler(new RegisterConfirmationEndpoint(thymeleafTemplateEngine, domain, deviceIdentifierManager));
         rootRouter.route(HttpMethod.POST, PATH_CONFIRM_REGISTRATION)
                 .handler(new RegisterConfirmationSubmissionRequestParseHandler())
                 .handler(userTokenRequestParseHandler)
                 .handler(passwordPolicyRequestParseHandler)
+                .handler(deviceIdentifierHandler)
                 .handler(policyChainHandler.create(ExtensionPoint.POST_REGISTRATION_CONFIRMATION))
                 .handler(new RegisterConfirmationSubmissionEndpoint(userService, environment));
 
@@ -614,12 +616,13 @@ public class RootProvider extends AbstractProtocolProvider {
                 .handler(new ResetPasswordOneTimeTokenHandler())
                 .handler(localeHandler)
                 .handler(policyChainHandler.create(ExtensionPoint.PRE_RESET_PASSWORD))
-                .handler(new ResetPasswordEndpoint(thymeleafTemplateEngine, domain));
+                .handler(new ResetPasswordEndpoint(thymeleafTemplateEngine, domain, deviceIdentifierManager));
         rootRouter.route(HttpMethod.POST, PATH_RESET_PASSWORD)
                 .handler(new ResetPasswordSubmissionRequestParseHandler())
                 .handler(userTokenRequestParseHandler)
                 .handler(new ResetPasswordOneTimeTokenHandler())
                 .handler(passwordPolicyRequestParseHandler)
+                .handler(deviceIdentifierHandler)
                 .handler(policyChainHandler.create(ExtensionPoint.POST_RESET_PASSWORD))
                 .handler(new ResetPasswordSubmissionEndpoint(userService, environment));
         rootRouter.route(PATH_RESET_PASSWORD)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordEndpoint.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.user.password;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
+import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.PasswordSettings;
@@ -49,9 +50,12 @@ public class ResetPasswordEndpoint extends AbstractEndpoint implements Handler<R
 
     private final Domain domain;
 
-    public ResetPasswordEndpoint(TemplateEngine engine, Domain domain) {
+    private final DeviceIdentifierManager deviceIdentifierManager;
+
+    public ResetPasswordEndpoint(TemplateEngine engine, Domain domain, DeviceIdentifierManager deviceIdentifierManager) {
         super(engine);
         this.domain = domain;
+        this.deviceIdentifierManager = deviceIdentifierManager;
     }
 
     @Override
@@ -84,7 +88,9 @@ public class ResetPasswordEndpoint extends AbstractEndpoint implements Handler<R
         routingContext.put(PASSWORD_VALIDATION, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/passwordValidation", actionParams, true));
 
         // render the reset password page
-        this.renderPage(routingContext, generateData(routingContext, domain, client), client, logger, "Unable to render reset password page");
+        final var data = generateData(routingContext, domain, client);
+        data.putAll(deviceIdentifierManager.getTemplateVariables(client));
+        this.renderPage(routingContext, data, client, logger, "Unable to render reset password page");
     }
 
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterConfirmationEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterConfirmationEndpoint.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.user.register;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
+import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
 import io.gravitee.am.gateway.handler.manager.form.FormManager;
 import io.gravitee.am.gateway.handler.root.resources.handler.user.UserRequestHandler;
 import io.gravitee.am.model.Domain;
@@ -52,10 +53,12 @@ public class RegisterConfirmationEndpoint extends UserRequestHandler {
 
     private final ThymeleafTemplateEngine engine;
     private final Domain domain;
+    private final DeviceIdentifierManager deviceIdentifierManager;
 
-    public RegisterConfirmationEndpoint(ThymeleafTemplateEngine thymeleafTemplateEngine, Domain domain) {
+    public RegisterConfirmationEndpoint(ThymeleafTemplateEngine thymeleafTemplateEngine, Domain domain, DeviceIdentifierManager deviceIdentifierManager) {
         this.engine = thymeleafTemplateEngine;
         this.domain = domain;
+        this.deviceIdentifierManager = deviceIdentifierManager;
     }
 
     @Override
@@ -99,7 +102,9 @@ public class RegisterConfirmationEndpoint extends UserRequestHandler {
         routingContext.put(PASSWORD_VALIDATION, UriBuilderRequest.resolveProxyRequest(routingContext.request(), routingContext.get(CONTEXT_PATH) + "/passwordValidation", actionParams, true));
 
         // render the registration confirmation page
-        engine.render(generateData(routingContext, domain, client), getTemplateFileName(client))
+        final var data = generateData(routingContext, domain, client);
+        data.putAll(deviceIdentifierManager.getTemplateVariables(client));
+        engine.render(data, getTemplateFileName(client))
                 .subscribe(
                         buffer -> {
                             routingContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterEndpoint.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.user.register;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
+import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.PasswordSettings;
@@ -54,11 +55,13 @@ public class RegisterEndpoint extends AbstractEndpoint implements Handler<Routin
 
     private final Domain domain;
     private final BotDetectionManager botDetectionManager;
+    private final DeviceIdentifierManager deviceIdentifierManager;
 
-    public RegisterEndpoint(TemplateEngine engine, Domain domain, BotDetectionManager botDetectionManager) {
+    public RegisterEndpoint(TemplateEngine engine, Domain domain, BotDetectionManager botDetectionManager, DeviceIdentifierManager deviceIdentifierManager) {
         super(engine);
         this.domain = domain;
         this.botDetectionManager = botDetectionManager;
+        this.deviceIdentifierManager = deviceIdentifierManager;
     }
 
     @Override
@@ -99,7 +102,7 @@ public class RegisterEndpoint extends AbstractEndpoint implements Handler<Routin
 
         final Map<String, Object> data = generateData(routingContext, domain, client);
         data.putAll(botDetectionManager.getTemplateVariables(domain, client));
-
+        data.putAll(deviceIdentifierManager.getTemplateVariables(client));
         // render the registration confirmation page
         this.renderPage(routingContext, data, client, logger, TEMPLATE_ERROR_MESSAGE);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration.html
@@ -173,5 +173,37 @@
     const passwordSettings = /*[[${passwordSettings}]]*/ null;
 </script>
 <script th:if="${error == null && success == null}" th:src="@{assets/js/password-validation-v3.js}"></script>
+
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+        });
+    });
+</script>
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3(fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+            if (fp.components && fp.components.platform && fp.components.platform.value) {
+                $("#form").append('<input type="hidden" name="deviceType" value="' + fp.components.platform.value + '"/>');
+            }
+        });
+    });
+</script>
+
+
 </body>
 </html>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div class="section">
-        <form role="form" class="form" th:action="${action}" method="post">
+        <form role="form" id="form" class="form" th:action="${action}" method="post">
             <div class="form-field">
                 <input class="input-field" type="password" id="password" name="password" th:placeholder="#{registration_confirmation.password.placeholder}" required/>
                 <button type="button" class="icon-button icon-input-field toggle-password">
@@ -132,5 +132,36 @@
     const passwordValidation = /*[[${passwordValidation}]]*/ null;
     const passwordHistory = /*[[${passwordHistory}]]*/ null;
 </script>
+
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+        });
+    });
+</script>
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3(fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+            if (fp.components && fp.components.platform && fp.components.platform.value) {
+                $("#form").append('<input type="hidden" name="deviceType" value="' + fp.components.platform.value + '"/>');
+            }
+        });
+    });
+</script>
+
 </body>
 </html>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/reset_password.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/reset_password.html
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div class="section">
-        <form role="form" class="form" th:action="${action}" method="post">
+        <form id="form" role="form" class="form" th:action="${action}" method="post">
             <div class="form-field">
                 <input class="input-field" type="password" id="password" name="password" th:placeholder="#{reset_password.password.placeholder}" required/>
                 <button type="button" class="icon-button icon-input-field toggle-password">
@@ -127,5 +127,35 @@
     const passwordHistory = /*[[${passwordHistory}]]*/ null;
     const passwordValidation = /*[[${passwordValidation}]]*/ null;
 </script>
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+        });
+    });
+</script>
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3(fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+            if (fp.components && fp.components.platform && fp.components.platform.value) {
+                $("#form").append('<input type="hidden" name="deviceType" value="' + fp.components.platform.value + '"/>');
+            }
+        });
+    });
+</script>
+
 </body>
 </html>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/RegisterConfirmationEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/RegisterConfirmationEndpointTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.root.endpoints.user;
 
+import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.user.register.RegisterConfirmationEndpoint;
 import io.gravitee.am.gateway.handler.root.resources.handler.dummies.SpyRoutingContext;
 import io.gravitee.am.model.Domain;
@@ -37,6 +38,8 @@ import static org.mockito.Mockito.*;
  */
 public class RegisterConfirmationEndpointTest {
 
+    private final DeviceIdentifierManager deviceIdentifierManager = mock(DeviceIdentifierManager.class);
+
     @Test
     public void must_render_engine_with_encoded_client_id() {
         final Domain domain = new Domain();
@@ -45,7 +48,7 @@ public class RegisterConfirmationEndpointTest {
         final Buffer buffer = mock(Buffer.class);
         final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
         when(engine.render(anyMap(), anyString())).thenReturn(Single.just(buffer));
-        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain);
+        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain, deviceIdentifierManager);
 
         final SpyRoutingContext ctx = new SpyRoutingContext();
         ctx.setMethod(HttpMethod.POST);
@@ -68,7 +71,7 @@ public class RegisterConfirmationEndpointTest {
         final Buffer buffer = mock(Buffer.class);
         final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
         when(engine.render(anyMap(), anyString())).thenReturn(Single.just(buffer));
-        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain);
+        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain, deviceIdentifierManager);
 
         final SpyRoutingContext ctx = new SpyRoutingContext();
         ctx.setMethod(HttpMethod.POST);
@@ -89,7 +92,7 @@ public class RegisterConfirmationEndpointTest {
         domain.setId("domain-id");
 
         final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
-        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain);
+        var registrationConfirmation = new RegisterConfirmationEndpoint(engine, domain, deviceIdentifierManager);
 
         final SpyRoutingContext ctx = new SpyRoutingContext();
         ctx.setMethod(HttpMethod.POST);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/ResetPasswordEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/endpoints/user/ResetPasswordEndpointTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.root.endpoints.user;
 
+import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.user.password.ResetPasswordEndpoint;
 import io.gravitee.am.gateway.handler.root.resources.handler.dummies.SpyRoutingContext;
 import io.gravitee.am.model.Domain;
@@ -42,6 +43,8 @@ import static org.mockito.Mockito.when;
  */
 public class ResetPasswordEndpointTest {
 
+    private final DeviceIdentifierManager deviceIdentifierManager = mock(DeviceIdentifierManager.class);
+
     @Test
     public void must_render_engine_with_encoded_client_id() {
         final Domain domain = new Domain();
@@ -50,7 +53,7 @@ public class ResetPasswordEndpointTest {
         final Buffer buffer = mock(Buffer.class);
         final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
         when(engine.render(anyMap(), anyString())).thenReturn(Single.just(buffer));
-        var registrationConfirmation = new ResetPasswordEndpoint(engine, domain);
+        var registrationConfirmation = new ResetPasswordEndpoint(engine, domain, deviceIdentifierManager);
 
         final SpyRoutingContext ctx = new SpyRoutingContext();
         ctx.setMethod(HttpMethod.GET);
@@ -74,7 +77,7 @@ public class ResetPasswordEndpointTest {
         final Buffer buffer = mock(Buffer.class);
         final ThymeleafTemplateEngine engine = mock(ThymeleafTemplateEngine.class);
         when(engine.render(anyMap(), anyString())).thenReturn(Single.just(buffer));
-        var resetPassword = new ResetPasswordEndpoint(engine, domain);
+        var resetPassword = new ResetPasswordEndpoint(engine, domain, deviceIdentifierManager);
 
         final SpyRoutingContext ctx = new SpyRoutingContext();
         ctx.setMethod(HttpMethod.GET);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterEndpointTest.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.user.register;
 
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
+import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
 import io.gravitee.am.gateway.handler.root.resources.handler.dummies.SpyRoutingContext;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.account.AccountSettings;
@@ -55,13 +56,15 @@ public class RegisterEndpointTest {
 
     @Mock
     private BotDetectionManager botDetectionManager;
+    @Mock
+    private DeviceIdentifierManager deviceIdentifierManager;
     private RegisterEndpoint registerEndpoint;
     private SpyRoutingContext context;
 
     @BeforeEach
     public void setup() {
         when(botDetectionManager.getTemplateVariables(any(), any())).thenReturn(Map.of());
-        registerEndpoint = new RegisterEndpoint(templateEngine, domain, botDetectionManager);
+        registerEndpoint = new RegisterEndpoint(templateEngine, domain, botDetectionManager, deviceIdentifierManager);
         context = new SpyRoutingContext();
         context.setMethod(HttpMethod.GET);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/registration.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/registration.html
@@ -84,7 +84,6 @@
                 <span th:case="invalid_email" th:text="#{registration.error.invalid.email}"/>
                 <span th:case="*" th:text="#{registration.error.information.missing}"/>
             </div>
-
             <button type="submit" id="submitBtn" class="button primary" th:text="#{registration.button.submit}"></button>
         </form>
     </div>
@@ -146,13 +145,13 @@
 
         $("#submitBtn").on('click', function (event){
             /*[# th:if="${bot_detection_plugin == 'google-recaptcha-v3-am-bot-detection'}"]*/
-                event.preventDefault();
-                grecaptcha.ready(function() {
-                  grecaptcha.execute(/*[[${bot_detection_configuration.siteKey}]]*/, {action: 'submit'}).then(function(token) {
+            event.preventDefault();
+            grecaptcha.ready(function() {
+                grecaptcha.execute(/*[[${bot_detection_configuration.siteKey}]]*/, {action: 'submit'}).then(function(token) {
                     $("#"+ /*[[${bot_detection_configuration.get('tokenParameterName')}]]*/ "no-name").val(token);
                     $("#form").unbind('submit').submit();
-                  });
                 });
+            });
             /*[/]*/
 
         });
@@ -174,5 +173,37 @@
     const passwordSettings = /*[[${passwordSettings}]]*/ null;
 </script>
 <script th:if="${error == null && success == null}" th:src="@{assets/js/password-validation-v3.js}"></script>
+
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+        });
+    });
+</script>
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3(fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+            if (fp.components && fp.components.platform && fp.components.platform.value) {
+                $("#form").append('<input type="hidden" name="deviceType" value="' + fp.components.platform.value + '"/>');
+            }
+        });
+    });
+</script>
+
+
 </body>
 </html>

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/registration_confirmation.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/registration_confirmation.html
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div class="section">
-        <form role="form" class="form" th:action="${action}" method="post">
+        <form role="form" id="form" class="form" th:action="${action}" method="post">
             <div class="form-field">
                 <input class="input-field" type="password" id="password" name="password" th:placeholder="#{registration_confirmation.password.placeholder}" required/>
                 <button type="button" class="icon-button icon-input-field toggle-password">
@@ -132,5 +132,36 @@
     const passwordValidation = /*[[${passwordValidation}]]*/ null;
     const passwordHistory = /*[[${passwordHistory}]]*/ null;
 </script>
+
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+        });
+    });
+</script>
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3(fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+            if (fp.components && fp.components.platform && fp.components.platform.value) {
+                $("#form").append('<input type="hidden" name="deviceType" value="' + fp.components.platform.value + '"/>');
+            }
+        });
+    });
+</script>
+
 </body>
 </html>

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/reset_password.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/reset_password.html
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div class="section">
-        <form role="form" class="form" th:action="${action}" method="post">
+        <form id="form" role="form" class="form" th:action="${action}" method="post">
             <div class="form-field">
                 <input class="input-field" type="password" id="password" name="password" th:placeholder="#{reset_password.password.placeholder}" required/>
                 <button type="button" class="icon-button icon-input-field toggle-password">
@@ -127,5 +127,35 @@
     const passwordHistory = /*[[${passwordHistory}]]*/ null;
     const passwordValidation = /*[[${passwordValidation}]]*/ null;
 </script>
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3-pro.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Pro'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3Pro("[[${fingerprint_js_v3_pro_browser_token}]]", "[[${fingerprint_js_v3_pro_region}]]", fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+        });
+    });
+</script>
+
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}"
+        th:src="@{assets/js/remember-device/fingerprintjs-v3.js}"></script>
+<script th:if="${rememberDeviceIsActive && deviceIdentifierProvider == 'FingerprintJsV3Community'}" th:attr="nonce=${script_inline_nonce}">
+    $(document).ready(function () {
+        loadFingerprintJsV3(fp => {
+            if (fp.visitorId) {
+                $("#form")
+                    .append('<input type="hidden" name="deviceId" value="' + fp.visitorId + '"/>')
+            }
+            if (fp.components && fp.components.platform && fp.components.platform.value) {
+                $("#form").append('<input type="hidden" name="deviceType" value="' + fp.components.platform.value + '"/>');
+            }
+        });
+    });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
 this will help to propose the remember device option during MFA enrollment

 when the autologin is enabled after reset pwd or registration action

fixes AM-3965

gravitee-io/issues#10031
