### PR TITLE
AM-6933 - fix: update package-lock

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -17,7 +17,7 @@
 openapi: 3.0.1
 info:
   title: Gravitee.io - Access Management API
-  version: 4.11.2-SNAPSHOT
+  version: 4.11.3-SNAPSHOT
 servers:
 - url: /management
 security:

--- a/release/package-lock.json
+++ b/release/package-lock.json
@@ -183,9 +183,10 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -1296,9 +1297,9 @@
       }
     },
     "chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
     },
     "colorette": {
       "version": "2.0.20",
@@ -1988,7 +1989,7 @@
         "@types/node": "^18.16.3",
         "@types/ps-tree": "^1.1.2",
         "@types/which": "^3.0.0",
-        "chalk": "5.3.0",
+        "chalk": "5.6.2",
         "fs-extra": "^11.1.1",
         "fx": "*",
         "globby": "^13.1.4",


### PR DESCRIPTION
## :id: Reference related issue. 
AM-6933

## :pencil2: A description of the changes proposed in the pull request
This pull request updates the `chalk` dependency in the `release/package-lock.json` file to a newer version. This change ensures the project uses the latest features and bug fixes provided by `chalk`.

Dependency updates:

* Upgraded `chalk` from version `5.3.0` to `5.6.2` throughout the `package-lock.json`, updating its resolved URL, integrity hash, and license field.

## :memo: Test scenarios 
N/A
