### PR TITLE
fix: notification after secret renewal

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ClientSecretManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ClientSecretManager.java
@@ -85,8 +85,7 @@ public class ClientSecretManager extends AbstractService<ClientSecretManager> im
     private Completable renewClientSecretNotifications(Payload payload) {
         return applicationService.findById(payload.getReferenceId()).flatMapCompletable(application ->
                 applicationSecretService.findById(payload.getReferenceId(), payload.getId()).flatMapCompletable(clientSecret ->
-                        clientSecretNotifierService.unregisterClientSecretExpiration(payload.getId())
-                                .andThen(clientSecretNotifierService.deleteClientSecretExpirationAcknowledgement(payload.getId()))
+                        removeClientSecretNotifications(clientSecret.getId())
                                 .andThen(clientSecretNotifierService.registerClientSecretExpiration(application, clientSecret))));
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoNotificationAcknowledgeRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoNotificationAcknowledgeRepository.java
@@ -78,7 +78,7 @@ public class MongoNotificationAcknowledgeRepository extends AbstractManagementMo
 
     @Override
     public Completable deleteByResourceId(String id, String resourceType) {
-        return Completable.fromPublisher(collection.deleteOne(and(eq(FIELD_RESOURCE_ID, id), eq(FIELD_RESOURCE_TYPE, resourceType))));
+        return Completable.fromPublisher(collection.deleteMany(and(eq(FIELD_RESOURCE_ID, id), eq(FIELD_RESOURCE_TYPE, resourceType))));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/NotificationAcknowledgeRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/NotificationAcknowledgeRepositoryTest.java
@@ -136,6 +136,17 @@ public class NotificationAcknowledgeRepositoryTest extends AbstractManagementTes
         acknowledge.setCounter(1);
         repository.create(acknowledge).blockingGet();
 
+        NotificationAcknowledge acknowledge1 = new NotificationAcknowledge();
+        acknowledge1.setId("testid1");
+        acknowledge1.setType("ui-notifier");
+        acknowledge1.setResourceId("resource");
+        acknowledge1.setAudienceId("audience");
+        acknowledge1.setCreatedAt(new Date());
+        acknowledge1.setUpdatedAt(new Date());
+        acknowledge1.setResourceType("resource_type");
+        acknowledge1.setCounter(1);
+        repository.create(acknowledge1).blockingGet();
+
         TestObserver<NotificationAcknowledge> testObserver = repository.findById(acknowledge.getId()).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertComplete();


### PR DESCRIPTION
Fixes: AM-5142
The problem was that when we set 2 notifiers (ui and log) then on renew it removed only one notifier from DB (log in this case). I have to change to remove all notifiers when resource is removed or renewed.
