### PR TITLE
fix: remove default application of empty/null values

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
@@ -92,15 +92,6 @@ export class ProviderSettingsComponent implements OnInit {
       .pipe(map((schema) => enrichFormWithCerts(schema, this.certificates)))
       .subscribe((data) => {
         this.providerSchema = data;
-        if (data) {
-          // handle default null values
-          Object.keys(this.providerSchema['properties']).forEach((key) => {
-            if (this.providerSchema['properties'][key].default && this.providerConfiguration[key] == null) {
-              this.providerConfiguration[key] = this.providerSchema['properties'][key].default;
-            }
-            this.providerSchema['properties'][key].default = '';
-          });
-        }
       });
   }
 


### PR DESCRIPTION
## :id: Reference related issue. 
fixes: [AM-5374](https://gravitee.atlassian.net/browse/AM-5374)

## :pencil2: A description of the changes proposed in the pull request
The changes introduced in this PR removes the re-application of default values to an existing LDAP configuration. When the initial configuration is created in the UI, the default values are applied correctly. Then when the user clears the value for any of the fields with a default value, the change is persisted to the database and the default value is no longer applied.

## :memo: Test scenarios 
Follow the reproduction steps in [AM-5374](https://gravitee.atlassian.net/browse/AM-5374)



[AM-5374]: https://gravitee.atlassian.net/browse/AM-5374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-5374]: https://gravitee.atlassian.net/browse/AM-5374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ