### PR TITLE
fix: revert the usage of Scheduler.computation for JWT signature

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/impl/JWTServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/impl/JWTServiceImpl.java
@@ -175,7 +175,7 @@ public class JWTServiceImpl implements JWTService {
         if (certificateProvider.getProvider().getClass().getSimpleName().equals(AWS_HSM_CERTIFICATE_PROVIDER)) {
             return signer.subscribeOn(Schedulers.io());
         } else {
-            return signer.subscribeOn(Schedulers.computation());
+            return signer;
         }
     }
 
@@ -193,7 +193,7 @@ public class JWTServiceImpl implements JWTService {
         if (certificateProvider.getProvider().getClass().getSimpleName().equals(AWS_HSM_CERTIFICATE_PROVIDER)) {
             return verifier.subscribeOn(Schedulers.io());
         } else {
-            return verifier.subscribeOn(Schedulers.computation());
+            return verifier;
         }
     }
 


### PR DESCRIPTION
 for some reason, if the computation scheduler contains only one thread

 the blockingGet made by the CookieSession handler never respond

 this is happening only when OIDC provider are defined for the application because the provider url set in the login page also sign a JWT to define the state param

related-to AM-5263
