### PR TITLE
fix: allow to enable proxy from plugin

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/http/WebClientBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/http/WebClientBuilder.java
@@ -71,6 +71,15 @@ public class WebClientBuilder {
         return createWebClient(vertx, options, null);
     }
 
+    public WebClient createWebClient(Vertx vertx, WebClientOptions options, String url, Boolean withSystemProxy){
+        var configurer = new WebClientOptionsConfigurer(environment);
+        if (!isExcludedHost(url) && withSystemProxy) {
+            configurer.setProxySettings(options);
+        }
+        configurer.setSSLSettings(options);
+        return WebClient.create(vertx, options);
+    }
+
     public WebClient createWebClient(Vertx vertx, WebClientOptions options, String url) {
         var configurer = new WebClientOptionsConfigurer(environment);
         if (!isExcludedHost(url)) {


### PR DESCRIPTION
Fixes: AM-5053
This relates to https://github.com/gravitee-io/gravitee-am-resource-http-factor/pull/63.
What was the issue: when useSystemProxy was not checked then the proxy was used even if the host was in excluded hosts because it passed null as a url. With this change the system proxy is used when checkbox is selected and url is not in excluded hosts.