### PR TITLE
feat: Allow IPv4 or IPv6 configuration

### DIFF
--- a/docker/management-ui/config/default.conf
+++ b/docker/management-ui/config/default.conf
@@ -1,6 +1,8 @@
 server {
     listen $HTTP_PORT;
     listen $HTTPS_PORT;
+    listen [::]:$HTTP_PORT;
+    listen [::]:$HTTPS_PORT;
     server_name $SERVER_NAME;
 
     index index.html index.htm;

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -21,11 +21,6 @@ case "`uname`" in
         ;;
 esac
 
-# Force IPv4 on Linux systems since IPv6 doesn't work correctly with jdk5 and lower
-if [ "$linux" = "true" ]; then
-   JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-fi
-
 # Searching for configuration 
 GRAVITEE_OPTS=""
 if [ -f "/etc/gravitee-am/gravitee.yml" ]

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee.bat
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee.bat
@@ -24,9 +24,6 @@ for %%B in (%~dp0\.) do set GRAVITEE_HOME=%%~dpB
 
 IF "%JAVA_HOME%"=="" GOTO nojavahome
 
-set JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
-
-
 set JAVA="%JAVA_HOME%/bin/java"
 
 rem Setup the classpath

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -21,11 +21,6 @@ case "`uname`" in
         ;;
 esac
 
-# Force IPv4 on Linux systems since IPv6 doesn't work correctly with jdk5 and lower
-if [ "$linux" = "true" ]; then
-   JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-fi
-
 # Searching for configuration
 GRAVITEE_OPTS=""
 if [ -f "/etc/gravitee-am/gravitee.yml" ]

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee.bat
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee.bat
@@ -24,9 +24,6 @@ for %%B in (%~dp0\.) do set GRAVITEE_HOME=%%~dpB
 
 IF "%JAVA_HOME%"=="" GOTO nojavahome
 
-set JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
-
-
 set JAVA="%JAVA_HOME%/bin/java"
 
 rem Setup the classpath


### PR DESCRIPTION
## :id: Reference related issue. 

https://github.com/gravitee-io/issues/issues/10247


## :pencil2: 

The option -Djava.net.preferIPv4Stack=true , block a deployment on an IPv6 cluster.
We can always add this option in the configuration JAVA_OPTS

