### PR TITLE
feat: add application type filtering to Applications overview (AM-6110)

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -1042,6 +1042,26 @@ paths:
         in: query
         schema:
           type: string
+      - name: type
+        in: query
+        description: >-
+          Filter applications by type. Multiple values can be provided
+          to match any of the specified types (OR logic). When omitted,
+          applications of all types are returned.
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - WEB
+            - NATIVE
+            - BROWSER
+            - SERVICE
+            - RESOURCE_SERVER
+            - AGENT
+        style: form
+        explode: true
       responses:
         "200":
           description: List registered applications for a security domain

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/ApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/ApplicationRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.management.api;
 
 import io.gravitee.am.model.Application;
+import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.repository.common.CrudRepository;
 import io.reactivex.rxjava3.core.Flowable;
@@ -43,6 +44,14 @@ public interface ApplicationRepository extends CrudRepository<Application, Strin
     Single<Page<Application>> search(String domain, String query, int page, int size);
 
     Single<Page<Application>> search(String domain, List<String> applicationIds, String query, int page, int size);
+
+    Single<Page<Application>> findByDomain(String domain, int page, int size, List<ApplicationType> types);
+
+    Single<Page<Application>> findByDomain(String domain, List<String> applicationIds, int page, int size, List<ApplicationType> types);
+
+    Single<Page<Application>> search(String domain, String query, int page, int size, List<ApplicationType> types);
+
+    Single<Page<Application>> search(String domain, List<String> applicationIds, String query, int page, int size, List<ApplicationType> types);
 
     Flowable<Application> findByCertificate(String certificate);
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/AbstractDialectHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/AbstractDialectHelper.java
@@ -419,6 +419,29 @@ public abstract class AbstractDialectHelper implements DatabaseDialectHelper {
     }
 
     @Override
+    public String buildSearchApplicationsQueryWithTypes(boolean wildcard, boolean withIds, int page, int size, String sort, boolean asc, List<String> types) {
+        StringBuilder builder = new StringBuilder("SELECT * FROM applications a WHERE ");
+        return buildSearchApplications(wildcard, withIds, builder, types)
+                .append(buildPagingClause(sort, asc, page, size))
+                .toString();
+    }
+
+    @Override
+    public String buildCountApplicationsQueryWithTypes(boolean wildcard, boolean withIds, List<String> types) {
+        StringBuilder builder = new StringBuilder("SELECT COUNT(DISTINCT a.id) FROM applications a WHERE ");
+        return buildSearchApplications(wildcard, withIds, builder, types)
+                .toString();
+    }
+
+    protected StringBuilder buildSearchApplications(boolean wildcard, boolean withIds, StringBuilder builder, List<String> types) {
+        StringBuilder result = buildSearchApplications(wildcard, withIds, builder);
+        if (types != null && !types.isEmpty()) {
+            result.append(" AND a.type IN (:types)");
+        }
+        return result;
+    }
+
+    @Override
     public String buildFindApplicationByDomainAndClient() {
         return new StringBuilder("SELECT * FROM applications a WHERE ")
                 .append(" a.domain = :domain ")

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/DatabaseDialectHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/DatabaseDialectHelper.java
@@ -20,6 +20,7 @@ import io.gravitee.am.repository.management.api.search.FilterCriteria;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.r2dbc.core.DatabaseClient;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -55,6 +56,18 @@ public interface DatabaseDialectHelper {
     String buildSearchApplicationsQuery(boolean wildcard, boolean withIds, int page, int size, String sort, boolean asc);
 
     String buildCountApplicationsQuery(boolean wildcard, boolean withIds);
+
+    default String buildSearchApplicationsQuery(boolean wildcard, boolean withIds, int page, int size, String sort, boolean asc, List<String> types) {
+        return buildSearchApplicationsQueryWithTypes(wildcard, withIds, page, size, sort, asc, types);
+    }
+
+    default String buildCountApplicationsQuery(boolean wildcard, boolean withIds, List<String> types) {
+        return buildCountApplicationsQueryWithTypes(wildcard, withIds, types);
+    }
+
+    String buildSearchApplicationsQueryWithTypes(boolean wildcard, boolean withIds, int page, int size, String sort, boolean asc, List<String> types);
+
+    String buildCountApplicationsQueryWithTypes(boolean wildcard, boolean withIds, List<String> types);
 
     String buildSearchProtectedResourceQuery(boolean wildcard, int page, int size, String sort, boolean asc);
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/application/SpringApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/application/SpringApplicationRepository.java
@@ -37,6 +37,12 @@ public interface SpringApplicationRepository extends RxJava3CrudRepository<JdbcA
     @Query("select count(a.id) from applications a where a.domain = :domain AND a.id IN (:applicationIds)")
     Single<Long> countByDomainAndApplicationIds(@Param("domain") String domain, @Param("applicationIds") List<String> applicationIds);
 
+    @Query("select count(a.id) from applications a where a.domain = :domain AND a.type IN (:types)")
+    Single<Long> countByDomainAndTypes(@Param("domain") String domain, @Param("types") List<String> types);
+
+    @Query("select count(a.id) from applications a where a.domain = :domain AND a.id IN (:applicationIds) AND a.type IN (:types)")
+    Single<Long> countByDomainAndApplicationIdsAndTypes(@Param("domain") String domain, @Param("applicationIds") List<String> applicationIds, @Param("types") List<String> types);
+
     @Query("select * from applications a where a.domain = :domain")
     Flowable<JdbcApplication> findByDomain(@Param("domain") String domain);
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -114,6 +114,7 @@ import static java.util.stream.Collectors.toSet;
 public class MongoApplicationRepository extends AbstractManagementMongoRepository implements ApplicationRepository {
 
     private static final String FIELD_CLIENT_ID = "settings.oauth.clientId";
+    private static final String FIELD_TYPE = "type";
     private static final String FIELD_APPLICATION_IDENTITY_PROVIDERS = "identityProviders";
     private static final String FIELD_IDENTITY = "identity";
     // Kept for retro-compatibility
@@ -244,6 +245,71 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
 
         return Single.zip(countOperation, applicationsOperation, (count, applications) -> new Page<>(applications, page, count))
                 .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<Page<Application>> findByDomain(String domain, int page, int size, List<ApplicationType> types) {
+        Bson query = buildDomainQueryWithTypes(eq(FIELD_DOMAIN, domain), types);
+        return queryApplications(query, page, size).observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<Page<Application>> findByDomain(String domain, List<String> applicationIds, int page, int size, List<ApplicationType> types) {
+        Bson query = buildDomainQueryWithTypes(and(eq(FIELD_DOMAIN, domain), in(FIELD_ID, applicationIds)), types);
+        return queryApplications(query, page, size).observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<Page<Application>> search(String domain, String query, int page, int size, List<ApplicationType> types) {
+        Bson mongoQuery = buildSearchQuery(query, domain, FIELD_DOMAIN, FIELD_CLIENT_ID);
+        mongoQuery = buildDomainQueryWithTypes(mongoQuery, types);
+        boolean useCollation = !isWildcardQuery(query);
+        return findPage(applicationsCollection, mongoQuery, page, size, MongoApplicationRepository::convert, useCollation);
+    }
+
+    @Override
+    public Single<Page<Application>> search(String domain, List<String> applicationIds, String query, int page, int size, List<ApplicationType> types) {
+        boolean useWildcard = isWildcardQuery(query);
+
+        Bson searchQuery;
+        if (useWildcard) {
+            String escapedQuery = escapeRegexMetacharacters(query);
+            String compactQuery = escapedQuery.replaceAll("\\*+", ".*");
+            String regex = "^" + compactQuery;
+            Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+            searchQuery = and(in(FIELD_ID, applicationIds), or(new BasicDBObject(FIELD_CLIENT_ID, pattern), new BasicDBObject(FIELD_NAME, pattern)));
+        } else {
+            searchQuery = and(in(FIELD_ID, applicationIds), or(eq(FIELD_CLIENT_ID, query), eq(FIELD_NAME, query)));
+        }
+
+        Bson mongoQuery = buildDomainQueryWithTypes(and(eq(FIELD_DOMAIN, domain), searchQuery), types);
+
+        CountOptions countOpts = useWildcard ? countOptions() : countOptions().collation(CASE_INSENSITIVE_COLLATION);
+        Single<Long> countOperation = Observable.fromPublisher(applicationsCollection.countDocuments(mongoQuery, countOpts)).first(0L);
+
+        FindPublisher<ApplicationMongo> findPublisher = withMaxTime(applicationsCollection.find(mongoQuery))
+                .sort(new BasicDBObject(FIELD_UPDATED_AT, -1))
+                .skip(size * page)
+                .limit(size);
+
+        if (!useWildcard) {
+            findPublisher = findPublisher.collation(CASE_INSENSITIVE_COLLATION);
+        }
+
+        Single<Set<Application>> applicationsOperation = Observable.fromPublisher(findPublisher)
+                .map(MongoApplicationRepository::convert)
+                .collect(HashSet::new, Set::add);
+
+        return Single.zip(countOperation, applicationsOperation, (count, applications) -> new Page<>(applications, page, count))
+                .observeOn(Schedulers.computation());
+    }
+
+    private static Bson buildDomainQueryWithTypes(Bson baseQuery, List<ApplicationType> types) {
+        if (types == null || types.isEmpty()) {
+            return baseQuery;
+        }
+        List<String> typeStrings = types.stream().map(Enum::name).toList();
+        return and(baseQuery, in(FIELD_TYPE, typeStrings));
     }
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/ApplicationService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/ApplicationService.java
@@ -51,6 +51,14 @@ public interface ApplicationService {
 
     Single<Page<Application>> search(String domain, List<String> applicationIds, String query, int page, int size);
 
+    Single<Page<Application>> findByDomain(String domain, int page, int size, List<ApplicationType> types);
+
+    Single<Page<Application>> findByDomain(String domain, List<String> applicationIds, int page, int size, List<ApplicationType> types);
+
+    Single<Page<Application>> search(String domain, String query, int page, int size, List<ApplicationType> types);
+
+    Single<Page<Application>> search(String domain, List<String> applicationIds, String query, int page, int size, List<ApplicationType> types);
+
     Flowable<Application> findByCertificate(String certificate);
 
     Flowable<Application> findByIdentityProvider(String identityProvider);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -241,6 +241,62 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
+    public Single<Page<Application>> findByDomain(String domain, int page, int size, List<ApplicationType> types) {
+        LOGGER.debug("Find applications by domain {} with types {}", domain, types);
+        if (types == null || types.isEmpty()) {
+            return findByDomain(domain, page, size);
+        }
+        return applicationRepository.findByDomain(domain, page, size, types)
+                .onErrorResumeNext(ex -> {
+                    LOGGER.error("An error occurs while trying to find applications by domain {} with types {}", domain, types, ex);
+                    return Single.error(new TechnicalManagementException(
+                            String.format("An error occurs while trying to find applications by domain %s with types", domain), ex));
+                });
+    }
+
+    @Override
+    public Single<Page<Application>> findByDomain(String domain, List<String> applicationIds, int page, int size, List<ApplicationType> types) {
+        LOGGER.debug("Find applications by domain {} and appIds with types {}", domain, types);
+        if (types == null || types.isEmpty()) {
+            return findByDomain(domain, applicationIds, page, size);
+        }
+        return applicationRepository.findByDomain(domain, applicationIds, page, size, types)
+                .onErrorResumeNext(ex -> {
+                    LOGGER.error("An error occurs while trying to find applications by domain {} with types {}", domain, types, ex);
+                    return Single.error(new TechnicalManagementException(
+                            String.format("An error occurs while trying to find applications by domain %s with types", domain), ex));
+                });
+    }
+
+    @Override
+    public Single<Page<Application>> search(String domain, String query, int page, int size, List<ApplicationType> types) {
+        LOGGER.debug("Search applications with query {} for domain {} with types {}", query, domain, types);
+        if (types == null || types.isEmpty()) {
+            return search(domain, query, page, size);
+        }
+        return applicationRepository.search(domain, query, page, size, types)
+                .onErrorResumeNext(ex -> {
+                    LOGGER.error("An error occurs while trying to search applications with query {} for domain {} with types {}", query, domain, types, ex);
+                    return Single.error(new TechnicalManagementException(
+                            String.format("An error occurs while trying to search applications with query %s by domain %s with types", query, domain), ex));
+                });
+    }
+
+    @Override
+    public Single<Page<Application>> search(String domain, List<String> applicationIds, String query, int page, int size, List<ApplicationType> types) {
+        LOGGER.debug("Search applications with query {} for domain {} and appIds with types {}", query, domain, types);
+        if (types == null || types.isEmpty()) {
+            return search(domain, applicationIds, query, page, size);
+        }
+        return applicationRepository.search(domain, applicationIds, query, page, size, types)
+                .onErrorResumeNext(ex -> {
+                    LOGGER.error("An error occurs while trying to search applications with query {} for domain {} with types {}", query, domain, types, ex);
+                    return Single.error(new TechnicalManagementException(
+                            String.format("An error occurs while trying to search applications with query %s by domain %s with types", query, domain), ex));
+                });
+    }
+
+    @Override
     public Flowable<Application> findByCertificate(String certificate) {
         LOGGER.debug("Find applications by certificate : {}", certificate);
         return applicationRepository.findByCertificate(certificate)

--- a/gravitee-am-ui/src/app/domain/applications/applications.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/applications.component.html
@@ -17,12 +17,26 @@
 -->
 <div class="gv-page-container">
   <h1 *ngIf="!isEmpty">Applications</h1>
-  <div *ngIf="!isEmpty" class="applications-search">
-    <mat-form-field appearance="fill" floatLabel="always">
+  <div *ngIf="!isEmpty" class="applications-search" fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="16px">
+    <mat-form-field appearance="fill" floatLabel="always" fxFlex="45">
       <mat-icon matPrefix>search</mat-icon>
       <mat-label>Search for applications</mat-label>
-      <input type="text" matInput placeholder="Search" (input)="onSearch($event)" />
+      <input #searchInput type="text" matInput placeholder="Search" (input)="onSearch($event)" />
     </mat-form-field>
+
+    <mat-form-field appearance="fill" floatLabel="always" fxFlex="30">
+      <mat-label>Application Type</mat-label>
+      <mat-select [(ngModel)]="selectedTypes" [multiple]="true" (selectionChange)="onTypeFilterChange()">
+        <mat-option *ngFor="let appType of applicationTypes" [value]="appType.type">
+          {{ appType.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <button mat-raised-button color="primary" class="clear-filters-btn" [disabled]="!hasActiveFilters" (click)="clearAllFilters()">
+      <mat-icon>filter_list_off</mat-icon>
+      <span>Clear filters</span>
+    </button>
   </div>
   <div class="gv-page-content" *ngIf="!isEmpty">
     <ngx-datatable

--- a/gravitee-am-ui/src/app/domain/applications/applications.component.scss
+++ b/gravitee-am-ui/src/app/domain/applications/applications.component.scss
@@ -1,13 +1,23 @@
 .applications-search {
   text-align: center;
-
-  mat-form-field {
-    width: 70%;
-  }
+  padding: 0 5%;
 
   mat-icon {
     padding-bottom: 4px;
     vertical-align: middle;
+  }
+
+  .clear-filters-btn {
+    white-space: nowrap;
+    height: 48px;
+
+    span {
+      margin-left: 4px;
+    }
+
+    &[disabled] {
+      opacity: 0.4;
+    }
   }
 }
 

--- a/gravitee-am-ui/src/app/services/application.service.ts
+++ b/gravitee-am-ui/src/app/services/application.service.ts
@@ -32,12 +32,20 @@ export class ApplicationService {
     private authService: AuthService,
   ) {}
 
-  findByDomain(domainId, page, size): Observable<any> {
-    return this.http.get<any>(this.appsURL + domainId + '/applications?page=' + page + '&size=' + size);
+  findByDomain(domainId, page, size, types?: string[]): Observable<any> {
+    let url = this.appsURL + domainId + '/applications?page=' + page + '&size=' + size;
+    if (types && types.length > 0) {
+      url += types.map(t => '&type=' + t).join('');
+    }
+    return this.http.get<any>(url);
   }
 
-  search(domainId, searchTerm): Observable<any> {
-    return this.http.get<any>(this.appsURL + domainId + '/applications?q=' + searchTerm);
+  search(domainId, searchTerm, types?: string[]): Observable<any> {
+    let url = this.appsURL + domainId + '/applications?q=' + searchTerm;
+    if (types && types.length > 0) {
+      url += types.map(t => '&type=' + t).join('');
+    }
+    return this.http.get<any>(url);
   }
 
   get(domainId, id): Observable<any> {


### PR DESCRIPTION
Allow administrators to filter applications by type (Web, Single-Page App, Native, Agentic Application, Backend to Backend, Resource Server) using a multi-select dropdown in the Applications list. The filter works in conjunction with the existing search functionality and is persisted in URL query parameters for bookmarkability.

Backend: Added type filtering support across the full stack — repository interfaces (MongoDB and JDBC), service layer, and REST API with a new repeatable `type` query parameter. OpenAPI spec updated accordingly.

Frontend: Added Application Type multi-select dropdown, a Clear Filters button (resets both search and type filter), and a loading guard to prevent UI flicker when clearing filters from a no-results state.

## :id: Reference related issue. https://gravitee.atlassian.net/browse/AM-6110


## :pencil2: A description of the changes proposed in the pull request


## :memo: Test scenarios 

Please see ticket https://gravitee.atlassian.net/browse/AM-6110


## :computer: Add screenshots for UI
<img width="1913" height="1012" alt="image" src="https://github.com/user-attachments/assets/0ddc4876-4cb4-4214-96da-baab3fab5ed3" />




