### PR TITLE
fix: AM-5890 prevent domain deployment on database connection failure TBD

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/exceptions/RepositoryExceptionMapper.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/exceptions/RepositoryExceptionMapper.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.exceptions;
+
+/**
+ * Strategy interface for mapping repository-specific exceptions to {@link RepositoryConnectionException}.
+ * Each repository type (JDBC, MongoDB, etc.) should provide its own implementation
+ * that identifies connection-related exceptions specific to that repository technology.
+ *
+ * @author GraviteeSource Team
+ */
+public interface RepositoryExceptionMapper {
+
+    /**
+     * Checks if the given throwable or its cause represents a connection error
+     * that should be wrapped as a {@link RepositoryConnectionException}.
+     *
+     * @param throwable the exception to check
+     * @return true if the exception represents a connection error, false otherwise
+     */
+    boolean isConnectionException(Throwable throwable);
+
+    /**
+     * Maps the given throwable to a {@link RepositoryConnectionException} if it represents
+     * a connection error, otherwise returns the original throwable.
+     *
+     * @param throwable the exception to map
+     * @return a RepositoryConnectionException if the throwable is a connection error,
+     *         otherwise the original throwable
+     */
+    default Throwable map(Throwable throwable) {
+        if (isConnectionException(throwable)) {
+            return new RepositoryConnectionException(throwable);
+        }
+        return throwable;
+    }
+}
+

--- a/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/exceptions/JdbcRepositoryExceptionMapper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/exceptions/JdbcRepositoryExceptionMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.exceptions;
+
+import io.gravitee.am.repository.exceptions.RepositoryConnectionException;
+import io.gravitee.am.repository.exceptions.RepositoryExceptionMapper;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import org.springframework.dao.NonTransientDataAccessResourceException;
+
+/**
+ * JDBC-specific implementation of {@link RepositoryExceptionMapper}.
+ * Maps JDBC and R2DBC connection exceptions to {@link RepositoryConnectionException}.
+ *
+ * @author GraviteeSource Team
+ */
+public class JdbcRepositoryExceptionMapper implements RepositoryExceptionMapper {
+
+    /**
+     * Checks if the throwable or its cause is a JDBC/R2DBC connection exception.
+     * Connection exceptions include:
+     * <ul>
+     *   <li>{@link NonTransientDataAccessResourceException} - Spring Data JDBC resource exceptions</li>
+     *   <li>{@link R2dbcNonTransientResourceException} - R2DBC non-transient resource exceptions</li>
+     * </ul>
+     *
+     * @param throwable the exception to check
+     * @return true if the exception represents a connection error
+     */
+    @Override
+    public boolean isConnectionException(Throwable throwable) {
+        return throwable instanceof NonTransientDataAccessResourceException ||
+               throwable instanceof R2dbcNonTransientResourceException ||
+               (throwable != null && throwable.getCause() instanceof R2dbcNonTransientResourceException);
+    }
+}
+

--- a/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/test/java/io/gravitee/am/repository/jdbc/exceptions/JdbcRepositoryExceptionMapperTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/test/java/io/gravitee/am/repository/jdbc/exceptions/JdbcRepositoryExceptionMapperTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.exceptions;
+
+import io.gravitee.am.repository.exceptions.RepositoryConnectionException;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.NonTransientDataAccessResourceException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class JdbcRepositoryExceptionMapperTest {
+
+    private final JdbcRepositoryExceptionMapper mapper = new JdbcRepositoryExceptionMapper();
+
+    @Test
+    void shouldMapJdbcNonTransientResourceToRepositoryConnection() {
+        Throwable mapped = mapper.map(new NonTransientDataAccessResourceException("jdbc down"));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldMapR2dbcNonTransientResourceToRepositoryConnection() {
+        Throwable mapped = mapper.map(new R2dbcNonTransientResourceException("r2dbc down"));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldMapCauseR2dbcNonTransientResourceToRepositoryConnection() {
+        Throwable mapped = mapper.map(new IllegalStateException(new R2dbcNonTransientResourceException("r2dbc cause")));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldPassThroughNonConnectionException() {
+        IllegalArgumentException original = new IllegalArgumentException("not a connection error");
+        Throwable mapped = mapper.map(original);
+        assertSame(original, mapped);
+    }
+
+    @Test
+    void shouldPassThroughWhenCauseIsNonConnectionException() {
+        RuntimeException original = new RuntimeException(new IllegalArgumentException("nested not a connection error"));
+        Throwable mapped = mapper.map(original);
+        assertSame(original, mapped);
+    }
+}
+
+

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationRepository.java
@@ -175,7 +175,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         LOGGER.debug("findAll()");
         return applicationRepository.findAll()
                 .map(this::toEntity)
-                .flatMap(app -> completeApplication(app).toFlowable());
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .onErrorResumeNext(this::mapExceptionAsFlowable);
     }
 
     @Override
@@ -196,7 +197,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         LOGGER.debug("findByDomain({})", domain);
         return applicationRepository.findByDomain(domain)
                 .map(this::toEntity)
-                .flatMap(app -> completeApplication(app).toFlowable());
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .onErrorResumeNext(this::mapExceptionAsFlowable);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcDomainRepository.java
@@ -88,7 +88,7 @@ public class JdbcDomainRepository extends AbstractJdbcRepository implements Doma
     public Flowable<Domain> findAll() {
         LOGGER.debug("findAll()");
         Flowable<Domain> domains = domainRepository.findAll().map(this::toDomain);
-        return domains.flatMap(this::completeDomain);
+        return domains.flatMap(this::completeDomain).onErrorResumeNext(this::mapExceptionAsFlowable);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcIdentityProviderRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcIdentityProviderRepository.java
@@ -114,7 +114,8 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
     public Flowable<IdentityProvider> findAll(ReferenceType referenceType, String referenceId) {
         LOGGER.debug("findAll({}, {}", referenceType, referenceId);
         return this.identityProviderRepository.findAll(referenceType.name(), referenceId)
-                .map(this::toEntity);
+                .map(this::toEntity)
+                .onErrorResumeNext(this::mapExceptionAsFlowable);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/exceptions/MongoRepositoryExceptionMapper.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/exceptions/MongoRepositoryExceptionMapper.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.exceptions;
+
+import com.mongodb.MongoServerUnavailableException;
+import com.mongodb.MongoSocketOpenException;
+import com.mongodb.MongoTimeoutException;
+import io.gravitee.am.repository.exceptions.RepositoryConnectionException;
+import io.gravitee.am.repository.exceptions.RepositoryExceptionMapper;
+
+/**
+ * MongoDB-specific implementation of {@link RepositoryExceptionMapper}.
+ * Maps MongoDB connection exceptions to {@link RepositoryConnectionException}.
+ *
+ * @author GraviteeSource Team
+ */
+public class MongoRepositoryExceptionMapper implements RepositoryExceptionMapper {
+
+    /**
+     * Checks if the throwable or its cause is a MongoDB connection exception.
+     * Connection exceptions include:
+     * <ul>
+     *   <li>{@link MongoTimeoutException} - MongoDB operation timeout</li>
+     *   <li>{@link MongoServerUnavailableException} - MongoDB server unavailable</li>
+     *   <li>{@link MongoSocketOpenException} - MongoDB socket connection failure</li>
+     * </ul>
+     *
+     * @param throwable the exception to check
+     * @return true if the exception represents a connection error
+     */
+    @Override
+    public boolean isConnectionException(Throwable throwable) {
+        return isConnectionError(throwable) ||
+                isConnectionError(throwable.getCause());
+    }
+
+    private static boolean isConnectionError(Throwable error) {
+        return error instanceof MongoTimeoutException ||
+                error instanceof MongoServerUnavailableException ||
+                error instanceof MongoSocketOpenException;
+    }
+}
+

--- a/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/test/java/io/gravitee/am/repository/mongodb/exceptions/MongoRepositoryExceptionMapperTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/test/java/io/gravitee/am/repository/mongodb/exceptions/MongoRepositoryExceptionMapperTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.exceptions;
+
+import com.mongodb.MongoServerUnavailableException;
+import com.mongodb.MongoSocketOpenException;
+import com.mongodb.MongoTimeoutException;
+import io.gravitee.am.repository.exceptions.RepositoryConnectionException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class MongoRepositoryExceptionMapperTest {
+
+    private final MongoRepositoryExceptionMapper mapper = new MongoRepositoryExceptionMapper();
+
+    @Test
+    void shouldMapTimeoutToRepositoryConnection() {
+        Throwable mapped = mapper.map(new MongoTimeoutException("timeout"));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldMapServerUnavailableToRepositoryConnection() {
+        Throwable mapped = mapper.map(new MongoServerUnavailableException("down"));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldMapSocketOpenToRepositoryConnection() {
+        Throwable mapped = mapper.map(new MongoSocketOpenException("socket", null));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldMapCauseTimeoutToRepositoryConnection() {
+        Throwable mapped = mapper.map(new RuntimeException(new MongoTimeoutException("timeout")));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldMapCauseServerUnavailableToRepositoryConnection() {
+        Throwable mapped = mapper.map(new IllegalArgumentException(new MongoServerUnavailableException("down")));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldMapCauseSocketOpenToRepositoryConnection() {
+        Throwable mapped = mapper.map(new IllegalStateException(new MongoSocketOpenException("socket", null)));
+        assertInstanceOf(RepositoryConnectionException.class, mapped);
+    }
+
+    @Test
+    void shouldPassThroughNonConnectionException() {
+        IllegalStateException original = new IllegalStateException("other");
+        Throwable mapped = mapper.map(original);
+        assertSame(original, mapped);
+    }
+
+    @Test
+    void shouldPassThroughWhenCauseIsNonConnectionException() {
+        RuntimeException original = new RuntimeException(new IllegalArgumentException("not a connection error"));
+        Throwable mapped = mapper.map(original);
+        assertSame(original, mapped);
+    }
+}
+
+

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/AbstractMongoRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/common/AbstractMongoRepository.java
@@ -20,10 +20,14 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import io.gravitee.am.model.UserId;
 import io.gravitee.am.repository.common.UserIdFields;
+import io.gravitee.am.repository.mongodb.exceptions.MongoRepositoryExceptionMapper;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.MaybeSource;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.SingleSource;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.functions.Predicate;
 import org.bson.Document;
@@ -63,6 +67,8 @@ public abstract class AbstractMongoRepository {
      * Default UserFields for entities linked to the User.
      */
     protected static final UserIdFields DEFAULT_USER_FIELDS = new UserIdFields(FIELD_USER_ID, FIELD_USER_SOURCE, FIELD_USER_EXTERNAL_ID);
+
+    private static final MongoRepositoryExceptionMapper exceptionMapper = new MongoRepositoryExceptionMapper();
 
     @Autowired
     protected FilterCriteriaParser filterCriteriaParser;
@@ -121,5 +127,49 @@ public abstract class AbstractMongoRepository {
                 .flatMapCompletable(indexName -> Completable
                         .fromPublisher(collection.dropIndex(indexName))
                         .doOnError(e -> logger.error("An error has occurred while deleting index {}", indexName, e)));
+    }
+
+    /**
+     * Maps a throwable to a RepositoryConnectionException if it represents a connection error,
+     * otherwise returns the original throwable.
+     *
+     * @param throwable the exception to map
+     * @return a RepositoryConnectionException if it's a connection error, otherwise the original throwable
+     */
+    protected Throwable mapException(Throwable throwable) {
+        return exceptionMapper.map(throwable);
+    }
+
+    /**
+     * Maps a throwable to a RepositoryConnectionException in a Maybe error if it represents a connection error,
+     * otherwise returns the original throwable as a Maybe.
+     *
+     * @param error the exception to map
+     * @return a Maybe error if it's a connection error, otherwise the original throwable as a Maybe
+     */
+    protected <T> MaybeSource<T> mapExceptionAsMaybe(Throwable error) {
+        return Maybe.error(mapException(error));
+    }
+
+    /**
+     * Maps a throwable to a RepositoryConnectionException in a Flowable error if it represents a connection error,
+     * otherwise returns the original throwable as a Flowable.
+     *
+     * @param error the exception to map
+     * @return a Flowable error if it's a connection error, otherwise the original throwable as a Flowable
+     */
+    protected <T> Flowable<T> mapExceptionAsFlowable(Throwable error) {
+        return Flowable.fromMaybe(mapExceptionAsMaybe(error));
+    }
+
+    /**
+     * Maps a throwable to a RepositoryConnectionException in a Single error if it represents a connection error,
+     * otherwise returns the original throwable as a Single.
+     *
+     * @param error the exception to map
+     * @return a Single error if it's a connection error, otherwise the original throwable as a Single
+     */
+    protected <T> SingleSource<T> mapExceptionAsSingle(Throwable error) {
+        return Single.fromMaybe(mapExceptionAsMaybe(error));
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -142,7 +142,8 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
     @Override
     public Flowable<Application> findAll() {
         return Flowable.fromPublisher(applicationsCollection.find()).map(MongoApplicationRepository::convert)
-                .observeOn(Schedulers.computation());
+                .observeOn(Schedulers.computation())
+                .onErrorResumeNext(this::mapExceptionAsFlowable);
     }
 
     @Override
@@ -160,7 +161,8 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
     @Override
     public Flowable<Application> findByDomain(String domain) {
         return Flowable.fromPublisher(withMaxTime(applicationsCollection.find(eq(FIELD_DOMAIN, domain)))).map(MongoApplicationRepository::convert)
-                .observeOn(Schedulers.computation());
+                .observeOn(Schedulers.computation())
+                .onErrorResumeNext(this::mapExceptionAsFlowable);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
@@ -110,7 +110,8 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
     @Override
     public Flowable<Domain> findAll() {
         return Flowable.fromPublisher(withMaxTime(domainsCollection.find())).map(MongoDomainRepository::convert)
-                .observeOn(Schedulers.computation());
+                .observeOn(Schedulers.computation())
+                .onErrorResumeNext(this::mapExceptionAsFlowable);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoIdentityProviderRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoIdentityProviderRepository.java
@@ -76,7 +76,8 @@ public class MongoIdentityProviderRepository extends AbstractManagementMongoRepo
     public Flowable<IdentityProvider> findAll(ReferenceType referenceType, String referenceId) {
         return Flowable.fromPublisher(withMaxTime(identitiesCollection.find(and(eq(FIELD_REFERENCE_TYPE, referenceType.name()), eq(FIELD_REFERENCE_ID, referenceId)))))
                 .map(this::convert)
-                .observeOn(Schedulers.computation());
+                .observeOn(Schedulers.computation())
+                .onErrorResumeNext(this::mapExceptionAsFlowable);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryTest.java
@@ -64,6 +64,28 @@ public class ApplicationRepositoryTest extends AbstractManagementTest {
     private ApplicationRepository applicationRepository;
 
     @Test
+    public void testFindAll() {
+        // create applications
+        Application application = new Application();
+        application.setName("testApp");
+        application.setDomain("testDomain");
+        applicationRepository.create(application).blockingGet();
+        Application application2 = new Application();
+        application2.setName("testApp2");
+        application2.setDomain("testDomain");
+        applicationRepository.create(application2).blockingGet();
+
+        // fetch applications
+        TestObserver<List<Application>> testObserver = applicationRepository.findAll().toList().test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(applications -> applications.size() == 2);
+        testObserver.assertValue(applications -> applications.stream().allMatch(a -> a.getName().equals("testApp") || a.getName().equals("testApp2")));
+    }
+
+    @Test
     public void testFindByDomain() {
         // create application
         Application application = new Application();

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/IdentityProviderRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/IdentityProviderRepositoryTest.java
@@ -44,6 +44,30 @@ public class IdentityProviderRepositoryTest extends AbstractManagementTest {
     private IdentityProviderRepository identityProviderRepository;
 
     @Test
+    public void testFindAll() {
+        // baseline count
+        int beforeCount = identityProviderRepository.findAll().toList().blockingGet().size();
+
+        // create idps
+        IdentityProvider idp1 = buildIdentityProvider();
+        identityProviderRepository.create(idp1).blockingGet();
+
+        IdentityProvider idp2 = buildIdentityProvider();
+        identityProviderRepository.create(idp2).blockingGet();
+
+        // fetch all
+        TestObserver<List<IdentityProvider>> testObserver = identityProviderRepository.findAll().toList().test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(idps -> idps.size() == beforeCount + 2);
+        testObserver.assertValue(idps -> idps.stream().map(IdentityProvider::getName)
+                .collect(Collectors.toSet())
+                .containsAll(Arrays.asList(idp1.getName(), idp2.getName())));
+    }
+
+    @Test
     public void testFindByDomain() {
         // create idp
         IdentityProvider identityProvider = buildIdentityProvider();


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-5890](https://gravitee.atlassian.net/browse/AM-5890)

## :pencil2: A description of the changes proposed in the pull request
Map database connectivity exceptions to a db-agnostic `RepositoryConnectionException`, expanding the pattern used in user repository implementations, and introducing it to a select few other repositories and repository methods that are used during manager initialisations. When such critical data cannot be retrieved during the gateway startup, the exception is propagated, causing the domains to remain unloaded. At this point the readiness health check returns "unhealthy", and it will continue to do so until database connection has been restored and the `SyncManager` retries the domain deployments.

The exception mapping pattern has been established in all base repository classes but utilised sparingly to minimise change.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-5890]: https://gravitee.atlassian.net/browse/AM-5890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ