### PR TITLE
AM-6881 - fix: bump gravitee-bom to pick up netty CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <properties>
         <bouncycastle-extension.version>1.81</bouncycastle-extension.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-bom.version>9.0.0-alpha.4</gravitee-bom.version>
         <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
         <gravitee-plugin.version>5.0.0-alpha.3</gravitee-plugin.version>
         <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>


### PR DESCRIPTION
## :id: Reference
[AM-6881](https://gravitee.atlassian.net/browse/AM-6881)

## :pencil2: Description

Upgrades `gravitee-bom` from `9.0.0-alpha.2` to `9.0.0-alpha.4` to pick up **Netty 4.2.12.Final** (or higher), fixing [CVE-2026-33870](https://nvd.nist.gov/vuln/detail/CVE-2026-33870) (High severity).

**Before:** Netty 4.2.11.Final (vulnerable)
**After:** Netty version managed by gravitee-bom 9.0.0-alpha.4 (patched)

### What changed
- Single property bump in the root `pom.xml` — no code changes.

## :memo: Test scenarios
- Build compiles successfully with the new BOM version.
- No behavioral changes expected — this is a transitive dependency version bump.

[AM-6881]: https://gravitee.atlassian.net/browse/AM-6881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ