### PR TITLE
chore: update the CertificateProvider interface to provide jwtBuilder…

### DIFF
--- a/gravitee-am-certificate/gravitee-am-certificate-api/pom.xml
+++ b/gravitee-am-certificate/gravitee-am-certificate-api/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>gravitee-am-model</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.am.jwt</groupId>
+            <artifactId>gravitee-am-jwt</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.gravitee.plugin</groupId>

--- a/gravitee-am-certificate/gravitee-am-certificate-api/src/main/java/io/gravitee/am/certificate/api/CertificateProvider.java
+++ b/gravitee-am-certificate/gravitee-am-certificate-api/src/main/java/io/gravitee/am/certificate/api/CertificateProvider.java
@@ -15,11 +15,15 @@
  */
 package io.gravitee.am.certificate.api;
 
+import com.nimbusds.jose.JOSEException;
 import io.gravitee.am.common.plugin.AmPluginProvider;
+import io.gravitee.am.jwt.JWTBuilder;
+import io.gravitee.am.jwt.JWTParser;
 import io.gravitee.am.model.jose.JWK;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 
+import java.security.InvalidKeyException;
 import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.Date;
@@ -55,4 +59,11 @@ public interface CertificateProvider extends AmPluginProvider {
         return Single.just(Collections.emptyList());
     }
 
+    default Optional<JWTBuilder> jwtBuilder() throws InvalidKeyException, JOSEException {
+        return Optional.empty();
+    }
+
+    default Optional<JWTParser> jwtParser() throws InvalidKeyException, JOSEException  {
+        return Optional.empty();
+    }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-certificate/src/main/java/io/gravitee/am/gateway/certificate/impl/CertificateProviderManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-certificate/src/main/java/io/gravitee/am/gateway/certificate/impl/CertificateProviderManagerImpl.java
@@ -83,12 +83,12 @@ public class CertificateProviderManagerImpl implements CertificateProviderManage
             if (keyValue instanceof KeyPair) {
                 PrivateKey privateKey = ((KeyPair) keyValue).getPrivate();
                 PublicKey publicKey = ((KeyPair) keyValue).getPublic();
-                certificateProvider.setJwtBuilder(new DefaultJWTBuilder(privateKey, provider.signatureAlgorithm(), providerKey.getKeyId()));
-                certificateProvider.setJwtParser(new DefaultJWTParser(publicKey));
+                certificateProvider.setJwtBuilder(provider.jwtBuilder().orElse(new DefaultJWTBuilder(privateKey, provider.signatureAlgorithm(), providerKey.getKeyId())));
+                certificateProvider.setJwtParser(provider.jwtParser().orElse(new DefaultJWTParser(publicKey)));
             } else {
                 Key sharedKey = (Key) keyValue;
-                certificateProvider.setJwtBuilder(new DefaultJWTBuilder(sharedKey, provider.signatureAlgorithm(), providerKey.getKeyId()));
-                certificateProvider.setJwtParser(new DefaultJWTParser(sharedKey));
+                certificateProvider.setJwtBuilder(provider.jwtBuilder().orElse(new DefaultJWTBuilder(sharedKey, provider.signatureAlgorithm(), providerKey.getKeyId())));
+                certificateProvider.setJwtParser(provider.jwtParser().orElse(new DefaultJWTParser(sharedKey)));
             }
         } catch (UnsupportedOperationException ex) {
             // alg=none provider


### PR DESCRIPTION
… and jwtParser

 this update is required to improve preformance using CloudHSM plugin

 thanks to this change the plugin is able to provide a builder or parser backed by a Pool of Signature object

 this pool allow to avoid some network call to initialize the signature and provide a control on the concurrent actio on the HSM

fixes AM-5435

fixes gravitee-io/issues#10704
