### PR TITLE
Disable creating service users in domains

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/UsersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/UsersResourceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.exception.UserProviderNotFoundException;
+import io.gravitee.am.service.model.NewOrganizationUser;
 import io.gravitee.am.service.model.NewUser;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.util.Maps;
@@ -48,7 +49,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static io.gravitee.am.model.ReferenceType.ORGANIZATION;
-import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -179,8 +180,8 @@ public class UsersResourceTest extends JerseySpringTest {
         Page<User> values = readEntity(response, new TypeReference<>() {
         });
 
-        assertEquals(values.getCurrentPage(), 0);
-        assertEquals(values.getTotalCount(), 2);
+        assertThat(values.getCurrentPage()).isZero();
+        assertThat(values.getTotalCount()).isEqualTo(2);
         final Collection<User> data = values.getData();
 
         assertTrue(getFilteredElements(data, User::getId).containsAll(List.of("user-id-1", "domain-id-2")));
@@ -226,8 +227,8 @@ public class UsersResourceTest extends JerseySpringTest {
         Page<User> values = readEntity(response, new TypeReference<>() {
         });
 
-        assertEquals(values.getCurrentPage(), 0);
-        assertEquals(values.getTotalCount(), 2);
+        assertThat(values.getCurrentPage()).isZero();
+        assertThat(values.getTotalCount()).isEqualTo(2);
         final Collection<User> data = values.getData();
 
         assertTrue(getFilteredElements(data, User::getId).containsAll(List.of("user-id-1", "domain-id-2")));
@@ -240,7 +241,7 @@ public class UsersResourceTest extends JerseySpringTest {
     }
 
     private static <T> List<T> getFilteredElements(Collection<User> data, Function<User, T> mapper, boolean withNulls) {
-        return data.stream().map(mapper).filter(i -> withNulls || i != null).distinct().collect(toList());
+        return data.stream().map(mapper).filter(i -> withNulls || i != null).distinct().toList();
     }
 
     @Test
@@ -307,7 +308,7 @@ public class UsersResourceTest extends JerseySpringTest {
 
         when(organizationUserService.createGraviteeUser(any(), any(), any())).thenReturn(Single.just(mockUser));
 
-        final NewUser entity = new NewUser();
+        final var entity = new NewOrganizationUser();
         entity.setUsername("test");
         entity.setPassword("password");
         entity.setEmail("email@acme.fr");
@@ -341,7 +342,7 @@ public class UsersResourceTest extends JerseySpringTest {
 
         when(organizationUserService.createGraviteeUser(any(), any(), any())).thenReturn(Single.just(mockUser));
 
-        final NewUser entity = new NewUser();
+        final NewOrganizationUser entity = new NewOrganizationUser();
         entity.setUsername("test");
         entity.setEmail("test@test.com");
         entity.setServiceAccount(Boolean.TRUE);
@@ -408,8 +409,8 @@ public class UsersResourceTest extends JerseySpringTest {
         Page<User> values = readEntity(response, new TypeReference<>() {
         });
 
-        assertEquals(values.getCurrentPage(), 0);
-        assertEquals(values.getTotalCount(), 3);
+        assertThat(values.getCurrentPage()).isZero();
+        assertThat(values.getTotalCount()).isEqualTo(3);
         final Collection<User> data = values.getData();
 
         assertTrue(getFilteredElements(data, User::getId).containsAll(List.of("service-id-1", "user-id-2", "user-id-3")));

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AbstractUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/AbstractUserService.java
@@ -321,7 +321,7 @@ public abstract class AbstractUserService<T extends io.gravitee.am.service.Commo
         user.setCreatedAt(new Date());
         user.setUpdatedAt(user.getCreatedAt());
         user.setLastPasswordReset(user.getCreatedAt());
-        user.setServiceAccount(newUser.getServiceAccount());
+        user.setServiceAccount(false);
         return user;
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
@@ -108,6 +108,12 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
                 }));
     }
 
+    protected User transform(NewOrganizationUser newUser, ReferenceType referenceType, String referenceId) {
+        var user = super.transform(newUser, referenceType, referenceId);
+        user.setServiceAccount(newUser.isServiceAccount());
+        return user;
+    }
+
     public Single<User> createGraviteeUser(Organization organization, NewOrganizationUser newUser, io.gravitee.am.identityprovider.api.User principal) {
         if (StringUtils.isBlank(newUser.getUsername())) {
             return Single.error(() -> new UserInvalidException("Field [username] is required"));
@@ -134,7 +140,7 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
                                     newUser.setClient(null);
                                     // user is flagged as internal user
                                     newUser.setInternal(true);
-                                    if (newUser.getServiceAccount() == null || newUser.getServiceAccount().equals(Boolean.FALSE)) {
+                                    if (!newUser.isServiceAccount()) {
                                         String password = newUser.getPassword();
                                         if (password == null || !passwordService.isValid(password)) {
                                             return Single.error(InvalidPasswordException.of("Field [password] is invalid", "invalid_password_value"));
@@ -156,7 +162,7 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
                                                     .map(idpUser -> {
                                                         // Excepted for GraviteeIDP that manage Organization Users
                                                         // AM 'users' collection is not made for authentication (but only management stuff)
-                                                        if(newUser.getServiceAccount() == null || newUser.getServiceAccount().equals(Boolean.FALSE)) {
+                                                        if(!newUser.isServiceAccount()) {
                                                             userToPersist.setPassword(PWD_ENCODER.encode(newUser.getPassword()));
                                                         }
                                                         // set external id

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AbstractNewUser.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AbstractNewUser.java
@@ -79,8 +79,6 @@ public abstract class AbstractNewUser implements IUser {
 
     private Boolean forceResetPassword;
 
-    private Boolean serviceAccount;
-
     @Override
     @JsonIgnore
     public String getDisplayName() {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewOrganizationUser.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewOrganizationUser.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service.model;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -25,4 +26,10 @@ import lombok.ToString;
 public class NewOrganizationUser extends AbstractNewUser {
 
     private String email;
+    @Getter(AccessLevel.NONE)
+    private Boolean serviceAccount;
+
+    public boolean isServiceAccount() {
+        return Boolean.TRUE == serviceAccount;
+    }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
AM-4194

## :pencil2: A description of the changes proposed in the pull request

This PR removes the `serviceAccount` field from new user model to disallow creating service accounts on domain level.
Service accoutns should only be used in organisation context.