### PR TITLE
fix: load inherited reporter in a dedicated manager

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/GraviteeContextHolder.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/GraviteeContextHolder.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.common.utils;
+
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GraviteeContextHolder {
+    private Map<String, GraviteeContext> contextsByDomainId = new ConcurrentHashMap<>();
+
+    public void registerContext(GraviteeContext graviteeContext) {
+        if (graviteeContext.getDomainId() != null) {
+            contextsByDomainId.putIfAbsent(graviteeContext.getDomainId(), graviteeContext);
+        }
+    }
+
+    public Optional<GraviteeContext> getContext(String domainId) {
+        return Optional.ofNullable(contextsByDomainId.get(domainId));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-core/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-core/pom.xml
@@ -40,5 +40,23 @@
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.am.service</groupId>
+            <artifactId>gravitee-am-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.am.repository</groupId>
+            <artifactId>gravitee-am-repository-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.am.plugins.handlers</groupId>
+            <artifactId>gravitee-am-plugins-handlers-reporter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-am-gateway/gravitee-am-gateway-core/src/main/java/io/gravitee/am/gateway/core/reporter/GatewayGlobalReporterManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-core/src/main/java/io/gravitee/am/gateway/core/reporter/GatewayGlobalReporterManager.java
@@ -1,0 +1,283 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.gateway.core.reporter;
+
+
+import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.event.ReporterEvent;
+import io.gravitee.am.common.utils.GraviteeContext;
+import io.gravitee.am.common.utils.GraviteeContextHolder;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.Reporter;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.plugins.reporter.core.ReporterPluginManager;
+import io.gravitee.am.plugins.reporter.core.ReporterProviderConfiguration;
+import io.gravitee.am.repository.management.api.ReporterRepository;
+import io.gravitee.am.service.reporter.impl.AuditReporterVerticle;
+import io.gravitee.am.service.reporter.vertx.EventBusReporterWrapper;
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.common.service.Service;
+import io.gravitee.node.api.Node;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.vertx.rxjava3.core.RxHelper;
+import io.vertx.rxjava3.core.Vertx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static io.gravitee.node.api.Node.META_ORGANIZATIONS;
+
+/**
+ * Reporter manager responsible to load global reporters
+ * (reporter defined at Organization level with the inherit flag set to true)
+ *
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GatewayGlobalReporterManager extends AbstractService<GatewayGlobalReporterManager> implements Service<GatewayGlobalReporterManager>, EventListener<ReporterEvent, Payload>, InitializingBean {
+
+    private static final Logger logger = LoggerFactory.getLogger(GatewayGlobalReporterManager.class);
+    private String deploymentId;
+
+    @Autowired
+    @Lazy
+    private ReporterRepository reporterRepository;
+
+    @Autowired
+    private ReporterPluginManager reporterPluginManager;
+
+    @Autowired
+    private Vertx vertx;
+
+    @Autowired
+    private EventManager eventManager;
+
+    @Lazy
+    @Autowired
+    private Node node;
+
+    @Autowired
+    private GraviteeContextHolder contextHolder;
+
+    private final ConcurrentMap<String, io.gravitee.am.reporter.api.provider.Reporter> reporterPlugins = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Reporter> reporters = new ConcurrentHashMap<>();
+
+    private Set<String> organizationIds;
+    
+    @Override
+    public void onEvent(Event<ReporterEvent, Payload> event) {
+        var content = event.content();
+        var affectedReporterIsFromManagedOrganization = content.getReferenceType() == ReferenceType.ORGANIZATION && isOrgManaged(content.getReferenceId());
+        if (affectedReporterIsFromManagedOrganization) {
+            switch (event.type()) {
+                case DEPLOY:
+                    deployReporter(event.content().getId(), event.type());
+                    break;
+                case UPDATE:
+                    updateReporter(event.content().getId(), event.type());
+                    break;
+                case UNDEPLOY:
+                    removeReporter(event.content().getId());
+                    break;
+            }
+        }
+    }
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        logger.info("Register event listener for global reporter events");
+        eventManager.subscribeForEvents(this, ReporterEvent.class);
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        logger.info("Dispose event listener for global reporter events");
+        eventManager.unsubscribeForEvents(this, ReporterEvent.class, null);
+
+        if (deploymentId != null) {
+            vertx.rxUndeploy(deploymentId)
+                    .doFinally(() -> {
+                        for (io.gravitee.am.reporter.api.provider.Reporter reporter : reporterPlugins.values()) {
+                            try {
+                                logger.info("Stopping reporter: {}", reporter);
+                                reporter.stop();
+                            } catch (Exception ex) {
+                                logger.error("Unexpected error while stopping reporter", ex);
+                            }
+                        }
+                    })
+                    .subscribe();
+        }
+    }
+
+    private void updateReporter(String reporterId, ReporterEvent reporterEvent) {
+        final String eventType = reporterEvent.toString().toLowerCase();
+        logger.info("{} reporter event for {}", eventType, reporterId);
+        reporterRepository.findById(reporterId)
+                .subscribeOn(Schedulers.io())
+                .subscribe(
+                        reporter -> {
+                            updateReporterProvider(reporter);
+                            logger.info("Reporter {} {}d", reporterId, eventType);
+                        },
+                        error -> logger.error("Unable to {} reporter", eventType, error));
+    }
+
+    private void deployReporter(String reporterId, ReporterEvent reporterEvent) {
+        final String eventType = reporterEvent.toString().toLowerCase();
+        logger.info("{} reporter event for {}", eventType, reporterId);
+        reporterRepository.findById(reporterId)
+                .subscribeOn(Schedulers.io())
+                .subscribe(
+                        reporter -> {
+                            if (reporterPlugins.containsKey(reporterId)) {
+                                updateReporterProvider(reporter);
+                            } else {
+                                startReporterProvider(reporter);
+                            }
+                            logger.info("Reporter {} {}d", reporterId, eventType);
+                        },
+                        error -> logger.error("Unable to {} reporter", eventType, error));
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        logger.info("Initializing global reporters");
+        logger.debug("\t Starting global reporter verticle");
+
+        this.organizationIds = Optional.ofNullable((Set<String>)this.node.metadata().get(META_ORGANIZATIONS)).orElse(Set.of());
+        
+        Single<String> deployment = RxHelper.deployVerticle(vertx, applicationContext.getBean(AuditReporterVerticle.class));
+        deployment.subscribe(id -> {
+            // Deployed
+            deploymentId = id;
+
+            // Start reporters
+            findGlobalReporters()
+                    .subscribeOn(Schedulers.io())
+                    .subscribe(reporter -> {
+                                if (reporter.isInherited()) {
+                                    startReporterProvider(reporter);
+                                    logger.info("Reporters loaded for organization {}", reporter.getName());
+                                } else {
+                                    logger.info("\tReporter {} is not inherited, no reporter to start", reporter.getName());
+                                }
+                            },
+                            err -> {
+                                logger.error("Reporter service can not be started", err);
+                            });
+        }, err -> {
+            // Could not deploy
+            logger.error("Reporter service can not be started", err);
+        });
+    }
+
+     private Flowable<Reporter> findGlobalReporters() {
+        return reporterRepository.findByReferenceType(ReferenceType.ORGANIZATION)
+                .filter(Reporter::isInherited)
+                .filter(reporter -> isOrgManaged(reporter.getId()) );
+    }
+
+    private boolean isOrgManaged(String orgId) {
+        return organizationIds.isEmpty() || organizationIds.contains(orgId);
+    }
+
+    private void startReporterProvider(Reporter reporter) {
+        if (!reporter.isEnabled()) {
+            logger.info("\tReporter disabled: {} [{}]", reporter.getName(), reporter.getType());
+            return;
+        }
+        if (!needDeployment(reporter)) {
+            logger.info("Reporter {} already up to date", reporter.getId());
+            return;
+        }
+        logger.info("\tInitializing reporter: {} [{}]", reporter.getName(), reporter.getType());
+        var providerConfiguration = new ReporterProviderConfiguration(reporter, new GraviteeContext(reporter.getReference().id(), null, null));
+        io.gravitee.am.reporter.api.provider.Reporter reporterProvider = reporterPluginManager.create(providerConfiguration);
+
+        if (reporterProvider != null) {
+            try {
+                logger.info("Starting reporter: {}", reporter.getName());
+                io.gravitee.am.reporter.api.provider.Reporter eventBusReporter = new EventBusReporterWrapper(vertx, reporterProvider, reporter.getReference(), contextHolder);
+                eventBusReporter.start();
+                reporters.put(reporter.getId(), reporter);
+                reporterPlugins.put(reporter.getId(), eventBusReporter);
+                AuditReporterVerticle.incrementActiveReporter();
+            } catch (Exception ex) {
+                logger.error("Unexpected error while starting reporter", ex);
+            }
+        }
+    }
+
+    private void stopReporterProvider(String reporterId, io.gravitee.am.reporter.api.provider.Reporter reporter) {
+        if (reporter != null) {
+            try {
+                reporter.stop();
+                AuditReporterVerticle.decrementActiveReporter();
+            } catch (Exception ex) {
+                logger.error("Unable to stop reporter: {}", reporterId, ex);
+            }
+        }
+    }
+
+    private void updateReporterProvider(Reporter reporter) {
+        if (this.reporters.containsKey(reporter.getId())) {
+            if (needDeployment(reporter)) {
+                stopReporterProvider(reporter.getId(), reporterPlugins.get(reporter.getId()));
+                startReporterProvider(reporter);
+            } else {
+                logger.info("Reporter {} already up to date", reporter.getId());
+            }
+        } else {
+            logger.info("Reporter {} is no managed by global reporter manager, ignore the update command", reporter.getId());
+        }
+    }
+
+
+    private void removeReporter(String reporterId) {
+        if (this.reporters.containsKey(reporterId)) {
+            logger.info("Received global reporter event, delete reporter {}", reporterId);
+            reporters.remove(reporterId);
+            io.gravitee.am.reporter.api.provider.Reporter reporter = reporterPlugins.remove(reporterId);
+            stopReporterProvider(reporterId, reporter);
+        } else {
+            logger.info("Reporter {} is no managed by global reporter manager, ignore the remove command", reporterId);
+        }
+    }
+
+    /**
+     * @param reporter
+     * @return true if the Reporter has never been deployed or if the deployed version is not up to date
+     */
+    private boolean needDeployment(io.gravitee.am.model.Reporter reporter) {
+        final io.gravitee.am.model.Reporter deployedReporter = this.reporters.get(reporter.getId());
+        return (deployedReporter == null || deployedReporter.getUpdatedAt().before(reporter.getUpdatedAt()));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-core/src/main/java/io/gravitee/am/gateway/core/reporter/GlobalReporterConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-core/src/main/java/io/gravitee/am/gateway/core/reporter/GlobalReporterConfiguration.java
@@ -13,25 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.repository.management.api;
 
-import io.gravitee.am.model.Reference;
-import io.gravitee.am.model.ReferenceType;
-import io.gravitee.am.model.Reporter;
-import io.gravitee.am.repository.common.CrudRepository;
-import io.reactivex.rxjava3.core.Flowable;
+package io.gravitee.am.gateway.core.reporter;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
- * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ReporterRepository extends CrudRepository<Reporter, String> {
-
-    Flowable<Reporter> findAll();
-
-    Flowable<Reporter> findByReference(Reference reference);
-
-    Flowable<Reporter> findByReferenceType(ReferenceType type);
-
-    Flowable<Reporter> findInheritedFrom(Reference parentReference);
+@Configuration
+public class GlobalReporterConfiguration {
+    @Bean
+    public GatewayGlobalReporterManager globalAuditReporterManager() {
+        return new GatewayGlobalReporterManager();
+    }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/spring/ReactorConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.reactor.spring;
 
 import io.gravitee.am.gateway.certificate.spring.CertificateConfiguration;
+import io.gravitee.am.gateway.core.reporter.GatewayGlobalReporterManager;
 import io.gravitee.am.gateway.handler.SecurityDomainRouterFactory;
 import io.gravitee.am.gateway.reactor.Reactor;
 import io.gravitee.am.gateway.reactor.SecurityDomainHandlerRegistry;

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/ScheduledSyncService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/ScheduledSyncService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.services.sync;
 
+import io.gravitee.am.gateway.core.reporter.GatewayGlobalReporterManager;
 import io.gravitee.am.gateway.services.sync.healthcheck.SyncProbe;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.healthcheck.ProbeManager;
@@ -52,6 +53,9 @@ public class ScheduledSyncService extends AbstractService implements Runnable {
     private SyncManager syncStateManager;
 
     @Autowired
+    private GatewayGlobalReporterManager globalReporterManager;
+
+    @Autowired
     private SyncProbe syncProbe;
 
     @Autowired
@@ -72,6 +76,8 @@ public class ScheduledSyncService extends AbstractService implements Runnable {
             // Sync must start only when doStart() is invoked, that's the reason why we are not
             // using @Scheduled annotation on doSync() method.
             scheduler.schedule(this, new CronTrigger(cronTrigger));
+
+            this.globalReporterManager.start();
         } else {
             logger.warn("Sync service has been disabled");
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/spring/SyncConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/spring/SyncConfiguration.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.am.gateway.services.sync.spring;
 
+import io.gravitee.am.gateway.core.reporter.GlobalReporterConfiguration;
 import io.gravitee.am.gateway.services.sync.SyncManager;
 import io.gravitee.am.gateway.services.sync.healthcheck.SyncProbe;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -27,6 +29,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  * @author GraviteeSource Team
  */
 @Configuration
+@Import({GlobalReporterConfiguration.class})
 public class SyncConfiguration {
 
     @Bean
@@ -45,4 +48,5 @@ public class SyncConfiguration {
     public SyncProbe syncProbe() {
         return new SyncProbe();
     }
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.gravitee.am.common.env.RepositoriesEnvironment;
 import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.utils.GraviteeContextHolder;
 import io.gravitee.am.gateway.configuration.ConfigurationChecker;
+import io.gravitee.am.gateway.core.reporter.GlobalReporterConfiguration;
 import io.gravitee.am.gateway.event.EventManagerImpl;
 import io.gravitee.am.gateway.node.GatewayNode;
 import io.gravitee.am.gateway.node.GatewayNodeMetadataResolver;
@@ -75,7 +77,7 @@ import org.springframework.core.env.Environment;
         BotDetectionSpringConfiguration.class,
         DeviceIdentifierSpringConfiguration.class,
         PasswordDictionaryConfiguration.class,
-        AuthenticationDeviceNotifierSpringConfiguration.class,
+        AuthenticationDeviceNotifierSpringConfiguration.class
 })
 public class StandaloneConfiguration {
 
@@ -138,5 +140,10 @@ public class StandaloneConfiguration {
     @Qualifier("EnvironmentWithFallback")
     public RepositoriesEnvironment repositoriesEnvironment(Environment environment){
         return new RepositoriesEnvironment(environment);
+    }
+
+    @Bean
+    public GraviteeContextHolder graviteeContextHolder() {
+        return new GraviteeContextHolder();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementAuditReporterManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementAuditReporterManager.java
@@ -373,7 +373,7 @@ public class ManagementAuditReporterManager extends AbstractService<AuditReporte
                     }
                 } else {
                     // initialize NoOpReporter in order to allow to reload this reporter with valid implementation if it is enabled through the UI
-                    auditReporters.put(reporter, new EventBusReporterWrapper<>(vertx, new NoOpReporter(), reporter.getReference()));
+                    auditReporters.put(reporter, new EventBusReporterWrapper<>(vertx, new NoOpReporter(), reporter.getReference(), null));
                     reporters.put(reporter.getId(), reporter);
                 }
             }
@@ -381,11 +381,11 @@ public class ManagementAuditReporterManager extends AbstractService<AuditReporte
 
         private Reporter<?, ?> createWrapper(AuditReporter auditReporter, io.gravitee.am.model.Reporter reporterConfig) {
             if (additionalReferences.isEmpty()) {
-                return new EventBusReporterWrapper<>(vertx, auditReporter, reporterConfig.getReference());
+                return new EventBusReporterWrapper<>(vertx, auditReporter, reporterConfig.getReference(), null);
             }
             var allReferences = new ArrayList<>(additionalReferences);
             allReferences.add(0, reporterConfig.getReference());
-            return new EventBusReporterWrapper<>(vertx, auditReporter, allReferences);
+            return new EventBusReporterWrapper<>(vertx, auditReporter, allReferences, null);
 
         }
     }

--- a/gravitee-am-reporter/gravitee-am-reporter-kafka/src/main/java/io/gravitee/am/reporter/kafka/dto/AuditMessageValueDto.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-kafka/src/main/java/io/gravitee/am/reporter/kafka/dto/AuditMessageValueDto.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.reporter.kafka.dto;
 
 import io.gravitee.am.common.utils.GraviteeContext;
+import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.reporter.api.audit.model.Audit;
 import io.gravitee.node.api.Node;
 import lombok.Builder;
@@ -62,7 +63,7 @@ public class AuditMessageValueDto {
     }
 
     public static AuditMessageValueDto from(Audit audit, GraviteeContext context, Node node) {
-        return builder()
+        var builder = builder()
                 .id(audit.getId())
                 .referenceId(audit.getReferenceId())
                 .referenceType(Objects.toString(audit.getReferenceType()))
@@ -73,9 +74,13 @@ public class AuditMessageValueDto {
                 .actor(AuditEntityDto.from(audit.getActor()))
                 .target(AuditEntityDto.from(audit.getTarget()))
                 .outcome(AuditOutcomeDto.from(audit.getOutcome()))
-                .context(context)
-                .node(node)
-                .build();
+                .node(node);
+
+        builder = builder.context(context);
+        if (context.getDomainId() == null && audit.getReferenceType() == ReferenceType.DOMAIN) {
+            builder = builder.domainId(audit.getReferenceId());
+        }
+        return builder.build();
     }
 
     @SuppressWarnings("unused") // additional methods for @lombok.Builder

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcReporterRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.am.repository.jdbc.management.api;
 
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.model.Reference;
+import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.Reporter;
 import io.gravitee.am.repository.jdbc.management.AbstractJdbcRepository;
 import io.gravitee.am.repository.jdbc.management.api.model.JdbcReporter;
@@ -121,6 +122,13 @@ public class JdbcReporterRepository extends AbstractJdbcRepository implements Re
     public Flowable<Reporter> findByReference(Reference reference) {
         LOGGER.debug("findByReference({})", reference);
         return reporterRepository.findByReferenceTypeAndReferenceId(reference.type(), reference.id())
+                .map(this::toEntity);
+    }
+
+    @Override
+    public Flowable<Reporter> findByReferenceType(ReferenceType refType) {
+        LOGGER.debug("findByReferenceType({})", refType);
+        return reporterRepository.findByReferenceType(refType)
                 .map(this::toEntity);
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringReporterRepository.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface SpringReporterRepository extends RxJava3CrudRepository<JdbcReporter, String> {
+    Flowable<JdbcReporter> findByReferenceType(ReferenceType referenceType);
     Flowable<JdbcReporter> findByReferenceTypeAndReferenceId(ReferenceType referenceType, String referenceId);
     Flowable<JdbcReporter> findByReferenceTypeAndReferenceIdAndInheritedTrue(ReferenceType referenceType, String referenceId);
 }

--- a/gravitee-am-repository/gravitee-am-repository-junit/src/main/java/io/gravitee/am/repository/junit/management/MemoryReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-junit/src/main/java/io/gravitee/am/repository/junit/management/MemoryReporterRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.junit.management;
 
 import io.gravitee.am.model.Reference;
+import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.Reporter;
 import io.gravitee.am.repository.junit.MemoryRepository;
 import io.gravitee.am.repository.management.api.ReporterRepository;
@@ -32,6 +33,11 @@ public class MemoryReporterRepository extends MemoryRepository<Reporter,String> 
     @Override
     public Flowable<Reporter> findByReference(Reference reference) {
         return findMany(x->x.getReference().equals(reference));
+    }
+
+    @Override
+    public Flowable<Reporter> findByReferenceType(ReferenceType type) {
+        return findMany(x->x.getReference().type().equals(type));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoReporterRepository.java
@@ -69,6 +69,11 @@ public class MongoReporterRepository extends AbstractManagementMongoRepository i
         return Flowable.fromPublisher(reportersCollection.find(query)).map(this::convert);
     }
 
+    @Override
+    public Flowable<Reporter> findByReferenceType(ReferenceType referenceType) {
+        return Flowable.fromPublisher(reportersCollection.find(eq(FIELD_REFERENCE_TYPE, referenceType))).map(this::convert);
+    }
+
     private static Bson referenceMatches(Reference reference) {
         var query = and(eq(FIELD_REFERENCE_TYPE, reference.type()), eq(FIELD_REFERENCE_ID, reference.id()));
         // for backwards compatibility


### PR DESCRIPTION
 this change allow to keep a single kafka producer and single file descriptor active

fixes AM-5143

## discussion

This change seems working but it is maybe not the rigth solution.
The implementation introduced in 4.5.0 is more clean as it allow to fill the org, env and domainId in the kafka audit dto.
It maybe possible to introduce the kafka producer using the dataSource plugin mechanism we tried to introduced for the redis cache...
