### PR TITLE
fix: remove automatic assignment of default values for LDAP configura…

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
@@ -91,15 +91,6 @@ export class ProviderSettingsComponent implements OnInit {
       .pipe(map((schema) => enrichOIDCFormWithCerts(schema, this.certificates)))
       .subscribe((data) => {
         this.providerSchema = data;
-        if (data) {
-          // handle default null values
-          Object.keys(this.providerSchema['properties']).forEach((key) => {
-            if (this.providerSchema['properties'][key].default && this.providerConfiguration[key] == null) {
-              this.providerConfiguration[key] = this.providerSchema['properties'][key].default;
-            }
-            this.providerSchema['properties'][key].default = '';
-          });
-        }
       });
   }
 

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
@@ -91,6 +91,20 @@ export class ProviderSettingsComponent implements OnInit {
       .pipe(map((schema) => enrichOIDCFormWithCerts(schema, this.certificates)))
       .subscribe((data) => {
         this.providerSchema = data;
+        if (data) {
+          Object.keys(this.providerSchema['properties']).forEach((key) => {
+            // Only apply default values for boolean properties to fix AM-686 and LDAP issues
+            // This prevents overriding null values for non-boolean properties while still providing defaults for booleans
+            if (
+              this.providerSchema['properties'][key].default &&
+              this.providerSchema['properties'][key].type === 'boolean' &&
+              this.providerConfiguration[key] == null
+            ) {
+              this.providerConfiguration[key] = this.providerSchema['properties'][key].default;
+            }
+            this.providerSchema['properties'][key].default = '';
+          });
+        }
       });
   }
 


### PR DESCRIPTION
## :id: Reference related issue. 
fixes: AM-5374

## :pencil2: A description of the changes proposed in the pull request
The changes introduced in this PR removes the re-application of default values to an existing LDAP configuration. When the initial configuration is created in the UI, the default values are applied correctly. Then when the user clears the value for any of the fields with a default value, the change is persisted to the database and the default value is no longer applied.

## :memo: Test scenarios 
Follow reproduction steps outlined in the ticket [AM-5374](https://gravitee.atlassian.net/browse/AM-5374)

### Additional Testing
- Create a new LDAP entry, keep the default value for `Group search base`
- Save the LDAP provider
- Edit the record
- Verify the default value was saved (`ou=applications`)
- Edit the Group search base, by removing the value entirely
- Save the record
- Reload the page and verify the value is now empty



[AM-5374]: https://gravitee.atlassian.net/browse/AM-5374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ