### PR TITLE
fix: limit the number of threads available to perform blocking token …

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/JwtSignerExecutor.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/JwtSignerExecutor.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.utils;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * @author Eric Leleu (eric.leleu@graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class JwtSignerExecutor {
+
+    private Executor executor;
+
+    public JwtSignerExecutor(int nbOfThreads) {
+        this.executor = Executors.newFixedThreadPool(nbOfThreads) ;
+    }
+
+    public Executor getExecutor() {
+        return executor;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/impl/JWTServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/impl/JWTServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.am.common.crypto.CryptoUtils;
 import io.gravitee.am.common.exception.oauth2.InvalidTokenException;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.utils.JwtSignerExecutor;
 import io.gravitee.am.gateway.certificate.CertificateProvider;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
@@ -54,6 +55,9 @@ public class JWTServiceImpl implements JWTService {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtSignerExecutor executor;
 
     @Override
     public Single<String> encode(JWT jwt, CertificateProvider certificateProvider) {
@@ -173,7 +177,7 @@ public class JWTServiceImpl implements JWTService {
         });
 
         if (certificateProvider.getProvider().getClass().getSimpleName().equals(AWS_HSM_CERTIFICATE_PROVIDER)) {
-            return signer.subscribeOn(Schedulers.io());
+            return signer.subscribeOn(Schedulers.from(executor.getExecutor())).observeOn(Schedulers.computation());
         } else {
             return signer;
         }
@@ -191,7 +195,7 @@ public class JWTServiceImpl implements JWTService {
         });
 
         if (certificateProvider.getProvider().getClass().getSimpleName().equals(AWS_HSM_CERTIFICATE_PROVIDER)) {
-            return verifier.subscribeOn(Schedulers.io());
+            return verifier.subscribeOn(Schedulers.from(executor.getExecutor())).observeOn(Schedulers.computation());
         } else {
             return verifier;
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.gravitee.am.common.env.RepositoriesEnvironment;
 import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.utils.JwtSignerExecutor;
 import io.gravitee.am.gateway.configuration.ConfigurationChecker;
 import io.gravitee.am.gateway.core.upgrader.GatewayUpgraderConfiguration;
 import io.gravitee.am.gateway.event.EventManagerImpl;
@@ -55,6 +56,8 @@ import io.gravitee.node.plugin.cluster.standalone.StandaloneClusterManager;
 import io.gravitee.platform.repository.api.RepositoryScopeProvider;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.jackson.DatabindCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
@@ -88,6 +91,10 @@ import org.springframework.core.env.Environment;
         AuthenticationDeviceNotifierSpringConfiguration.class,
 })
 public class StandaloneConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(StandaloneConfiguration.class);
+    public static final String GRAVITEE_JWT_EXECUTOR_THREADS = "gravitee.jwt.executor.threads";
+    public static final int DEFAULT_JWT_EXECUTOR_THREADS = 20;
 
     @Bean
     public Node node() {
@@ -163,5 +170,12 @@ public class StandaloneConfiguration {
     @Bean
     public SingleDataPlaneProvider singleDataPlaneProvider(DataPlaneRegistry dataPlaneRegistry){
         return new SingleDataPlaneProvider(dataPlaneRegistry);
+    }
+
+    @Bean
+    public JwtSignerExecutor ioExecutor(Environment environment) {
+        int ioThreads = environment.getProperty(GRAVITEE_JWT_EXECUTOR_THREADS, Integer.class, DEFAULT_JWT_EXECUTOR_THREADS);
+        log.info("Initializing IO executor for remote signature with {} threads", ioThreads);
+        return new JwtSignerExecutor(ioThreads);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -187,6 +187,10 @@ jwt:
   #kid: default-gravitee-AM-key # kid (key ID) Header Parameter is a hint indicating which key was used to secure the JWT
   #expire-after: 604800 # the end of validity of the token in seconds (default 604800 = a week)
   #issuer: https://gravitee.am # the principal that issued the JWT (default https://gravitee.am)
+  ## Number of Threads available for Token signatures when
+  ## there are managed by a remote service like HSM
+  #executor:
+  #  threads: 20
 
 # SMTP configuration used to send mails
 email:


### PR DESCRIPTION
…signatures

 this is related to HSM plugin which is doing blocking call in a native library

 in this case the worker thread pool of VertX is not big enough

fixes AM-5482