### PR TITLE
fix: AM-6930 TCP reporter property name mismatch

### DIFF
--- a/gravitee-am-reporter/gravitee-am-reporter-tcp/src/main/resources/schemas/schema-form.json
+++ b/gravitee-am-reporter/gravitee-am-reporter-tcp/src/main/resources/schemas/schema-form.json
@@ -51,7 +51,7 @@
       "type": "object",
       "title": "SSL / TLS",
       "properties": {
-        "sslEnabled": {
+        "enabled": {
           "type": "boolean",
           "title": "Enable SSL/TLS",
           "default": false


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6930](https://gravitee.atlassian.net/browse/AM-6930)

## :pencil2: A description of the changes proposed in the pull request
Amend schema property name to match that of data model, ensuring SSL/TLS setting in the UI can be used to control the TCP reporter's connection mode.

Note: the TCP reporter feature is unreleased, so the schema backward incompatibility is allowed: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-access-management/29664/workflows/fae9fb87-1bc3-4bf2-a7c8-14f066a0f31d/jobs/396164

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-6930]: https://gravitee.atlassian.net/browse/AM-6930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ