### PR TITLE
fix: add warn log on enrichAuthFlowContext policy

### DIFF
--- a/gravitee-am-policy/gravitee-am-policy-enrich-auth-flow/src/main/java/io/gravitee/am/policy/enrich/auth/EnrichAuthFlowPolicy.java
+++ b/gravitee-am-policy/gravitee-am-policy-enrich-auth-flow/src/main/java/io/gravitee/am/policy/enrich/auth/EnrichAuthFlowPolicy.java
@@ -71,7 +71,10 @@ public class EnrichAuthFlowPolicy {
                 enrichAuthFlowContext(context)
                         .subscribe(
                                 success -> policyChain.doNext(request, response),
-                                error -> policyChain.failWith(PolicyResult.failure(GATEWAY_POLICY_ENRICH_AUTH_FLOW_ERROR_KEY, error.getMessage()))
+                                error -> {
+                                    LOGGER.warn("An error occurs while enriching authentication flow context", error);
+                                    policyChain.failWith(PolicyResult.failure(GATEWAY_POLICY_ENRICH_AUTH_FLOW_ERROR_KEY, error.getMessage()));
+                                }
                         );
             }
         } else {


### PR DESCRIPTION
fixes AM-5739

## Description

Addition of warning log when the EnrichAuthFlowContext fails due to repository error.
This is useful to debug in production as the PolicyChain wrap the Exception in a PolicyChainException as if the policy return a failure result. As policyChainException are logged with debug level in the FailureHandler, we have to manage this specific case inside the policies.