### PR TITLE
feat: add Java SDK module for the Management API

### DIFF
--- a/gravitee-am-management-api-sdk-java/.gitignore
+++ b/gravitee-am-management-api-sdk-java/.gitignore
@@ -1,0 +1,6 @@
+target/
+*.iml
+.idea/
+.project
+.classpath
+.settings/

--- a/gravitee-am-management-api-sdk-java/README.md
+++ b/gravitee-am-management-api-sdk-java/README.md
@@ -1,0 +1,222 @@
+# Gravitee AM Management API — Java SDK
+
+Java client for the [Gravitee Access Management](https://github.com/gravitee-io/gravitee-access-management) Management API.
+
+Generated from `docs/mapi/openapi.yaml` at build time via [openapi-generator](https://openapi-generator.tech/) (`java` / `okhttp-gson`). Sources are **not committed** — the reactor build regenerates them from the spec on every build.
+
+---
+
+## Coordinates
+
+```xml
+<dependency>
+    <groupId>io.gravitee.am</groupId>
+    <artifactId>gravitee-am-management-api-sdk-java</artifactId>
+    <version>4.12.0-alpha.3-SNAPSHOT</version>
+</dependency>
+```
+
+Runtime dependencies pulled in transitively: `okhttp3`, `gson`, `gson-fire`, `jakarta.annotation-api`.
+
+JDK 17+.
+
+---
+
+## Building locally
+
+```bash
+mvn -pl gravitee-am-management-api-sdk-java -am clean install
+```
+
+Regenerates sources from `docs/mapi/openapi.yaml`, compiles, and installs the jar to `~/.m2`.
+
+---
+
+## Configuration
+
+All APIs share a single `ApiClient`. Configure it once; inject it (or `Configuration.getDefaultApiClient()`) into each `*Api` class.
+
+### Base path
+
+```java
+import io.gravitee.am.sdk.management.invoker.ApiClient;
+import io.gravitee.am.sdk.management.invoker.Configuration;
+
+ApiClient client = Configuration.getDefaultApiClient();
+client.setBasePath("https://am.example.com/management");
+```
+
+### Authentication — bearer token
+
+The Management API accepts an OAuth2 bearer token issued by AM itself. Obtain a token out-of-band (user login, `/management/auth/token`, etc.) and hand it to the SDK:
+
+```java
+client.setBearerToken("eyJhbGciOiJIUzI1NiJ9...");
+```
+
+For refreshable credentials, pass a `Supplier<String>` so each request picks up the latest value:
+
+```java
+client.setBearerToken(() -> tokenCache.current());
+```
+
+### Authentication — basic / API key
+
+The same `ApiClient` exposes `setUsername` / `setPassword` and `setApiKey` — pick whichever matches the security scheme enabled on your AM instance.
+
+### Timeouts & HTTP client tuning
+
+```java
+client.setConnectTimeout(10_000);
+client.setReadTimeout(30_000);
+client.setWriteTimeout(30_000);
+```
+
+Or supply a fully-configured `OkHttpClient`: `new ApiClient(okHttpClient)`.
+
+---
+
+## Usage
+
+Every mutating endpoint is scoped by **organization** and **environment**. Use the reserved identifier `DEFAULT` if you're running against a single-tenant install.
+
+```java
+String orgId = "DEFAULT";
+String envId = "DEFAULT";
+```
+
+All SDK methods throw `io.gravitee.am.sdk.management.invoker.ApiException` on non-2xx responses. `ApiException#getCode()` is the HTTP status; `getResponseBody()` is the raw body.
+
+### Domains
+
+```java
+import io.gravitee.am.sdk.management.api.DomainApi;
+import io.gravitee.am.sdk.management.model.Domain;
+import io.gravitee.am.sdk.management.model.NewDomain;
+
+DomainApi domains = new DomainApi(client);
+
+// Create
+NewDomain newDomain = new NewDomain()
+        .name("customers")
+        .description("Customer-facing tenant");
+Domain created = domains.createDomain(orgId, envId, newDomain);
+String domainId = created.getId();
+
+// Get one
+Domain fetched = domains.findDomain(orgId, envId, domainId);
+
+// Get by HRID (human-readable id, usually the slug)
+Domain byHrid = domains.findDomainByHrid(orgId, envId, "customers");
+```
+
+> **Listing domains.** The Management API exposes domain listings under organization/environment-scoped endpoints (e.g. via `OrganizationApi` / `EnvironmentApi`). Browse the generated `target/generated-sources/openapi/src/main/java/io/gravitee/am/sdk/management/api/` folder to discover the exact method for your installation.
+
+### Applications
+
+```java
+import io.gravitee.am.sdk.management.api.ApplicationApi;
+import io.gravitee.am.sdk.management.model.Application;
+import io.gravitee.am.sdk.management.model.ApplicationPage;
+import io.gravitee.am.sdk.management.model.NewApplication;
+
+ApplicationApi applications = new ApplicationApi(client);
+
+// Create — type drives the OAuth2 client flow (WEB, NATIVE, SERVICE, BROWSER, ...)
+NewApplication newApp = new NewApplication()
+        .name("web-portal")
+        .type(NewApplication.TypeEnum.WEB)
+        .description("Public-facing portal");
+Application app = applications.createApplication(orgId, envId, domainId, newApp);
+String applicationId = app.getId();
+
+// Get one
+Application found = applications.findApplication(orgId, envId, domainId, applicationId);
+
+// List (paginated) — page index, size, free-text query
+ApplicationPage page = applications.listApplications(orgId, envId, domainId, 0, 25, null);
+page.getData().forEach(a -> System.out.println(a.getName() + " → " + a.getId()));
+```
+
+### Identity providers
+
+```java
+import io.gravitee.am.sdk.management.api.IdentityProviderApi;
+import io.gravitee.am.sdk.management.model.IdentityProvider;
+import io.gravitee.am.sdk.management.model.NewIdentityProvider;
+import io.gravitee.am.sdk.management.model.FilteredIdentityProviderInfo;
+
+import java.util.List;
+
+IdentityProviderApi idps = new IdentityProviderApi(client);
+
+// Create — `configuration` is a provider-specific JSON string
+String inlineConfig = """
+    {
+      "users": [
+        {"username": "alice", "password": "s3cret", "firstname": "Alice"}
+      ]
+    }
+    """;
+
+NewIdentityProvider newIdp = new NewIdentityProvider()
+        .name("inline-users")
+        .type("inline-am-idp")
+        .configuration(inlineConfig);
+IdentityProvider idp = idps.createIdentityProvider(orgId, envId, domainId, newIdp);
+String idpId = idp.getId();
+
+// List (with an optional `userProvider` filter — true/false/null)
+List<FilteredIdentityProviderInfo> all = idps.listIdentityProviders(orgId, envId, domainId, null);
+```
+
+---
+
+## Async calls
+
+Every sync method has an `Async` sibling that takes an `ApiCallback<T>`:
+
+```java
+applications.listApplicationsAsync(orgId, envId, domainId, 0, 25, null,
+        new ApiCallback<>() {
+            @Override public void onSuccess(ApplicationPage result, int statusCode, Map<String, List<String>> headers) {
+                result.getData().forEach(System.out::println);
+            }
+            @Override public void onFailure(ApiException e, int statusCode, Map<String, List<String>> headers) {
+                e.printStackTrace();
+            }
+            @Override public void onUploadProgress(long bytesWritten, long contentLength, boolean done) {}
+            @Override public void onDownloadProgress(long bytesRead, long contentLength, boolean done) {}
+        });
+```
+
+Returns an `okhttp3.Call` you can `cancel()`.
+
+---
+
+## Error handling
+
+```java
+try {
+    domains.findDomain(orgId, envId, "missing-id");
+} catch (ApiException e) {
+    switch (e.getCode()) {
+        case 401 -> refreshToken();
+        case 404 -> logger.info("domain not found");
+        default  -> logger.error("AM call failed: {} — {}", e.getCode(), e.getResponseBody(), e);
+    }
+}
+```
+
+`ApiException#getResponseHeaders()` exposes the response headers map for correlation-id style debugging.
+
+---
+
+## Discovering the rest of the surface
+
+- Generated API classes: `target/generated-sources/openapi/src/main/java/io/gravitee/am/sdk/management/api/`
+- Generated models:     `target/generated-sources/openapi/src/main/java/io/gravitee/am/sdk/management/model/`
+
+IDEs need `mvn generate-sources` to run once before autocomplete works (the `target/` tree is gitignored).
+
+The canonical reference is `docs/mapi/openapi.yaml` — every method, model, and field on this SDK corresponds 1:1 to a schema there.

--- a/gravitee-am-management-api-sdk-java/pom.xml
+++ b/gravitee-am-management-api-sdk-java/pom.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.am</groupId>
+        <artifactId>gravitee-am-parent</artifactId>
+        <version>4.12.0-alpha.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gravitee-am-management-api-sdk-java</artifactId>
+    <name>Gravitee IO - Access Management - Management API Java SDK</name>
+    <description>Java client SDK generated from the Access Management Management API OpenAPI specification.</description>
+
+    <properties>
+        <openapi-generator.version>7.11.0</openapi-generator.version>
+        <jackson.version>2.18.2</jackson.version>
+        <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
+        <sdk.package.base>io.gravitee.am.sdk.management</sdk.package.base>
+    </properties>
+
+    <dependencies>
+        <!-- okhttp-gson generator runtime deps -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gsonfire</groupId>
+            <artifactId>gson-fire</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation-api.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                Pre-generation spec transform. The upstream OpenAPI spec is produced by the
+                Management API's swagger scan and has two quirks that Java's strictly-typed
+                client generators reject (TypeScript tolerates them at runtime):
+
+                  * The `NewProtectedResourceFeature` / `UpdateProtectedResourceFeature`
+                    parents declare the discriminator `type` as an unconstrained `string`,
+                    while their subclasses (`NewMcpTool`, `UpdateMcpTool`) redeclare `type`
+                    with an enum — producing parent-`String` vs subclass-`Enum` field and
+                    getter collisions in Java.
+
+                  * The sibling `ProtectedResourceFeature` parent already expresses `type`
+                    as an enum; subclasses correctly inherit. We reshape the two stale
+                    parents to match that working pattern.
+
+                We copy the spec into target/ and rewrite it locally — the upstream Java
+                code and the committed spec are left untouched.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-openapi-spec</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}"/>
+                                <copy file="${project.basedir}/../docs/mapi/openapi.yaml"
+                                      tofile="${project.build.directory}/openapi-patched.yaml"
+                                      overwrite="true"/>
+
+                                <!-- Promote `type` to an enum on the two stale parent schemas.
+                                     Matches only where `type: string` immediately precedes
+                                     `discriminator:` with no existing `enum:` block. -->
+                                <replaceregexp file="${project.build.directory}/openapi-patched.yaml"
+                                               match="(\n        type:\n          type: string\n)(      discriminator:)"
+                                               replace="\1          enum:${line.separator}          - MCP_TOOL${line.separator}\2"
+                                               flags="g"
+                                               byline="false"/>
+
+                                <!-- Remove the redundant `type` redeclaration from subclass
+                                     allOf overrides (anchored by the 10-space indent unique
+                                     to that context, with the scopes sibling as tail anchor). -->
+                                <replaceregexp file="${project.build.directory}/openapi-patched.yaml"
+                                               match="\n          type:\n            type: string\n            enum:\n            - MCP_TOOL\n(          scopes:)"
+                                               replace="${line.separator}\1"
+                                               flags="g"
+                                               byline="false"/>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Post-generation fix. Even with the spec reshaped, openapi-generator
+                        hard-codes `this.type = getClass().getSimpleName()` into the
+                        discriminator subclass constructors. Parent `type` is now a typed
+                        enum, so the String assignment won't compile. Gson populates `type`
+                        from the JSON payload during deserialization, so the assignment is
+                        redundant — strip it.
+                    -->
+                    <execution>
+                        <id>patch-discriminator-subclass-constructors</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                        <configuration>
+                            <target>
+                                <replaceregexp match="\s*this\.type = this\.getClass\(\)\.getSimpleName\(\);\s*\n"
+                                               replace="${line.separator}"
+                                               flags="g"
+                                               byline="false">
+                                    <fileset dir="${project.build.directory}/generated-sources/openapi/src/main/java/io/gravitee/am/sdk/management/model">
+                                        <include name="McpTool.java"/>
+                                        <include name="NewMcpTool.java"/>
+                                        <include name="UpdateMcpTool.java"/>
+                                    </fileset>
+                                </replaceregexp>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-management-api-sdk</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <generatorName>java</generatorName>
+                            <inputSpec>${project.build.directory}/openapi-patched.yaml</inputSpec>
+                            <output>${project.build.directory}/generated-sources/openapi</output>
+                            <apiPackage>${sdk.package.base}.api</apiPackage>
+                            <modelPackage>${sdk.package.base}.model</modelPackage>
+                            <invokerPackage>${sdk.package.base}.invoker</invokerPackage>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <skipValidateSpec>true</skipValidateSpec>
+                            <configOptions>
+                                <library>okhttp-gson</library>
+                                <dateLibrary>java8</dateLibrary>
+                                <openApiNullable>false</openApiNullable>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                                <useJakartaEe>true</useJakartaEe>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>add-generated-sources</id>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/openapi/src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Generated sources are build output; skip license header check. -->
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <module>gravitee-am-plugins-handlers</module>
         <module>gravitee-am-gateway</module>
         <module>gravitee-am-management-api</module>
+        <module>gravitee-am-management-api-sdk-java</module>
         <module>gravitee-am-ui</module>
         <module>gravitee-am-resource</module>
         <module>gravitee-am-botdetection</module>


### PR DESCRIPTION
Adds `gravitee-am-management-api-sdk-java`, a new Maven module that generates a Java client for the Access Management Management API from `docs/mapi/openapi.yaml` via openapi-generator (`java` / `okhttp-gson`). The module is self-contained: it applies local pre- and post-generation regex patches to work around two spec/generator quirks that strictly-typed Java clients reject (discriminator enum mismatch on the `New/Update ProtectedResourceFeature` subclasses and a redundant `String` assignment in generator-emitted subclass constructors). Upstream Java source and the committed OpenAPI spec are left untouched. Generated sources are not committed — the reactor regenerates them on every build, and consumers depend on the published artifact.

## :id: Reference related issue.


## :pencil2: A description of the changes proposed in the pull request

- New module `gravitee-am-management-api-sdk-java` added to the root reactor (`pom.xml`).
- `pom.xml` wires `openapi-generator-maven-plugin` at `generate-sources`: input = `docs/mapi/openapi.yaml`, generator = `java`, library = `okhttp-gson`.
- Pre-generation patch: rewrites discriminator enum values for the `New/Update ProtectedResourceFeature` subclasses so the generated Java discriminator matches the schema.
- Post-generation patch: strips a redundant `String` assignment that openapi-generator emits in subclass constructors (doesn't compile under strict settings).
- License-header check skipped for generated sources.
- `README.md` documents module purpose, generator configuration, and the patch rationale.
- `.gitignore` excludes the generated `target/` output — generated sources are not committed; consumers depend on the published artifact.
- No changes to the OpenAPI spec or any other module.

## :memo: Test scenarios

- `mvn -pl gravitee-am-management-api-sdk-java -am clean install` succeeds from a clean checkout (verifies generation, patches, compilation).
- Snapshot publish path: on merge to `master`, `publish_bundle` (`mvn deploy -P gio-artifactory-snapshot`) and `deploy-snapshot-on-nexus` push the SDK jar to Gravitee Artifactory / Nexus snapshots — no extra CI wiring required.
- Release publish path: release workflow (`gio_action=release`) deploys via `gio-artifactory-release,gio-release`; Maven Central via `publish_maven_central`.

## :computer: Add screenshots for UI

N/A — no UI changes.

## :books: Any other comments that will help with documentation

- See module `README.md` for generator configuration and the two patches applied.
- The patches are regex-based and narrowly scoped; if the underlying spec/generator issues are fixed upstream, the patches should be removed.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822