### PR TITLE
WIP: feat: assertions mapping for SAML

### DIFF
--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/SAMLAssertionAttribute.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/SAMLAssertionAttribute.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SAMLAssertionAttribute {
+    private String attributeName;
+    private String attributeValue;
+
+    public SAMLAssertionAttribute(SAMLAssertionAttribute other) {
+        this.attributeName = other.attributeName;
+        this.attributeValue = other.attributeValue;
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationSAMLSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationSAMLSettings.java
@@ -16,7 +16,11 @@
 package io.gravitee.am.model.application;
 
 import io.gravitee.am.common.saml2.Binding;
+import io.gravitee.am.model.SAMLAssertionAttribute;
 import io.gravitee.am.model.oidc.Client;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * See <a href="https://www.oasis-open.org/committees/download.php/56786/sstc-saml-metadata-errata-2.0-wd-05-diff.pdf">2.4.4 Element <SPSSODescriptor></a>
@@ -56,6 +60,12 @@ public class ApplicationSAMLSettings {
      */
     private String responseBinding = Binding.INITIAL_REQUEST;
 
+    /**
+     * Custom assertion attribute mappings.
+     * These override default attributes if the same name is used.
+     */
+    private List<SAMLAssertionAttribute> assertionAttributes;
+
     public ApplicationSAMLSettings() {
     }
 
@@ -67,6 +77,9 @@ public class ApplicationSAMLSettings {
         this.wantResponseSigned = other.wantResponseSigned;
         this.wantAssertionsSigned = other.wantAssertionsSigned;
         this.responseBinding = other.responseBinding;
+        this.assertionAttributes = other.assertionAttributes != null
+                ? new ArrayList<>(other.assertionAttributes.stream().map(SAMLAssertionAttribute::new).toList())
+                : null;
     }
 
     public String getEntityId() {
@@ -125,6 +138,14 @@ public class ApplicationSAMLSettings {
         this.responseBinding = responseBinding;
     }
 
+    public List<SAMLAssertionAttribute> getAssertionAttributes() {
+        return assertionAttributes;
+    }
+
+    public void setAssertionAttributes(List<SAMLAssertionAttribute> assertionAttributes) {
+        this.assertionAttributes = assertionAttributes;
+    }
+
     public void copyTo(Client client) {
         client.setEntityId(this.entityId);
         client.setAttributeConsumeServiceUrl(this.attributeConsumeServiceUrl);
@@ -133,5 +154,6 @@ public class ApplicationSAMLSettings {
         client.setWantResponseSigned(this.wantResponseSigned);
         client.setWantAssertionsSigned(this.wantAssertionsSigned);
         client.setResponseBinding(this.responseBinding);
+        client.setSamlAssertionAttributes(this.assertionAttributes);
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
@@ -27,6 +27,7 @@ import io.gravitee.am.model.MFASettings;
 import io.gravitee.am.model.PasswordSettings;
 import io.gravitee.am.model.PasswordSettingsAware;
 import io.gravitee.am.model.Resource;
+import io.gravitee.am.model.SAMLAssertionAttribute;
 import io.gravitee.am.model.SecretExpirationSettings;
 import io.gravitee.am.model.TokenClaim;
 import io.gravitee.am.model.account.AccountSettings;
@@ -276,6 +277,8 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     private String responseBinding;
 
+    private List<SAMLAssertionAttribute> samlAssertionAttributes;
+
     // ----------- Refresh token Settings -----------
     private boolean disableRefreshTokenRotation;
 
@@ -369,6 +372,9 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
         this.wantResponseSigned = other.wantResponseSigned;
         this.wantAssertionsSigned = other.wantAssertionsSigned;
         this.responseBinding = other.responseBinding;
+        this.samlAssertionAttributes = other.samlAssertionAttributes != null
+                ? new ArrayList<>(other.samlAssertionAttributes.stream().map(SAMLAssertionAttribute::new).toList())
+                : null;
         this.disableRefreshTokenRotation = other.disableRefreshTokenRotation;
         this.secretExpirationSettings = other.secretExpirationSettings;
     }
@@ -1111,6 +1117,14 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     public void setResponseBinding(String responseBinding) {
         this.responseBinding = responseBinding;
+    }
+
+    public List<SAMLAssertionAttribute> getSamlAssertionAttributes() {
+        return samlAssertionAttributes;
+    }
+
+    public void setSamlAssertionAttributes(List<SAMLAssertionAttribute> samlAssertionAttributes) {
+        this.samlAssertionAttributes = samlAssertionAttributes;
     }
 
     public boolean isBackchannelUserCodeParameter() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.am.model.Application;
 import io.gravitee.am.model.CookieSettings;
 import io.gravitee.am.model.MFASettings;
 import io.gravitee.am.model.PasswordSettings;
+import io.gravitee.am.model.SAMLAssertionAttribute;
 import io.gravitee.am.model.SecretExpirationSettings;
 import io.gravitee.am.model.TokenClaim;
 import io.gravitee.am.model.account.AccountSettings;
@@ -53,6 +54,7 @@ import io.gravitee.am.repository.mongodb.management.internal.model.ApplicationMo
 import io.gravitee.am.repository.mongodb.management.internal.model.ApplicationOAuthSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.ApplicationSAMLSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.ApplicationScopeSettingsMongo;
+import io.gravitee.am.repository.mongodb.management.internal.model.SAMLAssertionAttributeMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.ApplicationSecretSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.ApplicationSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.ClientSecretMongo;
@@ -639,6 +641,13 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationSAMLSettingsMongo.setWantResponseSigned(other.isWantResponseSigned());
         applicationSAMLSettingsMongo.setWantAssertionsSigned(other.isWantAssertionsSigned());
         applicationSAMLSettingsMongo.setResponseBinding(other.getResponseBinding());
+        if (other.getAssertionAttributes() != null) {
+            applicationSAMLSettingsMongo.setAssertionAttributes(
+                other.getAssertionAttributes().stream()
+                    .map(MongoApplicationRepository::convert)
+                    .toList()
+            );
+        }
         return applicationSAMLSettingsMongo;
     }
 
@@ -654,6 +663,13 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationSAMLSettings.setWantResponseSigned(other.isWantResponseSigned());
         applicationSAMLSettings.setWantAssertionsSigned(other.isWantAssertionsSigned());
         applicationSAMLSettings.setResponseBinding(other.getResponseBinding());
+        if (other.getAssertionAttributes() != null) {
+            applicationSAMLSettings.setAssertionAttributes(
+                other.getAssertionAttributes().stream()
+                    .map(MongoApplicationRepository::convert)
+                    .toList()
+            );
+        }
         return applicationSAMLSettings;
     }
 
@@ -671,6 +687,20 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationScopeSettingsMongo.setScopeApproval(other.getScopeApproval());
         applicationScopeSettingsMongo.setDefaultScope(other.isDefaultScope());
         return applicationScopeSettingsMongo;
+    }
+
+    private static SAMLAssertionAttributeMongo convert(SAMLAssertionAttribute other) {
+        SAMLAssertionAttributeMongo mongo = new SAMLAssertionAttributeMongo();
+        mongo.setAttributeName(other.getAttributeName());
+        mongo.setAttributeValue(other.getAttributeValue());
+        return mongo;
+    }
+
+    private static SAMLAssertionAttribute convert(SAMLAssertionAttributeMongo other) {
+        SAMLAssertionAttribute attr = new SAMLAssertionAttribute();
+        attr.setAttributeName(other.getAttributeName());
+        attr.setAttributeValue(other.getAttributeValue());
+        return attr;
     }
 
     private static AccountSettings convert(AccountSettingsMongo accountSettingsMongo) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationSAMLSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationSAMLSettingsMongo.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.repository.mongodb.management.internal.model;
 
+import java.util.List;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -28,6 +30,7 @@ public class ApplicationSAMLSettingsMongo {
     private boolean wantResponseSigned = true;
     private boolean wantAssertionsSigned;
     private String responseBinding;
+    private List<SAMLAssertionAttributeMongo> assertionAttributes;
 
     public String getEntityId() {
         return entityId;
@@ -83,5 +86,13 @@ public class ApplicationSAMLSettingsMongo {
 
     public void setResponseBinding(String responseBinding) {
         this.responseBinding = responseBinding;
+    }
+
+    public List<SAMLAssertionAttributeMongo> getAssertionAttributes() {
+        return assertionAttributes;
+    }
+
+    public void setAssertionAttributes(List<SAMLAssertionAttributeMongo> assertionAttributes) {
+        this.assertionAttributes = assertionAttributes;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/SAMLAssertionAttributeMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/SAMLAssertionAttributeMongo.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.management.internal.model;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class SAMLAssertionAttributeMongo {
+
+    private String attributeName;
+    private String attributeValue;
+
+    public String getAttributeName() {
+        return attributeName;
+    }
+
+    public void setAttributeName(String attributeName) {
+        this.attributeName = attributeName;
+    }
+
+    public String getAttributeValue() {
+        return attributeValue;
+    }
+
+    public void setAttributeValue(String attributeValue) {
+        this.attributeValue = attributeValue;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationSAMLSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationSAMLSettings.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.am.service.model;
 
+import io.gravitee.am.model.SAMLAssertionAttribute;
 import io.gravitee.am.model.application.ApplicationSAMLSettings;
 import io.gravitee.am.service.utils.SetterUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -33,6 +35,7 @@ public class PatchApplicationSAMLSettings {
     private Optional<Boolean> wantResponseSigned;
     private Optional<Boolean> wantAssertionsSigned;
     private Optional<String> responseBinding;
+    private Optional<List<SAMLAssertionAttribute>> assertionAttributes;
 
     public Optional<String> getEntityId() {
         return entityId;
@@ -90,6 +93,14 @@ public class PatchApplicationSAMLSettings {
         this.responseBinding = responseBinding;
     }
 
+    public Optional<List<SAMLAssertionAttribute>> getAssertionAttributes() {
+        return assertionAttributes;
+    }
+
+    public void setAssertionAttributes(Optional<List<SAMLAssertionAttribute>> assertionAttributes) {
+        this.assertionAttributes = assertionAttributes;
+    }
+
     public ApplicationSAMLSettings patch(ApplicationSAMLSettings _toPatch) {
         // create new object for audit purpose (patch json result)
         ApplicationSAMLSettings toPatch = _toPatch == null ? new ApplicationSAMLSettings() : new ApplicationSAMLSettings(_toPatch);
@@ -100,6 +111,7 @@ public class PatchApplicationSAMLSettings {
         SetterUtils.safeSet(toPatch::setWantResponseSigned, this.getWantResponseSigned());
         SetterUtils.safeSet(toPatch::setWantAssertionsSigned, this.getWantAssertionsSigned());
         SetterUtils.safeSet(toPatch::setResponseBinding, this.getResponseBinding());
+        SetterUtils.safeSet(toPatch::setAssertionAttributes, this.getAssertionAttributes());
         return toPatch;
     }
 }

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/saml2/saml2.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/saml2/saml2.component.html
@@ -87,6 +87,66 @@
       </div>
       <div class="gv-form-section">
         <div class="gv-form-section-title">
+          <h5>Assertion Mapping</h5>
+          <small>Customise the SAML assertion content sent to the Service Provider</small>
+          <mat-divider></mat-divider>
+        </div>
+        <div>
+          <small>Map user attributes to SAML assertion attributes. Custom mappings override default attributes.</small>
+          <table class="assertion-attributes-table" *ngIf="assertionAttributes.length > 0">
+            <thead>
+              <tr>
+                <th>Attribute Name</th>
+                <th>Attribute Value</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let attr of assertionAttributes; let i = index">
+                <td>
+                  <mat-form-field appearance="outline" floatLabel="always" class="attribute-field">
+                    <input
+                      matInput
+                      type="text"
+                      placeholder="e.g. http://schemas.xmlsoap.org/.../emailaddress"
+                      [name]="'attrName' + i"
+                      [(ngModel)]="attr.attributeName"
+                      (ngModelChange)="onAssertionAttributeChange()"
+                      [disabled]="!editMode"
+                    />
+                  </mat-form-field>
+                </td>
+                <td>
+                  <mat-form-field appearance="outline" floatLabel="always" class="attribute-field">
+                    <input
+                      matInput
+                      type="text"
+                      placeholder="e.g. {#context.attributes['user'].email}"
+                      [name]="'attrValue' + i"
+                      [(ngModel)]="attr.attributeValue"
+                      (ngModelChange)="onAssertionAttributeChange()"
+                      [disabled]="!editMode"
+                    />
+                  </mat-form-field>
+                </td>
+                <td>
+                  <button mat-icon-button type="button" (click)="removeAssertionAttribute(i)" [disabled]="!editMode">
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div *ngIf="assertionAttributes.length === 0" class="no-attributes-hint">
+            <small>No custom assertion attributes defined. Click the button below to add one.</small>
+          </div>
+          <button mat-stroked-button type="button" (click)="addAssertionAttribute()" [disabled]="!editMode">
+            <mat-icon>add</mat-icon> Add Attribute
+          </button>
+        </div>
+      </div>
+      <div class="gv-form-section">
+        <div class="gv-form-section-title">
           <h5>Certificate</h5>
           <small>The SP's base-64 encoded public key certificate, which is used by the IdP to verify SAML authorization requests</small>
           <mat-divider></mat-divider>

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/saml2/saml2.component.scss
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/saml2/saml2.component.scss
@@ -1,0 +1,30 @@
+.assertion-attributes-table {
+  width: 100%;
+  margin-bottom: 16px;
+  border-collapse: collapse;
+
+  th {
+    padding: 8px 4px;
+    border-bottom: 1px solid rgb(0 0 0 / 12%);
+    text-align: left;
+  }
+
+  td {
+    padding: 4px;
+    vertical-align: middle;
+
+    &:last-child {
+      width: 48px;
+      text-align: center;
+    }
+  }
+
+  .attribute-field {
+    width: 100%;
+  }
+}
+
+.no-attributes-hint {
+  padding: 16px 0;
+  color: rgb(0 0 0 / 54%);
+}


### PR DESCRIPTION
## :id: Reference related issue. 

Closes: AM-5611

## Summary                                                                                                                                                                                              
  - Add SAML assertion attribute mapping for IdP mode - allows customizing SAML assertion attributes sent to Service Providers                                                                            
  - Support SpEL expressions for dynamic attribute values (e.g., `{#context.attributes['user'].email}`)                                                                                                   
  - Custom attributes override default user attributes when same name is used                                                                                                                             
                                                                                                                                                                                                          
  ## Changes                                                                                                                                                                                              
  - Model: `SAMLAssertionAttribute`, `ApplicationSAMLSettings.assertionAttributes`, `Client.samlAssertionAttributes`                                                                                      
  - Repository: MongoDB model + converter, JDBC via JSON serialization                                                                                                                                    
  - Service: `PatchApplicationSAMLSettings` with assertion attributes support                                                                                                                             
  - UI: Key-value editor in SAML 2.0 application settings                                                                                                                                                 
                                                                                                                                                                                                          
  ## Test plan                                                                                                                                                                                            
  - [ ] Unit test: `ApplicationRepositoryTest.testSamlAssertionAttributes`                                                                                                                                
  - [ ] Manual: Configure assertion attributes in UI, verify persistence after save/reload