### PR TITLE
Am 5573 sanitise redirect

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/utils/RedirectUtils.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/utils/RedirectUtils.java
@@ -55,4 +55,43 @@ public class RedirectUtils {
         }
         return builder;
     }
+
+    /**
+     * Builds a redirect URL by combining a base URI and a redirect path.
+     * Handles trailing slashes properly to prevent double slashes which are rejected by Jetty.
+     * 
+     * @param redirectUri the base URI (may have trailing slashes)
+     * @param redirectPath the path to append (may or may not start with slash)
+     * @return the properly formatted redirect URL
+     */
+    public static String buildCockpitRedirectUrl(String redirectUri, String redirectPath) {
+        if (redirectUri == null) {
+            return redirectPath;
+        }
+        
+        try {
+            UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(redirectUri);
+            
+            // Remove trailing slashes from the base path
+            String basePath = builder.build().getPath();
+            if (basePath != null && basePath.endsWith("/")) {
+                builder.replacePath(basePath.replaceAll("/+$", ""));
+            }
+            
+            // Add the redirect path
+            if (redirectPath != null && !redirectPath.isEmpty()) {
+                if (!redirectPath.startsWith("/")) {
+                    redirectPath = "/" + redirectPath;
+                }
+                builder.path(redirectPath);
+            }
+            
+            return builder.build().toUriString();
+        } catch (Exception e) {
+            // Fallback to simple concatenation if UriComponentsBuilder fails
+            return redirectUri.replaceAll("/+$", "") + 
+                   (redirectPath != null && !redirectPath.isEmpty() && !redirectPath.startsWith("/") ? "/" : "") + 
+                   redirectPath;
+        }
+    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/utils/RedirectUtils.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/utils/RedirectUtils.java
@@ -75,7 +75,7 @@ public class RedirectUtils {
             // Remove trailing slashes from the base path
             String basePath = builder.build().getPath();
             if (basePath != null && basePath.endsWith("/")) {
-                builder.replacePath(basePath.replaceAll("/+$", ""));
+                builder.replacePath(removeTrailingSlashes(basePath));
             }
             
             // Add the redirect path
@@ -89,9 +89,22 @@ public class RedirectUtils {
             return builder.build().toUriString();
         } catch (Exception e) {
             // Fallback to simple concatenation if UriComponentsBuilder fails
-            return redirectUri.replaceAll("/+$", "") + 
+            return removeTrailingSlashes(redirectUri) + 
                    (redirectPath != null && !redirectPath.isEmpty() && !redirectPath.startsWith("/") ? "/" : "") + 
                    redirectPath;
         }
+    }
+
+    private static String removeTrailingSlashes(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+        
+        int end = input.length();
+        while (end > 0 && input.charAt(end - 1) == '/') {
+            end--;
+        }
+        
+        return end == input.length() ? input : input.substring(0, end);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/utils/RedirectUtilsTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/utils/RedirectUtilsTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.utils;
+
+import io.gravitee.am.management.handlers.management.api.utils.RedirectUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class RedirectUtilsTest {
+
+    @Test
+    public void testBuildRedirectUrl_redirectUriWithTrailingSlash() {
+        // Test case: redirect_uri ends with slash, should be handled properly
+        String result = RedirectUtils.buildCockpitRedirectUrl("https://example.com/", "/environments/env1");
+        assertEquals("https://example.com/environments/env1", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_redirectUriWithoutTrailingSlash() {
+        // Test case: redirect_uri doesn't end with slash, should work normally
+        String result = RedirectUtils.buildCockpitRedirectUrl("https://example.com", "/environments/env1");
+        assertEquals("https://example.com/environments/env1", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_complexUrlWithTrailingSlash() {
+        // Test case: complex URL with path and trailing slash
+        String result = RedirectUtils.buildCockpitRedirectUrl("https://subdomain.example.com:8080/path/", "/environments/env1");
+        assertEquals("https://subdomain.example.com:8080/path/environments/env1", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_multipleTrailingSlashes() {
+        // Test case: redirect_uri has multiple trailing slashes
+        String result = RedirectUtils.buildCockpitRedirectUrl("https://example.com///", "/environments/env1");
+        assertEquals("https://example.com/environments/env1", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_redirectPathWithoutLeadingSlash() {
+        // Test case: redirectPath doesn't start with slash (should be added)
+        String result = RedirectUtils.buildCockpitRedirectUrl("https://example.com", "environments/env1");
+        assertEquals("https://example.com/environments/env1", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_redirectPathWithLeadingSlash() {
+        // Test case: redirectPath already starts with slash
+        String result = RedirectUtils.buildCockpitRedirectUrl("https://example.com", "/environments/env1");
+        assertEquals("https://example.com/environments/env1", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_emptyRedirectPath() {
+        // Test case: empty redirectPath
+        String result = RedirectUtils.buildCockpitRedirectUrl("https://example.com/", "");
+        assertEquals("https://example.com", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_nullRedirectUri() {
+        // Test case: null redirectUri should return redirectPath
+        String result = RedirectUtils.buildCockpitRedirectUrl(null, "/environments/env1");
+        assertEquals("/environments/env1", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_nullRedirectUriAndEmptyPath() {
+        // Test case: null redirectUri and empty path
+        String result = RedirectUtils.buildCockpitRedirectUrl(null, "");
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testBuildRedirectUrl_redirectPathWithoutLeadingSlashAndEmptyBase() {
+        // Test case: redirectPath without leading slash and base URI without trailing slash
+        String result = RedirectUtils.buildCockpitRedirectUrl("https://example.com", "environments/env1");
+        assertEquals("https://example.com/environments/env1", result);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/adapter/HelloCommandAdapter.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/adapter/HelloCommandAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.service.impl.adapter;
 
+import com.google.common.base.Strings;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.service.InstallationService;
@@ -78,10 +79,18 @@ public class HelloCommandAdapter implements CommandAdapter<io.gravitee.exchange.
                             .defaultOrganizationId(Organization.DEFAULT)
                             .defaultEnvironmentId(Environment.DEFAULT);
                     Map<String, String> additionalInformation = new HashMap<>(installation.getAdditionalInformation());
-                    additionalInformation.put(API_URL, apiURL);
-                    additionalInformation.put(UI_URL, uiURL);
+                    additionalInformation.put(API_URL, sanitizeUrl(apiURL));
+                    additionalInformation.put(UI_URL, sanitizeUrl(uiURL));
                     payloadBuilder.additionalInformation(additionalInformation);
                     return new HelloCommand(payloadBuilder.build());
                 });
+    }
+
+    private static String sanitizeUrl(String url) {
+        if (Strings.isNullOrEmpty(url)) {
+            return null;
+        }
+
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
fixes: AM-5573

## :pencil2: A description of the changes proposed in the pull request
This pull request improves the handling of URL concatenation and sanitization throughout the authentication and service layers, specifically addressing issues with trailing slashes that could cause malformed URLs or Jetty rejections. It introduces a new utility method for building redirect URLs safely, applies this method in authentication flows, and ensures URLs are sanitized before being sent in payloads. Comprehensive unit tests have also been added to verify these changes.

**Redirect URL handling and sanitization:**

* Added `RedirectUtils.buildCockpitRedirectUrl` to safely combine a base URI and redirect path, removing trailing slashes and preventing double slashes in redirect URLs. This method is now used in `CockpitAuthenticationFilter` to construct redirect URLs. [[1]](diffhunk://#diff-c446df1f5a7f3c0f7fbaa00f75b1814e298bede6e5c406d003111896aadb5252R58-R96) [[2]](diffhunk://#diff-24379310eb1532888be291f691e1f92a22d3e885df6b13766d8d810f7e92301dR27) [[3]](diffhunk://#diff-24379310eb1532888be291f691e1f92a22d3e885df6b13766d8d810f7e92301dL143-R148)
* Updated `CockpitAuthenticationFilter` to use the new utility method for building redirect URLs, ensuring correct formatting and avoiding Jetty errors.

**Service payload URL sanitization:**

* Introduced `sanitizeUrl` in `HelloCommandAdapter` to remove trailing slashes from `apiURL` and `uiURL` before including them in the `additionalInformation` payload. [[1]](diffhunk://#diff-6b13d7064f01263ab60ca9261d628bf63d0b7bd8b01cf4f7c0f54578dd5515b2L81-R95) [[2]](diffhunk://#diff-6b13d7064f01263ab60ca9261d628bf63d0b7bd8b01cf4f7c0f54578dd5515b2R18)

**Testing improvements:**

* Added comprehensive unit tests for `RedirectUtils.buildCockpitRedirectUrl` covering various edge cases with trailing slashes and empty/null values.
* Enhanced `HelloCommandAdapterTest` to verify that URLs with trailing slashes are properly sanitized in the payload. [[1]](diffhunk://#diff-b20b30259be1130c7d1e82195c354cdab314e8dfa1154de5d59ba44d5635d505R109-R135) [[2]](diffhunk://#diff-b20b30259be1130c7d1e82195c354cdab314e8dfa1154de5d59ba44d5635d505L35-R35)

## :memo: Test scenarios 

Set the env vars for your local AM instance to reproduce the error:
```
<env name="console_ui_url" value="http://localhost:4200/" />
<env name="console_api_url" value="http://localhost:8093/management" />
```

Log into cockpit and follow the steps to create a new linked installation to your local AM instance

Once the installation has been verified, go to topology and click Login to Access Management:

<img width="1578" height="273" alt="image" src="https://github.com/user-attachments/assets/7b26da87-342d-4d58-bca2-ea40248fd941" />

Now that the issue is fixed it should successfully login and redirect you to the environment dashboard

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

