### PR TITLE
fix: restore default value for JDBC IDP

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/main/resources/schemas/schema-form.json
@@ -25,6 +25,7 @@
     },
     "usersTable" : {
       "type" : "string",
+      "default": "users",
       "title": "The table used to run query",
       "description": "The table used to run query to search for users."
     },


### PR DESCRIPTION
 the default values is used in the queries default values

 as this IDP is not providing the 'use system cluster' settings

 it is useless to remove the default value

related-to AM-4809