### PR TITLE
fix(helm): remove probes from upgrader manifest

### DIFF
--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -115,8 +115,10 @@ spec:
               containerPort: {{ .Values.api.http.services.core.http.port | default "18093" }}
             {{- end }}
           env:
+            {{- if .Values.api.upgrader }}
             - name: upgrade.mode
               value: "false"
+            {{- end }}
             {{- if $plugins }}
             - name: GRAVITEE_PLUGINS_PATH_0
               value: '${gravitee.home}/plugins'

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -104,54 +104,6 @@ spec:
             - name: GRAVITEE_PLUGINS_PATH_1
               value: '${gravitee.home}/plugins-ext'
             {{- end }}
-            {{- if .Values.cockpit.enabled }}
-            - name: gravitee_cockpit_enabled
-              value: "true"
-            - name: gravitee_cockpit_url
-              value: {{ .Values.cockpit.url }}
-            - name: gravitee_cockpit_ws_endpoints_0
-              value: {{ .Values.cockpit.controller }}
-            - name: gravitee_cockpit_keystore_type
-              value: pkcs12
-            - name: gravitee_cockpit_keystore_path
-              value: /opt/graviteeio-am-management-api/cockpit/keystore.p12
-            - name: gravitee_cockpit_keystore_password
-              {{- toYaml .Values.cockpit.keystore.password | nindent 14}}
-            {{- if .Values.cockpit.truststore }}
-            - name: gravitee_cockpit_truststore_type
-              value: pkcs12
-            - name: gravitee_cockpit_truststore_path
-              value: /opt/graviteeio-am-management-api/cockpit/truststore.p12
-            - name: gravitee_cockpit_truststore_password
-              {{- toYaml .Values.cockpit.truststore.password | nindent 14}}
-            {{- end }}
-            - name: gravitee_cockpit_ssl_verifyHostname
-              value: "{{ .Values.cockpit.ssl.verifyHostname }}"
-            {{- end }}
-            {{- if .Values.cloud.enabled }}
-            - name: gravitee_cloud_enabled
-              value: "true"
-            - name: gravitee_cloud_url
-              value: {{ .Values.cloud.url }}
-            - name: gravitee_cloud_connector_ws_endpoints_0
-              value: {{ .Values.cloud.controller }}
-            - name: gravitee_cloud_connector_ws_ssl_keystore_type
-              value: pkcs12
-            - name: gravitee_cloud_connector_ws_ssl_keystore_path
-              value: /opt/graviteeio-am-management-api/cockpit/keystore.p12
-            - name: gravitee_cloud_connector_ws_ssl_keystore_password
-              {{- toYaml .Values.cloud.connector.ws.ssl.keystore.password | nindent 14 }}
-            {{- if .Values.cloud.connector.ws.ssl.truststore }}
-            - name: gravitee_cloud_connector_ws_ssl_truststore_type
-              value: pkcs12
-            - name: gravitee_cloud_connector_ws_ssl_truststore_path
-              value: /opt/graviteeio-am-management-api/cockpit/truststore.p12
-            - name: gravitee_cloud_connector_ws_ssl_truststore_password
-              {{- toYaml .Values.cloud.connector.ws.ssl.truststore.password | nindent 14 }}
-            {{- end }}
-            - name: gravitee_cloud_connector_ws_ssl_verifyHost
-              value: "{{ .Values.cloud.connector.ws.ssl.verifyHost }}"
-            {{- end }}
 {{- if .Values.api.env | default .Values.api.deployment.extraEnvs }}
 {{ toYaml ( .Values.api.env | default .Values.api.deployment.extraEnvs ) | indent 12 }}
 {{- end }}
@@ -169,8 +121,6 @@ spec:
                 command: {{ .Values.api.lifecycle.preStop }}
             {{- end }}
           {{- end }}
-          livenessProbe: {{ toYaml .Values.api.livenessProbe | nindent 12 }}
-          readinessProbe: {{ toYaml .Values.api.readinessProbe | nindent 12 }}
           resources: {{ toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:
             - name: config
@@ -187,16 +137,6 @@ spec:
             - name: graviteeio-am-jdbc-ext
               mountPath: /opt/graviteeio-am-management-api/plugins/ext/reporter-am-jdbc
           {{- end }}
-          {{- if .Values.cockpit.enabled }}
-            - name: gravitee-cockpit-certificates
-              mountPath: /opt/graviteeio-am-management-api/cockpit
-              readOnly: true
-          {{- end }}
-          {{- if .Values.cloud.enabled }}
-            - name: gravitee-cloud-certificates
-              mountPath: /opt/graviteeio-am-management-api/cloud
-              readOnly: true
-          {{- end }}
           {{- include "deployment.pluginVolumeMounts" $pluginParams | indent 12 }}
           {{- with .Values.api.extraVolumeMounts }}
           {{- tpl . $ | nindent 12 }}
@@ -212,16 +152,6 @@ spec:
         {{- if and .Values.jdbc.drivers (eq .Values.management.type "jdbc") }}
         - name: graviteeio-am-jdbc-ext
           emptyDir: { }
-        {{- end }}
-        {{- if .Values.cockpit.enabled }}
-        - name: gravitee-cockpit-certificates
-          secret:
-            secretName: gravitee-cockpit-certificates
-        {{- end }}
-        {{- if .Values.cloud.enabled }}
-        - name: gravitee-cloud-certificates
-          mountPath: /opt/graviteeio-am-management-api/cloud
-          readOnly: true
         {{- end }}
         {{- include "deployment.pluginVolumes" $pluginParams | indent 8 }}
         {{- with .Values.api.extraVolumes }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -244,7 +244,11 @@ applications:
 
 api:
   enabled: true
-  upgrader: false
+  ## upgrader can be enabled
+  ## this is missing by default to be sure that upgrades are managed on mAPI startup
+  ## * missing upgrader key or upgrader = false will not execute the upgrader job but will execute the upgrade on MAPI startup
+  ## * upgrader = true will execute the upgrader job and the upgrader will not be executed on MAPI startup
+  #upgrader: false
   name: management-api
   logging:
     debug: false


### PR DESCRIPTION
 as upgraders are executed before listening the HTTP port

 and we are not able to evaluate the duration of an upgrade

 as consequence we decided to remove probes for upgraders

 we also cleanup the cockpit/cloud settings as it is useless to connect to cockpit during upgrade

Default value for the upgrader fwk has been removed to always execute the upgraders during mAPI startup (legacy behaviour)

fixes AM-4313
