### PR TITLE
AM-5599 rate limit expire reset

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/repository/ratelimit/model/RateLimit.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/repository/ratelimit/model/RateLimit.java
@@ -51,6 +51,7 @@ public class RateLimit implements Serializable {
         this.setCounter(rateLimit.getCounter());
         this.setLimit(rateLimit.getLimit());
         this.setResetTime(rateLimit.getResetTime());
+        this.setSubscription(rateLimit.getSubscription());
     }
 
     public long getCounter() {
@@ -109,5 +110,25 @@ public class RateLimit implements Serializable {
 
     public boolean hasNotExpired() {
         return System.currentTimeMillis() <= resetTime;
+    }
+
+    public static class RateLimitBuilder {
+        private RateLimit rateLimit;
+        private RateLimitBuilder() {}
+
+        public static RateLimitBuilder builder(RateLimit rateLimit) {
+            RateLimitBuilder builder = new RateLimitBuilder();
+            builder.rateLimit = new RateLimit(rateLimit);
+            return builder;
+        }
+
+        public RateLimitBuilder counter(long counter) {
+            rateLimit.counter = counter;
+            return this;
+        }
+
+        public RateLimit build() {
+            return rateLimit;
+        }
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/ratelimit/api/JdbcRateLimitApiRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/ratelimit/api/JdbcRateLimitApiRepository.java
@@ -36,11 +36,21 @@ public class JdbcRateLimitApiRepository extends AbstractJdbcRepository implement
 
     @Override
     public Single<RateLimit> incrementAndGet(String key, long weight, Supplier<RateLimit> supplier) {
-        return findNotExpiredById(key)
-                .doOnSuccess(rl ->  rl.setCounter(rl.getCounter() + weight))
-                .doOnSuccess(rl -> LOGGER.debug("Incrementing rate limit entry for key {} with weight {}", rl.getKey(), weight))
-                .compose(this::update)
+        return findById(key)
+                .flatMapSingle(rateLimit -> {
+                    LOGGER.debug("Incrementing rate limit entry for key {} with weight {}", rateLimit.getKey(), weight);
+                    if (rateLimit.hasNotExpired()) {
+                        LOGGER.debug("Rate limit entry for key {} has not expired yet", rateLimit.getKey());
+                        rateLimit.setCounter(rateLimit.getCounter() + weight);
+                        return update(rateLimit);
+                    } else {
+                        LOGGER.debug("Rate limit entry for key {} has expired", rateLimit.getKey());
 
+                        RateLimit newRateLimit = supplier.get();
+                        newRateLimit.setCounter(weight);
+                        return update(newRateLimit);
+                    }
+                })
                 .switchIfEmpty(createNew(weight, supplier)
                         .doOnSuccess(rl -> LOGGER.debug("Creating new rate limit entry for key {} with weight {}", rl.getKey(), weight))
                         .compose(this::insert));
@@ -53,18 +63,17 @@ public class JdbcRateLimitApiRepository extends AbstractJdbcRepository implement
                 .map(this::toEntity);
     }
 
-    private Maybe<RateLimit> update(Maybe<RateLimit> rateLimit) {
-        return rateLimit
+    private Single<RateLimit> update(RateLimit rateLimit) {
+        return Single.just(rateLimit)
                 .map(this::toJdbcEntity)
-                .flatMapSingle(requestObjectRepository::save)
+                .flatMap(requestObjectRepository::save)
                 .map(this::toEntity);
     }
 
-    private Maybe<RateLimit> findNotExpiredById(String key){
+    private Maybe<RateLimit> findById(String key){
         return requestObjectRepository
                 .findById(key)
-                .map(this::toEntity)
-                .filter(RateLimit::hasNotExpired);
+                .map(this::toEntity);
     }
 
     private Single<RateLimit> createNew(long weight, Supplier<RateLimit> supplier){


### PR DESCRIPTION
## :id: Reference related issue. 
fixes: AM-5599


## :pencil2: A description of the changes proposed in the pull request
Implements the reset of the rate limit item if the reset time has passed.

## :memo: Test scenarios 
 - Configure Rate Limit on Mongo/Postgres/Redis to have a small timeout, 30 secs and small limit, 5
 - Make 5 requests within 30 seconds
 - Verify the 6th request is status code 429
 - Wait 30 seconds for the expiry to pass
 - Make another request
 - Verify the status code 200


## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a