### PR TITLE
fix: do not propagate the IDP exception when the user aborted the aut…

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/exception/authentication/UserAuthenticationAbortedException.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/exception/authentication/UserAuthenticationAbortedException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.exception.authentication;
+
+/**
+ * @author Eric Leleu (eric.leleu@graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UserAuthenticationAbortedException extends AuthenticationException{
+
+    final String errorCode;
+
+    public UserAuthenticationAbortedException(String error, String description) {
+        super(description);
+        errorCode = error;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return "access_denied";
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackFailureHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginCallbackFailureHandler.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.root.resources.handler.login;
 
 import io.gravitee.am.common.exception.authentication.AuthenticationException;
+import io.gravitee.am.common.exception.authentication.UserAuthenticationAbortedException;
 import io.gravitee.am.common.exception.oauth2.OAuth2Exception;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.oauth2.Parameters;
@@ -286,15 +287,17 @@ public class LoginCallbackFailureHandler extends LoginAbstractHandler {
             params.setAll(originalParams);
         }
         params.set(Parameters.CLIENT_ID, client.getClientId());
-        params.set(ConstantKeys.ERROR_PARAM_KEY, "social_authentication_failed");
-        String errorDescription = encodeURIComponent(throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage());
-        params.set(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, errorDescription);
 
-        String toHash = "social_authentication_failed" + "$" + errorDescription;
-        if (context.session() != null) {
-            context.session().put(ERROR_HASH, HashUtil.generateSHA256(toHash));
+        if (!(throwable instanceof UserAuthenticationAbortedException)) {
+            params.set(ConstantKeys.ERROR_PARAM_KEY, "social_authentication_failed");
+            String errorDescription = encodeURIComponent(throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage());
+            params.set(ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY, errorDescription);
+
+            String toHash = "social_authentication_failed" + "$" + errorDescription;
+            if (context.session() != null) {
+                context.session().put(ERROR_HASH, HashUtil.generateSHA256(toHash));
+            }
         }
-
 
         String uri = getUri(context, params);
         closeRemoteSessionAndRedirect(context, authentication, uri);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSocialAuthenticationHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSocialAuthenticationHandler.java
@@ -146,12 +146,13 @@ public class LoginSocialAuthenticationHandler implements Handler<RoutingContext>
     private void enhanceSocialIdentityProviders(List<IdentityProvider> identityProviders, RoutingContext context, Handler<AsyncResult<List<SocialProviderData>>> resultHandler) {
         Observable.fromIterable(identityProviders)
                 .flatMapSingle(identityProvider -> {
+                    IdentityProvider providerCopy = new IdentityProvider(identityProvider);
                     // get social identity provider type (currently use for display purpose (logo, description, ...)
-                    identityProvider.setType(socialProviders.getOrDefault(identityProvider.getType(), identityProvider.getType()));
+                    providerCopy.setType(socialProviders.getOrDefault(identityProvider.getType(), identityProvider.getType()));
                     // get social sign in url
-                    return getAuthorizeUrl(identityProvider.getId(), context)
-                            .map(authorizeUrl -> new SocialProviderData(identityProvider, authorizeUrl))
-                            .defaultIfEmpty(new SocialProviderData(identityProvider, null));
+                    return getAuthorizeUrl(providerCopy.getId(), context)
+                            .map(authorizeUrl -> new SocialProviderData(providerCopy, authorizeUrl))
+                            .defaultIfEmpty(new SocialProviderData(providerCopy, null));
                 })
                 .toList()
                 .subscribe(socialProviderData -> resultHandler.handle(Future.succeededFuture(socialProviderData)),

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/auth/provider/SocialAuthenticationProviderTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/auth/provider/SocialAuthenticationProviderTest.java
@@ -18,10 +18,12 @@ package io.gravitee.am.gateway.handler.root.resources.auth.provider;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.exception.authentication.BadCredentialsException;
 import io.gravitee.am.common.exception.authentication.LoginCallbackFailedException;
+import io.gravitee.am.common.exception.authentication.UserAuthenticationAbortedException;
 import io.gravitee.am.gateway.handler.common.auth.event.AuthenticationEvent;
 import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
 import io.gravitee.am.gateway.handler.common.auth.user.EndUserAuthentication;
 import io.gravitee.am.gateway.handler.common.auth.user.UserAuthenticationManager;
+import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.identityprovider.api.social.CloseSessionMode;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.User;
@@ -33,6 +35,8 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.ext.web.RoutingContext;
+import lombok.Getter;
+import lombok.Setter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,11 +51,20 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static io.gravitee.am.common.utils.ConstantKeys.ERROR_DESCRIPTION_PARAM_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.ERROR_PARAM_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.ID_TOKEN_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.OIDC_PROVIDER_ID_TOKEN_KEY;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -111,13 +124,16 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertNotNull(userAsyncResult.result());
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNotNull(asyncResult.result);
         verify(userAuthenticationManager, times(1)).connect(any(), any(), any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.SUCCESS), any());
     }
@@ -153,13 +169,17 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertNotNull(userAsyncResult.result());
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertFalse(asyncResult.isFailed());
         verify(userAuthenticationManager, times(1)).connect(any(), any(), any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.SUCCESS), any());
     }
@@ -208,13 +228,17 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertNotNull(userAsyncResult.result());
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertFalse(asyncResult.isFailed());
         verify(userAuthenticationManager, times(1)).connect(any(), any(), any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.SUCCESS), any());
         verify(routingContext, keepAlive == CloseSessionMode.KEEP_ACTIVE ? never() : times(1)).put(OIDC_PROVIDER_ID_TOKEN_KEY, "idp_id_token_value");
@@ -251,13 +275,17 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertNotNull(userAsyncResult.result());
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertFalse(asyncResult.isFailed());
         verify(userAuthenticationManager, times(1)).connect(any(), any(), any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.SUCCESS), any());
     }
@@ -293,13 +321,16 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
-        authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
-            latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertNotNull(userAsyncResult.result());
-        });
 
+        Result asyncResult = new Result();
+        authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
+            latch.countDown();
+        });
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertFalse(asyncResult.isFailed());
         verify(userAuthenticationManager, times(1)).connect(any(), any(), any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.SUCCESS), any());
     }
@@ -322,14 +353,127 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertTrue(userAsyncResult.failed());
-            Assert.assertTrue(userAsyncResult.cause() instanceof BadCredentialsException);
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertTrue(asyncResult.isFailed());
+        Assert.assertTrue(asyncResult.getCause() instanceof BadCredentialsException);
+        verify(userAuthenticationManager, never()).connect(any());
+        verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.FAILURE), any());
+    }
+
+    @Test
+    public void shouldNotAuthenticateUser_errorParameter() throws Exception {
+        JsonObject credentials = new JsonObject();
+        credentials.put("username", "my-user-id");
+        credentials.put("password", "my-user-password");
+        credentials.put("provider", "idp");
+
+        Client client = new Client();
+
+        when(authenticationProvider.loadUserByUsername(any(EndUserAuthentication.class))).thenReturn(Maybe.just(new DefaultUser("my-user-id")));
+        when(routingContext.get("client")).thenReturn(client);
+        when(routingContext.get("provider")).thenReturn(authenticationProvider);
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        final io.vertx.core.http.HttpServerRequest delegateRequest = mock(io.vertx.core.http.HttpServerRequest.class);
+        when(httpServerRequest.getDelegate()).thenReturn(delegateRequest);
+        when(httpServerRequest.getParam(ERROR_PARAM_KEY)).thenReturn("login_required");
+        when(delegateRequest.method()).thenReturn(HttpMethod.POST);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        Result asyncResult = new Result();
+        authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
+            latch.countDown();
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertTrue(asyncResult.isFailed());
+        Assert.assertTrue(asyncResult.getCause() instanceof BadCredentialsException && asyncResult.getCause().getMessage().contains("login_required"));
+        verify(userAuthenticationManager, never()).connect(any());
+        verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.FAILURE), any());
+    }
+
+    @Test
+    public void shouldNotAuthenticateUser_errorParameter_access_denied_User_auth_aborted_franceConnect() throws Exception {
+        JsonObject credentials = new JsonObject();
+        credentials.put("username", "my-user-id");
+        credentials.put("password", "my-user-password");
+        credentials.put("provider", "idp");
+
+        Client client = new Client();
+
+        when(authenticationProvider.loadUserByUsername(any(EndUserAuthentication.class))).thenReturn(Maybe.just(new DefaultUser("my-user-id")));
+        when(routingContext.get("client")).thenReturn(client);
+        when(routingContext.get("provider")).thenReturn(authenticationProvider);
+        IdentityProvider mockIdp = mock(IdentityProvider.class);
+        when(mockIdp.getType()).thenReturn("franceconnect-am-idp");
+        when(identityProviderManager.getIdentityProvider(any())).thenReturn(mockIdp);
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        final io.vertx.core.http.HttpServerRequest delegateRequest = mock(io.vertx.core.http.HttpServerRequest.class);
+        when(httpServerRequest.getDelegate()).thenReturn(delegateRequest);
+        when(httpServerRequest.getParam(ERROR_PARAM_KEY)).thenReturn("access_denied");
+        when(httpServerRequest.getParam(ERROR_DESCRIPTION_PARAM_KEY)).thenReturn("User auth aborted");
+        when(delegateRequest.method()).thenReturn(HttpMethod.POST);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
+        authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+                asyncResult.setFailed(userAsyncResult.failed());
+                asyncResult.setCause(userAsyncResult.cause());
+                latch.countDown();
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertTrue(asyncResult.isFailed());
+        Assert.assertTrue(asyncResult.getCause() instanceof UserAuthenticationAbortedException);
+        verify(userAuthenticationManager, never()).connect(any());
+        verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.FAILURE), any());
+    }
+
+    @Test
+    public void shouldNotAuthenticateUser_errorParameter_access_denied_User_auth_aborted_noFranceConnect() throws Exception {
+        JsonObject credentials = new JsonObject();
+        credentials.put("username", "my-user-id");
+        credentials.put("password", "my-user-password");
+        credentials.put("provider", "idp");
+
+        Client client = new Client();
+
+        when(authenticationProvider.loadUserByUsername(any(EndUserAuthentication.class))).thenReturn(Maybe.just(new DefaultUser("my-user-id")));
+        when(routingContext.get("client")).thenReturn(client);
+        when(routingContext.get("provider")).thenReturn(authenticationProvider);
+        IdentityProvider mockIdp = mock(IdentityProvider.class);
+        when(mockIdp.getType()).thenReturn("unknown-am-idp");
+        when(identityProviderManager.getIdentityProvider(any())).thenReturn(mockIdp);
+        when(routingContext.request()).thenReturn(httpServerRequest);
+        final io.vertx.core.http.HttpServerRequest delegateRequest = mock(io.vertx.core.http.HttpServerRequest.class);
+        when(httpServerRequest.getDelegate()).thenReturn(delegateRequest);
+        when(httpServerRequest.getParam(ERROR_PARAM_KEY)).thenReturn("access_denied");
+        when(httpServerRequest.getParam(ERROR_DESCRIPTION_PARAM_KEY)).thenReturn("User auth aborted");
+        when(delegateRequest.method()).thenReturn(HttpMethod.POST);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
+        authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+                asyncResult.setFailed(userAsyncResult.failed());
+                asyncResult.setCause(userAsyncResult.cause());
+                latch.countDown();
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertTrue(asyncResult.isFailed());
+        Assert.assertTrue(asyncResult.getCause() instanceof BadCredentialsException);
         verify(userAuthenticationManager, never()).connect(any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.FAILURE), any());
     }
@@ -352,14 +496,17 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertTrue(userAsyncResult.failed());
-            Assert.assertTrue(userAsyncResult.cause() instanceof BadCredentialsException);
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertTrue(asyncResult.isFailed());
+        Assert.assertTrue(asyncResult.getCause() instanceof BadCredentialsException);
         verify(userAuthenticationManager, never()).connect(any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.FAILURE), any());
     }
@@ -391,13 +538,17 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertTrue(userAsyncResult.succeeded());
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertFalse(asyncResult.isFailed());
         verify(userAuthenticationManager).connect(any(), any(), any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.SUCCESS), any());
     }
@@ -428,13 +579,16 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertTrue(userAsyncResult.succeeded());
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertFalse(asyncResult.isFailed());
         verify(userAuthenticationManager).connect(any(), any(), any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.SUCCESS), any());
     }
@@ -467,13 +621,16 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertTrue(userAsyncResult.succeeded());
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertFalse(asyncResult.isFailed());
         verify(userAuthenticationManager).connect(any(), any(), any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.SUCCESS), any());
     }
@@ -505,14 +662,17 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertTrue(userAsyncResult.failed());
-            Assert.assertTrue(userAsyncResult.cause() instanceof LoginCallbackFailedException);
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertTrue(asyncResult.isFailed());
+        Assert.assertTrue(asyncResult.getCause() instanceof LoginCallbackFailedException);
         verify(userAuthenticationManager, never()).connect(any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.FAILURE), any());
     }
@@ -544,14 +704,16 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertTrue(userAsyncResult.failed());
-            Assert.assertTrue(userAsyncResult.cause() instanceof LoginCallbackFailedException);
         });
-
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assert.assertTrue(asyncResult.isFailed());
+        Assert.assertTrue(asyncResult.getCause() instanceof LoginCallbackFailedException);
         verify(userAuthenticationManager, never()).connect(any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.FAILURE), any());
     }
@@ -582,15 +744,27 @@ public class SocialAuthenticationProviderTest {
         when(delegateRequest.method()).thenReturn(HttpMethod.POST);
 
         CountDownLatch latch = new CountDownLatch(1);
+        Result asyncResult = new Result();
         authProvider.authenticate(routingContext, credentials, userAsyncResult -> {
+            asyncResult.setFailed(userAsyncResult.failed());
+            asyncResult.setCause(userAsyncResult.cause());
+            asyncResult.setResult(userAsyncResult.result());
             latch.countDown();
-            Assert.assertNotNull(userAsyncResult);
-            Assert.assertTrue(userAsyncResult.failed());
-            Assert.assertTrue(userAsyncResult.cause() instanceof LoginCallbackFailedException);
         });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+        Assert.assertTrue(asyncResult.isFailed());
+        Assert.assertTrue(asyncResult.getCause() instanceof LoginCallbackFailedException);
         verify(userAuthenticationManager, never()).connect(any());
         verify(eventManager).publishEvent(argThat(evt -> evt == AuthenticationEvent.FAILURE), any());
+    }
+
+    @Setter
+    @Getter
+    private static class Result {
+        boolean failed;
+        Throwable cause;
+        io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User result;
     }
 }


### PR DESCRIPTION
…hentication

fixes AM-5491

# Description

The purpose of this PR is to not display the error message on the Login page when a user abort the login with FranceConnect. The abort button on FC callback AM with an "access_denied" error and error _description "user auth aborted", as there is an error parameter AM propagate a generic error on the Login page but in this specific case the has been interrupted by the user.

This PR doesn't implement the ideal solution where the IDP Plugin is able to interpret the error as this solution will required changes in the IdenttyProvider interface and brings a BreakingChange for each IDP plugin.

A improvement will have to be manage in a future feature version to manage this case in a clean way.