### PR TITLE
fix: new sessions should be MFA challenged by ACTIVATED factors

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpoint.java
@@ -572,12 +572,19 @@ public class MFAChallengeEndpoint extends MFAEndpoint {
             throw FactorNotFoundException.withMessage("No factor found for the end user");
         }
 
-        return enrolledFactors
+        Optional<EnrolledFactor> firstPrimary = enrolledFactors
                 .stream()
                 .filter(e -> TRUE.equals(e.isPrimary()))
+                .findFirst();
+
+        Optional<EnrolledFactor> firstActivated = enrolledFactors
+                .stream()
+                .filter(e -> ACTIVATED.equals(e.getStatus()))
+                .findFirst();
+
+        return firstPrimary.or(() -> firstActivated)
                 .map(enrolledFactor -> factorManager.getFactor(enrolledFactor.getFactorId()))
-                .findFirst()
-                .orElse(factorManager.getFactor(enrolledFactors.get(0).getFactorId()));
+                .orElseGet(() -> factorManager.getFactor(enrolledFactors.get(0).getFactorId()));
     }
 
     private EnrolledFactor getEnrolledFactor(RoutingContext routingContext,

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengeEndpointTest.java
@@ -76,6 +76,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.ApplicationContext;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -592,6 +593,64 @@ public class MFAChallengeEndpointTest extends RxWebTestBase {
 
         verify(auditService).report(any());
         verify(userService, never()).addFactor(any(), any(), any());
+    }
+
+    @Test
+    public void shouldPickActivatedFactor_whenPendingFactorIsOlder() throws Exception {
+        // AM-6875: when no factor is in session and the user has both an older PENDING_ACTIVATION
+        // factor and a newer ACTIVATED factor, getFactor() must select the ACTIVATED one.
+        final var endUser = new User();
+        EnrolledFactor pending = new EnrolledFactor();
+        pending.setFactorId("pending-factor");
+        pending.setStatus(FactorStatus.PENDING_ACTIVATION);
+        pending.setCreatedAt(new Date(1_000));
+        EnrolledFactor activated = new EnrolledFactor();
+        activated.setFactorId("activated-factor");
+        activated.setStatus(FactorStatus.ACTIVATED);
+        activated.setCreatedAt(new Date(2_000));
+        endUser.setFactors(List.of(pending, activated));
+
+        router.route(HttpMethod.POST, "/mfa/challenge")
+                .order(-1)
+                .handler(routingContext -> {
+                    Client client = new Client();
+                    ApplicationFactorSettings pendingSettings = new ApplicationFactorSettings();
+                    pendingSettings.setId("pending-factor");
+                    ApplicationFactorSettings activatedSettings = new ApplicationFactorSettings();
+                    activatedSettings.setId("activated-factor");
+                    FactorSettings factorSettings = new FactorSettings();
+                    factorSettings.setApplicationFactors(List.of(pendingSettings, activatedSettings));
+                    client.setFactorSettings(factorSettings);
+                    routingContext.getDelegate().setUser(new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(endUser));
+                    routingContext.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+                    routingContext.next();
+                });
+
+        Factor activatedFactor = mock(Factor.class);
+        when(activatedFactor.getId()).thenReturn("activated-factor");
+        FactorProvider factorProvider = mock(FactorProvider.class);
+        when(factorProvider.verify(any())).thenReturn(Completable.complete());
+        when(factorProvider.useVariableFactorSecurity(any())).thenReturn(false);
+        when(factorManager.getFactor("activated-factor")).thenReturn(activatedFactor);
+        when(factorManager.get("activated-factor")).thenReturn(factorProvider);
+        when(verifyAttemptService.checkVerifyAttempt(any(), any(), any(), any())).thenReturn(Maybe.empty());
+
+        testRequest(HttpMethod.POST,
+                "/mfa/challenge",
+                req -> {
+                    req.setChunked(true);
+                    req.putHeader(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED);
+                    req.write(Buffer.buffer("code=123456&factorId=activated-factor"));
+                },
+                res -> {
+                    String location = res.getHeader("Location");
+                    Assert.assertTrue(location.endsWith("/oauth/authorize"));
+                },
+                302,
+                "Found", null);
+
+        verify(factorManager).getFactor("activated-factor");
+        verify(factorManager, never()).getFactor("pending-factor");
     }
 
     @Test

--- a/gravitee-am-test/specs/gateway/mfa/fixture/mfa-flow-fixture.ts
+++ b/gravitee-am-test/specs/gateway/mfa/fixture/mfa-flow-fixture.ts
@@ -83,7 +83,7 @@ export async function processMfaEnrollment(ctx: TestSuiteContext) {
     {
       'X-XSRF-TOKEN': xsrf,
       factorId: factorId,
-      ser_mfa_enrollment: true,
+      user_mfa_enrollment: true,
     },
     {
       Cookie: enrollmentPage.headers['set-cookie'],
@@ -96,6 +96,61 @@ export async function processMfaEnrollment(ctx: TestSuiteContext) {
     cookie: enrollmentPostResponse.headers['set-cookie'],
     location: enrollmentPostResponse.headers['location'],
     factorId: factorId,
+  };
+}
+
+/**
+ * Like processMfaEnrollment, but submits the enrollment form with an explicit factorId,
+ * bypassing the page-rendered default. The endpoint validates that the chosen factorId is
+ * configured on the application (MFAEnrollEndpoint.getValidFactor), so it must be one of
+ * the application factors.
+ */
+export async function processMfaEnrollmentForFactor(ctx: TestSuiteContext, chosenFactorId: string) {
+  const authResponse = await get(ctx.clientAuthUrl, 302);
+  const loginPage = await followUpGet(authResponse, 200);
+
+  let xsrf = extractDomValue(loginPage, '[name=X-XSRF-TOKEN]');
+  let action = extractDomAttr(loginPage, 'form', 'action');
+
+  const loginPostResponse = await postForm(
+    action,
+    {
+      'X-XSRF-TOKEN': xsrf,
+      username: ctx.user.username,
+      password: ctx.user.password,
+      client_id: ctx.client.clientId,
+    },
+    {
+      Cookie: loginPage.headers['set-cookie'],
+      'Content-type': 'application/x-www-form-urlencoded',
+    },
+    302,
+  );
+
+  const enrollLocationResponse = await followUpGet(loginPostResponse, 302);
+  const enrollmentPage = await followUpGet(enrollLocationResponse, 200);
+
+  xsrf = extractDomValue(enrollmentPage, '[name=X-XSRF-TOKEN]');
+  action = extractDomAttr(enrollmentPage, 'form', 'action');
+
+  const enrollmentPostResponse = await postForm(
+    action,
+    {
+      'X-XSRF-TOKEN': xsrf,
+      factorId: chosenFactorId,
+      user_mfa_enrollment: true,
+    },
+    {
+      Cookie: enrollmentPage.headers['set-cookie'],
+      'Content-type': 'application/x-www-form-urlencoded',
+    },
+    302,
+  );
+
+  return {
+    cookie: enrollmentPostResponse.headers['set-cookie'],
+    location: enrollmentPostResponse.headers['location'],
+    factorId: chosenFactorId,
   };
 }
 

--- a/gravitee-am-test/specs/gateway/mfa/mfa-challange-required.spec.ts
+++ b/gravitee-am-test/specs/gateway/mfa/mfa-challange-required.spec.ts
@@ -17,7 +17,14 @@ import fetch from 'cross-fetch';
 import { afterAll, beforeAll, beforeEach, expect, jest } from '@jest/globals';
 import { Domain, enableDomain, initClient, initDomain, removeDomain, TestSuiteContext } from './fixture/mfa-setup-fixture';
 import { withRetry } from '@utils-commands/retry';
-import { followUpGet, get, postForm, processMfaEndToEnd, processMfaEnrollment } from './fixture/mfa-flow-fixture';
+import {
+  followUpGet,
+  get,
+  postForm,
+  processMfaEndToEnd,
+  processMfaEnrollment,
+  processMfaEnrollmentForFactor,
+} from './fixture/mfa-flow-fixture';
 import { extractDomAttr, extractDomValue } from './fixture/mfa-extract-fixture';
 import { getWellKnownOpenIdConfiguration } from '@gateway-commands/oauth-oidc-commands';
 import { waitFor } from '@management-commands/domain-management-commands';
@@ -58,11 +65,12 @@ const domain = {
 } as Domain;
 
 beforeAll(async () => {
-  await initDomain(domain, 5);
+  await initDomain(domain, 6);
 
   const defaultClient1 = await initClient(domain, 'default-1', defaultApplicationSettings(domain));
   const defaultClient2 = await initClient(domain, 'default-2', defaultApplicationSettings(domain));
   const defaultClient3 = await initClient(domain, 'default-3', defaultApplicationSettings(domain));
+  const secondEnrollmentClient = await initClient(domain, 'second-enroll', defaultApplicationSettings(domain));
 
   const rememberDeviceClientSettings = defaultApplicationSettings(domain);
   rememberDeviceClientSettings.settings.mfa.rememberDevice = {
@@ -84,6 +92,7 @@ beforeAll(async () => {
   defaultClientCtx3 = new TestSuiteContext(domain, defaultClient3, domain.domain.users[2], oidc.body.authorization_endpoint);
   rememberMeCtx1 = new TestSuiteContext(domain, rememberDeviceClient1, domain.domain.users[3], oidc.body.authorization_endpoint);
   rememberMeCtx2 = new TestSuiteContext(domain, rememberDeviceClient2, domain.domain.users[4], oidc.body.authorization_endpoint);
+  secondEnrollmentCtx = new TestSuiteContext(domain, secondEnrollmentClient, domain.domain.users[5], oidc.body.authorization_endpoint);
 });
 
 afterAll(async () => {
@@ -95,6 +104,7 @@ let defaultClientCtx2: TestSuiteContext;
 let defaultClientCtx3: TestSuiteContext;
 let rememberMeCtx1: TestSuiteContext;
 let rememberMeCtx2: TestSuiteContext;
+let secondEnrollmentCtx: TestSuiteContext;
 
 describe('When Challenge REQUIRED and factor not enrolled', () =>
   it('should Enroll', async () => {
@@ -168,4 +178,52 @@ describe('When Challenge REQUIRED and factor enrolled and no session issued usin
 
     expect(authResponse.headers['location']).toBeDefined();
     expect(authResponse.headers['location']).toContain('code=');
+  }));
+
+describe('When user has a stale PENDING factor and a later ACTIVATED factor (AM-6875)', () =>
+  it('should challenge the ACTIVATED factor, not the older PENDING one', async () => {
+    const ctx = secondEnrollmentCtx;
+    const factorA = domain.domain.factors[0].id;
+    const factorB = domain.domain.factors[1].id;
+
+    const firstEnrollment = await processMfaEnrollmentForFactor(ctx, factorA);
+    const challengeAfterA = await get(firstEnrollment.location, 302, { Cookie: firstEnrollment.cookie });
+    await followUpGet(challengeAfterA, 200);
+
+    const secondEnrollment = await processMfaEnrollmentForFactor(ctx, factorB);
+    const challengeAfterB = await get(secondEnrollment.location, 302, { Cookie: secondEnrollment.cookie });
+    const challengePageB = await followUpGet(challengeAfterB, 200);
+
+    let xsrf = extractDomValue(challengePageB, '[name=X-XSRF-TOKEN]');
+    let action = extractDomAttr(challengePageB, 'form', 'action');
+    const challengePostB = await postForm(
+      action,
+      { 'X-XSRF-TOKEN': xsrf, factorId: factorB, code: '1234', rememberDeviceConsent: 'off' },
+      { Cookie: challengePageB.headers['set-cookie'], 'Content-type': 'application/x-www-form-urlencoded' },
+      302,
+    );
+    const finalAfterB = await followUpGet(challengePostB, 302);
+    expect(finalAfterB.headers['location']).toContain('code=');
+
+    const authResponse = await get(ctx.clientAuthUrl, 302);
+    const loginPage = await followUpGet(authResponse, 200);
+    xsrf = extractDomValue(loginPage, '[name=X-XSRF-TOKEN]');
+    action = extractDomAttr(loginPage, 'form', 'action');
+    const loginPostResponse = await postForm(
+      action,
+      {
+        'X-XSRF-TOKEN': xsrf,
+        username: ctx.user.username,
+        password: ctx.user.password,
+        client_id: ctx.client.clientId,
+      },
+      { Cookie: loginPage.headers['set-cookie'], 'Content-type': 'application/x-www-form-urlencoded' },
+      302,
+    );
+    const challengeLocation = await followUpGet(loginPostResponse, 302);
+    const challengePage = await followUpGet(challengeLocation, 200);
+
+    const challengedFactorId = extractDomValue(challengePage, '[name=factorId]');
+    expect(challengedFactorId).toBe(factorB);
+    expect(challengedFactorId).not.toBe(factorA);
   }));


### PR DESCRIPTION
How to test:
Create two factors EMAIL and SMS
Enroll EMAIL factor but do not enter the code. At this moment user has EMAIL factor added with status ACTIVATION_PENDING
Open new session or logout
Login again, enroll SMS, enter the code. At this moemmtn user has two factors by one is ACTIVATED (SMS)
Logout, login again. The challange is sent to EMAIL instead to SMS.