### PR TITLE
fix: AM-6940 Always match CIMD client redirect_uris exactly

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandler.java
@@ -19,6 +19,7 @@ import io.gravitee.am.common.exception.oauth2.RedirectMismatchException;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.jwt.TokenPurpose;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
 import io.gravitee.am.gateway.handler.root.service.RedirectUriValidator;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.gateway.handler.root.service.user.model.UserToken;
@@ -118,15 +119,29 @@ public class RedirectUriValidationHandler implements Handler<RoutingContext> {
         if (!StringUtils.hasLength(returnUrl)) {
             List<String> registeredRedirectUris = domain.isRedirectUriExpressionLanguageEnabled() ?
                     getFilteredRegisteredRedirectUris(context) : getRegisteredRedirectUris(context);
-            RedirectUriValidator validator = new RedirectUriValidator(this::checkMatchingRedirectUri);
+            final Client client = context.get(ConstantKeys.CLIENT_CONTEXT_KEY);
+            // CIMD clients always require exact URI matching
+            final RedirectUriValidator.CheckMethod checkMethod = ClientIds.isUrlShaped(client.getClientId())
+                    ? this::checkExactRedirectUri
+                    : this::checkMatchingRedirectUri;
+            RedirectUriValidator validator = new RedirectUriValidator(checkMethod);
             validator.validate(registeredRedirectUris, requestedRedirectUri, operation);
         }
     }
 
     private void checkMatchingRedirectUri(String requestedRedirect, List<String> registeredClientRedirectUris) {
+        validateRedirectUri(requestedRedirect, registeredClientRedirectUris,
+                this.domain.isRedirectUriStrictMatching() || this.domain.usePlainFapiProfile());
+    }
+
+    private void checkExactRedirectUri(String requestedRedirect, List<String> registeredClientRedirectUris) {
+        validateRedirectUri(requestedRedirect, registeredClientRedirectUris, true);
+    }
+
+    private void validateRedirectUri(String requestedRedirect, List<String> registeredClientRedirectUris, boolean strictMatching) {
         if (registeredClientRedirectUris
                 .stream()
-                .noneMatch(registeredClientUri -> redirectMatches(requestedRedirect, registeredClientUri, this.domain.isRedirectUriStrictMatching() || this.domain.usePlainFapiProfile()))) {
+                .noneMatch(registeredClientUri -> redirectMatches(requestedRedirect, registeredClientUri, strictMatching))) {
             throw new RedirectMismatchException(String.format("The redirect_uri [ %s ] MUST match the registered callback URL for this application", requestedRedirect));
         }
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandlerTest.java
@@ -157,4 +157,56 @@ public class RedirectUriValidationHandlerTest {
 
         Mockito.verify(ctx, Mockito.times(1)).next();
     }
+
+    @Test
+    public void cimd_client_rejects_non_exact_redirect_uri_even_when_domain_allows_non_strict_matching() {
+        Domain domain = new Domain();
+        OIDCSettings oidcSettings = OIDCSettings.defaultSettings();
+        oidcSettings.setRedirectUriStrictMatching(false);
+        domain.setOidc(oidcSettings);
+        final var handler = new RedirectUriValidationHandler(domain);
+
+        RoutingContext ctx = Mockito.mock();
+        HttpServerRequest request = Mockito.mock();
+        Mockito.when(ctx.request()).thenReturn(request);
+        Mockito.when(request.getParam(ConstantKeys.RETURN_URL_KEY)).thenReturn(null);
+        // Sub-path of the registered URI — would match under non-strict (prefix) matching
+        Mockito.when(request.getParam(io.gravitee.am.common.oauth2.Parameters.REDIRECT_URI))
+                .thenReturn("https://redirect.example.com/callback/sub");
+
+        Client client = new Client();
+        client.setClientId("http://example.com/my-app"); // URL-shaped → CIMD client
+        client.setRedirectUris(List.of("https://redirect.example.com/callback"));
+        Mockito.when(ctx.get(CLIENT_CONTEXT_KEY)).thenReturn(client);
+
+        handler.handle(ctx);
+
+        Mockito.verify(ctx, Mockito.never()).next();
+        Mockito.verify(ctx).fail(Mockito.any(Throwable.class));
+    }
+
+    @Test
+    public void cimd_client_accepts_exact_redirect_uri_match() {
+        Domain domain = new Domain();
+        OIDCSettings oidcSettings = OIDCSettings.defaultSettings();
+        oidcSettings.setRedirectUriStrictMatching(false);
+        domain.setOidc(oidcSettings);
+        final var handler = new RedirectUriValidationHandler(domain);
+
+        RoutingContext ctx = Mockito.mock();
+        HttpServerRequest request = Mockito.mock();
+        Mockito.when(ctx.request()).thenReturn(request);
+        Mockito.when(request.getParam(ConstantKeys.RETURN_URL_KEY)).thenReturn(null);
+        Mockito.when(request.getParam(io.gravitee.am.common.oauth2.Parameters.REDIRECT_URI))
+                .thenReturn("https://redirect.example.com/callback");
+
+        Client client = new Client();
+        client.setClientId("http://example.com/my-app"); // URL-shaped → CIMD client
+        client.setRedirectUris(List.of("https://redirect.example.com/callback"));
+        Mockito.when(ctx.get(CLIENT_CONTEXT_KEY)).thenReturn(client);
+
+        handler.handle(ctx);
+
+        Mockito.verify(ctx, Mockito.times(1)).next();
+    }
 }

--- a/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
@@ -16,7 +16,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { setup } from '../../test-fixture';
-import { CimdAuthorizeFixture, setupCimdAuthorizeFixture } from './fixtures/cimd-authorize-fixture';
+import { CIMD_REDIRECT_URI, CimdAuthorizeFixture, setupCimdAuthorizeFixture } from './fixtures/cimd-authorize-fixture';
 import {
   clearWireMockRequestJournal,
   countGetRequestsForPathSubstring,
@@ -135,5 +135,14 @@ describe('CIMD authorize - ENABLED_BASE', () => {
   it('should return invalid_client_metadata when private_key_jwt metadata has no jwks and no jwks_uri', async () => {
     const response = await fixture.authorize(fixture.buildClientId('private-key-jwt-missing-jwks'));
     fixture.expectInvalidClientMetadata(response, 'private_key_jwt requires jwks or jwks_uri');
+  });
+
+  it('should enforce exact redirect_uri matching for CIMD clients', async () => {
+    const response = await fixture.authorize(
+      fixture.buildClientId('valid-none'),
+      CIMD_REDIRECT_URI + '/sub',
+    );
+    const error = fixture.readOAuthError(response);
+    expect(error.error).toBe('redirect_uri_mismatch');
   });
 });


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6940](https://gravitee.atlassian.net/browse/AM-6940)

## :pencil2: A description of the changes proposed in the pull request
Ignore domain OIDC "redirect uri strict matching" setting when validating OAuth requests for CIMD clients. It is a strict requirement of CIMD to match redirect URIs exactly.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/ section 4.5

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6940]: https://gravitee.atlassian.net/browse/AM-6940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ