### PR TITLE
feat(helm): rework gateway probes definition with default value and customisation

### DIFF
--- a/helm/templates/api/_api-deployment-probes.tpl
+++ b/helm/templates/api/_api-deployment-probes.tpl
@@ -1,0 +1,96 @@
+{{- define "api.httpHeadersProbes" -}}
+    {{- $httpHeadersProbes := dict }}
+    {{- if and
+        .Values.api.http.services.core.http.enabled
+        (eq (default "basic" .Values.api.http.services.core.http.authentication.type) "basic")
+        .Values.api.http.services.core.http.authentication.password
+    }}
+      {{- $httpHeadersProbes = dict "httpHeaders" (list (dict
+          "name" "Authorization"
+          "value" (printf "Basic %s" (printf "admin:%s" .Values.api.http.services.core.http.authentication.password | b64enc))
+      )) }}
+    {{- end }}
+
+    {{- $httpHeadersProbes | toYaml }}
+{{- end }}
+
+{{- define "api.computeLivenessProbe" -}}
+    {{- $httpHeadersProbes := (include "api.httpHeadersProbes" . | fromYaml) -}}
+
+    {{- $defaultLivenessProbe := dict
+        "initialDelaySeconds" 30
+        "periodSeconds" 30
+        "timeoutSeconds" 3
+        "successThreshold" 1
+        "failureThreshold" 3
+        "httpGet" (merge (dict
+          "path" "/_node/health?probes=jetty-http-server"
+          "scheme" "HTTP"
+          "port" (.Values.api.http.services.core.http.port | default 18082)
+        ) $httpHeadersProbes)
+    }}
+
+    {{- $computeLivenessProbe := (mergeOverwrite $defaultLivenessProbe .Values.api.livenessProbe) -}}
+    {{- if or
+            (hasKey $computeLivenessProbe "tcpSocket")
+            (hasKey $computeLivenessProbe "exec")
+    }}
+      {{- $_ := unset $computeLivenessProbe "httpGet" }}
+    {{- end }}
+
+    {{- $computeLivenessProbe | toYaml }}
+{{- end }}
+
+{{- define "api.computeReadinessProbe" -}}
+    {{- $httpHeadersProbes := (include "api.httpHeadersProbes" . | fromYaml) -}}
+
+    {{- $defaultReadinessProbe := dict
+        "initialDelaySeconds" 30
+        "periodSeconds" 30
+        "timeoutSeconds" 3
+        "successThreshold" 1
+        "failureThreshold" 3
+        "httpGet" (merge (dict
+          "path" "/_node/health?probes=jetty-http-server"
+          "scheme" "HTTP"
+          "port" (.Values.api.http.services.core.http.port | default 18082)
+        ) $httpHeadersProbes)
+    }}
+
+    {{- $computeReadinessProbe := (mergeOverwrite $defaultReadinessProbe .Values.api.readinessProbe) -}}
+    {{- if or
+            (hasKey $computeReadinessProbe "tcpSocket")
+            (hasKey $computeReadinessProbe "exec")
+    }}
+      {{- $_ := unset $computeReadinessProbe "httpGet" }}
+    {{- end }}
+
+    {{- $computeReadinessProbe | toYaml }}
+{{- end }}
+
+{{- define "api.computeStartupProbe" -}}
+    {{- $httpHeadersProbes := (include "api.httpHeadersProbes" . | fromYaml) -}}
+
+    {{- $defaultStartupProbe := dict
+        "initialDelaySeconds" 10
+        "periodSeconds" 10
+        "timeoutSeconds" 1
+        "successThreshold" 1
+        "failureThreshold" 29
+        "httpGet" (merge (dict
+          "path" "/_node/health?probes=jetty-http-server,management-repository"
+          "scheme" "HTTP"
+          "port" (.Values.api.http.services.core.http.port | default 18082)
+        ) $httpHeadersProbes)
+    }}
+
+    {{- $computeStartupProbe := (mergeOverwrite $defaultStartupProbe .Values.api.startupProbe) -}}
+    {{- if or
+            (hasKey $computeStartupProbe "tcpSocket")
+            (hasKey $computeStartupProbe "exec")
+    }}
+      {{- $_ := unset $computeStartupProbe "httpGet" }}
+    {{- end }}
+
+    {{- $computeStartupProbe | toYaml }}
+{{- end }}

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -2,6 +2,9 @@
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "am.serviceAccount" . -}}
 {{- $logbackVolumeName := include "api.logbackVolumeName" . -}}
+{{- $computeLivenessProbe := (include "api.computeLivenessProbe" . | fromYaml) -}}
+{{- $computeReadinessProbe := (include "api.computeReadinessProbe" . | fromYaml) -}}
+{{- $computeStartupProbe := (include "api.computeStartupProbe" . | fromYaml) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -185,8 +188,9 @@ spec:
                 command: {{ .Values.api.lifecycle.preStop }}
             {{- end }}
           {{- end }}
-          livenessProbe: {{ toYaml .Values.api.livenessProbe | nindent 12 }}
-          readinessProbe: {{ toYaml .Values.api.readinessProbe | nindent 12 }}
+          livenessProbe: {{ toYaml $computeLivenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml $computeReadinessProbe | nindent 12 }}
+          startupProbe: {{ toYaml $computeStartupProbe | nindent 12 }}
           resources: {{ toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:
             - name: config

--- a/helm/templates/gateway/_gateway-deployment-probes.tpl
+++ b/helm/templates/gateway/_gateway-deployment-probes.tpl
@@ -1,0 +1,107 @@
+{{- define "gateway.httpHeadersProbes" -}}
+    {{- $httpHeadersProbes := dict }}
+    {{- if and
+        .Values.gateway.services.core.http.enabled
+        (eq (default "basic" .Values.gateway.services.core.http.authentication.type) "basic")
+        .Values.gateway.services.core.http.authentication.password
+    }}
+      {{- $httpHeadersProbes = dict "httpHeaders" (list (dict
+          "name" "Authorization"
+          "value" (printf "Basic %s" (printf "admin:%s" .Values.gateway.services.core.http.authentication.password | b64enc))
+      )) }}
+    {{- end }}
+
+    {{- $httpHeadersProbes | toYaml }}
+{{- end }}
+
+{{- define "gateway.gatewayServiceCoreScheme" -}}
+    {{- $gatewayServiceCoreScheme := ( ternary "HTTPS" "HTTP" .Values.gateway.services.core.http.secured) }}
+    {{- $gatewayServiceCoreScheme }}
+{{- end }}
+
+{{- define "gateway.computeLivenessProbe" -}}
+    {{- $httpHeadersProbes := (include "gateway.httpHeadersProbes" . | fromYaml) -}}
+    {{- $gatewayServiceCoreScheme := (include "gateway.gatewayServiceCoreScheme" .) -}}
+
+    {{- $defaultLivenessProbe := dict
+        "initialDelaySeconds" 30
+        "periodSeconds" 30
+        "timeoutSeconds" 3
+        "successThreshold" 1
+        "failureThreshold" 3
+        "httpGet" (merge (dict
+          "path" "/_node/health?probes=http-server"
+          "scheme" $gatewayServiceCoreScheme
+          "port" (.Values.gateway.services.core.http.port | default 18082)
+        ) $httpHeadersProbes)
+    }}
+
+    {{- $computeLivenessProbe := (mergeOverwrite $defaultLivenessProbe .Values.gateway.livenessProbe) -}}
+    {{- if or
+            (hasKey $computeLivenessProbe "tcpSocket")
+            (hasKey $computeLivenessProbe "exec")
+    }}
+      {{- $_ := unset $computeLivenessProbe "httpGet" }}
+    {{- end }}
+
+    {{- $computeLivenessProbe | toYaml }}
+{{- end }}
+
+{{- define "gateway.computeReadinessProbe" -}}
+    {{- $httpHeadersProbes := (include "gateway.httpHeadersProbes" . | fromYaml) -}}
+    {{- $gatewayServiceCoreScheme := (include "gateway.gatewayServiceCoreScheme" .) -}}
+    {{- $httpGetPath := (ternary "/_node/health?probes=security-domain-sync" "/_node/health?probes=http-server" (eq .Values.gateway.readinessProbe.domainSync true)) -}}
+
+    {{- $defaultReadinessProbe := dict
+        "initialDelaySeconds" 30
+        "periodSeconds" 30
+        "timeoutSeconds" 3
+        "successThreshold" 1
+        "failureThreshold" 3
+        "httpGet" (merge (dict
+          "path" $httpGetPath
+          "scheme" $gatewayServiceCoreScheme
+          "port" (.Values.gateway.services.core.http.port | default 18082)
+        ) $httpHeadersProbes)
+    }}
+
+    {{- $computeReadinessProbe := (mergeOverwrite $defaultReadinessProbe .Values.gateway.readinessProbe) -}}
+    {{- if or
+            (hasKey $computeReadinessProbe "tcpSocket")
+            (hasKey $computeReadinessProbe "exec")
+    }}
+      {{- $_ := unset $computeReadinessProbe "httpGet" }}
+    {{- end }}
+
+    {{- $_ := unset $computeReadinessProbe "domainSync" }}
+
+    {{- $computeReadinessProbe | toYaml }}
+{{- end }}
+
+{{- define "gateway.computeStartupProbe" -}}
+    {{- $httpHeadersProbes := (include "gateway.httpHeadersProbes" . | fromYaml) -}}
+    {{- $gatewayServiceCoreScheme := (include "gateway.gatewayServiceCoreScheme" .) -}}
+
+    {{- $defaultStartupProbe := dict
+        "initialDelaySeconds" 10
+        "periodSeconds" 10
+        "timeoutSeconds" 1
+        "successThreshold" 1
+        "failureThreshold" 29
+        "httpGet" (merge (dict
+          "path" "/_node/health?probes=http-server,security-domain-sync"
+          "scheme" $gatewayServiceCoreScheme
+          "port" (.Values.gateway.services.core.http.port | default 18082)
+        ) $httpHeadersProbes)
+    }}
+
+    {{- $computeStartupProbe := (mergeOverwrite $defaultStartupProbe .Values.gateway.startupProbe) -}}
+    {{- if or
+            (hasKey $computeStartupProbe "tcpSocket")
+            (hasKey $computeStartupProbe "exec")
+    }}
+      {{- $_ := unset $computeStartupProbe "httpGet" }}
+    {{- end }}
+
+    {{- $computeStartupProbe | toYaml }}
+{{- end }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -2,6 +2,9 @@
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "am.serviceAccount" . -}}
 {{- $logbackVolumeName := include "gateway.logbackVolumeName" . -}}
+{{- $computeLivenessProbe := (include "gateway.computeLivenessProbe" . | fromYaml) -}}
+{{- $computeReadinessProbe := (include "gateway.computeReadinessProbe" . | fromYaml) -}}
+{{- $computeStartupProbe := (include "gateway.computeStartupProbe" . | fromYaml) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -135,30 +138,9 @@ spec:
                 command: {{ .Values.gateway.lifecycle.preStop }}
             {{- end }}
           {{- end }}
-          livenessProbe: {{ toYaml .Values.gateway.livenessProbe | nindent 12 }}
-          readinessProbe:
-            {{- if eq .Values.gateway.readinessProbe.domainSync true }}
-            httpGet:
-              path: /_node/health?probes=security-domain-sync
-              port: {{ .Values.gateway.services.core.http.port | default 18082 }}
-              {{- if eq .Values.gateway.services.core.http.secured true}}
-              scheme: HTTPS
-              {{- end }}
-              {{- if eq .Values.gateway.services.core.http.authentication.type "basic" }}
-              httpHeaders:
-                - name: Authorization
-                  value: {{ print "Basic "}}{{print "admin:" .Values.gateway.services.core.http.authentication.password | b64enc }}
-              {{- end }}
-            initialDelaySeconds: {{ .Values.gateway.readinessProbe.initialDelaySeconds | default 5 }}
-            failureThreshold: {{ .Values.gateway.readinessProbe.failureThreshold | default 3 }}
-            periodSeconds: {{ .Values.gateway.readinessProbe.periodSeconds | default 30 }}
-            {{- else }}
-            {{- $readinessProbe := unset (.Values.gateway.readinessProbe | deepCopy) "domainSync" -}}
-            {{ toYaml $readinessProbe | nindent 12 }}
-            {{- end }}
-          {{- if and (.Values.gateway.startupProbe) (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-          startupProbe: {{ toYaml .Values.gateway.startupProbe | nindent 12 }}
-          {{- end }}
+          livenessProbe: {{ toYaml $computeLivenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml $computeReadinessProbe | nindent 12 }}
+          startupProbe: {{ toYaml $computeStartupProbe | nindent 12 }}
           resources: {{ toYaml .Values.gateway.resources | nindent 12 }}
           volumeMounts:
             - name: config

--- a/helm/tests/api/configmap_sync_test.yaml
+++ b/helm/tests/api/configmap_sync_test.yaml
@@ -23,7 +23,7 @@ tests:
                 http:
                   enabled: true
                   port: 18093
-                  host: localhost
+                  host: 0.0.0.0
                   authentication:
                     type: basic
                     users:

--- a/helm/tests/api/deployment_probes_test.yaml
+++ b/helm/tests/api/deployment_probes_test.yaml
@@ -1,0 +1,400 @@
+suite: "Deployment probes Tests"
+templates:
+  - "api/api-deployment.yaml"
+  - "api/api-configmap.yaml"
+
+tests:
+
+###
+## Startup probe
+###
+
+  - it: "Get default startupProbe values"
+    template: api/api-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=jetty-http-server,management-repository
+              port: 18093
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Get default startupProbe values with authenticated internal api"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        http:
+          services:
+            core:
+              http:
+                authentication:
+                  password: adminadmin
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=jetty-http-server,management-repository
+              port: 18093
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Get default startupProbe values with unauthenticated internal api"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        http:
+          services:
+            core:
+              http:
+                authentication:
+                  type: none
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              path: /_node/health?probes=jetty-http-server,management-repository
+              port: 18093
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Overwrite default startupProbe values with initialDelaySeconds"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        startupProbe:
+          initialDelaySeconds: 15
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=jetty-http-server,management-repository
+              port: 18093
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Overwrite default startupProbe values with httpGet.path/port"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        startupProbe:
+          httpGet:
+            path: /another/endpoint
+            port: 8082
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /another/endpoint
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Set tcpSocket should overwrite httpGet definition in startupProbe"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        startupProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          failureThreshold: 10
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            httpGet:
+              path:
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 10
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+
+  - it: "Set exec command should overwrite httpGet definition in startupProbe"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        startupProbe:
+          exec:
+            command: "curl -u 'admin:adminadmin' 'http://localhost:18093/_node/health?probes=jetty-http-server'"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=jetty-http-server,management-repository
+              port: 18093
+              scheme: HTTP
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            exec:
+              command: "curl -u 'admin:adminadmin' 'http://localhost:18093/_node/health?probes=jetty-http-server'"
+
+###
+## Liveness probe
+###
+
+  - it: "Get default livenessProbe values"
+    template: api/api-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=jetty-http-server
+              port: 18093
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Overwrite default livenessProbe values with initialDelaySeconds"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        livenessProbe:
+          initialDelaySeconds: 40
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=jetty-http-server
+              port: 18093
+              scheme: HTTP
+            initialDelaySeconds: 40
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Overwrite default livenessProbe values with httpGet.path/port"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        livenessProbe:
+          httpGet:
+            path: /another/endpoint
+            port: 8082
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /another/endpoint
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Set tcpSocket should overwrite httpGet definition in livenessProbe"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        livenessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          failureThreshold: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            httpGet:
+              path:
+      - isSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            failureThreshold: 3
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+
+###
+## Readiness probe
+###
+
+  - it: "Get default readinessProbe values"
+    template: api/api-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=jetty-http-server
+              port: 18093
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Overwrite default readinessProbe values with initialDelaySeconds"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        readinessProbe:
+          initialDelaySeconds: 40
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=jetty-http-server
+              port: 18093
+              scheme: HTTP
+            initialDelaySeconds: 40
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Overwrite default readinessProbe values with httpGet.path/port"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        readinessProbe:
+          httpGet:
+            path: /another/endpoint
+            port: 8082
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /another/endpoint
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Set tcpSocket should overwrite httpGet definition in readinessProbe"
+    template: api/api-deployment.yaml
+    set:
+      api:
+        readinessProbe:
+          domainSync: false
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          failureThreshold: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            httpGet:
+              path:
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/helm/tests/gateway/configmap_sync_test.yaml
+++ b/helm/tests/gateway/configmap_sync_test.yaml
@@ -23,7 +23,7 @@ tests:
                 http:
                   enabled: true
                   port: 18092
-                  host: localhost
+                  host: 0.0.0.0
                   authentication:
                     type: basic
                     users:

--- a/helm/tests/gateway/deployment_probes_test.yaml
+++ b/helm/tests/gateway/deployment_probes_test.yaml
@@ -1,0 +1,477 @@
+suite: "Deployment probes Tests"
+templates:
+  - "gateway/gateway-deployment.yaml"
+  - "gateway/gateway-configmap.yaml"
+
+tests:
+
+###
+## Startup probe
+###
+
+  - it: "Get default startupProbe values"
+    template: gateway/gateway-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server,security-domain-sync
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Get default startupProbe values with authenticated internal api"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        services:
+          core:
+            http:
+              authentication:
+                type: basic
+                password: adminadmin
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server,security-domain-sync
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Get default startupProbe values with unauthenticated internal api"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        services:
+          core:
+            http:
+              authentication:
+                type: none
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              path: /_node/health?probes=http-server,security-domain-sync
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Get default startupProbe values with secure internal api"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        services:
+          core:
+            http:
+              secured: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server,security-domain-sync
+              port: 18092
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Overwrite default startupProbe values with initialDelaySeconds"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        startupProbe:
+          initialDelaySeconds: 15
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server,security-domain-sync
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Overwrite default startupProbe values with httpGet.path/port"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        startupProbe:
+          httpGet:
+            path: /another/endpoint
+            port: 8082
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 29
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /another/endpoint
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+  - it: "Set tcpSocket should overwrite httpGet definition in startupProbe"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        startupProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          failureThreshold: 10
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            httpGet:
+              path:
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            failureThreshold: 10
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+
+  - it: "Set exec command should overwrite httpGet definition in startupProbe"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        startupProbe:
+          exec:
+            command: "curl -u 'admin:adminadmin' 'http://localhost:18093/_node/health?probes=jetty-http-server'"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server,security-domain-sync
+              port: 18092
+              scheme: HTTP
+      - isSubset:
+          path: "spec.template.spec.containers[0].startupProbe"
+          content:
+            exec:
+              command: "curl -u 'admin:adminadmin' 'http://localhost:18093/_node/health?probes=jetty-http-server'"
+
+###
+## Liveness probe
+###
+
+  - it: "Get default livenessProbe values"
+    template: gateway/gateway-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Overwrite default livenessProbe values with initialDelaySeconds"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        livenessProbe:
+          initialDelaySeconds: 40
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 40
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Overwrite default livenessProbe values with httpGet.path/port"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        livenessProbe:
+          httpGet:
+            path: /another/endpoint
+            port: 8082
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /another/endpoint
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Set tcpSocket should overwrite httpGet definition in livenessProbe"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        livenessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          failureThreshold: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            httpGet:
+              path:
+      - isSubset:
+          path: "spec.template.spec.containers[0].livenessProbe"
+          content:
+            failureThreshold: 3
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+
+###
+## Readiness probe
+###
+
+  - it: "Get default readinessProbe values"
+    template: gateway/gateway-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Overwrite default readinessProbe values with initialDelaySeconds"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        readinessProbe:
+          initialDelaySeconds: 40
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=http-server
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 40
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Overwrite default readinessProbe values with httpGet.path/port"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        readinessProbe:
+          httpGet:
+            path: /another/endpoint
+            port: 8082
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /another/endpoint
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Backward compatibility with readinessProbe domainSync enable"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        readinessProbe:
+          domainSync: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=security-domain-sync
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Backward compatibility with readinessProbe domainSync enable overwriting initialDelaySeconds"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        readinessProbe:
+          domainSync: true
+          initialDelaySeconds: 40
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+                - name: Authorization
+                  value: Basic YWRtaW46YWRtaW5hZG1pbg==
+              path: /_node/health?probes=security-domain-sync
+              port: 18092
+              scheme: HTTP
+            initialDelaySeconds: 40
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+
+  - it: "Set tcpSocket should overwrite httpGet definition in readinessProbe"
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        readinessProbe:
+          domainSync: false
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          failureThreshold: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            httpGet:
+              path:
+      - isSubset:
+          path: "spec.template.spec.containers[0].readinessProbe"
+          content:
+            failureThreshold: 3
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -317,19 +317,50 @@ api:
     topologySpreadConstraints: []
     # revisionHistoryLimit: 10
 
-  livenessProbe:
-    tcpSocket:
-      port: http
-    initialDelaySeconds: 30
-    periodSeconds: 30
-    failureThreshold: 3
+  livenessProbe: {}
+  # Default value are below. What you define here will overwrite and merge with default value
+  #    httpGet:
+  #      httpHeaders:
+  #        - name: Authorization
+  #        value: Basic <base64 encoded string with "admin:" + gateway.services.core.http.authentication.password>
+  #      path: /_node/health?probes=jetty-http-server
+  #      port: 18092
+  #      scheme: HTTPS
+  #    initialDelaySeconds: 30
+  #    periodSeconds: 30
+  #    timeoutSeconds: 3
+  #    successThreshold: 1
+  #    failureThreshold: 3
 
-  readinessProbe:
-    tcpSocket:
-      port: http
-    initialDelaySeconds: 30
-    periodSeconds: 30
-    failureThreshold: 3
+  readinessProbe: {}
+  # Default value are below. What you define here will overwrite and merge with default value
+  #    httpGet:
+  #      httpHeaders:
+  #        - name: Authorization
+  #        value: Basic <base64 encoded string with "admin:" + gateway.services.core.http.authentication.password>
+  #      path: /_node/health?probes=jetty-http-server
+  #      port: 18092
+  #      scheme: HTTPS
+  #    initialDelaySeconds: 30
+  #    periodSeconds: 30
+  #    timeoutSeconds: 3
+  #    successThreshold: 1
+  #    failureThreshold: 3
+
+  startupProbe: {}
+  # Default value are below. What you define here will overwrite and merge with default value
+  #    httpGet:
+  #      httpHeaders:
+  #        - name: Authorization
+  #        value: Basic <base64 encoded string with "admin:" + gateway.services.core.http.authentication.password>
+  #      path: /_node/health?probes=jetty-http-server,management-repository
+  #      port: 18092
+  #      scheme: HTTPS
+  #    initialDelaySeconds: 10
+  #    periodSeconds: 10
+  #    timeoutSeconds: 1
+  #    successThreshold: 1
+  #    failureThreshold: 29
 
   pdb:
     enabled: false
@@ -400,7 +431,10 @@ api:
         http:
           enabled: true
           port: 18093
-          host: localhost
+          # We open the technical api to everywhere (inside kube)
+          # to allow kubelet do the healthcheck for default startup/liveness/readiness probes.
+          # if you change this value to localhost or 127.0.0.1, please overwrite the probes definition
+          host: 0.0.0.0
           authentication:
             password: adminadmin
         ingress:
@@ -647,22 +681,56 @@ gateway:
     topologySpreadConstraints: []
     # revisionHistoryLimit: 10
 
-  livenessProbe:
-    tcpSocket:
-      port: http
-    initialDelaySeconds: 30
-    periodSeconds: 30
-    failureThreshold: 3
+  livenessProbe: {}
+    # Default value are below. What you define here will overwrite and merge with default value
+#    httpGet:
+#      httpHeaders:
+#        - name: Authorization
+#        value: Basic <base64 encoded string with "admin:" + gateway.services.core.http.authentication.password>
+#      path: /_node/health?probes=http-server
+#      port: 18092
+#      scheme: HTTPS
+#    initialDelaySeconds: 30
+#    periodSeconds: 30
+#    timeoutSeconds: 3
+#    successThreshold: 1
+#    failureThreshold: 3
 
   readinessProbe:
     # use the node endpoint as readinessProbe to test the domain synchronization
     # in this case, the gateway.services.core.http.host must be defined to the Pod IP or 0.0.0.0
+    # Deprecated: please, rather than using this flag,
+    # overwrite `httpGet.path` with value `/_node/health?probes=http-server,security-domain-sync`
     domainSync: false
-    tcpSocket:
-      port: http
-    initialDelaySeconds: 10
-    periodSeconds: 30
-    failureThreshold: 3
+    # Default value are below. What you define here will overwrite and merge with default value
+    #    httpGet:
+    #      httpHeaders:
+    #        - name: Authorization
+    #        value: Basic <base64 encoded string with "admin:" + gateway.services.core.http.authentication.password>
+    #      path: /_node/health?probes=http-server
+    #      port: 18092
+    #      scheme: HTTPS
+    #    initialDelaySeconds: 30
+    #    periodSeconds: 30
+    #    timeoutSeconds: 3
+    #    successThreshold: 1
+    #    failureThreshold: 3
+
+  startupProbe: {}
+  # Default value are below. What you define here will overwrite and merge with default value
+  #    httpGet:
+  #      httpHeaders:
+  #        - name: Authorization
+  #        value: Basic <base64 encoded string with "admin:" + gateway.services.core.http.authentication.password>
+  #      path: /_node/health?probes=http-server,security-domain-sync
+  #      port: 18092
+  #      scheme: HTTPS
+  #    initialDelaySeconds: 10
+  #    periodSeconds: 10
+  #    timeoutSeconds: 1
+  #    successThreshold: 1
+  #    failureThreshold: 29
+
 
   pdb:
     enabled: false
@@ -711,7 +779,10 @@ gateway:
       http:
         enabled: true
         port: 18092
-        host: localhost
+        # We open the technical api to everywhere (inside kube)
+        # to allow kubelet do the healthcheck for default startup/liveness/readiness probes.
+        # if you change this value to localhost or 127.0.0.1, please overwrite the probes definition
+        host: 0.0.0.0
         authentication:
           type: basic
           password: adminadmin


### PR DESCRIPTION
## :id: Reference related issue. 

TT-5491

## :pencil2: A description of the changes proposed in the pull request

This commit will keep the existing startup/liveness/readiness probe in
values.yaml but change the current behaviour:

Now we define default values which are overwrite when customer define
something in values.

It is backward compatible to ensure that existing values continue to
work as previously. Except for one specific case: if you not defined your probes definition but keep close the internal-api (to localhost).
In that case, Your deployment will fail until you open the internal api or overwrite the default probes.

Also I asked for a deprecation of `gateway.readinessProbe.domainSync` as
we can overwrite it in a "better" way now.

## :memo: Test scenarios 

Deploy AM from helm package into a kube cluster and test default
and different values for probes.

