### PR TITLE
feat: AM-2741 configurable web client protocol

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -405,6 +405,7 @@ gateway:
 #httpClient:
 #  timeout: 10000 # in milliseconds
 #  readTimeout: 5000 # in milliseconds
+#  maxPoolSize: 10
 #  proxy:
 #    enabled: false
 #    exclude-hosts: # list of hosts to exclude from proxy (wildcard hosts are supported)
@@ -434,6 +435,11 @@ gateway:
 #      type: jks # Supports jks, pem, pkcs12
 #      path: ${gravitee.home}/security/truststore.jks
 #      password: secret
+#   http2:
+#     enabled: true
+#     maxPoolSize: 10
+#     connectionWindowSize: 65535
+#     keepAliveTimeout: 60 # in seconds
 
 # Organizations and Environments configuration
 # Associate this gateway to a list of environments and their organizations. Use hrids to define these values.

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -460,6 +460,8 @@ gateway:
 # global configuration of the http client
 #httpClient:
 #  timeout: 10000 # in milliseconds
+#  readTimeout: 5000 # in milliseconds
+#  maxPoolSize: 10
 #  proxy:
 #    enabled: false
 #    exclude-hosts: # list of hosts to exclude from proxy (wildcard hosts are supported)
@@ -489,6 +491,11 @@ gateway:
 #      type: jks # Supports jks, pem, pkcs12
 #      path: ${gravitee.home}/security/truststore.jks
 #      password: secret
+#   http2:
+#     enabled: true
+#     maxPoolSize: 10
+#     connectionWindowSize: 65535
+#     keepAliveTimeout: 60 # in seconds
 
 # Allows to enable or disable recaptcha (see https://developers.google.com/recaptcha/docs/v3). This only affect the AM login page.
 #reCaptcha:

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/http/WebClientBuilderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/http/WebClientBuilderTest.java
@@ -256,4 +256,86 @@ class WebClientBuilderTest {
         assertTrue(webClientOptions.isTrustAll());
         assertNull(webClientOptions.getProxyOptions());
     }
+
+    @Test
+    void shouldEnableHttp2WithDefaultSettings() {
+        WebClientOptions webClientOptions = new WebClientOptions();
+        when(environment.getProperty("httpClient.http2.enabled", Boolean.class, true)).thenReturn(true);
+        when(environment.getProperty("httpClient.http2.maxPoolSize", Integer.class, 10)).thenReturn(10);
+        when(environment.getProperty("httpClient.http2.connectionWindowSize", Integer.class, 65535)).thenReturn(65535);
+        when(environment.getProperty("httpClient.http2.keepAliveTimeout", Integer.class, 60)).thenReturn(60);
+
+        webClientBuilder.createWebClient(vertx, webClientOptions);
+
+        assertTrue(webClientOptions.isUseAlpn());
+        assertEquals(10, webClientOptions.getHttp2MaxPoolSize());
+        assertEquals(65535, webClientOptions.getHttp2ConnectionWindowSize());
+        assertEquals(60, webClientOptions.getHttp2KeepAliveTimeout());
+    }
+
+    @Test
+    void shouldDisableHttp2WhenExplicitlyDisabled() {
+        WebClientOptions webClientOptions = new WebClientOptions();
+        when(environment.getProperty("httpClient.http2.enabled", Boolean.class, true)).thenReturn(false);
+
+        webClientBuilder.createWebClient(vertx, webClientOptions);
+
+        assertFalse(webClientOptions.isUseAlpn());
+    }
+
+    @Test
+    void shouldApplyCustomHttp2MaxPoolSize() {
+        WebClientOptions webClientOptions = new WebClientOptions();
+        when(environment.getProperty("httpClient.http2.enabled", Boolean.class, true)).thenReturn(true);
+        when(environment.getProperty("httpClient.http2.maxPoolSize", Integer.class, 10)).thenReturn(50);
+        when(environment.getProperty("httpClient.http2.connectionWindowSize", Integer.class, 65535)).thenReturn(65535);
+        when(environment.getProperty("httpClient.http2.keepAliveTimeout", Integer.class, 60)).thenReturn(60);
+
+        webClientBuilder.createWebClient(vertx, webClientOptions);
+
+        assertTrue(webClientOptions.isUseAlpn());
+        assertEquals(50, webClientOptions.getHttp2MaxPoolSize());
+    }
+
+    @Test
+    void shouldApplyCustomHttp2ConnectionWindowSize() {
+        WebClientOptions webClientOptions = new WebClientOptions();
+        when(environment.getProperty("httpClient.http2.enabled", Boolean.class, true)).thenReturn(true);
+        when(environment.getProperty("httpClient.http2.maxPoolSize", Integer.class, 10)).thenReturn(10);
+        when(environment.getProperty("httpClient.http2.connectionWindowSize", Integer.class, 65535)).thenReturn(131072);
+        when(environment.getProperty("httpClient.http2.keepAliveTimeout", Integer.class, 60)).thenReturn(60);
+
+        webClientBuilder.createWebClient(vertx, webClientOptions);
+
+        assertTrue(webClientOptions.isUseAlpn());
+        assertEquals(131072, webClientOptions.getHttp2ConnectionWindowSize());
+    }
+
+    @Test
+    void shouldApplyCustomHttp2KeepAliveTimeout() {
+        WebClientOptions webClientOptions = new WebClientOptions();
+        when(environment.getProperty("httpClient.http2.enabled", Boolean.class, true)).thenReturn(true);
+        when(environment.getProperty("httpClient.http2.maxPoolSize", Integer.class, 10)).thenReturn(10);
+        when(environment.getProperty("httpClient.http2.connectionWindowSize", Integer.class, 65535)).thenReturn(65535);
+        when(environment.getProperty("httpClient.http2.keepAliveTimeout", Integer.class, 60)).thenReturn(200);
+
+        webClientBuilder.createWebClient(vertx, webClientOptions);
+
+        assertTrue(webClientOptions.isUseAlpn());
+        assertEquals(200, webClientOptions.getHttp2KeepAliveTimeout());
+    }
+
+    @Test
+    void shouldConfigureHttp2ForUrlBasedWebClient() throws Exception {
+        when(environment.getProperty("httpClient.timeout", Integer.class, 10000)).thenReturn(10000);
+        when(environment.getProperty("httpClient.maxPoolSize", Integer.class, 10)).thenReturn(10);
+        when(environment.getProperty("httpClient.http2.enabled", Boolean.class, true)).thenReturn(true);
+        when(environment.getProperty("httpClient.http2.maxPoolSize", Integer.class, 10)).thenReturn(10);
+        when(environment.getProperty("httpClient.http2.connectionWindowSize", Integer.class, 65535)).thenReturn(65535);
+        when(environment.getProperty("httpClient.http2.keepAliveTimeout", Integer.class, 60)).thenReturn(60);
+
+        var webClient = webClientBuilder.createWebClient(vertx, new java.net.URL("https://example.com"));
+
+        assertNotNull(webClient);
+    }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-2741](https://gravitee.atlassian.net/browse/AM-2741)

## :pencil2: A description of the changes proposed in the pull request
Expose configurable settings for
 - http/1.1 max pool size (preserves existing default of 10)
 - http/2
    - enabled (**true by default**; configures ALPN so that requests are made with http/2 if available, otherwise they will fall back to http/1.1)
    - max pool size (mirrors existing default of 10)
    - connection window size (defaults to vertx's default of 65535)
    - keep alive timeout (defaults to vertx's default of 60 seconds)

## :memo: Test scenarios 
Primarily affects identity provider communication in IDP modules and the gateway (OAuth2 generic, OIDC providers and http). Accordingly, steps similar to https://gravitee.atlassian.net/browse/AM-4040 can be used to configure an external IDP. We can then observe logs according to configuration provided in the gateway's `gravitee.yml` (requires DEBUG level logging in `logback.xml`):

```
10:19:55.043 [Thread-24] [] DEBUG i.g.am.service.http.WebClientBuilder - HTTP/2 enabled with ALPN protocol negotiation
```

```
10:36:45.390 [Thread-16] [] DEBUG i.g.am.service.http.WebClientBuilder - HTTP/1.1 mode with optimized connection pooling
```

Note that web clients are also used by services for:
 - reCAPTCHA verification
 - Newsletter subscriptions
 - Authenticated device notifications

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
?


[AM-2741]: https://gravitee.atlassian.net/browse/AM-2741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ