### PR TITLE
chore(dep): upgrade gravitee-bom to version 8..3.39

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/core/http/GraviteeVertxHttpServerRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/core/http/GraviteeVertxHttpServerRequest.java
@@ -102,7 +102,18 @@ public class GraviteeVertxHttpServerRequest implements HttpServerRequest {
 
     @Override
     public @Nullable HostAndPort authority() {
+        if (delegate instanceof HttpServerRequest) {
+            return ((HttpServerRequest) delegate).authority();
+        }
         return HostAndPort.create(this.host, -1);
+    }
+
+    @Override
+    public @Nullable HostAndPort authority(boolean real) {
+        if (delegate instanceof HttpServerRequest) {
+            return ((HttpServerRequest) delegate).authority(real);
+        }
+        return authority();
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/dummies/DummyHttpRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/dummies/DummyHttpRequest.java
@@ -166,6 +166,11 @@ public class DummyHttpRequest implements HttpServerRequest {
     }
 
     @Override
+    public @Nullable HostAndPort authority(boolean real) {
+        return null;
+    }
+
+    @Override
     public long bytesRead() {
         return 0;
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/dummies/DummyHttpRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/dummies/DummyHttpRequest.java
@@ -149,6 +149,11 @@ public class DummyHttpRequest implements HttpServerRequest {
     }
 
     @Override
+    public @Nullable HostAndPort authority(boolean real) {
+        return null;
+    }
+
+    @Override
     public long bytesRead() {
         return 0;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
     <properties>
         <awaitility.version>4.2.2</awaitility.version>
-        <gravitee-bom.version>8.3.34</gravitee-bom.version>
+        <gravitee-bom.version>8.3.39</gravitee-bom.version>
         <gravitee-common.version>4.2.0</gravitee-common.version>
         <gravitee-plugin.version>4.6.0</gravitee-plugin.version>
         <gravitee-node.version>7.1.0</gravitee-node.version>


### PR DESCRIPTION
This PR upgrade the gio BOM to use the latest version of VertX, netty and SpringSecurity