### PR TITLE
fix: AM-5712 gauge chart widget percentage rounding

### DIFF
--- a/gravitee-am-ui/src/app/components/widget/chart-gauge/widget-chart-gauge.component.ts
+++ b/gravitee-am-ui/src/app/components/widget/chart-gauge/widget-chart-gauge.component.ts
@@ -42,7 +42,7 @@ export class WidgetChartGaugeComponent implements OnChanges {
           ? `<div style="text-align: center;"><p>No data to display</p></div>`
           : `<div style="text-align: center;">
           <p>${title}</p>
-          <p>${percentage}: % <small style="font-size: 65%">(${current}/${max})</small></p>
+          <p>${percentage.toFixed(1)}% <small style="font-size: 65%">(${current}/${max})</small></p>
          </div>`;
       this.chartOptions = {
         title: {


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-5712](https://gravitee.atlassian.net/browse/AM-5712)

## :pencil2: A description of the changes proposed in the pull request
Update formatting of title/label used in the gauge chart component (as used by the _User registration_ chart on the dashboard):
- round percentage to one decimal place
- remove extraneous colon and space

## :memo: Test scenarios 
- Create multiple pre-registered users in AM, optionally completing the registration of some
- Navigate to the dashboard

## :computer: Add screenshots for UI

### Before
<img width="591" height="496" alt="image" src="https://github.com/user-attachments/assets/72b707c5-d9b7-473b-a501-985a934f1de7" />

### After
<img width="590" height="495" alt="image" src="https://github.com/user-attachments/assets/e385f7c5-dc4a-4502-ae81-f30be56b75e7" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am