### PR TITLE
fix: use tokenRequest HttpResponse instead of generate a new one

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/token/TokenEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/token/TokenEndpoint.java
@@ -87,11 +87,7 @@ public class TokenEndpoint implements Handler<RoutingContext> {
             tokenRequest.setConfirmationMethodX5S256(context.get(ConstantKeys.PEER_CERTIFICATE_THUMBPRINT));
         }
 
-        io.vertx.core.http.HttpServerRequest request = context.request().getDelegate();
-        Request serverRequest = new VertxHttpServerRequest(request);
-        Response serverResponse = new VertxHttpServerResponse(request, serverRequest.metrics());
-
-        tokenGranter.grant(tokenRequest, serverResponse, client)
+        tokenGranter.grant(tokenRequest, tokenRequest.getHttpResponse(), client)
                 .subscribe(accessToken -> context.response()
                         .putHeader(HttpHeaders.CACHE_CONTROL, "no-store")
                         .putHeader(HttpHeaders.PRAGMA, "no-cache")


### PR DESCRIPTION
fixes AM-5744

# description

This is a minor optimization to avoid useless object creation.