### PR TITLE
fix: AM-6937 enforce private IP restrictions for CIMD fetches

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/web/PrivateOrReservedHostException.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/web/PrivateOrReservedHostException.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.web;
+
+/**
+ * Thrown when a URL host must not be used because it identifies a private, loopback,
+ * link-local, or any-local address (SSRF mitigation).
+ * 
+ * @author GraviteeSource Team
+ */
+public class PrivateOrReservedHostException extends RuntimeException {
+
+    public PrivateOrReservedHostException() {
+        super("Host resolves to a private, loopback, link-local, or any-local address.");
+    }
+
+    public PrivateOrReservedHostException(String message) {
+        super(message);
+    }
+
+    public PrivateOrReservedHostException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
@@ -18,11 +18,14 @@ package io.gravitee.am.common.web;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
@@ -73,6 +76,15 @@ public class UriBuilder {
 
     private static final Pattern LOCALHOST_PATTERN = Pattern.compile(
             LOCALHOST_HOST_REGEX + "|" + LOCALHOST_IPV4_REGEX + "|" + LOCALHOST_IPV6_REGEX);
+
+    private static final Pattern PRIVATE_IP_PATTERN = Pattern.compile(
+            "^10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+            + "|^172\\.(1[6-9]|2\\d|3[01])\\.\\d{1,3}\\.\\d{1,3}$"
+            + "|^192\\.168\\.\\d{1,3}\\.\\d{1,3}$"
+            + "|^169\\.254\\.\\d{1,3}\\.\\d{1,3}$"
+            + "|^fe[89ab][0-9a-f]:[0-9a-f:]*$"
+            + "|^fc[0-9a-f]{2}:[0-9a-f:]*$"
+            + "|^fd[0-9a-f]{2}:[0-9a-f:]*$");
 
     private String scheme;
     private String host;
@@ -312,6 +324,35 @@ public class UriBuilder {
         return LOCALHOST_PATTERN.matcher(host.toLowerCase()).matches();
     }
 
+    /**
+     * Returns {@code true} if {@code host} (as returned by {@link URI#getHost()}, bracket-free)
+     * is an IP address literal that falls in a private, loopback, link-local, or any-local range,
+     * or if {@link #isLocalhost(String)} matches (e.g. {@code localhost}).
+     */
+    public static boolean isPrivateOrReservedIpLiteral(String host) {
+        if (host == null || host.isBlank()) return false;
+        if (isLocalhost(host)) return true;
+        if (!isIpLiteral(host)) return false;
+        final String lower = host.toLowerCase(Locale.ROOT);
+        if (PRIVATE_IP_PATTERN.matcher(lower).matches()) return true;
+        try {
+            InetAddress addr = InetAddress.getByName(host);
+            return addr.isLoopbackAddress() || addr.isSiteLocalAddress()
+                    || addr.isLinkLocalAddress() || addr.isAnyLocalAddress();
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns {@code true} if {@code host} is a numeric IP address literal (IPv4 or IPv6)
+     * rather than a DNS hostname. IPv6 hosts must be bracket-free (as returned by
+     * {@link URI#getHost()}).
+     */
+    public static boolean isIpLiteral(String host) {
+        if (host == null) return false;
+        return host.matches("[0-9]+(?:\\.[0-9]+){1,3}") || host.contains(":");
+    }
 
     public static String buildErrorRedirect(String baseRedirectUri, ErrorInfo error, boolean fragment, Map<String, String> extraParams) throws URISyntaxException {
         final URI redirectUri = UriBuilder.fromURIString(baseRedirectUri).build();

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/web/UriBuilderPrivateIpTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/web/UriBuilderPrivateIpTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.web;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class UriBuilderPrivateIpTest {
+
+    private final String description;
+    private final String host;
+    private final boolean expected;
+
+    public UriBuilderPrivateIpTest(String description, String host, boolean expected) {
+        this.description = description;
+        this.host = host;
+        this.expected = expected;
+    }
+
+    @Parameters(name = "{0}: isPrivateOrReservedIpLiteral({1}) = {2}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                // Localhost hostname — no DNS; handled before IP-literal checks
+                {"localhost name",       "localhost",        true},
+                // Loopback — delegated to isLocalhost
+                {"loopback ipv4",        "127.0.0.1",        true},
+                {"loopback ipv6",        "::1",              true},
+                // Private class A
+                {"private class A low",  "10.0.0.1",         true},
+                {"private class A high", "10.255.255.255",   true},
+                // Private class B
+                {"private class B low",  "172.16.0.1",       true},
+                {"private class B high", "172.31.255.255",   true},
+                {"class B lower edge",   "172.15.255.255",   false},
+                {"class B upper edge",   "172.32.0.0",       false},
+                // Private class C
+                {"private class C",      "192.168.0.1",      true},
+                {"private class C high", "192.168.255.255",  true},
+                // IPv4 link-local (includes AWS IMDS endpoint)
+                {"link-local ipv4",      "169.254.0.1",      true},
+                {"AWS IMDS",             "169.254.169.254",  true},
+                // Any-local
+                {"any-local",            "0.0.0.0",          true},
+                // IPv6 link-local (fe80::/10)
+                {"link-local ipv6",      "fe80::1",          true},
+                {"link-local ipv6 alt",  "fe80:0:0:0:1:2:3:4", true},
+                // IPv6 unique-local (fc00::/7 — fc and fd prefixes)
+                {"unique-local fc",      "fc00::1",          true},
+                {"unique-local fd",      "fd12:3456::1",     true},
+                // Public addresses — must not be blocked
+                {"public ipv4 Google",   "8.8.8.8",          false},
+                {"public ipv4 CF",       "1.1.1.1",          false},
+                {"public ipv6",          "2606:4700::1",     false},
+                // Hostnames — must return false (not IP literals)
+                {"hostname",             "example.com",      false},
+                {"unresolvable",         "non-resolvable.invalid", false},
+        });
+    }
+
+    @Test
+    public void test() {
+        Assert.assertEquals(description, expected, UriBuilder.isPrivateOrReservedIpLiteral(host));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
@@ -18,10 +18,12 @@ package io.gravitee.am.gateway.handler.common.client.cimd.impl;
 import io.gravitee.am.common.oidc.ClientAuthenticationMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.common.web.PrivateOrReservedHostException;
 import io.gravitee.am.gateway.handler.common.client.cimd.CachedLogo;
 import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
+import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
 import lombok.extern.slf4j.Slf4j;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.CIMDSettings;
@@ -32,6 +34,7 @@ import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.gravitee.am.service.utils.RetryAtMostWithDelay;
 import io.gravitee.am.service.utils.jwk.converter.JWKConverter;
 import io.gravitee.am.service.utils.vertx.BoundedBufferWriteStream;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.buffer.Buffer;
@@ -72,15 +75,18 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
     private final WebClient webClient;
     private final CimdMetadataDocumentService cimdMetadataDocumentService;
     private final CimdMetadataDocumentManager cimdMetadataDocumentManager;
+    private final HostSsrfGuard hostSsrfGuard;
 
     public CimdMetadataServiceImpl(Domain domain,
                                    WebClient webClient,
                                    CimdMetadataDocumentService cimdMetadataDocumentService,
-                                   CimdMetadataDocumentManager cimdMetadataDocumentManager) {
+                                   CimdMetadataDocumentManager cimdMetadataDocumentManager,
+                                   HostSsrfGuard hostSsrfGuard) {
         this.domain = domain;
         this.webClient = webClient;
         this.cimdMetadataDocumentService = cimdMetadataDocumentService;
         this.cimdMetadataDocumentManager = cimdMetadataDocumentManager;
+        this.hostSsrfGuard = hostSsrfGuard;
     }
 
     @Override
@@ -96,8 +102,8 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
 
             final String canonicalId = ClientIds.canonicalize(clientId);
             final CIMDSettings settings = getCimdSettings();
-            final URI clientIdUri = toUri(canonicalId);
-            validateUrlTrust(clientIdUri, settings);
+            final URI clientIdUri = toUri(canonicalId, "client_id");
+            validateUrlTrust(clientIdUri, settings, "client_id");
 
             // [1] Local in-memory cache hit
             var cached = cimdMetadataDocumentManager.get(canonicalId);
@@ -127,7 +133,8 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
                     .switchIfEmpty(
                             Maybe.defer(() -> {
                                 log.debug("CIMD cache miss, fetching from origin for domain={}, clientId={}", domain.getId(), canonicalId);
-                                return fetchMetadataWithTtl(canonicalId, settings)
+                                return validateNotPrivateHost(clientIdUri.getHost(), "client_id", settings)
+                                        .andThen(fetchMetadataWithTtl(canonicalId, settings))
                                         .flatMap(fetchResult -> {
                                             final FetchResult.CacheRequirements cache = fetchResult.cacheRequirements();
                                             if (!cache.noCache()) {
@@ -158,26 +165,30 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
         return domain.getOidc().getCimdSettings();
     }
 
-    private URI toUri(String clientId) {
+    private URI toUri(String value, String fieldName) {
         try {
-            return UriBuilder.fromHttpUrl(clientId).build();
+            return UriBuilder.fromHttpUrl(value).build();
         } catch (IllegalArgumentException | URISyntaxException ex) {
-            throw new InvalidClientMetadataException("client_id is not a valid URL.");
+            throw new InvalidClientMetadataException(fieldName + " is not a valid URL.");
         }
     }
 
-    private void validateUrlTrust(URI clientIdUri, CIMDSettings settings) {
-        if (!settings.isAllowUnsecuredHttpUri() && "http".equalsIgnoreCase(clientIdUri.getScheme())) {
-            throw new InvalidClientMetadataException("Unsecured HTTP client_id is not allowed.");
+    private void validateUrlTrust(URI uri, CIMDSettings settings, String fieldName) {
+        if (!settings.isAllowUnsecuredHttpUri() && "http".equalsIgnoreCase(uri.getScheme())) {
+            throw new InvalidClientMetadataException("Unsecured HTTP " + fieldName + " is not allowed.");
         }
 
-        final String host = clientIdUri.getHost();
+        final String host = uri.getHost();
         if (host == null || host.isBlank()) {
-            throw new InvalidClientMetadataException("client_id host is missing.");
+            throw new InvalidClientMetadataException(fieldName + " host is missing.");
         }
 
         if (!isAllowedDomain(host, settings.getAllowedDomains())) {
-            throw new InvalidClientMetadataException("client_id host is not in allowed domains.");
+            throw new InvalidClientMetadataException(fieldName + " host is not in allowed domains.");
+        }
+
+        if (!settings.isAllowPrivateIpAddress() && UriBuilder.isPrivateOrReservedIpLiteral(host)) {
+            throw new InvalidClientMetadataException(fieldName + " resolves to a private or reserved IP address.");
         }
     }
 
@@ -204,6 +215,17 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
                     }
                     return normalizedHost.equals(pattern);
                 });
+    }
+
+    private Completable validateNotPrivateHost(String host, String fieldName, CIMDSettings settings) {
+        if (settings.isAllowPrivateIpAddress()) {
+            return Completable.complete();
+        }
+        return hostSsrfGuard.assertNotPrivateHost(host)
+                .onErrorResumeNext(e -> e instanceof PrivateOrReservedHostException
+                        ? Completable.error(new InvalidClientMetadataException(
+                                fieldName + " resolves to a private or reserved IP address."))
+                        : Completable.error(e));
     }
 
     private Single<FetchResult> fetchMetadataWithTtl(String clientId, CIMDSettings settings) {
@@ -392,18 +414,24 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
 
         final URI uri;
         try {
-            uri = toUri(logoUri);
+            uri = toUri(logoUri, "logo_uri");
         } catch (Exception ex) {
             log.debug("CIMD logo pre-fetch skipped — invalid URI: {}", logoUri);
             return;
         }
         try {
-            validateUrlTrust(uri, settings);
+            validateUrlTrust(uri, settings, "logo_uri");
         } catch (Exception ex) {
             log.debug("CIMD logo pre-fetch skipped — URI not trusted: {}", logoUri);
             return;
         }
 
+        validateNotPrivateHost(uri.getHost(), "logo_uri", settings).subscribe(
+                () -> sendLogoPrefetchRequest(clientId, logoUri, metadataTtlSeconds, settings),
+                err -> log.debug("CIMD logo pre-fetch skipped — {}", err.getMessage()));
+    }
+
+    private void sendLogoPrefetchRequest(String clientId, String logoUri, long metadataTtlSeconds, CIMDSettings settings) {
         final long timeoutMs = resolveTimeoutMs(settings);
         final var logoCollector = new BoundedBufferWriteStream(MAX_LOGO_SIZE_BYTES);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -37,6 +37,7 @@ import io.gravitee.am.gateway.handler.common.client.ClientLookupService;
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
+import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
 import io.gravitee.am.gateway.handler.common.client.cimd.impl.CimdMetadataServiceImpl;
 import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.gateway.handler.common.client.impl.ClientManagerImpl;
@@ -253,11 +254,17 @@ public class CommonConfiguration {
     }
 
     @Bean
+    public HostSsrfGuard hostSsrfGuard() {
+        return new HostSsrfGuard();
+    }
+
+    @Bean
     public CimdMetadataService cimdMetadataService(Domain domain,
                                                    @Qualifier("oidcWebClient") WebClient webClient,
                                                    CimdMetadataDocumentService cimdMetadataDocumentService,
-                                                   CimdMetadataDocumentManager cimdMetadataDocumentManager) {
-        return new CimdMetadataServiceImpl(domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager);
+                                                   CimdMetadataDocumentManager cimdMetadataDocumentManager,
+                                                   HostSsrfGuard hostSsrfGuard) {
+        return new CimdMetadataServiceImpl(domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, hostSsrfGuard);
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/web/HostSsrfGuard.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/web/HostSsrfGuard.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.web;
+
+import io.gravitee.am.common.web.PrivateOrReservedHostException;
+import io.gravitee.am.common.web.UriBuilder;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Guards against SSRF by rejecting hostnames whose DNS resolution includes a private,
+ * loopback, link-local, or any-local address.
+ * 
+ * @author GraviteeSource Team
+ */
+public class HostSsrfGuard {
+
+    @FunctionalInterface
+    public interface DnsResolver {
+        InetAddress[] resolve(String host) throws UnknownHostException;
+    }
+
+    private final DnsResolver dnsResolver;
+
+    public HostSsrfGuard() {
+        this(InetAddress::getAllByName);
+    }
+
+    public HostSsrfGuard(DnsResolver dnsResolver) {
+        this.dnsResolver = dnsResolver;
+    }
+
+    /**
+     * Resolves {@code host} via DNS and completes with an error if any resolved address is
+     * private, loopback, link-local, or any-local. IP literals are skipped — callers should
+     * validate literals separately (for example {@link UriBuilder#isPrivateOrReservedIpLiteral(String)}).
+     * Unresolvable hosts complete normally so a later HTTP client can surface a more specific error.
+     */
+    public Completable assertNotPrivateHost(String host) {
+        if (host == null || UriBuilder.isIpLiteral(host)) {
+            return Completable.complete();
+        }
+        return Single.fromCallable(() -> dnsResolver.resolve(host))
+                .subscribeOn(Schedulers.io())
+                .flatMapCompletable(addrs -> {
+                    for (InetAddress addr : addrs) {
+                        if (addr.isLoopbackAddress() || addr.isSiteLocalAddress()
+                                || addr.isLinkLocalAddress() || addr.isAnyLocalAddress()) {
+                            return Completable.error(new PrivateOrReservedHostException());
+                        }
+                    }
+                    return Completable.complete();
+                })
+                .onErrorResumeNext(e -> e instanceof PrivateOrReservedHostException
+                        ? Completable.error(e)
+                        : Completable.complete());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.common.client.cimd.impl;
 import io.gravitee.am.gateway.handler.common.client.cimd.CachedLogo;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
+import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
 import io.gravitee.am.model.CimdMetadataDocument;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.application.ApplicationSecretSettings;
@@ -30,13 +31,17 @@ import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.ext.web.client.HttpRequest;
 import io.vertx.rxjava3.ext.web.client.HttpResponse;
 import io.vertx.rxjava3.ext.web.client.WebClient;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -46,8 +51,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.time.Duration;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
@@ -64,7 +69,18 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class CimdMetadataServiceImplTest {
 
+    @BeforeClass
+    public static void setupSchedulers() {
+        RxJavaPlugins.setIoSchedulerHandler(s -> Schedulers.trampoline());
+    }
+
+    @AfterClass
+    public static void resetSchedulers() {
+        RxJavaPlugins.reset();
+    }
+
     private static final String CLIENT_URL = "https://localhost/metadata";
+    private static final String EXTERNAL_URL = "https://external.example.com/metadata";
 
     @Mock
     private WebClient webClient;
@@ -83,10 +99,11 @@ public class CimdMetadataServiceImplTest {
 
     private CimdMetadataService cimdMetadataService;
     private CIMDSettings cimdSettings;
+    private Domain domain;
 
     @Before
     public void setUp() {
-        Domain domain = new Domain();
+        domain = new Domain();
         domain.setId("domain-id");
         domain.setName("test-domain");
 
@@ -103,7 +120,9 @@ public class CimdMetadataServiceImplTest {
         when(cimdMetadataDocumentService.upsert(any(), anyString(), anyString(), any(Duration.class)))
                 .thenReturn(Single.just(new CimdMetadataDocument()));
 
-        cimdMetadataService = new CimdMetadataServiceImpl(domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager);
+        HostSsrfGuard hostSsrfGuard = new HostSsrfGuard(host -> new java.net.InetAddress[]{java.net.InetAddress.getByName("8.8.8.8")});
+        cimdMetadataService = new CimdMetadataServiceImpl(domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager,
+                hostSsrfGuard);
     }
 
     @Test
@@ -139,15 +158,13 @@ public class CimdMetadataServiceImplTest {
     }
 
     @Test
-    public void shouldAllowIpLiteralWhenPrivateIpIsDisabled() {
+    public void shouldRejectLoopbackIpLiteralWhenPrivateIpIsDisabled() {
         cimdSettings.setAllowPrivateIpAddress(false);
-        mockFetchSuccess(metadataPayload("https://127.0.0.1/metadata"));
 
         TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://127.0.0.1/metadata", templateClient()).test();
 
-        testObserver.assertComplete();
-        testObserver.assertNoErrors();
-        testObserver.assertValue(client -> "https://127.0.0.1/metadata".equals(client.getClientId()));
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verifyNoInteractions(webClient);
     }
 
     @Test
@@ -175,12 +192,186 @@ public class CimdMetadataServiceImplTest {
     }
 
     @Test
+    public void shouldRejectPrivateClassAIpWhenPrivateIpIsDisabled() {
+        cimdSettings.setAllowPrivateIpAddress(false);
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://10.0.0.1/metadata", templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldRejectPrivateClassBIpWhenPrivateIpIsDisabled() {
+        cimdSettings.setAllowPrivateIpAddress(false);
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://172.16.0.1/metadata", templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldRejectPrivateClassCIpWhenPrivateIpIsDisabled() {
+        cimdSettings.setAllowPrivateIpAddress(false);
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://192.168.1.1/metadata", templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldRejectLinkLocalIpv4WhenPrivateIpIsDisabled() {
+        cimdSettings.setAllowPrivateIpAddress(false);
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://169.254.169.254/metadata", templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldRejectLoopbackIpv6WhenPrivateIpIsDisabled() {
+        cimdSettings.setAllowPrivateIpAddress(false);
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://[::1]/metadata", templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldRejectLinkLocalIpv6WhenPrivateIpIsDisabled() {
+        cimdSettings.setAllowPrivateIpAddress(false);
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://[fe80::1]/metadata", templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldAllowPublicIpWhenPrivateIpIsDisabled() {
+        cimdSettings.setAllowPrivateIpAddress(false);
+        mockFetchSuccess(metadataPayload("https://8.8.8.8/metadata"));
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://8.8.8.8/metadata", templateClient()).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> "https://8.8.8.8/metadata".equals(client.getClientId()));
+    }
+
+    @Test
+    public void shouldAllowPrivateIpRangesWhenPrivateIpIsEnabled() {
+        cimdSettings.setAllowPrivateIpAddress(true);
+        mockFetchSuccess(metadataPayload("https://10.0.0.1/metadata"));
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://10.0.0.1/metadata", templateClient()).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+    }
+
+    @Test
+    public void shouldRejectLogoUriWithPrivateIpWhenPrivateIpIsDisabled() {
+        // Use a non-private client_id URL so Phase 1 does not block the main request.
+        // The logo_uri has a private IP — prefetchLogoAsync must not fetch it.
+        cimdSettings.setAllowPrivateIpAddress(false);
+        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://192.168.0.1/logo.png");
+        dbDoc.setClientId(EXTERNAL_URL);
+        dbDoc.setMetadata(metadataPayloadWithLogo(EXTERNAL_URL, "https://192.168.0.1/logo.png"));
+        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", EXTERNAL_URL))
+                .thenReturn(Maybe.just(dbDoc));
+        when(cimdMetadataDocumentManager.get(EXTERNAL_URL)).thenReturn(Optional.empty());
+        when(cimdMetadataDocumentManager.getLogoByClientId(EXTERNAL_URL)).thenReturn(Optional.empty());
+
+        cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test().assertComplete();
+
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldSkipLogoPrefetchWhenLogoHostnameResolvesToPrivateIp() {
+        cimdSettings.setAllowPrivateIpAddress(false);
+        HostSsrfGuard rejectingGuard = new HostSsrfGuard(host ->
+                new java.net.InetAddress[]{java.net.InetAddress.getLoopbackAddress()});
+        cimdMetadataService = new CimdMetadataServiceImpl(
+                domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, rejectingGuard);
+        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://branding.vendor.example/logo.png");
+        dbDoc.setClientId(EXTERNAL_URL);
+        dbDoc.setMetadata(metadataPayloadWithLogo(EXTERNAL_URL, "https://branding.vendor.example/logo.png"));
+        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", EXTERNAL_URL))
+                .thenReturn(Maybe.just(dbDoc));
+        when(cimdMetadataDocumentManager.get(EXTERNAL_URL)).thenReturn(Optional.empty());
+        when(cimdMetadataDocumentManager.getLogoByClientId(EXTERNAL_URL)).thenReturn(Optional.empty());
+
+        cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test().assertComplete();
+
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldSkipLogoPrefetchAfterOriginFetchWhenLogoHostnameResolvesToPrivateIp() throws Exception {
+        cimdSettings.setAllowPrivateIpAddress(false);
+        HostSsrfGuard selectiveGuard = new HostSsrfGuard(host -> {
+            if ("external.example.com".equalsIgnoreCase(host)) {
+                return new java.net.InetAddress[]{java.net.InetAddress.getByName("8.8.8.8")};
+            }
+            return new java.net.InetAddress[]{java.net.InetAddress.getLoopbackAddress()};
+        });
+        cimdMetadataService = new CimdMetadataServiceImpl(
+                domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, selectiveGuard);
+        mockFetchSuccess(metadataPayloadWithLogo(EXTERNAL_URL, "https://branding.vendor.example/logo.png"));
+
+        cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test().assertComplete();
+
+        verify(request, times(1)).rxSend();
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+    }
+
+    @Test
+    public void shouldRejectWhenHostSsrfGuardRejectsHostname() {
+        HostSsrfGuard rejectingGuard = new HostSsrfGuard(host ->
+                new java.net.InetAddress[]{java.net.InetAddress.getLoopbackAddress()});
+        cimdMetadataService = new CimdMetadataServiceImpl(
+                domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, rejectingGuard);
+        cimdSettings.setAllowPrivateIpAddress(false);
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldAllowWhenHostSsrfGuardAllowsHostname() throws Exception {
+        java.net.InetAddress publicIp = java.net.InetAddress.getByName("8.8.8.8");
+        HostSsrfGuard allowingGuard = new HostSsrfGuard(host -> new java.net.InetAddress[]{publicIp});
+        cimdMetadataService = new CimdMetadataServiceImpl(
+                domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, allowingGuard);
+        cimdSettings.setAllowPrivateIpAddress(false);
+        mockFetchSuccess(metadataPayload(EXTERNAL_URL));
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValueCount(1);
+    }
+
+    @Test
     public void shouldRejectHostOutsideAllowedDomains() {
         cimdSettings.setAllowedDomains(List.of("*.example.com"));
 
         TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
 
-        testObserver.assertError(InvalidClientMetadataException.class);
+        testObserver.assertError(e -> e instanceof InvalidClientMetadataException
+                && e.getMessage().contains("client_id")
+                && e.getMessage().contains("allowed domains"));
         verifyNoInteractions(webClient);
     }
 
@@ -691,6 +882,23 @@ public class CimdMetadataServiceImplTest {
                 .thenReturn(Maybe.just(dbDoc));
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
+
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void shouldNotFetchLogoWhenLogoHostOutsideAllowedDomains() {
+        cimdSettings.setAllowedDomains(List.of("*.example.com"));
+        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://cdn.evil.net/logo.png");
+        dbDoc.setClientId(EXTERNAL_URL);
+        dbDoc.setMetadata(metadataPayloadWithLogo(EXTERNAL_URL, "https://cdn.evil.net/logo.png"));
+        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", EXTERNAL_URL))
+                .thenReturn(Maybe.just(dbDoc));
+        when(cimdMetadataDocumentManager.get(EXTERNAL_URL)).thenReturn(Optional.empty());
+        when(cimdMetadataDocumentManager.getLogoByClientId(EXTERNAL_URL)).thenReturn(Optional.empty());
+
+        cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test().assertComplete();
 
         verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
         verifyNoInteractions(webClient);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/web/HostSsrfGuardTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/web/HostSsrfGuardTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.web;
+
+import io.gravitee.am.common.web.PrivateOrReservedHostException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class HostSsrfGuardTest {
+
+    @Test
+    public void shouldRejectHostnameThatResolvesToLoopbackAddress() throws Exception {
+        InetAddress loopback = InetAddress.getByName("127.0.0.1");
+        HostSsrfGuard guard = new HostSsrfGuard(host -> new InetAddress[]{loopback});
+
+        TestObserver<?> obs = guard.assertNotPrivateHost("internal.example.com").test();
+        obs.awaitDone(2, java.util.concurrent.TimeUnit.SECONDS);
+        obs.assertError(PrivateOrReservedHostException.class);
+    }
+
+    @Test
+    public void shouldRejectHostnameThatResolvesToPrivateSiteLocalAddress() throws Exception {
+        InetAddress privateIp = InetAddress.getByName("10.0.0.1");
+        HostSsrfGuard guard = new HostSsrfGuard(host -> new InetAddress[]{privateIp});
+
+        TestObserver<?> obs = guard.assertNotPrivateHost("internal.corp").test();
+        obs.awaitDone(2, java.util.concurrent.TimeUnit.SECONDS);
+        obs.assertError(PrivateOrReservedHostException.class);
+    }
+
+    @Test
+    public void shouldRejectHostnameThatResolvesToLinkLocalAddress() throws Exception {
+        InetAddress linkLocal = InetAddress.getByName("169.254.169.254");
+        HostSsrfGuard guard = new HostSsrfGuard(host -> new InetAddress[]{linkLocal});
+
+        TestObserver<?> obs = guard.assertNotPrivateHost("metadata.local").test();
+        obs.awaitDone(2, java.util.concurrent.TimeUnit.SECONDS);
+        obs.assertError(e -> e instanceof PrivateOrReservedHostException
+                && e.getMessage().contains("link-local"));
+    }
+
+    @Test
+    public void shouldAllowHostnameThatResolvesToPublicAddress() throws Exception {
+        InetAddress publicIp = InetAddress.getByName("8.8.8.8");
+        HostSsrfGuard guard = new HostSsrfGuard(host -> new InetAddress[]{publicIp});
+
+        TestObserver<?> obs = guard.assertNotPrivateHost("example.com").test();
+        obs.awaitDone(2, java.util.concurrent.TimeUnit.SECONDS);
+        obs.assertComplete();
+        obs.assertNoErrors();
+    }
+
+    @Test
+    public void shouldAllowUnresolvableHostname() {
+        HostSsrfGuard guard = new HostSsrfGuard(host -> { throw new UnknownHostException(host); });
+
+        TestObserver<?> obs = guard.assertNotPrivateHost("non-resolvable.invalid").test();
+        obs.awaitDone(2, java.util.concurrent.TimeUnit.SECONDS);
+        obs.assertComplete();
+        obs.assertNoErrors();
+    }
+
+    @Test
+    public void shouldSkipDnsCheckForIpv4Literal() {
+        HostSsrfGuard.DnsResolver neverCalled = host -> {
+            throw new AssertionError("DNS resolver must not be called for IP literals");
+        };
+        HostSsrfGuard guard = new HostSsrfGuard(neverCalled);
+
+        // IP literals are handled by isIpLiteral() short-circuit
+        TestObserver<?> obs = guard.assertNotPrivateHost("10.0.0.1").test();
+        obs.awaitDone(2, java.util.concurrent.TimeUnit.SECONDS);
+        obs.assertComplete();
+        obs.assertNoErrors();
+    }
+
+    @Test
+    public void shouldSkipDnsCheckForIpv6Literal() {
+        HostSsrfGuard.DnsResolver neverCalled = host -> {
+            throw new AssertionError("DNS resolver must not be called for IP literals");
+        };
+        HostSsrfGuard guard = new HostSsrfGuard(neverCalled);
+
+        TestObserver<?> obs = guard.assertNotPrivateHost("::1").test();
+        obs.awaitDone(2, java.util.concurrent.TimeUnit.SECONDS);
+        obs.assertComplete();
+        obs.assertNoErrors();
+    }
+
+    @Test
+    public void shouldHandleNullHostGracefully() {
+        HostSsrfGuard guard = new HostSsrfGuard();
+
+        TestObserver<?> obs = guard.assertNotPrivateHost(null).test();
+        obs.awaitDone(2, java.util.concurrent.TimeUnit.SECONDS);
+        obs.assertComplete();
+        obs.assertNoErrors();
+    }
+}


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6937](https://gravitee.atlassian.net/browse/AM-6937)

## :pencil2: A description of the changes proposed in the pull request
Enforce the CIMD "Allow private/loopback IP addresses" restriction when fetching CIMD metadata documents and logo resources.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6937]: https://gravitee.atlassian.net/browse/AM-6937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ