### PR TITLE
chore(ci): add max auto rerun on PR workflow

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -2041,6 +2041,7 @@ workflows:
     when:
       and:
         - equal: [ pull_requests, << pipeline.parameters.gio_action >> ]
+    max_auto_reruns: 3
     jobs:
       - setup:
           context: cicd-orchestrator


### PR DESCRIPTION
This change expect to reduce the "rerun from failed" due to flacky Integration tests