### PR TITLE
feat: enable skip Xms and Xmx with GIO_DISABLE_STARTING_MEMORY

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -62,17 +62,20 @@ if [ ! -f "$runjar" ]; then
 fi
 GRAVITEE_BOOT_CLASSPATH="$runjar"
 
-if [ "x$GIO_MIN_MEM" = "x" ]; then
-    GIO_MIN_MEM=256m
-fi
-if [ "x$GIO_MAX_MEM" = "x" ]; then
-    GIO_MAX_MEM=256m
-fi
+# enable skip Xms and Xmx to use percentage of resources in k8s
+if [ "x$GIO_DISABLE_STARTING_MEMORY" = "x" ]; then
+  if [ "x$GIO_MIN_MEM" = "x" ]; then
+      GIO_MIN_MEM=256m
+  fi
+  if [ "x$GIO_MAX_MEM" = "x" ]; then
+      GIO_MAX_MEM=256m
+  fi
 
-# min and max heap sizes should be set to the same value to avoid
-# stop-the-world GC pauses during resize
-JAVA_OPTS="$JAVA_OPTS -Xms${GIO_MIN_MEM}"
-JAVA_OPTS="$JAVA_OPTS -Xmx${GIO_MAX_MEM}"
+  # min and max heap sizes should be set to the same value to avoid
+  # stop-the-world GC pauses during resize
+  JAVA_OPTS="$JAVA_OPTS -Xms${GIO_MIN_MEM}"
+  JAVA_OPTS="$JAVA_OPTS -Xmx${GIO_MAX_MEM}"
+fi
 
 # set to headless, just in case
 JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee.bat
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/bin/gravitee.bat
@@ -34,6 +34,20 @@ for /f %%i in ('dir ..\lib\gravitee-am-gateway-standalone-bootstrap-*.jar /s /b'
 
 set GRAVITEE_BOOT_CLASSPATH=%runjar%
 
+REM enable skip Xms and Xmx to use percentage of resources
+if "%GIO_DISABLE_STARTING_MEMORY%" == "" (
+    if "%GIO_MIN_MEM%" == "" (
+    set GIO_MIN_MEM=256m
+    )
+
+    if "%GIO_MAX_MEM%" == "" (
+    set GIO_MAX_MEM=256m
+    )
+
+    REM min and max heap sizes should be set to the same value to avoid
+    REM stop-the-world GC pauses during resize
+    set JAVA_OPTS=%JAVA_OPTS% -Xms%GIO_MIN_MEM% -Xmx%GIO_MAX_MEM%
+)
 
 # Display our environment
 echo "========================================================================="

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -62,11 +62,19 @@ if [ ! -f "$runjar" ]; then
 fi
 GRAVITEE_BOOT_CLASSPATH="$runjar"
 
-if [ "x$GIO_MIN_MEM" = "x" ]; then
-    GIO_MIN_MEM=256m
-fi
-if [ "x$GIO_MAX_MEM" = "x" ]; then
-    GIO_MAX_MEM=256m
+# enable skip Xms and Xmx to use percentage of resources in k8s
+if [ "x$GIO_DISABLE_STARTING_MEMORY" = "x" ]; then
+  if [ "x$GIO_MIN_MEM" = "x" ]; then
+      GIO_MIN_MEM=256m
+  fi
+  if [ "x$GIO_MAX_MEM" = "x" ]; then
+      GIO_MAX_MEM=256m
+  fi
+
+  # min and max heap sizes should be set to the same value to avoid
+  # stop-the-world GC pauses during resize
+  JAVA_OPTS="$JAVA_OPTS -Xms${GIO_MIN_MEM}"
+  JAVA_OPTS="$JAVA_OPTS -Xmx${GIO_MAX_MEM}"
 fi
 
 # min and max heap sizes should be set to the same value to avoid

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee.bat
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/bin/gravitee.bat
@@ -34,6 +34,20 @@ for /f %%i in ('dir ..\lib\gravitee-am-management-api-standalone-bootstrap-*.jar
 
 set GRAVITEE_BOOT_CLASSPATH=%runjar%
 
+REM enable skip Xms and Xmx to use percentage of resources
+if "%GIO_DISABLE_STARTING_MEMORY%" == "" (
+    if "%GIO_MIN_MEM%" == "" (
+    set GIO_MIN_MEM=256m
+    )
+
+    if "%GIO_MAX_MEM%" == "" (
+    set GIO_MAX_MEM=256m
+    )
+
+    REM min and max heap sizes should be set to the same value to avoid
+    REM stop-the-world GC pauses during resize
+    set JAVA_OPTS=%JAVA_OPTS% -Xms%GIO_MIN_MEM% -Xmx%GIO_MAX_MEM%
+)
 
 # Display our environment
 echo "========================================================================="


### PR DESCRIPTION
This PR standardizes Java memory configuration across all products. It was enabled a few months ago on APIM but not yet on the other products.

https://gravitee.atlassian.net/browse/AE-143