### PR TITLE
fix: helm session timeout value

### DIFF
--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -28,7 +28,7 @@ data:
         {{- if .Values.gateway.http.cookie.session }}
         session:
           name: {{ .Values.gateway.http.cookie.session.name | default "GRAVITEE_IO_AM_SESSION" }}
-          timeout: {{ .Values.gateway.http.cookie.session.timeout | default 1800000 }}
+          timeout: {{ .Values.gateway.http.cookie.session.timeout | default 1800000 | int }}
         {{- end }}
     {{- end }}
     {{- if .Values.gateway.http.csrf }}

--- a/helm/tests/gateway/configmap_http_test.yaml
+++ b/helm/tests/gateway/configmap_http_test.yaml
@@ -248,3 +248,32 @@ tests:
                   password: "t0pS3cre7"
                   secret: secret_pkcs12
                   watch: true
+  - it: Should render session timeout as integer not scientific notation
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        http:
+          cookie:
+            secure: false
+            sameSite: Lax
+            session:
+              name: session-gravitee
+              timeout: 1800000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            http:
+              cookie:
+                secure: false
+                sameSite: Lax
+                session:
+                  name: session-gravitee
+                  timeout: 1800000
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: "1\\.8e\\+06"


### PR DESCRIPTION
Fixes AM-5715
How to test:
Just generate helm template with gravitee.http.cookie.session.timeout: 12345678