### PR TITLE
fix(deps): update gravitee-bom to 9.0.0-alpha.5 to fix CVE-2026-1605

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <properties>
         <bouncycastle-extension.version>1.81</bouncycastle-extension.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <gravitee-bom.version>9.0.0-alpha.4</gravitee-bom.version>
+        <gravitee-bom.version>9.0.0-alpha.5</gravitee-bom.version>
         <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
         <gravitee-plugin.version>5.0.0</gravitee-plugin.version>
         <gravitee-node.version>9.0.0-alpha.2</gravitee-node.version>


### PR DESCRIPTION
## :id: Reference related issue

[AM-6911](https://gravitee.atlassian.net/browse/AM-6911) — CVE-2026-1605 - AM package upgrade

## :pencil2: A description of the changes proposed in the pull request

### CVE Details

- **CVE Identifier:** CVE-2026-1605
- **Severity:** HIGH
- **Affected Packages:** jetty-ee10-servlets, jetty-ee10-servlet, jetty-ee10-webapp, jetty-ee-webapp, jetty-io, jetty-security, jetty-util, jetty-session, jetty-jmx, jetty-server

### Fix

Updates `gravitee-bom` to **9.0.0-alpha.5** which upgrades Jetty Server to **12.1.1** to resolve CVE-2026-1605.


## :memo: Test scenarios

- Verify gateway starts and routes requests correctly after Jetty upgrade
- Verify management API starts and serves requests correctly
- Run existing integration test suite to confirm no regressions

## :computer: Add screenshots for UI

N/A — dependency upgrade only

## :books: Any other comments that will help with documentation

N/A

## :man: :woman: @mentions of the person or team responsible for reviewing proposed changes

[AM-6911]: https://gravitee.atlassian.net/browse/AM-6911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ