### PR TITLE
test: AM-6249 add coverage for mutual-TLS authentication

### DIFF
--- a/gravitee-am-test/api/config/dev.setup.js
+++ b/gravitee-am-test/api/config/dev.setup.js
@@ -35,5 +35,6 @@ process.env.INTERNAL_FAKE_SMTP_PORT = '5025';
 process.env.SFR_URL = 'http://localhost:8181';
 process.env.INTERNAL_SFR_URL = 'http://wiremock:8080';
 process.env.AM_GATEWAY_SYNC_GRACE_PERIOD = '5000';
+process.env.MTLS_URL = 'https://localhost:1443/am';
 process.env.KAFKA_BOOTSTRAP_URL = 'localhost:9092';
 process.env.TCP_REPORTER_HOST = 'localhost';

--- a/gravitee-am-test/api/utils/certificate-utils.ts
+++ b/gravitee-am-test/api/utils/certificate-utils.ts
@@ -15,6 +15,36 @@
  */
 
 import * as forge from 'node-forge';
+import { createHash, randomBytes } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+/** Forge attribute shape accepted by cert.setSubject / setIssuer. */
+type CertAttr = { name?: string; shortName?: string; value: string };
+
+/**
+ * Core self-signed cert builder. Handles all the repetitive forge steps so
+ * the public generators only need to prepare their inputs.
+ */
+function buildSelfSignedPem(
+  attrs: CertAttr[],
+  serialNumber: string,
+  notBefore: Date,
+  notAfter: Date,
+  extensions: object[] = [],
+): string {
+  const keypair = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keypair.publicKey;
+  cert.serialNumber = serialNumber;
+  cert.validity.notBefore = notBefore;
+  cert.validity.notAfter = notAfter;
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs); // self-signed
+  if (extensions.length) cert.setExtensions(extensions);
+  cert.sign(keypair.privateKey, forge.md.sha256.create());
+  return forge.pki.certificateToPem(cert);
+}
 
 /**
  * Generate a self-signed X.509 certificate in PEM format.
@@ -36,74 +66,45 @@ export function generateCertificatePEM(
 ): string {
   const { subjectDN = 'CN=Test Certificate, O=Test Org, C=US', validDays = 365, expired = false, serialNumber } = options;
 
-  // Generate a key pair
-  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const serial = serialNumber || Date.now().toString();
 
-  // Create certificate
-  const cert = forge.pki.createCertificate();
-  cert.publicKey = keys.publicKey;
-  // Serial number must be a hex string (without 0x prefix) or decimal string
-  // Use timestamp as decimal string for better compatibility
-  cert.serialNumber = serialNumber || Date.now().toString();
-
-  // Set certificate validity
   const now = new Date();
   const notBefore = new Date(now);
-  notBefore.setDate(notBefore.getDate() - 1); // Start 1 day ago to avoid timing issues
+  notBefore.setDate(notBefore.getDate() - 1); // 1 day ago to avoid clock-skew issues
 
   const notAfter = new Date(now);
   if (expired) {
-    // Set expiration to 1 year ago
     notAfter.setFullYear(notAfter.getFullYear() - 1);
   } else {
-    // Set expiration to validDays from now
     notAfter.setDate(notAfter.getDate() + validDays);
   }
 
-  cert.validity.notBefore = notBefore;
-  cert.validity.notAfter = notAfter;
+  const attrMap: Record<string, string> = {
+    CN: 'commonName',
+    C: 'countryName',
+    O: 'organizationName',
+    OU: 'organizationalUnitName',
+    L: 'localityName',
+    ST: 'stateOrProvinceName',
+    E: 'emailAddress',
+  };
 
-  // Parse subjectDN or use default attributes
-  let subjectAttrs;
-
-  if (subjectDN && subjectDN.includes('=')) {
-    // Parse DN string format: "CN=Name, O=Org, C=US"
-    const parts = subjectDN.split(',').map((p) => p.trim());
-    const attrMap: { [key: string]: string } = {
-      CN: 'commonName',
-      C: 'countryName',
-      O: 'organizationName',
-      OU: 'organizationalUnitName',
-      L: 'localityName',
-      ST: 'stateOrProvinceName',
-      E: 'emailAddress',
-    };
-
-    subjectAttrs = parts.map((part) => {
-      const [key, ...valueParts] = part.split('=');
-      const keyTrimmed = key.trim().toUpperCase();
-      const value = valueParts.join('=').trim();
-      const forgeKey = attrMap[keyTrimmed] || key.trim();
-      return { name: forgeKey, value };
+  let attrs: CertAttr[];
+  if (subjectDN.includes('=')) {
+    attrs = subjectDN.split(',').map((part) => {
+      const [key, ...rest] = part.trim().split('=');
+      return { name: attrMap[key.trim().toUpperCase()] ?? key.trim(), value: rest.join('=').trim() };
     });
   } else {
-    // Use default attributes
-    subjectAttrs = [
+    attrs = [
       { name: 'countryName', value: 'US' },
       { name: 'organizationName', value: 'Test Org' },
-      { name: 'commonName', value: `Test Certificate ${cert.serialNumber}` },
+      { name: 'commonName', value: `Test Certificate ${serial}` },
     ];
   }
 
-  cert.setSubject(subjectAttrs);
-  cert.setIssuer(subjectAttrs); // Self-signed, so issuer = subject
-
-  // Set extensions
-  cert.setExtensions([
-    {
-      name: 'basicConstraints',
-      cA: true,
-    },
+  const extensions = [
+    { name: 'basicConstraints', cA: true },
     {
       name: 'keyUsage',
       keyCertSign: true,
@@ -112,16 +113,10 @@ export function generateCertificatePEM(
       keyEncipherment: true,
       dataEncipherment: true,
     },
-  ]);
+  ];
 
-  // Sign certificate with private key
-  cert.sign(keys.privateKey, forge.md.sha256.create());
+  const pem = buildSelfSignedPem(attrs, serial, notBefore, notAfter, extensions);
 
-  // Convert to PEM format
-  const pem = forge.pki.certificateToPem(cert);
-
-  // Ensure proper PEM format (should already be correct, but verify)
-  // PEM should start with -----BEGIN CERTIFICATE----- and end with -----END CERTIFICATE-----
   if (!pem.includes('-----BEGIN CERTIFICATE-----') || !pem.includes('-----END CERTIFICATE-----')) {
     throw new Error('Generated certificate is not in valid PEM format');
   }
@@ -137,7 +132,6 @@ export function generateCertificatePEM(
  * @returns PEM-encoded certificate string
  */
 export function generateUniqueCertificatePEM(index?: number): string {
-  // Use a numeric serial number for better compatibility
   const serialNumber = index !== undefined ? `${Date.now()}${index}` : Date.now().toString();
   return generateCertificatePEM({
     subjectDN: `CN=Test Certificate ${serialNumber}, O=Test Org, C=US`,
@@ -155,4 +149,40 @@ export function generateExpiredCertificatePEM(): string {
     expired: true,
     subjectDN: 'CN=Expired Test Certificate, O=Test Org, C=US',
   });
+}
+
+/** Cert produced by generateSelfSignedCert — PEM, its Subject DN string, and pre-computed SHA-256 thumbprint. */
+export type SelfSignedCert = {
+  pem: string;
+  subjectDn: string;
+  thumbprintS256: string;
+};
+
+/**
+ * Generate an ephemeral RSA 2048 self-signed certificate suitable for mTLS client-auth tests.
+ * Uses a random serial and a single CN RDN to avoid DN ordering ambiguity with BouncyCastle.
+ */
+export function generateSelfSignedCert(cn: string): SelfSignedCert {
+  const pem = buildSelfSignedPem(
+    [{ shortName: 'CN', value: cn }],
+    randomBytes(16).toString('hex'),
+    new Date(),
+    new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+  );
+  return { pem, subjectDn: `CN=${cn}`, thumbprintS256: certThumbprintS256(pem) };
+}
+
+/**
+ * Compute the SHA-256 thumbprint (x5t#S256) of a PEM-encoded certificate.
+ * Returns a Base64URL-encoded string, matching RFC 7517 §4.9.
+ */
+export function certThumbprintS256(pem: string): string {
+  const cert = forge.pki.certificateFromPem(pem);
+  const der = forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes();
+  return createHash('sha256').update(Buffer.from(der, 'binary')).digest('base64url');
+}
+
+/** Read a PEM cert or key from a path relative to process.cwd() (e.g. `/certs/client-a/client.crt`). */
+export function readCert(relPath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relPath), 'utf8');
 }

--- a/gravitee-am-test/specs/gateway/token-auth-methods/fixtures/mtls-auth-fixture.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/fixtures/mtls-auth-fixture.ts
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as forge from 'node-forge';
-import { createHash, randomBytes } from 'crypto';
-import fs from 'fs';
-import path from 'path';
+import { generateSelfSignedCert } from '@utils/certificate-utils';
 import { Agent } from 'https';
 import fetch from 'cross-fetch';
 import { Domain } from '@management-models/Domain';
@@ -33,6 +30,17 @@ import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
 import { uniqueName } from '@utils-commands/misc';
 import { Fixture } from '../../../test-fixture';
 
+/** POST to a token endpoint through nginx mTLS, presenting a client certificate. */
+export async function postWithClientCert(url: string, body: string, cert: string, key: string): Promise<Response> {
+  const agent = new Agent({ rejectUnauthorized: false, cert, key });
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+    agent,
+  } as any) as Promise<Response>;
+}
+
 export interface MtlsAuthFixture extends Fixture {
   domain: Domain;
   oidc: DomainOidcConfig;
@@ -43,70 +51,6 @@ export interface MtlsAuthFixture extends Fixture {
   /** clientId of the tls_client_auth app configured for CN=a (used in nginx edge-stack tests) */
   edgeTlsClientId: string;
 }
-
-/**
- * Encodes a PEM certificate for the X-Client-Cert header.
- *
- * CertificateUtils.extractPeerCertificate() pre-processes the header value by
- * replacing literal +, / and = characters, then calls URLDecoder.decode().
- * encodeURIComponent produces a fully percent-encoded string (no literal +/=/),
- * so the pre-processing step is a no-op and decode() recovers the original PEM.
- */
-export function encodeCertForHeader(pem: string): string {
-  return encodeURIComponent(pem);
-}
-
-/** PEM text for paths under `cwd`, e.g. `/certs/client-a/client.crt`. */
-export function readCert(relPath: string): string {
-  return fs.readFileSync(path.join(process.cwd(), relPath), 'utf8');
-}
-
-/** POST with mutual TLS (used for `gateway-mtls` nginx edge tests). */
-export async function postWithClientCert(
-  url: string,
-  body: string,
-  cert: string,
-  key: string,
-): Promise<Response> {
-  const agent = new Agent({ rejectUnauthorized: false, cert, key });
-  return fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-    agent,
-  } as any) as Promise<Response>;
-}
-
-interface GeneratedCert {
-  pem: string;
-  subjectDn: string;
-  forgeCert: forge.pki.Certificate;
-}
-
-function generateSelfSignedCert(cn: string): GeneratedCert {
-  const keypair = forge.pki.rsa.generateKeyPair(2048);
-  const cert = forge.pki.createCertificate();
-  cert.publicKey = keypair.publicKey;
-  cert.serialNumber = randomBytes(16).toString('hex');
-  cert.validity.notBefore = new Date();
-  cert.validity.notAfter = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
-  const attrs = [{ shortName: 'CN', value: cn }];
-  cert.setSubject(attrs);
-  cert.setIssuer(attrs);
-  cert.sign(keypair.privateKey, forge.md.sha256.create());
-  return {
-    pem: forge.pki.certificateToPem(cert),
-    // Single-RDN subject avoids DN ordering ambiguity with BouncyCastle's areEqual()
-    subjectDn: `CN=${cn}`,
-    forgeCert: cert,
-  };
-}
-
-function certThumbprintS256(cert: forge.pki.Certificate): string {
-  const der = forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes();
-  return createHash('sha256').update(Buffer.from(der, 'binary')).digest('base64url');
-}
-
 
 export const setupMtlsAuthFixture = async (): Promise<MtlsAuthFixture> => {
   const accessToken = await requestAdminAccessToken();
@@ -188,7 +132,6 @@ export const setupMtlsAuthFixture = async (): Promise<MtlsAuthFixture> => {
     // Inline jwks is used because the jwksUri path goes through JWKConverter.convert(RSAKey)
     // which does not copy x5t#S256 to AM's JWK model, making getX5tS256() always null.
     // The inline path (getKeys(Client)) returns the stored JWKSet directly, preserving x5tS256.
-    const thumbprint = certThumbprintS256(validCert.forgeCert);
     const ssApp = await createApplication(domain.id, accessToken, {
       name: uniqueName('mtls-ss-app', true),
       type: 'SERVICE',
@@ -204,7 +147,7 @@ export const setupMtlsAuthFixture = async (): Promise<MtlsAuthFixture> => {
               redirectUris: ['http://localhost:4000/'],
               grantTypes: ['client_credentials'],
               tokenEndpointAuthMethod: 'self_signed_tls_client_auth',
-              jwks: { keys: [{ kty: 'RSA', x5tS256: thumbprint }] },
+              jwks: { keys: [{ kty: 'RSA', x5tS256: validCert.thumbprintS256 }] },
             },
           },
         },

--- a/gravitee-am-test/specs/gateway/token-auth-methods/fixtures/mtls-auth-fixture.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/fixtures/mtls-auth-fixture.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as forge from 'node-forge';
+import { createHash, randomBytes } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { Agent } from 'https';
+import fetch from 'cross-fetch';
+import { Domain } from '@management-models/Domain';
+import {
+  DomainOidcConfig,
+  patchDomain,
+  safeDeleteDomain,
+  setupDomainForTest,
+  waitForOidcReady,
+} from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createApplication, updateApplication } from '@management-commands/application-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+export interface MtlsAuthFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  tlsAuthClientId: string;
+  selfSignedClientId: string;
+  validCertPem: string;
+  wrongCertPem: string;
+  /** clientId of the tls_client_auth app configured for CN=a (used in nginx edge-stack tests) */
+  edgeTlsClientId: string;
+}
+
+/**
+ * Encodes a PEM certificate for the X-Client-Cert header.
+ *
+ * CertificateUtils.extractPeerCertificate() pre-processes the header value by
+ * replacing literal +, / and = characters, then calls URLDecoder.decode().
+ * encodeURIComponent produces a fully percent-encoded string (no literal +/=/),
+ * so the pre-processing step is a no-op and decode() recovers the original PEM.
+ */
+export function encodeCertForHeader(pem: string): string {
+  return encodeURIComponent(pem);
+}
+
+/** PEM text for paths under `cwd`, e.g. `/certs/client-a/client.crt`. */
+export function readCert(relPath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relPath), 'utf8');
+}
+
+/** POST with mutual TLS (used for `gateway-mtls` nginx edge tests). */
+export async function postWithClientCert(
+  url: string,
+  body: string,
+  cert: string,
+  key: string,
+): Promise<Response> {
+  const agent = new Agent({ rejectUnauthorized: false, cert, key });
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+    agent,
+  } as any) as Promise<Response>;
+}
+
+interface GeneratedCert {
+  pem: string;
+  subjectDn: string;
+  forgeCert: forge.pki.Certificate;
+}
+
+function generateSelfSignedCert(cn: string): GeneratedCert {
+  const keypair = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keypair.publicKey;
+  cert.serialNumber = randomBytes(16).toString('hex');
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+  const attrs = [{ shortName: 'CN', value: cn }];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keypair.privateKey, forge.md.sha256.create());
+  return {
+    pem: forge.pki.certificateToPem(cert),
+    // Single-RDN subject avoids DN ordering ambiguity with BouncyCastle's areEqual()
+    subjectDn: `CN=${cn}`,
+    forgeCert: cert,
+  };
+}
+
+function certThumbprintS256(cert: forge.pki.Certificate): string {
+  const der = forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes();
+  return createHash('sha256').update(Buffer.from(der, 'binary')).digest('base64url');
+}
+
+
+export const setupMtlsAuthFixture = async (): Promise<MtlsAuthFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  let domain: Domain | null = null;
+
+  try {
+    // Generate certs before domain setup; RSA 2048 generation takes ~1-2s each
+    const validCert = generateSelfSignedCert('mtls-test-client');
+    const wrongCert = generateSelfSignedCert('mtls-wrong-client');
+
+    const { domain: createdDomain, oidcConfig } = await setupDomainForTest(uniqueName('mtls', true), {
+      accessToken,
+      waitForStart: true,
+    });
+    domain = createdDomain;
+
+    await waitForSyncAfter(domain.id, () =>
+      patchDomain(domain.id, accessToken, {
+        oidc: {
+          clientRegistrationSettings: {
+            allowLocalhostRedirectUri: true,
+            allowHttpSchemeRedirectUri: true,
+          },
+        },
+      }),
+    );
+    await waitForOidcReady(domain.hrid);
+
+    // tls_client_auth app — authenticated via certificate Subject DN
+    const tlsApp = await createApplication(domain.id, accessToken, {
+      name: uniqueName('mtls-tls-app', true),
+      type: 'SERVICE',
+      redirectUris: ['http://localhost:4000/'],
+    });
+    const updatedTlsApp = await waitForSyncAfter(domain.id, () =>
+      updateApplication(
+        domain.id,
+        accessToken,
+        {
+          settings: {
+            oauth: {
+              redirectUris: ['http://localhost:4000/'],
+              grantTypes: ['client_credentials'],
+              tokenEndpointAuthMethod: 'tls_client_auth',
+              tlsClientAuthSubjectDn: validCert.subjectDn,
+            },
+          },
+        },
+        tlsApp.id,
+      ),
+    );
+
+    // tls_client_auth app for edge-stack tests — Subject DN matches client-a cert (CN=a) from
+    // gravitee-am-test/certs/client-a/, which is signed by the Test-CA trusted by gateway-mtls nginx.
+    const edgeTlsApp = await createApplication(domain.id, accessToken, {
+      name: uniqueName('mtls-edge-app', true),
+      type: 'SERVICE',
+      redirectUris: ['http://localhost:4000/'],
+    });
+    const updatedEdgeTlsApp = await waitForSyncAfter(domain.id, () =>
+      updateApplication(
+        domain.id,
+        accessToken,
+        {
+          settings: {
+            oauth: {
+              redirectUris: ['http://localhost:4000/'],
+              grantTypes: ['client_credentials'],
+              tokenEndpointAuthMethod: 'tls_client_auth',
+              tlsClientAuthSubjectDn: 'CN=a',
+            },
+          },
+        },
+        edgeTlsApp.id,
+      ),
+    );
+
+    // self_signed_tls_client_auth app — authenticated via certificate SHA-256 thumbprint.
+    // Inline jwks is used because the jwksUri path goes through JWKConverter.convert(RSAKey)
+    // which does not copy x5t#S256 to AM's JWK model, making getX5tS256() always null.
+    // The inline path (getKeys(Client)) returns the stored JWKSet directly, preserving x5tS256.
+    const thumbprint = certThumbprintS256(validCert.forgeCert);
+    const ssApp = await createApplication(domain.id, accessToken, {
+      name: uniqueName('mtls-ss-app', true),
+      type: 'SERVICE',
+      redirectUris: ['http://localhost:4000/'],
+    });
+    const updatedSsApp = await waitForSyncAfter(domain.id, () =>
+      updateApplication(
+        domain.id,
+        accessToken,
+        {
+          settings: {
+            oauth: {
+              redirectUris: ['http://localhost:4000/'],
+              grantTypes: ['client_credentials'],
+              tokenEndpointAuthMethod: 'self_signed_tls_client_auth',
+              jwks: { keys: [{ kty: 'RSA', x5tS256: thumbprint }] },
+            },
+          },
+        },
+        ssApp.id,
+      ),
+    );
+
+    return {
+      accessToken,
+      domain,
+      oidc: oidcConfig,
+      tlsAuthClientId: updatedTlsApp.settings.oauth.clientId,
+      selfSignedClientId: updatedSsApp.settings.oauth.clientId,
+      validCertPem: validCert.pem,
+      wrongCertPem: wrongCert.pem,
+      edgeTlsClientId: updatedEdgeTlsApp.settings.oauth.clientId,
+      cleanUp: async () => {
+        await safeDeleteDomain(domain.id, accessToken);
+      },
+    };
+  } catch (error) {
+    if (domain?.id) {
+      try {
+        await safeDeleteDomain(domain.id, accessToken);
+      } catch (e) {
+        console.error('Cleanup failed after setup error:', e);
+      }
+    }
+    throw error;
+  }
+};

--- a/gravitee-am-test/specs/gateway/token-auth-methods/mtls-auth.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/mtls-auth.jest.spec.ts
@@ -16,13 +16,8 @@
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { performPost } from '@gateway-commands/oauth-oidc-commands';
 import { setup } from '../../test-fixture';
-import {
-  MtlsAuthFixture,
-  encodeCertForHeader,
-  postWithClientCert,
-  readCert,
-  setupMtlsAuthFixture,
-} from './fixtures/mtls-auth-fixture';
+import { MtlsAuthFixture, postWithClientCert, setupMtlsAuthFixture } from './fixtures/mtls-auth-fixture';
+import { readCert } from '@utils/certificate-utils';
 
 setup(300000);
 
@@ -49,7 +44,7 @@ describe('mTLS OAuth Client Authentication (RFC 8705)', () => {
         `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.tlsAuthClientId)}`,
         {
           'Content-type': 'application/x-www-form-urlencoded',
-          'X-Client-Cert': encodeCertForHeader(fixture.validCertPem),
+          'X-Client-Cert': encodeURIComponent(fixture.validCertPem),
         },
       ).expect(200);
 
@@ -64,7 +59,7 @@ describe('mTLS OAuth Client Authentication (RFC 8705)', () => {
         `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.tlsAuthClientId)}`,
         {
           'Content-type': 'application/x-www-form-urlencoded',
-          'X-Client-Cert': encodeCertForHeader(fixture.wrongCertPem),
+          'X-Client-Cert': encodeURIComponent(fixture.wrongCertPem),
         },
       ).expect(401);
     });
@@ -89,7 +84,7 @@ describe('mTLS OAuth Client Authentication (RFC 8705)', () => {
         `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.selfSignedClientId)}`,
         {
           'Content-type': 'application/x-www-form-urlencoded',
-          'X-Client-Cert': encodeCertForHeader(fixture.validCertPem),
+          'X-Client-Cert': encodeURIComponent(fixture.validCertPem),
         },
       ).expect(200);
 
@@ -104,7 +99,7 @@ describe('mTLS OAuth Client Authentication (RFC 8705)', () => {
         `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.selfSignedClientId)}`,
         {
           'Content-type': 'application/x-www-form-urlencoded',
-          'X-Client-Cert': encodeCertForHeader(fixture.wrongCertPem),
+          'X-Client-Cert': encodeURIComponent(fixture.wrongCertPem),
         },
       ).expect(401);
     });

--- a/gravitee-am-test/specs/gateway/token-auth-methods/mtls-auth.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/mtls-auth.jest.spec.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { setup } from '../../test-fixture';
+import {
+  MtlsAuthFixture,
+  encodeCertForHeader,
+  postWithClientCert,
+  readCert,
+  setupMtlsAuthFixture,
+} from './fixtures/mtls-auth-fixture';
+
+setup(300000);
+
+const JWT_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+describe('mTLS OAuth Client Authentication (RFC 8705)', () => {
+  let fixture: MtlsAuthFixture;
+
+  beforeAll(async () => {
+    fixture = await setupMtlsAuthFixture();
+  });
+
+  afterAll(async () => {
+    if (fixture) {
+      await fixture.cleanUp();
+    }
+  });
+
+  describe('tls_client_auth', () => {
+    it('should obtain access_token when client presents certificate with configured Subject DN', async () => {
+      const response = await performPost(
+        fixture.oidc.token_endpoint,
+        '',
+        `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.tlsAuthClientId)}`,
+        {
+          'Content-type': 'application/x-www-form-urlencoded',
+          'X-Client-Cert': encodeCertForHeader(fixture.validCertPem),
+        },
+      ).expect(200);
+
+      expect(response.body.access_token).toMatch(JWT_FORMAT);
+      expect(response.body.token_type).toEqual('bearer');
+    });
+
+    it('should reject request when client presents certificate with wrong Subject DN', async () => {
+      await performPost(
+        fixture.oidc.token_endpoint,
+        '',
+        `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.tlsAuthClientId)}`,
+        {
+          'Content-type': 'application/x-www-form-urlencoded',
+          'X-Client-Cert': encodeCertForHeader(fixture.wrongCertPem),
+        },
+      ).expect(401);
+    });
+
+    it('should reject request when no client certificate is presented', async () => {
+      await performPost(
+        fixture.oidc.token_endpoint,
+        '',
+        `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.tlsAuthClientId)}`,
+        {
+          'Content-type': 'application/x-www-form-urlencoded',
+        },
+      ).expect(401);
+    });
+  });
+
+  describe('self_signed_tls_client_auth', () => {
+    it('should obtain access_token when certificate SHA-256 thumbprint matches JWKS entry', async () => {
+      const response = await performPost(
+        fixture.oidc.token_endpoint,
+        '',
+        `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.selfSignedClientId)}`,
+        {
+          'Content-type': 'application/x-www-form-urlencoded',
+          'X-Client-Cert': encodeCertForHeader(fixture.validCertPem),
+        },
+      ).expect(200);
+
+      expect(response.body.access_token).toMatch(JWT_FORMAT);
+      expect(response.body.token_type).toEqual('bearer');
+    });
+
+    it('should reject request when certificate thumbprint is not registered in JWKS', async () => {
+      await performPost(
+        fixture.oidc.token_endpoint,
+        '',
+        `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.selfSignedClientId)}`,
+        {
+          'Content-type': 'application/x-www-form-urlencoded',
+          'X-Client-Cert': encodeCertForHeader(fixture.wrongCertPem),
+        },
+      ).expect(401);
+    });
+
+    it('should reject request when no client certificate is presented', async () => {
+      await performPost(
+        fixture.oidc.token_endpoint,
+        '',
+        `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.selfSignedClientId)}`,
+        {
+          'Content-type': 'application/x-www-form-urlencoded',
+        },
+      ).expect(401);
+    });
+  });
+
+  describe('tls_client_auth via nginx mTLS edge stack', () => {
+    let edgeTokenEndpoint: string;
+    let clientACert: string;
+    let clientAKey: string;
+    let clientBCert: string;
+    let clientBKey: string;
+
+    beforeAll(() => {
+      const tokenPath = new URL(fixture.oidc.token_endpoint).pathname;
+      edgeTokenEndpoint = `${process.env.MTLS_URL}${tokenPath}`;
+      clientACert = readCert('/certs/client-a/client.crt');
+      clientAKey = readCert('/certs/client-a/client.key');
+      clientBCert = readCert('/certs/client-b/client.crt');
+      clientBKey = readCert('/certs/client-b/client.key');
+    });
+
+    it('should issue token when CA-signed cert with matching Subject DN passes through nginx', async () => {
+      const response = await postWithClientCert(
+        edgeTokenEndpoint,
+        `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.edgeTlsClientId)}`,
+        clientACert,
+        clientAKey,
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.access_token).toMatch(JWT_FORMAT);
+      expect(body.token_type).toEqual('bearer');
+    });
+
+    it('should reject when CA-signed cert Subject DN does not match configured value', async () => {
+      const response = await postWithClientCert(
+        edgeTokenEndpoint,
+        `grant_type=client_credentials&client_id=${encodeURIComponent(fixture.edgeTlsClientId)}`,
+        clientBCert,
+        clientBKey,
+      );
+      expect(response.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6249](https://gravitee.atlassian.net/browse/AM-6249)

## :pencil2: A description of the changes proposed in the pull request
Add test coverage for mutual-TLS OAuth 2.0 authentication methods `tls_client_auth` and `self_signed_tls_client_auth`.

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
https://datatracker.ietf.org/doc/html/rfc8705

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6249]: https://gravitee.atlassian.net/browse/AM-6249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ