### PR TITLE
AM-5484 use vertx timer to prevent timer thread failures

### DIFF
--- a/gravitee-am-reporter/gravitee-am-reporter-file/src/main/java/io/gravitee/am/reporter/file/vertx/VertxFileWriter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-file/src/main/java/io/gravitee/am/reporter/file/vertx/VertxFileWriter.java
@@ -91,7 +91,7 @@ public class VertxFileWriter<T extends ReportEntry> {
     /**
      * Interface to provide the current time and time in a specific time zone.
      */
-    interface TimeProvider {
+    protected interface TimeProvider {
         default ZonedDateTime now() {
             return ZonedDateTime.now();
         }
@@ -100,7 +100,7 @@ public class VertxFileWriter<T extends ReportEntry> {
         }
     }
 
-    public VertxFileWriter(Vertx vertx, Formatter<T> formatter, String filename, long retainDays, TimeProvider timeProvider) throws IOException {
+    protected VertxFileWriter(Vertx vertx, Formatter<T> formatter, String filename, long retainDays, TimeProvider timeProvider) throws IOException {
         this(vertx, formatter, filename, retainDays);
         this.timeProvider = timeProvider;
     }


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-5484
For some reason the rollover thread wasn't triggered (executed) on the schedule time. 
There are some general code improvements we can take by using the Vertx Timer instead. 

## :pencil2: A description of the changes proposed in the pull request

User Vertx timer in each file reporter thread rather than the static shared timer. 
Added test coverage to the scheduled work, and ensure the rollover is triggered and a new log file is created.

## :memo: Test scenarios 

Follow the Jira ticket for details of test steps.

