### PR TITLE
fix: remove the purge manager service dependency

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
@@ -648,13 +648,6 @@
                                     <type>zip</type>
                                 </artifactItem>
 
-                                <artifactItem>
-                                    <groupId>io.gravitee.am.gateway</groupId>
-                                    <artifactId>gravitee-am-gateway-services-purge</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-
                                 <!-- Reporters -->
                                 <artifactItem>
                                     <groupId>io.gravitee.am.reporter</groupId>


### PR DESCRIPTION
since the purge manager is not a service plugin anymore, the artifactItem is not required anymore

related-to AM-5432
