### PR TITLE
fix: evaluate session state before FORM rendering and submission

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -276,4 +276,10 @@ public interface ConstantKeys {
     String PROTOCOL_VALUE_SAML_REDIRECT = "SAML/HTTP-Redirect";
     String PROTOCOL_VALUE_SAML_POST = "SAML/HTTP-POST";
     String IDP_CODE_VERIFIER = "idp_code_verifier";
+
+    // This const is used by the authorization endpoint to flag an ongoing authentication
+    String SESSION_KEY_AUTH_FLOW_STATE = "auth_state";
+    // note: Create an enum if another value becomes useful
+    String SESSION_KEY_AUTH_FLOW_STATE_ONGOING = "ongoing";
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-core/src/main/java/io/gravitee/am/gateway/core/LegacySettingsKeys.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-core/src/main/java/io/gravitee/am/gateway/core/LegacySettingsKeys.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.core;
+
+
+import org.springframework.core.env.Environment;
+
+import static java.util.Objects.isNull;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum LegacySettingsKeys {
+
+    HANDLER_SKIP_BYPASS_DIRECT_REQUEST_HDL("legacy.handler.skipBypassDirectRequestHandler", Boolean.FALSE),
+    OIDC_FILTER_CUSTOM_PROMPT("legacy.openid.filterCustomPrompt", Boolean.FALSE),
+    OIDC_SCOPE_FULL_PROFILE("legacy.openid.openid_scope_full_profile", Boolean.FALSE),
+    OIDC_ALWAYS_ENHANCE_SCOPE("legacy.openid.always_enhance_scopes", Boolean.FALSE),
+    HANDLER_ALWAYS_APPLY_BODY_HDL("legacy.handler.alwaysApplyBodyHandler", Boolean.FALSE),
+    REGISTRATION_KEEP_PARAMS("legacy.registration.keepParams", Boolean.TRUE),
+    RESET_PWD_KEEP_PARAMS("legacy.resetPassword.keepParam", Boolean.TRUE),
+    OIDC_SANITIZE_PARAM_ENCODING("legacy.openid.sanitizeParametersEncoding", Boolean.TRUE);
+
+    private String key;
+    private Boolean defaultValue;
+
+    LegacySettingsKeys(String key, Boolean defaultValue) {
+        this.key = key;
+        this.defaultValue = defaultValue;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Boolean getDefaultValue() {
+        return defaultValue;
+    }
+
+    public boolean from(Environment environment) {
+        return isNull(environment) ? defaultValue : environment.getProperty(key, Boolean.class, defaultValue);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProvider.java
@@ -19,6 +19,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.core.env.Environment;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.OIDC_SANITIZE_PARAM_ENCODING;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class StaticEnvironmentProvider {
 
@@ -33,7 +35,7 @@ public class StaticEnvironmentProvider {
 
     public static boolean sanitizeParametersEncoding() {
         if (sanitizeParametersEncoding == null) {
-            sanitizeParametersEncoding = getEnvironmentProperty("legacy.openid.sanitizeParametersEncoding", boolean.class, true);
+            sanitizeParametersEncoding = OIDC_SANITIZE_PARAM_ENCODING.from(env);
         }
         return sanitizeParametersEncoding;
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/RedirectHelper.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/RedirectHelper.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.common.vertx.utils;
+
+
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.service.utils.vertx.RequestUtils;
+import io.gravitee.common.http.HttpHeaders;
+import io.vertx.rxjava3.core.MultiMap;
+import io.vertx.rxjava3.core.http.HttpServerResponse;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RedirectHelper {
+
+    /**
+     * Compute the URL on which a user has to be redirected by looking into the
+     * user session, then the request and finally if no returnUrl is found, forge
+     * an URL to authorization endpoint.
+     *
+     * @param context
+     * @param queryParams
+     * @return
+     */
+    public static String getReturnUrl(RoutingContext context, MultiMap queryParams) {
+        // look into the session
+        if (context.session().get(ConstantKeys.RETURN_URL_KEY) != null) {
+            return context.session().get(ConstantKeys.RETURN_URL_KEY);
+        }
+        // look into the request parameters
+        if (context.request().getParam(ConstantKeys.RETURN_URL_KEY) != null) {
+            return context.request().getParam(ConstantKeys.RETURN_URL_KEY);
+        }
+        // fallback to the OAuth 2.0 authorize endpoint
+        return UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/oauth/authorize", queryParams, true);
+    }
+
+    public static void doRedirect(HttpServerResponse response, String url) {
+        response.putHeader(HttpHeaders.LOCATION, url)
+                .setStatusCode(302)
+                .end();
+    }
+
+    /**
+     * Retrieve the redirectUrl from the routing context using the {@link #getReturnUrl(RoutingContext, MultiMap)} method
+     * and apply the redirect (302 status) on the HttpResponse.
+     *
+     * @param context
+     */
+    public static void doRedirect(RoutingContext context) {
+        final MultiMap queryParams = RequestUtils.getCleanedQueryParams(context.request());
+        final String redirectUri = getReturnUrl(context, queryParams);
+        doRedirect(context.response(), redirectUri);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/AuthenticationFlowChainHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/internal/AuthenticationFlowChainHandler.java
@@ -15,10 +15,13 @@
  */
 package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.internal;
 
+import io.gravitee.am.common.utils.ConstantKeys;
 import io.vertx.core.Handler;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 
 import java.util.List;
+
+import static org.springframework.util.StringUtils.hasText;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -34,6 +37,10 @@ public class AuthenticationFlowChainHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(RoutingContext routingContext) {
+        if (routingContext.session() != null && !hasText(routingContext.session().get(ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE))) {
+            routingContext.session().put(ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE, ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE_ONGOING);
+        }
+
         new AuthenticationFlowChain(steps)
                 .exitHandler(stepHandler -> stepHandler.handle(routingContext))
                 .handle(routingContext);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProviderTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/utils/StaticEnvironmentProviderTest.java
@@ -20,6 +20,7 @@ import org.springframework.core.env.Environment;
 
 import org.junit.Test;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.OIDC_SANITIZE_PARAM_ENCODING;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
@@ -29,7 +30,7 @@ public class StaticEnvironmentProviderTest {
 
     @BeforeClass
     public static void setup() {
-        when(env.getProperty("legacy.openid.sanitizeParametersEncoding", boolean.class, true))
+        when(env.getProperty(OIDC_SANITIZE_PARAM_ENCODING.getKey(), Boolean.class, OIDC_SANITIZE_PARAM_ENCODING.getDefaultValue()))
                 .thenReturn(false)
                 .thenReturn(true);
         StaticEnvironmentProvider.setEnvironment(env);
@@ -41,6 +42,6 @@ public class StaticEnvironmentProviderTest {
 
         // Call method twice to test cached value is used
         assertFalse(StaticEnvironmentProvider.sanitizeParametersEncoding());
-        verify(env).getProperty("legacy.openid.sanitizeParametersEncoding", boolean.class, true);
+        verify(env).getProperty(OIDC_SANITIZE_PARAM_ENCODING.getKey(), Boolean.class, OIDC_SANITIZE_PARAM_ENCODING.getDefaultValue());
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/session/SessionManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/session/SessionManager.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.manager.session;
+
+
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SessionManager {
+
+
+
+    public void cleanSessionAfterAuth(RoutingContext context) {
+        cleanSessionOnMfaChallenge(context);
+        if (context.session() != null) {
+            context.session().remove(ConstantKeys.TRANSACTION_ID_KEY);
+            context.session().remove(ConstantKeys.USER_CONSENT_COMPLETED_KEY);
+            context.session().remove(ConstantKeys.WEBAUTHN_CREDENTIAL_ID_CONTEXT_KEY);
+            context.session().remove(ConstantKeys.WEBAUTHN_CREDENTIAL_INTERNAL_ID_CONTEXT_KEY);
+            context.session().remove(ConstantKeys.PASSWORDLESS_AUTH_ACTION_KEY);
+            context.session().remove(ConstantKeys.MFA_FACTOR_ID_CONTEXT_KEY);
+            context.session().remove(ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY);
+            context.session().remove(ConstantKeys.MFA_CHALLENGE_COMPLETED_KEY);
+            context.session().remove(ConstantKeys.USER_LOGIN_COMPLETED_KEY);
+            context.session().remove(ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY);
+
+            context.session().remove(ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE);
+        }
+    }
+
+    public void cleanSessionOnMfaChallenge(RoutingContext context) {
+        if (context.session() != null) {
+            context.session().remove(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY);
+            context.session().remove(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY);
+
+            context.session().remove(ConstantKeys.ENROLLED_FACTOR_ID_KEY);
+            context.session().remove(ConstantKeys.ENROLLED_FACTOR_SECURITY_VALUE_KEY);
+            context.session().remove(ConstantKeys.ENROLLED_FACTOR_PHONE_NUMBER);
+            context.session().remove(ConstantKeys.ENROLLED_FACTOR_EXTENSION_PHONE_NUMBER);
+            context.session().remove(ConstantKeys.ENROLLED_FACTOR_EMAIL_ADDRESS);
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/AbstractEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/AbstractEndpoint.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.am.gateway.handler.root.resources.endpoint;
 
-import io.gravitee.am.common.utils.ConstantKeys;
-import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.manager.form.FormManager;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.UserActivityService;
@@ -24,7 +22,6 @@ import io.gravitee.am.service.exception.NotImplementedException;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.MediaType;
 import io.reactivex.rxjava3.core.Single;
-import io.vertx.rxjava3.core.MultiMap;
 import io.vertx.rxjava3.core.buffer.Buffer;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.ext.web.RoutingContext;
@@ -40,7 +37,6 @@ import static io.gravitee.am.common.utils.ConstantKeys.USER_ACTIVITY_ENABLED;
 import static io.gravitee.am.common.utils.ConstantKeys.USER_ACTIVITY_RETENTION_TIME;
 import static io.gravitee.am.common.utils.ConstantKeys.USER_CONSENT_IP_LOCATION;
 import static io.gravitee.am.common.utils.ConstantKeys.USER_CONSENT_USER_AGENT;
-import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
 import static java.lang.Boolean.TRUE;
 
 /**
@@ -91,20 +87,6 @@ public abstract class AbstractEndpoint {
     protected Single<Buffer> renderPage(Map<String, Object> data, Client client) {
         return templateEngine.render(data, getTemplateFileName(client));
     }
-
-    protected final String getReturnUrl(RoutingContext context, MultiMap queryParams) {
-        // look into the session
-        if (context.session().get(ConstantKeys.RETURN_URL_KEY) != null) {
-            return context.session().get(ConstantKeys.RETURN_URL_KEY);
-        }
-        // look into the request parameters
-        if (context.request().getParam(ConstantKeys.RETURN_URL_KEY) != null) {
-            return context.request().getParam(ConstantKeys.RETURN_URL_KEY);
-        }
-        // fallback to the OAuth 2.0 authorize endpoint
-        return UriBuilderRequest.resolveProxyRequest(context.request(), context.get(CONTEXT_PATH) + "/oauth/authorize", queryParams, true);
-    }
-
 
     protected void addUserActivityTemplateVariables(RoutingContext routingContext, UserActivityService userActivityService) {
         routingContext.put(USER_ACTIVITY_ENABLED, userActivityService.canSaveUserActivity());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginCallbackEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginCallbackEndpoint.java
@@ -48,6 +48,7 @@ import static io.gravitee.am.common.utils.ConstantKeys.OIDC_PROVIDER_ID_TOKEN_KE
 import static io.gravitee.am.common.utils.ConstantKeys.PARAM_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.STATUS_SIGNED_IN;
 import static io.gravitee.am.common.web.UriBuilder.encodeURIComponent;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.getReturnUrl;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.LOGGER;
 import static io.gravitee.am.gateway.handler.root.RootProvider.PATH_LOGIN_CALLBACK;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginPostEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginPostEndpoint.java
@@ -17,13 +17,11 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.login;
 
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
-import io.gravitee.am.service.utils.vertx.RequestUtils;
-import io.gravitee.common.http.HttpHeaders;
 import io.vertx.core.Handler;
-import io.vertx.rxjava3.core.MultiMap;
-import io.vertx.rxjava3.core.http.HttpServerResponse;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 import io.vertx.rxjava3.ext.web.Session;
+
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.doRedirect;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -34,20 +32,12 @@ public class LoginPostEndpoint extends AbstractEndpoint implements Handler<Routi
     @Override
     public void handle(RoutingContext context) {
         final Session session = context.session();
-        final MultiMap queryParams = RequestUtils.getCleanedQueryParams(context.request());
-        final String redirectUri = getReturnUrl(context, queryParams);
 
         // save that the user has just been signed in
         session.put(ConstantKeys.USER_LOGIN_COMPLETED_KEY, true);
 
         // the login process is done
         // redirect the user to the original request
-        doRedirect(context.response(), redirectUri);
-    }
-
-    private void doRedirect(HttpServerResponse response, String url) {
-        response.putHeader(HttpHeaders.LOCATION, url)
-                .setStatusCode(302)
-                .end();
+        doRedirect(context);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
@@ -26,6 +26,7 @@ import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.utils.HashUtil;
 import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
+import io.gravitee.am.gateway.handler.manager.session.SessionManager;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.model.ApplicationFactorSettings;
@@ -115,6 +116,7 @@ import static io.gravitee.am.common.utils.ConstantKeys.WEBAUTHN_CREDENTIAL_INTER
 import static io.gravitee.am.factor.api.FactorContext.KEY_USER;
 import static io.gravitee.am.gateway.handler.common.utils.RoutingContextUtils.getEvaluableAttributes;
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.getReturnUrl;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.resolveProxyRequest;
 import static io.gravitee.am.gateway.handler.root.resources.handler.webauthn.WebAuthnHandler.getOrigin;
@@ -144,6 +146,7 @@ public class MFAChallengeEndpoint extends MFAEndpoint {
     private final VerifyAttemptService verifyAttemptService;
     private final EmailService emailService;
     private final AuditService auditService;
+    private final SessionManager sessionManager;
 
     public MFAChallengeEndpoint(FactorManager factorManager,
                                 UserService userService,
@@ -167,6 +170,7 @@ public class MFAChallengeEndpoint extends MFAEndpoint {
         this.verifyAttemptService = verifyAttemptService;
         this.emailService = emailService;
         this.auditService = auditService;
+        this.sessionManager = new SessionManager();
     }
 
     @Override
@@ -722,14 +726,7 @@ public class MFAChallengeEndpoint extends MFAEndpoint {
     }
 
     private void cleanSession(RoutingContext ctx) {
-        ctx.session().remove(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY);
-        ctx.session().remove(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY);
-
-        ctx.session().remove(ConstantKeys.ENROLLED_FACTOR_ID_KEY);
-        ctx.session().remove(ConstantKeys.ENROLLED_FACTOR_SECURITY_VALUE_KEY);
-        ctx.session().remove(ConstantKeys.ENROLLED_FACTOR_PHONE_NUMBER);
-        ctx.session().remove(ConstantKeys.ENROLLED_FACTOR_EXTENSION_PHONE_NUMBER);
-        ctx.session().remove(ConstantKeys.ENROLLED_FACTOR_EMAIL_ADDRESS);
+        sessionManager.cleanSessionOnMfaChallenge(ctx);
     }
 
     private boolean userHasFido2Factor(io.gravitee.am.model.User endUser) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAEnrollEndpoint.java
@@ -40,14 +40,12 @@ import io.gravitee.am.model.factor.EnrolledFactorSecurity;
 import io.gravitee.am.model.factor.FactorStatus;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.utils.vertx.RequestUtils;
-import io.gravitee.common.http.HttpHeaders;
 import io.reactivex.rxjava3.core.Observable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.rxjava3.core.MultiMap;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
-import io.vertx.rxjava3.core.http.HttpServerResponse;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 import io.vertx.rxjava3.ext.web.Session;
 import io.vertx.rxjava3.ext.web.common.template.TemplateEngine;
@@ -65,6 +63,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.doRedirect;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static org.springframework.util.StringUtils.hasText;
@@ -123,7 +122,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
             var context = new MfaFilterContext(routingContext, routingContext.get(ConstantKeys.CLIENT_CONTEXT_KEY), factorManager, ruleEngine);
             if (context.userHasMatchingActivatedFactors()) {
                 logger.warn("User already has a factor.");
-                redirectToAuthorize(routingContext);
+                doRedirect(routingContext);
                 return;
             }
 
@@ -224,7 +223,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
             // user request a skipEnrollment but it is required,
             // redirect back to the authorize endpoint to force
             // the enrollment
-            redirectToAuthorize(routingContext);
+            doRedirect(routingContext);
             return;
         }
 
@@ -245,7 +244,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
                         // that means the user has also skipped the MFA challenge page
                         routingContext.session().put(ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY, true);
                         routingContext.session().put(ConstantKeys.MFA_CHALLENGE_COMPLETED_KEY, true);
-                        redirectToAuthorize(routingContext);
+                        doRedirect(routingContext);
                     });
             return true;
         }
@@ -309,7 +308,7 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
             // update the session
             routingContext.session().put(ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY, true);
             // redirect to the original request
-            redirectToAuthorize(routingContext);
+            doRedirect(routingContext);
         } else {
             // parameters are invalid
             routingContext.fail(400);
@@ -328,12 +327,6 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
                 endUser.getFactors().stream()
                         .filter(enrolledFactor -> !recoveryCodeFactors.contains(enrolledFactor.getFactorId()))
                         .anyMatch(enrolledFactor -> enrolledFactor.getStatus() == FactorStatus.ACTIVATED);
-    }
-
-    private void redirectToAuthorize(RoutingContext routingContext) {
-        final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-        final String returnURL = getReturnUrl(routingContext, queryParams);
-        doRedirect(routingContext.response(), returnURL);
     }
 
     private EnrolledFactor getSecurityFactor(MultiMap params, io.gravitee.am.model.Factor factor) {
@@ -392,10 +385,6 @@ public class MFAEnrollEndpoint extends AbstractEndpoint implements Handler<Routi
     @Override
     public String getTemplateSuffix() {
         return Template.MFA_ENROLL.template();
-    }
-
-    private void doRedirect(HttpServerResponse response, String url) {
-        response.putHeader(HttpHeaders.LOCATION, url).setStatusCode(302).end();
     }
 
     @Getter

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFARecoveryCodeEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFARecoveryCodeEndpoint.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 import static io.gravitee.am.common.factor.FactorSecurityType.RECOVERY_CODE;
 import static io.gravitee.am.factor.api.FactorContext.KEY_USER;
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.doRedirect;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
 
 /**
@@ -112,7 +113,7 @@ public class MFARecoveryCodeEndpoint extends AbstractEndpoint implements Handler
                 final EnrolledFactor factorToUpdate = recoveryFactor.get();
                 factorToUpdate.setStatus(FactorStatus.ACTIVATED);
 
-                userService.updateFactor(endUser.getId(), factorToUpdate, new DefaultUser(endUser))
+                userService.upsertFactor(endUser.getId(), factorToUpdate, new DefaultUser(endUser))
                         .ignoreElement()
                         .subscribe(
                                 () -> {
@@ -169,15 +170,6 @@ public class MFARecoveryCodeEndpoint extends AbstractEndpoint implements Handler
                 .filter(ftr -> ftr.getSecurity() != null && ftr.getSecurity().getType().equals(RECOVERY_CODE))
                 .map(EnrolledFactor::getSecurity)
                 .findFirst();
-    }
-
-    private void doRedirect(RoutingContext routingContext) {
-        final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-        final String returnUrl = getReturnUrl(routingContext, queryParams);
-        routingContext.response()
-                .putHeader(io.vertx.core.http.HttpHeaders.LOCATION, returnUrl)
-                .setStatusCode(302)
-                .end();
     }
 
     private Optional<EnrolledFactor> getRecoveryFactor(io.gravitee.am.model.User user) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordSubmissionEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordSubmissionEndpoint.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
 
 import static io.gravitee.am.common.utils.ConstantKeys.CLAIM_QUERY_PARAM;
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.RESET_PWD_KEEP_PARAMS;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.getReturnUrl;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -43,7 +45,6 @@ import static io.gravitee.am.common.utils.ConstantKeys.CLAIM_QUERY_PARAM;
  */
 public class ResetPasswordSubmissionEndpoint extends UserRequestHandler {
 
-    public static final String GATEWAY_ENDPOINT_RESET_PWD_KEEP_PARAMS = "legacy.resetPassword.keepParams";
     private static final Logger logger = LoggerFactory.getLogger(ResetPasswordSubmissionEndpoint.class);
     private final UserService userService;
 
@@ -51,7 +52,7 @@ public class ResetPasswordSubmissionEndpoint extends UserRequestHandler {
 
     public ResetPasswordSubmissionEndpoint(UserService userService, Environment environment) {
         this.userService = userService;
-        this.keepParams = environment.getProperty(GATEWAY_ENDPOINT_RESET_PWD_KEEP_PARAMS, boolean.class, true);
+        this.keepParams = RESET_PWD_KEEP_PARAMS.from(environment);
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterConfirmationSubmissionEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterConfirmationSubmissionEndpoint.java
@@ -33,13 +33,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.REGISTRATION_KEEP_PARAMS;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class RegisterConfirmationSubmissionEndpoint extends UserRequestHandler {
 
-    public static final String GATEWAY_ENDPOINT_REGISTRATION_KEEP_PARAMS = "legacy.registration.keepParams";
     private static final Logger logger = LoggerFactory.getLogger(RegisterConfirmationSubmissionEndpoint.class);
 
     private final UserService userService;
@@ -47,7 +48,7 @@ public class RegisterConfirmationSubmissionEndpoint extends UserRequestHandler {
 
     public RegisterConfirmationSubmissionEndpoint(UserService userService, Environment environment) {
         this.userService = userService;
-        this.keepParams = environment.getProperty(GATEWAY_ENDPOINT_REGISTRATION_KEEP_PARAMS, boolean.class, true);
+        this.keepParams = REGISTRATION_KEEP_PARAMS.from(environment);
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpoint.java
@@ -27,17 +27,18 @@ import io.vertx.rxjava3.core.http.HttpServerResponse;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 import org.springframework.core.env.Environment;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.REGISTRATION_KEEP_PARAMS;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class RegisterSubmissionEndpoint implements Handler<RoutingContext> {
-    public static final String GATEWAY_ENDPOINT_REGISTRATION_KEEP_PARAMS = "legacy.registration.keepParams";
 
     private final boolean keepParams;
 
     public RegisterSubmissionEndpoint(Environment environment) {
-        this.keepParams = environment.getProperty(GATEWAY_ENDPOINT_REGISTRATION_KEEP_PARAMS, boolean.class, true);
+        this.keepParams = REGISTRATION_KEEP_PARAMS.from(environment);
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginPostEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginPostEndpoint.java
@@ -17,13 +17,13 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.webauthn;
 
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
-import io.gravitee.am.service.utils.vertx.RequestUtils;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.MediaType;
 import io.vertx.core.Handler;
 import io.vertx.core.json.Json;
-import io.vertx.rxjava3.core.MultiMap;
 import io.vertx.rxjava3.ext.web.RoutingContext;
+
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.doRedirect;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -55,11 +55,6 @@ public class WebAuthnLoginPostEndpoint extends AbstractEndpoint implements Handl
     private void authenticateV1(RoutingContext ctx) {
         // at this stage the user has been authenticated
         // redirect the user to the original request
-        final MultiMap queryParams = RequestUtils.getCleanedQueryParams(ctx.request());
-        final String redirectUri = getReturnUrl(ctx, queryParams);
-
-        ctx.response().putHeader(io.vertx.core.http.HttpHeaders.LOCATION, redirectUri)
-                .setStatusCode(302)
-                .end();
+        doRedirect(ctx);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterEndpoint.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.getReturnUrl;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterPostEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterPostEndpoint.java
@@ -31,6 +31,8 @@ import io.vertx.rxjava3.core.MultiMap;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.getReturnUrl;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterSuccessEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterSuccessEndpoint.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.gravitee.am.gateway.handler.common.utils.ThymeleafDataHelper.generateData;
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.doRedirect;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -135,12 +136,7 @@ public class WebAuthnRegisterSuccessEndpoint extends WebAuthnHandler {
                 .subscribe(__ -> {
                             // at this stage the registration has been done
                             // redirect the user to the original request
-                            final MultiMap queryParams = RequestUtils.getCleanedQueryParams(routingContext.request());
-                            final String redirectUri = getReturnUrl(routingContext, queryParams);
-                            routingContext.response()
-                                    .putHeader(HttpHeaders.LOCATION, redirectUri)
-                                    .setStatusCode(302)
-                                    .end();
+                            doRedirect(routingContext);
                         },
                         error -> {
                             logger.error("An error has occurred when updating the webauthn credential {}", credentialId, error);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnResponseEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnResponseEndpoint.java
@@ -16,10 +16,10 @@
 package io.gravitee.am.gateway.handler.root.resources.endpoint.webauthn;
 
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
-import io.gravitee.am.service.utils.vertx.RequestUtils;
 import io.vertx.core.Handler;
-import io.vertx.rxjava3.core.MultiMap;
 import io.vertx.rxjava3.ext.web.RoutingContext;
+
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.doRedirect;
 
 /**
  * The callback route to verify attestations and assertions. Usually this route is <pre>/webauthn/response</pre>
@@ -36,11 +36,6 @@ public class WebAuthnResponseEndpoint extends AbstractEndpoint implements Handle
     public void handle(RoutingContext ctx) {
         // at this stage the user has been authenticated
         // redirect the user to the original request
-        final MultiMap queryParams = RequestUtils.getCleanedQueryParams(ctx.request());
-        final String redirectUri = getReturnUrl(ctx, queryParams);
-
-        ctx.response().putHeader(io.vertx.core.http.HttpHeaders.LOCATION, redirectUri)
-                .setStatusCode(302)
-                .end();
+        doRedirect(ctx);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/BypassDirectRequestHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/BypassDirectRequestHandler.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.root.resources.handler;
+
+
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.vertx.core.Handler;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import lombok.extern.slf4j.Slf4j;
+
+import static io.gravitee.am.gateway.handler.common.vertx.utils.RedirectHelper.doRedirect;
+import static org.springframework.util.StringUtils.hasText;
+
+/**
+ * This handler is used to evaluate if an authentication step is coming from a regular flow
+ * or has been accessed directly by the user (hit the login page instead of the authorization endpoint)
+ *
+ * If the step is not coming from regular flow, the user is redirected to the authorization endpoint
+ * in order to evaluate the user session and go to the right action (login, mfa challenge, redirect to the app, etc ...)
+ *
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class BypassDirectRequestHandler implements Handler<RoutingContext> {
+
+    private final boolean skipHandlerExecution;
+
+    public BypassDirectRequestHandler(boolean skip) {
+        this.skipHandlerExecution = skip;
+    }
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+        if (needAuthFlowStateEvaluation(routingContext)) {
+            routingContext.session().put(ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE, ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE_ONGOING);
+            doRedirect(routingContext);
+        } else {
+            // ongoing SESSION_KEY_AUTH_FLOW_STATE present into the session
+            // continue
+            routingContext.next();
+        }
+    }
+
+    /**
+     * SESSION_KEY_AUTH_FLOW_STATE is used by the authorization endpoint to flag an ongoing authentication
+     * If this flag is missing, a redirect to the authorization endpoint is triggered to route the user to the right step
+     *
+     * @param routingContext
+     * @return true if a redirect to the authorization endpoint is required, false otherwise
+     */
+    private boolean needAuthFlowStateEvaluation(RoutingContext routingContext) {
+        return !skipHandlerExecution && (routingContext.session() == null ||
+                !hasText(routingContext.session().get(ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE)) ||
+                !ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE_ONGOING.equalsIgnoreCase(routingContext.session().get(ConstantKeys.SESSION_KEY_AUTH_FLOW_STATE)));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/ConditionalBodyHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/ConditionalBodyHandler.java
@@ -21,6 +21,8 @@ import io.vertx.rxjava3.ext.web.RoutingContext;
 import io.vertx.rxjava3.ext.web.handler.BodyHandler;
 import org.springframework.core.env.Environment;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.HANDLER_ALWAYS_APPLY_BODY_HDL;
+
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
@@ -35,7 +37,7 @@ public class ConditionalBodyHandler implements Handler<RoutingContext> {
 
     ConditionalBodyHandler(Environment env, Handler<RoutingContext> bodyHandler) {
         this.delegatedBodyHandler = bodyHandler;
-        this.alwaysApplyBodyHandler = env.getProperty("legacy.handler.alwaysApplyBodyHandler", Boolean.class, false);
+        this.alwaysApplyBodyHandler = HANDLER_ALWAYS_APPLY_BODY_HDL.from(env);
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordSubmissionEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ResetPasswordSubmissionEndpointTest.java
@@ -37,6 +37,7 @@ import org.springframework.core.env.Environment;
 
 import java.util.Collections;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.RESET_PWD_KEEP_PARAMS;
 import static io.vertx.core.http.HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 import static org.mockito.ArgumentMatchers.any;
@@ -59,7 +60,7 @@ public class ResetPasswordSubmissionEndpointTest extends RxWebTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        when(environment.getProperty(eq(ResetPasswordSubmissionEndpoint.GATEWAY_ENDPOINT_RESET_PWD_KEEP_PARAMS), any(), eq(true))).thenReturn(true);
+        when(environment.getProperty(eq(RESET_PWD_KEEP_PARAMS.getKey()), any(), eq(RESET_PWD_KEEP_PARAMS.getDefaultValue()))).thenReturn(true);
 
         ResetPasswordSubmissionEndpoint resetPasswordSubmissionEndpoint = new ResetPasswordSubmissionEndpoint(userService, environment);
         router.route(HttpMethod.POST, "/resetPassword")

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterConfirmationSubmissionEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterConfirmationSubmissionEndpointTest.java
@@ -34,6 +34,7 @@ import org.springframework.core.env.Environment;
 
 import java.util.Collections;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.REGISTRATION_KEEP_PARAMS;
 import static io.vertx.core.http.HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,7 +56,7 @@ public class RegisterConfirmationSubmissionEndpointTest extends RxWebTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        when(environment.getProperty(eq(RegisterSubmissionEndpoint.GATEWAY_ENDPOINT_REGISTRATION_KEEP_PARAMS), any(), eq(true))).thenReturn(true);
+        when(environment.getProperty(eq(REGISTRATION_KEEP_PARAMS.getKey()), any(), eq(REGISTRATION_KEEP_PARAMS.getDefaultValue()))).thenReturn(true);
         RegisterConfirmationSubmissionEndpoint registerConfirmationSubmissionEndpoint = new RegisterConfirmationSubmissionEndpoint(userService, environment);
         router.route(HttpMethod.POST, "/confirmRegistration")
                 .handler(BodyHandler.create())

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpointTest.java
@@ -37,6 +37,7 @@ import org.springframework.core.env.Environment;
 
 import java.util.Collections;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.REGISTRATION_KEEP_PARAMS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -60,7 +61,7 @@ public class RegisterSubmissionEndpointTest extends RxWebTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        when(environment.getProperty(eq(RegisterSubmissionEndpoint.GATEWAY_ENDPOINT_REGISTRATION_KEEP_PARAMS), any(), eq(true))).thenReturn(true);
+        when(environment.getProperty(eq(REGISTRATION_KEEP_PARAMS.getKey()), any(), eq(REGISTRATION_KEEP_PARAMS.getDefaultValue()))).thenReturn(true);
         router.route(HttpMethod.POST, "/register")
                 .handler(BodyHandler.create())
                 .handler(new RegisterProcessHandler(userService, domain))

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/OAuth2Provider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/OAuth2Provider.java
@@ -68,6 +68,7 @@ import io.gravitee.am.gateway.handler.oidc.service.idtoken.IDTokenService;
 import io.gravitee.am.gateway.handler.oidc.service.jwe.JWEService;
 import io.gravitee.am.gateway.handler.oidc.service.jwk.JWKService;
 import io.gravitee.am.gateway.handler.oidc.service.request.RequestObjectService;
+import io.gravitee.am.gateway.handler.root.resources.handler.BypassDirectRequestHandler;
 import io.gravitee.am.gateway.handler.root.resources.handler.LocaleHandler;
 import io.gravitee.am.gateway.handler.root.resources.handler.common.RedirectUriValidationHandler;
 import io.gravitee.am.gateway.handler.root.resources.handler.transactionid.TransactionIdHandler;
@@ -91,6 +92,10 @@ import io.vertx.rxjava3.ext.web.templ.thymeleaf.ThymeleafTemplateEngine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.env.Environment;
+
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.HANDLER_SKIP_BYPASS_DIRECT_REQUEST_HDL;
+
+//import static io.gravitee.am.gateway.core.LegacySettingsKeys.HANDLER_SKIP_BYPASS_DIRECT_REQUEST_HDL;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -281,7 +286,9 @@ public class OAuth2Provider extends AbstractProtocolProvider {
 
         // Authorization consent endpoint
         Handler<RoutingContext> userConsentPrepareContextHandler = new UserConsentPrepareContextHandler();
+        final var bypassDirectrequestHandler = new BypassDirectRequestHandler(HANDLER_SKIP_BYPASS_DIRECT_REQUEST_HDL.from(environment));
         oauth2Router.route(HttpMethod.GET, "/consent")
+                .handler(bypassDirectrequestHandler)
                 .handler(new AuthorizationRequestParseClientHandler(clientSyncService))
                 .handler(new AuthorizationRequestParseProviderConfigurationHandler(openIDDiscoveryService))
                 .handler(authenticationFlowContextHandler)
@@ -293,6 +300,7 @@ public class OAuth2Provider extends AbstractProtocolProvider {
                 .handler(localeHandler)
                 .handler(new UserConsentEndpoint(userConsentService, thymeleafTemplateEngine, domain));
         oauth2Router.route(HttpMethod.POST, "/consent")
+                .handler(bypassDirectrequestHandler)
                 .handler(new AuthorizationRequestParseClientHandler(clientSyncService))
                 .handler(new AuthorizationRequestParseProviderConfigurationHandler(openIDDiscoveryService))
                 .handler(authenticationFlowContextHandler)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/AuthorizationEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/AuthorizationEndpoint.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.oauth2.resources.endpoint.authorization;
 
 import io.gravitee.am.common.oauth2.ResponseMode;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.manager.session.SessionManager;
 import io.gravitee.am.gateway.handler.oauth2.exception.AccessDeniedException;
 import io.gravitee.am.gateway.handler.oauth2.exception.ServerErrorException;
 import io.gravitee.am.gateway.handler.oauth2.service.par.PushedAuthorizationRequestService;
@@ -55,11 +56,13 @@ public class AuthorizationEndpoint implements Handler<RoutingContext> {
     private final Flow flow;
     private final ThymeleafTemplateEngine engine;
     private final PushedAuthorizationRequestService parService;
+    private final SessionManager sessionManager;
 
     public AuthorizationEndpoint(Flow flow, ThymeleafTemplateEngine engine, PushedAuthorizationRequestService parService) {
         this.flow = flow;
         this.engine = engine;
         this.parService = parService;
+        this.sessionManager = new SessionManager();
     }
 
     @Override
@@ -142,17 +145,6 @@ public class AuthorizationEndpoint implements Handler<RoutingContext> {
     }
 
     private void cleanSession(RoutingContext context) {
-        context.session().remove(ConstantKeys.TRANSACTION_ID_KEY);
-        context.session().remove(ConstantKeys.USER_CONSENT_COMPLETED_KEY);
-        context.session().remove(ConstantKeys.WEBAUTHN_CREDENTIAL_ID_CONTEXT_KEY);
-        context.session().remove(ConstantKeys.WEBAUTHN_CREDENTIAL_INTERNAL_ID_CONTEXT_KEY);
-        context.session().remove(ConstantKeys.PASSWORDLESS_AUTH_ACTION_KEY);
-        context.session().remove(ConstantKeys.MFA_FACTOR_ID_CONTEXT_KEY);
-        context.session().remove(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY);
-        context.session().remove(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY);
-        context.session().remove(ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY);
-        context.session().remove(ConstantKeys.MFA_CHALLENGE_COMPLETED_KEY);
-        context.session().remove(ConstantKeys.USER_LOGIN_COMPLETED_KEY);
-        context.session().remove(ConstantKeys.MFA_ENROLL_CONDITIONAL_SKIPPED_KEY);
+        sessionManager.cleanSessionAfterAuth(context);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/scope/impl/ScopeManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/scope/impl/ScopeManagerImpl.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -39,6 +39,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.OIDC_ALWAYS_ENHANCE_SCOPE;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -58,8 +60,10 @@ public class ScopeManagerImpl extends AbstractService implements ScopeManager, I
     @Autowired
     private EventManager eventManager;
 
+    @Autowired
+    private Environment environment;
+
     @Deprecated
-    @Value("${legacy.openid.always_enhance_scopes:false}")
     private boolean alwaysProvideEnhancedScopes;
 
     @Override
@@ -75,7 +79,7 @@ public class ScopeManagerImpl extends AbstractService implements ScopeManager, I
 
         logger.info("Register event listener for scopes events for domain {}", domain.getName());
         eventManager.subscribeForEvents(this, ScopeEvent.class, domain.getId());
-
+        this.alwaysProvideEnhancedScopes = OIDC_ALWAYS_ENHANCE_SCOPE.from(environment);
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpoint.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.gravitee.am.common.utils.ConstantKeys.ID_TOKEN_EXCLUDED_CLAIMS;
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.OIDC_SCOPE_FULL_PROFILE;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -89,7 +90,7 @@ public class UserInfoEndpoint implements Handler<RoutingContext> {
         this.jwtService = jwtService;
         this.jweService = jweService;
         this.openIDDiscoveryService = openIDDiscoveryService;
-        this.legacyOpenidScope = environment.getProperty("legacy.openid.openid_scope_full_profile", boolean.class, false);
+        this.legacyOpenidScope = OIDC_SCOPE_FULL_PROFILE.from(environment);
         this.subjectManager = subjectManager;
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 
 import static com.nimbusds.jose.JWEAlgorithm.RSA_OAEP;
 import static io.gravitee.am.common.oidc.ClientAuthenticationMethod.*;
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.OIDC_FILTER_CUSTOM_PROMPT;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -123,7 +124,7 @@ public class OpenIDDiscoveryServiceImpl implements OpenIDDiscoveryService, Initi
         openIDProviderMetadata.setGrantTypesSupported(GrantTypeUtils.getSupportedGrantTypes());
         openIDProviderMetadata.setClaimTypesSupported(ClaimType.supportedValues());
         openIDProviderMetadata.setSubjectTypesSupported(SubjectTypeUtils.getSupportedSubjectTypes());
-        final Boolean filterCustomValues = env.getProperty("legacy.openid.filterCustomPrompt", Boolean.class, false);
+        final Boolean filterCustomValues = OIDC_FILTER_CUSTOM_PROMPT.from(env);
         openIDProviderMetadata.setPromptValuesSupported(Prompt.supportedValues(filterCustomValues));
 
         // id_token

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/impl/IDTokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/impl/IDTokenServiceImpl.java
@@ -47,8 +47,9 @@ import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.reactivex.rxjava3.core.Single;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -59,6 +60,7 @@ import java.util.Set;
 
 import static io.gravitee.am.common.oidc.Scope.FULL_PROFILE;
 import static io.gravitee.am.common.utils.ConstantKeys.ID_TOKEN_EXCLUDED_CLAIMS;
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.OIDC_SCOPE_FULL_PROFILE;
 import static io.gravitee.am.gateway.handler.common.jwt.JWTService.TokenType.ID_TOKEN;
 
 /**
@@ -66,7 +68,7 @@ import static io.gravitee.am.gateway.handler.common.jwt.JWTService.TokenType.ID_
  * @author GraviteeSource Team
  */
 @Slf4j
-public class IDTokenServiceImpl implements IDTokenService {
+public class IDTokenServiceImpl implements IDTokenService, InitializingBean {
 
     private static final String DEFAULT_DIGEST_ALGORITHM = "SHA-512";
 
@@ -94,9 +96,16 @@ public class IDTokenServiceImpl implements IDTokenService {
     @Autowired
     private SubjectManager subjectManager;
 
+    @Autowired
+    private Environment environment;
+
     @Deprecated
-    @Value("${legacy.openid.openid_scope_full_profile:false}")
     private boolean legacyOpenidScope;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.legacyOpenidScope = OIDC_SCOPE_FULL_PROFILE.from(environment);
+    }
 
     @Override
     public Single<String> create(OAuth2Request oAuth2Request, Client client, User user, ExecutionContext executionContext) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpointHandlerTest.java
@@ -60,6 +60,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import static io.gravitee.am.gateway.core.LegacySettingsKeys.OIDC_SCOPE_FULL_PROFILE;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
@@ -93,8 +94,7 @@ public class UserInfoEndpointHandlerTest extends RxWebTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        when(env.getProperty("legacy.openid.openid_scope_full_profile", boolean.class, false)).thenReturn(false);
+        when(env.getProperty(OIDC_SCOPE_FULL_PROFILE.getKey(), Boolean.class, OIDC_SCOPE_FULL_PROFILE.getDefaultValue())).thenReturn(false);
         userInfoEndpoint = new UserInfoEndpoint(userEnhancer, jwtService, jweService, openIDDiscoveryService, env, subjectManager);
 
         router.route(HttpMethod.GET, "/userinfo")


### PR DESCRIPTION
 a new attribute has been added to the session to determine if the session is ongoing or not

 if it is actions related to a form are executed as usual

 if it is not a redirect to authorization endpoint is perform to follow the auth flow

 this is to avoid issues when a user is fully authenticated but use the back arraow on the browser

 this solution is not perfect as a back click before the end of the auth flow

 will not skip the page rendering

fixes AM-4342
