### PR TITLE
fix: AM-5534 users search type detection

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/users/users.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/users.component.spec.ts
@@ -14,16 +14,84 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of } from 'rxjs';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { UsersComponent } from './users.component';
+import { UserService } from '../../../services/user.service';
+import { OrganizationService } from '../../../services/organization.service';
+import { DialogService } from '../../../services/dialog.service';
+import { SnackbarService } from '../../../services/snackbar.service';
+import { AuthService } from '../../../services/auth.service';
+import { ApplicationService } from '../../../services/application.service';
+import { ProviderService } from '../../../services/provider.service';
 
 describe('UsersComponent', () => {
   let component: UsersComponent;
   let fixture: ComponentFixture<UsersComponent>;
 
   beforeEach(waitForAsync(() => {
+    const userServiceStub = {
+      findByDomain: jest.fn().mockReturnValue(of({ totalCount: 0, data: [] })),
+      search: jest.fn().mockReturnValue(of({ totalCount: 0, data: [] })),
+      delete: jest.fn().mockReturnValue(of(void 0)),
+    } as Partial<UserService> as UserService;
+
+    const organizationServiceStub = {
+      users: jest.fn().mockReturnValue(of({ totalCount: 0, data: [] })),
+    } as Partial<OrganizationService> as OrganizationService;
+
+    const dialogServiceStub = {
+      confirm: jest.fn().mockReturnValue(of(true)),
+    } as Partial<DialogService> as DialogService;
+
+    const snackbarServiceStub = {
+      open: jest.fn(),
+    } as Partial<SnackbarService> as SnackbarService;
+
+    const authServiceStub = {
+      hasPermissions: jest.fn().mockReturnValue(false),
+    } as Partial<AuthService> as AuthService;
+
+    const applicationServiceStub = {
+      findByDomain: jest.fn().mockReturnValue(of({ data: [] })),
+    } as Partial<ApplicationService> as ApplicationService;
+
+    const providerServiceStub = {
+      findByDomain: jest.fn().mockReturnValue(of([])),
+    } as Partial<ProviderService> as ProviderService;
+
+    const activatedRouteStub = {
+      snapshot: { data: { domain: { id: 'test-domain' } } },
+    } as any as ActivatedRoute;
+
+    const routerStub = {
+      routerState: { snapshot: { url: '/domains/test-domain/users' } },
+    } as Partial<Router> as Router;
+
+    const matDialogStub = {
+      open: jest.fn(),
+    } as Partial<MatDialog> as MatDialog;
+
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
       declarations: [UsersComponent],
+      providers: [
+        { provide: UserService, useValue: userServiceStub },
+        { provide: OrganizationService, useValue: organizationServiceStub },
+        { provide: DialogService, useValue: dialogServiceStub },
+        { provide: SnackbarService, useValue: snackbarServiceStub },
+        { provide: AuthService, useValue: authServiceStub },
+        { provide: ApplicationService, useValue: applicationServiceStub },
+        { provide: ProviderService, useValue: providerServiceStub },
+        { provide: ActivatedRoute, useValue: activatedRouteStub },
+        { provide: Router, useValue: routerStub },
+        { provide: MatDialog, useValue: matDialogStub },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
       teardown: { destroyAfterEach: false },
     }).compileComponents();
   }));
@@ -36,5 +104,45 @@ describe('UsersComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('isAdvancedSearch', () => {
+    it('should return true if the search query is an advanced search', () => {
+      const searchQueries = [
+        'username eq "bob"',
+        'email co "@someplace.co.uk"',
+        'title pr',
+        'age gt 21',
+        'meta.lastModified ge "2020-01-01T00:00:00Z"',
+        'userType sw "Admin"',
+        'nickName ew "y"',
+        'name.familyName ne "Smith"',
+        'username eq "bob" and email co "@somewhere.com"',
+        '(username eq "bob") or (username eq "alice")',
+        '"tricky and string" or title pr',
+        'nickName ew ""',
+        'name.familyName eq   "O\'Connor"',
+      ];
+      expect(searchQueries.map(query => component['isAdvancedSearch'](query))).not.toContain(false);
+    });
+
+    it('should return false if the search query is not an advanced search', () => {
+      const searchQueries = [
+        '@someplace.co.uk',
+        'just some random text',
+        '"this string contains co inside"',
+        '"escaped \\"eq\\" inside quotes"',
+        'foo.eq.bar',
+        'anderson',
+        'coral reef',
+        'not_equal',
+        'gtx1080',
+        '"foo \\"co\\" bar"',
+        'co',
+        '"eq"',
+        'sw "start"and',
+      ];
+      expect(searchQueries.map(query => component['isAdvancedSearch'](query))).not.toContain(true);
+    });
   });
 });

--- a/gravitee-am-ui/src/app/domain/settings/users/users.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/users.component.ts
@@ -32,7 +32,8 @@ import { ProviderService } from '../../../services/provider.service';
   styleUrls: ['./users.component.scss'],
 })
 export class UsersComponent implements OnInit {
-  private re = /\b(eq|ne|co|sw|ew|pr|gt|ge|lt|le|and|or)\b/gi;
+  private readonly scimOperatorPattern = /"(?:\\.|[^"\\])*"|\b[\w.-]+\s+(?<op>pr|eq|ne|co|sw|ew|gt|ge|lt|le)\b/gi;
+  
   isLoading: boolean;
   searchValue: string;
   organizationContext: boolean;
@@ -77,7 +78,7 @@ export class UsersComponent implements OnInit {
     this.loadUsers(null);
   }
 
-  loadUsers(searchQuery) {
+  loadUsers(searchQuery: string | null) {
     let findUsers: any;
     let advancedSearchMode = false;
     if (searchQuery) {
@@ -194,8 +195,13 @@ export class UsersComponent implements OnInit {
     this.dialog.open(UsersSearchInfoDialogComponent, {});
   }
 
-  private isAdvancedSearch(searchQuery): boolean {
-    return searchQuery.match(this.re);
+  private isAdvancedSearch(searchQuery: string): boolean {
+    this.scimOperatorPattern.lastIndex = 0;
+    let match;
+    while ((match = this.scimOperatorPattern.exec(searchQuery))) {
+      if (match.groups?.op) return true;
+    }
+    return false;
   }
 }
 

--- a/gravitee-am-ui/src/jest.config.js
+++ b/gravitee-am-ui/src/jest.config.js
@@ -15,7 +15,7 @@
  */
 module.exports = {
   preset: 'jest-preset-angular',
-  setupFilesAfterEnv: ['<rootDir>/src/setupJest.ts'],
+  setupFilesAfterEnv: ['<rootDir>/setupJest.ts'],
   collectCoverage: false,
-  collectCoverageFrom: ['src/**/*.ts'],
+  collectCoverageFrom: ['**/*.ts'],
 };

--- a/gravitee-am-ui/src/setupJest.ts
+++ b/gravitee-am-ui/src/setupJest.ts
@@ -1,3 +1,7 @@
+import 'jest-preset-angular/setup-jest';
+import 'zone.js';
+import 'zone.js/testing';
+
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-5534](https://gravitee.atlassian.net/browse/AM-5534)

## :pencil2: A description of the changes proposed in the pull request
Improve the accuracy of SCIM 2.0 syntax detection when searching for users in the UI. This avoids using the `filter` query parameter ([API docs](https://documentation.gravitee.io/am/guides/user-management/users#list-users-with-a-filter-filter)) instead of the `q` parameter (for [plain text searches](https://documentation.gravitee.io/am/guides/user-management/users#list-users-with-a-query-q)) for queries that might otherwise resemble SCIM operators and thereby avoid unexpected syntax errors being displayed.

For example, `joe.bloggs@someplace.co.uk` should not be considered an advanced query simply because it contains the operator `co` (contains) - but `email co "someplace.co.uk"` should.

## :memo: Test scenarios 
In Settings > User Management > Users, enter various queries into the Search box and press Enter.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
SCIM 2.0 syntax: https://datatracker.ietf.org/doc/html/rfc7644

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am
