### PR TITLE
fix: prevent notification for certificates without expiry date

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/CertificateNotifierServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/CertificateNotifierServiceImpl.java
@@ -64,7 +64,7 @@ public class CertificateNotifierServiceImpl implements CertificateNotifierServic
 
     @Override
     public void registerCertificateExpiration(Certificate certificate) {
-        if (certificateNotifierSettings.enabled()) {
+        if (certificateNotifierSettings.enabled() && certificate.getExpiresAt() != null) {
             findDomain(certificate.getDomain())
                     .flatMapPublisher(domain ->
                                     domainOwnersProvider.retrieveDomainOwners(domain)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/CertificateNotifierServiceImplTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/CertificateNotifierServiceImplTest.java
@@ -103,6 +103,13 @@ public class CertificateNotifierServiceImplTest {
 
     }
 
+    @Test
+    public void shouldNotNotifyUser_NoExpiryCertificate() throws Exception {
+        certificate.setExpiresAt(null);
+
+        cut.registerCertificateExpiration(certificate);
+        verify(notifierService,never()).register(any(), any(), any());
+    }
 
     @Test
     public void shouldNotifyUser_EmailOnly() throws Exception {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/CertificateNotifierServiceImplTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/CertificateNotifierServiceImplTest.java
@@ -40,6 +40,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Date;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/CertificateNotifierServiceImplTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/CertificateNotifierServiceImplTest.java
@@ -98,6 +98,7 @@ public class CertificateNotifierServiceImplTest {
 
         certificate = new Certificate();
         certificate.setDomain(domain.getId());
+        certificate.setExpiresAt(Date.from(Instant.now().plus(60, ChronoUnit.DAYS)));
 
         when(domainService.findById(certificate.getDomain())).thenReturn(Maybe.just(domain));
 


### PR DESCRIPTION
## :id: Reference related issue. 
re-application of PR from [6313](https://github.com/gravitee-io/gravitee-access-management/pull/6313)

