### PR TITLE
Fix/AM-4856 exception in the login callback failure handler

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackOpenIDConnectFlowHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackOpenIDConnectFlowHandler.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.springframework.util.StringUtils.hasLength;
+
 /**
  * Handle OpenID Connect response with response_type = id_token or id_token token.
  * For this kind of response, the OIDC provider redirects user to the OAuth 2.0 client with parameters as fragment instead of query.
@@ -85,7 +87,7 @@ public class LoginCallbackOpenIDConnectFlowHandler implements Handler<RoutingCon
 
             // else check OpenID Connect flow validity
             final String hashValue = request.getParam(ConstantKeys.URL_HASH_PARAMETER);
-            if (hashValue == null || hashValue.isEmpty()) {
+            if (!hasLength(hashValue)) {
                 context.fail(new InternalAuthenticationServiceException("No URL hash value found"));
                 return;
             }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackOpenIDConnectFlowHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackOpenIDConnectFlowHandler.java
@@ -85,7 +85,7 @@ public class LoginCallbackOpenIDConnectFlowHandler implements Handler<RoutingCon
 
             // else check OpenID Connect flow validity
             final String hashValue = request.getParam(ConstantKeys.URL_HASH_PARAMETER);
-            if (hashValue == null) {
+            if (hashValue == null || hashValue.isEmpty()) {
                 context.fail(new InternalAuthenticationServiceException("No URL hash value found"));
                 return;
             }


### PR DESCRIPTION
## :id:
[AM-4856](https://gravitee.atlassian.net/browse/AM-4856)

## :pencil2:
Update validation of parameters in OpenID Connect authorization flow to prevent an unhandled 500 internal server error. Specifically, check for an empty `urlHash` value.

## :memo: Test scenarios 
Define an application and navigate to the gateway page `/<application>/login/callback`. For example, locally I used `http://localhost:8092/test1/login/callback`.

It should no longer return a 500 status code. Instead, it redirects to the access error page.

## :man: :woman:
@gravitee-io/am 


[AM-4856]: https://gravitee.atlassian.net/browse/AM-4856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ