### PR TITLE
fix: r2dbc-mssql in 1.0.1+ version problem with cursoredExecution

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest_MSSQL.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-jdbc/src/test/java/io/gravitee/am/identityprovider/jdbc/configuration/JdbcAuthenticationProviderConfigurationTest_MSSQL.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 public class JdbcAuthenticationProviderConfigurationTest_MSSQL extends JdbcAuthenticationProviderConfigurationTest {
 
     public String url() {
-        return "r2dbc:tc:sqlserver:///?TC_IMAGE_TAG=2019-latest";
+        return "r2dbc:tc:sqlserver:///?TC_IMAGE_TAG=2022-latest&preferCursoredExecution=false";
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/provider/impl/ConnectionFactoryProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/provider/impl/ConnectionFactoryProvider.java
@@ -54,6 +54,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 public class ConnectionFactoryProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionFactoryProvider.class);
     public static final String TAG_SOURCE = "pool";
+    public static final String TAG_PREFER_CURSORED_EXECUTION = "preferCursoredExecution";
     public static final String TAG_DRIVER = "r2dbc_driver";
     public static final String TAG_DATABASE = "r2dbc_db";
     public static final String TAG_SERVER = "r2dbc_server";
@@ -178,7 +179,10 @@ public class ConnectionFactoryProvider {
 
             builder = TlsOptionsHelper.setSSLOptions(builder, environment, prefix, driver);
 
-            connectionPool = (ConnectionPool)ConnectionFactories.get(builder.build());
+            final String preferCursorExecution = environment.getProperty(prefix + "preferCursorExecution", "false");
+            builder.option(Option.valueOf(TAG_PREFER_CURSORED_EXECUTION), preferCursorExecution);
+
+            connectionPool = ConnectionFactories.get(builder.build());
         }
 
         LOGGER.info("Connection pool created for {} database", prefix);

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/MssqlR2DBCContainer.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/MssqlR2DBCContainer.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.jdbc.common;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
 import org.testcontainers.containers.MSSQLR2DBCDatabaseContainer;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -44,7 +45,10 @@ public class MssqlR2DBCContainer implements R2dbcDatabaseContainer {
     }
 
     public ConnectionFactoryOptions getOptions() {
-        return MSSQLR2DBCDatabaseContainer.getOptions(dbContainer);
+        return ConnectionFactoryOptions.builder()
+                .option(Option.valueOf("preferCursoredExecution"), false) // due to r2dbc-mssql 1.0.1+
+                .from(MSSQLR2DBCDatabaseContainer.getOptions(dbContainer))
+                .build();
     }
 
     @Override


### PR DESCRIPTION
fixes AM-5106

added preferCursoredExecution boolean property to mssql connection option
also made tests to work with preferCursoredExecution=false

Changes between 1.0.0 and 1.0.1 -> https://github.com/r2dbc/r2dbc-mssql/compare/v1.0.0.RELEASE...v1.0.1.RELEASE

In MssqlConnectionConfiguration they changed
![image](https://github.com/user-attachments/assets/ab5a0493-30fd-4618-9d1d-fa8eea286607)

The DefaultCursorPreference returns true, when the query is "SELECT"

The documenations states:

_Whether to prefer cursors or direct execution for queries. Uses by default direct. Cursors require more round-trips but are more backpressure-friendly. Defaults to direct execution. Can be boolean or a Predicate<String> accepting the SQL query. (Optional)_

It seems like the feature is broken, I created an issue on r2dbc-mssql repo
