### PR TITLE
fix: AM-6923 Elasticsearch TCP reporter template

### DIFF
--- a/gravitee-am-reporter/gravitee-am-reporter-tcp/src/main/resources/elasticsearch/index/audit.ftl
+++ b/gravitee-am-reporter/gravitee-am-reporter-tcp/src/main/resources/elasticsearch/index/audit.ftl
@@ -20,7 +20,6 @@
     "referenceType":"${audit.getReferenceType()?j_string}",
   </#if>
   "referenceId":"${audit.getReferenceId()}"
-  <#if audit.getStatus()??>,"status":"${audit.getStatus()}"</#if>
   <#if audit.getOutcome()??>
     ,"outcome": {
       <#if audit.getOutcome().getStatus()??>"status":"${audit.getOutcome().getStatus()}"<#if audit.getOutcome().getMessage()??>,</#if></#if>

--- a/gravitee-am-test/api/commands/utils/tcp-consumer.ts
+++ b/gravitee-am-test/api/commands/utils/tcp-consumer.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as net from 'net';
+
+const DEFAULT_TCP_WAIT_TIMEOUT_MS = 20000;
+const DEFAULT_TCP_ASSERT_NO_WINDOW_MS = 5000;
+
+export interface TcpAuditPayload {
+  event_type?: string;
+  referenceType?: string;
+  referenceId?: string;
+  [key: string]: unknown;
+}
+
+export interface TcpWaitOptions {
+  timeoutMs?: number;
+  predicate: (msg: TcpAuditPayload) => boolean;
+}
+
+export interface TcpAssertNoOptions {
+  windowMs?: number;
+  predicate: (msg: TcpAuditPayload) => boolean;
+}
+
+export interface TcpServer {
+  /** OS-assigned port the server is listening on. Pass this to the reporter config. */
+  readonly port: number;
+  /**
+   * Calls trigger(), then resolves with the first audit message matching predicate.
+   * Rejects if no match arrives within timeoutMs.
+   */
+  waitForMessage(options: TcpWaitOptions, trigger: () => Promise<void>): Promise<TcpAuditPayload>;
+  /**
+   * Calls trigger(), waits windowMs, then asserts no audit message matched predicate.
+   */
+  assertNoMessage(options: TcpAssertNoOptions, trigger: () => Promise<void>): Promise<void>;
+  close(): Promise<void>;
+}
+
+/**
+ * Starts a TCP server on a random OS-assigned port.
+ *
+ * The TCP reporter sends each event as a single-line compressed JSON blob
+ * followed by CRLF. This server buffers incoming bytes, splits on line
+ * endings, and JSON-parses each non-empty line.
+ *
+ * Obtain the port first, then pass it to the reporter configuration so the
+ * reporter connects back to this server.
+ */
+export async function startTcpServer(): Promise<TcpServer> {
+  const handlers: Array<(payload: TcpAuditPayload) => void> = [];
+  const activeSockets = new Set<net.Socket>();
+
+  const server = net.createServer((socket) => {
+    activeSockets.add(socket);
+    socket.on('close', () => activeSockets.delete(socket));
+
+    let buf = '';
+    socket.on('data', (chunk) => {
+      buf += chunk.toString('utf8');
+      const lines = buf.split(/\r?\n/);
+      buf = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const payload: TcpAuditPayload = JSON.parse(line);
+          for (const handler of handlers) {
+            handler(payload);
+          }
+        } catch {
+          // ignore malformed lines
+        }
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+    server.on('error', reject);
+  });
+
+  const port = (server.address() as net.AddressInfo).port;
+
+  const close = (): Promise<void> =>
+    new Promise((resolve) => {
+      for (const socket of activeSockets) {
+        socket.destroy();
+      }
+      server.close(() => resolve());
+    });
+
+  return {
+    port,
+
+    async waitForMessage(options: TcpWaitOptions, trigger: () => Promise<void>): Promise<TcpAuditPayload> {
+      const { timeoutMs = DEFAULT_TCP_WAIT_TIMEOUT_MS, predicate } = options;
+
+      let resolveResult: (v: TcpAuditPayload) => void;
+      let rejectResult: (e: unknown) => void;
+      const result = new Promise<TcpAuditPayload>((res, rej) => {
+        resolveResult = res;
+        rejectResult = rej;
+      });
+
+      const removeHandler = () => {
+        const idx = handlers.indexOf(handler);
+        if (idx !== -1) handlers.splice(idx, 1);
+      };
+
+      const handler = (payload: TcpAuditPayload) => {
+        if (predicate(payload)) {
+          clearTimeout(timer);
+          removeHandler();
+          resolveResult(payload);
+        }
+      };
+      handlers.push(handler);
+
+      const timer = setTimeout(() => {
+        removeHandler();
+        rejectResult(new Error(`Timeout: no TCP message matching predicate within ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      try {
+        await trigger();
+      } catch (err) {
+        clearTimeout(timer);
+        removeHandler();
+        rejectResult(err);
+      }
+
+      return result;
+    },
+
+    async assertNoMessage(options: TcpAssertNoOptions, trigger: () => Promise<void>): Promise<void> {
+      const { windowMs = DEFAULT_TCP_ASSERT_NO_WINDOW_MS, predicate } = options;
+
+      let matched: TcpAuditPayload | null = null;
+      const handler = (payload: TcpAuditPayload) => {
+        if (predicate(payload)) {
+          matched = payload;
+        }
+      };
+      handlers.push(handler);
+
+      try {
+        await trigger();
+        await new Promise<void>((r) => setTimeout(r, windowMs));
+      } finally {
+        const idx = handlers.indexOf(handler);
+        if (idx !== -1) handlers.splice(idx, 1);
+      }
+
+      if (matched !== null) {
+        throw new Error(`Expected no TCP message matching predicate, but received one: ${JSON.stringify(matched)}`);
+      }
+    },
+
+    close,
+  };
+}

--- a/gravitee-am-test/specs/gateway/reporters/domain-reporter-tcp.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/reporters/domain-reporter-tcp.jest.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, expect } from '@jest/globals';
+import { loginUserNameAndPassword } from '@gateway-commands/login-commands';
+import { waitFor } from '@management-commands/domain-management-commands';
+import { updateDomainReporter } from '@management-commands/reporter-management-commands';
+import { TcpServer, startTcpServer } from '@utils-commands/tcp-consumer';
+import { DomainReporterTcpFixture, setupDomainReporterTcpFixture } from './fixture/domain-reporter-tcp-fixture';
+import { setup } from '../../test-fixture';
+
+setup(200000);
+
+let fixture: DomainReporterTcpFixture;
+let tcpServer: TcpServer;
+
+beforeAll(async () => {
+  fixture = await setupDomainReporterTcpFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+beforeEach(async () => {
+  tcpServer = await startTcpServer();
+});
+
+afterEach(async () => {
+  try {
+    await tcpServer.close();
+  } catch {
+    // ignore
+  }
+});
+
+describe('TCP Reporter - Domain Level Gateway', () => {
+  describe('Enabled', () => {
+    it('should receive USER_LOGIN event over TCP in ELASTICSEARCH format', async () => {
+      await fixture.addReporter('localhost', tcpServer.port);
+
+      const received = await tcpServer.waitForMessage(
+        { predicate: (msg) => msg.event_type === 'USER_LOGIN' },
+        () =>
+          loginUserNameAndPassword(
+            fixture.application.settings.oauth.clientId,
+            fixture.user,
+            fixture.user.password,
+            false,
+            fixture.openIdConfiguration,
+            fixture.domain,
+          ).then(() => {}),
+      );
+
+      expect(received).toBeDefined();
+      expect(received.event_type).toEqual('USER_LOGIN');
+      expect(received.referenceType).toEqual('DOMAIN');
+      expect(received.referenceId).toEqual(fixture.domain.id);
+    });
+  });
+
+  describe('Disabled', () => {
+    it('should not receive USER_LOGIN event over TCP when reporter is disabled', async () => {
+      const reporter = await fixture.addReporter('localhost', tcpServer.port);
+
+      await updateDomainReporter(fixture.domain.id, fixture.accessToken, reporter.id, {
+        type: reporter.type,
+        name: reporter.name,
+        enabled: false,
+        configuration: reporter.configuration,
+      });
+
+      // waitForSyncAfter does not work for disabled reporters, so wait manually
+      await waitFor(5000);
+
+      await tcpServer.assertNoMessage(
+        { predicate: (msg) => msg.event_type === 'USER_LOGIN' },
+        () =>
+          loginUserNameAndPassword(
+            fixture.application.settings.oauth.clientId,
+            fixture.user,
+            fixture.user.password,
+            false,
+            fixture.openIdConfiguration,
+            fixture.domain,
+          ).then(() => {}),
+      );
+    });
+  });
+});

--- a/gravitee-am-test/specs/gateway/reporters/fixture/domain-reporter-tcp-fixture.ts
+++ b/gravitee-am-test/specs/gateway/reporters/fixture/domain-reporter-tcp-fixture.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import { Reporter } from '@management-models/Reporter';
+import { DomainOidcConfig, safeDeleteDomain, setupDomainForTest } from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createUser } from '@management-commands/user-management-commands';
+import { createDomainReporter, deleteDomainReporter } from '@management-commands/reporter-management-commands';
+import { getAllIdps } from '@management-commands/idp-management-commands';
+import { createApplication, updateApplication } from '@management-commands/application-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+export interface DomainReporterTcpFixture extends Fixture {
+  domain: Domain;
+  application: Application;
+  user: any & { password: string };
+  openIdConfiguration: DomainOidcConfig;
+  addReporter(host: string, port: number, output?: string): Promise<Reporter>;
+  cleanUp(): Promise<void>;
+}
+
+export const setupDomainReporterTcpFixture = async (): Promise<DomainReporterTcpFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  const { domain, oidcConfig } = await setupDomainForTest(uniqueName('reporter-tcp-domain', true), { accessToken, waitForStart: true });
+
+  const idpSet = await getAllIdps(domain.id, accessToken);
+  const defaultIdpId = idpSet.values().next().value.id;
+
+  const appName = uniqueName('reporter-tcp-app', true);
+  const app = await createApplication(domain.id, accessToken, {
+    name: appName,
+    type: 'WEB',
+    redirectUris: ['https://auth-nightly.gravitee.io/myApp/callback'],
+  }).then((created) =>
+    updateApplication(
+      domain.id,
+      accessToken,
+      {
+        settings: {
+          oauth: {
+            redirectUris: ['https://auth-nightly.gravitee.io/myApp/callback'],
+            grantTypes: ['authorization_code'],
+            scopeSettings: [{ scope: 'openid', defaultScope: true }],
+          },
+        },
+        identityProviders: [{ identity: defaultIdpId, priority: -1 }],
+      },
+      created.id,
+    ).then((updated) => {
+      updated.settings.oauth.clientSecret = created.settings.oauth.clientSecret;
+      return updated;
+    }),
+  );
+
+  const password = 'SomeP@ssw0rd';
+  const username = uniqueName('reporter-tcp-user', true);
+  const user = {
+    username,
+    password,
+    firstName: 'Reporter',
+    lastName: 'User',
+    email: `${username}@test.com`,
+    preRegistration: false,
+  };
+  await waitForSyncAfter(domain.id, () => createUser(domain.id, accessToken, user));
+
+  const reporterIds: string[] = [];
+
+  const addReporter = async (host: string, port: number, output: string = 'ELASTICSEARCH'): Promise<Reporter> => {
+    const reporter = await waitForSyncAfter(domain.id, () =>
+      createDomainReporter(domain.id, accessToken, {
+        type: 'reporter-am-tcp',
+        name: uniqueName('gw-tcp-reporter', true),
+        enabled: true,
+        configuration: JSON.stringify({ host, port, output }),
+      }),
+    );
+    reporterIds.push(reporter.id);
+    return reporter;
+  };
+
+  const cleanUp = async (): Promise<void> => {
+    for (const id of reporterIds) {
+      try {
+        await deleteDomainReporter(domain.id, accessToken, id);
+      } catch {
+        // ignore
+      }
+    }
+    await safeDeleteDomain(domain.id, accessToken);
+  };
+
+  return {
+    accessToken,
+    domain,
+    application: app,
+    user,
+    openIdConfiguration: oidcConfig,
+    addReporter,
+    cleanUp,
+  };
+};


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6923](https://gravitee.atlassian.net/browse/AM-6923)

## :pencil2: A description of the changes proposed in the pull request
Remove erroneous `status` property from Elasticsearch template for TCP reporter events.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6923]: https://gravitee.atlassian.net/browse/AM-6923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ