### PR TITLE
fix: AM-5529 set lastPasswordReset date upon registration and connect flow

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
@@ -355,15 +355,15 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
             existingUser.setDynamicRoles(preConnectedUser.getDynamicRoles());
             existingUser.setDynamicGroups(preConnectedUser.getDynamicGroups());
 
-            // set last password reset
-            if (existingUser.getLastPasswordReset() == null) {
-                existingUser.setLastPasswordReset(existingUser.getUpdatedAt() == null ? new Date() : existingUser.getUpdatedAt());
-            }
-
             // set additional information
             Map<String, Object> additionalInformation = ofNullable(preConnectedUser.getAdditionalInformation()).orElse(Map.of());
             removeOriginalProviderOidcTokensIfNecessary(existingUser, afterAuthentication, additionalInformation);
             extractAdditionalInformation(existingUser, additionalInformation);
+        }
+
+        // populate last password reset if missing
+        if (existingUser.getLastPasswordReset() == null) {
+            existingUser.setLastPasswordReset(existingUser.getUpdatedAt() == null ? new Date() : existingUser.getUpdatedAt());
         }
 
         return userService.update(existingUser, updateActions);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
@@ -116,6 +116,73 @@ public class UserAuthenticationServiceTest {
     }
 
     @Test
+    public void shouldConnect_knownUser_populateLastPasswordReset_fromUpdatedAt() {
+        String domainId = "Domain";
+        String source = "SRC";
+        String id = "id";
+
+        io.gravitee.am.identityprovider.api.User user = mock(io.gravitee.am.identityprovider.api.User.class);
+        when(user.getId()).thenReturn(id);
+        HashMap<String, Object> additionalInformation = new HashMap<>();
+        additionalInformation.put("source", source);
+        when(user.getAdditionalInformation()).thenReturn(additionalInformation);
+
+        User updatedUser = mock(User.class);
+        when(updatedUser.isEnabled()).thenReturn(true);
+
+        when(domain.getId()).thenReturn(domainId);
+        final User foundUser = new User();
+        foundUser.setAccountNonLocked(true);
+        final Date updatedAt = new Date(1_725_000_000_000L);
+        foundUser.setUpdatedAt(updatedAt);
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(userService.findByDomainAndExternalIdAndSource(domainId, id, source)).thenReturn(Maybe.just(foundUser));
+        when(userService.update(any(), any())).thenReturn(Single.just(updatedUser));
+        when(userService.enhance(updatedUser)).thenReturn(Single.just(updatedUser));
+        when(rulesEngine.fire(any(), any(), any(), any())).thenReturn(Single.just(executionContext));
+
+        TestObserver<User> testObserver = userAuthenticationService.connect(user).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(userService, times(1)).update(argThat(u -> updatedAt.equals(u.getLastPasswordReset())), any());
+    }
+
+    @Test
+    public void shouldConnect_knownUser_populateLastPasswordReset_whenUpdatedAtNull() {
+        String domainId = "Domain";
+        String source = "SRC";
+        String id = "id";
+
+        io.gravitee.am.identityprovider.api.User user = mock(io.gravitee.am.identityprovider.api.User.class);
+        when(user.getId()).thenReturn(id);
+        HashMap<String, Object> additionalInformation = new HashMap<>();
+        additionalInformation.put("source", source);
+        when(user.getAdditionalInformation()).thenReturn(additionalInformation);
+
+        User updatedUser = mock(User.class);
+        when(updatedUser.isEnabled()).thenReturn(true);
+
+        when(domain.getId()).thenReturn(domainId);
+        final User foundUser = new User();
+        foundUser.setAccountNonLocked(true);
+        // updatedAt is intentionally left null
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(userService.findByDomainAndExternalIdAndSource(domainId, id, source)).thenReturn(Maybe.just(foundUser));
+        when(userService.update(any(), any())).thenReturn(Single.just(updatedUser));
+        when(userService.enhance(updatedUser)).thenReturn(Single.just(updatedUser));
+        when(rulesEngine.fire(any(), any(), any(), any())).thenReturn(Single.just(executionContext));
+
+        TestObserver<User> testObserver = userAuthenticationService.connect(user).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(userService, times(1)).update(argThat(u -> u.getLastPasswordReset() != null), any());
+    }
+
+    @Test
     public void shouldConnect_knownUser() {
         String domainId = "Domain";
         String source = "SRC";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
@@ -269,6 +269,7 @@ public class UserServiceImpl implements UserService {
 
     private Single<User> registerUser(User user, Optional<AccountSettings> accountSettings, String source, io.gravitee.am.identityprovider.api.User idpUser, MultiMap queryParams) {
         // AM 'users' collection is not made for authentication (but only management stuff)
+        var now = new Date();
         // clear password
         user.setPassword(null);
         // set external id
@@ -283,11 +284,11 @@ public class UserServiceImpl implements UserService {
         // additional information
         extractAdditionalInformation(user, idpUser.getAdditionalInformation());
         // set date information
-        user.setCreatedAt(new Date());
-        user.setUpdatedAt(user.getCreatedAt());
+        user.setCreatedAt(now);
+        user.setUpdatedAt(now);
         accountSettings.ifPresent(settings -> {
             if (settings.isAutoLoginAfterRegistration() && !settings.isSendVerifyRegistrationAccountEmail()) {
-                user.setLoggedAt(new Date());
+                user.setLoggedAt(now);
                 user.setLoginsCount(1L);
             }
             if (settings.isSendVerifyRegistrationAccountEmail()) {
@@ -297,6 +298,7 @@ public class UserServiceImpl implements UserService {
                 user.setRegistrationUserUri(domainService.buildUrl(domain, REGISTRATION_VERIFY.redirectUri(), queryParams));
             }
         });
+        user.setLastPasswordReset(now);
         return userService.create(user);
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
@@ -65,6 +65,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -1484,5 +1485,48 @@ public class UserServiceTest {
 
         verify(emailService, times(1)).send(any(), any(), any(), any());
         verify(auditService, times(1)).report(any());
+    }
+
+    @Test
+    public void shouldInitializeUserWhenRegistered() {
+        when(userValidator.validate(any())).thenReturn(Completable.complete());
+        when(commonUserService.findByDomainAndUsernameAndSource(any(), anyString(), anyString()))
+                .thenReturn(Maybe.empty());
+
+        final DefaultUser idpUser = new DefaultUser("username");
+        idpUser.setId("external-idp-id");
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.create(any())).thenReturn(Single.just(idpUser));
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+
+        final org.mockito.ArgumentCaptor<User> userCaptor = org.mockito.ArgumentCaptor.forClass(User.class);
+        when(commonUserService.create(userCaptor.capture())).thenAnswer(inv -> {
+            User toCreate = userCaptor.getValue();
+            return Single.just(toCreate);
+        });
+        when(commonUserService.enhance(any())).thenAnswer(inv -> Single.just(inv.getArgument(0)));
+
+        final Client client = new Client();
+        client.setId("clientId");
+        final User input = new User();
+        input.setUsername("username");
+        input.setPassword("raw-password");
+
+        var testObserver = userService.register(client, input).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        final User user = userCaptor.getValue();
+        Assertions.assertNull(user.getPassword());
+        Assertions.assertEquals("external-idp-id", user.getExternalId());
+        Assertions.assertNotNull(user.getSource());
+        Assertions.assertEquals(ReferenceType.DOMAIN, user.getReferenceType());
+        Assertions.assertEquals("id", user.getReferenceId());
+        Assertions.assertTrue(user.isInternal());
+        Assertions.assertNotNull(user.getCreatedAt());
+        Assertions.assertNotNull(user.getUpdatedAt());
+        Assertions.assertEquals(user.getCreatedAt(), user.getUpdatedAt());
+        Assertions.assertNotNull(user.getLastPasswordReset());
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-5529](https://gravitee.atlassian.net/browse/AM-5529)

## :pencil2: A description of the changes proposed in the pull request

- Set a user's _last password reset_ date during the connect flow if missing, for linked accounts as well as individual ones.
- Set a user's _last password reset_ date during registration. This provides a more accurate value for password expiry calculations.

## :memo: Test scenarios 
See JIRA.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-5529]: https://gravitee.atlassian.net/browse/AM-5529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ