### PR TITLE
AM-5459: set datasource as highest precedence in mongo provider

### DIFF
--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
@@ -87,6 +87,11 @@ public abstract class MongoAbstractProvider implements InitializingBean {
     }
 
     private ClientWrapper<MongoClient> buildClientWrapper(Scope scope) {
+        // Datasource takes precedence over everything else
+        if (shouldUseDatasource()) {
+            return configureDatasourceClient();
+        }
+
         // If the scope is Gateway, we have to use the DataPlane client
         if (StringUtils.hasText(this.identityProviderEntity.getDataPlaneId()) && scope == Scope.GATEWAY && configuration.isUseSystemCluster()) {
             final var provider = this.dataPlaneRegistry.getProviderById(this.identityProviderEntity.getDataPlaneId());
@@ -94,10 +99,6 @@ public abstract class MongoAbstractProvider implements InitializingBean {
             if (provider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)) {
                 return provider.getClientWrapper();
             }
-        }
-
-        if (shouldUseDatasource()) {
-            return configureDatasourceClient();
         }
 
         if (!this.commonConnectionProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)) {


### PR DESCRIPTION
## :id: Reference related issue. 
AM-5459

## :pencil2: A description of the changes proposed in the pull request
This pull request updates the logic in the `MongoAbstractProvider` class to ensure that datasource configuration is prioritized when building the MongoDB client wrapper. The main change is to check for the presence of a datasource before any other client selection logic.

Client selection logic improvements:

* The check for `shouldUseDatasource()` and the corresponding call to `configureDatasourceClient()` have been moved to the beginning of the `buildClientWrapper` method, ensuring that datasource configuration takes precedence over other client options.
* The previous redundant check for `shouldUseDatasource()` at the end of the method has been removed to prevent duplicate logic and streamline the client selection process.

## :memo: Test scenarios 
Same as AM-5459

## :computer: Add screenshots for UI
n/a

