### PR TITLE
fix: AM-5309 lift limit on users count

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/AbstractUsersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/AbstractUsersResource.java
@@ -36,9 +36,6 @@ import javax.inject.Named;
  */
 public abstract class AbstractUsersResource extends AbstractResource {
 
-    protected static final int MAX_USERS_SIZE_PER_PAGE = 30;
-    protected static final String MAX_USERS_SIZE_PER_PAGE_STRING = "30";
-
     @Autowired
     protected UserService userService;
 
@@ -61,12 +58,12 @@ public abstract class AbstractUsersResource extends AbstractResource {
 
     private Single<Page<User>> executeSearchUsers(CommonUserService service, ReferenceType referenceType, String referenceId, String query, String filter, int page, int size) {
         if (query != null) {
-            return service.search(referenceType, referenceId, query, page, Integer.min(size, MAX_USERS_SIZE_PER_PAGE));
+            return service.search(referenceType, referenceId, query, page, size);
         }
         if (filter != null) {
             return Single.defer(() -> {
                 FilterCriteria filterCriteria = FilterCriteria.convert(SCIMFilterParser.parse(filter));
-                return service.search(referenceType, referenceId, filterCriteria, page, Integer.min(size, MAX_USERS_SIZE_PER_PAGE));
+                return service.search(referenceType, referenceId, filterCriteria, page, size);
             }).onErrorResumeNext(ex -> {
                 if (ex instanceof IllegalArgumentException) {
                     return Single.error(new BadRequestException(ex.getMessage()));
@@ -74,7 +71,7 @@ public abstract class AbstractUsersResource extends AbstractResource {
                 return Single.error(ex);
             });
         }
-        return service.findAll(referenceType, referenceId, page, Integer.min(size, MAX_USERS_SIZE_PER_PAGE));
+        return service.findAll(referenceType, referenceId, page, size);
     }
 
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UsersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UsersResource.java
@@ -37,6 +37,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
@@ -95,7 +96,7 @@ public class UsersResource extends AbstractUsersResource {
             @QueryParam("q") String query,
             @QueryParam("filter") String filter,
             @QueryParam("page") @DefaultValue("0") int page,
-            @QueryParam("size") @DefaultValue(MAX_USERS_SIZE_PER_PAGE_STRING) int size,
+            @QueryParam("size") @Max(1000) @DefaultValue("30") int size,
             @Suspended final AsyncResponse response) {
 
         io.gravitee.am.identityprovider.api.User authenticatedUser = getAuthenticatedUser();

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/OrganizationUsersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/users/OrganizationUsersResource.java
@@ -37,6 +37,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
@@ -92,7 +93,7 @@ public class OrganizationUsersResource extends AbstractUsersResource {
             @QueryParam("q") String query,
             @QueryParam("filter") String filter,
             @QueryParam("page") @DefaultValue("0") int page,
-            @QueryParam("size") @DefaultValue(MAX_USERS_SIZE_PER_PAGE_STRING) int size,
+            @QueryParam("size") @Max(1000) @DefaultValue("30") int size,
             @Suspended final AsyncResponse response) {
 
         io.gravitee.am.identityprovider.api.User authenticatedUser = getAuthenticatedUser();


### PR DESCRIPTION
In case of size greater then 1000 the api returns 400
`{"message":"[1025: must be less than or equal to 1000]","http_status":400}`