### PR TITLE
fix provide an option to reuse system settings when creating a Mongo IDP

### DIFF
--- a/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/DataPlaneProvider.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/DataPlaneProvider.java
@@ -26,6 +26,7 @@ import io.gravitee.am.dataplane.api.repository.ResourceRepository;
 import io.gravitee.am.dataplane.api.repository.ScopeApprovalRepository;
 import io.gravitee.am.dataplane.api.repository.UserActivityRepository;
 import io.gravitee.am.dataplane.api.repository.UserRepository;
+import io.gravitee.am.repository.provider.ClientWrapper;
 
 public interface DataPlaneProvider {
 
@@ -52,4 +53,8 @@ public interface DataPlaneProvider {
     ResourceRepository getResourceRepository();
 
     PermissionTicketRepository getPermissionTicketRepository();
+
+    boolean canHandle(String backendType);
+
+    <T> ClientWrapper<T> getClientWrapper();
 }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/provider/JdbcDataPlaneProvider.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/provider/JdbcDataPlaneProvider.java
@@ -29,6 +29,10 @@ import io.gravitee.am.dataplane.api.repository.ScopeApprovalRepository;
 import io.gravitee.am.dataplane.api.repository.UserActivityRepository;
 import io.gravitee.am.dataplane.api.repository.UserRepository;
 import io.gravitee.am.dataplane.jdbc.spring.JdbcDataPlaneSpringConfiguration;
+import io.gravitee.am.repository.jdbc.provider.impl.R2DBCPoolWrapper;
+import io.gravitee.am.repository.provider.ClientWrapper;
+import io.gravitee.am.repository.provider.ConnectionProvider;
+import io.r2dbc.spi.ConnectionFactory;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
@@ -42,6 +46,9 @@ public class JdbcDataPlaneProvider implements DataPlaneProvider, InitializingBea
 
     @Autowired
     private DataPlaneDescription dataPlaneDescription;
+
+    @Autowired
+    private R2DBCPoolWrapper clientWrapper;
 
     @Autowired
     private CredentialRepository credentialRepository;
@@ -79,11 +86,20 @@ public class JdbcDataPlaneProvider implements DataPlaneProvider, InitializingBea
     @Override
     public void afterPropertiesSet() throws Exception {
         log.info("DataPlane provider loaded with id {}", dataPlaneDescription.id());
-
     }
 
     @Override
     public void stop() {
 
+    }
+
+    @Override
+    public boolean canHandle(String backendType) {
+        return ConnectionProvider.BACKEND_TYPE_RDBMS.equals(backendType);
+    }
+
+    @Override
+    public ClientWrapper<ConnectionFactory> getClientWrapper() {
+        return this.clientWrapper;
     }
 }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/provider/MongoDataPlaneProvider.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/provider/MongoDataPlaneProvider.java
@@ -31,6 +31,7 @@ import io.gravitee.am.dataplane.api.repository.UserActivityRepository;
 import io.gravitee.am.dataplane.api.repository.UserRepository;
 import io.gravitee.am.dataplane.mongodb.spring.MongoDataPlaneSpringConfiguration;
 import io.gravitee.am.repository.provider.ClientWrapper;
+import io.gravitee.am.repository.provider.ConnectionProvider;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
@@ -91,5 +92,15 @@ public class MongoDataPlaneProvider implements DataPlaneProvider, InitializingBe
         if (mongoClientWrapper != null) {
             mongoClientWrapper.releaseClient();
         }
+    }
+
+    @Override
+    public boolean canHandle(String backendType) {
+        return ConnectionProvider.BACKEND_TYPE_MONGO.equals(backendType);
+    }
+
+    @Override
+    public ClientWrapper<MongoClient> getClientWrapper() {
+        return this.mongoClientWrapper;
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -307,6 +307,10 @@ handlers:
       maxRequestOperations: 1000
 
 repositories:
+  # specify which scope is used as reference
+  # to initialize the IdentityProviders with the "use system cluster"
+  # option enabled (only management and gateway scopes are allowed as value)
+  system-cluster: management
   # Management repository is used to store global configuration such as domains, clients, ...
   # This is the default configuration using MongoDB (single server)
   # For more information about MongoDB configuration, please have a look to:

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
@@ -25,7 +25,6 @@
     },
     "usersTable" : {
       "type" : "string",
-      "default": "users",
       "title": "The table used to run query",
       "description": "The table used to run query to search for users."
     },

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoIdentityProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoIdentityProviderConfiguration.java
@@ -56,6 +56,8 @@ public class MongoIdentityProviderConfiguration implements IdentityProviderConfi
 
     private PasswordEncoderOptions passwordEncoderOptions;
 
+    private boolean useSystemCluster;
+
     @Override
     public boolean userProvider() {
         return this.userProvider;
@@ -239,5 +241,13 @@ public class MongoIdentityProviderConfiguration implements IdentityProviderConfi
 
     public void setPasswordEncoderOptions(PasswordEncoderOptions passwordEncoderOptions) {
         this.passwordEncoderOptions = passwordEncoderOptions;
+    }
+
+    public boolean isUseSystemCluster() {
+        return useSystemCluster;
+    }
+
+    public void setUseSystemCluster(boolean useSystemCluster) {
+        this.useSystemCluster = useSystemCluster;
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/resources/schemas/schema-form.json
@@ -45,6 +45,12 @@
       "widget": "password",
       "sensitive": true
     },
+    "useSystemCluster" : {
+      "type" : "boolean",
+      "default" : false,
+      "title": "Use System Cluster",
+      "description": "Use MongoCluster configured in the system configuration instead of the values defined in this form"
+    },
     "database" : {
       "type" : "string",
       "title": "The database used to run query",
@@ -52,7 +58,6 @@
     },
     "usersCollection" : {
       "type" : "string",
-      "default": "users",
       "title": "The collection used to run query",
       "description": "The collection which is containing all the users."
     },
@@ -154,5 +159,18 @@
     "usernameField",
     "passwordField",
     "passwordEncoder"
+  ],
+  "anyOf":[
+    {
+      "required": [
+        "uri"
+      ]
+    },
+    {
+      "required": [
+        "host",
+        "port"
+      ]
+    }
   ]
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/EmbeddedClient.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/EmbeddedClient.java
@@ -65,7 +65,7 @@ public class EmbeddedClient implements InitializingBean, DisposableBean {
 
         int port = Network.freeServerPort(InetAddress.getLocalHost());
 
-        Version.Main version = Version.Main.V6_0;
+        Version.Main version = Version.Main.V7_0;
         var mongod = Mongod.builder().net(Start.to(Net.class)
                 .initializedWith(Net.builder().port(port).isIpv6(Network.localhostIsIPv6()).build()))
                 .build();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/authentication/MongoAuthenticationProviderTestConfiguration.java
@@ -27,6 +27,10 @@ import io.gravitee.am.identityprovider.api.IdentityProviderRoleMapper;
 import io.gravitee.am.identityprovider.mongo.MongoIdentityProviderConfiguration;
 import io.gravitee.am.identityprovider.mongo.utils.PasswordEncoder;
 import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneLoader;
+import io.gravitee.am.plugins.dataplane.core.DataPlanePluginManager;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistryImpl;
 import io.gravitee.am.repository.provider.ConnectionProvider;
 import io.reactivex.rxjava3.core.Observable;
 import org.bson.Document;
@@ -36,6 +40,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -61,6 +67,11 @@ public class MongoAuthenticationProviderTestConfiguration implements Initializin
         users.forEach(doc -> Observable.fromPublisher(collection.insertOne(doc)).blockingFirst());
     }
 
+    @Bean
+    public DataPlaneRegistry dataPlaneRegistry() {
+        return new DataPlaneRegistryImpl(mock(DataPlaneLoader.class), mock(DataPlanePluginManager.class));
+    }
+    
     @Bean
     public MongoIdentityProviderConfiguration mongoIdentityProviderConfiguration() {
         MongoIdentityProviderConfiguration configuration = new MongoIdentityProviderConfiguration();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProviderTestConfiguration.java
@@ -15,6 +15,10 @@
  */
 package io.gravitee.am.identityprovider.mongo.user;
 
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 import io.gravitee.am.identityprovider.api.DefaultIdentityProviderMapper;
@@ -27,6 +31,10 @@ import io.gravitee.am.identityprovider.mongo.authentication.EmbeddedClient;
 import io.gravitee.am.identityprovider.mongo.authentication.EmbeddedMongoConnectionProvider;
 import io.gravitee.am.identityprovider.mongo.utils.PasswordEncoder;
 import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneLoader;
+import io.gravitee.am.plugins.dataplane.core.DataPlanePluginManager;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistryImpl;
 import io.gravitee.am.repository.provider.ConnectionProvider;
 import io.reactivex.rxjava3.core.Observable;
 import org.bson.Document;
@@ -34,8 +42,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.UUID;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -63,6 +69,11 @@ public class MongoUserProviderTestConfiguration implements InitializingBean {
         Document doc6 = new Document("username", "UserWithCase").append("email", "user02@acme.com").append("alternative_email", "user02-alt@acme.com").append("password", "user02").append("_id", UUID.randomUUID().toString());
         Observable.fromPublisher(collection.insertOne(doc6)).blockingFirst();
 
+    }
+
+    @Bean
+    public DataPlaneRegistry dataPlaneRegistry() {
+        return new DataPlaneRegistryImpl(mock(DataPlaneLoader.class), mock(DataPlanePluginManager.class));
     }
 
     @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/IdentityProvidersResource.java
@@ -131,19 +131,19 @@ public class IdentityProvidersResource extends AbstractResource {
     public void create(
             @PathParam("organizationId") String organizationId,
             @PathParam("environmentId") String environmentId,
-            @PathParam("domain") String domain,
+            @PathParam("domain") String domainId,
             @Parameter(name = "identity", required = true)
             @Valid @NotNull final NewIdentityProvider newIdentityProvider,
             @Suspended final AsyncResponse response) {
         final User authenticatedUser = getAuthenticatedUser();
 
-        checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_IDENTITY_PROVIDER, Acl.CREATE)
+        checkAnyPermission(organizationId, environmentId, domainId, Permission.DOMAIN_IDENTITY_PROVIDER, Acl.CREATE)
                 .andThen(identityProviderManager.checkPluginDeployment(newIdentityProvider.getType()))
-                .andThen(domainService.findById(domain)
-                        .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
-                        .flatMapSingle(__ -> identityProviderService.create(domain, newIdentityProvider, authenticatedUser))
+                .andThen(domainService.findById(domainId)
+                        .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId)))
+                        .flatMapSingle(domain -> identityProviderService.create(domain, newIdentityProvider, authenticatedUser))
                         .map(identityProvider -> Response.created(URI.create("/organizations/" + organizationId + "/environments/"
-                                                    + environmentId + "/domains/" + domain + "/identities/" + identityProvider.getId()))
+                                                    + environmentId + "/domains/" + domainId + "/identities/" + identityProvider.getId()))
                                             .entity(identityProvider)
                                             .build()
                         ))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainsResourceTest.java
@@ -84,7 +84,7 @@ public class DomainsResourceTest extends JerseySpringTest {
         domain.setDataPlaneId("data-plane-id");
 
         doReturn(Single.just(domain)).when(domainService).create(eq("DEFAULT"), eq("DEFAULT"), any(), any());
-        doReturn(Single.just(new IdentityProvider())).when(defaultIdentityProviderService).create(domain.getId());
+        doReturn(Single.just(new IdentityProvider())).when(defaultIdentityProviderService).create(domain);
         doReturn(Single.just(new Reporter())).when(reporterService).createDefault(argThat(ref -> ref.id().equals(domain.getId())));
 
         final Response response = target("domains").request().post(Entity.json(newDomain));

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/IdentityProvidersResourceTest.java
@@ -15,6 +15,12 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources;
 
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+
 import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
@@ -30,13 +36,6 @@ import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -99,7 +98,7 @@ public class IdentityProvidersResourceTest extends JerseySpringTest {
         identityProvider.setDomainWhitelist(List.of());
 
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
-        doReturn(Single.just(identityProvider)).when(identityProviderService).create(eq(domainId), any(), any());
+        doReturn(Single.just(identityProvider)).when(identityProviderService).create(any(Domain.class), any(), any());
         doReturn(Completable.complete()).when(identityProviderManager).checkPluginDeployment(any());
 
         final Response response = target("domains")

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DefaultIdentityProviderService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DefaultIdentityProviderService.java
@@ -15,14 +15,15 @@
  */
 package io.gravitee.am.management.service;
 
+import java.util.Map;
+
+import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.service.model.NewIdentityProvider;
 import io.reactivex.rxjava3.core.Single;
 
-import java.util.Map;
-
 public interface DefaultIdentityProviderService {
-    Single<IdentityProvider> create(String domainId);
+    Single<IdentityProvider> create(Domain domain);
 
     Map<String, Object> createProviderConfiguration(String referenceId, NewIdentityProvider identityProvider);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
@@ -15,23 +15,6 @@
  */
 package io.gravitee.am.management.service.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.BaseEncoding;
-import io.gravitee.am.common.env.RepositoriesEnvironment;
-import io.gravitee.am.management.service.DefaultIdentityProviderService;
-import io.gravitee.am.model.IdentityProvider;
-import io.gravitee.am.model.ReferenceType;
-import io.gravitee.am.repository.Scope;
-import io.gravitee.am.service.IdentityProviderService;
-import io.gravitee.am.service.authentication.crypto.password.PasswordEncoderOptions;
-import io.gravitee.am.service.model.NewIdentityProvider;
-import io.reactivex.rxjava3.core.Single;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
-
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -42,6 +25,23 @@ import java.util.Optional;
 import java.util.Set;
 
 import static io.gravitee.am.service.utils.BackendConfigurationUtils.getMongoDatabaseName;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.BaseEncoding;
+import io.gravitee.am.common.env.RepositoriesEnvironment;
+import io.gravitee.am.management.service.DefaultIdentityProviderService;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.repository.Scope;
+import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.authentication.crypto.password.PasswordEncoderOptions;
+import io.gravitee.am.service.model.NewIdentityProvider;
+import io.reactivex.rxjava3.core.Single;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @Slf4j
@@ -69,20 +69,20 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
     }
 
     @Override
-    public Single<IdentityProvider> create(String domainId) {
+    public Single<IdentityProvider> create(Domain domain) {
         NewIdentityProvider newIdentityProvider = new NewIdentityProvider();
-        newIdentityProvider.setId(DEFAULT_IDP_PREFIX + domainId.toLowerCase());
+        newIdentityProvider.setId(DEFAULT_IDP_PREFIX + domain.getId().toLowerCase());
         newIdentityProvider.setName(DEFAULT_IDP_NAME);
         if (useMongoRepositories()) {
             newIdentityProvider.setType(DEFAULT_MONGO_IDP_TYPE);
-            newIdentityProvider.setConfiguration(createProviderConfig(domainId, null));
+            newIdentityProvider.setConfiguration(createProviderConfig(domain.getId(), null));
         } else if (useJdbcRepositories()) {
             newIdentityProvider.setType(DEFAULT_JDBC_IDP_TYPE);
-            newIdentityProvider.setConfiguration(createProviderConfig(domainId, newIdentityProvider));
+            newIdentityProvider.setConfiguration(createProviderConfig(domain.getId(), newIdentityProvider));
         } else {
             return Single.error(new IllegalStateException("Unable to create Default IdentityProvider with " + managementBackend() + " backend"));
         }
-        return identityProviderService.create(ReferenceType.DOMAIN, domainId, newIdentityProvider, null, true);
+        return identityProviderService.create(domain, newIdentityProvider, null, true);
     }
 
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -394,7 +394,7 @@ public class DomainServiceImpl implements DomainService {
                     if (!createDefaultIdentityProvider) {
                         return Single.just(domain);
                     }
-                    return defaultIdentityProviderService.create(domain.getId()).map(__ -> domain);
+                    return defaultIdentityProviderService.create(domain).map(__ -> domain);
                 })
                 // create default reporter
                 .flatMap(domain -> {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderServiceProxyImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderServiceProxyImpl.java
@@ -25,6 +25,7 @@ import io.gravitee.am.management.service.AbstractSensitiveProxy;
 import io.gravitee.am.management.service.IdentityProviderPluginService;
 import io.gravitee.am.management.service.IdentityProviderServiceProxy;
 import io.gravitee.am.management.service.exception.IdentityProviderPluginSchemaNotFoundException;
+import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
@@ -129,6 +130,18 @@ public class IdentityProviderServiceProxyImpl extends AbstractSensitiveProxy imp
                                 .doOnSuccess(identityProvider1 -> auditService.report(AuditBuilder.builder(IdentityProviderAuditBuilder.class).principal(principal).type(EventType.IDENTITY_PROVIDER_UPDATED).oldValue(safeOldIdp).identityProvider(identityProvider1)))
                                 .doOnError(throwable -> auditService.report(AuditBuilder.builder(IdentityProviderAuditBuilder.class).principal(principal).type(EventType.IDENTITY_PROVIDER_UPDATED).reference(new Reference(referenceType, referenceId)).throwable(throwable))))
                 );
+    }
+
+    @Override
+    public Single<IdentityProvider> create(Domain domain, NewIdentityProvider newIdentityProvider, User principal, boolean system) {
+        return identityProviderService.create(domain, newIdentityProvider, principal, system)                .flatMap(this::filterSensitiveData)
+                .doOnSuccess(identityProvider1 -> auditService.report(AuditBuilder.builder(IdentityProviderAuditBuilder.class).principal(principal).type(EventType.IDENTITY_PROVIDER_CREATED).identityProvider(identityProvider1)))
+                .doOnError(throwable -> auditService.report(AuditBuilder.builder(IdentityProviderAuditBuilder.class).principal(principal).type(EventType.IDENTITY_PROVIDER_CREATED).reference(domain.asReference()).throwable(throwable)));
+    }
+
+    @Override
+    public Single<IdentityProvider> assignDataPlane(IdentityProvider identityProvider, String dataPlaneId) {
+        return identityProviderService.assignDataPlane(identityProvider, dataPlaneId);
     }
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainIdpUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainIdpUpgrader.java
@@ -61,7 +61,7 @@ public class DomainIdpUpgrader extends AsyncUpgrader {
                         (isEmpty -> {
                     if (isEmpty) {
                         logger.info("No default idp found for domain {}, update domain", domain.getName());
-                        return defaultIdentityProviderService.create(domain.getId());
+                        return defaultIdentityProviderService.create(domain);
                     }
                     return Single.just(new IdentityProvider());
                 });

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/IdentityProviderDataPlaneUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/IdentityProviderDataPlaneUpgrader.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.upgrades;
+
+import static io.gravitee.am.management.service.impl.upgrades.UpgraderOrder.IDP_DATA_PLANE_UPGRADER;
+
+import io.gravitee.am.dataplane.api.DataPlaneDescription;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.service.IdentityProviderService;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class IdentityProviderDataPlaneUpgrader extends AsyncUpgrader{
+
+    @Autowired
+    private IdentityProviderService identityProviderService;
+
+    @Override
+    Completable doUpgrade() {
+        log.debug("Applying Data Plane for IdentityProvider upgrade");
+        return Completable.fromPublisher(identityProviderService.findAll(ReferenceType.DOMAIN)
+                .flatMapMaybe(this::upgradeDomain));
+    }
+
+    private Maybe<IdentityProvider> upgradeDomain(IdentityProvider idp) {
+        if (idp.getDataPlaneId() == null) {
+            return Maybe.fromSingle(identityProviderService.assignDataPlane(idp, DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
+        }
+        return Maybe.empty();
+    }
+
+    @Override
+    public int getOrder() {
+        return IDP_DATA_PLANE_UPGRADER;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/UpgraderOrder.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/UpgraderOrder.java
@@ -37,6 +37,7 @@ public final class UpgraderOrder {
     public static final int DOMAIN_PASSWORD_POLICIES_UPGRADER = 16;
     public static final int ORG_DEFAULT_REPORTER_UPGRADER = 17;
     public static final int DOMAIN_DATA_PLANE_UPGRADER = 18;
+    public static final int IDP_DATA_PLANE_UPGRADER = 19;
 
     private UpgraderOrder() {
         throw new UnsupportedOperationException("utility class, don't instantiate");

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceTest.java
@@ -15,7 +15,19 @@
  */
 package io.gravitee.am.management.service.impl;
 
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import io.gravitee.am.common.env.RepositoriesEnvironment;
+import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.authentication.crypto.password.PasswordEncoderOptions;
@@ -31,18 +43,6 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
-
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DefaultIdentityProviderServiceTest {
@@ -67,11 +67,11 @@ public class DefaultIdentityProviderServiceTest {
         String domainId = "domain";
         ArgumentCaptor<NewIdentityProvider> newIdentityProviderArgumentCaptor = ArgumentCaptor.forClass(NewIdentityProvider.class);
 
-        when(identityProviderService.create(any(), eq(domainId), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean())).thenReturn(Single.just(new IdentityProvider()));
-        TestObserver<IdentityProvider> observer = cut.create(domainId).test();
+        when(identityProviderService.create(any(Domain.class), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean())).thenReturn(Single.just(new IdentityProvider()));
+        TestObserver<IdentityProvider> observer = cut.create(new Domain(domainId)).test();
         observer.assertComplete();
 
-        verify(identityProviderService).create(any(), eq(domainId), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean());
+        verify(identityProviderService).create(any(Domain.class), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean());
         NewIdentityProvider capturedIdp = newIdentityProviderArgumentCaptor.getValue();
         assertNotNull(capturedIdp);
         assertEquals("default-idp-domain", capturedIdp.getId());
@@ -84,12 +84,12 @@ public class DefaultIdentityProviderServiceTest {
         String domainId = "domain";
         environment.setProperty("repositories.management.type", "jdbc");
         ArgumentCaptor<NewIdentityProvider> newIdentityProviderArgumentCaptor = ArgumentCaptor.forClass(NewIdentityProvider.class);
-        when(identityProviderService.create(any(), eq(domainId), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean())).thenReturn(Single.just(new IdentityProvider()));
+        when(identityProviderService.create(any(Domain.class), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean())).thenReturn(Single.just(new IdentityProvider()));
 
-        TestObserver<IdentityProvider> observer = cut.create(domainId).test();
+        TestObserver<IdentityProvider> observer = cut.create(new Domain(domainId)).test();
         observer.assertComplete();
 
-        verify(identityProviderService).create(any(), eq(domainId), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean());
+        verify(identityProviderService).create(any(Domain.class), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean());
         NewIdentityProvider capturedIdp = newIdentityProviderArgumentCaptor.getValue();
         assertNotNull(capturedIdp);
         assertEquals("default-idp-domain", capturedIdp.getId());
@@ -103,12 +103,12 @@ public class DefaultIdentityProviderServiceTest {
         String domainId = "domaindomaindomaindomaindomaindomaindomaindomaindomaindomaindomaindomaindomaindomaindomaindomaindomain";
         environment.setProperty("repositories.management.type", "jdbc");
         ArgumentCaptor<NewIdentityProvider> newIdentityProviderArgumentCaptor = ArgumentCaptor.forClass(NewIdentityProvider.class);
-        when(identityProviderService.create(any(), eq(domainId), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean())).thenReturn(Single.just(new IdentityProvider()));
+        when(identityProviderService.create(any(Domain.class), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean())).thenReturn(Single.just(new IdentityProvider()));
 
-        TestObserver<IdentityProvider> observer = cut.create(domainId).test();
+        TestObserver<IdentityProvider> observer = cut.create(new Domain(domainId)).test();
         observer.assertComplete();
 
-        verify(identityProviderService).create(any(), eq(domainId), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean());
+        verify(identityProviderService).create(any(Domain.class), newIdentityProviderArgumentCaptor.capture(), isNull(), anyBoolean());
         NewIdentityProvider capturedIdp = newIdentityProviderArgumentCaptor.getValue();
         assertNotNull(capturedIdp);
         assertNotEquals("default-idp-domain", capturedIdp.getId());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -361,7 +361,7 @@ public class DomainServiceTest {
     public void shouldCreate() {
         NewDomain newDomain = new NewDomain();
         newDomain.setName("my-domain");
-        newDomain.setDataPlaneId("default");
+        newDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
         when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
         when(domainReadService.listAll()).thenReturn(Flowable.empty());
         Domain domain = new Domain();
@@ -369,8 +369,8 @@ public class DomainServiceTest {
         domain.setReferenceId(ENVIRONMENT_ID);
         domain.setId("domain-id");
         domain.setVersion(DomainVersion.V2_0);
-        domain.setDataPlaneId("default");
-        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription("default","default","mongodb","test", "http://localhost:8092")));
+        domain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription(DataPlaneDescription.DEFAULT_DATA_PLANE_ID,"default","mongodb","test", "http://localhost:8092")));
         when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, "my-domain")).thenReturn(Maybe.empty());
         when(domainRepository.create(any(Domain.class))).thenReturn(Single.just(domain));
         when(scopeService.create(any(), any(NewSystemScope.class))).thenReturn(Single.just(new Scope()));
@@ -411,7 +411,7 @@ public class DomainServiceTest {
 
         NewDomain newDomain = new NewDomain();
         newDomain.setName("my-domain");
-        newDomain.setDataPlaneId("default");
+        newDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
         when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
         when(domainReadService.listAll()).thenReturn(Flowable.empty());
         Domain domain = new Domain();
@@ -419,8 +419,8 @@ public class DomainServiceTest {
         domain.setReferenceId(ENVIRONMENT_ID);
         domain.setId("domain-id");
         domain.setVersion(DomainVersion.V2_0);
-        domain.setDataPlaneId("default");
-        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription("default","default","mongodb","test", "http://localhost:8092")));
+        domain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription(DataPlaneDescription.DEFAULT_DATA_PLANE_ID,"default","mongodb","test", "http://localhost:8092")));
         when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, "my-domain")).thenReturn(Maybe.empty());
         when(domainRepository.create(any(Domain.class))).thenReturn(Single.just(domain));
         when(scopeService.create(any(), any(NewSystemScope.class))).thenReturn(Single.just(new Scope()));
@@ -460,7 +460,7 @@ public class DomainServiceTest {
 
         NewDomain newDomain = new NewDomain();
         newDomain.setName("my-domain");
-        newDomain.setDataPlaneId("default");
+        newDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
         when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
         when(domainReadService.listAll()).thenReturn(Flowable.empty());
         Domain domain = new Domain();
@@ -468,8 +468,8 @@ public class DomainServiceTest {
         domain.setReferenceId(ENVIRONMENT_ID);
         domain.setId("domain-id");
         domain.setVersion(DomainVersion.V2_0);
-        domain.setDataPlaneId("default");
-        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription("default","default","mongodb","test", "http://localhost:8092")));
+        domain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription(DataPlaneDescription.DEFAULT_DATA_PLANE_ID,"default","mongodb","test", "http://localhost:8092")));
         when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, "my-domain")).thenReturn(Maybe.empty());
         when(domainRepository.create(any(Domain.class))).thenReturn(Single.just(domain));
         when(scopeService.create(any(), any(NewSystemScope.class))).thenReturn(Single.just(new Scope()));
@@ -509,7 +509,7 @@ public class DomainServiceTest {
         NewDomain newDomain = Mockito.mock(NewDomain.class);
         when(newDomain.getName()).thenReturn("my-domain");
         when(newDomain.getDataPlaneId()).thenReturn("default");
-        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription("default","default","mongodb","test", "http://localhost:8092")));
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription(DataPlaneDescription.DEFAULT_DATA_PLANE_ID,"default","mongodb","test", "http://localhost:8092")));
         when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, "my-domain")).thenReturn(Maybe.error(TechnicalException::new));
 
         TestObserver<Domain> testObserver = new TestObserver<>();
@@ -526,7 +526,7 @@ public class DomainServiceTest {
         NewDomain newDomain = Mockito.mock(NewDomain.class);
         when(newDomain.getName()).thenReturn("my-domain");
         when(newDomain.getDataPlaneId()).thenReturn("default");
-        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription("default","default","mongodb","test", "http://localhost:8092")));
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription(DataPlaneDescription.DEFAULT_DATA_PLANE_ID,"default","mongodb","test", "http://localhost:8092")));
         when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, "my-domain")).thenReturn(Maybe.empty());
         when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
 
@@ -544,7 +544,7 @@ public class DomainServiceTest {
         NewDomain newDomain = Mockito.mock(NewDomain.class);
         when(newDomain.getName()).thenReturn("my-domain");
         when(newDomain.getDataPlaneId()).thenReturn("default");
-        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription("default","default","mongodb","test", "http://localhost:8092")));
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription(DataPlaneDescription.DEFAULT_DATA_PLANE_ID,"default","mongodb","test", "http://localhost:8092")));
         when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, "my-domain")).thenReturn(Maybe.just(new Domain()));
 
         TestObserver<Domain> testObserver = new TestObserver<>();
@@ -875,7 +875,7 @@ public class DomainServiceTest {
         domain.setName(DOMAIN_ID);
         domain.setPath("/test");
         domain.setVersion(DomainVersion.V2_0);
-        domain.setDataPlaneId("default");
+        domain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
 
         when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
 
@@ -898,7 +898,7 @@ public class DomainServiceTest {
         domain.setReferenceId(ENVIRONMENT_ID);
         domain.setName(DOMAIN_ID);
         domain.setPath("/test");
-        domain.setDataPlaneId("default");
+        domain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
 
         when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
         when(domainRepository.findByHrid(any(), anyString(), anyString())).thenReturn(Maybe.just(domain));
@@ -938,7 +938,7 @@ public class DomainServiceTest {
         domain.setName(DOMAIN_ID);
         domain.setPath("/test");
         domain.setVersion(DomainVersion.V2_0);
-        domain.setDataPlaneId("default");
+        domain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
 
         when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
 
@@ -959,7 +959,7 @@ public class DomainServiceTest {
         updateDomain.setReferenceId(ENVIRONMENT_ID);
         updateDomain.setName(DOMAIN_ID + "1");
         updateDomain.setPath("/test");
-        updateDomain.setDataPlaneId("default");
+        updateDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
 
         Domain domain = new Domain();
         domain.setId(DOMAIN_ID);
@@ -968,11 +968,11 @@ public class DomainServiceTest {
         domain.setReferenceId(ENVIRONMENT_ID);
         domain.setName(DOMAIN_ID);
         domain.setPath("/test");
-        domain.setDataPlaneId("default");
+        domain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
 
         Domain updatedDomain = new Domain(domain);
         updatedDomain.setName(UUID.randomUUID().toString());
-        updatedDomain.setDataPlaneId("default");
+        updatedDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
 
         when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
         when(domainRepository.findByHrid(any(), anyString(), anyString())).thenReturn(Maybe.empty());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/IdentityProviderDataPlaneUpgraderTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/IdentityProviderDataPlaneUpgraderTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.upgrades;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.am.dataplane.api.DataPlaneDescription;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.service.IdentityProviderService;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IdentityProviderDataPlaneUpgraderTest {
+
+    @Mock
+    private IdentityProviderService identityProviderService;
+
+    @InjectMocks
+    private IdentityProviderDataPlaneUpgrader upgrader;
+
+    @Test
+    void shouldAssignDefaultDataPlaneId() {
+        IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setId("identityProvider-id");
+        identityProvider.setName("identityProvider");
+        when(identityProviderService.findAll(ReferenceType.DOMAIN)).thenReturn(Flowable.just(identityProvider));
+        ArgumentCaptor<IdentityProvider> argumentCaptor = ArgumentCaptor.forClass(IdentityProvider.class);
+        when(identityProviderService.assignDataPlane(argumentCaptor.capture(), eq(DataPlaneDescription.DEFAULT_DATA_PLANE_ID))).thenAnswer(i -> Single.just(i.getArgument(1)));
+        assertTrue(upgrader.upgrade());
+
+        assertNull(argumentCaptor.getValue().getDataPlaneId());
+    }
+
+    @Test
+    void shouldNotChangeDataPlaneId() {
+        IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setId("identityProvider-id");
+        identityProvider.setName("identityProvider");
+        identityProvider.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(identityProviderService.findAll(ReferenceType.DOMAIN)).thenReturn(Flowable.just(identityProvider));
+
+        assertTrue(upgrader.upgrade());
+
+        verify(identityProviderService, never()).assignDataPlane(any(), any());
+    }
+
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -356,6 +356,10 @@ user:
     maxRequestOperations: 1000
 
 repositories:
+  # specify which scope is used as reference
+  # to initialize the IdentityProviders with the "use system cluster"
+  # option enabled (only management and gateway scopes are allowed as value)
+  system-cluster: management
   # Management repository is used to store global configuration such as domains, clients, ...
   # This is the default configuration using MongoDB (single server)
   # For more information about MongoDB configuration, please have a look to:

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/IdentityProvider.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/IdentityProvider.java
@@ -65,6 +65,10 @@ public class IdentityProvider {
     private Date updatedAt;
 
     private String passwordPolicy;
+    /**
+     * ID of Data Plane
+     */
+    private String dataPlaneId;
 
     public IdentityProvider(IdentityProvider other) {
         this.id = other.id;
@@ -82,6 +86,7 @@ public class IdentityProvider {
         this.createdAt = other.createdAt;
         this.updatedAt = other.updatedAt;
         this.passwordPolicy = other.passwordPolicy;
+        this.dataPlaneId = other.dataPlaneId;
     }
 
     @Override

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/SingleDataPlaneLoader.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/SingleDataPlaneLoader.java
@@ -40,7 +40,7 @@ public class SingleDataPlaneLoader implements DataPlaneLoader {
 
     @Override
     public void load(Consumer<DataPlaneDescription> storage) {
-        var dataPlaneId = configuration.getProperty(DATA_PLANE_ID_KEY, String.class, "default");
+        var dataPlaneId = configuration.getProperty(DATA_PLANE_ID_KEY, String.class, DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
         var dataPlaneUrl = configuration.getProperty(DATA_PLANE_GW_URL_KEY, String.class);
         var dataPlaneType = configuration.getProperty(DATA_PLANE_TYPE_KEY, String.class, "mongodb");
         storage.accept(new DataPlaneDescription(dataPlaneId, dataPlaneId, dataPlaneType, DATA_PLANE_KEY, dataPlaneUrl));

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/Scope.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/Scope.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.repository;
 
+import java.util.Locale;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
@@ -39,4 +41,7 @@ public enum Scope {
         return "repositories." + name;
     }
 
+    public static Scope fromName(String name) {
+        return Scope.valueOf(name.toUpperCase(Locale.ROOT));
+    }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/provider/impl/R2DBCConnectionProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/provider/impl/R2DBCConnectionProvider.java
@@ -91,6 +91,7 @@ public class R2DBCConnectionProvider implements ConnectionProvider<ConnectionFac
     private ReactiveTransactionManager transactionManager;
 
     private boolean notUseMngSettingsForOauth2;
+    private boolean notUseGwSettingsForOauth2;
     private boolean notUseMngSettingsForGateway;
 
     @Override
@@ -141,7 +142,7 @@ public class R2DBCConnectionProvider implements ConnectionProvider<ConnectionFac
     @Override
     public ClientWrapper getClientWrapper(String name) {
         if (OAUTH2.getName().equals(name) && notUseMngSettingsForOauth2) {
-            return oauthConnectionFactory;
+            return notUseGwSettingsForOauth2 ? oauthConnectionFactory : getClientWrapper(GATEWAY.getName());
         } else if (GATEWAY.getName().equals(name) && notUseMngSettingsForGateway) {
             return gatewayConnectionFactory;
         } else {
@@ -184,7 +185,9 @@ public class R2DBCConnectionProvider implements ConnectionProvider<ConnectionFac
     @Override
     public void afterPropertiesSet() throws Exception {
         final var useMngSettingsForOauth2 = environment.getProperty(OAUTH2.getRepositoryPropertyKey() +".use-management-settings", Boolean.class, true);
+        final var useGwSettingsForOauth2 = environment.getProperty(OAUTH2.getRepositoryPropertyKey() + ".use-gateway-settings", Boolean.class, false);
         final var useMngSettingsForGateway = environment.getProperty(GATEWAY.getRepositoryPropertyKey() +".use-management-settings", Boolean.class, true);
+        notUseGwSettingsForOauth2 = !useGwSettingsForOauth2;
         notUseMngSettingsForOauth2 = !useMngSettingsForOauth2;
         notUseMngSettingsForGateway = !useMngSettingsForGateway;
         // create the connection pool just after the bean Initialization to guaranty the uniqueness
@@ -192,7 +195,7 @@ public class R2DBCConnectionProvider implements ConnectionProvider<ConnectionFac
         if (notUseMngSettingsForGateway) {
             gatewayConnectionFactory = new R2DBCPoolWrapper(new ConnectionFactoryProvider(environment, GATEWAY.getRepositoryPropertyKey()));
         }
-        if (notUseMngSettingsForOauth2) {
+        if (notUseMngSettingsForOauth2 && notUseGwSettingsForOauth2) {
             oauthConnectionFactory = new R2DBCPoolWrapper(new ConnectionFactoryProvider(environment, OAUTH2.getRepositoryPropertyKey()));
         }
     }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcIdentityProviderRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcIdentityProviderRepository.java
@@ -63,6 +63,7 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
     public static final String COL_ROLE_MAPPER = "role_mapper";
     public static final String COL_GROUP_MAPPER = "group_mapper";
     public static final String COL_PASSWORD_POLICY = "password_policy";
+    public static final String COL_DATA_PLANE_ID = "data_plane_id";
 
     private static final List<String> columns = List.of(
             COL_ID,
@@ -79,7 +80,8 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
             COL_MAPPERS,
             COL_ROLE_MAPPER,
             COL_GROUP_MAPPER,
-            COL_PASSWORD_POLICY
+            COL_PASSWORD_POLICY,
+            COL_DATA_PLANE_ID
     );
 
     private String insertStatement;
@@ -161,6 +163,7 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
         insertSpec = addQuotedField(insertSpec, COL_ID, item.getId(), String.class);
         insertSpec = addQuotedField(insertSpec, COL_TYPE, item.getType(), String.class);
         insertSpec = addQuotedField(insertSpec, COL_NAME, item.getName(), String.class);
+        insertSpec = addQuotedField(insertSpec, COL_DATA_PLANE_ID, item.getDataPlaneId(), String.class);
         insertSpec = addQuotedField(insertSpec, COL_SYSTEM, item.isSystem(), boolean.class);
         insertSpec = addQuotedField(insertSpec, COL_EXTERNAL, item.isExternal(), boolean.class);
         insertSpec = addQuotedField(insertSpec, COL_REFERENCE_ID, item.getReferenceId(), String.class);
@@ -189,6 +192,7 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
         update = addQuotedField(update, COL_ID, item.getId(), String.class);
         update = addQuotedField(update, COL_TYPE, item.getType(), String.class);
         update = addQuotedField(update, COL_NAME, item.getName(), String.class);
+        update = addQuotedField(update, COL_DATA_PLANE_ID, item.getDataPlaneId(), String.class);
         update = addQuotedField(update, COL_SYSTEM, item.isSystem(), boolean.class);
         update = addQuotedField(update, COL_EXTERNAL, item.isExternal(), boolean.class);
         update = addQuotedField(update, COL_REFERENCE_ID, item.getReferenceId(), String.class);

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcIdentityProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcIdentityProvider.java
@@ -55,4 +55,6 @@ public class JdbcIdentityProvider {
     private LocalDateTime updatedAt;
     @Column("password_policy")
     private String passwordPolicy;
+    @Column("data_plane_id")
+    private String dataPlaneId;
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_7_0/4.7.0-update-identity-table.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_7_0/4.7.0-update-identity-table.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.7.0-update-identity-table
+      author: GraviteeSource Team
+      changes:
+        #############################
+        # identities #
+        ############################
+        - addColumn:
+            tableName: identities
+            columns:
+              - column: { name: data_plane_id, type: nvarchar(64), constraints: { nullable: true } }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -161,3 +161,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_7_0/4.7.0-update-events-table.yml
   - include:
       - file: liquibase/changelogs/v4_7_0/4.7.0-create-dp-upgraders.yml
+  - include:
+      - file: liquibase/changelogs/v4_7_0/4.7.0-update-identity-table.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoIdentityProviderRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoIdentityProviderRepository.java
@@ -141,6 +141,7 @@ public class MongoIdentityProviderRepository extends AbstractManagementMongoRepo
         var identityProvider = new IdentityProvider();
         identityProvider.setId(identityProviderMongo.getId());
         identityProvider.setName(identityProviderMongo.getName());
+        identityProvider.setDataPlaneId(identityProviderMongo.getDataPlaneId());
         identityProvider.setType(identityProviderMongo.getType());
         identityProvider.setSystem(identityProviderMongo.isSystem());
         identityProvider.setConfiguration(identityProviderMongo.getConfiguration());
@@ -187,6 +188,7 @@ public class MongoIdentityProviderRepository extends AbstractManagementMongoRepo
             identityProviderMongo.setId(identityProvider.getId());
             identityProviderMongo.setName(identityProvider.getName());
             identityProviderMongo.setType(identityProvider.getType());
+            identityProviderMongo.setDataPlaneId(identityProvider.getDataPlaneId());
             identityProviderMongo.setSystem(identityProvider.isSystem());
             identityProviderMongo.setConfiguration(identityProvider.getConfiguration());
             identityProviderMongo.setReferenceType(identityProvider.getReferenceType());

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/IdentityProviderMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/IdentityProviderMongo.java
@@ -67,6 +67,8 @@ public class IdentityProviderMongo extends Auditable {
 
     private String passwordPolicy;
 
+    private String dataPlaneId;
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/IdentityProviderRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/IdentityProviderRepositoryTest.java
@@ -79,6 +79,7 @@ public class IdentityProviderRepositoryTest extends AbstractManagementTest {
         identityProvider.setExternal(true);
         identityProvider.setSystem(true);
         identityProvider.setType("type" + random);
+        identityProvider.setDataPlaneId(UUID.randomUUID().toString());
 
         Map<String, String> mappers = new HashMap<>();
         mappers.put("mapper", "mapper" + random);
@@ -116,6 +117,7 @@ public class IdentityProviderRepositoryTest extends AbstractManagementTest {
         testObserver.assertValue(idp -> idp.getName().equals(identityProvider.getName()));
         testObserver.assertValue(idp -> idp.getType().equals(identityProvider.getType()));
         testObserver.assertValue(idp -> idp.isSystem() == identityProvider.isSystem());
+        testObserver.assertValue(idp -> idp.getDataPlaneId().equals(identityProvider.getDataPlaneId()));
         testObserver.assertValue(idp -> idp.getConfiguration().equals(identityProvider.getConfiguration()));
         testObserver.assertValue(idp -> idp.getReferenceId().equals(identityProvider.getReferenceId()));
         testObserver.assertValue(idp -> idp.getReferenceType().equals(identityProvider.getReferenceType()));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/IdentityProviderService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/IdentityProviderService.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.service;
 
 import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
@@ -48,6 +49,8 @@ public interface IdentityProviderService {
 
     Single<IdentityProvider> create(ReferenceType referenceType, String referenceId, NewIdentityProvider newIdentityProvider, User principal, boolean system);
 
+    Single<IdentityProvider> create(Domain domain, NewIdentityProvider newIdentityProvider, User principal, boolean system);
+
     Single<IdentityProvider> update(ReferenceType referenceType, String referenceId, String id, UpdateIdentityProvider updateIdentityProvider, User principal, boolean isUpgrader);
 
     Completable delete(ReferenceType referenceType, String referenceId, String identityProviderId, User principal);
@@ -55,10 +58,6 @@ public interface IdentityProviderService {
     Flowable<IdentityProvider> findWithPasswordPolicy(ReferenceType referenceType, String referenceId, String passwordPolicy);
 
     Single<IdentityProvider> updatePasswordPolicy(String domain, String id, AssignPasswordPolicy assignPasswordPolicy);
-
-    default Single<IdentityProvider> create(String domain, NewIdentityProvider identityProvider) {
-        return create(domain, identityProvider, null);
-    }
 
     default Single<IdentityProvider> update(String domain, String id, UpdateIdentityProvider updateIdentityProvider, boolean isUpgrader) {
         return update(domain, id, updateIdentityProvider, null, isUpgrader);
@@ -68,13 +67,15 @@ public interface IdentityProviderService {
         return delete(domain, identityProviderId, null);
     }
 
-    default Single<IdentityProvider> create(String domain, NewIdentityProvider identityProvider, User principal) {
-        return create(ReferenceType.DOMAIN, domain, identityProvider, principal, false);
+    default Single<IdentityProvider> create(Domain domain, NewIdentityProvider identityProvider, User principal) {
+        return create(domain, identityProvider, principal, false);
     }
 
     default Single<IdentityProvider> update(String domain, String id, UpdateIdentityProvider updateIdentityProvider, User principal, boolean isUpgrader) {
         return update(ReferenceType.DOMAIN, domain, id, updateIdentityProvider, principal, isUpgrader);
     }
+
+    Single<IdentityProvider> assignDataPlane(IdentityProvider identityProvider, String dataPlaneId);
 
     default Completable delete(String domain, String identityProviderId, User principal) {
         return delete(ReferenceType.DOMAIN, domain, identityProviderId, principal);

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <angus-mail.version>2.0.3</angus-mail.version>
         <angus-activation.version>2.0.2</angus-activation.version>
         <mongodb-driver-reactivestreams.version>4.11.2</mongodb-driver-reactivestreams.version>
-        <embed.mongo.version>4.7.1</embed.mongo.version>
+        <embed.mongo.version>4.18.1</embed.mongo.version>
         <json-patch.version>1.9</json-patch.version>
         <guava.version>32.1.3-jre</guava.version>
         <zxing.version>3.4.1</zxing.version>


### PR DESCRIPTION
This is the same as https://github.com/gravitee-io/gravitee-access-management/pull/5569 but on master in order to manage the DataPlane specificities

fixes AM-4809

