### PR TITLE
fix: avoid change-after-check error in password policy component

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/password-policy/pass-policy-status/password-policy-status.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/password-policy/pass-policy-status/password-policy-status.component.ts
@@ -207,11 +207,9 @@ export class PasswordPolicyStatusComponent implements OnChanges, OnDestroy {
     }
     this.rules.forEach((rule) => {
       if (this.ruleResults[rule.id]) {
-        console.log(`setting rule ${rule.id} to CHECKING`);
         this.ruleResults[rule.id].status = RuleStatus.CHECKING;
       }
       rule.check(input).then((ruleResults) => {
-        console.log(`results for rule ${rule.id}: ${JSON.stringify(ruleResults, null, 2)}`);
         for (const result of ruleResults) {
           this.ruleResults[result.id] = result;
         }
@@ -221,14 +219,10 @@ export class PasswordPolicyStatusComponent implements OnChanges, OnDestroy {
   }
   private checkAllRulesValid() {
     let allRulesValid = true;
-    console.log('all results: ', this.ruleResults);
     for (const result of Object.values(this.ruleResults)) {
-      console.log('rule result', result);
       allRulesValid &&= result.status === RuleStatus.VALID;
     }
-    console.log(`emitting valid=${allRulesValid}`);
     setTimeout(() => {
-      console.log('do emit');
       this.valid.emit(allRulesValid);
     }, 0);
   }

--- a/gravitee-am-ui/src/app/domain/settings/password-policy/pass-policy-status/password-policy-status.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/password-policy/pass-policy-status/password-policy-status.component.ts
@@ -203,7 +203,11 @@ export class PasswordPolicyStatusComponent implements OnChanges, OnDestroy {
   private checkRules(input: PasswordInput) {
     if (input.pass == null) {
       this.ruleResults = {};
+      setTimeout(() => this.valid.emit(false));
       return;
+    }
+    if (this.rules.length == 0) {
+      setTimeout(() => this.valid.emit(true));
     }
     this.rules.forEach((rule) => {
       if (this.ruleResults[rule.id]) {

--- a/gravitee-am-ui/src/app/domain/settings/password-policy/pass-policy-status/password-policy-status.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/password-policy/pass-policy-status/password-policy-status.component.ts
@@ -207,22 +207,30 @@ export class PasswordPolicyStatusComponent implements OnChanges, OnDestroy {
     }
     this.rules.forEach((rule) => {
       if (this.ruleResults[rule.id]) {
+        console.log(`setting rule ${rule.id} to CHECKING`);
         this.ruleResults[rule.id].status = RuleStatus.CHECKING;
       }
       rule.check(input).then((ruleResults) => {
+        console.log(`results for rule ${rule.id}: ${JSON.stringify(ruleResults, null, 2)}`);
         for (const result of ruleResults) {
           this.ruleResults[result.id] = result;
         }
+        this.checkAllRulesValid();
       });
-      this.checkAllRulesValid();
     });
   }
   private checkAllRulesValid() {
     let allRulesValid = true;
+    console.log('all results: ', this.ruleResults);
     for (const result of Object.values(this.ruleResults)) {
+      console.log('rule result', result);
       allRulesValid &&= result.status === RuleStatus.VALID;
     }
-    this.valid.emit(allRulesValid);
+    console.log(`emitting valid=${allRulesValid}`);
+    setTimeout(() => {
+      console.log('do emit');
+      this.valid.emit(allRulesValid);
+    }, 0);
   }
 
   private excludeUserProfileInfoRule() {

--- a/gravitee-am-ui/src/app/domain/settings/users/creation/user-creation.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/creation/user-creation.component.html
@@ -188,7 +188,7 @@
                 [policy]="passwordPolicy"
                 [password]="user.password"
                 [profile]="{ id: user.id, firstName: user.firstName, lastName: user.lastName, email: user.email }"
-                (valid)="passwordValid = $event"
+                (valid)="setPasswordValid($event)"
               />
             }
           </div>
@@ -236,7 +236,7 @@
       </div>
       <div fxLayout="row" fxLayoutAlign="end">
         <a mat-button [routerLink]="['..']" style="margin-right: 20px">CANCEL</a>
-        <button mat-raised-button [disabled]="!(userForm.valid && passwordValid) || userForm.pristine" type="submit">CREATE</button>
+        <button mat-raised-button [disabled]="!canCreateUser(userForm)" type="submit">CREATE</button>
       </div>
     </form>
     <div class="gv-page-description" fxFlex>

--- a/gravitee-am-ui/src/app/domain/settings/users/creation/user-creation.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/creation/user-creation.component.ts
@@ -186,7 +186,6 @@ export class UserCreationComponent implements OnInit {
     });
   }
   setPasswordValid(value: boolean) {
-    console.log('passwordValid: ', value);
     this.passwordValid = value;
   }
   canCreateUser(userForm: NgForm) {

--- a/gravitee-am-ui/src/app/domain/settings/users/creation/user-creation.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/creation/user-creation.component.ts
@@ -26,6 +26,7 @@ import { DomainPasswordPolicy } from '../../password-policy/domain-password-poli
 import { PasswordPolicyService } from '../../../../services/password-policy.service';
 
 import { UserClaimComponent } from './user-claim.component';
+import { NgForm } from '@angular/forms';
 enum AccountType {
   User = 'user',
   ServiceAccount = 'service',
@@ -183,5 +184,13 @@ export class UserCreationComponent implements OnInit {
     this.passwordPolicyService.getPolicyForIdp(this.domainId, this.user.source).subscribe((policy) => {
       this.passwordPolicy = policy;
     });
+  }
+  setPasswordValid(value: boolean) {
+    console.log('passwordValid: ', value);
+    this.passwordValid = value;
+  }
+  canCreateUser(userForm: NgForm) {
+    const formValid = userForm.valid && !userForm.pristine;
+    return formValid && (this.passwordValid || this.preRegistration);
   }
 }

--- a/gravitee-am-ui/src/app/domain/settings/users/creation/user-creation.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/creation/user-creation.component.ts
@@ -17,6 +17,7 @@ import { Component, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { each } from 'lodash';
+import { NgForm } from '@angular/forms';
 
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { UserService } from '../../../../services/user.service';
@@ -26,7 +27,6 @@ import { DomainPasswordPolicy } from '../../password-policy/domain-password-poli
 import { PasswordPolicyService } from '../../../../services/password-policy.service';
 
 import { UserClaimComponent } from './user-claim.component';
-import { NgForm } from '@angular/forms';
 enum AccountType {
   User = 'user',
   ServiceAccount = 'service',
@@ -52,7 +52,7 @@ export class UserCreationComponent implements OnInit {
   @ViewChild('dynamic', { read: ViewContainerRef }) viewContainerRef: ViewContainerRef;
   private domainId: string;
 
-  passwordPolicy: DomainPasswordPolicy;
+  passwordPolicy: DomainPasswordPolicy = {};
   passwordValid: boolean;
 
   constructor(
@@ -181,13 +181,19 @@ export class UserCreationComponent implements OnInit {
   }
 
   loadPasswordPolicy() {
-    this.passwordPolicyService.getPolicyForIdp(this.domainId, this.user.source).subscribe((policy) => {
-      this.passwordPolicy = policy;
-    });
+    if (this.domainId == null) {
+      this.passwordPolicy = {};
+    } else {
+      this.passwordPolicyService.getPolicyForIdp(this.domainId, this.user.source).subscribe((policy) => {
+        this.passwordPolicy = policy;
+      });
+    }
   }
+
   setPasswordValid(value: boolean) {
     this.passwordValid = value;
   }
+
   canCreateUser(userForm: NgForm) {
     const formValid = userForm.valid && !userForm.pristine;
     return formValid && (this.passwordValid || this.preRegistration);


### PR DESCRIPTION
## :id: Reference related issue. 

AM-4500


## :pencil2: A description of the changes proposed in the pull request

This PR changes how the password-policy-status components performs validation to avoid update-after-check error.
It also fixes the check for the 'create' button on create user screen to properly ignore password validity when pre-registration is selected.