### PR TITLE
AM-5378 feat: Set read preference on audit read queries

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -180,6 +180,10 @@ services:
 #  file:
 #    directory:  # directory where the files are created (this directory have to exist): default value = ${gravitee.home}/audit-logs/
 #    output: JSON # JSON, ELASTICSEARCH, MESSAGE_PACK, CSV
+#  mongodb: # Configuration of read preference for querying audit records from mongodb, defaults to primary if not provided
+#    readPreference: secondary # primary, secondary, primaryPreferred, secondaryPreferred, nearest
+#    readPreferenceMaxStaleness: 120000 # Milliseconds value, min 90000. Lets users specify a maximum replication lag, or "staleness", for reads from secondaries.
+
 
 # JWT used to generate signed token for OAuth 2.0/OpenID Connect protocols and to verify emails
 jwt:

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -118,6 +118,7 @@
 #    output: JSON # JSON, ELASTICSEARCH, MESSAGE_PACK, CSV
 #  mongodb: # Configuration of read preference for querying audit records from mongodb, defaults to primary if not provided
 #    readPreference: secondary # primary, secondary, primaryPreferred, secondaryPreferred, nearest
+#    readPreferenceMaxStaleness: 120000 # Milliseconds value, min 90000. Lets users specify a maximum replication lag, or "staleness", for reads from secondaries.
 
 # Management API AM service configurations. Provided values are default values.
 # All services are enabled by default. To stop one of them, you have to add the property 'enabled: false' (See the

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -116,6 +116,8 @@
 #  file:
 #    directory:  # directory where the files are created (this directory have to exist): default value = ${gravitee.home}/audit-logs/
 #    output: JSON # JSON, ELASTICSEARCH, MESSAGE_PACK, CSV
+#  mongodb: # Configuration of read preference for querying audit records from mongodb, defaults to primary if not provided
+#    readPreference: secondary # primary, secondary, primaryPreferred, secondaryPreferred, nearest
 
 # Management API AM service configurations. Provided values are default values.
 # All services are enabled by default. To stop one of them, you have to add the property 'enabled: false' (See the

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
@@ -547,12 +547,12 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
             return this.reportableCollection;
         }
 
-        // Default to primary
-        ReadPreference readPreferenceValue = ReadPreference.primary();
+        ReadPreference readPreferenceValue;
         try {
             readPreferenceValue = ReadPreference.valueOf(this.readPreference);
-        } catch (IllegalArgumentException ex){
-            logger.error("Invalid read preference value: {}, defaulting to PRIMARY", this.readPreference);
+        } catch (IllegalArgumentException ex) {
+            logger.error("Invalid read preference value: {}", this.readPreference, ex);
+            return this.reportableCollection;
         }
 
         // Max staleness is only compatible with NON-PRIMARY read preference

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
@@ -547,7 +547,13 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
             return this.reportableCollection;
         }
 
-        ReadPreference readPreferenceValue = ReadPreference.valueOf(this.readPreference);
+        // Default to primary
+        ReadPreference readPreferenceValue = ReadPreference.primary();
+        try {
+            readPreferenceValue = ReadPreference.valueOf(this.readPreference);
+        } catch (IllegalArgumentException ex){
+            logger.error("Invalid read preference value: {}, defaulting to PRIMARY", this.readPreference);
+        }
 
         // Max staleness is only compatible with NON-PRIMARY read preference
         if (readPreferenceValue != ReadPreference.primary()) {

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
@@ -123,7 +123,7 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
     @Value("${management.mongodb.ensureIndexOnStart:true}")
     private boolean ensureIndexOnStart;
 
-    @Value("${management.mongodb.readPreference:PRIMARY}")
+    @Value("${reporters.mongodb.readPreference:PRIMARY}")
     private String readPreference;
 
     @Value("${management.mongodb.cursorMaxTime:60000}")

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/constants/MongoAuditReporterConstants.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/constants/MongoAuditReporterConstants.java
@@ -55,7 +55,9 @@ public class MongoAuditReporterConstants {
   private static final String OLDER_INDEX_REFERENCE_TARGET_TIMESTAMP_NAME = "referenceType_1_referenceId_1_target.alternativeId_1_timestamp_-1";
   private static final String OLDER_INDEX_REFERENCE_ACTOR_TARGET_TIMESTAMP_NAME = "referenceType_1_referenceId_1_actor.alternativeId_1_target.alternativeId_1_timestamp_-1";
 
-  public static final List<String> OLD_INDICES = List.of(
+    public static final Long MIN_READ_PREFERENCE_STALENESS = 90000l;
+
+    public static final List<String> OLD_INDICES = List.of(
       OLD_INDEX_REFERENCE_TIMESTAMP_NAME,
       OLD_INDEX_REFERENCE_TYPE_TIMESTAMP_NAME,
       OLD_INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME,


### PR DESCRIPTION
## :id: Reference related issue. 
closes: AM-5378

## :pencil2: A description of the changes proposed in the pull request
This PR introduces new configuration properties for the mongodb reporter which will allow users to set the readPreference and max staleness of the audit queries to reduce load on the system.

## :memo: Test scenarios 

### Testing Notes

Save this docker compose file so you can use it to build the expected containers:

### Docker Compose

```yaml
version: '3.8'

services:
  mongo1:
    image: mongo:8
    container_name: mongo1
    ports:
      - "27017:27017"
    command: ["--replSet", "rs0", "--bind_ip_all"]
    networks:
      - mongo-cluster
    healthcheck:
      test: ["CMD", "mongosh", "--quiet", "localhost:27017/test", "--eval", "db.runCommand({ ping: 1 })"]
      interval: 10s
      timeout: 5s
      retries: 5
    volumes:
      - ./data/mongo1:/data/db

  mongo2:
    image: mongo:8
    container_name: mongo2
    command: ["--replSet", "rs0", "--bind_ip_all"]
    networks:
      - mongo-cluster
    healthcheck:
      test: ["CMD", "mongosh", "--quiet", "localhost:27017/test", "--eval", "db.runCommand({ ping: 1 })"]
      interval: 10s
      timeout: 5s
      retries: 5
    volumes:
      - ./data/mongo2:/data/db

  mongo3:
    image: mongo:8
    container_name: mongo3
    command: ["--replSet", "rs0", "--bind_ip_all"]
    networks:
      - mongo-cluster
    healthcheck:
      test: ["CMD", "mongosh", "--quiet", "localhost:27017/test", "--eval", "db.runCommand({ ping: 1 })"]
      interval: 10s
      timeout: 5s
      retries: 5
    volumes:
      - ./data/mongo3:/data/db

networks:
  mongo-cluster:
    driver: bridge
```

### Configuring the Docker containers

Build docker containers with read replica set up:

``` bash
docker compose -f mongo_replica.yaml up -d
```

Wait for the containers to be ready/healthy

``` bash
docker ps
```

Get the network addresses of all the containers

``` bash
docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mongo1
docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mongo2
docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mongo3
```

⚠️ It is crucial that you update your hosts file if you restart the docker containers as the mapped IP will change ⚠️ 

Update your /etc/conf/hosts file to set up the DNS addresses (needs sudo saved)

```text
# MongoDB Docker Replica Set
172.21.0.3  mongo1
172.21.0.2  mongo2
172.21.0.4  mongo3
```

Shell into the `mongo1` container

``` bash
docker exec -it mongo1 mongosh
```

```bash
rs.initiate(
  {
    _id: "rs0",
    members: [
      { _id: 0, host: "mongo1:27017", priority: 10 }, // Higher priority
      { _id: 1, host: "mongo2:27017", priority: 1 },  // Default priority
      { _id: 2, host: "mongo3:27017", priority: 1 }   // Default priority
    ]
  }
)
```

Spam this command until there are 1 PRIMARY and 2 SECONDARY nodes:

```bash
rs.status()
```

### Configuring Gravitee AM Management API

Update the config file `gravitee.yaml`

```yaml

# Set up the database connection
management:
type: mongodb
mongodb:
    dbname: ${ds.mongodb.dbname}
    uri: mongodb://mongo1:27017,mongo2:27017,mongo3:27017/?replicaSet=rs0

# Set up the reporter to use the new property
reporters:
  mongodb:
    readPreference: secondary
    readPreferenceMaxStaleness: 95000

```

Run the application and go through the process of creating a new domain and users etc and then verify audit log entries are showing up in the grid.

## :books: Any other comments that will help with documentation

As shown above there is a new optional property available in the Management API yaml configuration:

```yaml
reporters:
  mongodb:
    readPreference: secondary
    readPreferenceMaxStaleness: 95000
```

The available values for this new `readPreference` property are: 
 - primary
 - secondary
 - primaryPreferred
 - secondaryPreferred
 - nearest

The property `readPreferenceMaxStaleness` cannot be less than 90,000 milliseconds (90 seconds)