### PR TITLE
fix: AM-3945 username cannot be blank

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/resources/users/UserEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/resources/users/UserEndpoint.java
@@ -116,7 +116,7 @@ public class UserEndpoint extends AbstractUserEndpoint {
             final String userId = context.request().getParam("id");
 
             // username is required
-            if (user.getUserName() == null || user.getUserName().isEmpty()) {
+            if (user.getUserName() == null || user.getUserName().isBlank()) {
                 context.fail(new InvalidValueException("Field [userName] is required"));
                 return;
             }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/resources/users/UpdateUserEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/resources/users/UpdateUserEndpointHandlerTest.java
@@ -173,6 +173,52 @@ public class UpdateUserEndpointHandlerTest extends RxWebTestBase {
     }
 
     @Test
+    public void shouldReturn400WhenUsernameIsBlank() throws Exception {
+        router.route("/Users").handler(userEndpoint::update);
+
+        testRequest(
+                HttpMethod.PUT,
+                "/Users",
+                req -> {
+                    req.setChunked(true);
+                    User user = getUser();
+                    user.setUserName("   ");
+                    req.write(Json.encode(user));
+                },
+                400,
+                "Bad Request",
+                "{\n" +
+                        "  \"status\" : \"400\",\n" +
+                        "  \"scimType\" : \"invalidValue\",\n" +
+                        "  \"detail\" : \"Field [userName] is required\",\n" +
+                        "  \"schemas\" : [ \"urn:ietf:params:scim:api:messages:2.0:Error\" ]\n" +
+                        "}");
+    }
+
+    @Test
+    public void shouldReturn400WhenUsernameIsNull() throws Exception {
+        router.route("/Users").handler(userEndpoint::update);
+
+        testRequest(
+                HttpMethod.PUT,
+                "/Users",
+                req -> {
+                    req.setChunked(true);
+                    User user = getUser();
+                    user.setUserName(null);
+                    req.write(Json.encode(user));
+                },
+                400,
+                "Bad Request",
+                "{\n" +
+                        "  \"status\" : \"400\",\n" +
+                        "  \"scimType\" : \"invalidValue\",\n" +
+                        "  \"detail\" : \"Field [userName] is required\",\n" +
+                        "  \"schemas\" : [ \"urn:ietf:params:scim:api:messages:2.0:Error\" ]\n" +
+                        "}");
+    }
+
+    @Test
     public void shouldReturn400WhenEmailFormatInvalidException() throws Exception {
         router.route("/Users").handler(userEndpoint::update);
         when(userService.update(any(), any(), eq(null), anyString(), any(), any())).thenReturn(Single.error(new EmailFormatInvalidException("Invalid email")));

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UsernameEntity.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/UsernameEntity.java
@@ -15,17 +15,16 @@
  */
 package io.gravitee.am.management.handlers.management.api.model;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
 /**
  * Entity for updating a user's username.
  */
+@Data
 public class UsernameEntity {
+
+    @NotBlank(message = "username must not be blank")
     private String username;
 
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserResource.java
@@ -200,7 +200,7 @@ public class UserResource extends AbstractResource {
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_USER, Acl.UPDATE)
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
-                        .flatMapSingle(irrelevant -> userService.updateUsername(ReferenceType.DOMAIN, domain, userId, username.getUsername(), authenticatedUser)))
+                        .flatMapSingle(irrelevant -> userService.updateUsername(ReferenceType.DOMAIN, domain, userId, username.getUsername().trim(), authenticatedUser)))
                 .subscribe(response::resume, response::resume);
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UserResource.java
@@ -162,7 +162,7 @@ public class UserResource extends AbstractResource {
         final io.gravitee.am.identityprovider.api.User authenticatedUser = getAuthenticatedUser();
 
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_USER, Acl.UPDATE)
-                .andThen(organizationUserService.updateUsername(ReferenceType.ORGANIZATION, organizationId, userId, username.getUsername(), authenticatedUser))
+                .andThen(organizationUserService.updateUsername(ReferenceType.ORGANIZATION, organizationId, userId, username.getUsername().trim(), authenticatedUser))
                 .map(UserEntity::new)
                 .subscribe(response::resume, response::resume);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -338,7 +338,7 @@ user:
         pattern: ^[^±!£$%^&*§¡€¢¶•ªº«»\\/<>?|=]{0,100}$
   username:
     policy:
-      pattern: ^[^±!£$%^&*§¡€¢¶•ªº«»\\/<>?:;|=,]{1,100}$
+      pattern: ^[^±!£$%^&*§¡€¢¶•ªº«»\\/<>?:;|=, ]{1,100}$
   registration:
     email:
       #subject: New user registration

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/user/UserValidatorImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/user/UserValidatorImpl.java
@@ -64,8 +64,8 @@ public class UserValidatorImpl implements UserValidator {
         return this.validate(user, true);
     }
 
-    private boolean isValid(String userInfo, Pattern pattern) {
-        return userInfo == null || pattern.matcher(userInfo).matches();
+    private boolean isValid(String string, Pattern pattern) {
+        return string == null || pattern.matcher(string).matches();
     }
 
     @Override

--- a/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.html
@@ -37,12 +37,14 @@
                       required
                       #username="ngModel"
                       name="username"
+                      pattern="^[^\s].*[^\s]$"
                       [(ngModel)]="user.username"
                       placeholder="Updated Username"
                       [disabled]="!editMode() || !canEdit"
                     />
                     <mat-hint>The username of the user.</mat-hint>
                     <mat-error *ngIf="username.errors?.required">Enter username</mat-error>
+                    <mat-error *ngIf="username.errors?.pattern">Username cannot start or end with whitespace</mat-error>
                   </mat-form-field>
                   <button
                     *ngIf="editMode() && canEdit"

--- a/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.ts
@@ -246,7 +246,7 @@ export class UserProfileComponent implements OnInit {
           this.snackbarService.open('Username updated');
         }),
       )
-      .subscribe();
+      .subscribe((data) => this.usernameForm.resetForm({ username: data.username }));
   }
 
   private unlockUser(user) {


### PR DESCRIPTION
fixes AM-3945
![image](https://github.com/user-attachments/assets/9c1a082f-8714-4f4e-b32e-391dc615d9b3)

For 4.1-4.4 "Self account management" there is no "update username" capability.
For 4.5/master it will be separate PR.