### PR TITLE
fix: Use last identity to set source field on idp user

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
@@ -200,7 +200,7 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
                         .flatMap(idpUser -> {
                             // retrieve information from the idp user and update the user
                             Map<String, Object> additionalInformation = idpUser.getAdditionalInformation() == null ? new HashMap<>() : new HashMap<>(idpUser.getAdditionalInformation());
-                            additionalInformation.put(SOURCE_FIELD, user.getSource());
+                            additionalInformation.put(SOURCE_FIELD, user.getLastIdentityUsed());
                             additionalInformation.put(Parameters.CLIENT_ID, user.getClient());
                             ((DefaultUser) idpUser).setAdditionalInformation(additionalInformation);
                             final User preConnectedUser = create0(idpUser, false);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.common.auth.user.impl;
 
+import com.google.common.base.Strings;
 import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.common.exception.authentication.AccountDisabledException;
 import io.gravitee.am.common.exception.authentication.AccountEnforcePasswordException;
@@ -82,6 +83,7 @@ import static java.util.Optional.ofNullable;
 public class UserAuthenticationServiceImpl implements UserAuthenticationService {
 
     private static final String SOURCE_FIELD = "source";
+    private static final String LAST_IDENTITY_FIELD = "last_identity";
     private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
@@ -200,7 +202,8 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
                         .flatMap(idpUser -> {
                             // retrieve information from the idp user and update the user
                             Map<String, Object> additionalInformation = idpUser.getAdditionalInformation() == null ? new HashMap<>() : new HashMap<>(idpUser.getAdditionalInformation());
-                            additionalInformation.put(SOURCE_FIELD, user.getLastIdentityUsed());
+                            additionalInformation.put(SOURCE_FIELD, user.getSource());
+                            additionalInformation.put(LAST_IDENTITY_FIELD, user.getLastIdentityUsed());
                             additionalInformation.put(Parameters.CLIENT_ID, user.getClient());
                             ((DefaultUser) idpUser).setAdditionalInformation(additionalInformation);
                             final User preConnectedUser = create0(idpUser, false);
@@ -389,7 +392,7 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
         return userService.create(preConnectedUser);
     }
 
-    private User create0(io.gravitee.am.identityprovider.api.User principal, boolean afterAuthentication) {
+    protected User create0(io.gravitee.am.identityprovider.api.User principal, boolean afterAuthentication) {
         final User preConnectedUser = new User();
         preConnectedUser.setExternalId(principal.getId());
         preConnectedUser.setUsername(principal.getUsername());
@@ -405,6 +408,11 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
             preConnectedUser.setLastLoginWithCredentials(preConnectedUser.getLoggedAt());
             preConnectedUser.setLoginsCount(1L);
         }
+
+        if (principal.getAdditionalInformation().get(LAST_IDENTITY_FIELD) != null) {
+           preConnectedUser.setLastIdentityUsed(principal.getAdditionalInformation().get(LAST_IDENTITY_FIELD).toString());
+        }
+
         preConnectedUser.setDynamicRoles(principal.getRoles());
         preConnectedUser.setDynamicGroups(principal.getGroups());
 
@@ -440,10 +448,15 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
             return true;
         }
 
+        // If we have a last identity configured, use that for the link query
+        final String providerId = Strings.isNullOrEmpty(preConnectedUser.getLastIdentityUsed())
+                ? preConnectedUser.getSource()
+                : preConnectedUser.getLastIdentityUsed();
+
         return ofNullable(existingUser.getIdentities())
                 .orElse(List.of())
                 .stream()
-                .anyMatch(u -> u.getUserId().equals(preConnectedUser.getExternalId()) && u.getProviderId().equals(preConnectedUser.getSource()));
+                .anyMatch(u -> u.getUserId().equals(preConnectedUser.getExternalId()) && u.getProviderId().equals(providerId));
     }
 
     private void upsertLinkedIdentities(User existingUser, User preConnectedUser) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
@@ -85,12 +85,14 @@ public class UserAuthenticationServiceTest {
         String domainId = "Domain";
         String username = "foo";
         String source = "SRC";
+        String idp = "LDAP_1";
         String id = "id";
         io.gravitee.am.identityprovider.api.User user = mock(io.gravitee.am.identityprovider.api.User.class);
         when(user.getUsername()).thenReturn(username);
         when(user.getId()).thenReturn(id);
         HashMap<String, Object> additionalInformation = new HashMap<>();
         additionalInformation.put("source", source);
+        additionalInformation.put("last_identity", idp);
         additionalInformation.put("op_id_token", "somevalue");
         when(user.getAdditionalInformation()).thenReturn(additionalInformation);
 
@@ -658,6 +660,47 @@ public class UserAuthenticationServiceTest {
         testObserver.assertNoErrors();
         verify(userService, never()).create(any());
         verify(userService, times(1)).update(any(), argThat(updateActions -> !updateActions.updateIdentities())); //
+    }
+
+    @Test
+    public void shouldConnect_accountLinking_differentProviderIdentity() {
+        String domainId = "Domain";
+        String source = "SRC1";
+        String lastIdentity = "LDAP_1";
+        String id = "id1";
+        io.gravitee.am.identityprovider.api.User user = mock(io.gravitee.am.identityprovider.api.User.class);
+        when(user.getId()).thenReturn(id);
+        HashMap<String, Object> additionalInformation = new HashMap<>();
+        additionalInformation.put("source", source);
+        additionalInformation.put("last_identity", lastIdentity);
+        additionalInformation.put("newKey", "newValue");
+        when(user.getAdditionalInformation()).thenReturn(additionalInformation);
+        User updatedUser = mock(User.class);
+        when(updatedUser.isEnabled()).thenReturn(true);
+        when(domain.getId()).thenReturn(domainId);
+
+        final UserIdentity userIdentity = new UserIdentity();
+        userIdentity.setUserId(id);
+        userIdentity.setProviderId(lastIdentity);
+
+        final User foundUser = new User();
+        foundUser.setId(id);
+        foundUser.setAccountNonLocked(true);
+        foundUser.setIdentities(List.of(userIdentity));
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(userService.findByDomainAndExternalIdAndSource(domainId, id, source)).thenReturn(Maybe.just(foundUser));
+        when(userService.update(any(), any())).thenReturn(Single.just(updatedUser));
+        when(userService.enhance(updatedUser)).thenReturn(Single.just(updatedUser));
+        when(rulesEngine.fire(any(), any(), any(), any())).thenReturn(Single.just(executionContext));
+
+        TestObserver testObserver = userAuthenticationService.connect(user).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(userService, never()).create(any());
+        verify(userService, times(1)).update(any(), argThat(updateActions -> updateActions.updateIdentities())); //
     }
 
     @Test


### PR DESCRIPTION
## :id: Reference related issue. 
fixes: AM-5385

## :pencil2: A description of the changes proposed in the pull request
This pull request introduces a small but important change to how user authentication information is handled before authentication. Specifically, it updates the source field in the user's additional information to use the last identity provider used, rather than the user's source.

* The `SOURCE_FIELD` in the `additionalInformation` map is now set to `user.getLastIdentityUsed()` instead of `user.getSource()`, ensuring that the most recent identity provider is accurately tracked during pre-authentication. (`gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java`)

## :memo: Test scenarios 
We need to test the following scenarios:
- Authentication via LDAP
- Dynamic Role Mapping via LDAP
- Updated Role Mapping via LDAP (Add a new group to an existing user and verify the role is mapped when they log in next)
- Multiple LDAP providers + role mapping

## :bug: Steps to reproduce the bug in AM-5385:

ℹ️ Database Models are available here: [DB Models](https://drive.google.com/drive/folders/16eLKR_G-kuc20HSy7NEJo2YukYvJ7MPg?usp=drive_link)

### LDAP Configuration

 - Spin up two LDAP instances via [docker compose](https://drive.google.com/file/d/1-dbyJje-RxkXhm8TI1QW4bz00F1tClIR/view?usp=drive_link) this should create two containers for LDAP and the phpLDAPAdmin application which can be used to configure the LDAP instances
 - Import the following configuration files into each of the LDAP instances to set up the groups and users: 
   - [LDAP_1.ldif](https://drive.google.com/file/d/1I-2iKd9fwWW5MjxiYXapaCtjzYj2rwl3/view?usp=drive_link)
   - [LDAP_2.ldif](https://drive.google.com/file/d/16KGPPhPS8K09fhOv6TWTnHWCeEt5UuIW/view?usp=drive_link)


### AM Application Configuration

- Create two LDAP Identity Providers in the AM domain
- Create two roles: Engineer, Worker
- Configure these two LDAP instances (`example1` should be `LDAP_1`, `example2` should be `LDAP_2`)
- Set LDAP_1 to have role mappers:
   - `Workers` = `{#profile['memberOf'].contains('workers')}`
   - `Engineers` = `{#profile['memberOf'].contains('engineers')}`
- Create an application in AM and set up the two LDAP providers as Identity Providers for the application, drag LDAP_1 to be the priority IDP
- **Keep note of the Application Client Secret**
- Create Account Linking Policy in pre connect flow that will connect users by username (`username` =  `John`)

### Reproducing the bug:

- Ensure there are no users named john in the system first
- Open the application and copy the link to log in, paste that into the browser
- Login form should display, login as username: john, password: john
- Navigate to settings/Users and verify the user account has been created and that the roles are mapped correctly
- Back in the application overview page copy the URL to log out, and paste it into the browser
- Now we need to switch the IDP to be LDAP_2, you can do this by dragging the IDP to the top in the Applications -> <APP> -> Identity Providers
- Back in the application overview page copy the URL to log in, and paste it into the browser, **keep this page open**
- Navigate to settings/Users and verify the user account exists and that the roles are still mapped correctly and that the identity is linked to the account in LDAP_1
 
This is where the **bug begins**:
- Open the browser where you previously logged in, the url should contain a code, we need to send a get token request to the API, this can be done via the CURL command:

```bash
curl -X POST \
              http://localhost:8092/stc/oauth/token \
  -u '8945fca6-215b-497c-85fc-a6215b797c1e:|client_secret|' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=authorization_code&code=|code|&redirect_uri=https://www.google.com/callback&client_id=8945fca6-215b-497c-85fc-a6215b797c1e'
```

You will need to update this command to have your client ID etc.


### Bug Verification (Before fix)

- Navigate to settings/Users and verify the user account exists and that the roles are now empty but the identity is still linked to the account in LDAP_1

### Fix Verification

- Navigate to settings/Users and verify the user account exists and that the roles are still mapped correctly and that the identity is linked to the account in LDAP_1


### Dynamic Role Mapping Verification
- Log into phpLDAPAdmin for `LDAP_1` and remove John from the Engineers group
- Log in as John in AM
- Navigate to settings/Users and verify the user account exists and that the `worker` role is still mapped correctly (`engineer` should be removed) and that the identity is linked to the account in LDAP_1