### PR TITLE
fix: AM-4048: 500 when deleting non-existing account token

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/OrganizationUserResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/OrganizationUserResource.java
@@ -191,7 +191,9 @@ public class OrganizationUserResource extends AbstractResource {
         final var authenticatedUser = getAuthenticatedUser();
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_USER, Acl.UPDATE)
                 .andThen(organizationUserService.revokeToken(organizationId, userId, tokenId, authenticatedUser))
-                .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
+                .map(revoked -> Response.noContent().build())
+                .switchIfEmpty(Maybe.just(Response.status(Response.Status.NOT_FOUND).build()))
+                .subscribe(response::resume, response::resume);
     }
 
     @PUT
@@ -261,7 +263,7 @@ public class OrganizationUserResource extends AbstractResource {
 
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_USER, Acl.DELETE)
                 .andThen(organizationUserService.delete(ReferenceType.ORGANIZATION, organizationId, user, authenticatedUser))
-                .subscribe(u-> response.resume(Response.noContent().build()), response::resume);
+                .subscribe(u -> response.resume(Response.noContent().build()), response::resume);
     }
 
     @POST

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/OrganizationUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/OrganizationUserService.java
@@ -23,6 +23,7 @@ import io.gravitee.am.service.model.NewAccountAccessToken;
 import io.gravitee.am.service.model.NewOrganizationUser;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 
 /**
@@ -45,5 +46,5 @@ public interface OrganizationUserService extends CommonUserService {
 
     Single<User> findByAccessToken(String tokenId, String tokenValue);
 
-    Completable revokeToken(String organizationId, String userId, String tokenId, io.gravitee.am.identityprovider.api.User authenticatedUser);
+    Maybe<AccountAccessToken> revokeToken(String organizationId, String userId, String tokenId, io.gravitee.am.identityprovider.api.User authenticatedUser);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
@@ -253,9 +253,9 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
     }
 
     @Override
-    public Completable revokeToken(String organizationId, String userId, String tokenId, io.gravitee.am.identityprovider.api.User principal) {
+    public Maybe<AccountAccessToken> revokeToken(String organizationId, String userId, String tokenId, io.gravitee.am.identityprovider.api.User principal) {
         return getUserService().findById(Reference.organization(organizationId), UserId.internal(userId))
-                .flatMap(user ->
+                .flatMapMaybe(user ->
                         getUserService().revokeToken(organizationId, userId, tokenId)
                                 .doOnSuccess(revoked -> auditService.report(AuditBuilder.builder(UserAuditBuilder.class)
                                         .principal(principal)
@@ -267,9 +267,7 @@ public class OrganizationUserServiceImpl extends AbstractUserService<io.gravitee
                                         .type(EventType.ACCOUNT_ACCESS_TOKEN_REVOKED)
                                         .user(user)
                                         .accountToken(tokenId)
-                                        .throwable(x)))
-                )
-                .ignoreElement();
+                                        .throwable(x))));
     }
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/OrganizationUserService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/OrganizationUserService.java
@@ -21,6 +21,7 @@ import io.gravitee.am.model.User;
 import io.gravitee.am.service.model.NewAccountAccessToken;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 
 /**
@@ -52,5 +53,5 @@ public interface OrganizationUserService extends CommonUserService {
 
     Single<User> findByAccessToken(String token, String tokenValue);
 
-    Single<AccountAccessToken> revokeToken(String organizationId, String userId, String tokenId);
+    Maybe<AccountAccessToken> revokeToken(String organizationId, String userId, String tokenId);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/OrganizationUserServiceImpl.java
@@ -226,13 +226,11 @@ public class OrganizationUserServiceImpl extends AbstractUserService<Organizatio
     }
 
     @Override
-    public Single<AccountAccessToken> revokeToken(String organizationId, String userId, String tokenId) {
+    public Maybe<AccountAccessToken> revokeToken(String organizationId, String userId, String tokenId) {
         return accessTokenRepository.findById(tokenId)
                 .filter(token -> token.referenceId().equals(organizationId))
                 .filter(token -> token.userId().equals(userId))
-                .flatMapSingle(token -> accessTokenRepository.delete(token.tokenId())
-                        .andThen(Single.just(token)))
-                .toSingle();
+                .flatMap(token -> accessTokenRepository.delete(token.tokenId()).andThen(Maybe.just(token)));
     }
 
     @Override

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/OrganizationUserServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/OrganizationUserServiceTest.java
@@ -479,7 +479,8 @@ public class OrganizationUserServiceTest {
         when(accessTokenRepository.findById("tokenId")).thenReturn(Maybe.just(tokenToDelete));
         userService.revokeToken("wrongOrgId", "userId", "tokenId")
                 .test()
-                .assertError(NoSuchElementException.class);
+                .assertNoValues()
+                .assertComplete();
     }
 
     @Test
@@ -488,6 +489,7 @@ public class OrganizationUserServiceTest {
         when(accessTokenRepository.findById("tokenId")).thenReturn(Maybe.just(tokenToDelete));
         userService.revokeToken("orgId", "wrongUserId", "tokenId")
                 .test()
-                .assertError(NoSuchElementException.class);
+                .assertNoValues()
+                .assertComplete();
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
AM-4048

## :pencil2: A description of the changes proposed in the pull request

Changes the org user management api to return 404 instead of 500 when revoking a non-existig account access token