### PR TITLE
AM-4792 - Improve memory usage in AM Gateway

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceTest.java
@@ -113,7 +113,7 @@ public class EmailServiceTest {
                 new ConditionalTemplateConfigurationFactory(new FileExtensionMatcher("html"), tcHTML));
         freemarkerConfiguration.setTemplateLoader(new FileTemplateLoader(new File("src/test/resources/templates")));
 
-        when(this.emailService.getDefaultDictionaryProvider()).thenReturn(new FileSystemDictionaryProvider("src/test/resources/templates/i18n"));
+        when(this.emailService.getDefaultDictionaryProvider()).thenReturn(FileSystemDictionaryProvider.getInstance("src/test/resources/templates/i18n"));
 
         when(this.graviteeMessageResolver.getDynamicDictionaryProvider()).thenReturn(this.domainBasedDictionaryProvider);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/spring/SecurityDomainRouterConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/spring/SecurityDomainRouterConfiguration.java
@@ -37,7 +37,6 @@ import org.springframework.context.annotation.Import;
  */
 @Import({
         ThymeleafConfiguration.class,
-        ServiceConfiguration.class,
         FreemarkerConfiguration.class
 })
 @Configuration

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewService.java
@@ -82,7 +82,7 @@ public class PreviewService implements InitializingBean {
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        final FileSystemDictionaryProvider fileSystemDictionaryProvider = new FileSystemDictionaryProvider(templatesDirectory.endsWith("/") ? templatesDirectory + "i18n/" : templatesDirectory + "/i18n/");
+        final FileSystemDictionaryProvider fileSystemDictionaryProvider = FileSystemDictionaryProvider.getInstance(templatesDirectory.endsWith("/") ? templatesDirectory + "i18n/" : templatesDirectory + "/i18n/");
         if (this.templateEngine instanceof SpringTemplateEngine templateEngine) {
             this.graviteeMessageResolver = new SpringGraviteeMessageSource(fileSystemDictionaryProvider, domainBasedDictionaryProvider);
             templateEngine.setMessageSource((MessageSource) this.graviteeMessageResolver);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/GraviteeMessageResolver.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/i18n/GraviteeMessageResolver.java
@@ -36,7 +36,7 @@ public class GraviteeMessageResolver extends AbstractMessageResolver {
     private final DynamicDictionaryProvider domainBasedDictionaryProvider;
 
     public GraviteeMessageResolver(String i18nLocation) {
-        this(new FileSystemDictionaryProvider(i18nLocation), new DomainBasedDictionaryProvider());
+        this(FileSystemDictionaryProvider.getInstance(i18nLocation), new DomainBasedDictionaryProvider());
     }
 
     public GraviteeMessageResolver(FileSystemDictionaryProvider fileSystemDictionaryProvider, DynamicDictionaryProvider domainBasedDictionaryProvider) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EmailServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EmailServiceImpl.java
@@ -53,7 +53,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
     @Override
     public void afterPropertiesSet() throws Exception {
         this.emailSender = new EmailSender(mailSender, templatesPath);
-        this.defaultDictionaryProvider = new FileSystemDictionaryProvider(Paths.get(templatesPath, "i18n").toFile().getAbsolutePath());
+        this.defaultDictionaryProvider = FileSystemDictionaryProvider.getInstance(Paths.get(templatesPath, "i18n").toFile().getAbsolutePath());
     }
 
     @Override

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/FileSystemDictionaryProviderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/FileSystemDictionaryProviderTest.java
@@ -53,7 +53,7 @@ public class FileSystemDictionaryProviderTest {
 
     @Before
     public void initProvider() {
-        this.directoryProvider = new FileSystemDictionaryProvider(this.directory);
+        this.directoryProvider = FileSystemDictionaryProvider.getInstance(this.directory);
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/FreemarkerMessageResolverTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/i18n/FreemarkerMessageResolverTest.java
@@ -28,7 +28,7 @@ import java.util.Locale;
  */
 public class FreemarkerMessageResolverTest {
 
-    private DictionaryProvider directoryProvider = new FileSystemDictionaryProvider("src/test/resources/i18n_default");
+    private DictionaryProvider directoryProvider = FileSystemDictionaryProvider.getInstance("src/test/resources/i18n_default");
 
     private FreemarkerMessageResolver cut;
 


### PR DESCRIPTION
There two commits:

* First one about Spring Context footprint to reduce the Domain memory footprint by 50%
* Seconf about FileSystemDictionaryProvider to load a provider only once. (save 40MB for 519 domains loaded)