### PR TITLE
fix: AM-3982: fix code verifier extraction

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackParseHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackParseHandler.java
@@ -184,7 +184,7 @@ public class LoginCallbackParseHandler implements Handler<RoutingContext> {
         return stateJwtCertProvider.getProvider()
                 .key()
                 .map(k -> {
-                    var ecv = new String(Base64.getUrlDecoder().decode((String) stateJwt.get(Claims.ENCRYPTED_CODE_VERIFIER)));
+                    var ecv = (String) stateJwt.get(Claims.ENCRYPTED_CODE_VERIFIER);
                     return CryptoUtils.decrypt(ecv, (Key) k.getValue());
                 });
     }


### PR DESCRIPTION
AM-3982

Removes left-over base64 decode step from code verifier extraction code.