### PR TITLE
fix: do not validate the config of Cert, Idp and Reporter using the @…

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
@@ -28,8 +28,6 @@ import io.gravitee.am.service.authentication.crypto.password.PasswordEncoderOpti
 import io.gravitee.am.service.model.NewIdentityProvider;
 import io.reactivex.rxjava3.core.Single;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -41,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 
 import static io.gravitee.am.service.utils.BackendConfigurationUtils.getMongoDatabaseName;
 
@@ -121,7 +118,7 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
 
             configMap.put("uri", mongoUri);
             configMap.put("host", (mongoHost != null) ? mongoHost : "");
-            configMap.put("port", mongoPort);
+            configMap.put("port", Integer.parseInt(mongoPort));
             configMap.put("enableCredentials", false);
             configMap.put("database", mongoDBName);
             configMap.put("usersCollection", "idp_users_" + lowerCaseId);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/PluginConfigurationValidationService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/PluginConfigurationValidationService.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.service;
+
+public interface PluginConfigurationValidationService {
+    void validate(String pluginType, String configuration);
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/InvalidPluginConfigurationException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/InvalidPluginConfigurationException.java
@@ -13,35 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.service.model;
+package io.gravitee.am.service.exception;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
+import io.gravitee.common.http.HttpStatusCode;
 
-/**
- * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
- * @author GraviteeSource Team
- */
-@Getter
-@Setter
-public class UpdateCertificate {
+public class InvalidPluginConfigurationException extends AbstractManagementException {
 
-    @NotBlank
-    private String name;
-
-    @NotBlank
-    private String type;
-
-    @NotNull
-    private String configuration;
+    protected InvalidPluginConfigurationException(String message) {
+        super(message);
+    }
 
     @Override
-    public String toString() {
-        return "UpdateCertificate{" +
-                "name='" + name + '\'' +
-                ", type='" + type + '\'' +
-                '}';
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    public static InvalidPluginConfigurationException fromValidationError(String error) {
+        return new InvalidPluginConfigurationException(error);
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
@@ -41,6 +41,7 @@ import io.gravitee.am.service.CertificatePluginService;
 import io.gravitee.am.service.CertificateService;
 import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.TaskManager;
 import io.gravitee.am.service.exception.AbstractManagementException;
 import io.gravitee.am.service.exception.CertificateNotFoundException;
@@ -149,6 +150,9 @@ public class CertificateServiceImpl implements CertificateService {
 
     @Autowired
     private CertificatePluginManager certificatePluginManager;
+
+    @Autowired
+    private PluginConfigurationValidationService validationService;
 
     @Autowired
     private Environment environment;
@@ -288,6 +292,9 @@ public class CertificateServiceImpl implements CertificateService {
                 .flatMap(oldCertificate -> {
                     try {
                         var certificate = getCertificateToUpdate(updateCertificate, oldCertificate);
+                        // for update validate config against schema here instead of the resource
+                        // as certificate may be system certificate so on the UI config is empty.
+                        validationService.validate(certificate.getType(), certificate.getConfiguration());
                         return certificateRepository.update(validate(certificate));
                     } catch (IOException | CertificateException ex) {
                         log.error("An error occurs while trying to update certificate binaries", ex);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PluginConfigurationValidationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PluginConfigurationValidationServiceImpl.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.service.impl;
+
+
+import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidatorsRegistry;
+import io.gravitee.am.service.PluginConfigurationValidationService;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+@RequiredArgsConstructor
+public class PluginConfigurationValidationServiceImpl implements PluginConfigurationValidationService {
+    private final PluginConfigurationValidatorsRegistry pluginValidatorsRegistry;
+
+    @Override
+    public void validate(String pluginType, String configuration) {
+        pluginValidatorsRegistry.get(pluginType)
+                .ifPresent(pluginValidator -> {
+                    final var result = pluginValidator.validate(configuration);
+                    if (!result.isValid()) {
+                        throw InvalidPluginConfigurationException.fromValidationError(result.getMsg());
+                    }
+                });
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateIdentityProvider.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateIdentityProvider.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 @Getter
 @Setter
-public class UpdateIdentityProvider implements PluginConfigurationPayload {
+public class UpdateIdentityProvider {
 
     @NotNull
     private String name;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateReporter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateReporter.java
@@ -24,7 +24,7 @@ import lombok.Data;
  * @author GraviteeSource Team
  */
 @Data
-public class UpdateReporter implements PluginConfigurationPayload {
+public class UpdateReporter {
 
     private boolean enabled;
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/CertificateServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/CertificateServiceTest.java
@@ -116,6 +116,9 @@ public class CertificateServiceTest {
     private CertificatePluginService certificatePluginService;
 
     @Mock
+    private PluginConfigurationValidationService validationService;
+
+    @Mock
     private TaskManager taskManager;
 
     @Mock
@@ -320,6 +323,7 @@ public class CertificateServiceTest {
         verify(certificatePluginManager, times(1)).validate(any());
         verify(certificateRepository, times(1)).update(any());
         verify(eventService, times(1)).create(any());
+        verify(validationService).validate(any(), any());
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/CertificateServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/CertificateServiceImplTest.java
@@ -28,6 +28,7 @@ import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.CertificatePluginService;
 import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.TaskManager;
 import io.gravitee.am.service.exception.CertificateWithApplicationsException;
 import io.gravitee.am.service.exception.CertificateWithIdpException;
@@ -78,6 +79,9 @@ class CertificateServiceImplTest {
 
     @Mock
     private TaskManager taskManager;
+
+    @Mock
+    private PluginConfigurationValidationService validationService;
 
     @InjectMocks
     private CertificateServiceImpl service;


### PR DESCRIPTION
…Valid annotation

 at REST level we do not know if certificate, identityProvier or reporter are a system one

 as in case of system plugin, the config is empty validation is failing

 as consequence for these 2 classes, we are doing validation in the service layer to test the system flag

fixes AM-4771

