### PR TITLE
fix(helm): use right default service port from helm chart

### DIFF
--- a/helm/templates/api/_api-deployment-probes.tpl
+++ b/helm/templates/api/_api-deployment-probes.tpl
@@ -26,7 +26,7 @@
         "httpGet" (merge (dict
           "path" "/_node/health?probes=jetty-http-server"
           "scheme" "HTTP"
-          "port" (.Values.api.http.services.core.http.port | default 18082)
+          "port" (.Values.api.http.services.core.http.port | default 18093)
         ) $httpHeadersProbes)
     }}
 
@@ -53,7 +53,7 @@
         "httpGet" (merge (dict
           "path" "/_node/health?probes=jetty-http-server"
           "scheme" "HTTP"
-          "port" (.Values.api.http.services.core.http.port | default 18082)
+          "port" (.Values.api.http.services.core.http.port | default 18093)
         ) $httpHeadersProbes)
     }}
 
@@ -80,7 +80,7 @@
         "httpGet" (merge (dict
           "path" "/_node/health?probes=jetty-http-server,management-repository"
           "scheme" "HTTP"
-          "port" (.Values.api.http.services.core.http.port | default 18082)
+          "port" (.Values.api.http.services.core.http.port | default 18093)
         ) $httpHeadersProbes)
     }}
 

--- a/helm/templates/gateway/_gateway-deployment-probes.tpl
+++ b/helm/templates/gateway/_gateway-deployment-probes.tpl
@@ -32,7 +32,7 @@
         "httpGet" (merge (dict
           "path" "/_node/health?probes=http-server"
           "scheme" $gatewayServiceCoreScheme
-          "port" (.Values.gateway.services.core.http.port | default 18082)
+          "port" (.Values.gateway.services.core.http.port | default 18092)
         ) $httpHeadersProbes)
     }}
 
@@ -61,7 +61,7 @@
         "httpGet" (merge (dict
           "path" $httpGetPath
           "scheme" $gatewayServiceCoreScheme
-          "port" (.Values.gateway.services.core.http.port | default 18082)
+          "port" (.Values.gateway.services.core.http.port | default 18092)
         ) $httpHeadersProbes)
     }}
 
@@ -91,7 +91,7 @@
         "httpGet" (merge (dict
           "path" "/_node/health?probes=http-server,security-domain-sync"
           "scheme" $gatewayServiceCoreScheme
-          "port" (.Values.gateway.services.core.http.port | default 18082)
+          "port" (.Values.gateway.services.core.http.port | default 18092)
         ) $httpHeadersProbes)
     }}
 


### PR DESCRIPTION
## :id: Reference related issue. 

TT-5491

## :pencil2: A description of the changes proposed in the pull request

During previous rework about gateway probes definition with default
value and customisation, we backported default values from helm chart.

However according to the one define in application settings
(gravitee.yaml). They are false.

This commit fix it and align default value between helm chart and
application setting.

