### PR TITLE
fix: provide an option to reuse system settings when creating a Mongo…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -307,6 +307,10 @@ handlers:
       maxRequestOperations: 1000
 
 repositories:
+  # specify which scope is used as reference
+  # to initialize the IdentityProviders with the "use system cluster"
+  # option enabled (only management and gateway scopes are allowed as value)
+  system-cluster: management
   # Management repository is used to store global configuration such as domains, clients, ...
   # This is the default configuration using MongoDB (single server)
   # For more information about MongoDB configuration, please have a look to:
@@ -360,6 +364,7 @@ repositories:
   oauth2:
     type: mongodb
     use-management-settings: true
+    use-gateway-settings: false
     mongodb:
       dbname: ${ds.mongodb.dbname}
       host: ${ds.mongodb.host}

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
@@ -25,7 +25,6 @@
     },
     "usersTable" : {
       "type" : "string",
-      "default": "users",
       "title": "The table used to run query",
       "description": "The table used to run query to search for users."
     },

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoIdentityProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoIdentityProviderConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.am.identityprovider.mongo;
 import io.gravitee.am.common.password.PasswordSaltFormat;
 import io.gravitee.am.identityprovider.api.IdentityProviderConfiguration;
 import io.gravitee.am.identityprovider.mongo.utils.PasswordEncoder;
+import io.gravitee.am.repository.Scope;
 import io.gravitee.am.repository.mongodb.provider.MongoConnectionConfiguration;
 import io.gravitee.am.service.authentication.crypto.password.PasswordEncoderOptions;
 
@@ -55,6 +56,8 @@ public class MongoIdentityProviderConfiguration implements IdentityProviderConfi
     private boolean usernameCaseSensitive = false;
 
     private PasswordEncoderOptions passwordEncoderOptions;
+
+    private boolean useSystemCluster;
 
     @Override
     public boolean userProvider() {
@@ -239,5 +242,13 @@ public class MongoIdentityProviderConfiguration implements IdentityProviderConfi
 
     public void setPasswordEncoderOptions(PasswordEncoderOptions passwordEncoderOptions) {
         this.passwordEncoderOptions = passwordEncoderOptions;
+    }
+
+    public boolean isUseSystemCluster() {
+        return useSystemCluster;
+    }
+
+    public void setUseSystemCluster(boolean useSystemCluster) {
+        this.useSystemCluster = useSystemCluster;
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
@@ -58,7 +58,6 @@
     },
     "usersCollection" : {
       "type" : "string",
-      "default": "users",
       "title": "The collection used to run query",
       "description": "The collection which is containing all the users."
     },

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
@@ -45,6 +45,12 @@
       "widget": "password",
       "sensitive": true
     },
+    "useSystemCluster" : {
+      "type" : "boolean",
+      "default" : false,
+      "title": "Use System Cluster",
+      "description": "Use MongoCluster configured in the system configuration instead of the values defined in this form"
+    },
     "database" : {
       "type" : "string",
       "title": "The database used to run query",
@@ -154,5 +160,18 @@
     "usernameField",
     "passwordField",
     "passwordEncoder"
+  ],
+  "anyOf":[
+    {
+      "required": [
+        "uri"
+      ]
+    },
+    {
+      "required": [
+        "host",
+        "port"
+      ]
+    }
   ]
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -356,6 +356,10 @@ user:
     maxRequestOperations: 1000
 
 repositories:
+  # specify which scope is used as reference
+  # to initialize the IdentityProviders with the "use system cluster"
+  # option enabled (only management and gateway scopes are allowed as value)
+  system-cluster: management
   # Management repository is used to store global configuration such as domains, clients, ...
   # This is the default configuration using MongoDB (single server)
   # For more information about MongoDB configuration, please have a look to:
@@ -409,6 +413,7 @@ repositories:
   oauth2:
     type: mongodb
     use-management-settings: true
+    use-gateway-settings: false
     mongodb:
       dbname: ${ds.mongodb.dbname}
       host: ${ds.mongodb.host}

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/Scope.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/Scope.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.repository;
 
+import java.util.Locale;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
@@ -39,4 +41,7 @@ public enum Scope {
         return "repositories." + name;
     }
 
+    public static Scope fromName(String name) {
+        return Scope.valueOf(name.toUpperCase(Locale.ROOT));
+    }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/provider/impl/R2DBCConnectionProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/provider/impl/R2DBCConnectionProvider.java
@@ -92,6 +92,7 @@ public class R2DBCConnectionProvider implements ConnectionProvider<ConnectionFac
     private ReactiveTransactionManager transactionManager;
 
     private boolean notUseMngSettingsForOauth2;
+    private boolean notUseGwSettingsForOauth2;
     private boolean notUseMngSettingsForGateway;
 
     @Override
@@ -142,7 +143,7 @@ public class R2DBCConnectionProvider implements ConnectionProvider<ConnectionFac
     @Override
     public ClientWrapper getClientWrapper(String name) {
         if (OAUTH2.getName().equals(name) && notUseMngSettingsForOauth2) {
-            return oauthConnectionFactory;
+            return notUseGwSettingsForOauth2 ? oauthConnectionFactory : getClientWrapper(GATEWAY.getName());
         } else if (GATEWAY.getName().equals(name) && notUseMngSettingsForGateway) {
             return gatewayConnectionFactory;
         } else {
@@ -172,7 +173,9 @@ public class R2DBCConnectionProvider implements ConnectionProvider<ConnectionFac
     @Override
     public void afterPropertiesSet() throws Exception {
         final var useMngSettingsForOauth2 = environment.getProperty(OAUTH2.getRepositoryPropertyKey() +".use-management-settings", Boolean.class, true);
+        final var useGwSettingsForOauth2 = environment.getProperty(OAUTH2.getRepositoryPropertyKey() + ".use-gateway-settings", Boolean.class, false);
         final var useMngSettingsForGateway = environment.getProperty(GATEWAY.getRepositoryPropertyKey() +".use-management-settings", Boolean.class, true);
+        notUseGwSettingsForOauth2 = !useGwSettingsForOauth2;
         notUseMngSettingsForOauth2 = !useMngSettingsForOauth2;
         notUseMngSettingsForGateway = !useMngSettingsForGateway;
         // create the connection pool just after the bean Initialization to guaranty the uniqueness
@@ -180,7 +183,7 @@ public class R2DBCConnectionProvider implements ConnectionProvider<ConnectionFac
         if (notUseMngSettingsForGateway) {
             gatewayConnectionFactory = new R2DBCPoolWrapper(new ConnectionFactoryProvider(environment, GATEWAY.getRepositoryPropertyKey()));
         }
-        if (notUseMngSettingsForOauth2) {
+        if (notUseMngSettingsForOauth2 && notUseGwSettingsForOauth2) {
             oauthConnectionFactory = new R2DBCPoolWrapper(new ConnectionFactoryProvider(environment, OAUTH2.getRepositoryPropertyKey()));
         }
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/provider/impl/MongoConnectionProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/provider/impl/MongoConnectionProvider.java
@@ -48,21 +48,24 @@ public class MongoConnectionProvider implements ConnectionProvider<MongoClient, 
     private ClientWrapper<MongoClient> gatewayMongoClient;
 
     private boolean notUseMngSettingsForOauth2;
+    private boolean notUseGwSettingsForOauth2;
     private boolean notUseMngSettingsForGateway;
 
     @Override
     public void afterPropertiesSet() throws Exception {
         final var useMngSettingsForOauth2 = environment.getProperty(OAUTH2.getRepositoryPropertyKey() + ".use-management-settings", Boolean.class, true);
-        final var notUseGatewaySettings = environment.getProperty(Scope.GATEWAY.getRepositoryPropertyKey() + ".use-management-settings", Boolean.class, true);
+        final var useGwSettingsForOauth2 = environment.getProperty(OAUTH2.getRepositoryPropertyKey() + ".use-gateway-settings", Boolean.class, false);
+        final var useMngSettingsForGateway = environment.getProperty(Scope.GATEWAY.getRepositoryPropertyKey() + ".use-management-settings", Boolean.class, true);
+        notUseGwSettingsForOauth2 = !useGwSettingsForOauth2;
         notUseMngSettingsForOauth2 = !useMngSettingsForOauth2;
-        notUseMngSettingsForGateway = !notUseGatewaySettings;
+        notUseMngSettingsForGateway = !useMngSettingsForGateway;
         // create the common client just after the bean Initialization to guaranty the uniqueness
         commonMongoClient = new MongoClientWrapper(new MongoFactory(environment, MANAGEMENT.getRepositoryPropertyKey()).getObject());
-        if (notUseMngSettingsForOauth2) {
-            oauthMongoClient = new MongoClientWrapper(new MongoFactory(environment, OAUTH2.getRepositoryPropertyKey()).getObject());
-        }
         if (notUseMngSettingsForGateway) {
             gatewayMongoClient = new MongoClientWrapper(new MongoFactory(environment, GATEWAY.getRepositoryPropertyKey()).getObject());
+        }
+        if (notUseMngSettingsForOauth2 && notUseGwSettingsForOauth2) {
+            oauthMongoClient = new MongoClientWrapper(new MongoFactory(environment, OAUTH2.getRepositoryPropertyKey()).getObject());
         }
     }
 
@@ -74,7 +77,7 @@ public class MongoConnectionProvider implements ConnectionProvider<MongoClient, 
     @Override
     public ClientWrapper getClientWrapper(String name) {
         if (OAUTH2.getName().equals(name) && notUseMngSettingsForOauth2) {
-            return oauthMongoClient;
+            return notUseGwSettingsForOauth2 ? oauthMongoClient : getClientWrapper(GATEWAY.getName());
         } else if (GATEWAY.getName().equals(name) && notUseMngSettingsForGateway) {
             return gatewayMongoClient;
         } else {


### PR DESCRIPTION
… IDP

fixes AM-4809

## Description

Before the fix, each Mongo IDP plugin created through the REST API (different from the default one) was initializing its own connection pool. This fix propose an option to use the connection pool coming from the repository layer, you can peek the respository scope you want to use (management, gateway) so if different cluster are configured, you can peek the right one. We also introduce the `use-gateway-settings` for the oauth2 scope so the oauth2 repositories can reuse the same connection pool as the gateway repositories.


Here is some numbers to demontrate the changes:
* A single domain with the default IDP is created with one mAPI and ona GW started:

51 connections established

* After the creation of 5 Mongo IDP on the same cluster: 

76 connections established

* After a restart:

74 connections established

* Restart AM using the fix, only enable the use-gateway-settings flag:

70 connections established

* Update the 5 Mongo IDP to target the Gateway scope:

Connections decrease to 45 open connections.

* After a restart:

27 connections established
