### PR TITLE
chore: fix aws s3 from parameter

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -126,7 +126,7 @@ commands:
                 version: 2.22.35
             - aws-s3/sync:
                 arguments: --endpoint-url https://cellar-c2.services.clever-cloud.com --acl public-read
-                from: ~/release/
+                from: /home/circleci/release/
                 to: "s3://gravitee-dry-releases-downloads/"
       - when:
           condition:
@@ -137,7 +137,7 @@ commands:
                 version: 2.22.35
             - aws-s3/sync:
                 arguments: --endpoint-url https://cellar-c2.services.clever-cloud.com --acl public-read
-                from: ~/release/
+                from: /home/circleci/release/
                 to: "s3://gravitee-releases-downloads/"
   restore-maven-job-cache:
     description: Restore Maven cache for a dedicated job


### PR DESCRIPTION
fix pipeline error ```The user-provided path ~/release/ does not exist.```
