### PR TITLE
fix: align SCIM list behaviour with the RFC [BREAKING CHANGE]

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/resources/groups/GroupsEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/resources/groups/GroupsEndpoint.java
@@ -59,7 +59,7 @@ public class GroupsEndpoint extends AbstractGroupEndpoint {
         // A value less than 1 SHALL be interpreted as 1.
         try {
             final String startIndex = context.request().getParam("startIndex");
-            page = Integer.parseInt(startIndex);
+            page = Integer.max(Integer.parseInt(startIndex), 1);
         } catch (Exception ex) {
             log.error("Error parsing 'startIndex' parameter", ex);
         }
@@ -68,7 +68,7 @@ public class GroupsEndpoint extends AbstractGroupEndpoint {
         // A value of "0"  indicates that no resource results are to be returned except for "totalResults".
         try {
             final String count = context.request().getParam("count");
-            size = Integer.min(Integer.parseInt(count), MAX_ITEMS_PER_PAGE);
+            size = Integer.min(Integer.max(Integer.parseInt(count), 0), MAX_ITEMS_PER_PAGE);
         } catch (Exception ex) {
             log.error("Error parsing 'count' parameter", ex);
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/resources/users/UsersEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/resources/users/UsersEndpoint.java
@@ -55,15 +55,15 @@ public class UsersEndpoint extends AbstractUserEndpoint {
 
     public void list(RoutingContext context) {
         // Pagination (https://tools.ietf.org/html/rfc7644#section-3.4.2.4)
-        Integer page = DEFAULT_START_INDEX;
+        Integer startIndex = DEFAULT_START_INDEX;
         Integer size = MAX_ITEMS_PER_PAGE;
         Filter filter = null;
 
         // The 1-based index of the first query result.
         // A value less than 1 SHALL be interpreted as 1.
-        final String startIndex = context.request().getParam("startIndex");
-        if (StringUtils.isNumeric(startIndex)) {
-            page = Integer.valueOf(startIndex);
+        final String startIndexParam = context.request().getParam("startIndex");
+        if (StringUtils.isNumeric(startIndexParam)) {
+            startIndex = Integer.max(Integer.valueOf(startIndexParam), 1);
         }
 
         // Non-negative integer. Specifies the desired  results per page, e.g., 10.
@@ -71,7 +71,7 @@ public class UsersEndpoint extends AbstractUserEndpoint {
         // A value of "0"  indicates that no resource results are to be returned except for "totalResults".
         final String count = context.request().getParam("count");
         if (StringUtils.isNumeric(count)) {
-            size = Integer.min(Integer.parseInt(count), MAX_ITEMS_PER_PAGE);
+            size = Integer.min(Integer.max(Integer.valueOf(count), 0), MAX_ITEMS_PER_PAGE);
         }
 
         // Filter results
@@ -86,7 +86,7 @@ public class UsersEndpoint extends AbstractUserEndpoint {
         }
 
         // user service use 0-based index
-        userService.list(filter, page - 1, size, location(context.request()))
+        userService.list(filter, startIndex - 1, size, location(context.request()))
                 .subscribe(
                         users -> context.response()
                                 .putHeader(HttpHeaders.CACHE_CONTROL, "no-store")

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/GroupServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/GroupServiceTest.java
@@ -256,7 +256,7 @@ public class GroupServiceTest {
         final Page page = new Page(groups, 0, groups.size());
         final String domainID = "any-domain-id";
         when(domain.getId()).thenReturn(domainID);
-        when(groupRepository.findAll(ReferenceType.DOMAIN, domainID, 0, 10)).thenReturn(Single.just(page));
+        when(groupRepository.findAllScim(ReferenceType.DOMAIN, domainID, 0, 10)).thenReturn(Single.just(page));
 
         TestObserver<ListResponse<Group>> observer = groupService.list(null, 0, 10, "").test();
         observer.assertNoErrors();
@@ -266,7 +266,7 @@ public class GroupServiceTest {
                 listResp.getResources().stream().map(Group::getDisplayName).collect(Collectors.joining(","))
                         .equals(groups.stream().map(io.gravitee.am.model.Group::getName).collect(Collectors.joining(","))));
 
-        verify(groupRepository, times(1)).findAll(ReferenceType.DOMAIN, domainID, 0, 10);
+        verify(groupRepository, times(1)).findAllScim(ReferenceType.DOMAIN, domainID, 0, 10);
     }
 
     @Test
@@ -276,12 +276,12 @@ public class GroupServiceTest {
         final String domainID = "any-domain-id";
         Filter dummyFilter = new Filter(Operator.EQUALITY, new AttributePath("", "", ""), "", false, null);
         when(domain.getId()).thenReturn(domainID);
-        when(groupRepository.search(any(ReferenceType.class), anyString(), any(FilterCriteria.class), anyInt(), anyInt())).thenReturn(Single.just(page));
+        when(groupRepository.searchScim(any(ReferenceType.class), anyString(), any(FilterCriteria.class), anyInt(), anyInt())).thenReturn(Single.just(page));
 
         TestObserver<ListResponse<Group>> observer = groupService.list(dummyFilter, 0, 10, "").test();
         observer.assertNoErrors();
         observer.assertComplete();
 
-        verify(groupRepository, times(1)).search(any(ReferenceType.class), anyString(), any(FilterCriteria.class), anyInt(), anyInt());
+        verify(groupRepository, times(1)).searchScim(any(ReferenceType.class), anyString(), any(FilterCriteria.class), anyInt(), anyInt());
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/UserServiceTest.java
@@ -32,7 +32,6 @@ import io.gravitee.am.gateway.handler.scim.model.User;
 import io.gravitee.am.gateway.handler.scim.service.impl.UserServiceImpl;
 import io.gravitee.am.identityprovider.api.UserProvider;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.Group;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.PasswordHistory;
 import io.gravitee.am.model.ReferenceType;
@@ -173,7 +172,7 @@ public class UserServiceTest {
         final Page page = new Page(users, 0, users.size());
         final String domainID = "any-domain-id";
         when(domain.getId()).thenReturn(domainID);
-        when(userRepository.findAll(ReferenceType.DOMAIN, domainID, 0, 10)).thenReturn(Single.just(page));
+        when(userRepository.findAllScim(ReferenceType.DOMAIN, domainID, 0, 10)).thenReturn(Single.just(page));
         when(groupService.findByMember(any())).thenReturn(Flowable.empty());
 
         TestObserver<ListResponse<io.gravitee.am.gateway.handler.scim.model.User>> observer = userService.list(null, 0, 10, "").test();
@@ -184,7 +183,7 @@ public class UserServiceTest {
                 listResp.getResources().stream().map(io.gravitee.am.gateway.handler.scim.model.User::getUserName).collect(Collectors.joining(","))
                         .equals(users.stream().map(io.gravitee.am.model.User::getUsername).collect(Collectors.joining(","))));
 
-        verify(userRepository, times(1)).findAll(ReferenceType.DOMAIN, domainID, 0, 10);
+        verify(userRepository, times(1)).findAllScim(ReferenceType.DOMAIN, domainID, 0, 10);
     }
 
     @Test

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/common/Page.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/common/Page.java
@@ -48,4 +48,8 @@ public class Page<T> {
     public long getTotalCount() {
         return totalCount;
     }
+
+    public static int pageFromOffset(int offset, int size) {
+        return size > 0 ? (offset/size) : 0;
+    }
 }

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/GroupRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/GroupRepository.java
@@ -36,9 +36,17 @@ public interface GroupRepository extends CrudRepository<Group, String> {
 
     Flowable<Group> findAll(ReferenceType referenceType, String referenceId);
 
-    Single<Page<Group>> findAll(ReferenceType referenceType, String referenceId, int page, int size);
+    default Single<Page<Group>> findAll(ReferenceType referenceType, String referenceId, int page, int size) {
+        return findAllScim(referenceType, referenceId, page * size, size);
+    }
 
-    Single<Page<Group>> search(ReferenceType referenceType, String referenceId, FilterCriteria criteria, int page, int size);
+    Single<Page<Group>> findAllScim(ReferenceType referenceType, String referenceId, int page, int size);
+
+    default Single<Page<Group>> search(ReferenceType referenceType, String referenceId, FilterCriteria criteria, int page, int size) {
+        return searchScim(referenceType, referenceId, criteria, page * size, size);
+    }
+
+    Single<Page<Group>> searchScim(ReferenceType referenceType, String referenceId, FilterCriteria criteria, int page, int size);
 
     Flowable<Group> findByIdIn(List<String> ids);
 

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/UserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/UserRepository.java
@@ -41,9 +41,32 @@ public interface UserRepository extends CommonUserRepository {
 
     Single<Page<User>> findAll(ReferenceType referenceType, String referenceId, int page, int size);
 
+    /**
+     * Same implementation as findAll for SCIM request as for SCIM pagination the startingIndex value is used instead of the page number.
+     *
+     * @param referenceType
+     * @param referenceId
+     * @param startIndex index of the record from which the search as to start
+     * @param count
+     * @return
+     */
+    Single<Page<User>> findAllScim(ReferenceType referenceType, String referenceId, int startIndex, int count);
+
     Single<Page<User>> search(ReferenceType referenceType, String referenceId, String query, int page, int size);
 
     Single<Page<User>> search(ReferenceType referenceType, String referenceId, FilterCriteria criteria, int page, int size);
+
+    /**
+     * Same implementation as search for SCIM request as for SCIM pagination the startingIndex value is used instead of the page number.
+     *
+     * @param referenceType
+     * @param referenceId
+     * @param criteria
+     * @param startIndex index of the record from which the search as to start
+     * @param count
+     * @return
+     */
+    Single<Page<User>> searchScim(ReferenceType referenceType, String referenceId, FilterCriteria criteria, int startIndex, int count);
 
     Flowable<User> findByDomainAndEmail(String domain, String email, boolean strict);
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/AbstractDialectHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/AbstractDialectHelper.java
@@ -100,11 +100,16 @@ public abstract class AbstractDialectHelper implements DatabaseDialectHelper {
     }
 
     @Override
-    public ScimSearch prepareScimSearchQuery(StringBuilder queryBuilder, FilterCriteria criteria, String sortField, int page, int size, ScimRepository scimRepository) {
+    public ScimSearch prepareScimSearchQueryUsingOffset(StringBuilder queryBuilder, FilterCriteria criteria, String sortField, int offset, int size, ScimRepository scimRepository) {
         ScimSearch search = new ScimSearch();
         processFilters(queryBuilder, criteria, search, scimRepository);
-        search.buildQueries(size > 0 ? buildPagingClause(StringUtils.hasLength(sortField)? sortField : "id" , page, size): "");
+        search.buildQueries(size > 0 ? buildPagingClauseUsingOffset(StringUtils.hasLength(sortField)? sortField : "id" , offset, size): "");
         return search;
+    }
+
+    @Override
+    public ScimSearch prepareScimSearchQuery(StringBuilder queryBuilder, FilterCriteria filterCriteria, String sortField, int page, int size, ScimRepository scimRepository) {
+        return prepareScimSearchQueryUsingOffset(queryBuilder, filterCriteria, sortField, page * size, size, scimRepository);
     }
 
     private ScimSearch processFilters(StringBuilder queryBuilder, FilterCriteria criteria, ScimSearch search, ScimRepository scimRepository) {
@@ -281,6 +286,11 @@ public abstract class AbstractDialectHelper implements DatabaseDialectHelper {
     }
 
     protected abstract ScimSearch processJsonFilter(StringBuilder queryBuilder, FilterCriteria criteria, ScimSearch search);
+
+    @Override
+    public String buildPagingClause(int page, int size) {
+        return buildPagingClause("id", page, size);
+    }
 
     @Override
     public String buildSearchUserQuery(boolean wildcard, int page, int size, boolean organizationUser) {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/DatabaseDialectHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/DatabaseDialectHelper.java
@@ -36,6 +36,8 @@ public interface DatabaseDialectHelper {
 
     ScimSearch prepareScimSearchQuery(StringBuilder queryBuilder, FilterCriteria filterCriteria, String sortField, int page, int size, ScimRepository scimRepository);
 
+    ScimSearch prepareScimSearchQueryUsingOffset(StringBuilder queryBuilder, FilterCriteria filterCriteria, String sortField, int offset, int size, ScimRepository scimRepository);
+
     String buildFindUserByReferenceAndEmail(ReferenceType referenceType, String referenceId, String email, boolean strict);
 
     String buildSearchUserQuery(boolean wildcard, int page, int size, boolean organizationUser);
@@ -66,7 +68,11 @@ public interface DatabaseDialectHelper {
 
     String buildPagingClause(int page, int size);
 
-    String buildPagingClause(String field, int page, int size);
+    default String buildPagingClause(String field, int page, int size) {
+        return buildPagingClauseUsingOffset(field, page * size, size);
+    }
+
+    String buildPagingClauseUsingOffset(String field, int offset, int size);
 
     enum ScimRepository {GROUPS, ORGANIZATION_USERS, USERS}
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/MsSqlHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/MsSqlHelper.java
@@ -85,12 +85,8 @@ public class MsSqlHelper extends AbstractDialectHelper {
         return search;
     }
 
-    public String buildPagingClause(int page, int size) {
-        return buildPagingClause("id", page, size);
-    }
-
-    public String buildPagingClause(String field, int page, int size) {
-        return " ORDER BY "+ field +" OFFSET "+ (page * size) +" ROWS FETCH NEXT " + size + " ROWS ONLY ";
+    public String buildPagingClauseUsingOffset(String field, int offset, int size) {
+        return " ORDER BY "+ field +" OFFSET "+ offset +" ROWS FETCH NEXT " + size + " ROWS ONLY ";
     }
 
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/MySqlHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/MySqlHelper.java
@@ -74,12 +74,8 @@ public class MySqlHelper extends AbstractDialectHelper {
         return search;
     }
 
-    public String buildPagingClause(int page, int size) {
-        return buildPagingClause("id", page, size);
-    }
-
-    public String buildPagingClause(String field, int page, int size) {
-        return " ORDER BY " + field + " LIMIT " + size + " OFFSET " + (page * size);
+    public String buildPagingClauseUsingOffset(String field, int offset, int size) {
+        return " ORDER BY " + field + " LIMIT " + size + " OFFSET " + offset;
     }
 
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/PostgresqlHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/PostgresqlHelper.java
@@ -135,12 +135,8 @@ public class PostgresqlHelper extends AbstractDialectHelper {
                 .append(" ) ");
     }
 
-    public String buildPagingClause(int page, int size) {
-        return buildPagingClause("id", page, size);
-    }
-
-    public String buildPagingClause(String field, int page, int size) {
-        return " ORDER BY " + field + " LIMIT " + size + " OFFSET " + (page * size);
+    public String buildPagingClauseUsingOffset(String field, int offset, int size) {
+        return " ORDER BY " + field + " LIMIT " + size + " OFFSET " + offset;
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/OffsetPageRequest.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/OffsetPageRequest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.repository.jdbc.management.api;
+
+
+import org.springframework.data.domain.AbstractPageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class OffsetPageRequest extends AbstractPageRequest {
+    private final int offset;
+    private final Sort sort;
+
+    public OffsetPageRequest(int offset, int size) {
+        this(offset, size, Sort.unsorted());
+    }
+
+    public OffsetPageRequest(int offset, int size, Sort sort) {
+        super(size > 0 ? (offset/size) : 0, size);
+        this.offset = offset;
+        this.sort = sort;
+    }
+
+    @Override
+    public Pageable next() {
+        return new OffsetPageRequest(offset + getPageSize(), getPageSize(), this.sort);
+    }
+
+    @Override
+    public Pageable previous() {
+        return new OffsetPageRequest(Integer.max(0, offset - getPageSize()), getPageSize(), this.sort);
+    }
+
+    @Override
+    public Pageable first() {
+        return new OffsetPageRequest(0, getPageSize(), this.sort);
+    }
+
+    @Override
+    public Sort getSort() {
+        return this.sort;
+    }
+
+    @Override
+    public Pageable withPage(int pageNumber) {
+        return new OffsetPageRequest(pageNumber * getPageSize(), getPageSize(), this.sort);
+    }
+}

--- a/gravitee-am-service/pom.xml
+++ b/gravitee-am-service/pom.xml
@@ -155,7 +155,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>${spring-security.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <commons-cli.version>1.4</commons-cli.version>
         <ognl.version>3.3.4</ognl.version>
         <mockito-jupiter.version>4.4.0</mockito-jupiter.version>
-        <test-container.version>1.17.6</test-container.version>
+        <test-container.version>1.20.3</test-container.version>
 
         <!-- R2DBC dependencies -->
         <spring-data-r2dbc.version>3.2.2</spring-data-r2dbc.version>
@@ -126,13 +126,6 @@
         <jdbc-mssql.version>7.4.1.jre8</jdbc-mssql.version>
         <jdbc-mysql.version>8.0.33</jdbc-mysql.version>
         <jdbc-mariadb.version>2.4.0</jdbc-mariadb.version>
-
-        <!--
-        we have to redefine the property here
-        due to the spring-security-crypto dep into
-        the gravitee-am-service module
-        -->
-        <spring-security.version>6.2.1</spring-security.version>
 
         <!-- External plugins versions -->
         <gravitee-policy-callout-http.version>3.0.0</gravitee-policy-callout-http.version>


### PR DESCRIPTION
 in the RFC the startIndex represent the entity position on the storage but on AM we were considering the page number

fixes AM-4310

## :warning: NOTE

This PR is a draft on top of AM-4300 PR to run the CI on the "ordered" result seach/list fix.
AM-4300 need to be merged first and apply on 4.6.0/master before beeing able to apply this one on 4.6.0/master 