### PR TITLE
fix: use DomainBased dictionary outside of the common EmailService

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
@@ -38,6 +38,8 @@ import io.gravitee.am.model.safe.DomainProperties;
 import io.gravitee.am.model.safe.UserProperties;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.DomainReadService;
+import io.gravitee.am.service.i18n.CompositeDictionaryProvider;
+import io.gravitee.am.service.i18n.DictionaryProvider;
 import io.gravitee.am.service.i18n.FreemarkerMessageResolver;
 import io.gravitee.am.service.i18n.GraviteeMessageResolver;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
@@ -68,7 +70,7 @@ import static io.gravitee.am.service.utils.UserProfileUtils.preferredLanguage;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class EmailServiceImpl implements EmailService, InitializingBean {
+public class EmailServiceImpl implements EmailService {
 
     private final boolean enabled;
     private final String resetPasswordSubject;
@@ -127,11 +129,6 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
         this.mfaVerifyAttemptSubject = mfaVerifyAttemptSubject;
         this.registrationVerifySubject = registrationVerifySubject;
         this.userRegistrationExpireAfter = userRegistrationExpiresAfter;
-    }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        this.emailService.setDictionaryProvider(this.graviteeMessageResolver.getDynamicDictionaryProvider());
     }
 
     @Override
@@ -326,12 +323,20 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
         var result = new StringWriter(1024);
 
         var dataModel = new HashMap<>(params);
-        dataModel.put(FreemarkerMessageResolver.METHOD_NAME, new FreemarkerMessageResolver(this.emailService.getDictionaryProvider().getDictionaryFor(preferredLanguage)));
+        dataModel.put(FreemarkerMessageResolver.METHOD_NAME, new FreemarkerMessageResolver(getDictionaryProvider().getDictionaryFor(preferredLanguage)));
 
         var env = plainTextTemplate.createProcessingEnvironment(dataModel, result);
         env.process();
 
         return result.toString();
+    }
+
+    public DictionaryProvider getDictionaryProvider() {
+        if (graviteeMessageResolver.getDynamicDictionaryProvider() != null) {
+            return new CompositeDictionaryProvider(graviteeMessageResolver.getDynamicDictionaryProvider(), emailService.getDefaultDictionaryProvider());
+        } else {
+            return emailService.getDefaultDictionaryProvider();
+        }
     }
 
     private String getTemplateName(io.gravitee.am.model.Template template, Client client) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceImplTest.java
@@ -22,13 +22,13 @@ import io.gravitee.am.gateway.handler.common.email.impl.EmailServiceImpl;
 import io.gravitee.am.jwt.JWTBuilder;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.Email;
-import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.Template;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.DomainReadService;
 import io.gravitee.am.service.i18n.DictionaryProvider;
+import io.gravitee.am.service.i18n.GraviteeMessageResolver;
 import io.vertx.rxjava3.core.MultiMap;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -46,12 +46,18 @@ import static freemarker.template.Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENT
 import static java.util.concurrent.TimeUnit.DAYS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
+
 public class EmailServiceImplTest {
 
     @Mock
@@ -75,6 +81,9 @@ public class EmailServiceImplTest {
 
     @Mock
     private DomainReadService domainService;
+
+    @Mock
+    private GraviteeMessageResolver graviteeMessageResolver;
 
     @InjectMocks
     private EmailService emailServiceSpy;
@@ -125,7 +134,7 @@ public class EmailServiceImplTest {
         var templateLoader = Mockito.mock(TemplateLoader.class);
         when(domain.getId()).thenReturn("id");
         final DictionaryProvider mockDictionaryProvider = Mockito.mock(DictionaryProvider.class);
-        when(this.emailService.getDictionaryProvider()).thenReturn(mockDictionaryProvider);
+        when(this.emailService.getDefaultDictionaryProvider()).thenReturn(mockDictionaryProvider);
         when(mockDictionaryProvider.getDictionaryFor(any())).thenReturn(new Properties());
 
         when(freemarkerConfiguration.getIncompatibleImprovements()).thenReturn(DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
@@ -173,7 +182,7 @@ public class EmailServiceImplTest {
         var templateLoader = Mockito.mock(TemplateLoader.class);
 
         final DictionaryProvider mockDictionaryProvider = Mockito.mock(DictionaryProvider.class);
-        when(this.emailService.getDictionaryProvider()).thenReturn(mockDictionaryProvider);
+        when(this.emailService.getDefaultDictionaryProvider()).thenReturn(mockDictionaryProvider);
         when(mockDictionaryProvider.getDictionaryFor(any())).thenReturn(new Properties());
 
         when(freemarkerConfiguration.getIncompatibleImprovements()).thenReturn(DEFAULT_INCOMPATIBLE_IMPROVEMENTS);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceTest.java
@@ -116,10 +116,6 @@ public class EmailServiceTest {
         when(this.emailService.getDefaultDictionaryProvider()).thenReturn(FileSystemDictionaryProvider.getInstance("src/test/resources/templates/i18n"));
 
         when(this.graviteeMessageResolver.getDynamicDictionaryProvider()).thenReturn(this.domainBasedDictionaryProvider);
-
-        cut.afterPropertiesSet();
-
-        doReturn(new CompositeDictionaryProvider(this.graviteeMessageResolver.getDynamicDictionaryProvider(), emailService.getDefaultDictionaryProvider())).when(emailService).getDictionaryProvider();
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/EmailServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/EmailServiceImpl.java
@@ -39,17 +39,18 @@ import io.gravitee.am.model.safe.DomainProperties;
 import io.gravitee.am.model.safe.UserProperties;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.DomainReadService;
+import io.gravitee.am.service.i18n.CompositeDictionaryProvider;
+import io.gravitee.am.service.i18n.DictionaryProvider;
 import io.gravitee.am.service.i18n.DomainBasedDictionaryProvider;
 import io.gravitee.am.service.i18n.FreemarkerMessageResolver;
 import io.gravitee.am.service.impl.I18nDictionaryService;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.EmailAuditBuilder;
 import io.netty.handler.codec.http.QueryStringDecoder;
-import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
 import io.vertx.rxjava3.core.MultiMap;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
@@ -71,7 +72,7 @@ import static io.gravitee.am.service.utils.UserProfileUtils.preferredLanguage;
  * @author GraviteeSource Team
  */
 @Component("managementEmailService")
-public class EmailServiceImpl implements EmailService, InitializingBean {
+public class EmailServiceImpl implements EmailService {
 
     private static final String ADMIN_CLIENT = "admin";
 
@@ -95,8 +96,6 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
     private final DomainReadService domainService;
 
     private final I18nDictionaryService i18nDictionaryService;
-
-    private final DomainBasedDictionaryProvider dictionaryProvider;
 
     private final Environment environment;
 
@@ -123,43 +122,32 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
         this.registrationVerifySubject = registrationVerifySubject();
         this.registrationVerifyExpireAfter = registrationVerifyExpireAfter();
         this.certificateExpirySubject = certificateExpirySubject();
-        this.dictionaryProvider = new DomainBasedDictionaryProvider();
         this.i18nDictionaryService = i18nDictionaryService;
-
-    }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        this.emailService.setDictionaryProvider(dictionaryProvider);
     }
 
     @Override
     public Maybe<Email> send(Domain domain, Application client, io.gravitee.am.model.Template template, User user) {
         if (enabled) {
             return refreshDomainDictionaries(domain)
-                    .andThen(prepareAndSend(domain, client, template, user));
+                    .flatMapMaybe(provider -> prepareAndSend(domain, client, template, user, provider));
         }
         return Maybe.empty();
     }
 
-    private Maybe<Email> prepareAndSend(Domain domain, Application client, io.gravitee.am.model.Template template, User user) {
+    private Maybe<Email> prepareAndSend(Domain domain, Application client, io.gravitee.am.model.Template template, User user, DomainBasedDictionaryProvider dictionaryProvider) {
         // get raw email template
         return getEmailTemplate(template, user).map(emailTemplate -> {
             // prepare email
             Email email = prepareEmail(domain, client, template, emailTemplate, user);
             // send email
-            sendEmail(email, user);
+            sendEmail(email, user, dictionaryProvider);
             return email;
         });
     }
 
-    private Completable refreshDomainDictionaries(Domain domain) {
-        return Completable.fromAction(this.dictionaryProvider::resetDictionaries)
-                .andThen(this.i18nDictionaryService.findAll(ReferenceType.DOMAIN, domain.getId())
-                .map(dict -> {
-                    this.dictionaryProvider.loadDictionary(dict);
-                    return dict;
-                }).ignoreElements().onErrorComplete());
+    private Single<DomainBasedDictionaryProvider> refreshDomainDictionaries(Domain domain) {
+        return this.i18nDictionaryService.findAll(ReferenceType.DOMAIN, domain.getId())
+                .collect(DomainBasedDictionaryProvider::new, (prov, dict) -> prov.loadDictionary(dict));
     }
 
     @Override
@@ -167,11 +155,11 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
         return emailManager.getEmail(template, user, getDefaultSubject(template), getDefaultExpireAt(template));
     }
 
-    private void sendEmail(Email email, User user) {
+    private void sendEmail(Email email, User user, DomainBasedDictionaryProvider dictionaryProvider) {
         if (enabled) {
             try {
                 final var locale = preferredLanguage(user, Locale.ENGLISH);
-                final var emailToSend = processEmailTemplate(email, locale);
+                final var emailToSend = processEmailTemplate(email, locale, dictionaryProvider);
                 emailService.send(emailToSend);
                 auditService.report(AuditBuilder.builder(EmailAuditBuilder.class)
                         .reference(Reference.domain(user.getReferenceId()))
@@ -191,7 +179,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
     public Maybe<Email> getFinalEmail(Domain domain, Application client, io.gravitee.am.model.Template template, User user, Map<String, Object> params) {
         // get raw email template
         return emailManager.getEmail(template, ReferenceType.DOMAIN, domain.getId(), user, getDefaultSubject(template), getDefaultExpireAt(template))
-                .map(emailTemplate -> {
+                .flatMap(emailTemplate -> {
                     // prepare email
                     final var email = prepareEmail(domain, client, template, emailTemplate, user);
 
@@ -203,34 +191,43 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
 
                     // send email
                     var locale = preferredLanguage(user, Locale.ENGLISH);
-                    return processEmailTemplate(email, locale);
+                    return refreshDomainDictionaries(domain)
+                            .map(provider -> processEmailTemplate(email, locale, provider)).toMaybe();
                 });
     }
 
-    private Email processEmailTemplate(Email email, Locale locale) throws IOException, TemplateException {
+    private Email processEmailTemplate(Email email, Locale locale, DomainBasedDictionaryProvider dictionaryProvider) throws IOException, TemplateException {
         final Template template = freemarkerConfiguration.getTemplate(email.getTemplate());
         final Template plainTextTemplate = new Template("subject", new StringReader(email.getSubject()), freemarkerConfiguration);
         // compute email subject
-        final String subject = processTemplate(plainTextTemplate, email.getParams(), locale);
+        final String subject = processTemplate(plainTextTemplate, email.getParams(), locale, dictionaryProvider);
         // compute email content
-        final String content = processTemplate(template, email.getParams(), locale);
+        final String content = processTemplate(template, email.getParams(), locale, dictionaryProvider);
         final Email emailToSend = new Email(email);
         emailToSend.setSubject(subject);
         emailToSend.setContent(content);
         return emailToSend;
     }
 
-    private String processTemplate(Template plainTextTemplate, Map<String, Object> params, Locale preferredLanguage) throws TemplateException, IOException {
+    private String processTemplate(Template plainTextTemplate, Map<String, Object> params, Locale preferredLanguage, DomainBasedDictionaryProvider dictionaryProvider) throws TemplateException, IOException {
         var result = new StringWriter(1024);
 
         var dataModel = new HashMap<>(params);
-        dataModel.put(FreemarkerMessageResolver.METHOD_NAME, new FreemarkerMessageResolver(this.emailService.getDictionaryProvider().getDictionaryFor(preferredLanguage)));
+        dataModel.put(FreemarkerMessageResolver.METHOD_NAME, new FreemarkerMessageResolver(this.computeDictionaryProvider(dictionaryProvider).getDictionaryFor(preferredLanguage)));
 
         var env = plainTextTemplate.createProcessingEnvironment(new SimpleHash(dataModel,
                 new DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_22).build()), result);
         env.process();
 
         return result.toString();
+    }
+
+    public DictionaryProvider computeDictionaryProvider(DomainBasedDictionaryProvider dictionaryProvider) {
+        if (dictionaryProvider != null) {
+            return new CompositeDictionaryProvider(dictionaryProvider, emailService.getDefaultDictionaryProvider());
+        } else {
+            return emailService.getDefaultDictionaryProvider();
+        }
     }
 
     private Email prepareEmail(Domain domain, Application client, io.gravitee.am.model.Template template, io.gravitee.am.model.Email emailTemplate, User user) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EmailService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EmailService.java
@@ -28,7 +28,4 @@ public interface EmailService {
 
     DictionaryProvider getDefaultDictionaryProvider();
 
-    DictionaryProvider getDictionaryProvider();
-
-    void setDictionaryProvider(DictionaryProvider provider);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EmailServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EmailServiceImpl.java
@@ -62,20 +62,6 @@ public class EmailServiceImpl implements EmailService, InitializingBean {
     }
 
     @Override
-    public DictionaryProvider getDictionaryProvider() {
-        if (this.dictionaryProvider != null) {
-            return this.dictionaryProvider;
-        } else {
-            return this.getDefaultDictionaryProvider();
-        }
-    }
-
-    @Override
-    public void setDictionaryProvider(DictionaryProvider provider) {
-        this.dictionaryProvider = new CompositeDictionaryProvider(provider, this.getDefaultDictionaryProvider());
-    }
-
-    @Override
     public DictionaryProvider getDefaultDictionaryProvider() {
         return this.defaultDictionaryProvider;
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/VerifyAttemptServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/VerifyAttemptServiceImpl.java
@@ -23,7 +23,6 @@ import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.repository.gateway.api.VerifyAttemptRepository;
 import io.gravitee.am.repository.management.api.search.VerifyAttemptCriteria;
-import io.gravitee.am.service.EmailService;
 import io.gravitee.am.service.VerifyAttemptService;
 import io.gravitee.am.service.exception.MFAValidationAttemptException;
 import io.reactivex.rxjava3.core.Completable;
@@ -44,9 +43,6 @@ import java.util.Optional;
 @Component
 public class VerifyAttemptServiceImpl implements VerifyAttemptService {
     private static final Logger LOGGER = LoggerFactory.getLogger(VerifyAttemptServiceImpl.class);
-
-    @Autowired
-    EmailService emailService;
 
     @Lazy
     @Autowired


### PR DESCRIPTION
 this is to avoid issue oin Gateway since the common service layer is loaded before the domain so the SpringContext is not specific to the domain

 the Management API has also been changed to load the dictionaries everytime an email needs to be sent

fixes AM-4945