### PR TITLE
fix: upgraders should be launched before any plugin initialization

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/node/ManagementNode.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/node/ManagementNode.java
@@ -67,7 +67,8 @@ public class ManagementNode extends JettyNode {
     @Override
     public List<Class<? extends LifecycleComponent>> components() {
         List<Class<? extends LifecycleComponent>> components = super.components();
-
+        components.addAll(SystemUpgraderConfiguration.getComponents());
+        components.addAll(UpgraderConfiguration.getComponents());
         components.add(PluginEventListener.class);
         components.add(AuditReporterManager.class);
         components.add(IdentityProviderManager.class);
@@ -77,8 +78,6 @@ public class ManagementNode extends JettyNode {
         components.add(AlertTriggerProviderManager.class);
         components.add(AlertEventProducerManager.class);
         components.add(TasksLoader.class);
-        components.addAll(SystemUpgraderConfiguration.getComponents());
-        components.addAll(UpgraderConfiguration.getComponents());
         return components;
     }
 }


### PR DESCRIPTION
fixes AM-4603
the primary problem was about initialization of Inline IDP. For first run, IDP couldn't find any roleMappers as uprgrader wasn't launched yet. And this is why after the restart, inline-idp started to work.    
