### PR TITLE
fix: remove GIS from the session on prompt=login

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestParseParametersHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestParseParametersHandler.java
@@ -45,6 +45,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
+import static io.gravitee.am.common.jwt.Claims.GIO_INTERNAL_SUB;
 import static io.gravitee.am.common.utils.ConstantKeys.PROVIDER_METADATA_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.REQUEST_OBJECT_FROM_URI;
 import static io.gravitee.am.common.utils.ConstantKeys.STRONG_AUTH_COMPLETED_KEY;
@@ -128,6 +129,7 @@ public class AuthorizationRequestParseParametersHandler extends AbstractAuthoriz
         ctx.clearUser();
         ctx.session().remove(STRONG_AUTH_COMPLETED_KEY);
         ctx.session().remove(USER_ID_KEY);
+        ctx.session().remove(GIO_INTERNAL_SUB);
     }
 
     private void parsePKCEParameter(RoutingContext context, Client client) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/AuthorizationRequestParseParametersHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/AuthorizationRequestParseParametersHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.resources.handler;
 
+import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.oauth2.GrantType;
 import io.gravitee.am.common.oauth2.ResponseType;
 import io.gravitee.am.common.oidc.AcrValues;
@@ -432,6 +433,7 @@ public class AuthorizationRequestParseParametersHandlerTest extends RxWebTestBas
 
         Mockito.verify(session, times(1)).remove(STRONG_AUTH_COMPLETED_KEY);
         Mockito.verify(session, times(1)).remove(USER_ID_KEY);
+        Mockito.verify(session, times(1)).remove(Claims.GIO_INTERNAL_SUB);
     }
 
 


### PR DESCRIPTION
 this avoid to retrieve the user profile and force token request for external provider

fixes AM-4703
