### PR TITLE
chore: bump gravitee-am-gateway-handler-saml2-idp version to 5.0.0-alpha.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
 
         <!-- Plugins included to full-bundle -->
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
-        <gravitee-am-gateway-handler-saml2-idp.version>5.0.0-alpha.2</gravitee-am-gateway-handler-saml2-idp.version>
+        <gravitee-am-gateway-handler-saml2-idp.version>5.0.0-alpha.3</gravitee-am-gateway-handler-saml2-idp.version>
         <gravitee-am-resource-sfr.version>2.0.0-alpha.1</gravitee-am-resource-sfr.version>
         <gravitee-am-resource-http.version>2.0.0-alpha.1</gravitee-am-resource-http.version>
         <gravitee-am-resource-orange-contact-everyone.version>2.0.0-alpha.1</gravitee-am-resource-orange-contact-everyone.version>


### PR DESCRIPTION
## :id: Reference related issue.

[AM-6953](https://gravitee.atlassian.net/browse/AM-6953) — Migrate `gravitee-am-identityprovider-saml` to Vert.x 5.

Bundles the fixes from [gravitee-am-gateway-handler-saml2-idp#64](https://github.com/gravitee-io/gravitee-am-gateway-handler-saml2-idp/pull/64).

## :pencil2: A description of the changes proposed in the pull request

Bumps `gravitee-am-gateway-handler-saml2-idp` from `5.0.0-alpha.2` to `5.0.0-alpha.3` in the root `pom.xml`.

`alpha.3` fixes the SAML2 IdP plugin under Vert.x 5 (AM 5.x). Several Vert.x 4 → 5 API changes broke the SSO POST-binding flow:

- **Parse HTTP-POST `AuthnRequest` body** — `BodyHandler.create()` added to the SSO POST route so `SAMLRequest` / `RelayState` form params are parsed and merged into request parameters before the SAML decoder reads them. Without this, POST-binding AuthnRequests came through empty under Vert.x 5.
- **Defer SSO POST template render** — switched from `engine.render(...)` to `engine.rxRender(...)` wrapped in `Single.defer(...)`. The vertx-rxjava3 `render` wrapper auto-subscribes eagerly and snapshotted `routingContext.data()` before the `ACTION_KEY` / `PARAMETERS` puts ran, producing an empty auto-post form. `cleanAuthFlowContext` refactored to return `Completable` so ordering with the puts and render is preserved.
- **Sub-router mount API** — replaced deprecated `router.mountSubRouter(path, sub)` with `router.route(path + "/*").subRouter(sub)`.
- **User context API** — replaced removed `RoutingContext.setUser(...)` / `clearUser()` with `userContext().setUser(...)` / `userContext().clear()` (via `UserContextInternal`) in `LogoutServiceEndpoint` and tests.
- **Imports** — switched `SingleSignOnServiceCallbackPostEndpoint` to core `io.vertx.core.MultiMap` (rxjava3 wrapper no longer needed).

Also aligns AM parent / orb versions and CircleCI config with the Vert.x 5 / AM 5.x line.

## :memo: Test scenarios

- Configure a SAML2 SP using HTTP-POST binding against an AM 5.x gateway with the bumped plugin.
- Verify the full SSO POST round-trip completes — AuthnRequest parameters are parsed on the IdP side and the SP receives a populated auto-submit response form (no `MessageDecodingException: No SAML Request present in request`, no empty auto-post form).
- Verify SP-initiated logout still works (user context API change).

## :computer: Add screenshots for UI

N/A — dependency version bump only.

## :books: Any other comments that will help with documentation

None.

## :man: :woman: @mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am-team

[AM-6953]: https://gravitee.atlassian.net/browse/AM-6953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ