### PR TITLE
chore: upgrade gravitee-node to 6.7.0 to include the CloudHSM feature…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <gravitee-bom.version>8.1.19</gravitee-bom.version>
         <gravitee-common.version>4.2.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.0</gravitee-plugin.version>
-        <gravitee-node.version>6.4.4</gravitee-node.version>
+        <gravitee-node.version>6.7.0</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>


### PR DESCRIPTION
… in the license model

related-to AM-4162
