### PR TITLE
feat: AM-6659 advertise CIMD support in discovery endpoint

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDProviderMetadata.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDProviderMetadata.java
@@ -141,6 +141,9 @@ public class OpenIDProviderMetadata {
     @JsonProperty("claims_parameter_supported")
     private Boolean claimsParameterSupported = Boolean.FALSE;
 
+    @JsonProperty("client_id_metadata_document_supported")
+    private Boolean clientIdMetadataDocumentSupported;
+
     @JsonProperty("request_parameter_supported")
     private Boolean requestParameterSupported = Boolean.TRUE;
 
@@ -482,6 +485,14 @@ public class OpenIDProviderMetadata {
 
     public void setClaimsParameterSupported(Boolean claimsParameterSupported) {
         this.claimsParameterSupported = claimsParameterSupported;
+    }
+
+    public Boolean getClientIdMetadataDocumentSupported() {
+        return clientIdMetadataDocumentSupported;
+    }
+
+    public void setClientIdMetadataDocumentSupported(Boolean clientIdMetadataDocumentSupported) {
+        this.clientIdMetadataDocumentSupported = clientIdMetadataDocumentSupported;
     }
 
     public Boolean getRequestParameterSupported() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
@@ -116,6 +116,11 @@ public class OpenIDDiscoveryServiceImpl implements OpenIDDiscoveryService, Initi
             openIDProviderMetadata.setRegistrationTemplatesEndpoint(openIDProviderMetadata.getRegistrationEndpoint() + "_templates");
         }
 
+        // Client ID Metadata Document (RFC 9728)
+        if (domain.useCimd()) {
+            openIDProviderMetadata.setClientIdMetadataDocumentSupported(true);
+        }
+
         // supported parameters
         openIDProviderMetadata.setScopesSupported(scopeService.getDiscoveryScope());
         openIDProviderMetadata.setResponseTypesSupported(ResponseTypeUtils.getSupportedResponseTypes());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
@@ -205,4 +205,18 @@ public class OpenIDDiscoveryServiceTest {
         assertTrue(openIDProviderMetadata.getBackchannelTokenDeliveryModesSupported().containsAll(List.of(CIBADeliveryMode.POLL)));
     }
 
+    @Test
+    public void shouldOmitClientIdMetadataDocumentSupportedWhenCimdDisabled() {
+        when(domain.useCimd()).thenReturn(false);
+        final OpenIDProviderMetadata metadata = openIDDiscoveryService.getConfiguration("/");
+        assertNull(metadata.getClientIdMetadataDocumentSupported());
+    }
+
+    @Test
+    public void shouldAdvertiseClientIdMetadataDocumentSupportedWhenCimdEnabled() {
+        when(domain.useCimd()).thenReturn(true);
+        final OpenIDProviderMetadata metadata = openIDDiscoveryService.getConfiguration("/");
+        assertTrue(Boolean.TRUE.equals(metadata.getClientIdMetadataDocumentSupported()));
+    }
+
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Domain.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Domain.java
@@ -559,6 +559,12 @@ public class Domain implements Resource {
                 this.getOidc().getCibaSettings().isEnabled();
     }
 
+    public boolean useCimd() {
+        return this.getOidc() != null &&
+                this.getOidc().getCimdSettings() != null &&
+                this.getOidc().getCimdSettings().isEnabled();
+    }
+
     public boolean isRedirectUriExpressionLanguageEnabled() {
         return this.getOidc() != null &&
                 this.getOidc().getClientRegistrationSettings() != null &&

--- a/gravitee-am-test/specs/gateway/cimd/cimd-authorize-disabled-base.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-authorize-disabled-base.jest.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { afterAll, beforeAll, describe, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { setup } from '../../test-fixture';
 import { CimdAuthorizeFixture, setupCimdAuthorizeFixture } from './fixtures/cimd-authorize-fixture';
 
@@ -33,6 +33,10 @@ afterAll(async () => {
 });
 
 describe('CIMD authorize - DISABLED_BASE', () => {
+  it('should not advertise client_id_metadata_document_supported in OIDC discovery when CIMD is disabled', () => {
+    expect(fixture.openIdConfiguration.client_id_metadata_document_supported).toBeUndefined();
+  });
+
   it('should load a pre-registered URL client_id when CIMD is disabled', async () => {
     const response = await fixture.authorize(fixture.preRegisteredUrlApplication.settings.oauth.clientId);
     fixture.expectLoginRedirect(response);

--- a/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
@@ -38,6 +38,10 @@ afterAll(async () => {
 });
 
 describe('CIMD authorize - ENABLED_BASE', () => {
+  it('should advertise client_id_metadata_document_supported in OIDC discovery', () => {
+    expect(fixture.openIdConfiguration.client_id_metadata_document_supported).toBe(true);
+  });
+
   it('should continue authorization with URL client_id when CIMD metadata is valid', async () => {
     const response = await fixture.authorize(fixture.buildClientId('valid-none'));
     fixture.expectLoginRedirect(response);


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6659](https://gravitee.atlassian.net/browse/AM-6659)

## :pencil2: A description of the changes proposed in the pull request
Advertise support of CIMD in the discovery endpoint when the feature is enabled on a security domain by including the property `client_id_metadata_document_supported` with the value `true`.

## :memo: Test scenarios 
Review JSON of `<gateway>/<domain>/oidc/.well-known/openid-configuration` when CIMD is enabled and disabled.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6659]: https://gravitee.atlassian.net/browse/AM-6659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ