### PR TITLE
Fix AWS ALB certificate decoding

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -2,12 +2,12 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.10.1
-  keeper: gravitee-io/keeper@0.6.2
+  keeper: gravitee-io/keeper@0.6.3
   gh: circleci/github-cli@2.2.0
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
   helm: circleci/helm@2.0.1
-  aquasec: gravitee-io/aquasec@1.0.4
+  aquasec: gravitee-io/aquasec@1.0.5
 
 executors:
   ubuntu:
@@ -1586,19 +1586,16 @@ jobs:
       - setup_remote_docker
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/am-gateway:<< pipeline.parameters.graviteeio_version >>
-          debug: true
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/am-gateway:<< pipeline.parameters.graviteeio_version >>
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/am-management-api:<< pipeline.parameters.graviteeio_version >>
-          debug: true
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/am-management-api:<< pipeline.parameters.graviteeio_version >>
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/am-management-ui:<< pipeline.parameters.graviteeio_version >>
-          debug: true
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/am-management-ui:<< pipeline.parameters.graviteeio_version >>
           scanner_url: https://82fb8f75da.cloud.aquasec.com
@@ -2050,7 +2047,6 @@ workflows:
           requires:
             - publish-images-azure-registry
           built_docker_image_file: /tmp/built-docker-images.txt
-          debug: true
           filters:
             branches:
               only:

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/CertificateUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/CertificateUtils.java
@@ -62,10 +62,10 @@ public class CertificateUtils {
         if (certHeaderValue != null) {
             try {
                 certHeaderValue = certHeaderValue
-                        .replaceAll("\\+","%2F")
-                        .replaceAll("//","%2B")
-                        .replaceAll("=","%3D")
-                        .replaceAll("\t", "\n");
+                        .replace("+", "%2B")
+                        .replace("/", "%2F")
+                        .replace("=", "%3D")
+                        .replace("\t", "\n");
 
                 certHeaderValue = URLDecoder.decode(certHeaderValue, Charset.defaultCharset());
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/CertificateUtilsTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/auth/provider/CertificateUtilsTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.handler.oauth2.resources.auth.provider;
+
+
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CertificateUtilsTest {
+
+    public static final String HEADER = "X-HEADER";
+
+    @Test
+    public void testCertificateValidation_FromHeader_NotEncoded() throws Exception {
+        var certPayload = "-----BEGIN CERTIFICATE-----\n" +
+                "MIICCTCCAa+gAwIBAgIUN7ooxea0kJHv18V9kpQ7Xen2gSowCgYIKoZIzj0EAwIw\n" +
+                "WjELMAkGA1UEBhMCRlIxDTALBgNVBAgMBE5vcmQxDjAMBgNVBAcMBUxpbGxlMRcw\n" +
+                "FQYDVQQKDA5NeU9yZ2FuaXphdGlvbjETMBEGA1UEAwwKQ29tbW9uTmFtZTAeFw0y\n" +
+                "NTA1MjIxNzU4NTRaFw0yNTA2MjExNzU4NTRaMFoxCzAJBgNVBAYTAkZSMQ0wCwYD\n" +
+                "VQQIDAROb3JkMQ4wDAYDVQQHDAVMaWxsZTEXMBUGA1UECgwOTXlPcmdhbml6YXRp\n" +
+                "b24xEzARBgNVBAMMCkNvbW1vbk5hbWUwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n" +
+                "AARRtfM1dgex0RW2Zf+vbWX1NCKxxVVmreKn3zMGuDGjFlqWc0VKe2wQal032H3H\n" +
+                "qaH2ju/wPHhihhIPE1i7m7alo1MwUTAdBgNVHQ4EFgQUUkMQCUtFHNyGoZ0Qv+gf\n" +
+                "mpsH/iEwHwYDVR0jBBgwFoAUUkMQCUtFHNyGoZ0Qv+gfmpsH/iEwDwYDVR0TAQH/\n" +
+                "BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiByzweeBYRCDSesw/3++jcesRZddaxE\n" +
+                "yhFkQJuzSYRwiQIhAK9WZoFE8dCVi8403a8e5jql6PKwkVjVt4ZX/bWAeq5U\n" +
+                "-----END CERTIFICATE-----\n";
+
+        RoutingContext routingContext = Mockito.mock(RoutingContext.class);
+        HttpServerRequest httpRequest = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(routingContext.request()).thenReturn(httpRequest);
+        Mockito.when(httpRequest.getHeader(HEADER)).thenReturn(certPayload);
+
+        var cert = CertificateUtils.extractPeerCertificate(routingContext, HEADER);
+        Assertions.assertTrue(cert.isPresent());
+    }
+}


### PR DESCRIPTION
**A description of the changes proposed in the pull request:**

Introduced changes added to sort out the problem with situation when AWS ALB stands in front of Gravitee and make certificate encoding, skipping few characters: '+' ,'=', '/'; Proposed changes adds encoding for that, so decoding should work correctly on Gravitee side.
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/mutual-authentication.html

fixes AM-5152


This PR has been opened to add UnitTest and execute the CI before merging the PR oppened by https://github.com/rkarpen2

original PR: https://github.com/gravitee-io/gravitee-access-management/pull/5914