### PR TITLE
fix: AM-6968 support CIMD clients in SSO checks

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/ClientLookupService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/ClientLookupService.java
@@ -20,6 +20,8 @@ import io.reactivex.rxjava3.core.Maybe;
 
 public interface ClientLookupService {
 
+    Maybe<Client> findById(String id);
+
     Maybe<Client> findByClientId(String clientId);
 
     Maybe<Client> findByDomainAndClientId(String domain, String clientId);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/impl/CimdAwareClientLookupServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/impl/CimdAwareClientLookupServiceImpl.java
@@ -54,6 +54,12 @@ public class CimdAwareClientLookupServiceImpl implements ClientLookupService {
     }
 
     @Override
+    public Maybe<Client> findById(String id) {
+        // id can only be an application id, so we can just use the default lookup service
+        return defaultClientLookupService.findById(id);
+    }
+
+    @Override
     public Maybe<Client> findByClientId(String clientId) {
         return defaultClientLookupService.findByClientId(clientId)
                 .switchIfEmpty(resolveFromCimd(clientId));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/impl/DefaultClientLookupServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/impl/DefaultClientLookupServiceImpl.java
@@ -37,6 +37,11 @@ public class DefaultClientLookupServiceImpl implements ClientLookupService {
     }
 
     @Override
+    public Maybe<Client> findById(String id) {
+        return clientSyncService.findById(id);
+    }
+
+    @Override
     public Maybe<Client> findByClientId(String clientId) {
         if (protectedResourceSyncService == null) {
             return clientSyncService.findByClientId(clientId);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/web/WebConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/web/WebConfiguration.java
@@ -16,7 +16,7 @@
 package io.gravitee.am.gateway.handler.common.spring.web;
 
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
-import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
+import io.gravitee.am.gateway.handler.common.client.ClientLookupService;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.service.LoginAttemptGatewayService;
@@ -35,6 +35,7 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.service.AuthenticationFlowContextService;
 import io.gravitee.am.service.impl.user.UserEnhancer;
 import io.vertx.core.http.CookieSameSite;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -68,8 +69,8 @@ public class WebConfiguration {
     }
 
     @Bean
-    public SSOSessionHandler ssoSessionHandler(ClientSyncService clientSyncService, AuthenticationFlowContextService authenticationFlowContextService, LoginAttemptGatewayService loginAttemptService, Domain domain) {
-        return new SSOSessionHandler(clientSyncService, authenticationFlowContextService, loginAttemptService, domain);
+    public SSOSessionHandler ssoSessionHandler(@Qualifier("complexClientLookupService") ClientLookupService clientLookupService, AuthenticationFlowContextService authenticationFlowContextService, LoginAttemptGatewayService loginAttemptService, Domain domain) {
+        return new SSOSessionHandler(clientLookupService, authenticationFlowContextService, loginAttemptService, domain);
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/SSOSessionHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/SSOSessionHandler.java
@@ -23,7 +23,7 @@ import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.dataplane.api.search.LoginAttemptCriteria;
-import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
+import io.gravitee.am.gateway.handler.common.client.ClientLookupService;
 import io.gravitee.am.gateway.handler.common.service.LoginAttemptGatewayService;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.CookieSession;
 import io.gravitee.am.model.Domain;
@@ -66,13 +66,13 @@ import static java.util.Optional.ofNullable;
 public class SSOSessionHandler implements Handler<RoutingContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SSOSessionHandler.class);
-    private ClientSyncService clientSyncService;
+    private ClientLookupService clientLookupService;
     private AuthenticationFlowContextService authenticationFlowContextService;
     private LoginAttemptGatewayService loginAttemptService;
     private Domain domain;
 
-    public SSOSessionHandler(ClientSyncService clientSyncService, AuthenticationFlowContextService authenticationFlowContextService, LoginAttemptGatewayService loginAttemptService, Domain domain) {
-        this.clientSyncService = clientSyncService;
+    public SSOSessionHandler(ClientLookupService clientLookupService, AuthenticationFlowContextService authenticationFlowContextService, LoginAttemptGatewayService loginAttemptService, Domain domain) {
+        this.clientLookupService = clientLookupService;
         this.authenticationFlowContextService = authenticationFlowContextService;
         this.loginAttemptService = loginAttemptService;
         this.domain = domain;
@@ -237,8 +237,8 @@ public class SSOSessionHandler implements Handler<RoutingContext> {
     }
 
     private Single<Optional<Client>> getClient(String clientId) {
-        return clientSyncService.findById(clientId)
-                .switchIfEmpty(Maybe.defer(() -> clientSyncService.findByClientId(clientId)))
+        return clientLookupService.findById(clientId)
+                .switchIfEmpty(Maybe.defer(() -> clientLookupService.findByClientId(clientId)))
                 .map(Optional::ofNullable)
                 .defaultIfEmpty(Optional.empty());
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/impl/CimdAwareClientLookupServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/impl/CimdAwareClientLookupServiceImplTest.java
@@ -59,6 +59,35 @@ public class CimdAwareClientLookupServiceImplTest {
     }
 
     @Test
+    public void shouldFindTemplateClientByIdWithoutInvokingCimd() {
+        // When a CIMD user's session stores user.getClient() = templateId (the internal UUID
+        // inherited by the synthesized client), looking up by that UUID resolves the template
+        // directly without triggering remote CIMD metadata resolution.
+        Client template = new Client();
+        template.setId("software-template-id");
+        when(clientSyncService.findById("software-template-id")).thenReturn(Maybe.just(template));
+
+        TestObserver<Client> observer = complexClientLookupService.findById("software-template-id").test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(template);
+        verifyNoInteractions(cimdMetadataService);
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenTemplateNotFoundById() {
+        when(clientSyncService.findById("software-template-id")).thenReturn(Maybe.empty());
+
+        TestObserver<Client> observer = complexClientLookupService.findById("software-template-id").test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertNoValues();
+        verifyNoInteractions(cimdMetadataService);
+    }
+
+    @Test
     public void shouldReturnRegisteredClientWithoutCallingCimd() {
         Client registeredClient = new Client();
         when(clientSyncService.findByClientId("registered-client")).thenReturn(Maybe.just(registeredClient));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/impl/ComplexClientLookupServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/impl/ComplexClientLookupServiceImplTest.java
@@ -48,6 +48,31 @@ public class ComplexClientLookupServiceImplTest {
     }
 
     @Test
+    public void shouldFindClientById() {
+        Client client = new Client();
+        when(clientSyncService.findById("client-uuid")).thenReturn(Maybe.just(client));
+
+        TestObserver<Client> observer = clientLookupService.findById("client-uuid").test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(client);
+        verify(protectedResourceSyncService, never()).findByClientId("client-uuid");
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenClientNotFoundById() {
+        when(clientSyncService.findById("client-uuid")).thenReturn(Maybe.empty());
+
+        TestObserver<Client> observer = clientLookupService.findById("client-uuid").test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertNoValues();
+        verify(protectedResourceSyncService, never()).findByClientId("client-uuid");
+    }
+
+    @Test
     public void shouldReturnClientFromClientSyncServiceWithoutFallback() {
         Client client = new Client();
         when(clientSyncService.findByClientId("client-id")).thenReturn(Maybe.just(client));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/impl/RegularClientLookupServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/impl/RegularClientLookupServiceImplTest.java
@@ -47,6 +47,31 @@ public class RegularClientLookupServiceImplTest {
     }
 
     @Test
+    public void shouldFindClientById() {
+        Client client = new Client();
+        when(clientSyncService.findById("client-uuid")).thenReturn(Maybe.just(client));
+
+        TestObserver<Client> observer = clientLookupService.findById("client-uuid").test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(client);
+        verifyNoInteractions(protectedResourceSyncService);
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenClientNotFoundById() {
+        when(clientSyncService.findById("client-uuid")).thenReturn(Maybe.empty());
+
+        TestObserver<Client> observer = clientLookupService.findById("client-uuid").test();
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertNoValues();
+        verifyNoInteractions(protectedResourceSyncService);
+    }
+
+    @Test
     public void shouldReturnClientFromClientSyncService() {
         Client client = new Client();
         when(clientSyncService.findByClientId("client-id")).thenReturn(Maybe.just(client));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/SSOSessionHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/SSOSessionHandlerTest.java
@@ -18,7 +18,7 @@ package io.gravitee.am.gateway.handler.common.vertx.web.handler;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.gateway.certificate.CertificateProvider;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
-import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
+import io.gravitee.am.gateway.handler.common.client.ClientLookupService;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.service.LoginAttemptGatewayService;
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
 public class SSOSessionHandlerTest extends RxWebTestBase {
 
     @Mock
-    private ClientSyncService clientSyncService;
+    private ClientLookupService clientLookupService;
     @Mock
     private JWTService jwtService;
     @Mock
@@ -93,7 +93,7 @@ public class SSOSessionHandlerTest extends RxWebTestBase {
 
         router.route("/login")
                 .handler(new CookieSessionHandler(jwtService, certificateManager, subjectManager, userEnhancer, "am-cookie", 30 * 60 * 60))
-                .handler(new SSOSessionHandler(clientSyncService, authenticationFlowContextService, loginAttemptService, domain))
+                .handler(new SSOSessionHandler(clientLookupService, authenticationFlowContextService, loginAttemptService, domain))
                 .handler(rc -> {
                     if (rc.session().isDestroyed()) {
                         rc.response().setStatusCode(401).end();
@@ -206,8 +206,8 @@ public class SSOSessionHandlerTest extends RxWebTestBase {
         client.setId("client-id");
         client.setClientId("test-client");
 
-        when(clientSyncService.findById(anyString())).thenReturn(Maybe.empty());
-        when(clientSyncService.findByClientId(client.getClientId())).thenReturn(Maybe.just(client));
+        when(clientLookupService.findById(anyString())).thenReturn(Maybe.empty());
+        when(clientLookupService.findByClientId(client.getClientId())).thenReturn(Maybe.just(client));
 
         router.route().order(-1).handler(routingContext -> {
             setUser(routingContext, new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(user));
@@ -233,8 +233,8 @@ public class SSOSessionHandlerTest extends RxWebTestBase {
         requestedClient.setClientId("requested-client");
         requestedClient.setIdentityProviders(getApplicationIdentityProviders("idp-1"));
 
-        when(clientSyncService.findById(anyString())).thenReturn(Maybe.empty());
-        when(clientSyncService.findByClientId(anyString())).thenAnswer(
+        when(clientLookupService.findById(anyString())).thenReturn(Maybe.empty());
+        when(clientLookupService.findByClientId(anyString())).thenAnswer(
                 invocation -> {
                     String argument = invocation.getArgument(0);
                     if (argument.equals("test-client")) {
@@ -276,8 +276,8 @@ public class SSOSessionHandlerTest extends RxWebTestBase {
         requestedClient.setClientId("requested-client");
         requestedClient.setIdentityProviders(getApplicationIdentityProviders("idp-2"));
 
-        when(clientSyncService.findById(anyString())).thenReturn(Maybe.empty());
-        when(clientSyncService.findByClientId(anyString())).thenAnswer(
+        when(clientLookupService.findById(anyString())).thenReturn(Maybe.empty());
+        when(clientLookupService.findByClientId(anyString())).thenAnswer(
                 invocation -> {
                     String argument = invocation.getArgument(0);
                     if (argument.equals("test-client")) {
@@ -330,8 +330,8 @@ public class SSOSessionHandlerTest extends RxWebTestBase {
         attempts.setAttempts(2);
         when(loginAttemptService.checkAccount(any(), any(), any())).thenReturn(Maybe.just(attempts));
 
-        when(clientSyncService.findById(anyString())).thenReturn(Maybe.empty());
-        when(clientSyncService.findByClientId(anyString())).thenAnswer(
+        when(clientLookupService.findById(anyString())).thenReturn(Maybe.empty());
+        when(clientLookupService.findByClientId(anyString())).thenAnswer(
                 invocation -> {
                     String argument = invocation.getArgument(0);
                     if (argument.equals("test-client")) {
@@ -394,8 +394,8 @@ public class SSOSessionHandlerTest extends RxWebTestBase {
         attempts.setAttempts(1);
         when(loginAttemptService.checkAccount(any(), any(), any())).thenReturn(Maybe.just(attempts));
 
-        when(clientSyncService.findById(anyString())).thenReturn(Maybe.empty());
-        when(clientSyncService.findByClientId(anyString())).thenAnswer(
+        when(clientLookupService.findById(anyString())).thenReturn(Maybe.empty());
+        when(clientLookupService.findByClientId(anyString())).thenAnswer(
                 invocation -> {
                     String argument = invocation.getArgument(0);
                     if (argument.equals("test-client")) {
@@ -434,8 +434,8 @@ public class SSOSessionHandlerTest extends RxWebTestBase {
         requestedClient.setClientId("requested-client");
         requestedClient.setIdentityProviders(getApplicationIdentityProviders("idp-2"));
 
-        when(clientSyncService.findById(anyString())).thenReturn(Maybe.empty());
-        when(clientSyncService.findByClientId(anyString())).thenAnswer(
+        when(clientLookupService.findById(anyString())).thenReturn(Maybe.empty());
+        when(clientLookupService.findByClientId(anyString())).thenAnswer(
                 invocation -> {
                     String argument = invocation.getArgument(0);
                     if (argument.equals("test-client")) {
@@ -457,6 +457,71 @@ public class SSOSessionHandlerTest extends RxWebTestBase {
         testRequest(
                 HttpMethod.GET,
                 "/login?client_id=requested-client",
+                HttpStatusCode.FORBIDDEN_403, "Forbidden");
+    }
+
+    @Test
+    public void shouldInvoke_cimdClient_sameIdp() throws Exception {
+        User user = new User();
+        user.setId("user-id");
+        user.setClient("template-uuid");
+        user.setSource("idp-1");
+
+        Client templateClient = new Client();
+        templateClient.setId("template-uuid");
+        templateClient.setClientId("template-client");
+
+        Client cimdClient = new Client();
+        cimdClient.setId("template-uuid");
+        cimdClient.setClientId("https://example.com/cimd-client");
+        cimdClient.setIdentityProviders(getApplicationIdentityProviders("idp-1"));
+
+        when(clientLookupService.findById("template-uuid")).thenReturn(Maybe.just(templateClient));
+        when(clientLookupService.findById("https://example.com/cimd-client")).thenReturn(Maybe.empty());
+        when(clientLookupService.findByClientId("https://example.com/cimd-client")).thenReturn(Maybe.just(cimdClient));
+
+        router.route().order(-1).handler(routingContext -> {
+            setUser(routingContext, new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(user));
+            routingContext.next();
+        });
+
+        testRequest(
+                HttpMethod.GET,
+                "/login?client_id=https://example.com/cimd-client",
+                HttpStatusCode.OK_200, "OK");
+    }
+
+    @Test
+    public void shouldNotInvoke_cimdClient_differentIdp() throws Exception {
+        // User originally logged in via a regular client (idp-1), now trying a CIMD client (idp-2).
+        // The CIMD client has a different template UUID than the user's stored client, so the
+        // "same client" short-circuit doesn't apply and the IdP check fires.
+        User user = new User();
+        user.setId("user-id");
+        user.setClient("regular-client-uuid");
+        user.setSource("idp-1");
+
+        Client regularClient = new Client();
+        regularClient.setId("regular-client-uuid");
+        regularClient.setClientId("regular-client");
+
+        Client cimdClient = new Client();
+        cimdClient.setId("template-uuid");
+        cimdClient.setClientId("https://example.com/cimd-client");
+        cimdClient.setIdentityProviders(getApplicationIdentityProviders("idp-2"));
+
+        when(clientLookupService.findById("regular-client-uuid")).thenReturn(Maybe.just(regularClient));
+        when(clientLookupService.findById("https://example.com/cimd-client")).thenReturn(Maybe.empty());
+        when(clientLookupService.findByClientId("https://example.com/cimd-client")).thenReturn(Maybe.just(cimdClient));
+
+        router.route().order(-1).handler(routingContext -> {
+            setUser(routingContext, new io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User(user));
+            routingContext.next();
+        });
+
+        testRequest(
+                HttpMethod.GET,
+                "/login?client_id=https://example.com/cimd-client",
                 HttpStatusCode.FORBIDDEN_403, "Forbidden");
     }
 


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6968](https://gravitee.atlassian.net/browse/AM-6968)

## :pencil2: A description of the changes proposed in the pull request
Support the lookup of CIMD clients during SSO validation (IDP sharing across clients and brute force checks).

## :memo: Test scenarios 

- Create two applications with different IDPs, one a regular application, the other a template assigned to domain's CIMD settings
- Log in to regular application
- In the same browser session, log in using CIMD `client_id`

Should be redirected to error page with "Forbidden: Invalid request for the current SSO context" message and status code 403.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-6968]: https://gravitee.atlassian.net/browse/AM-6968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ