### PR TITLE
fix: AM-6955 Restrict CIMD grant_types and scope

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
@@ -26,6 +26,7 @@ import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentMan
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
 import lombok.extern.slf4j.Slf4j;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.application.ApplicationScopeSettings;
 import io.gravitee.am.model.oidc.CIMDSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.JWKSet;
@@ -48,6 +49,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -310,8 +313,15 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
             throw new InvalidClientMetadataException("private_key_jwt requires jwks or jwks_uri.");
         }
 
-        final List<String> grantTypes = readOptionalStringArray(metadata, "grant_types", DEFAULT_GRANT_TYPES);
-        final List<String> responseTypes = readOptionalStringArray(metadata, "response_types", DEFAULT_RESPONSE_TYPES);
+        final List<String> grantTypes = intersect(
+                readOptionalStringArray(metadata, "grant_types", DEFAULT_GRANT_TYPES),
+                templateClient.getAuthorizedGrantTypes());
+        final List<String> responseTypes = intersect(
+                readOptionalStringArray(metadata, "response_types", DEFAULT_RESPONSE_TYPES),
+                templateClient.getResponseTypes());
+        final List<ApplicationScopeSettings> scopes = intersectScopes(
+                metadata.getString("scope"),
+                templateClient.getScopeSettings());
 
         final Client synthesizedClient;
         try {
@@ -325,6 +335,7 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
         synthesizedClient.setTokenEndpointAuthMethod(tokenEndpointAuthMethod);
         synthesizedClient.setAuthorizedGrantTypes(grantTypes);
         synthesizedClient.setResponseTypes(responseTypes);
+        synthesizedClient.setScopeSettings(scopes);
         synthesizedClient.setClientName(metadata.getString("client_name", synthesizedClient.getClientName()));
         final String logoUri = metadata.getString("logo_uri");
         if (logoUri != null && !logoUri.isBlank()) {
@@ -375,6 +386,25 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
     private List<String> readOptionalStringArray(JsonObject metadata, String key, List<String> defaultValue) {
         final List<String> values = readOptionalStringArray(metadata, key);
         return values != null ? values : defaultValue;
+    }
+
+    private static List<String> intersect(List<String> requested, List<String> allowed) {
+        if (requested == null || requested.isEmpty() || allowed == null || allowed.isEmpty()) {
+            return List.of();
+        }
+        final var allowedSet = new HashSet<>(allowed);
+        return requested.stream().filter(allowedSet::contains).toList();
+    }
+
+    private static List<ApplicationScopeSettings> intersectScopes(
+            String requested, List<ApplicationScopeSettings> templateScopes) {
+        if (requested == null || requested.isBlank() || templateScopes == null || templateScopes.isEmpty()) {
+            return templateScopes;
+        }
+        final Set<String> scopes = new HashSet<>(Arrays.asList(requested.split("\\s+")));
+        return templateScopes.stream()
+                .filter(s -> scopes.contains(s.getScope()))
+                .toList();
     }
 
     private JWKSet toModelJwkSet(JsonObject jwksAsJson) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
@@ -20,6 +20,7 @@ import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentMan
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
 import io.gravitee.am.model.CimdMetadataDocument;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.application.ApplicationScopeSettings;
 import io.gravitee.am.model.application.ApplicationSecretSettings;
 import io.gravitee.am.model.application.ClientSecret;
 import io.gravitee.am.model.oidc.CIMDSettings;
@@ -253,6 +254,9 @@ public class CimdMetadataServiceImplTest {
 
     @Test
     public void shouldSynthesizeClientWithMetadataValues() {
+        Client template = templateClient();
+        template.setAuthorizedGrantTypes(List.of("authorization_code", "client_credentials"));
+        template.setResponseTypes(List.of("code", "token"));
         JsonObject metadata = new JsonObject()
                 .put("client_id", CLIENT_URL)
                 .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
@@ -263,7 +267,7 @@ public class CimdMetadataServiceImplTest {
                 .put("response_types", new JsonArray().add("token"));
         mockFetchSuccess(metadata.encode());
 
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
 
         testObserver.assertComplete();
         testObserver.assertNoErrors();
@@ -381,7 +385,7 @@ public class CimdMetadataServiceImplTest {
     @Test
     public void shouldDefaultGrantTypesToAuthorizationCodeWhenAbsent() {
         Client template = templateClient();
-        template.setAuthorizedGrantTypes(List.of("client_credentials"));
+        // template already includes authorization_code — default intersects to ["authorization_code"]
         JsonObject metadata = new JsonObject()
                 .put("client_id", CLIENT_URL)
                 .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
@@ -396,9 +400,45 @@ public class CimdMetadataServiceImplTest {
     }
 
     @Test
+    public void shouldIntersectGrantTypesWithTemplate() {
+        Client template = templateClient();
+        template.setAuthorizedGrantTypes(List.of("authorization_code"));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none")
+                .put("grant_types", new JsonArray().add("authorization_code").add("client_credentials"));
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> List.of("authorization_code").equals(client.getAuthorizedGrantTypes()));
+    }
+
+    @Test
+    public void shouldExcludeGrantTypesNotInTemplate() {
+        Client template = templateClient();
+        template.setAuthorizedGrantTypes(List.of("authorization_code"));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none")
+                .put("grant_types", new JsonArray().add("client_credentials"));
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> client.getAuthorizedGrantTypes().isEmpty());
+    }
+
+    @Test
     public void shouldDefaultResponseTypesToCodeWhenAbsent() {
         Client template = templateClient();
-        template.setResponseTypes(List.of("token"));
+        // template already includes code — default intersects to ["code"]
         JsonObject metadata = new JsonObject()
                 .put("client_id", CLIENT_URL)
                 .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
@@ -410,6 +450,151 @@ public class CimdMetadataServiceImplTest {
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValue(client -> List.of("code").equals(client.getResponseTypes()));
+    }
+
+    @Test
+    public void shouldIntersectResponseTypesWithTemplate() {
+        Client template = templateClient();
+        template.setResponseTypes(List.of("code"));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none")
+                .put("response_types", new JsonArray().add("code").add("token"));
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> List.of("code").equals(client.getResponseTypes()));
+    }
+
+    @Test
+    public void shouldExcludeResponseTypesNotInTemplate() {
+        Client template = templateClient();
+        template.setResponseTypes(List.of("code"));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none")
+                .put("response_types", new JsonArray().add("token"));
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> client.getResponseTypes().isEmpty());
+    }
+
+    @Test
+    public void shouldIntersectScopeWithTemplateScopes() {
+        Client template = templateClient();
+        template.setScopeSettings(List.of(
+                scopeSetting("read", false),
+                scopeSetting("write", false)));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none")
+                .put("scope", "read");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client ->
+                client.getScopeSettings() != null
+                        && client.getScopeSettings().size() == 1
+                        && "read".equals(client.getScopeSettings().get(0).getScope()));
+    }
+
+    @Test
+    public void shouldPreserveDefaultScopesWithinIntersection() {
+        Client template = templateClient();
+        template.setScopeSettings(List.of(
+                scopeSetting("read", true),
+                scopeSetting("write", false)));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none")
+                .put("scope", "read write");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client ->
+                client.getScopeSettings() != null
+                        && client.getScopeSettings().size() == 2
+                        && client.getScopeSettings().stream().anyMatch(s -> "read".equals(s.getScope()) && s.isDefaultScope())
+                        && client.getScopeSettings().stream().anyMatch(s -> "write".equals(s.getScope()) && !s.isDefaultScope()));
+    }
+
+    @Test
+    public void shouldRestrictDefaultScopeWhenExcludedByIntersection() {
+        Client template = templateClient();
+        template.setScopeSettings(List.of(
+                scopeSetting("read", true)));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none")
+                .put("scope", "write");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client ->
+                client.getScopeSettings() != null && client.getScopeSettings().isEmpty());
+    }
+
+    @Test
+    public void shouldPreserveTemplateScopesWhenScopeIsBlankInMetadata() {
+        Client template = templateClient();
+        template.setScopeSettings(List.of(scopeSetting("read", true)));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none")
+                .put("scope", "");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client ->
+                client.getScopeSettings() != null
+                        && client.getScopeSettings().size() == 1
+                        && "read".equals(client.getScopeSettings().get(0).getScope()));
+    }
+
+    @Test
+    public void shouldPreserveTemplateScopesWhenNoScopeInMetadata() {
+        Client template = templateClient();
+        template.setScopeSettings(List.of(
+                scopeSetting("read", true),
+                scopeSetting("write", false)));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, template).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client ->
+                client.getScopeSettings() != null
+                        && client.getScopeSettings().size() == 2);
     }
 
     @Test
@@ -908,5 +1093,11 @@ public class CimdMetadataServiceImplTest {
         template.setClientSecrets(List.of(new ClientSecret()));
         template.setSecretSettings(List.of(new ApplicationSecretSettings()));
         return template;
+    }
+
+    private ApplicationScopeSettings scopeSetting(String scope, boolean defaultScope) {
+        ApplicationScopeSettings s = new ApplicationScopeSettings(scope);
+        s.setDefaultScope(defaultScope);
+        return s;
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6955](https://gravitee.atlassian.net/browse/AM-6955)

## :pencil2: A description of the changes proposed in the pull request
Apply consistent resolution for OAuth `grant_types` and `scope` when authenticating a client by CIMD. The values become the intersection of those defined in the document metadata and template application's OAuth settings.

When `grant_types` is omitted from CIMD metadata document, assume `['authorization_code']` before intersecting with the grant types of the template client.
When `scope` is omitted from CIMD metadata document, inherit those from the template client.

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6955]: https://gravitee.atlassian.net/browse/AM-6955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ