### PR TITLE
AM-5510 update delete statement to support mssql

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringAccountAccessTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringAccountAccessTokenRepository.java
@@ -27,6 +27,6 @@ public interface SpringAccountAccessTokenRepository extends RxJava3CrudRepositor
     @Query("select * from account_access_tokens a where a.user_id = :userId and a.reference_id = :refId and a.reference_type = :refType")
     Flowable<JdbcAccountAccessToken> findByUserId(@Param("refType") String refType, @Param("refId") String refId, @Param("userId") String userId);
 
-    @Query("delete from account_access_tokens a where a.user_id = :userId and a.reference_id = :refId and a.reference_type = :refType")
+    @Query("delete from account_access_tokens where user_id = :userId and reference_id = :refId and reference_type = :refType")
     Maybe<Long> deleteByUserId(@Param("refType") String refType, @Param("refId") String refId, @Param("userId") String userId);
 }


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-5510

**MsSQL server doesn’t support delete statement with alias which can cause the following error:**
```
delete from account_access_tokens a where a.user_id = 'user-1' and a.reference_id = 'account-123' and a.reference_type = 'ACCOUNT'

SQL Error [102] [S0001]: Incorrect syntax near 'a'.
```

**updating the statement to the following can fix this:**
```
delete from account_access_tokens where user_id = 'user-1' and reference_id = 'account-123' and reference_type = 'ACCOUNT'

Updated Rows	1
Execute time	0.111s
```

## :pencil2: A description of the changes proposed in the pull request

update the statement to not use alias.

## :memo: Test scenarios 


