### PR TITLE
fix: use the tid as seed to generate the moving factor

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpointTest.java
@@ -23,6 +23,7 @@ import io.gravitee.am.factor.api.FactorProvider;
 import io.gravitee.am.gateway.handler.common.email.EmailService;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.handler.root.resources.handler.dummies.SpyRoutingContext;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.model.Credential;
@@ -43,10 +44,12 @@ import io.gravitee.am.service.VerifyAttemptService;
 import io.gravitee.am.service.exception.MFAValidationAttemptException;
 import io.gravitee.am.service.reporter.builder.gateway.VerifyAttemptAuditBuilder;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Session;
 import io.vertx.rxjava3.core.buffer.Buffer;
@@ -54,16 +57,21 @@ import io.vertx.rxjava3.ext.web.common.template.TemplateEngine;
 import io.vertx.rxjava3.ext.web.handler.BodyHandler;
 import io.vertx.rxjava3.ext.web.handler.SessionHandler;
 import io.vertx.rxjava3.ext.web.sstore.LocalSessionStore;
+import io.vertx.rxjava3.ext.web.sstore.SessionStore;
+import io.vertx.rxjava3.ext.web.sstore.cookie.CookieSessionStore;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.ApplicationContext;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 import static io.vertx.core.http.HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
@@ -232,7 +240,83 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
                     assertEquals("1234", enrolledFactor.getChannel().getAdditionalData().get(ConstantKeys.MFA_ENROLLMENT_EXTENSION_PHONE_NUMBER));
                 },
                 HttpStatusCode.FOUND_302, "Found", null);
+   }
 
+    @Test
+    public void shouldSendCode_withEmail_tidUsedAsMovingFactor() throws Exception {
+        FactorProvider factorProvider = mock(FactorProvider.class);
+        when(factorProvider.needChallengeSending()).thenReturn(true);
+        when(factorProvider.useVariableFactorSecurity(any())).thenReturn(true);
+        when(factorProvider.sendChallenge(any())).thenReturn(Completable.complete());
+        Factor factor = mock(Factor.class);
+        when(factor.getId()).thenReturn("factorId");
+        when(factor.getFactorType()).thenReturn(FactorType.EMAIL);
+        when(factorManager.get("factorId")).thenReturn(factorProvider);
+        when(factorManager.getFactor("factorId")).thenReturn(factor);
+        when(templateEngine.render(any(Map.class), any())).thenReturn(Single.just(Buffer.buffer()));
+
+        SpyRoutingContext spyRoutingContext = new SpyRoutingContext();
+        spyRoutingContext.setMethod(HttpMethod.GET);
+        Client client = new Client();
+        client.setFactors(Collections.singleton("factorId"));
+        spyRoutingContext.session().put(ConstantKeys.ENROLLED_FACTOR_ID_KEY, "factorId");
+        spyRoutingContext.session().put(ConstantKeys.ENROLLED_FACTOR_EMAIL_ADDRESS, "user01@acme.fr");
+        spyRoutingContext.setUser(io.vertx.rxjava3.ext.auth.User.newInstance(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(new User())));
+        spyRoutingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+        spyRoutingContext.put(ConstantKeys.TRANSACTION_ID_KEY, UUID.randomUUID().toString());
+
+        mfaChallengeEndpoint.handle(spyRoutingContext);
+
+        int attempt = 20;
+        while (!spyRoutingContext.ended() && attempt > 0) {
+            Thread.sleep(1000);
+            --attempt;
+        }
+
+        assertTrue(spyRoutingContext.session().data().containsKey(MFAChallengeEndpoint.PREVIOUS_TRANSACTION_ID_KEY));
+        assertNull(spyRoutingContext.response().headers().get("location"));
+        assertEquals(MediaType.TEXT_HTML, spyRoutingContext.response().headers().get(HttpHeaders.CONTENT_TYPE));
+    }
+
+    @Test
+    public void shouldVerify_withEmail_tidRemovedFromSession() throws Exception {
+        FactorProvider factorProvider = mock(FactorProvider.class);
+        when(factorProvider.verify(any())).thenReturn(Completable.complete());
+        ArgumentCaptor<EnrolledFactor> enrolledFactorArgumentCaptor = ArgumentCaptor.forClass(EnrolledFactor.class);
+        when(factorProvider.changeVariableFactorSecurity(enrolledFactorArgumentCaptor.capture())).thenReturn(Single.just(new EnrolledFactor()));
+        Factor factor = mock(Factor.class);
+        when(factor.getId()).thenReturn("factorId");
+        when(factor.getFactorType()).thenReturn(FactorType.EMAIL);
+        when(factorManager.get("factorId")).thenReturn(factorProvider);
+        when(factorManager.getFactor("factorId")).thenReturn(factor);
+        when(verifyAttemptService.checkVerifyAttempt(any(), any(), any(), any())).thenReturn(Maybe.empty());
+        when(userService.addFactor(any(), any(), any())).thenReturn(Single.just(mock(User.class)));
+
+        SpyRoutingContext spyRoutingContext = new SpyRoutingContext();
+        spyRoutingContext.setMethod(HttpMethod.POST);
+        Client client = new Client();
+        client.setFactors(Collections.singleton("factorId"));
+        spyRoutingContext.session().put(ConstantKeys.ENROLLED_FACTOR_ID_KEY, "factorId");
+        spyRoutingContext.session().put(ConstantKeys.ENROLLED_FACTOR_EMAIL_ADDRESS, "user01@acme.fr");
+        spyRoutingContext.setUser(io.vertx.rxjava3.ext.auth.User.newInstance(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(new User())));
+        spyRoutingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+        spyRoutingContext.put(ConstantKeys.TRANSACTION_ID_KEY, UUID.randomUUID().toString());
+
+        spyRoutingContext.request().formAttributes().add("code", "123456");
+        spyRoutingContext.request().formAttributes().add("factorId", "factorId");
+
+        mfaChallengeEndpoint.handle(spyRoutingContext);
+
+        int attempt = 20;
+        while (!spyRoutingContext.ended() && attempt > 0) {
+            Thread.sleep(1000);
+            --attempt;
+        }
+
+        assertFalse(spyRoutingContext.session().data().containsKey(MFAChallengeEndpoint.PREVIOUS_TRANSACTION_ID_KEY));
+        String location = spyRoutingContext.response().headers().get("location");
+        assertNotNull(location);
+        assertTrue(location.contains("/oauth/authorize"));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/dummies/DummySession.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/dummies/DummySession.java
@@ -67,13 +67,13 @@ public class DummySession extends Session {
             }
 
             @Override
-            public <T> T remove(String s) {
-                return null;
+            public <T> T remove(String key) {
+                return (T)data.remove(key);
             }
 
             @Override
             public Map<String, Object> data() {
-                return null;
+                return data;
             }
 
             @Override
@@ -119,6 +119,11 @@ public class DummySession extends Session {
     }
 
     @Override
+    public <T> T remove(String key) {
+        return (T)data.remove(key);
+    }
+
+    @Override
     public <T> T get(String key) {
         return (T) data.get(key);
     }
@@ -133,5 +138,10 @@ public class DummySession extends Session {
     public Session putIfAbsent(String key, Object obj) {
         data.putIfAbsent(key, obj);
         return this;
+    }
+
+    @Override
+    public Map<String, Object> data() {
+        return data;
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/transaction/TransactionHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/transaction/TransactionHandler.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.reactor.impl.transaction;
 
+import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.common.utils.UUID;
 import io.vertx.core.Handler;
 import io.vertx.rxjava3.ext.web.RoutingContext;
@@ -47,6 +48,7 @@ public class TransactionHandler implements Handler<RoutingContext> {
             context.request().headers().set(transactionHeader, transactionId);
         }
         context.response().headers().set(transactionHeader,transactionId);
+        context.put(ConstantKeys.TRANSACTION_ID_KEY, transactionId);
 
         context.next();
     }

--- a/gravitee-am-test/specs/gateway/mfa.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/mfa.jest.spec.ts
@@ -277,17 +277,8 @@ describe('MFA', () => {
 
       expect(authorize2.headers['location']).toBeDefined();
       expect(authorize2.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/mfa/challenge`);
-      await performGet(authorize2.headers['location'], '', {
-        Cookie: authorize2.headers['set-cookie'],
-      }).expect(200);
 
-      const email = await getLastEmail();
-      expect(email).toBeDefined();
-      const verificationCode = email.contents[0].data.match('.*class="otp-code".*<span[^>]*>.([0-9]{6}).<\\/span>')[1];
-      expect(verificationCode).toBeDefined();
-      await clearEmails();
-
-      const successfulVerification = await verifyFactor(authorize2, verificationCode, emailFactor);
+      const successfulVerification = await verifyFactorOnEmailEnrollment(authorize2, emailFactor);
       await logoutUser(openIdConfiguration.end_session_endpoint, successfulVerification);
     });
 
@@ -723,6 +714,33 @@ const verifyFactor = async (challenge, code, factor) => {
       Cookie: challengeResponse.headers['set-cookie'],
       'Content-type': 'application/x-www-form-urlencoded',
     },
+  ).expect(302);
+
+  expect(successfulVerification.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/oauth/authorize`);
+  return successfulVerification;
+};
+
+const verifyFactorOnEmailEnrollment = async (challenge, factor) => {
+  const challengeResponse = await extractXsrfTokenAndActionResponse(challenge);
+
+  const email = await getLastEmail();
+  expect(email).toBeDefined();
+  const verificationCode = email.contents[0].data.match('.*class="otp-code".*<span[^>]*>.([0-9]{6}).<\\/span>')[1];
+  expect(verificationCode).toBeDefined();
+  await clearEmails();
+
+  const successfulVerification = await performPost(
+      challengeResponse.action,
+      '',
+      {
+        factorId: factor.id,
+        code: verificationCode,
+        'X-XSRF-TOKEN': challengeResponse.token,
+      },
+      {
+        Cookie: challengeResponse.headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
   ).expect(302);
 
   expect(successfulVerification.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${domain.hrid}/oauth/authorize`);


### PR DESCRIPTION
      this change allows to generate a new challenge even during the enrollment phase
    
      Since the code is renewed on each challenge call, the Jest test has to be rework for
    
      email factor otherwise the code read before the verification method is invalidated
    
      due to the second call on challenge endpoint made to get the XSRF token


fixes AM-4734

