### PR TITLE
fix: AM-6898 improve information shown for CIMD settings

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
@@ -75,7 +75,7 @@
               <input
                 matInput
                 type="number"
-                placeholder="3000"
+                placeholder="Fetch timeout"
                 name="fetchTimeoutMs"
                 [(ngModel)]="cimdSettings.fetchTimeoutMs"
                 (ngModelChange)="onFormChange()"
@@ -89,7 +89,7 @@
               <input
                 matInput
                 type="number"
-                placeholder="20"
+                placeholder="Maximum response size"
                 name="maxResponseSizeKb"
                 [(ngModel)]="cimdSettings.maxResponseSizeKb"
                 (ngModelChange)="onFormChange()"
@@ -145,7 +145,7 @@
               <input
                 matInput
                 type="number"
-                placeholder="3600"
+                placeholder="Cache TTL"
                 name="cacheTtlSeconds"
                 [(ngModel)]="cimdSettings.cacheTtlSeconds"
                 (ngModelChange)="onFormChange()"
@@ -159,7 +159,7 @@
               <input
                 matInput
                 type="number"
-                placeholder="500"
+                placeholder="Maximum number of entries"
                 name="cacheMaxEntries"
                 [(ngModel)]="cimdSettings.cacheMaxEntries"
                 (ngModelChange)="onFormChange()"
@@ -177,7 +177,7 @@
       </form>
     </div>
     <div class="gv-page-description" fxFlex>
-      <h3>CIMD?</h3>
+      <h3>What is CIMD?</h3>
       <div class="gv-page-description-content">
         <p>
           Client-Initiated Metadata Document (CIMD) allows OAuth 2.0 clients to retrieve their own metadata from a well-known URI, enabling

--- a/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.ts
@@ -50,12 +50,22 @@ export class CimdSettingsComponent implements OnInit {
   }
 
   save() {
-    this.domainService.patchCimdSettings(this.domainId, this.cimdSettings).subscribe((data) => {
-      this.domainStore.set(data);
-      this.domain = data;
-      this.cimdSettings = deepClone(data.oidc?.cimdSettings) || {};
-      this.formChanged = false;
-      this.snackbarService.open('CIMD configuration updated');
+    this.domainService.patchCimdSettings(this.domainId, this.cimdSettings).subscribe({
+      next: (data) => {
+        this.domainStore.set(data);
+        this.domain = data;
+        this.cimdSettings = deepClone(data.oidc?.cimdSettings) || {};
+        this.formChanged = false;
+        this.snackbarService.open('CIMD configuration updated');
+      },
+      error: (error: unknown) => {
+        const httpError = error as { error?: { message?: string } };
+        if (httpError?.error?.message) {
+          this.snackbarService.open(httpError.error.message);
+        } else {
+          this.snackbarService.open('Failed to update CIMD configuration');
+        }
+      },
     });
   }
 

--- a/gravitee-am-ui/src/app/services/domain.service.ts
+++ b/gravitee-am-ui/src/app/services/domain.service.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpContext } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { AppConfig } from '../../config/app.config';
+import { SKIP_ERROR_SNACKBAR } from '../interceptors/http-request.interceptor';
 
 import { AuthService } from './auth.service';
 
@@ -129,9 +130,15 @@ export class DomainService {
   }
 
   patchCimdSettings(id, cimdSettings): Observable<any> {
-    return this.http.patch<any>(this.domainsURL + id, {
-      oidc: { cimdSettings },
-    });
+    return this.http.patch<any>(
+      this.domainsURL + id,
+      {
+        oidc: { cimdSettings },
+      },
+      {
+        context: new HttpContext().set(SKIP_ERROR_SNACKBAR, true),
+      },
+    );
   }
 
   patchScimSettings(id, domain): Observable<any> {


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6898](https://gravitee.atlassian.net/browse/AM-6898)

## :pencil2: A description of the changes proposed in the pull request

- Use descriptive prompts as placeholders in CIMD settings
- Tweak onscreen help title
- Show snackbar when saving form fails

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
<img width="1424" height="858" alt="image" src="https://github.com/user-attachments/assets/4ba35ce2-bb3a-4d74-81ed-8dba8325d310" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6898]: https://gravitee.atlassian.net/browse/AM-6898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ