### PR TITLE
fix: AM-4068 with 'includeLinkedIdentities'=true the mongo db query uses more…

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractUserRepository.java
@@ -71,6 +71,8 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
     protected static final String FIELD_EMAIL = "email";
     protected static final String FIELD_ADDITIONAL_INFO_EMAIL = "additionalInformation.email";
     protected static final String FIELD_EXTERNAL_ID = "externalId";
+    protected static final String FIELD_IDENTITIES_USERNAME = "identities.username";
+    protected static final String FIELD_IDENTITIES_PROVIDER_ID = "identities.providerId";
     private static final String INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE = "referenceType_1_referenceId_1_username_1_source_1";
     private static final String INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME = "rt1ri1u1s1";
     private static final String INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE = "rt1ri1u1s1_unique";
@@ -94,6 +96,7 @@ public abstract class AbstractUserRepository<T extends UserMongo> extends Abstra
         super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_LAST_NAME, 1), new IndexOptions().name("rt1ri1l1"));
         super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EXTERNAL_ID, 1), new IndexOptions().name("rt1ri1ext1"));
         super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EXTERNAL_ID, 1).append(FIELD_SOURCE, 1), new IndexOptions().name("rt1ri1ext1s1"));
+        super.createIndex(usersCollection, new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_IDENTITIES_USERNAME, 1).append(FIELD_IDENTITIES_PROVIDER_ID, 1), new IndexOptions().name("rt1ri1iu1ip1"));
         createOrUpdateIndex();
     }
 


### PR DESCRIPTION
… general index for referenceType and referenceId only - it basically makes a collection scan

query:
![image](https://github.com/user-attachments/assets/4d9dad0d-4353-4131-bac9-0c682231223d)
plan:
![image](https://github.com/user-attachments/assets/22ca9ae8-1362-4e0e-b333-e8467d45c936)

when query is extended with OR...identities_username=... then more general index is fired which makes basically collection scan.