### PR TITLE
[AM-4985] Add support for escaping regex special characters in FilterCriteriaParser

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/users/users.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/users.component.ts
@@ -82,7 +82,7 @@ export class UsersComponent implements OnInit {
     let advancedSearchMode = false;
     if (searchQuery) {
       advancedSearchMode = this.isAdvancedSearch(searchQuery);
-      const searchTerm = !advancedSearchMode ? 'q=' + searchQuery + '*' : 'filter=' + searchQuery;
+      const searchTerm = !advancedSearchMode ? 'q=' + searchQuery + '*' : 'filter=' + encodeURIComponent(searchQuery);
       findUsers = this.userService.search(this.domainId, searchTerm, this.page.pageNumber, this.page.size, this.organizationContext);
     } else {
       findUsers = this.organizationContext


### PR DESCRIPTION
## :id: Reference related issue. 
fixes: AM-4985 - [Link](https://gravitee.atlassian.net/browse/AM-4985)

## :pencil2: A description of the changes proposed in the pull request
This pull request improves the handling and testing of regex special characters in filter criteria parsing for MongoDB queries. The changes ensure that when using regex-based operators, special characters in filter values are properly escaped, preventing malformed queries and potential security issues. Additionally, comprehensive parameterised tests are added to verify correct escaping for all supported regex characters.

**Regex handling improvements:**

* Added a list of regex operators (`co`, `sw`, `ew`) and a list of allowed regex special characters to `FilterCriteriaParser`, and implemented logic to escape these characters in filter values when a regex operator is used. 

**Testing enhancements:**

* Introduced parameterised tests in `FilterCriteriaParserTest` to validate that all allowed regex special characters are correctly escaped in filter values for regex operators.

## :memo: Test scenarios 
Follow the steps outlined in the ticket for testing, straight forward to set up and verify.

Alternatively:
 - Create two users with email addresses:
 - `bug.admin@bug.com`
 - `bug+admin@bug.com`
 
Navigate to the user management page: https://example.com/environments/default/domains/my-domain/settings/users
Search for these users using the SCIM query language:

- `email ew "+admin@bug.com"` -> Should return only 1 record
- `email ew ".admin@bug.com"` -> Should return only 1 record
- `email ew "@bug.com"` -> Should return both records

## 📓  Notes
Although the ticket specifically calls out a set of characters to support, some of these are explicitly restricted by the current implementation, namely: `;`, `{`, `}`, `$` and `^`
