### PR TITLE
fix: remove invalid settings from the values.yaml example

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -791,8 +791,6 @@ gateway:
   #   request:
   #     transaction:
   #       header: X-Gravitee-Transaction-Id
-  #     request:
-  #       header: X-Gravitee-Request-Id
   # sharding_tags:
   replicaCount: 1
   image:


### PR DESCRIPTION
fixes AM-5077

# Context:

This param was probably a bad copy/past from the APIM chart as this parameters is note managed by AM either by the Gravitee node module.