### PR TITLE
fix: allow to add a new Android Key Root Certificate without overridi…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/GraviteeWebAuthnOptions.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/GraviteeWebAuthnOptions.java
@@ -15,9 +15,19 @@
  */
 package io.gravitee.am.gateway.handler.vertx.auth.webauthn;
 
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.impl.jose.JWS;
 import io.vertx.ext.auth.webauthn.WebAuthnOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -26,6 +36,164 @@ import org.slf4j.LoggerFactory;
 public class GraviteeWebAuthnOptions extends WebAuthnOptions {
     private static Logger LOGGER = LoggerFactory.getLogger(GraviteeWebAuthnOptions.class);
 
+    /* Android Keystore Root is not published anywhere.
+     * This certificate was extracted from one of the attestations
+     * The last certificate in x5c must match this certificate
+     * This needs to be checked to ensure that malicious party won't generate fake attestations
+     */
+    private static final String ANDROID_KEYSTORE_ROOT =
+            "MIICizCCAjKgAwIBAgIJAKIFntEOQ1tXMAoGCCqGSM49BAMCMIGYMQswCQYDVQQG" +
+                    "EwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNTW91bnRhaW4gVmll" +
+                    "dzEVMBMGA1UECgwMR29vZ2xlLCBJbmMuMRAwDgYDVQQLDAdBbmRyb2lkMTMwMQYD" +
+                    "VQQDDCpBbmRyb2lkIEtleXN0b3JlIFNvZnR3YXJlIEF0dGVzdGF0aW9uIFJvb3Qw" +
+                    "HhcNMTYwMTExMDA0MzUwWhcNMzYwMTA2MDA0MzUwWjCBmDELMAkGA1UEBhMCVVMx" +
+                    "EzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcxFTAT" +
+                    "BgNVBAoMDEdvb2dsZSwgSW5jLjEQMA4GA1UECwwHQW5kcm9pZDEzMDEGA1UEAwwq" +
+                    "QW5kcm9pZCBLZXlzdG9yZSBTb2Z0d2FyZSBBdHRlc3RhdGlvbiBSb290MFkwEwYH" +
+                    "KoZIzj0CAQYIKoZIzj0DAQcDQgAE7l1ex+HA220Dpn7mthvsTWpdamguD/9/SQ59" +
+                    "dx9EIm29sa/6FsvHrcV30lacqrewLVQBXT5DKyqO107sSHVBpKNjMGEwHQYDVR0O" +
+                    "BBYEFMit6XdMRcOjzw0WEOR5QzohWjDPMB8GA1UdIwQYMBaAFMit6XdMRcOjzw0W" +
+                    "EOR5QzohWjDPMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgKEMAoGCCqG" +
+                    "SM49BAMCA0cAMEQCIDUho++LNEYenNVg8x1YiSBq3KNlQfYNns6KGYxmSGB7AiBN" +
+                    "C/NR2TB8fVvaNTQdqEcbY6WFZTytTySn502vQX3xvw==";
+
+    /* Android Keystore Root is not published anywhere.
+     * https://developer.android.com/privacy-and-security/security-key-attestation
+     */
+    private static final String ANDROID_KEYSTORE_ROOT_1 =
+            "MIIFYDCCA0igAwIBAgIJAOj6GWMU0voYMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV\n" +
+                    "BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTYwNTI2MTYyODUyWhcNMjYwNTI0MTYy\n" +
+                    "ODUyWjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0B\n" +
+                    "AQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdS\n" +
+                    "Sxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7\n" +
+                    "tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggj\n" +
+                    "nar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGq\n" +
+                    "C4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQ\n" +
+                    "oVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+O\n" +
+                    "JtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/Eg\n" +
+                    "sTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRi\n" +
+                    "igHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+M\n" +
+                    "RPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9E\n" +
+                    "aDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5Um\n" +
+                    "AGMCAwEAAaOBpjCBozAdBgNVHQ4EFgQUNmHhAHyIBQlRi0RsR/8aTMnqTxIwHwYD\n" +
+                    "VR0jBBgwFoAUNmHhAHyIBQlRi0RsR/8aTMnqTxIwDwYDVR0TAQH/BAUwAwEB/zAO\n" +
+                    "BgNVHQ8BAf8EBAMCAYYwQAYDVR0fBDkwNzA1oDOgMYYvaHR0cHM6Ly9hbmRyb2lk\n" +
+                    "Lmdvb2dsZWFwaXMuY29tL2F0dGVzdGF0aW9uL2NybC8wDQYJKoZIhvcNAQELBQAD\n" +
+                    "ggIBACDIw41L3KlXG0aMiS//cqrG+EShHUGo8HNsw30W1kJtjn6UBwRM6jnmiwfB\n" +
+                    "Pb8VA91chb2vssAtX2zbTvqBJ9+LBPGCdw/E53Rbf86qhxKaiAHOjpvAy5Y3m00m\n" +
+                    "qC0w/Zwvju1twb4vhLaJ5NkUJYsUS7rmJKHHBnETLi8GFqiEsqTWpG/6ibYCv7rY\n" +
+                    "DBJDcR9W62BW9jfIoBQcxUCUJouMPH25lLNcDc1ssqvC2v7iUgI9LeoM1sNovqPm\n" +
+                    "QUiG9rHli1vXxzCyaMTjwftkJLkf6724DFhuKug2jITV0QkXvaJWF4nUaHOTNA4u\n" +
+                    "JU9WDvZLI1j83A+/xnAJUucIv/zGJ1AMH2boHqF8CY16LpsYgBt6tKxxWH00XcyD\n" +
+                    "CdW2KlBCeqbQPcsFmWyWugxdcekhYsAWyoSf818NUsZdBWBaR/OukXrNLfkQ79Iy\n" +
+                    "ZohZbvabO/X+MVT3rriAoKc8oE2Uws6DF+60PV7/WIPjNvXySdqspImSN78mflxD\n" +
+                    "qwLqRBYkA3I75qppLGG9rp7UCdRjxMl8ZDBld+7yvHVgt1cVzJx9xnyGCC23Uaic\n" +
+                    "MDSXYrB4I4WHXPGjxhZuCuPBLTdOLU8YRvMYdEvYebWHMpvwGCF6bAx3JBpIeOQ1\n" +
+                    "wDB5y0USicV3YgYGmi+NZfhA4URSh77Yd6uuJOJENRaNVTzk";
+
+    private static final String ANDROID_KEYSTORE_ROOT_2 =
+            "MIIFHDCCAwSgAwIBAgIJANUP8luj8tazMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV\n" +
+                    "BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTkxMTIyMjAzNzU4WhcNMzQxMTE4MjAz\n" +
+                    "NzU4WjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0B\n" +
+                    "AQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdS\n" +
+                    "Sxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7\n" +
+                    "tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggj\n" +
+                    "nar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGq\n" +
+                    "C4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQ\n" +
+                    "oVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+O\n" +
+                    "JtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/Eg\n" +
+                    "sTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRi\n" +
+                    "igHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+M\n" +
+                    "RPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9E\n" +
+                    "aDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5Um\n" +
+                    "AGMCAwEAAaNjMGEwHQYDVR0OBBYEFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMB8GA1Ud\n" +
+                    "IwQYMBaAFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMA8GA1UdEwEB/wQFMAMBAf8wDgYD\n" +
+                    "VR0PAQH/BAQDAgIEMA0GCSqGSIb3DQEBCwUAA4ICAQBOMaBc8oumXb2voc7XCWnu\n" +
+                    "XKhBBK3e2KMGz39t7lA3XXRe2ZLLAkLM5y3J7tURkf5a1SutfdOyXAmeE6SRo83U\n" +
+                    "h6WszodmMkxK5GM4JGrnt4pBisu5igXEydaW7qq2CdC6DOGjG+mEkN8/TA6p3cno\n" +
+                    "L/sPyz6evdjLlSeJ8rFBH6xWyIZCbrcpYEJzXaUOEaxxXxgYz5/cTiVKN2M1G2ok\n" +
+                    "QBUIYSY6bjEL4aUN5cfo7ogP3UvliEo3Eo0YgwuzR2v0KR6C1cZqZJSTnghIC/vA\n" +
+                    "D32KdNQ+c3N+vl2OTsUVMC1GiWkngNx1OO1+kXW+YTnnTUOtOIswUP/Vqd5SYgAI\n" +
+                    "mMAfY8U9/iIgkQj6T2W6FsScy94IN9fFhE1UtzmLoBIuUFsVXJMTz+Jucth+IqoW\n" +
+                    "Fua9v1R93/k98p41pjtFX+H8DslVgfP097vju4KDlqN64xV1grw3ZLl4CiOe/A91\n" +
+                    "oeLm2UHOq6wn3esB4r2EIQKb6jTVGu5sYCcdWpXr0AUVqcABPdgL+H7qJguBw09o\n" +
+                    "jm6xNIrw2OocrDKsudk/okr/AwqEyPKw9WnMlQgLIKw1rODG2NvU9oR3GVGdMkUB\n" +
+                    "ZutL8VuFkERQGt6vQ2OCw0sV47VMkuYbacK/xyZFiRcrPJPb41zgbQj9XAEyLKCH\n" +
+                    "ex0SdDrx+tWUDqG8At2JHA==";
+
+    private static final String ANDROID_KEYSTORE_ROOT_3 =
+            "MIIFHDCCAwSgAwIBAgIJAMNrfES5rhgxMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV\n" +
+                    "BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMjExMTE3MjMxMDQyWhcNMzYxMTEzMjMx\n" +
+                    "MDQyWjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0B\n" +
+                    "AQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdS\n" +
+                    "Sxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7\n" +
+                    "tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggj\n" +
+                    "nar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGq\n" +
+                    "C4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQ\n" +
+                    "oVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+O\n" +
+                    "JtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/Eg\n" +
+                    "sTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRi\n" +
+                    "igHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+M\n" +
+                    "RPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9E\n" +
+                    "aDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5Um\n" +
+                    "AGMCAwEAAaNjMGEwHQYDVR0OBBYEFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMB8GA1Ud\n" +
+                    "IwQYMBaAFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMA8GA1UdEwEB/wQFMAMBAf8wDgYD\n" +
+                    "VR0PAQH/BAQDAgIEMA0GCSqGSIb3DQEBCwUAA4ICAQBTNNZe5cuf8oiq+jV0itTG\n" +
+                    "zWVhSTjOBEk2FQvh11J3o3lna0o7rd8RFHnN00q4hi6TapFhh4qaw/iG6Xg+xOan\n" +
+                    "63niLWIC5GOPFgPeYXM9+nBb3zZzC8ABypYuCusWCmt6Tn3+Pjbz3MTVhRGXuT/T\n" +
+                    "QH4KGFY4PhvzAyXwdjTOCXID+aHud4RLcSySr0Fq/L+R8TWalvM1wJJPhyRjqRCJ\n" +
+                    "erGtfBagiALzvhnmY7U1qFcS0NCnKjoO7oFedKdWlZz0YAfu3aGCJd4KHT0MsGiL\n" +
+                    "Zez9WP81xYSrKMNEsDK+zK5fVzw6jA7cxmpXcARTnmAuGUeI7VVDhDzKeVOctf3a\n" +
+                    "0qQLwC+d0+xrETZ4r2fRGNw2YEs2W8Qj6oDcfPvq9JySe7pJ6wcHnl5EZ0lwc4xH\n" +
+                    "7Y4Dx9RA1JlfooLMw3tOdJZH0enxPXaydfAD3YifeZpFaUzicHeLzVJLt9dvGB0b\n" +
+                    "HQLE4+EqKFgOZv2EoP686DQqbVS1u+9k0p2xbMA105TBIk7npraa8VM0fnrRKi7w\n" +
+                    "lZKwdH+aNAyhbXRW9xsnODJ+g8eF452zvbiKKngEKirK5LGieoXBX7tZ9D1GNBH2\n" +
+                    "Ob3bKOwwIWdEFle/YF/h6zWgdeoaNGDqVBrLr2+0DtWoiB1aDEjLWl9FmyIUyUm7\n" +
+                    "mD/vFDkzF+wm7cyWpQpCVQ==";
+
+    private static final String ANDROID_KEYSTORE_ROOT_4 =
+            "MIIFHDCCAwSgAwIBAgIJAPHBcqaZ6vUdMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV\n" +
+                    "BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMjIwMzIwMTgwNzQ4WhcNNDIwMzE1MTgw\n" +
+                    "NzQ4WjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0B\n" +
+                    "AQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdS\n" +
+                    "Sxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7\n" +
+                    "tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggj\n" +
+                    "nar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGq\n" +
+                    "C4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQ\n" +
+                    "oVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+O\n" +
+                    "JtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/Eg\n" +
+                    "sTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRi\n" +
+                    "igHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+M\n" +
+                    "RPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9E\n" +
+                    "aDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5Um\n" +
+                    "AGMCAwEAAaNjMGEwHQYDVR0OBBYEFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMB8GA1Ud\n" +
+                    "IwQYMBaAFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMA8GA1UdEwEB/wQFMAMBAf8wDgYD\n" +
+                    "VR0PAQH/BAQDAgIEMA0GCSqGSIb3DQEBCwUAA4ICAQB8cMqTllHc8U+qCrOlg3H7\n" +
+                    "174lmaCsbo/bJ0C17JEgMLb4kvrqsXZs01U3mB/qABg/1t5Pd5AORHARs1hhqGIC\n" +
+                    "W/nKMav574f9rZN4PC2ZlufGXb7sIdJpGiO9ctRhiLuYuly10JccUZGEHpHSYM2G\n" +
+                    "tkgYbZba6lsCPYAAP83cyDV+1aOkTf1RCp/lM0PKvmxYN10RYsK631jrleGdcdkx\n" +
+                    "oSK//mSQbgcWnmAEZrzHoF1/0gso1HZgIn0YLzVhLSA/iXCX4QT2h3J5z3znluKG\n" +
+                    "1nv8NQdxei2DIIhASWfu804CA96cQKTTlaae2fweqXjdN1/v2nqOhngNyz1361mF\n" +
+                    "mr4XmaKH/ItTwOe72NI9ZcwS1lVaCvsIkTDCEXdm9rCNPAY10iTunIHFXRh+7KPz\n" +
+                    "lHGewCq/8TOohBRn0/NNfh7uRslOSZ/xKbN9tMBtw37Z8d2vvnXq/YWdsm1+JLVw\n" +
+                    "n6yYD/yacNJBlwpddla8eaVMjsF6nBnIgQOf9zKSe06nSTqvgwUHosgOECZJZ1Eu\n" +
+                    "zbH4yswbt02tKtKEFhx+v+OTge/06V+jGsqTWLsfrOCNLuA8H++z+pUENmpqnnHo\n" +
+                    "vaI47gC+TNpkgYGkkBT6B/m/U01BuOBBTzhIlMEZq9qkDWuM2cA5kW5V3FJUcfHn\n" +
+                    "w1IdYIg2Wxg7yHcQZemFQg==";
+
+
+    private Map<String, List<X509Certificate>> additionalRootCertificates = new HashMap<>();
+
+    public GraviteeWebAuthnOptions(JsonObject json) {
+        super(json);
+        initAdditionalRootCertificates();
+    }
+
+    public GraviteeWebAuthnOptions() {
+        super();
+        initAdditionalRootCertificates();
+    }
+
     @Override
     public WebAuthnOptions putRootCertificate(String key, String value) {
         try {
@@ -33,6 +201,30 @@ public class GraviteeWebAuthnOptions extends WebAuthnOptions {
         } catch (IllegalArgumentException e) {
             LOGGER.warn("Root Certificate {} can't be loaded due to {}, please update the certificate.", key, e.getMessage(), e);
             return this;
+        }
+    }
+
+    public @Nullable List<X509Certificate> getAdditionalRootCertificate(String key) {
+        return this.additionalRootCertificates == null ? null : this.additionalRootCertificates.get(key);
+    }
+
+    private void initAdditionalRootCertificates() {
+        pushAdditionalRootCertificate("android-key", ANDROID_KEYSTORE_ROOT);
+        pushAdditionalRootCertificate("android-key", ANDROID_KEYSTORE_ROOT_1);
+        pushAdditionalRootCertificate("android-key", ANDROID_KEYSTORE_ROOT_2);
+        pushAdditionalRootCertificate("android-key", ANDROID_KEYSTORE_ROOT_3);
+        pushAdditionalRootCertificate("android-key", ANDROID_KEYSTORE_ROOT_4);
+    }
+
+    public WebAuthnOptions pushAdditionalRootCertificate(String key, String value) {
+        try {
+            X509Certificate cert = JWS.parseX5c(value);
+            cert.checkValidity();
+            this.additionalRootCertificates.putIfAbsent(key, new ArrayList<>());
+            this.additionalRootCertificates.get(key).add(cert);
+            return this;
+        } catch (CertificateException e) {
+            throw new IllegalArgumentException("Invalid additional root certificate", e);
         }
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/attestation/GraviteeAndroidKeyAttestation.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/attestation/GraviteeAndroidKeyAttestation.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.vertx.auth.webauthn.attestation;
+
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+import io.gravitee.am.gateway.handler.vertx.auth.webauthn.GraviteeWebAuthnOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.webauthn.AttestationCertificates;
+import io.vertx.ext.auth.webauthn.PublicKeyCredential;
+import io.vertx.ext.auth.webauthn.WebAuthnOptions;
+import io.vertx.ext.auth.webauthn.impl.AuthData;
+import io.vertx.ext.auth.impl.jose.JWK;
+import io.vertx.ext.auth.webauthn.impl.attestation.Attestation;
+import io.vertx.ext.auth.webauthn.impl.attestation.AttestationException;
+import io.vertx.ext.auth.webauthn.impl.metadata.MetaData;
+import io.vertx.ext.auth.webauthn.impl.metadata.MetaDataException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.*;
+import java.security.cert.*;
+import java.util.Collections;
+import java.util.List;
+
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
+import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.*;
+import static io.vertx.ext.auth.impl.asn.ASN1.*;
+import static io.vertx.ext.auth.webauthn.impl.metadata.MetaData.*;
+
+/**
+ * Implementation of the "android-key" attestation check.
+ * <p>
+ * Android KeyStore is a key management container, that defends key material from extraction.
+ * Depending on the device, it can be either software or hardware backed.
+ * <p>
+ * For example if authenticator required to be FIPS/CC/PCI/FIDO compliant, then it needs
+ * to be running on the device with FIPS/CC/PCI/FIDO compliant hardware, and it can be
+ * found getting KeyStore attestation.
+ *
+ * @author <a href="mailto:pmlopes@gmail.com>Paulo Lopes</a>
+ *
+ * This specific implementation is a copy of vertx codebase with a workaround
+ * to manage multiple root CA. This is to avoid issue since in june 2025 the CA
+ * has changed and old device are not able to use the new one.
+ *
+ * @author Eric Leleu (eric.leleu@graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class GraviteeAndroidKeyAttestation implements Attestation {
+
+    private static final JsonArray EMPTY = new JsonArray(Collections.emptyList());
+
+    @Override
+    public String fmt() {
+        return "android-key";
+    }
+
+    @Override
+    public AttestationCertificates validate(WebAuthnOptions options, MetaData metadata, byte[] clientDataJSON, JsonObject attestation, AuthData authData) throws AttestationException {
+        // Typical attestation object
+        //{
+        //    "fmt": "android-key",
+        //    "authData": "base64",
+        //    "attStmt": {
+        //        "alg": -7,
+        //        "sig": "base64",
+        //        "x5c": [
+        //            "base64",
+        //            "base64",
+        //            "base64"
+        //        ]
+        //    }
+        //}
+
+        try {
+            byte[] clientDataHash = Attestation.hash("SHA-256", clientDataJSON);
+
+            // Verifying attestation
+            // 1. Concatenate authData with clientDataHash to create signatureBase
+            byte[] signatureBase = Buffer.buffer()
+                    .appendBytes(authData.getRaw())
+                    .appendBytes(clientDataHash)
+                    .getBytes();
+            // 2. Verify signature sig over the signatureBase using
+            //    public key extracted from leaf certificate in x5c
+            JsonObject attStmt = attestation.getJsonObject("attStmt");
+            byte[] signature = base64UrlDecode(attStmt.getString("sig"));
+            List<X509Certificate> certChain = parseX5c(attStmt.getJsonArray("x5c"));
+            if (certChain.size() == 0) {
+                throw new AttestationException("Invalid certificate chain");
+            }
+
+            final X509Certificate leafCert = certChain.get(0);
+
+            // verify the signature
+            verifySignature(
+                    PublicKeyCredential.valueOf(attStmt.getInteger("alg")),
+                    leafCert,
+                    signature,
+                    signatureBase);
+
+            // meta data check
+            JsonObject statement = metadata.verifyMetadata(
+                    authData.getAaguidString(),
+                    PublicKeyCredential.valueOf(attStmt.getInteger("alg")),
+                    certChain);
+
+            // Verifying attestation certificate
+            // 1. Check that authData publicKey matches the public key in the attestation certificate
+            JWK coseKey = authData.getCredentialJWK();
+            if (!leafCert.getPublicKey().equals(coseKey.publicKey())) {
+                throw new AttestationException("Certificate public key does not match public key in authData!");
+            }
+            // 2. Find Android KeyStore Extension with OID “1.3.6.1.4.1.11129.2.1.17” in certificate extensions.
+            ASN attestationExtension = parseASN1(Buffer.buffer(leafCert.getExtensionValue("1.3.6.1.4.1.11129.2.1.17")));
+            if (!attestationExtension.is(OCTET_STRING)) {
+                throw new AttestationException("Attestation Extension is not an ASN.1 OCTECT string!");
+            }
+            // parse the octec as ASN.1 and expect it to se a sequence
+            attestationExtension = parseASN1(Buffer.buffer(attestationExtension.binary(0)));
+            if (!attestationExtension.is(SEQUENCE)) {
+                throw new AttestationException("Attestation Extension Value is not an ASN.1 SEQUENCE!");
+            }
+            // get the data at index 4 (certificate challenge)
+            byte[] data = attestationExtension.object(4).binary(0);
+
+            // 3. Check that attestationChallenge is set to the clientDataHash.
+            // verify that the client hash matches the certificate hash
+            if (!MessageDigest.isEqual(clientDataHash, data)) {
+                throw new AttestationException("Certificate attestation challenge is not set to the clientData hash!");
+            }
+            // 4. Check that both teeEnforced and softwareEnforced structures don’t contain allApplications(600) tag.
+            // This is important as the key must strictly bound to the caller app identifier.
+            ASN softwareEnforcedAuthz = attestationExtension.object(6);
+            for (Object object : softwareEnforcedAuthz.value) {
+                if (object instanceof ASN) {
+                    // verify if the that the list doesn't contain "allApplication" 600 flag
+                    if (((ASN) object).tag.number == 600) {
+                        throw new AttestationException("Software authorisation list contains 'allApplication' flag, which means that credential is not bound to the RP!");
+                    }
+                }
+            }
+            // 4. Check that both teeEnforced and softwareEnforced structures don’t contain allApplications(600) tag.
+            // This is important as the key must strictly bound to the caller app identifier.
+            ASN teeEnforcedAuthz = attestationExtension.object(7);
+            for (Object object : teeEnforcedAuthz.value) {
+                if (object instanceof ASN) {
+                    // verify if the that the list doesn't contain "allApplication" 600 flag
+                    if (((ASN) object).tag.number == 600) {
+                        throw new AttestationException("TEE authorisation list contains 'allApplication' flag, which means that credential is not bound to the RP!");
+                    }
+                }
+            }
+
+            if (statement == null || statement.getJsonArray("attestationRootCertificates", EMPTY).size() == 0) {
+                // 5. Check that root certificate(last in the chain) is set to the root certificate
+                // Google does not publish this certificate, so this was extracted from one of the attestations.
+                if (!validateRootCA(options, attStmt, options.getRootCertificate(fmt()))) {
+                    log.debug("Default Root certificate invalid for android-key, fallback to the updated ones");
+                    List<X509Certificate> additionalRootCertificates = ((GraviteeWebAuthnOptions) options).getAdditionalRootCertificate(fmt());
+                    if (!additionalRootCertificates.stream().anyMatch(cert -> validateRootCA(options, attStmt, cert))) {
+                        throw new AttestationException("Root certificate is invalid!");
+                    }
+                }
+            }
+
+            if (statement != null) {
+                // verify that the statement allows this type of attestation
+                if (!statementAttestationTypesContains(statement, ATTESTATION_ANONCA)) {
+                    throw new AttestationException("Metadata does not indicate support for anonca attestations");
+                }
+            }
+
+            return new AttestationCertificates()
+                    .setAlg(PublicKeyCredential.valueOf(attStmt.getInteger("alg")))
+                    .setX5c(attStmt.getJsonArray("x5c"));
+
+        } catch (MetaDataException | CertificateException | InvalidKeyException | SignatureException | NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+            throw new AttestationException(e);
+        }
+    }
+
+    private boolean validateRootCA(WebAuthnOptions options, JsonObject attStmt, X509Certificate rootCertificate) {
+        final JsonArray x5c = attStmt.getJsonArray("x5c");
+        try {
+            return  (rootCertificate != null && MessageDigest.isEqual(rootCertificate.getEncoded(), base64UrlDecode(x5c.getString(x5c.size() - 1))));
+        } catch (CertificateEncodingException e) {
+            log.error("Invalid root certificate", e);
+            return false;
+        }
+
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/META-INF/services/io.vertx.ext.auth.webauthn.impl.attestation.Attestation
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/META-INF/services/io.vertx.ext.auth.webauthn.impl.attestation.Attestation
@@ -1,7 +1,7 @@
 io.gravitee.am.gateway.handler.vertx.auth.webauthn.attestation.GraviteeNoneAttestation
 io.gravitee.am.gateway.handler.vertx.auth.webauthn.attestation.GraviteeTPMAttestation
+io.gravitee.am.gateway.handler.vertx.auth.webauthn.attestation.GraviteeAndroidKeyAttestation
 io.vertx.ext.auth.webauthn.impl.attestation.FidoU2fAttestation
 io.vertx.ext.auth.webauthn.impl.attestation.PackedAttestation
-io.vertx.ext.auth.webauthn.impl.attestation.AndroidKeyAttestation
 io.vertx.ext.auth.webauthn.impl.attestation.AndroidSafetynetAttestation
 io.vertx.ext.auth.webauthn.impl.attestation.AppleAttestation


### PR DESCRIPTION
…ng the existing one

 This is required since in June 2025, updated android versions has a new public key

 but old versions are still using the default one present in vertx WebAuhtnOptions

fixes AM-5347