### PR TITLE
chore: update gravitee parent v

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.25</version>
+        <version>22.5.0</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
For 4.7+ the version must be updated to 23.4.0