### PR TITLE
Fix: AM-4944 organization-level IdP whitelist retention

### DIFF
--- a/gravitee-am-ui/src/app/services/organization.service.ts
+++ b/gravitee-am-ui/src/app/services/organization.service.ts
@@ -110,6 +110,7 @@ export class OrganizationService {
       name: idp.name,
       type: idp.type,
       configuration: idp.configuration,
+      domainWhitelist: idp.domainWhitelist,
       mappers: idp.mappers,
       roleMapper: idp.roleMapper,
       groupMapper: idp.groupMapper,

--- a/gravitee-am-ui/src/app/services/provider.service.ts
+++ b/gravitee-am-ui/src/app/services/provider.service.ts
@@ -64,7 +64,6 @@ export class ProviderService {
       mappers: provider.mappers,
       roleMapper: provider.roleMapper,
       groupMapper: provider.groupMapper,
-      passwordPolicy: provider.passwordPolicy,
     });
   }
 


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-4944](https://gravitee.atlassian.net/browse/AM-4944)

## :pencil2: A description of the changes proposed in the pull request
Add missing parameter to PUT request body so that _Domain Whitelist_ settings are retained when updating social identity provider settings at the organization level in the UI.

## :memo: Test scenarios 
1. Navigate to Organization > Identity Providers > New provider (+)
2. Select any social identity provider type (e.g. Google)
3. Select Next, then enter required values and press Create
4. Edit any setting and press SAVE
5. Confirm _Domain Whitelist_ are preserved (e.g. `gmail.com`)

## :computer: Add screenshots for UI
<img width="1116" height="710" alt="image" src="https://github.com/user-attachments/assets/32a2141b-b67d-43c8-8eb3-f89005c1f7b1" />


## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-4944]: https://gravitee.atlassian.net/browse/AM-4944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ