### PR TITLE
test: AM-6248 coverage for private_key_jwt authentication

### DIFF
--- a/docker/local-stack/dev/docker-compose.yml
+++ b/docker/local-stack/dev/docker-compose.yml
@@ -111,6 +111,7 @@ services:
     volumes:
       - ./wiremock/request-sfr.json:/tmp/request-sfr.json
       - ./wiremock/request-cimd.json:/tmp/request-cimd.json
+      - ./wiremock/request-jwks.json:/tmp/request-jwks.json
     command:
       - sh
       - -ec
@@ -120,6 +121,9 @@ services:
           -H "Content-Type: application/json"
         curl -fsS -X POST http://wiremock:8080/__admin/mappings/import \
           -d @/tmp/request-cimd.json \
+          -H "Content-Type: application/json"
+        curl -fsS -X POST http://wiremock:8080/__admin/mappings/import \
+          -d @/tmp/request-jwks.json \
           -H "Content-Type: application/json"
 
   ciba:

--- a/docker/local-stack/dev/wiremock/request-cimd.json
+++ b/docker/local-stack/dev/wiremock/request-cimd.json
@@ -267,6 +267,37 @@
     {
       "request": {
         "method": "GET",
+        "urlPath": "/cimd/ENABLED_BASE/private-key-jwt-with-jwks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "client_id": "http://wiremock:8080/cimd/ENABLED_BASE/private-key-jwt-with-jwks",
+          "client_name": "CIMD PKJWT With JWKS",
+          "redirect_uris": [
+            "https://client.example.com/callback"
+          ],
+          "token_endpoint_auth_method": "private_key_jwt",
+          "jwks": {
+            "keys": [
+              {
+                "kty": "RSA",
+                "e": "AQAB",
+                "use": "sig",
+                "kid": "123",
+                "n": "uo-DsCNGkKqJ9jDgzmS3-GCFvezuvb0b0Qux58Y_DzbIPM_6xg9J9J1weCSiWg4GxXcBtbrd6bsc1dyj9yKRpJ3I_t68BCeGvhaQ-LYcfyQ36ckw-ibG3wYHECFoOd5sxSvDnswCy1er5vgMCOf-wzHjfZJAkQudq7gl0-45D_T_syRqbTOZ_GZiNF1mJD0493VGvkLFwsKrLbPUpZeOev74X2rMS8RnLsvglzoS3ycvFKwKk9EcK6wxV6a59h-vCUQy28BJIJYd9W5SNT6M655ZikpacbIsIcaTO0L3FO4UxWGaL7Z6Y5EboO7B8Ev4amrCGzY7WH3Jyc0vY9rEHQ"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
         "urlPath": "/cimd/ENABLED_BASE/invalid-json"
       },
       "response": {

--- a/docker/local-stack/dev/wiremock/request-jwks.json
+++ b/docker/local-stack/dev/wiremock/request-jwks.json
@@ -1,0 +1,31 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/jwks/pkjwt-test-key"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "keys": [
+            {
+              "kty": "RSA",
+              "e": "AQAB",
+              "use": "sig",
+              "kid": "123",
+              "n": "uo-DsCNGkKqJ9jDgzmS3-GCFvezuvb0b0Qux58Y_DzbIPM_6xg9J9J1weCSiWg4GxXcBtbrd6bsc1dyj9yKRpJ3I_t68BCeGvhaQ-LYcfyQ36ckw-ibG3wYHECFoOd5sxSvDnswCy1er5vgMCOf-wzHjfZJAkQudq7gl0-45D_T_syRqbTOZ_GZiNF1mJD0493VGvkLFwsKrLbPUpZeOev74X2rMS8RnLsvglzoS3ycvFKwKk9EcK6wxV6a59h-vCUQy28BJIJYd9W5SNT6M655ZikpacbIsIcaTO0L3FO4UxWGaL7Z6Y5EboO7B8Ev4amrCGzY7WH3Jyc0vY9rEHQ"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "importOptions": {
+    "duplicatePolicy": "OVERWRITE",
+    "deleteAllNotInImport": false
+  }
+}

--- a/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
@@ -137,6 +137,11 @@ describe('CIMD authorize - ENABLED_BASE', () => {
     fixture.expectInvalidClientMetadata(response, 'private_key_jwt requires jwks or jwks_uri');
   });
 
+  it('should continue authorization when private_key_jwt metadata includes jwks', async () => {
+    const response = await fixture.authorize(fixture.buildClientId('private-key-jwt-with-jwks'));
+    fixture.expectLoginRedirect(response);
+  });
+
   it('should enforce exact redirect_uri matching for CIMD clients', async () => {
     const response = await fixture.authorize(
       fixture.buildClientId('valid-none'),

--- a/gravitee-am-test/specs/gateway/token-auth-methods/fixtures/private-key-jwt-fixture.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/fixtures/private-key-jwt-fixture.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import {
+  DomainOidcConfig,
+  patchDomain,
+  safeDeleteDomain,
+  setupDomainForTest,
+  waitForOidcReady,
+} from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createApplication, updateApplication } from '@management-commands/application-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+export interface PrivateKeyJwtFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  app: Application;
+  clientId: string;
+}
+
+export const setupPrivateKeyJwtFixture = async (): Promise<PrivateKeyJwtFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  let domain: Domain | null = null;
+  try {
+    const { domain: createdDomain, oidcConfig } = await setupDomainForTest(uniqueName('pkjwt', true), {
+      accessToken,
+      waitForStart: true,
+    });
+    domain = createdDomain;
+
+    await waitForSyncAfter(domain.id, () =>
+      patchDomain(domain.id, accessToken, {
+        oidc: {
+          clientRegistrationSettings: {
+            allowLocalhostRedirectUri: true,
+            allowHttpSchemeRedirectUri: true,
+          },
+        },
+      }),
+    );
+    await waitForOidcReady(domain.hrid);
+
+    const app = await createApplication(domain.id, accessToken, {
+      name: uniqueName('pkjwt-app', true),
+      type: 'SERVICE',
+      redirectUris: ['http://localhost:4000/'],
+    });
+
+    const updatedApp = await waitForSyncAfter(domain.id, () =>
+      updateApplication(
+        domain.id,
+        accessToken,
+        {
+          settings: {
+            oauth: {
+              redirectUris: ['http://localhost:4000/'],
+              grantTypes: ['client_credentials'],
+              tokenEndpointAuthMethod: 'private_key_jwt',
+              tokenEndpointAuthSigningAlg: 'RS256',
+              jwksUri: 'http://wiremock:8080/jwks/pkjwt-test-key',
+            },
+          },
+        },
+        app.id,
+      ),
+    );
+
+    return {
+      accessToken,
+      domain,
+      oidc: oidcConfig,
+      app: updatedApp,
+      clientId: updatedApp.settings.oauth.clientId,
+      cleanUp: async () => {
+        await safeDeleteDomain(domain.id, accessToken);
+      },
+    };
+  } catch (error) {
+    if (domain?.id && accessToken) {
+      try {
+        await safeDeleteDomain(domain.id, accessToken);
+      } catch (e) {
+        console.error('Cleanup failed after setup error:', e);
+      }
+    }
+    throw error;
+  }
+};

--- a/gravitee-am-test/specs/gateway/token-auth-methods/private-key-jwt-auth.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/private-key-jwt-auth.jest.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import * as jose from 'jose';
+import crypto from 'crypto';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { setup } from '../../test-fixture';
+import { PrivateKeyJwtFixture, setupPrivateKeyJwtFixture } from './fixtures/private-key-jwt-fixture';
+import { privateJwk } from '@api-fixtures/oidc';
+
+setup(200000);
+
+const JWT_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
+async function createPrivateKeyJwtAssertion(clientId: string, audience: string, privateKeyJwk: jose.JWK): Promise<string> {
+  const privateKey = await jose.importJWK(privateKeyJwk, 'RS256');
+  const now = Math.floor(Date.now() / 1000);
+  return new jose.SignJWT({})
+    .setProtectedHeader({ alg: 'RS256', kid: '123' })
+    .setIssuer(clientId)
+    .setSubject(clientId)
+    .setAudience(audience)
+    .setJti(crypto.randomUUID())
+    .setIssuedAt(now)
+    .setExpirationTime(now + 300)
+    .sign(privateKey);
+}
+
+describe('private_key_jwt', () => {
+  let fixture: PrivateKeyJwtFixture;
+
+  beforeAll(async () => {
+    fixture = await setupPrivateKeyJwtFixture();
+  });
+
+  afterAll(async () => {
+    if (fixture) {
+      await fixture.cleanUp();
+    }
+  });
+
+  it('should obtain token using private_key_jwt', async () => {
+    const assertion = await createPrivateKeyJwtAssertion(fixture.clientId, fixture.oidc.token_endpoint, privateJwk as jose.JWK);
+
+    const response = await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      `grant_type=client_credentials&client_assertion_type=${encodeURIComponent(CLIENT_ASSERTION_TYPE)}&client_assertion=${encodeURIComponent(assertion)}`,
+      { 'Content-type': 'application/x-www-form-urlencoded' },
+    ).expect(200);
+
+    expect(response.body.access_token).toMatch(JWT_FORMAT);
+    expect(response.body.token_type).toEqual('bearer');
+  });
+
+  it('should reject token request when JWT is signed with an unregistered key', async () => {
+    const { privateKey: unregisteredKey } = await jose.generateKeyPair('RS256');
+    const now = Math.floor(Date.now() / 1000);
+    const assertion = await new jose.SignJWT({})
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(fixture.clientId)
+      .setSubject(fixture.clientId)
+      .setAudience(fixture.oidc.token_endpoint)
+      .setJti(crypto.randomUUID())
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(unregisteredKey);
+
+    await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      `grant_type=client_credentials&client_assertion_type=${encodeURIComponent(CLIENT_ASSERTION_TYPE)}&client_assertion=${encodeURIComponent(assertion)}`,
+      { 'Content-type': 'application/x-www-form-urlencoded' },
+    ).expect(401);
+  });
+
+  it('should reject token request when JWT assertion has expired', async () => {
+    const privateKey = await jose.importJWK(privateJwk as jose.JWK, 'RS256');
+    const past = Math.floor(Date.now() / 1000) - 600;
+    const assertion = await new jose.SignJWT({})
+      .setProtectedHeader({ alg: 'RS256', kid: '123' })
+      .setIssuer(fixture.clientId)
+      .setSubject(fixture.clientId)
+      .setAudience(fixture.oidc.token_endpoint)
+      .setJti(crypto.randomUUID())
+      .setIssuedAt(past)
+      .setExpirationTime(past + 300)
+      .sign(privateKey);
+
+    await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      `grant_type=client_credentials&client_assertion_type=${encodeURIComponent(CLIENT_ASSERTION_TYPE)}&client_assertion=${encodeURIComponent(assertion)}`,
+      { 'Content-type': 'application/x-www-form-urlencoded' },
+    ).expect(401);
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6248](https://gravitee.atlassian.net/browse/AM-6248)

## :pencil2: A description of the changes proposed in the pull request
Add test coverage for `private_key_jwt` OAuth 2.0 / OIDC authentication.

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-6248]: https://gravitee.atlassian.net/browse/AM-6248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ