### PR TITLE
feat(mapi): bulk create users (domain & org)

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/Indexed.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/Indexed.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.utils;
+
+import io.reactivex.rxjava3.core.Flowable;
+
+import java.util.stream.Stream;
+
+/**
+ * A wrapper class for working with ordered streams of values where the position of an item in the source matters.
+ */
+public record Indexed<T>(int index, T value) {
+    public static <R> Indexed<R> of(R value, int index) {
+        return new Indexed<>(index, value);
+    }
+
+    /**
+     * Transforms an iterable: [a,b,c] into a flowable [(0,a), (1,b), (2, c)]
+     */
+    public static <R> Flowable<Indexed<R>> toIndexedFlowable(Iterable<R> source) {
+        return Flowable.fromIterable(source).zipWith(Flowable.fromStream(Stream.iterate(0, i -> i + 1)), Indexed::of);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkOperationResult.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkOperationResult.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.bulk;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import jakarta.ws.rs.core.Response;
+import lombok.With;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Map;
+
+public sealed interface BulkOperationResult {
+
+    int NO_INDEX = Integer.MIN_VALUE;
+
+    int index();
+
+    @JsonSerialize(using = ResponseStatusIntSerializer.class)
+    Response.Status httpStatus();
+
+    @JsonProperty("success")
+    default boolean success() {
+        return httpStatus().getStatusCode() < 400;
+    }
+
+    BulkOperationResult withIndex(int index);
+
+
+    record Success<T>(@With int index, Response.Status httpStatus, T response) implements BulkOperationResult {
+
+    }
+
+    record Error(@With int index, Response.Status httpStatus,
+                 Object errorDetails) implements BulkOperationResult {
+
+    }
+
+
+    static Comparator<BulkOperationResult> byIndex() {
+        return Comparator.comparing(BulkOperationResult::index);
+    }
+
+    static <R> BulkOperationResult success(Response.Status status, R body) {
+        return new Success<>(NO_INDEX, status, body);
+    }
+
+    static <R> BulkOperationResult ok(R body) {
+        return new Success<>(NO_INDEX, Response.Status.OK, body);
+    }
+
+    static <R> BulkOperationResult created(R body) {
+        return new Success<>(NO_INDEX, Response.Status.CREATED, body);
+    }
+
+    static BulkOperationResult error(Response.Status statusCode) {
+        return new Error(NO_INDEX, statusCode, null);
+    }
+
+    static BulkOperationResult error(Response.Status statusCode, Exception exception) {
+        return new Error(NO_INDEX, statusCode, Map.of("error", exception.getClass().getSimpleName(), "error_details", exception.getMessage()));
+    }
+
+    static BulkOperationResult error(Response.Status statusCode, Object errorDetails) {
+        return new Error(NO_INDEX, statusCode, errorDetails);
+    }
+
+
+    class ResponseStatusIntSerializer extends StdSerializer<Response.Status> {
+
+        protected ResponseStatusIntSerializer() {
+            super(Response.Status.class);
+        }
+
+        @Override
+        public void serialize(Response.Status value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeNumber(value.getStatusCode());
+        }
+    }
+
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkOperationResult.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkOperationResult.java
@@ -26,6 +26,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.With;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ import java.util.Map;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
+@ToString
 public class BulkOperationResult<T> {
 
     private static final int NO_INDEX = Integer.MIN_VALUE;

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkRequest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkRequest.java
@@ -15,33 +15,121 @@
  */
 package io.gravitee.am.management.handlers.management.api.bulk;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.am.common.utils.Indexed;
+import io.gravitee.am.model.Acl;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.core.Response;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
 import java.util.function.Function;
 
-public record BulkRequest<T>(List<T> items) {
+/**
+ * Represents a create, update or delete operation on multiple entities.
+ *
+ * @param <T> type of item included
+ */
+@RequiredArgsConstructor
+@Getter
+@Accessors(fluent = true)
+public class BulkRequest<T> {
+    @RequiredArgsConstructor
+    @Getter
+    @Accessors(fluent = true)
+    public enum Action {
+        CREATE(Acl.CREATE), UPDATE(Acl.UPDATE), DELETE(Acl.DELETE);
+        private final Acl requiredAcl;
+    }
+
+    @JsonProperty("action")
+    private final Action action;
+    @JsonProperty("items")
+    private final List<T> items;
+
+    protected BulkRequest(Action action) {
+        this(action, List.of());
+    }
 
     /**
      * Apply the processor to each individual item in this request. There's no guarantees about ordering or concurrency
-     * of processing; the response is guaranteed to have results of processing individual items in the input order
+     * of processing; the response is guaranteed to have results of processing individual items in the input order.
      */
-    public Single<Response> processOneByOne(Function<T, Single<BulkOperationResult>> processor) {
-        if (CollectionUtils.isEmpty(items)) {
+    public final <R> Single<Response> processOneByOne(Function<T, Single<BulkOperationResult<R>>> processor) {
+        if (CollectionUtils.isEmpty(items())) {
             return Single.just(Response.noContent().build());
         }
-        return Indexed.toIndexedFlowable(items)
+        return Indexed.toIndexedFlowable(items())
                 .flatMapSingle(indexed -> processor.apply(indexed.value())
                         .map(result -> result.withIndex(indexed.index())))
                 .toList()
                 .map(this::makeResponse);
     }
 
-    private Response makeResponse(List<BulkOperationResult> bulkOperationResults) {
-        var bulkResponse = new BulkResponse(bulkOperationResults);
+    private <R> Response makeResponse(List<BulkOperationResult<R>> bulkOperationResults) {
+        var bulkResponse = new BulkResponse<>(bulkOperationResults);
         return Response.status(bulkResponse.getStatus()).entity(bulkResponse).build();
+    }
+
+    /**
+     * A BulkRequest that defers deserialization of items until the endpoint provides the actual type to use.
+     * This allows defining a single /bulk endpoint that accepts different arguments for different actions. E.g.
+     * a CREATE action might use a complex DTO, while a simple list of ids will be enough for a bulk DELETE.
+     */
+    public static final class Generic extends BulkRequest<ObjectNode> {
+
+        @JsonCreator
+        public Generic(@JsonProperty("items") List<ObjectNode> items, @JsonProperty("action") Action action) {
+            super(action, items);
+        }
+
+        /**
+         * Convert this generic request to a concrete one, mapping each item to {@code itemType} using the provided mapper
+         *
+         * @return this request with items mapped to the expected type
+         */
+        public <T> BulkRequest<T> readItemsAs(Class<T> itemType, ObjectMapper mapper) {
+            return readItemsAs(mapper, mapper.constructType(itemType));
+        }
+
+        /**
+         * Similar to {@link #readItemsAs(Class, ObjectMapper)} but handles items with generic types.
+         *
+         * @return this request with items mapped to the expected type
+         */
+        public <T> BulkRequest<T> readItemsAs(TypeReference<T> itemType, ObjectMapper mapper) {
+            return readItemsAs(mapper, mapper.constructType(itemType));
+        }
+
+
+        @SuppressWarnings("unchecked") // always called with a JavaType representing T
+        private <T> BulkRequest<T> readItemsAs(ObjectMapper mapper, JavaType type) {
+            return new BulkRequest<>(action(), items().stream().map(x -> {
+                try {
+                    return (T) mapper.treeToValue(x, type);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }).toList());
+        }
+
+        /**
+         * Convenience overload for converting & processing items in one go
+         *
+         * @param <S> input item type
+         * @param <R> output item type
+         */
+        public <S, R> Single<Response> processOneByOne(Class<S> itemType, ObjectMapper mapper, Function<S, Single<BulkOperationResult<R>>> itemProcessor) {
+            return readItemsAs(itemType, mapper).processOneByOne(itemProcessor);
+        }
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkRequest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkRequest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.bulk;
+
+import io.gravitee.am.common.utils.Indexed;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.Response;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record BulkRequest<T>(List<T> items) {
+
+    /**
+     * Apply the processor to each individual item in this request. There's no guarantees about ordering or concurrency
+     * of processing; the response is guaranteed to have results of processing individual items in the input order
+     */
+    public Single<Response> processOneByOne(Function<T, Single<BulkOperationResult>> processor) {
+        if (CollectionUtils.isEmpty(items)) {
+            return Single.just(Response.noContent().build());
+        }
+        return Indexed.toIndexedFlowable(items)
+                .flatMapSingle(indexed -> processor.apply(indexed.value())
+                        .map(result -> result.withIndex(indexed.index())))
+                .toList()
+                .map(this::makeResponse);
+    }
+
+    private Response makeResponse(List<BulkOperationResult> bulkOperationResults) {
+        var bulkResponse = new BulkResponse(bulkOperationResults);
+        return Response.status(bulkResponse.getStatus()).entity(bulkResponse).build();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkResponse.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.bulk;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.ws.rs.core.Response;
+import lombok.Getter;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class BulkResponse {
+    private final List<BulkOperationResult> results;
+    @JsonIgnore
+    private final Response.Status status;
+
+    public BulkResponse(List<BulkOperationResult> results) {
+        if (CollectionUtils.isEmpty(results)) {
+            throw new IllegalArgumentException("BulkResponse must contain at least 1 result");
+        }
+        this.results = results.stream().sorted(BulkOperationResult.byIndex()).toList();
+        var statuses = results.stream().map(BulkOperationResult::httpStatus).collect(Collectors.toSet());
+        if (statuses.size() == 1) {
+            // all responses have the same status - let's just use this
+            this.status = statuses.iterator().next();
+        } else if (statuses.stream().allMatch(s -> s.getStatusCode() >= 500)) {
+            // we got various statuses, but all are some server error
+            this.status = Response.Status.INTERNAL_SERVER_ERROR;
+        } else if (statuses.stream().allMatch(s -> s.getStatusCode() >= 400)) {
+            // we got various statuses, but all are some errors, and there's at least one client error
+            this.status = Response.Status.BAD_REQUEST;
+        } else {
+            // any other mix - caller should inspect the response
+            this.status = Response.Status.OK;
+        }
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkResponse.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/bulk/BulkResponse.java
@@ -24,12 +24,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-public class BulkResponse {
-    private final List<BulkOperationResult> results;
+public class BulkResponse<T> {
+    private final List<BulkOperationResult<T>> results;
     @JsonIgnore
     private final Response.Status status;
 
-    public BulkResponse(List<BulkOperationResult> results) {
+    public BulkResponse(List<BulkOperationResult<T>> results) {
         if (CollectionUtils.isEmpty(results)) {
             throw new IllegalArgumentException("BulkResponse must contain at least 1 result");
         }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UsersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UsersResource.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources.organizations.environments.domains;
 
+import io.gravitee.am.management.handlers.management.api.bulk.BulkOperationResult;
+import io.gravitee.am.management.handlers.management.api.bulk.BulkRequest;
+import io.gravitee.am.management.handlers.management.api.bulk.BulkResponse;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractUsersResource;
 import io.gravitee.am.management.service.IdentityProviderServiceProxy;
 import io.gravitee.am.model.Acl;
@@ -22,7 +25,6 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.permissions.Permission;
-import io.gravitee.am.management.service.DomainService;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.model.NewUser;
 import io.gravitee.common.http.MediaType;
@@ -34,7 +36,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -68,9 +69,6 @@ public class UsersResource extends AbstractUsersResource {
     private ResourceContext resourceContext;
 
     @Autowired
-    private DomainService domainService;
-
-    @Autowired
     private IdentityProviderServiceProxy identityProviderService;
 
     @GET
@@ -83,11 +81,11 @@ public class UsersResource extends AbstractUsersResource {
                     "or DOMAIN_USER[LIST] permission on the specified organization. " +
                     "Each returned user is filtered and contains only basic information such as id and username and displayname. " +
                     "Last login and identity provider name will be also returned if current user has DOMAIN_USER[READ] permission on the domain, environment or organization.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "List users for a security domain",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = UserPage.class))),
-            @ApiResponse(responseCode = "500", description = "Internal server error")})
+
+    @ApiResponse(responseCode = "200", description = "List users for a security domain",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = UserPage.class)))
+    @ApiResponse(responseCode = "500", description = "Internal server error")
     public void list(
             @PathParam("organizationId") String organizationId,
             @PathParam("environmentId") String environmentId,
@@ -122,11 +120,10 @@ public class UsersResource extends AbstractUsersResource {
             description = "User must have the DOMAIN_USER[CREATE] permission on the specified domain " +
                     "or DOMAIN_USER[CREATE] permission on the specified environment " +
                     "or DOMAIN_USER[CREATE] permission on the specified organization")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "User successfully created",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = User.class))),
-            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @ApiResponse(responseCode = "201", description = "User successfully created",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = User.class)))
+    @ApiResponse(responseCode = "500", description = "Internal server error")
     public void create(
             @PathParam("organizationId") String organizationId,
             @PathParam("environmentId") String environmentId,
@@ -145,6 +142,46 @@ public class UsersResource extends AbstractUsersResource {
                                 .created(URI.create("/organizations/" + organizationId + "/environments/" + environmentId + "/domains/" + domainId + "/users/" + user.getId()))
                                 .entity(user)
                                 .build()))
+                .subscribe(response::resume, response::resume);
+    }
+
+
+    @POST
+    @Path("/bulk")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "bulkCreateUser",
+            summary = "Create multiple users on the specified security domain",
+            description = "User must have the DOMAIN_USER[CREATE] permission on the specified domain " +
+                    "or DOMAIN_USER[CREATE] permission on the specified environment " +
+                    "or DOMAIN_USER[CREATE] permission on the specified organization")
+
+    @ApiResponse(responseCode = "200", description = "Some users got created, inspect each result for details",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = BulkResponse.class)))
+    @ApiResponse(responseCode = "201", description = "All users successfully created",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = BulkResponse.class)))
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    public void bulkCreate(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("environmentId") String environmentId,
+            @PathParam("domain") String domainId,
+            @Parameter(name = "user", required = true)
+            @Valid @NotNull final BulkRequest<NewUser> newUsers,
+            @Suspended final AsyncResponse response) {
+
+        final io.gravitee.am.identityprovider.api.User authenticatedUser = getAuthenticatedUser();
+
+        checkAnyPermission(organizationId, environmentId, domainId, Permission.DOMAIN_USER, Acl.CREATE)
+                .andThen(domainService.findById(domainId)
+                        .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId)))
+                        .flatMapSingle(domain ->
+                                newUsers.processOneByOne(newUser -> userService.create(domain, newUser, authenticatedUser)
+                                        .map(BulkOperationResult::created)
+                                        .onErrorResumeNext(ex -> Single.just(BulkOperationResult.error(Response.Status.BAD_REQUEST, ex))))
+                        ))
                 .subscribe(response::resume, response::resume);
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UsersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/UsersResource.java
@@ -15,21 +15,25 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources.organizations.users;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.management.handlers.management.api.bulk.BulkOperationResult;
 import io.gravitee.am.management.handlers.management.api.bulk.BulkRequest;
 import io.gravitee.am.management.handlers.management.api.model.UserEntity;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractUsersResource;
 import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Organization;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.OrganizationService;
+import io.gravitee.am.service.exception.NotImplementedException;
 import io.gravitee.am.service.model.NewOrganizationUser;
 import io.gravitee.common.http.MediaType;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.SingleSource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -55,6 +59,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.net.URI;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -73,6 +78,8 @@ public class UsersResource extends AbstractUsersResource {
 
     @Autowired
     private OrganizationService organizationService;
+    @Autowired
+    private ObjectMapper mapper;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -143,29 +150,46 @@ public class UsersResource extends AbstractUsersResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
-            operationId = "bulkCreateOrganisationUser",
-            summary = "Create a platform user or Service Account",
-            description = "User must have the ORGANIZATION_USER[READ] permission on the specified organization")
+            operationId = "bulkOrganisationUserOperatiom",
+            summary = "Create/update/delete platform users or Service Accounts",
+            description = "User must have the ORGANIZATION_USER[CREATE/UPDATE/DELETE] permission on the specified organization")
 
     @ApiResponse(responseCode = "201", description = "Users or Service Accounts successfully created",
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = NewOrganizationUser.class)))
+                    schema = @Schema(oneOf = {BulkCreateOrganizationUser.class})))
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public void create(
             @PathParam("organizationId") String organizationId,
-            @Valid @NotNull final BulkRequest<NewOrganizationUser> newOrganizationUsers,
+            @Valid @NotNull final BulkRequest.Generic bulkRequest,
             @Suspended final AsyncResponse response) {
 
         final io.gravitee.am.identityprovider.api.User authenticatedUser = getAuthenticatedUser();
 
-        checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_USER, Acl.CREATE)
+        checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_USER, bulkRequest.action().requiredAcl())
                 .andThen(organizationService.findById(organizationId)
-                        .flatMap(organization -> newOrganizationUsers.processOneByOne(user ->
-                                organizationUserService.createGraviteeUser(organization, user, authenticatedUser)
-                                        .map(BulkOperationResult::created)
-                                        .onErrorResumeNext(ex -> Single.just(BulkOperationResult.error(Response.Status.BAD_REQUEST, ex)))
-                        )))
+                        .flatMap(organization -> processBulkRequest(bulkRequest, organization, authenticatedUser)))
                 .subscribe(response::resume, response::resume);
+    }
+
+    private static class BulkCreateOrganizationUser extends  BulkRequest<NewOrganizationUser> {
+        public BulkCreateOrganizationUser() {
+            super(Action.CREATE);
+        }
+    }
+
+    private SingleSource<?> processBulkRequest(BulkRequest.Generic bulkRequest, Organization organization, io.gravitee.am.identityprovider.api.User authenticatedUser) {
+        return switch (bulkRequest.action()) {
+            case CREATE -> bulkRequest.processOneByOne(NewOrganizationUser.class, mapper, user ->
+                    organizationUserService.createGraviteeUser(organization, user, authenticatedUser)
+                            .map(BulkOperationResult::created)
+                            .onErrorResumeNext(ex -> Single.just(BulkOperationResult.error(Response.Status.BAD_REQUEST, ex)))
+            );
+
+            case UPDATE, DELETE -> Single.error(new NotImplementedException("not implemented"));
+
+        };
+
+
     }
 
     @Path("{user}")

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/bulk/BulkRequestTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/bulk/BulkRequestTest.java
@@ -44,7 +44,7 @@ class BulkRequestTest {
                     return (BulkResponse) entity;
                 })
                 .test()
-                .awaitDone(MAX_DELAY_MS * 2, TimeUnit.MILLISECONDS)
+                .awaitDone(MAX_DELAY_MS * 5, TimeUnit.MILLISECONDS)
                 .assertComplete()
                 .assertValueCount(1)
                 .values()

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/bulk/BulkRequestTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/bulk/BulkRequestTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.bulk;
+
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.Response;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class BulkRequestTest {
+
+    private static final int MAX_DELAY_MS = 250;
+
+    @Test
+    void shouldReturnItemsInOriginalOrder() {
+        var items = (IntStream.iterate(0, i -> i + 1).limit(20).boxed().toList());
+
+        var expectedResults = items.stream().map(x -> BulkOperationResult.ok(pretendToDoStuff(x)).withIndex(x)).toList();
+
+        var actualResults = new BulkRequest<>(items)
+                // randomize delays so that the results are emitted in different order
+                .processOneByOne(i -> Single.just(BulkOperationResult.ok(pretendToDoStuff(i))).delay((long) Math.floor(Math.random() * MAX_DELAY_MS), TimeUnit.MILLISECONDS))
+                .map(Response::getEntity)
+                .map(entity -> {
+                    assertThat(entity).isInstanceOf(BulkResponse.class);
+                    return (BulkResponse) entity;
+                })
+                .test()
+                .awaitDone(MAX_DELAY_MS * 2, TimeUnit.MILLISECONDS)
+                .assertComplete()
+                .assertValueCount(1)
+                .values()
+                .get(0)
+                .getResults();
+
+        // even with out-of-order processing, results should be returned in the input order
+        AssertionsForInterfaceTypes.assertThat(actualResults).containsExactlyElementsOf(expectedResults);
+
+
+    }
+
+    int pretendToDoStuff(int value) {
+        return value + 100;
+    }
+
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/bulk/BulkResponseTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/bulk/BulkResponseTest.java
@@ -1,0 +1,38 @@
+package io.gravitee.am.management.handlers.management.api.bulk;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class BulkResponseTest {
+
+    @Test
+    void atLeastOneResultIsRequired() {
+        List<BulkOperationResult<Void>> noResults = List.of();
+        assertThatThrownBy(() -> new BulkResponse<>(noResults))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("BulkResponse must contain at least 1 result");
+    }
+
+    @Test
+    void resultsGetSortedByIndex() {
+        var results = Stream.of(
+                BulkOperationResult.success(Response.Status.OK,"a"),
+                BulkOperationResult.success(Response.Status.OK,"b"),
+                BulkOperationResult.success(Response.Status.OK,"c"),
+                BulkOperationResult.success(Response.Status.OK,"d"),
+                BulkOperationResult.success(Response.Status.OK,"e")
+        ).map(x->x.withIndex((int)Math.floor(Math.random()*100)))
+                .toList();
+        
+        var response = new BulkResponse<>(results);
+        assertThat(response.getResults()).isSortedAccordingTo(Comparator.comparing(BulkOperationResult::index));
+    }
+
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/bulk/BulkResponseTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/bulk/BulkResponseTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.am.management.handlers.management.api.bulk;
 
 import jakarta.ws.rs.core.Response;


### PR DESCRIPTION
## :id: Reference related issue. 
AM-3573

## :pencil2: A description of the changes proposed in the pull request
This PR introduces new bulk endpoints for creating domain & organisation users.
It's implemented using a new `BulkRequest` class that provides a unified way of representing and handling bulk execution of existing operations.
