### PR TITLE
AM-5268 fix: filtering application sensitive data in logs

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/management/ApplicationAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/management/ApplicationAuditBuilder.java
@@ -52,6 +52,7 @@ public class ApplicationAuditBuilder extends ManagementAuditBuilder<ApplicationA
                 safeApp.getSettings().getOauth().setClientSecret(null);
             }
             safeApp.setSecrets(List.of());
+            return safeApp;
         }
         return value;
     }


### PR DESCRIPTION
fixes AM-5268 AM-5268

due to removal of @JsonIgnore in ClientSecret
![image](https://github.com/user-attachments/assets/5b656552-a045-41ac-bb22-dbeffc7c5fb5)



