### PR TITLE
fix: manage application/jwt content type as UserInfo endpoint response

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpoint.java
@@ -118,7 +118,7 @@ public class UserInfoEndpoint implements Handler<RoutingContext> {
                                 jwt.setIss(openIDDiscoveryService.getIssuer(UriBuilderRequest.resolveProxyRequest(context)));
                                 jwt.setAud(accessToken.getAud());
                                 jwt.setIat(new Date().getTime() / 1000L);
-                                jwt.setExp(accessToken.getExp() / 1000L);
+                                jwt.setExp(accessToken.getExp());
 
                                 return jwtService.encodeUserinfo(jwt, client)//Sign if needed, else return unsigned JWT
                                         .flatMap(userinfo -> jweService.encryptUserinfo(userinfo, client));//Encrypt if needed, else return JWT

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/oidc/OpenIDConnectIdentityProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-api/src/main/java/io/gravitee/am/identityprovider/api/oidc/OpenIDConnectIdentityProviderConfiguration.java
@@ -30,6 +30,10 @@ public interface OpenIDConnectIdentityProviderConfiguration extends SocialIdenti
 
     boolean isUseIdTokenForUserInfo();
 
+    default boolean doesUserInfoProvideJwt() {
+        return false;
+    }
+
     KeyResolver getPublicKeyResolver();
 
     SignatureAlgorithm getSignatureAlgorithm();

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-common/src/main/java/io/gravitee/am/identityprovider/common/oauth2/authentication/AbstractOpenIDConnectAuthenticationProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-common/src/main/java/io/gravitee/am/identityprovider/common/oauth2/authentication/AbstractOpenIDConnectAuthenticationProvider.java
@@ -363,7 +363,7 @@ public abstract class AbstractOpenIDConnectAuthenticationProvider extends Abstra
     protected void generateJWTProcessor() {
         if (getConfiguration().isUseIdTokenForUserInfo()
                 || getConfiguration().doesUserInfoProvideJwt()
-                || ResponseType.ID_TOKEN.equals(getConfiguration().getResponseType())) {
+                || ProviderResponseType.ID_TOKEN.equals(getConfiguration().getProviderResponseType())) {
             if (getConfiguration().getPublicKeyResolver() == null || getConfiguration().getResolverParameter() == null) {
                 throw new IllegalStateException("An public key resolver must be supply to verify the ID Token");
             }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/java/io/gravitee/am/identityprovider/oauth2/OAuth2GenericIdentityProviderConfiguration.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/java/io/gravitee/am/identityprovider/oauth2/OAuth2GenericIdentityProviderConfiguration.java
@@ -59,7 +59,7 @@ public class OAuth2GenericIdentityProviderConfiguration implements OpenIDConnect
     private String clientAuthenticationCertificate;
     private boolean storeOriginalTokens;
     private CodeChallengeMethod codeChallengeMethod;
-
+    private boolean userInfoAsJwt = false;
     @Override
     public String getResponseType() {
         return responseType.value();
@@ -101,5 +101,10 @@ public class OAuth2GenericIdentityProviderConfiguration implements OpenIDConnect
     @Override
     public String getClientAuthenticationMethod() {
         return clientAuthenticationMethod;
+    }
+
+    @Override
+    public boolean doesUserInfoProvideJwt() {
+        return this.userInfoAsJwt;
     }
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/java/io/gravitee/am/identityprovider/oauth2/authentication/OAuth2GenericAuthenticationProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/java/io/gravitee/am/identityprovider/oauth2/authentication/OAuth2GenericAuthenticationProvider.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.identityprovider.oauth2.authentication;
 
+import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.am.identityprovider.api.IdentityProviderGroupMapper;
 import io.gravitee.am.identityprovider.api.IdentityProviderMapper;
 import io.gravitee.am.identityprovider.api.IdentityProviderRoleMapper;
@@ -178,4 +179,9 @@ public class OAuth2GenericAuthenticationProvider extends AbstractOpenIDConnectAu
             });
         }
     }
+
+    void setJwtProcessor(JWTProcessor jwtProcessor) {
+        this.jwtProcessor = jwtProcessor;
+    }
+
 }

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/resources/schemas/schema-form.json
@@ -88,6 +88,10 @@
       "type": "boolean",
       "title": "Use the ID Token to retrieve user information ? (response_type=id_token or UserInfo Endpoint is missing)"
     },
+    "userInfoAsJwt": {
+      "type": "boolean",
+      "title": "Does UserInfo endpoint provide user information signed using JWT ?"
+    },
     "signature": {
       "title": "Signature",
       "description": "Define how the ID Token has been signed.",


### PR DESCRIPTION
fixes AM-4666

# How to test

1. Create a domain "main-domain"
2. Create a domain "oidc-domain"
3. On OIDC domain, enable Open DCR and accept localhost with unsecured connection
4. On OIDC domain, create a B2B app with DCR & DCR_ADMIN scope
5. create a user in oidc-domain
6. request a token for this application

```
curl -X POST \
              http://localhost:8092/oidc-domain/oauth/token \
  -H 'Content-Type: application/x-www-form-urlencoded' \
              -u 'service:servicesecret' \
  -d 'grant_type=client_credentials'
```

7. Use this token to create a WEB application usingn DCR with a callback url targeting main-domain

```
curl -X POST http://localhost:8092/oidc-domain/oidc/register -H'Content-Type: application/json' -H'Authorization: Bearer $TOKEN' -d'
{ "redirect_uris": ["http://localhost:8092/main-domain/login/callback"], "client_name": "my web application",  "grant_types": [ "authorization_code","refresh_token"], "scope":"openid profile email", "userinfo_signed_response_alg": "RS256"}'
```
8. Configure an OIDC IDP on main-domain to target oidc-domain using the clientId and clientSecret created in step 7, enable "does UserInfo endpoint provide information signed using JWT".
9. create an app on main-domain and enable the OIDC provider
10. try to sign in a user on main-domain using the oidc provider.
11. should works :) 
