### PR TITLE
chore: fix circleci

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -125,9 +125,7 @@ commands:
                 region: cloudfront
                 version: 2.22.35
             - aws-s3/sync:
-                arguments: |
-                  --endpoint-url https://cellar-c2.services.clever-cloud.com \
-                  --acl public-read
+                arguments: --endpoint-url https://cellar-c2.services.clever-cloud.com --acl public-read
                 from: ~/release/
                 to: "s3://gravitee-dry-releases-downloads/"
       - when:
@@ -138,9 +136,7 @@ commands:
                 region: cloudfront
                 version: 2.22.35
             - aws-s3/sync:
-                arguments: |
-                  --endpoint-url https://cellar-c2.services.clever-cloud.com \
-                  --acl public-read
+                arguments: --endpoint-url https://cellar-c2.services.clever-cloud.com --acl public-read
                 from: ~/release/
                 to: "s3://gravitee-releases-downloads/"
   restore-maven-job-cache:


### PR DESCRIPTION
fixes: 
```
+ aws s3 sync '~/release/' s3://gravitee-releases-downloads/ --endpoint-url https://cellar-c2.services.clever-cloud.com '\
--acl' public-read

Unknown options: \
--acl,public-read
```
