### PR TITLE
fix: AM-6901 AM-6902 AM-6903 AM-6910 CIMD API

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -17,7 +17,7 @@
 openapi: 3.0.1
 info:
   title: Gravitee.io - Access Management API
-  version: 4.12.0-alpha.2-SNAPSHOT
+  version: 4.12.0-alpha.3-SNAPSHOT
 servers:
 - url: /management
 security:
@@ -12782,7 +12782,7 @@ components:
         maxResponseSizeKb:
           type: integer
           format: int32
-        softwareId:
+        templateId:
           type: string
     Certificate:
       type: object
@@ -15356,7 +15356,7 @@ components:
         maxResponseSizeKb:
           type: integer
           format: int32
-        softwareId:
+        templateId:
           type: string
     PatchChallengeSettings:
       type: object

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainCIMDSettingsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainCIMDSettingsResourceTest.java
@@ -119,8 +119,8 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         assertEquals("cacheTtlSeconds must be 7200", Integer.valueOf(7200), capturedCimd.getCacheTtlSeconds().get());
         assertTrue("cacheMaxEntries must be present", capturedCimd.getCacheMaxEntries().isPresent());
         assertEquals("cacheMaxEntries must be 500", Integer.valueOf(500), capturedCimd.getCacheMaxEntries().get());
-        assertTrue("softwareId must be present", capturedCimd.getSoftwareId().isPresent());
-        assertEquals("softwareId must match", "my-software-id", capturedCimd.getSoftwareId().get());
+        assertTrue("templateId must be present", capturedCimd.getTemplateId().isPresent());
+        assertEquals("templateId must match", "my-template-id", capturedCimd.getTemplateId().get());
     }
 
     @Test
@@ -153,7 +153,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         assertEquals("allowedDomains must contain 2 entries", 2, cimd.getAllowedDomains().size());
         assertEquals("cacheTtlSeconds must be 7200", 7200, cimd.getCacheTtlSeconds());
         assertEquals("cacheMaxEntries must be 500", 500, cimd.getCacheMaxEntries());
-        assertEquals("softwareId must match", "my-software-id", cimd.getSoftwareId());
+        assertEquals("templateId must match", "my-template-id", cimd.getTemplateId());
     }
 
     // -------------------------------------------------------------------------
@@ -186,7 +186,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
 
         PatchCIMDSettings capturedCimd = captured.getOidc().get().getCimdSettings().get();
         assertTrue("enabled must be true", capturedCimd.getEnabled().get());
-        assertEquals("softwareId must match", "my-software-id", capturedCimd.getSoftwareId().get());
+        assertEquals("templateId must match", "my-template-id", capturedCimd.getTemplateId().get());
         assertEquals("fetchTimeoutMs must be 3000", Integer.valueOf(3000), capturedCimd.getFetchTimeoutMs().get());
         assertEquals("cacheTtlSeconds must be 7200", Integer.valueOf(7200), capturedCimd.getCacheTtlSeconds().get());
     }
@@ -214,7 +214,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         CIMDSettings cimd = domain.getOidc().getCimdSettings();
         assertNotNull("cimdSettings must be present in response", cimd);
         assertTrue("enabled must be true", cimd.isEnabled());
-        assertEquals("softwareId must match", "my-software-id", cimd.getSoftwareId());
+        assertEquals("templateId must match", "my-template-id", cimd.getTemplateId());
         assertEquals("fetchTimeoutMs must be 3000", 3000, cimd.getFetchTimeoutMs());
         assertEquals("cacheTtlSeconds must be 7200", 7200, cimd.getCacheTtlSeconds());
     }
@@ -279,7 +279,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         cimdSettings.setAllowedDomains(Arrays.asList("example.com", "*.trusted.io"));
         cimdSettings.setCacheTtlSeconds(7200);
         cimdSettings.setCacheMaxEntries(500);
-        cimdSettings.setSoftwareId("my-software-id");
+        cimdSettings.setTemplateId("my-template-id");
 
         OIDCSettings oidcSettings = new OIDCSettings();
         oidcSettings.setCimdSettings(cimdSettings);
@@ -298,7 +298,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         patchCimd.setAllowedDomains(Optional.of(Arrays.asList("example.com", "*.trusted.io")));
         patchCimd.setCacheTtlSeconds(Optional.of(7200));
         patchCimd.setCacheMaxEntries(Optional.of(500));
-        patchCimd.setSoftwareId(Optional.of("my-software-id"));
+        patchCimd.setTemplateId(Optional.of("my-template-id"));
 
         PatchOIDCSettings patchOidc = new PatchOIDCSettings();
         patchOidc.setCimdSettings(Optional.of(patchCimd));

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -911,13 +911,13 @@ public class DomainServiceImpl implements DomainService {
             return Completable.error(new InvalidDomainException("CIMD settings are invalid: allowed domains must be a list of valid domains and wildcard is only allowed for first-level subdomain"));
         }
 
-        String softwareId = cimdSettings.getSoftwareId();
-        if (!StringUtils.hasText(softwareId)) {
-            return Completable.error(new InvalidDomainException("softwareId (template identifier) must be provided when Client ID Metadata Document is enabled"));
+        String templateId = cimdSettings.getTemplateId();
+        if (!StringUtils.hasText(templateId)) {
+            return Completable.error(new InvalidDomainException("templateId must be provided when Client ID Metadata Document is enabled"));
         }
 
-        return applicationService.findById(softwareId).filter(Application::isTemplate)
-                .switchIfEmpty(Maybe.error(new InvalidDomainException("softwareId must be a valid application id configured as template"))).ignoreElement();
+        return applicationService.findById(templateId).filter(Application::isTemplate)
+                .switchIfEmpty(Maybe.error(new InvalidDomainException("templateId must be a valid application id configured as template"))).ignoreElement();
     }
 
     private boolean hasInvalidDomain(CIMDSettings cimdSettings) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -890,13 +890,30 @@ public class DomainServiceImpl implements DomainService {
         }
 
         CIMDSettings cimdSettings = optCIMDSettings.get();
+
+        if (cimdSettings.getFetchTimeoutMs() <= 0) {
+            return Completable.error(new InvalidDomainException("CIMD settings are invalid: fetch timeout must be higher than 0"));
+        }
+
+        if (cimdSettings.getMaxResponseSizeKb() <= 0) {
+            return Completable.error(new InvalidDomainException("CIMD settings are invalid: maximum response size must be higher than 0"));
+        }
+
+        if (cimdSettings.getCacheTtlSeconds() <= 0) {
+            return Completable.error(new InvalidDomainException("CIMD settings are invalid: cache TTL must be higher than 0"));
+        }
+
+        if (cimdSettings.getCacheMaxEntries() <= 0) {
+            return Completable.error(new InvalidDomainException("CIMD settings are invalid: cache maximum entries must be higher than 0"));
+        }
+
         if (cimdSettings.getAllowedDomains() != null && !cimdSettings.getAllowedDomains().isEmpty() && hasInvalidDomain(cimdSettings)) {
             return Completable.error(new InvalidDomainException("CIMD settings are invalid: allowed domains must be a list of valid domains and wildcard is only allowed for first-level subdomain"));
         }
 
         String softwareId = cimdSettings.getSoftwareId();
         if (!StringUtils.hasText(softwareId)) {
-            return Completable.error(new InvalidDomainException("softwareId must be provided when Client ID Metadata Document is enabled"));
+            return Completable.error(new InvalidDomainException("softwareId (template identifier) must be provided when Client ID Metadata Document is enabled"));
         }
 
         return applicationService.findById(softwareId).filter(Application::isTemplate)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -116,6 +116,8 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -815,7 +817,7 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldNoPatch_ResetPasswordMultiFields_InvalidFields() {
+    public void shouldNotPatch_ResetPasswordMultiFields_InvalidFields() {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
         Domain domain = new Domain();
         domain.setId("my-domain");
@@ -846,86 +848,136 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldNoPatch_CIMD_contains_invalid_domain() {
+    public void shouldNotPatch_CIMD_invalidDomain() {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
-        Domain domain = new Domain();
-        domain.setId("my-domain");
-        domain.setHrid("my-domain");
-        domain.setReferenceType(ReferenceType.ENVIRONMENT);
-        domain.setReferenceId(ENVIRONMENT_ID);
-        domain.setName("my-domain");
-        domain.setPath("/test");
-        OIDCSettings oidcSettings = new OIDCSettings();
         CIMDSettings cimdSettings = new CIMDSettings();
         cimdSettings.setEnabled(true);
         cimdSettings.setSoftwareId("software-id");
-        cimdSettings.setAllowedDomains(List.of("*.com")); // invalid as wildcard with only root is forbidden
-        oidcSettings.setCimdSettings(cimdSettings);
-        domain.setOidc(oidcSettings);
-        when(patchDomain.patch(any())).thenReturn(domain);
-        when(domainRepository.findById("my-domain")).thenReturn(Maybe.just(domain));
-        doReturn(true).when(accountSettingsValidator).validate(any());
-        when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, domain.getHrid())).thenReturn(Maybe.just(new Domain(domain.getId())));
-        doReturn(Completable.complete()).when(tokenExchangeSettingsValidator).validate(any());
-        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
-        when(domainReadService.listAll()).thenReturn(Flowable.empty());
-        when(domainValidator.validate(any(), any())).thenReturn(Completable.complete());
-        when(virtualHostValidator.validateDomainVhosts(any(), any())).thenReturn(Completable.complete());
+        cimdSettings.setAllowedDomains(List.of("*.com")); // invalid hostname pattern for allowed domains
+        Domain domain = buildDomainWithCimdSettings(cimdSettings);
+        stubDomainPatch(patchDomain, domain);
 
-        domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertNotComplete()
-                .assertError(InvalidDomainException.class);
+        TestObserver<Domain> observer = domainService
+                .patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
+                .test();
 
+        assertInvalidDomainExceptionMessage(
+                observer,
+                "CIMD settings are invalid: allowed domains must be a list of valid domains and wildcard is only allowed for first-level subdomain");
         verify(domainRepository).findById(anyString());
         verify(applicationService, never()).findById(anyString());
         verify(domainRepository, never()).update(any(Domain.class));
     }
 
     @Test
-    public void shouldNoPatch_CIMD_reference_classical_app_not_template() {
+    public void shouldNotPatch_CIMD_applicationNotTemplate() {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
-        Domain domain = new Domain();
-        domain.setId("my-domain");
-        domain.setHrid("my-domain");
-        domain.setReferenceType(ReferenceType.ENVIRONMENT);
-        domain.setReferenceId(ENVIRONMENT_ID);
-        domain.setName("my-domain");
-        domain.setPath("/test");
-        OIDCSettings oidcSettings = new OIDCSettings();
         CIMDSettings cimdSettings = new CIMDSettings();
         cimdSettings.setEnabled(true);
         cimdSettings.setSoftwareId("software-id");
-        cimdSettings.setAllowedDomains(List.of("*.gravitee.io")); // invalid as wildcard with only root is forbidden
-        oidcSettings.setCimdSettings(cimdSettings);
-        domain.setOidc(oidcSettings);
-        when(patchDomain.patch(any())).thenReturn(domain);
-        when(domainRepository.findById("my-domain")).thenReturn(Maybe.just(domain));
-        doReturn(true).when(accountSettingsValidator).validate(any());
-        when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, domain.getHrid())).thenReturn(Maybe.just(new Domain(domain.getId())));
-        doReturn(Completable.complete()).when(tokenExchangeSettingsValidator).validate(any());
-        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
-        when(domainReadService.listAll()).thenReturn(Flowable.empty());
-        when(domainValidator.validate(any(), any())).thenReturn(Completable.complete());
-        when(virtualHostValidator.validateDomainVhosts(any(), any())).thenReturn(Completable.complete());
-        Application template = new Application();
-        template.setTemplate(false);
-        when(applicationService.findById(anyString())).thenReturn(Maybe.just(template));
+        cimdSettings.setAllowedDomains(List.of("*.gravitee.io"));
+        Domain domain = buildDomainWithCimdSettings(cimdSettings);
+        stubDomainPatch(patchDomain, domain);
+        Application application = new Application();
+        application.setTemplate(false);
+        when(applicationService.findById(anyString())).thenReturn(Maybe.just(application));
 
-        domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertNotComplete()
-                .assertError(InvalidDomainException.class);
+        TestObserver<Domain> observer = domainService
+                .patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
+                .test();
 
+        assertInvalidDomainExceptionMessage(observer, "softwareId must be a valid application id configured as template");
         verify(domainRepository).findById(anyString());
         verify(applicationService).findById(anyString());
         verify(domainRepository, never()).update(any(Domain.class));
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    public void shouldNotPatch_CIMD_fetchTimeoutNotPositive(int invalidFetchTimeoutMs) {
+        PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
+        CIMDSettings cimdSettings = new CIMDSettings();
+        cimdSettings.setEnabled(true);
+        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setFetchTimeoutMs(invalidFetchTimeoutMs);
+        Domain domain = buildDomainWithCimdSettings(cimdSettings);
+        stubDomainPatch(patchDomain, domain);
+
+        TestObserver<Domain> observer = domainService
+                .patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
+                .test();
+
+        assertInvalidDomainExceptionMessage(observer, "CIMD settings are invalid: fetch timeout must be higher than 0");
+        verify(domainRepository).findById(anyString());
+        verify(applicationService, never()).findById(anyString());
+        verify(domainRepository, never()).update(any(Domain.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    public void shouldNotPatch_CIMD_maxResponseSizeNotPositive(int invalidMaxKb) {
+        PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
+        CIMDSettings cimdSettings = new CIMDSettings();
+        cimdSettings.setEnabled(true);
+        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setMaxResponseSizeKb(invalidMaxKb);
+        Domain domain = buildDomainWithCimdSettings(cimdSettings);
+        stubDomainPatch(patchDomain, domain);
+
+        TestObserver<Domain> observer = domainService
+                .patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
+                .test();
+
+        assertInvalidDomainExceptionMessage(observer, "CIMD settings are invalid: maximum response size must be higher than 0");
+        verify(domainRepository).findById(anyString());
+        verify(applicationService, never()).findById(anyString());
+        verify(domainRepository, never()).update(any(Domain.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    public void shouldNotPatch_CIMD_cacheTtlNotPositive(int invalidTtlSeconds) {
+        PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
+        CIMDSettings cimdSettings = new CIMDSettings();
+        cimdSettings.setEnabled(true);
+        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setCacheTtlSeconds(invalidTtlSeconds);
+        Domain domain = buildDomainWithCimdSettings(cimdSettings);
+        stubDomainPatch(patchDomain, domain);
+
+        TestObserver<Domain> observer = domainService
+                .patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
+                .test();
+
+        assertInvalidDomainExceptionMessage(observer, "CIMD settings are invalid: cache TTL must be higher than 0");
+        verify(domainRepository).findById(anyString());
+        verify(applicationService, never()).findById(anyString());
+        verify(domainRepository, never()).update(any(Domain.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    public void shouldNotPatch_CIMD_cacheMaxEntriesNotPositive(int invalidMaxEntries) {
+        PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
+        CIMDSettings cimdSettings = new CIMDSettings();
+        cimdSettings.setEnabled(true);
+        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setCacheMaxEntries(invalidMaxEntries);
+        Domain domain = buildDomainWithCimdSettings(cimdSettings);
+        stubDomainPatch(patchDomain, domain);
+
+        TestObserver<Domain> observer = domainService
+                .patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
+                .test();
+
+        assertInvalidDomainExceptionMessage(observer, "CIMD settings are invalid: cache maximum entries must be higher than 0");
+        verify(domainRepository).findById(anyString());
+        verify(applicationService, never()).findById(anyString());
+        verify(domainRepository, never()).update(any(Domain.class));
+    }
+
     @Test
-    public void shouldPatch_hrid_already_exists() {
+    public void shouldPatch_hridAlreadyExists() {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
 
         Domain domain = new Domain();
@@ -1832,6 +1884,39 @@ public class DomainServiceTest {
         verify(certificateService).findById(fallbackCertId);
         verify(domainRepository, never()).update(any());
         verify(auditService, times(1)).report(any());
+    }
+
+    private static Domain buildDomainWithCimdSettings(CIMDSettings cimdSettings) {
+        Domain domain = new Domain();
+        domain.setId("my-domain");
+        domain.setHrid("my-domain");
+        domain.setReferenceType(ReferenceType.ENVIRONMENT);
+        domain.setReferenceId(ENVIRONMENT_ID);
+        domain.setName("my-domain");
+        domain.setPath("/test");
+        OIDCSettings oidcSettings = new OIDCSettings();
+        oidcSettings.setCimdSettings(cimdSettings);
+        domain.setOidc(oidcSettings);
+        return domain;
+    }
+
+    private void stubDomainPatch(PatchDomain patchDomain, Domain domain) {
+        when(patchDomain.patch(any())).thenReturn(domain);
+        when(domainRepository.findById("my-domain")).thenReturn(Maybe.just(domain));
+        doReturn(true).when(accountSettingsValidator).validate(any());
+        when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, domain.getHrid())).thenReturn(Maybe.just(new Domain(domain.getId())));
+        doReturn(Completable.complete()).when(tokenExchangeSettingsValidator).validate(any());
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
+        when(domainReadService.listAll()).thenReturn(Flowable.empty());
+        when(domainValidator.validate(any(), any())).thenReturn(Completable.complete());
+        when(virtualHostValidator.validateDomainVhosts(any(), any())).thenReturn(Completable.complete());
+    }
+
+    private static void assertInvalidDomainExceptionMessage(TestObserver<Domain> observer, String expectedMessage) {
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertNotComplete();
+        observer.assertError(
+                error -> error instanceof InvalidDomainException && expectedMessage.equals(error.getMessage()));
     }
 
     private static CorsSettings getCorsSettings(Set<String> allowedOrigins) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -852,7 +852,7 @@ public class DomainServiceTest {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
         CIMDSettings cimdSettings = new CIMDSettings();
         cimdSettings.setEnabled(true);
-        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setTemplateId("template-id");
         cimdSettings.setAllowedDomains(List.of("*.com")); // invalid hostname pattern for allowed domains
         Domain domain = buildDomainWithCimdSettings(cimdSettings);
         stubDomainPatch(patchDomain, domain);
@@ -874,7 +874,7 @@ public class DomainServiceTest {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
         CIMDSettings cimdSettings = new CIMDSettings();
         cimdSettings.setEnabled(true);
-        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setTemplateId("template-id");
         cimdSettings.setAllowedDomains(List.of("*.gravitee.io"));
         Domain domain = buildDomainWithCimdSettings(cimdSettings);
         stubDomainPatch(patchDomain, domain);
@@ -886,7 +886,7 @@ public class DomainServiceTest {
                 .patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, "my-domain"), "my-domain", patchDomain, null)
                 .test();
 
-        assertInvalidDomainExceptionMessage(observer, "softwareId must be a valid application id configured as template");
+        assertInvalidDomainExceptionMessage(observer, "templateId must be a valid application id configured as template");
         verify(domainRepository).findById(anyString());
         verify(applicationService).findById(anyString());
         verify(domainRepository, never()).update(any(Domain.class));
@@ -898,7 +898,7 @@ public class DomainServiceTest {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
         CIMDSettings cimdSettings = new CIMDSettings();
         cimdSettings.setEnabled(true);
-        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setTemplateId("template-id");
         cimdSettings.setFetchTimeoutMs(invalidFetchTimeoutMs);
         Domain domain = buildDomainWithCimdSettings(cimdSettings);
         stubDomainPatch(patchDomain, domain);
@@ -919,7 +919,7 @@ public class DomainServiceTest {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
         CIMDSettings cimdSettings = new CIMDSettings();
         cimdSettings.setEnabled(true);
-        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setTemplateId("template-id");
         cimdSettings.setMaxResponseSizeKb(invalidMaxKb);
         Domain domain = buildDomainWithCimdSettings(cimdSettings);
         stubDomainPatch(patchDomain, domain);
@@ -940,7 +940,7 @@ public class DomainServiceTest {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
         CIMDSettings cimdSettings = new CIMDSettings();
         cimdSettings.setEnabled(true);
-        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setTemplateId("template-id");
         cimdSettings.setCacheTtlSeconds(invalidTtlSeconds);
         Domain domain = buildDomainWithCimdSettings(cimdSettings);
         stubDomainPatch(patchDomain, domain);
@@ -961,7 +961,7 @@ public class DomainServiceTest {
         PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
         CIMDSettings cimdSettings = new CIMDSettings();
         cimdSettings.setEnabled(true);
-        cimdSettings.setSoftwareId("software-id");
+        cimdSettings.setTemplateId("template-id");
         cimdSettings.setCacheMaxEntries(invalidMaxEntries);
         Domain domain = buildDomainWithCimdSettings(cimdSettings);
         stubDomainPatch(patchDomain, domain);

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIMDSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIMDSettings.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.am.model.oidc;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -82,7 +81,7 @@ public class CIMDSettings {
     /**
      * Template identifier
      */
-    private String softwareId;
+    private String templateId;
 
     public boolean isEnabled() {
         return enabled;
@@ -148,12 +147,12 @@ public class CIMDSettings {
         this.cacheMaxEntries = cacheMaxEntries;
     }
 
-    public String getSoftwareId() {
-        return softwareId;
+    public String getTemplateId() {
+        return templateId;
     }
 
-    public void setSoftwareId(String softwareId) {
-        this.softwareId = softwareId;
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
     }
 
     public static CIMDSettings defaultSettings() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
@@ -457,7 +457,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         result.setAllowedDomains(cimdSettings.getAllowedDomains());
         result.setCacheTtlSeconds(cimdSettings.getCacheTtlSeconds());
         result.setCacheMaxEntries(cimdSettings.getCacheMaxEntries());
-        result.setSoftwareId(cimdSettings.getSoftwareId());
+        result.setTemplateId(cimdSettings.getTemplateId());
 
         return result;
     }
@@ -476,7 +476,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         result.setAllowedDomains(cimdSettings.getAllowedDomains());
         result.setCacheTtlSeconds(cimdSettings.getCacheTtlSeconds());
         result.setCacheMaxEntries(cimdSettings.getCacheMaxEntries());
-        result.setSoftwareId(cimdSettings.getSoftwareId());
+        result.setTemplateId(cimdSettings.getTemplateId());
 
         return result;
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/CIMDSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/CIMDSettingsMongo.java
@@ -30,7 +30,7 @@ public class CIMDSettingsMongo {
     private List<String> allowedDomains;
     private int cacheTtlSeconds;
     private int cacheMaxEntries;
-    private String softwareId;
+    private String templateId;
 
     public boolean isEnabled() {
         return enabled;
@@ -96,11 +96,11 @@ public class CIMDSettingsMongo {
         this.cacheMaxEntries = cacheMaxEntries;
     }
 
-    public String getSoftwareId() {
-        return softwareId;
+    public String getTemplateId() {
+        return templateId;
     }
 
-    public void setSoftwareId(String softwareId) {
-        this.softwareId = softwareId;
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIMDSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIMDSettings.java
@@ -46,7 +46,7 @@ public class PatchCIMDSettings {
     private Optional<Integer> cacheMaxEntries;
 
     // Security Policy
-    private Optional<String> softwareId;
+    private Optional<String> templateId;
 
     public Optional<Boolean> getEnabled() {
         return enabled;
@@ -112,12 +112,12 @@ public class PatchCIMDSettings {
         this.cacheMaxEntries = cacheMaxEntries;
     }
 
-    public Optional<String> getSoftwareId() {
-        return softwareId;
+    public Optional<String> getTemplateId() {
+        return templateId;
     }
 
-    public void setSoftwareId(Optional<String> softwareId) {
-        this.softwareId = softwareId;
+    public void setTemplateId(Optional<String> templateId) {
+        this.templateId = templateId;
     }
 
     public CIMDSettings patch(CIMDSettings toPatch) {
@@ -135,7 +135,7 @@ public class PatchCIMDSettings {
                 .ifPresent(opt -> result.setCacheTtlSeconds(opt.orElse(CIMDSettings.DEFAULT_CACHE_TTL_SECONDS)));
         Optional.ofNullable(getCacheMaxEntries())
                 .ifPresent(opt -> result.setCacheMaxEntries(opt.orElse(CIMDSettings.DEFAULT_CACHE_MAX_ENTRIES)));
-        SetterUtils.safeSet(result::setSoftwareId, this.getSoftwareId(), String.class);
+        SetterUtils.safeSet(result::setTemplateId, this.getTemplateId(), String.class);
 
         return result;
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIMDSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIMDSettings.java
@@ -126,11 +126,15 @@ public class PatchCIMDSettings {
         SetterUtils.safeSet(result::setEnabled, this.getEnabled(), boolean.class);
         SetterUtils.safeSet(result::setAllowUnsecuredHttpUri, this.getAllowUnsecuredHttpUri(), boolean.class);
         SetterUtils.safeSet(result::setAllowPrivateIpAddress, this.getAllowPrivateIpAddress(), boolean.class);
-        SetterUtils.safeSet(result::setFetchTimeoutMs, this.getFetchTimeoutMs(), int.class);
-        SetterUtils.safeSet(result::setMaxResponseSizeKb, this.getMaxResponseSizeKb(), int.class);
+        Optional.ofNullable(getFetchTimeoutMs())
+                .ifPresent(opt -> result.setFetchTimeoutMs(opt.orElse(CIMDSettings.DEFAULT_FETCH_TIMEOUT_MS)));
+        Optional.ofNullable(getMaxResponseSizeKb())
+                .ifPresent(opt -> result.setMaxResponseSizeKb(opt.orElse(CIMDSettings.DEFAULT_MAX_RESPONSE_SIZE_KB)));
         SetterUtils.safeSet(result::setAllowedDomains, this.getAllowedDomains());
-        SetterUtils.safeSet(result::setCacheTtlSeconds, this.getCacheTtlSeconds(), int.class);
-        SetterUtils.safeSet(result::setCacheMaxEntries, this.getCacheMaxEntries(), int.class);
+        Optional.ofNullable(getCacheTtlSeconds())
+                .ifPresent(opt -> result.setCacheTtlSeconds(opt.orElse(CIMDSettings.DEFAULT_CACHE_TTL_SECONDS)));
+        Optional.ofNullable(getCacheMaxEntries())
+                .ifPresent(opt -> result.setCacheMaxEntries(opt.orElse(CIMDSettings.DEFAULT_CACHE_MAX_ENTRIES)));
         SetterUtils.safeSet(result::setSoftwareId, this.getSoftwareId(), String.class);
 
         return result;

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/model/openid/PatchCIMDSettingsTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/model/openid/PatchCIMDSettingsTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.model.openid;
+
+import io.gravitee.am.model.oidc.CIMDSettings;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(JUnit4.class)
+public class PatchCIMDSettingsTest {
+
+    @Test
+    public void patchEmptyOptionalNumeric_restoresDomainDefaults() {
+        CIMDSettings existing = new CIMDSettings();
+        existing.setFetchTimeoutMs(9999);
+        existing.setMaxResponseSizeKb(99);
+        existing.setCacheTtlSeconds(111);
+        existing.setCacheMaxEntries(222);
+
+        PatchCIMDSettings patch = new PatchCIMDSettings();
+        patch.setFetchTimeoutMs(Optional.empty());
+        patch.setMaxResponseSizeKb(Optional.empty());
+        patch.setCacheTtlSeconds(Optional.empty());
+        patch.setCacheMaxEntries(Optional.empty());
+
+        CIMDSettings result = patch.patch(existing);
+        assertEquals(CIMDSettings.DEFAULT_FETCH_TIMEOUT_MS, result.getFetchTimeoutMs());
+        assertEquals(CIMDSettings.DEFAULT_MAX_RESPONSE_SIZE_KB, result.getMaxResponseSizeKb());
+        assertEquals(CIMDSettings.DEFAULT_CACHE_TTL_SECONDS, result.getCacheTtlSeconds());
+        assertEquals(CIMDSettings.DEFAULT_CACHE_MAX_ENTRIES, result.getCacheMaxEntries());
+    }
+
+    @Test
+    public void patchNullNumeric_skipsField() {
+        CIMDSettings existing = new CIMDSettings();
+        existing.setFetchTimeoutMs(9999);
+
+        PatchCIMDSettings patch = new PatchCIMDSettings();
+
+        CIMDSettings result = patch.patch(existing);
+        assertEquals(9999, result.getFetchTimeoutMs());
+    }
+
+    @Test
+    public void patchPresentOptionalNumeric_appliesValue() {
+        CIMDSettings existing = new CIMDSettings();
+        existing.setFetchTimeoutMs(5000);
+
+        PatchCIMDSettings patch = new PatchCIMDSettings();
+        patch.setFetchTimeoutMs(Optional.of(1000));
+
+        CIMDSettings result = patch.patch(existing);
+        assertEquals(1000, result.getFetchTimeoutMs());
+    }
+}

--- a/gravitee-am-test/api/management/models/CIMDSettings.ts
+++ b/gravitee-am-test/api/management/models/CIMDSettings.ts
@@ -85,7 +85,7 @@ export interface CIMDSettings {
    * @type {string}
    * @memberof CIMDSettings
    */
-  softwareId?: string;
+  templateId?: string;
 }
 
 /**
@@ -112,7 +112,7 @@ export function CIMDSettingsFromJSONTyped(json: any, ignoreDiscriminator: boolea
     enabled: json['enabled'] == null ? undefined : json['enabled'],
     fetchTimeoutMs: json['fetchTimeoutMs'] == null ? undefined : json['fetchTimeoutMs'],
     maxResponseSizeKb: json['maxResponseSizeKb'] == null ? undefined : json['maxResponseSizeKb'],
-    softwareId: json['softwareId'] == null ? undefined : json['softwareId'],
+    templateId: json['templateId'] == null ? undefined : json['templateId'],
   };
 }
 
@@ -134,6 +134,6 @@ export function CIMDSettingsToJSONTyped(value?: CIMDSettings | null, ignoreDiscr
     enabled: value['enabled'],
     fetchTimeoutMs: value['fetchTimeoutMs'],
     maxResponseSizeKb: value['maxResponseSizeKb'],
-    softwareId: value['softwareId'],
+    templateId: value['templateId'],
   };
 }

--- a/gravitee-am-test/api/management/models/PatchCIMDSettings.ts
+++ b/gravitee-am-test/api/management/models/PatchCIMDSettings.ts
@@ -85,7 +85,7 @@ export interface PatchCIMDSettings {
    * @type {string}
    * @memberof PatchCIMDSettings
    */
-  softwareId?: string;
+  templateId?: string;
 }
 
 /**
@@ -112,7 +112,7 @@ export function PatchCIMDSettingsFromJSONTyped(json: any, ignoreDiscriminator: b
     enabled: json['enabled'] == null ? undefined : json['enabled'],
     fetchTimeoutMs: json['fetchTimeoutMs'] == null ? undefined : json['fetchTimeoutMs'],
     maxResponseSizeKb: json['maxResponseSizeKb'] == null ? undefined : json['maxResponseSizeKb'],
-    softwareId: json['softwareId'] == null ? undefined : json['softwareId'],
+    templateId: json['templateId'] == null ? undefined : json['templateId'],
   };
 }
 
@@ -134,6 +134,6 @@ export function PatchCIMDSettingsToJSONTyped(value?: PatchCIMDSettings | null, i
     enabled: value['enabled'],
     fetchTimeoutMs: value['fetchTimeoutMs'],
     maxResponseSizeKb: value['maxResponseSizeKb'],
-    softwareId: value['softwareId'],
+    templateId: value['templateId'],
   };
 }

--- a/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
@@ -35,8 +35,8 @@
                 matInput
                 type="text"
                 placeholder="Enter the Template ID"
-                name="softwareId"
-                [(ngModel)]="cimdSettings.softwareId"
+                name="templateId"
+                [(ngModel)]="cimdSettings.templateId"
                 (ngModelChange)="onFormChange()"
                 [disabled]="!editMode"
                 required


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6901](https://gravitee.atlassian.net/browse/AM-6901)
[AM-6902](https://gravitee.atlassian.net/browse/AM-6902)
[AM-6903](https://gravitee.atlassian.net/browse/AM-6903)
[AM-6910](https://gravitee.atlassian.net/browse/AM-6910)

## :pencil2: A description of the changes proposed in the pull request
Update management API schema for domain CIMD settings:
- Validate all numerical settings are greater than 0 (return 400 with error message otherwise)
- Allow null values for numerical settings to restore defaults
- Rename `softwareId` property -> `templateId` to more closely match AM usage and to align with UI

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6901]: https://gravitee.atlassian.net/browse/AM-6901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-6902]: https://gravitee.atlassian.net/browse/AM-6902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-6903]: https://gravitee.atlassian.net/browse/AM-6903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-6910]: https://gravitee.atlassian.net/browse/AM-6910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ