### PR TITLE
fix: AM-6939 Use valid defaults for CIMD clients

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.gateway.handler.common.client.cimd.impl;
 
+import io.gravitee.am.common.oauth2.GrantType;
+import io.gravitee.am.common.oauth2.ResponseType;
 import io.gravitee.am.common.oidc.ClientAuthenticationMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.am.common.web.UriBuilder;
@@ -67,6 +69,9 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
     private static final int FETCH_RETRY_ATTEMPTS = 3;
     private static final int FETCH_RETRY_DELAY_MS = 100;
     private static final long MAX_LOGO_SIZE_BYTES = 256L * 1024L;
+    private static final String DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD = ClientAuthenticationMethod.NONE;
+    private static final List<String> DEFAULT_GRANT_TYPES = List.of(GrantType.AUTHORIZATION_CODE);
+    private static final List<String> DEFAULT_RESPONSE_TYPES = List.of(ResponseType.CODE);
 
     private final Domain domain;
     private final WebClient webClient;
@@ -286,7 +291,7 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
 
         final String tokenEndpointAuthMethod = metadata.getString(
                 "token_endpoint_auth_method",
-                ClientAuthenticationMethod.CLIENT_SECRET_BASIC
+                DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD
         );
         if (FORBIDDEN_SECRET_BASED_AUTH_METHODS.contains(tokenEndpointAuthMethod)) {
             throw new InvalidClientMetadataException("Secret-based token_endpoint_auth_method is not allowed for CIMD clients.");
@@ -305,8 +310,8 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
             throw new InvalidClientMetadataException("private_key_jwt requires jwks or jwks_uri.");
         }
 
-        final List<String> grantTypes = readOptionalStringArray(metadata, "grant_types");
-        final List<String> responseTypes = readOptionalStringArray(metadata, "response_types");
+        final List<String> grantTypes = readOptionalStringArray(metadata, "grant_types", DEFAULT_GRANT_TYPES);
+        final List<String> responseTypes = readOptionalStringArray(metadata, "response_types", DEFAULT_RESPONSE_TYPES);
 
         final Client synthesizedClient;
         try {
@@ -318,16 +323,12 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
         synthesizedClient.setClientId(clientId);
         synthesizedClient.setRedirectUris(redirectUris);
         synthesizedClient.setTokenEndpointAuthMethod(tokenEndpointAuthMethod);
+        synthesizedClient.setAuthorizedGrantTypes(grantTypes);
+        synthesizedClient.setResponseTypes(responseTypes);
         synthesizedClient.setClientName(metadata.getString("client_name", synthesizedClient.getClientName()));
         final String logoUri = metadata.getString("logo_uri");
         if (logoUri != null && !logoUri.isBlank()) {
             synthesizedClient.setLogoUri(logoUri);
-        }
-        if (grantTypes != null) {
-            synthesizedClient.setAuthorizedGrantTypes(grantTypes);
-        }
-        if (responseTypes != null) {
-            synthesizedClient.setResponseTypes(responseTypes);
         }
         if (metadata.containsKey("jwks_uri")) {
             synthesizedClient.setJwksUri(jwksUri);
@@ -369,6 +370,11 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
             }
             return value;
         }).toList();
+    }
+
+    private List<String> readOptionalStringArray(JsonObject metadata, String key, List<String> defaultValue) {
+        final List<String> values = readOptionalStringArray(metadata, key);
+        return values != null ? values : defaultValue;
     }
 
     private JWKSet toModelJwkSet(JsonObject jwksAsJson) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
@@ -350,7 +350,7 @@ public class CimdMetadataServiceImplTest {
     }
 
     @Test
-    public void shouldDefaultMissingTokenEndpointAuthMethodToClientSecretBasicAndReject() {
+    public void shouldDefaultMissingTokenEndpointAuthMethodToNone() {
         JsonObject metadata = new JsonObject()
                 .put("client_id", CLIENT_URL)
                 .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"));
@@ -358,7 +358,58 @@ public class CimdMetadataServiceImplTest {
 
         TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
 
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> "none".equals(client.getTokenEndpointAuthMethod())
+                && List.of("authorization_code").equals(client.getAuthorizedGrantTypes())
+                && List.of("code").equals(client.getResponseTypes()));
+    }
+
+    @Test
+    public void shouldRejectExplicitClientSecretBasic() {
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "client_secret_basic");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+
         testObserver.assertError(InvalidClientMetadataException.class);
+    }
+
+    @Test
+    public void shouldDefaultGrantTypesToAuthorizationCodeWhenAbsent() {
+        Client template = templateClient();
+        template.setAuthorizedGrantTypes(List.of("client_credentials"));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> List.of("authorization_code").equals(client.getAuthorizedGrantTypes()));
+    }
+
+    @Test
+    public void shouldDefaultResponseTypesToCodeWhenAbsent() {
+        Client template = templateClient();
+        template.setResponseTypes(List.of("token"));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> List.of("code").equals(client.getResponseTypes()));
     }
 
     @Test

--- a/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
@@ -132,9 +132,4 @@ describe('CIMD authorize - ENABLED_BASE', () => {
     const response = await fixture.authorize(fixture.buildClientId('private-key-jwt-missing-jwks'));
     fixture.expectInvalidClientMetadata(response, 'private_key_jwt requires jwks or jwks_uri');
   });
-
-  it('should return invalid_client_metadata when token_endpoint_auth_method is missing', async () => {
-    const response = await fixture.authorize(fixture.buildClientId('missing-token-auth-method'));
-    fixture.expectInvalidClientMetadata(response, 'Secret-based token_endpoint_auth_method is not allowed');
-  });
 });


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6939](https://gravitee.atlassian.net/browse/AM-6939)

## :pencil2: A description of the changes proposed in the pull request
Enforce compliant default values for CIMD clients. When omitted in metadata documents, assume:
- `token_endpoint_auth_method`: `"none"`
- `grant_types`: `["authorization_code"]`
- `response_types`: `["code"]`

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6939]: https://gravitee.atlassian.net/browse/AM-6939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ