### PR TITLE
fix: AM-5462 Only register the certifcate for notifications if it has an expiry date

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainNotifierServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainNotifierServiceImpl.java
@@ -139,7 +139,7 @@ public class DomainNotifierServiceImpl implements DomainNotifierService, Initial
 
     @Override
     public void registerCertificateExpiration(Certificate certificate) {
-        if (this.certificateNotificationEnabled) {
+        if (this.certificateNotificationEnabled && certificate.getExpiresAt() != null) {
             findDomain(certificate.getDomain())
                     .flatMapPublisher(domain ->
                             retrieveDomainOwners(domain)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainNotificationServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainNotificationServiceTest.java
@@ -160,7 +160,6 @@ public class DomainNotificationServiceTest {
         certificate.setExpiresAt(null);
 
         cut.registerCertificateExpiration(certificate);
-
         verify(notifierService,never()).register(any(), any(), any());
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainNotificationServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainNotificationServiceTest.java
@@ -156,7 +156,7 @@ public class DomainNotificationServiceTest {
     }
 
     @Test
-    public void shouldNotNotify_NoExpiryCertificate() throws Exception {
+    public void shouldNotNotifyUser_NoExpiryCertificate() throws Exception {
         certificate.setExpiresAt(null);
 
         cut.registerCertificateExpiration(certificate);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainNotificationServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainNotificationServiceTest.java
@@ -48,7 +48,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
@@ -131,6 +134,7 @@ public class DomainNotificationServiceTest {
 
         certificate = new Certificate();
         certificate.setDomain(domain.getId());
+        certificate.setExpiresAt(Date.from(Instant.now().plus(60, ChronoUnit.DAYS)));
 
         when(domainService.findById(certificate.getDomain())).thenReturn(Maybe.just(domain));
 
@@ -149,6 +153,15 @@ public class DomainNotificationServiceTest {
     @After
     public void cleanUp() {
         ReflectionTestUtils.setField(cut, "uiNotifierEnabled", false);
+    }
+
+    @Test
+    public void shouldNotNotify_NoExpiryCertificate() throws Exception {
+        certificate.setExpiresAt(null);
+
+        cut.registerCertificateExpiration(certificate);
+
+        verify(notifierService,never()).register(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## :id: Reference related issue. 
fixes: [AM-5462](https://gravitee.atlassian.net/browse/AM-5462)

## :pencil2: A description of the changes proposed in the pull request
This PR introduces a check on the registration of certificates for a notification when the certificate expires to ensure the certificate has an expiry date.

## :memo: Test scenarios 

### Docker Set Up
To reproduce the issue use the following docker compose file (make sure the volumes etc are all setup correctly)

```yaml
#
# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#         http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
#

volumes:
  datamongo: {}

services:

  nginx:
    image: nginx:1.21.1-alpine
    container_name: gio_am_nginx
    restart: always
    volumes:
      - ./config/nginx.conf:/etc/nginx/nginx.conf
    ports:
      - 8088:80
    depends_on:
      - management
      - gateway
      - webui

  mongodb:
    image: mongo:4.2
    container_name: gio_am_mongodb
    restart: always
    volumes:
      - datamongo:/data/db
      - ./logs/am-mongodb:/var/log/mongodb
    ports:
      - 27017:27017

  fakesmtp:
    image: gessnerfl/fake-smtp-server
    container_name: fakesmtp
    restart: always
    ports:
      - 5080:8080
      - 8025:8025

  gateway:
    image: graviteeio.azurecr.io/am-gateway:4.7.x-latest-noble
    container_name: gio_am_gateway
    restart: always
    links:
      - mongodb
    depends_on:
      - mongodb
    ports:
      - 8092:8092
    volumes:
      - ./logs/am-gateway:/opt/graviteeio-am-gateway/logs
      - ./license/gravitee-universe-v4.key:/opt/graviteeio-am-gateway/license/license.key
      - ./plugins/gravitee-am-certificate-hsm-aws-2.2.0.zip:/opt/graviteeio-am-gateway/plugins/gravitee-am-certificate-hsm-aws-2.2.0.zip
      - ./aws-hsm-am-certificate:/opt/graviteeio-am-gateway/plugins/ext/aws-hsm-am-certificate
      - ./config/logback.xml:/opt/graviteeio-am-gateway/config/logback.xml
    environment:
      - gravitee_repositories_management_mongodb_uri=mongodb://mongodb:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
      - gravitee_repositories_oauth2_mongodb_uri=mongodb://mongodb:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
      - gravitee_repositories_gateway_mongodb_uri=mongodb://mongodb:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
      - gravitee_certificates_awshsmamcertificate_log_type=file
      - gravitee_notifiers_ui_enabled=true
      - gravitee_services_notifier_enabled=true
      - gravitee_services_notifier_certificate_cronExpression="0 41 14 * * *"
      - gravitee_services_notifier_certificate_expiryThresholds="20,15,10,5,1"
      - GRAVITEE_EMAIL_ENABLED=true
      - GRAVITEE_EMAIL_HOST=fakesmtp
      - GRAVITEE_EMAIL_PORT=8025

  management:
    image: graviteeio.azurecr.io/am-management-api:4.7.x-latest-noble
    #image: graviteeio.azurecr.io/am-management-api:AM-5462-cert-expiry-fix-latest-noble
    container_name: gio_am_management
    restart: always
    links:
      - mongodb
    depends_on:
      - mongodb
    volumes:
      - ./logs/am-management-api:/opt/graviteeio-am-management-api/logs
      - ./license/gravitee-universe-v4.key:/opt/graviteeio-am-management-api/license/license.key
      - ./plugins/gravitee-am-certificate-hsm-aws-2.2.0.zip:/opt/graviteeio-am-management-api/plugins/gravitee-am-certificate-hsm-aws-2.2.0.zip
      - ./aws-hsm-am-certificate:/opt/graviteeio-am-management-api/plugins/ext/aws-hsm-am-certificate
      - ./config/logback.xml:/opt/graviteeio-am-management-api/config/logback.xml
      - ./config/gravitee.yml:/opt/graviteeio-am-management-api/config/gravitee.yml
    environment:
      - gravitee_repositories_management_mongodb_uri=mongodb://mongodb:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
      - gravitee_repositories_oauth2_mongodb_uri=mongodb://mongodb:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
      - gravitee_repositories_gateway_mongodb_uri=mongodb://mongodb:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
      - gravitee_certificates_awshsmamcertificate_log_type=file
      - gravitee_dataPlanes_0_id=default
      - gravitee_dataPlanes_0_type=mongodb
      - gravitee_dataPlanes_0_mongodb_uri=mongodb://mongodb:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
      - GRAVITEE_EMAIL_ENABLED=true
      - GRAVITEE_EMAIL_HOST=fakesmtp
      - GRAVITEE_EMAIL_PORT=8025


  webui:
    image: graviteeio.azurecr.io/am-management-ui:4.7.x-latest
    container_name: gio_am_webui
    restart: always
    depends_on:
      - management
    environment:
      - MGMT_API_URL=http://localhost:8088/am
      - MGMT_UI_URL=http://localhost:8088/am/ui
    volumes:
      - ./logs/am-webui:/var/log/httpd
```

### Gravitee.yaml configuration
This is the configuration required:

```yaml
#
# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#         http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
##################################################################################
services:
  core:
    http:
      enabled: true
      port: 18093
      host: localhost
      authentication:
        type: basic
        users:
          admin: adminadmin

  # Metrics service
  metrics:
    enabled: false
    prometheus:
      enabled: true
  purge:
    enabled: true                               # enable the JDBC purge task (default: true)
    cron: 0 0 23 * * *                          # configure the frequency (default: every day at 11 PM)
  notifier:
    enabled: true
    tryAvoidDuplicateNotification: false
  certificate:
    enabled: true
    cronExpression: 0 39 15 * * *
    expiryThresholds: 365,20,15,10,5,1
    expiryEmailSubject: Certificate will expire soon

license:
  expire-notification:
    enabled: true

notifiers:
  email:
    enabled: true
    host: fakesmtp
    port: 587
    username: user@my.domain
    password: password
    from: noreply@my.domain
    startTLSEnabled: false
    sslTrustAll: false
  ui:
    enabled: true
  log:
    enabled: true

domains:
  certificates:
    default:
      keysize: 2048
      alias: default
      keypass: gravitee
      storepass: gravitee
      validity: 365             # Validity of the certificate
      algorithm: SHA256withRSA  # Algorithm used to sign certificate
      name: cn=Gravitee.io      # Certificate X.500 name
jwt:
  secret: s3cR3t4grAv1t3310AMS1g1ingDftK3y # jwt secret used to sign JWT tokens (HMAC algorithm)
security:
  defaultAdmin: true
  accountAccessTokens:
    encoder:
      settings:
        rounds: 10
  providers:
    - type: memory
      enabled: false
      password-encoding-algo: BCrypt
      users:
        - user:
          username: admin
          email: stuart.clark@graviteesource.com
          firstname: Administrator
          lastname: Administrator
          password: $2a$10$NG5WLbspq8V1yJDzUKfUK.oum94qL/Ne3B5fQCgekw/Y4aOEaoFZq
          role: ORGANIZATION_OWNER

email:
  enabled: true
  host: fakesmtp
  subject: "[Gravitee.io] %s"
  port: 587
  from: noreply@my.domain
  username: user@my.domain
  password: password
  allowedfrom:
    - "*@*.*"
user:
  email:
    policy:
      pattern: ^[a-zA-Z0-9_+-]+(?:\.[a-zA-Z0-9_+-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,15}$
  password:
    policy:
      pattern: ^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\-#\"'&§`£€%°()|\[\]$^@])(?!.*(.)\1{2,}).{12,128}$
  name:
    strict:
      policy:
        pattern: ^[^±!@£$%^&*_+§¡€#¢¶•ªº«»\\/<>?:;|=.,]{0,100}$
    lax:
      policy:
        pattern: ^[^±!£$%^&*§¡€¢¶•ªº«»\\/<>?|=]{0,100}$
  username:
    policy:
      pattern: ^[^±!£$%^&*§¡€¢¶•ªº«»\\/<>?:;|=,]{1,100}$
  registration:
    email:
    token:
  resetPassword:
    email:
    token:
  bulk:
    maxRequestLength: 1048576
    maxRequestOperations: 1000

repositories:
  system-cluster: management
  management:
    type: mongodb
    mongodb:
      dbname: ${ds.mongodb.dbname}
      host: ${ds.mongodb.host}
      port: ${ds.mongodb.port}
  gateway:
    type: mongodb
    use-management-settings: true
    mongodb:
      dbname: ${ds.mongodb.dbname}
      host: ${ds.mongodb.host}
      port: ${ds.mongodb.port}
  oauth2:
    type: mongodb
    use-management-settings: true
    mongodb:
      dbname: ${ds.mongodb.dbname}
      host: ${ds.mongodb.host}
      port: ${ds.mongodb.port}
dataPlanes:
  - id: default
    name: Legacy domains
    type: mongodb
    mongodb:
      dbname: ${ds.mongodb.dbname}
      host: ${ds.mongodb.host}
      port: ${ds.mongodb.port}
gateway:
  url: http://localhost:8092
alerts:
  too_many_login_failures:
    name: "Too many login failures detected"
    description: "More than {threshold}% of logins are in failure over the last {window} second(s)"
    threshold: 10
    sampleSize: 1000
    window: 600
    severity: WARNING
ds:
  mongodb:
    dbname: gravitee-am
    host: localhost
    port: 27017

```

### HSM Certificate Setup/Creation
 * Log in to AM console and create a new AWS HSM certificate using the following configuration:
 * username: `amuser`
 * password: in keeper
 * host: 51.24.45.201
 * port: 3223
 * HSM Type: `hsm2m`
 * Private Key: `stu-prv`
 * Public Key: `stu-pub`
 * Disable Key Availability check: true
 * CA Cert: Ends with `WIWYcSU=`
 * Signing Algo: RSA256 (PKCS v1-5 using SHA 256)

### Observing the bug
In the Management API logs, there should be an exception thrown regarding the freemarker template

### Verifying the fix
Replace the docker image for the management API with `graviteeio.azurecr.io/am-management-api:AM-5462-cert-expiry-fix-latest-noble`

Restart the services and verify there are no exceptions thrown in the management API logs


[AM-5462]: https://gravitee.atlassian.net/browse/AM-5462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ