### PR TITLE
fix: introduce batchSize a configuration parameter for mongo reporter

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/user/MongoUserProvider.java
@@ -68,7 +68,7 @@ public class MongoUserProvider extends MongoAbstractProvider implements UserProv
 
     private MongoCollection<Document> usersCollection;
 
-    @Value("${management.mongodb.ensureIndexOnStart:true}")
+    @Value("${repositories.management.mongodb.ensureIndexOnStart:${management.mongodb.ensureIndexOnStart:true}}")
     private boolean ensureIndexOnStart;
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractManagementMongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/AbstractManagementMongoRepository.java
@@ -54,10 +54,10 @@ public abstract class AbstractManagementMongoRepository extends AbstractMongoRep
     @Qualifier("managementMongoTemplate")
     protected MongoDatabase mongoOperations;
 
-    @Value("${management.mongodb.ensureIndexOnStart:true}")
+    @Value("${repositories.management.mongodb.ensureIndexOnStart:${management.mongodb.ensureIndexOnStart:true}}")
     protected boolean ensureIndexOnStart;
 
-    @Value("${management.mongodb.cursorMaxTime:60000}")
+    @Value("${repositories.management.mongodb.cursorMaxTime:${management.mongodb.cursorMaxTime:60000}}")
     protected int cursorMaxTimeInMs;
 
     protected void createIndex(MongoCollection<?> collection, Map<Document, IndexOptions> indexes) {


### PR DESCRIPTION
This fix introduces batchSize a configuration parameter for mongo reporter

It also adapt the existing settings related to the management repository scope to read the new format first then fallback to the legacy settings

fixes AM-5683

## How to test:

* start MAPI with a timeout of 4 minutes

``` 
repositories:
  system-cluster: management
  management:
    type: mongodb
    mongodb:
      dbname: ${ds.mongodb.dbname}
      host: ${ds.mongodb.host}
      port: ${ds.mongodb.port}
      cursorMaxTime: 240000
      socketTimeout: 240000
```

* Create a domain and generate few audits (ex: "user login" or "token created")
* duplicate the audit using mongosh script (the doc need to be adapt to your domain)

```

// --- Configuration ---
const dbName = "gravitee-am";

// --- NEED TO BE ADAPTED
// --- you can replace 39c8f1e4-8af2-47ed-88f1-e48af277ede7 by your domainId in all this script
const collectionName = "reporter_audits_39c8f1e4-8af2-47ed-88f1-e48af277ede7";


// Paramètres d'insertion
const N = 50_000_000;
const BATCH_SIZE = 1000;


// --- Connexion et Sélection ---
// En MongoDB Shell, la connexion est gérée par défaut.
// On sélectionne la base de données et la collection.
const db = db.getSiblingDB(dbName);
const collection = db.getCollection(collectionName);


// --- Préparation des dates ---
const endDate = new Date();
// Calcule la date de début il y a 90 jours.
const startDate = new Date(endDate.getTime() - 90 * 24 * 60 * 60 * 1000);


// Calcule l'intervalle de temps en millisecondes entre chaque document
const deltaPerDoc = (endDate.getTime() - startDate.getTime()) / N;


// --- Logique d'insertion ---
let docsBatch = [];
let progressCounter = 0;


console.log(`Début de l'insertion de ${N} documents dans la collection ${collectionName}...`);
console.log(`Insertion par lots de ${BATCH_SIZE} documents.`);


// Boucle principale pour générer et insérer les documents
for (let i = 0; i < N; i++) {
   // Calcule le timestamp pour le document en cours
   const currentTimestamp = new Date(startDate.getTime() + i * deltaPerDoc);


   // Génère le document en utilisant la structure fournie dans le script Python
   const doc =     {
   "_id":  `6e5c28b0-cf21-4672-9c28-b0cf21867292c2-${i}`,
   "accessPoint": {
       "alternativeId": "oidc",
       "displayName": "oidc",
       "id": "4b383caa-def0-4bac-b83c-aadef0bbac28"
   },
   "actor": {
       "alternativeId": "oidc",
       "attributes": {},
       "displayName": "oidc",
       "id": "4b383caa-def0-4bac-b83c-aadef0bbac28",
       "referenceId": "39c8f1e4-8af2-47ed-88f1-e48af277ede7",
       "referenceType": "DOMAIN",
       "type": "APPLICATION"
   },
   "outcome": {
       "message": "[{\"op\":\"add\",\"path\":\"/ACCESS_TOKEN\",\"value\":\"uE8fEdITuWk4paQ0mh7_RKbOBhb9SM_91_mFJPbJaQU\"},{\"op\":\"add\",\"path\":\"/ID_TOKEN\",\"value\":\"Delivered for sub 'af367acf-21f1-4358-b67a-cf21f1f358da'\"},{\"op\":\"add\",\"path\":\"/grant_type\",\"value\":\"authorization_code\"},{\"op\":\"add\",\"path\":\"/scope\",\"value\":\"openid profile email\"}]",
       "status": "SUCCESS"
   },
   "referenceId": "39c8f1e4-8af2-47ed-88f1-e48af277ede7",
   "referenceType": "DOMAIN",
   "target": {
       "alternativeId": "user01",
       "attributes": {
       "sourceId": "default-idp-39c8f1e4-8af2-47ed-88f1-e48af277ede7",
       "externalId": "28b7fe07-ad9a-404b-b7fe-07ad9a104bc1",
       "accessTokenSubject": "aa883a96-2d8b-3f5a-8458-b879ecce87e2"
       },
       "displayName": "user01 use01",
       "id": "af367acf-21f1-4358-b67a-cf21f1f358da",
       "referenceId": "39c8f1e4-8af2-47ed-88f1-e48af277ede7",
       "referenceType": "DOMAIN",
       "type": "USER"
   },
   "timestamp": currentTimestamp,
   "transactionId": "5767f6a7-9805-4a6a-a7f6-a798052a6a8e",
   "type": "TOKEN_CREATED"
   };
   docsBatch.push(doc);


   // Si la taille du lot est atteinte, insère les documents.
   if (docsBatch.length >= BATCH_SIZE) {
       collection.insertMany(docsBatch);
       docsBatch = [];
   }


   // Affiche la progression
   if (i % 10000 === 0) {
       console.log(`Inséré ${i} documents...`);
   }
}


// Insère les documents restants dans le dernier lot
if (docsBatch.length > 0) {
   collection.insertMany(docsBatch);
}


console.log("Terminé !");


```


* once the script created all the records, go to the audit view
* select 90 days
* go to the last page of the tab
* the result should be displayed after 2-3minutes and Mongo should remains active

