### PR TITLE
chore: align OpenAPI spec version pre and post release

### DIFF
--- a/.circleci/scripts/oas-staleness-check.sh
+++ b/.circleci/scripts/oas-staleness-check.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 #
 # Options forwarded to scripts/regen-oas.sh:
 #   --also-make   Build upstream Maven modules before generating.
+#   --maven-settings <path>
+#                 Pass-through -s for CI (Artifactory).
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -29,6 +31,11 @@ REGEN_ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --also-make) REGEN_ARGS+=(--also-make); shift ;;
+    --maven-settings)
+      SETTINGS_PATH="${2:?--maven-settings requires a path}"
+      REGEN_ARGS+=(--maven-settings "$SETTINGS_PATH")
+      shift 2
+      ;;
     *) echo "Error: unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1050,9 +1050,6 @@ jobs:
           var-name: GITHUB_TOKEN
       - restore-maven-job-cache:
           jobName: pull_requests
-      - run:
-          name: Copy Maven settings
-          command: mkdir -p ~/.m2 && cp /tmp/.gravitee.settings.xml ~/.m2/settings.xml
       - restore_cache:
           keys:
             - v1-oasdiff-{{ checksum ".oasdiff-version" }}
@@ -1072,7 +1069,7 @@ jobs:
             - /usr/local/bin/oasdiff
       - run:
           name: Check OAS staleness
-          command: bash .circleci/scripts/oas-staleness-check.sh --also-make
+          command: bash .circleci/scripts/oas-staleness-check.sh --also-make --maven-settings /tmp/.gravitee.settings.xml
       - run:
           name: Check OAS breaking changes
           command: bash .circleci/scripts/oas-compat-check.sh
@@ -1303,6 +1300,7 @@ jobs:
 
             export CURRENT_GIT_BRANCH=$(git status | grep 'On branch' | awk '{print $3}')
 
+            bash scripts/regen-oas.sh --maven-settings /tmp/.gravitee.settings.xml
             git add --update
             git commit -m "${MVN_PRJ_VERSION}"
             git tag ${MVN_PRJ_VERSION}
@@ -1326,6 +1324,7 @@ jobs:
               echo "# ---- git Maintenance branch [${MAINTENANCE_GIT_BRANCH}] does not exist, creating it"
               git checkout -b ${MAINTENANCE_GIT_BRANCH}
               mvn -s /tmp/.gravitee.settings.xml -B versions:set -DnewVersion=${NEXT_PATCH_SNAPSHOT_VERSION} -DgenerateBackupPoms=false
+              bash scripts/regen-oas.sh --version-only --maven-settings /tmp/.gravitee.settings.xml
               git add --update
               git commit -m 'chore: prepare next version'
 
@@ -1384,6 +1383,7 @@ jobs:
               fi;
             fi;
             
+            bash scripts/regen-oas.sh --version-only --maven-settings /tmp/.gravitee.settings.xml
             git add --update
             git commit -m 'chore: prepare next version [skip ci]'
 

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -17,7 +17,7 @@
 openapi: 3.0.1
 info:
   title: Gravitee.io - Access Management API
-  version: 4.12.0-alpha.3-SNAPSHOT
+  version: 4.12.0-alpha.3
 servers:
 - url: /management
 security:

--- a/scripts/regen-oas.sh
+++ b/scripts/regen-oas.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # output. The license header and info.version are patched post-generation.
 #
 # Usage:
-#   bash scripts/regen-oas.sh [--output-dir <dir>] [--also-make]
+#   bash scripts/regen-oas.sh [options]
 #
 #   --output-dir <dir>   Directory to write openapi.yaml into.
 #                        Default: docs/mapi/ (overwrites the committed spec).
@@ -19,12 +19,20 @@ set -euo pipefail
 #   --also-make          Pass -am to Maven so upstream modules are built first.
 #                        Use this if the module is not already compiled locally.
 #
-# The script patches two things the plugin cannot produce correctly at build
-# time:
+#   --maven-settings <file>
+#                        Pass -s <file> to every Maven invocation (CI Artifactory).
+#
+#   --version-only       Skip generation: read project.version from Maven, strip
+#                        a trailing -SNAPSHOT for public info.version, and patch
+#                        only the info.version line in <output-dir>/openapi.yaml.
+#                        Cannot be combined with --also-make.
+#
+# The script patches two things the full-regeneration path cannot leave to the plugin:
 #
 #   info.version  The plugin invokes GraviteeApiDefinition.afterScan() which
 #                 reads Version.RUNTIME_VERSION (gravitee-common version, not
 #                 the project version). Patched from pom.xml post-generation.
+#                 Trimmed trailing -SNAPSHOT for the committed spec line.
 #
 #   License header  Extracted from the committed docs/mapi/openapi.yaml and
 #                   prepended to the generated file. The committed header is
@@ -35,113 +43,170 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
-SPEC="$REPO_ROOT/docs/mapi/openapi.yaml"
 MODULE="gravitee-am-management-api/gravitee-am-management-api-rest"
+DEFAULT_OUTPUT_DIR="$REPO_ROOT/docs/mapi"
+COMMITTED_SPEC="$REPO_ROOT/docs/mapi/openapi.yaml"
 
-OUTPUT_DIR="$REPO_ROOT/docs/mapi"
+OUTPUT_DIR=""
 ALSO_MAKE=""
+MAVEN_SETTINGS_FILE=""
+VERSION_ONLY=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --output-dir) OUTPUT_DIR="${2:?--output-dir requires a path}"; shift 2 ;;
     --also-make)  ALSO_MAKE="-am"; shift ;;
+    --maven-settings) MAVEN_SETTINGS_FILE="${2:?--maven-settings requires a path}"; shift 2 ;;
+    --version-only) VERSION_ONLY=true; shift ;;
     *) echo "Error: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
 
-mkdir -p "$OUTPUT_DIR"
-OUTPUT_FILE="$OUTPUT_DIR/openapi.yaml"
+[[ -z "$OUTPUT_DIR" ]] && OUTPUT_DIR="$DEFAULT_OUTPUT_DIR"
+OUTPUT_FILE="${OUTPUT_DIR}/openapi.yaml"
 
-echo "=== Regenerating OpenAPI spec ==="
+MAVEN_ARGS=(-B -ntp)
+if [[ -n "$MAVEN_SETTINGS_FILE" ]]; then
+  MAVEN_ARGS+=(-s "$MAVEN_SETTINGS_FILE")
+fi
+
+patch_info_version() {
+  local target_file="$1"
+  local oas_version="$2"
+  local tmp
+  tmp="$(mktemp)"
+  awk -v ver="$oas_version" '
+    /^info:/                         { in_info=1 }
+    in_info && /^[^ ]/ && !/^info:/ { in_info=0 }
+    in_info && /^  version: /        { print "  version: " ver; next }
+                                     { print }
+  ' "$target_file" > "$tmp"
+  mv "$tmp" "$target_file"
+}
+
+resolve_project_version() {
+  mvn "${MAVEN_ARGS[@]}" -pl "$MODULE" help:evaluate \
+    -Dexpression=project.version -q -DforceStdout | tail -1
+}
+
+if [[ "$VERSION_ONLY" == true ]]; then
+  echo "=== Patching OpenAPI info.version only ==="
+else
+  echo "=== Regenerating OpenAPI spec ==="
+fi
 echo "Output: $OUTPUT_FILE"
 echo ""
 
+# ---------------------------------------------------------------------------
+# Step 1: Validate
+# ---------------------------------------------------------------------------
+
+if [[ -n "$MAVEN_SETTINGS_FILE" && ! -f "$MAVEN_SETTINGS_FILE" ]]; then
+  echo "Error: maven settings file not found: ${MAVEN_SETTINGS_FILE}" >&2
+  exit 1
+fi
+
+if [[ "$VERSION_ONLY" == true && -n "$ALSO_MAKE" ]]; then
+  echo "Error: --version-only cannot be combined with --also-make" >&2
+  exit 2
+fi
+
+if [[ "$VERSION_ONLY" == true && ! -f "$OUTPUT_FILE" ]]; then
+  echo "Error: spec not found: ${OUTPUT_FILE}" >&2
+  exit 1
+fi
+
+[[ "$VERSION_ONLY" == false ]] && mkdir -p "$OUTPUT_DIR"
 cd "$REPO_ROOT"
 
 # ---------------------------------------------------------------------------
-# Step 1: Capture license header from the committed spec
+# Step 2 [full regen]: Capture license header from the committed spec
 # ---------------------------------------------------------------------------
 
-COMMITTED_SPEC="$REPO_ROOT/docs/mapi/openapi.yaml"
-HEADER_LINE_COUNT=0
-if [[ -f "$COMMITTED_SPEC" ]]; then
-  HEADER_LINE_COUNT=$(awk '/^openapi:/{print NR-1; exit}' "$COMMITTED_SPEC")
-  # Capture the header lines into a variable so the source file can be safely overwritten
-  HEADER_CONTENT=$(head -n "$HEADER_LINE_COUNT" "$COMMITTED_SPEC")
+if [[ "$VERSION_ONLY" == false ]]; then
+  HEADER_LINE_COUNT=0
+  if [[ -f "$COMMITTED_SPEC" ]]; then
+    HEADER_LINE_COUNT=$(awk '/^openapi:/{print NR-1; found=1; exit} END {if (!found) print 0}' "$COMMITTED_SPEC")
+    HEADER_CONTENT=$(head -n "$HEADER_LINE_COUNT" "$COMMITTED_SPEC")
+  fi
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2: Extract project version
+# Step 3: Extract project version
 # ---------------------------------------------------------------------------
 
-PROJECT_VERSION=$(mvn -B -ntp -pl "$MODULE" help:evaluate \
-  -Dexpression=project.version -q -DforceStdout 2>/dev/null | tail -1)
+PROJECT_VERSION="$(resolve_project_version)"
 
-if [[ -z "$PROJECT_VERSION" ]]; then
-  echo "Error: could not extract project version from pom.xml — Maven produced no output." >&2
+if [[ -z "$PROJECT_VERSION" ]] || [[ "$PROJECT_VERSION" == *"[ERROR]"* ]]; then
+  echo "Error: could not extract project.version from Maven (see Maven output)." >&2
   exit 1
 fi
 
+OAS_INFO_VERSION="${PROJECT_VERSION%-SNAPSHOT}"
 echo "Project version: ${PROJECT_VERSION}"
+echo "Public info.version: ${OAS_INFO_VERSION}"
 
 # ---------------------------------------------------------------------------
-# Step 3: Run the swagger-maven-plugin (generate-oas profile)
+# Step 4 [full regen]: Run the swagger-maven-plugin (generate-oas profile)
 # ---------------------------------------------------------------------------
 
-echo "Running swagger-maven-plugin-jakarta..."
-mvn -B -ntp \
-    -pl "$MODULE" \
-    process-classes \
-    -Pgenerate-oas \
-    -Doas.outputPath="$OUTPUT_DIR" \
-    -DskipTests \
-    $ALSO_MAKE
+if [[ "$VERSION_ONLY" == false ]]; then
+  echo "Running swagger-maven-plugin-jakarta..."
+  mvn "${MAVEN_ARGS[@]}" \
+      -pl "$MODULE" \
+      process-classes \
+      -Pgenerate-oas \
+      -Doas.outputPath="$OUTPUT_DIR" \
+      -DskipTests \
+      $ALSO_MAKE
 
-if [[ ! -f "$OUTPUT_FILE" ]]; then
-  echo "Error: expected ${OUTPUT_FILE} to be written by the plugin but it was not found." >&2
-  exit 1
+  if [[ ! -f "$OUTPUT_FILE" ]]; then
+    echo "Error: expected ${OUTPUT_FILE} to be written by the plugin but it was not found." >&2
+    exit 1
+  fi
 fi
 
 # ---------------------------------------------------------------------------
-# Step 4: Patch info.version
+# Step 5: Patch info.version
 #
-# The plugin invokes GraviteeApiDefinition.afterScan() which sets info.version
-# from Version.RUNTIME_VERSION.MAJOR_VERSION (gravitee-common library version).
-# Replace it with the actual project version extracted from pom.xml.
+# Replaces the runtime-library version written by the plugin with the Maven
+# project version, trimmed of a trailing -SNAPSHOT.
 # ---------------------------------------------------------------------------
 
-echo "Patching info.version → ${PROJECT_VERSION}"
-TMPFILE="$(mktemp)"
-sed "s/^  version: .*$/  version: ${PROJECT_VERSION}/" "$OUTPUT_FILE" > "$TMPFILE"
+echo "Patching info.version → ${OAS_INFO_VERSION}"
+patch_info_version "$OUTPUT_FILE" "$OAS_INFO_VERSION"
 
 # ---------------------------------------------------------------------------
-# Step 5: Prepend license header
+# Step 6 [full regen]: Prepend license header
 # ---------------------------------------------------------------------------
 
-{
-  [[ "$HEADER_LINE_COUNT" -gt 0 ]] && printf '%s\n\n' "$HEADER_CONTENT"
-  cat "$TMPFILE"
-} > "$OUTPUT_FILE"
-rm "$TMPFILE"
+if [[ "$VERSION_ONLY" == false ]]; then
+  TMPFILE="$(mktemp)"
+  {
+    [[ "$HEADER_LINE_COUNT" -gt 0 ]] && printf '%s\n\n' "$HEADER_CONTENT"
+    cat "$OUTPUT_FILE"
+  } > "$TMPFILE"
+  mv "$TMPFILE" "$OUTPUT_FILE"
 
-if [[ "$HEADER_LINE_COUNT" -eq 0 ]]; then
-  echo "Warning: could not extract license header from committed spec — header not prepended." >&2
-  echo "         Run 'mvn license:format -pl gravitee-am-management-api/gravitee-am-management-api-rest' to add it." >&2
+  if [[ "$HEADER_LINE_COUNT" -eq 0 ]]; then
+    echo "Warning: could not extract license header from committed spec — header not prepended." >&2
+    echo "         Run 'mvn license:format -pl gravitee-am-management-api/gravitee-am-management-api-rest' to add it." >&2
+  fi
 fi
 
 # ---------------------------------------------------------------------------
-# Step 6: Report
+# Step 7: Report
 # ---------------------------------------------------------------------------
 
 echo ""
 echo "✅  ${OUTPUT_FILE} written."
 echo ""
 
-if [[ "$OUTPUT_FILE" == "$SPEC" ]]; then
-  if git diff --quiet HEAD -- "$SPEC" 2>/dev/null; then
+if [[ "$VERSION_ONLY" == false && "$OUTPUT_FILE" == "$COMMITTED_SPEC" ]]; then
+  if git diff --quiet HEAD -- "$COMMITTED_SPEC" 2>/dev/null; then
     echo "No changes vs HEAD — spec was already up to date."
   else
     echo "Changes vs HEAD:"
-    git --no-pager diff --stat HEAD -- "$SPEC"
+    git --no-pager diff --stat HEAD -- "$COMMITTED_SPEC"
   fi
 fi


### PR DESCRIPTION
## :id: Reference related issue. 
n/a

## :pencil2: A description of the changes proposed in the pull request
Ensure `docs/mapi/openapi.yaml` is up-to-date and its `info.version` aligns with the AM version defined in maven in two points in the release workflow:
- At the releasable commit/tag
- Post-release, when the release branch is prepared for the next iteration

This resolves OAS staleness check failures that occur in automatic mergify branches where manual regeneration of the spec is not possible. For the general case, branches with release branch (maintenance) bases should benefit from synchronised versions and not require routine spec regeneration.

OpenAPI spec generation improvements:
- The spec version is trimmed of trailing `-SNAPSHOT` so we publish more meaningful values
- Resolving and patching versions is made more robust
- Maven settings can be passed when generating with swagger so we can avoid copying to `~/.m2`
- A new `--version-only` option is added to optimise usage post-release

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am