### PR TITLE
fix: AM-5529 password expired with unregistered user

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PasswordServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PasswordServiceImpl.java
@@ -126,6 +126,10 @@ public class PasswordServiceImpl implements PasswordService {
             return false;
         }
 
+        if (user.getLastPasswordReset() == null) {
+            return true;
+        }
+
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(user.getLastPasswordReset());
         calendar.add(Calendar.DAY_OF_MONTH, passwordPolicy.getExpiryDuration());

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/PasswordServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/PasswordServiceImplTest.java
@@ -320,6 +320,16 @@ public class PasswordServiceImplTest {
     }
 
     @Test
+    public void checkAccountPasswordExpiry_nullLastPasswordReset_shouldReturnExpired() {
+        User user = new User();
+        user.setLastPasswordReset(null);
+        PasswordPolicy passwordSettings = new PasswordPolicy();
+        passwordSettings.setExpiryDuration(90);
+
+        Assertions.assertThat(passwordService.checkAccountPasswordExpiry(user, passwordSettings)).isTrue();
+    }
+
+    @Test
     public void checkAccountPasswordExpiry_shouldNotReturnExpired() {
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DAY_OF_MONTH, -6);


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-5529](https://gravitee.atlassian.net/browse/AM-5529)

## :pencil2: A description of the changes proposed in the pull request
Block a user from logging in if they have a password expiration configured and their password has never been reset.

This affects a scenario where a pre-registered user attempts a login and this change avoids a `NullPointerException` when reading the `lastPasswordReset` property.

## :memo: Test scenarios 
See JIRA.

## :computer: Add screenshots for UI
Resulting failure message when pre-registered user attempts a login:
<img width="634" height="613" alt="image" src="https://github.com/user-attachments/assets/fa6ab9a1-5de6-4e23-b172-78df17dcc160" />


## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-5529]: https://gravitee.atlassian.net/browse/AM-5529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ