### PR TITLE
fix: CIMD Template Application field

### DIFF
--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -228,6 +228,7 @@ import { EmailComponent, EmailInfoDialogComponent } from './domain/components/em
 import { EmailService } from './services/email.service';
 import { EmailResolver } from './resolvers/email.resolver';
 import { SelectApplicationsComponent } from './domain/components/applications/select-applications.component';
+import { SelectTemplateApplicationComponent } from './domain/components/applications/select-template-application.component';
 import { ConsentsResolver } from './resolvers/consents.resolver';
 import { AuthorizationEngineService } from './services/authorization-engine.service';
 import { OpenFGAService } from './services/openfga.service';
@@ -641,6 +642,7 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     EmailComponent,
     EmailInfoDialogComponent,
     SelectApplicationsComponent,
+    SelectTemplateApplicationComponent,
     AuditsComponent,
     AuditComponent,
     AuditsSettingsComponent,

--- a/gravitee-am-ui/src/app/domain/components/applications/select-template-application.component.html
+++ b/gravitee-am-ui/src/app/domain/components/applications/select-template-application.component.html
@@ -1,0 +1,34 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-form-field appearance="outline" floatLabel="always">
+  <mat-label>Template Application</mat-label>
+  <input matInput placeholder="Search for a template application ..." [matAutocomplete]="auto" [formControl]="appCtrl" />
+  <button mat-icon-button matSuffix aria-label="Clear" (click)="clearApp($event)">
+    <mat-icon *ngIf="selectedApp">clear</mat-icon>
+  </button>
+  <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onAppSelectionChanged($event)" [displayWith]="displayFn">
+    <mat-option *ngFor="let app of filteredApps | async" [value]="app">
+      <span>{{ app.name }}</span>
+    </mat-option>
+    <mat-option *ngIf="hasNoTemplateApps" disabled>
+      No template applications found — configure one in Client Registration settings.
+    </mat-option>
+  </mat-autocomplete>
+  <mat-hint>The template application used in CIMD requests.</mat-hint>
+  <mat-error *ngIf="appCtrl.hasError('required')">Template Application is required.</mat-error>
+</mat-form-field>

--- a/gravitee-am-ui/src/app/domain/components/applications/select-template-application.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/applications/select-template-application.component.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { UntypedFormControl, Validators } from '@angular/forms';
+import { map, mergeMap, startWith, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+
+import { ApplicationService } from '../../../services/application.service';
+
+@Component({
+  selector: 'app-select-template-application',
+  templateUrl: './select-template-application.component.html',
+  standalone: false,
+})
+export class SelectTemplateApplicationComponent implements OnInit, OnChanges {
+  private domainId: string;
+  appCtrl = new UntypedFormControl();
+  filteredApps: Observable<any>;
+  hasNoTemplateApps = false;
+  selectedApp: any = null;
+  @Input() selectedAppId: string;
+  @Input() disabled: boolean;
+  @Input() required = false;
+  @Output() appSelected = new EventEmitter<string>();
+  @Output() appCleared = new EventEmitter<void>();
+
+  constructor(
+    private route: ActivatedRoute,
+    private applicationService: ApplicationService,
+  ) {}
+
+  ngOnInit() {
+    this.domainId = this.route.snapshot.data['domain']?.id;
+
+    if (this.required) {
+      this.appCtrl.setValidators(Validators.required);
+    }
+
+    if (this.disabled) {
+      this.appCtrl.disable();
+    }
+
+    this.filteredApps = this.appCtrl.valueChanges.pipe(
+      startWith(''),
+      mergeMap((value) => {
+        const searchTerm = typeof value === 'string' || value instanceof String ? value + '*' : '*';
+        return this.applicationService.search(this.domainId, searchTerm);
+      }),
+      map((value) => value['data'].filter((app) => app.template)),
+      tap((apps) => (this.hasNoTemplateApps = apps.length === 0)),
+    );
+
+    if (this.selectedAppId) {
+      this.applicationService.get(this.domainId, this.selectedAppId).subscribe((app) => {
+        this.selectedApp = app;
+        this.appCtrl.setValue(app, { emitEvent: false });
+      });
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['disabled'] && !changes['disabled'].firstChange) {
+      if (this.disabled) {
+        this.appCtrl.disable();
+      } else {
+        this.appCtrl.enable();
+      }
+    }
+  }
+
+  onAppSelectionChanged(event) {
+    this.selectedApp = event.option.value;
+    this.appSelected.emit(this.selectedApp.id);
+  }
+
+  displayFn(app?: any): string | undefined {
+    return app ? app.name : undefined;
+  }
+
+  clearApp(event) {
+    event.preventDefault();
+    this.selectedApp = null;
+    this.appCtrl.setValue('');
+    this.appCleared.emit();
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
@@ -29,21 +29,14 @@
 
         <div *ngIf="cimdSettings.enabled">
           <div class="gv-form-section" fxLayout="column">
-            <mat-form-field appearance="outline" floatLabel="always">
-              <mat-label>Template ID</mat-label>
-              <input
-                matInput
-                type="text"
-                placeholder="Enter the Template ID"
-                name="templateId"
-                [(ngModel)]="cimdSettings.templateId"
-                (ngModelChange)="onFormChange()"
-                [disabled]="!editMode"
-                required
-              />
-              <mat-hint>The template identifier used in CIMD requests.</mat-hint>
-              <mat-error>Template ID is required.</mat-error>
-            </mat-form-field>
+            <input type="hidden" name="templateId" [(ngModel)]="cimdSettings.templateId" required />
+            <app-select-template-application
+              [selectedAppId]="cimdSettings.templateId"
+              [disabled]="!editMode"
+              [required]="true"
+              (appSelected)="onTemplateAppSelected($event)"
+              (appCleared)="onTemplateAppCleared()"
+            ></app-select-template-application>
           </div>
 
           <div class="gv-form-section" fxLayout="column">
@@ -182,6 +175,11 @@
         <p>
           Client-Initiated Metadata Document (CIMD) allows OAuth 2.0 clients to retrieve their own metadata from a well-known URI, enabling
           dynamic configuration of client parameters without prior registration.
+        </p>
+        <h4>Template Application</h4>
+        <p>
+          CIMD requires at least one application to be configured as a <b>Template</b>. Templates are managed in the
+          <a [routerLink]="['../dcr/templates']">Client Registration settings</a>.
         </p>
       </div>
     </div>

--- a/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.ts
@@ -92,6 +92,16 @@ export class CimdSettingsComponent implements OnInit {
     this.formChanged = true;
   }
 
+  onTemplateAppSelected(appId: string) {
+    this.cimdSettings.templateId = appId;
+    this.formChanged = true;
+  }
+
+  onTemplateAppCleared() {
+    this.cimdSettings.templateId = null;
+    this.formChanged = true;
+  }
+
   onFormChange() {
     this.formChanged = true;
   }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6949](https://gravitee.atlassian.net/browse/AM-6949)

## :pencil2: A description of the changes proposed in the pull request
Replace text field component for CIMD Template ID for a combo component that autocompletes and filters template applications by name. This avoids a UX issue where raw IDs had to be entered before validation.

## :memo: Test scenarios 
Navigate to **Settings** > **OAuth 2.0** > **CIMD** and select a **Template Application**.

## :computer: Add screenshots for UI
**Before:**
<img width="1003" height="349" alt="image" src="https://github.com/user-attachments/assets/40ac5a71-adf9-41b6-aab5-c4ab4fb7f92e" />

**After:**
<img width="1403" height="386" alt="image" src="https://github.com/user-attachments/assets/70018613-d7d1-4a02-b863-d2a8c46fb808" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-6949]: https://gravitee.atlassian.net/browse/AM-6949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ