### PR TITLE
feat: show CIMD client logo in consent template

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/pom.xml
@@ -43,6 +43,44 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-rx-java3</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.am.model</groupId>
+            <artifactId>gravitee-am-model</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/main/java/io/gravitee/am/gateway/handler/cimd/CimdProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/main/java/io/gravitee/am/gateway/handler/cimd/CimdProvider.java
@@ -17,7 +17,9 @@ package io.gravitee.am.gateway.handler.cimd;
 
 import io.gravitee.am.gateway.handler.api.AbstractProtocolProvider;
 import io.gravitee.am.gateway.handler.cimd.resources.endpoint.CimdLogoEndpoint;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
+import io.gravitee.am.model.Domain;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.ext.web.Router;
@@ -38,13 +40,19 @@ public class CimdProvider extends AbstractProtocolProvider {
     @Autowired
     private CimdMetadataDocumentManager cimdMetadataDocumentManager;
 
+    @Autowired
+    private CimdLogoCacheService cimdLogoCacheService;
+
+    @Autowired
+    private Domain domain;
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
 
         final Router cimdRouter = Router.router(vertx);
         cimdRouter.route().handler(corsHandler);
-        cimdRouter.get("/logo").handler(new CimdLogoEndpoint(cimdMetadataDocumentManager));
+        cimdRouter.get("/logo").handler(new CimdLogoEndpoint(domain, cimdMetadataDocumentManager, cimdLogoCacheService));
         cimdRouter.route().failureHandler(new ErrorHandler());
 
         router.route(subRouterPath()).subRouter(cimdRouter);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/main/java/io/gravitee/am/gateway/handler/cimd/resources/endpoint/CimdLogoEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/main/java/io/gravitee/am/gateway/handler/cimd/resources/endpoint/CimdLogoEndpoint.java
@@ -16,8 +16,12 @@
 package io.gravitee.am.gateway.handler.cimd.resources.endpoint;
 
 import io.gravitee.am.gateway.handler.common.client.cimd.CachedLogo;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
 import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.oidc.CIMDSettings;
+import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.rxjava3.ext.web.RoutingContext;
@@ -25,19 +29,28 @@ import io.vertx.rxjava3.ext.web.RoutingContext;
 import java.util.Optional;
 
 /**
- * Serves a pre-fetched CIMD client logo from the in-memory logo cache.
+ * Serves a CIMD client logo from the in-memory cache, or fetches it synchronously on cache miss when
+ * non-expired metadata for the client is present and {@code logo_uri} is set.
  *
- * The caller supplies the {@code clientId} (the CIMD metadata URL) as a query parameter.
- * This endpoint performs a pure cache lookup — it never fetches remotely.
+ * <p>The caller supplies {@code clientId} (the canonical metadata URL) as a query parameter.
+ * Remote {@code logo_uri} values are never served directly to the browser; they are fetched by the
+ * gateway using the same trust rules as metadata logo pre-fetch.</p>
  */
 public class CimdLogoEndpoint implements Handler<RoutingContext> {
 
     private static final String PARAM_CLIENT_ID = "clientId";
 
+    private final Domain domain;
     private final CimdMetadataDocumentManager cimdMetadataDocumentManager;
+    private final CimdLogoCacheService cimdLogoCacheService;
 
-    public CimdLogoEndpoint(CimdMetadataDocumentManager cimdMetadataDocumentManager) {
+    public CimdLogoEndpoint(
+            Domain domain,
+            CimdMetadataDocumentManager cimdMetadataDocumentManager,
+            CimdLogoCacheService cimdLogoCacheService) {
+        this.domain = domain;
         this.cimdMetadataDocumentManager = cimdMetadataDocumentManager;
+        this.cimdLogoCacheService = cimdLogoCacheService;
     }
 
     @Override
@@ -48,17 +61,55 @@ public class CimdLogoEndpoint implements Handler<RoutingContext> {
             return;
         }
 
-        final Optional<CachedLogo> logo = cimdMetadataDocumentManager.getLogoByClientId(ClientIds.canonicalize(clientId));
-        if (logo.isEmpty()) {
-            routingContext.response().setStatusCode(404).end();
+        final String canonicalId = ClientIds.canonicalize(clientId);
+
+        final Optional<CachedLogo> cachedLogo = cimdMetadataDocumentManager.getLogoByClientId(canonicalId);
+        if (cachedLogo.isPresent()) {
+            endWithLogo(routingContext, cachedLogo.get());
             return;
         }
 
-        final CachedLogo cachedLogo = logo.get();
-        routingContext.response()
+        cimdMetadataDocumentManager.resolve(canonicalId)
+                .flatMap(doc -> {
+                    if (doc.isEmpty()) {
+                        return Single.just(Optional.<CachedLogo>empty());
+                    }
+                    final String logoUri = doc.get().getLogoUri();
+                    if (logoUri == null || logoUri.isBlank()) {
+                        return Single.just(Optional.<CachedLogo>empty());
+                    }
+                    final CIMDSettings settings = resolveCimdSettings();
+                    if (settings == null || !settings.isEnabled()) {
+                        return Single.just(Optional.<CachedLogo>empty());
+                    }
+                    return cimdLogoCacheService.fetchAndCacheNow(
+                            canonicalId, logoUri, CimdMetadataDocumentManager.remainingTtlSeconds(doc.get()), settings);
+                })
+                .subscribe(
+                        opt -> {
+                            if (opt.isEmpty()) {
+                                routingContext.response().setStatusCode(404).end();
+                            } else {
+                                endWithLogo(routingContext, opt.get());
+                            }
+                        },
+                        routingContext::fail);
+    }
+
+    private static void endWithLogo(RoutingContext routingContext, CachedLogo cachedLogo) {
+        routingContext
+                .response()
                 .putHeader("Content-Type", cachedLogo.contentType())
                 .putHeader("Cache-Control", "max-age=" + cachedLogo.maxAgeSeconds())
                 .setStatusCode(200)
                 .end(Buffer.buffer(cachedLogo.bytes()));
     }
+
+    private CIMDSettings resolveCimdSettings() {
+        if (domain == null || domain.getOidc() == null) {
+            return null;
+        }
+        return domain.getOidc().getCimdSettings();
+    }
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/test/java/io/gravitee/am/gateway/handler/cimd/resources/endpoint/CimdLogoEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/test/java/io/gravitee/am/gateway/handler/cimd/resources/endpoint/CimdLogoEndpointTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.cimd.resources.endpoint;
+
+import io.gravitee.am.gateway.handler.common.client.cimd.CachedLogo;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
+import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.model.CimdMetadataDocument;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.oidc.CIMDSettings;
+import io.gravitee.am.model.oidc.OIDCSettings;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import io.vertx.rxjava3.core.http.HttpServerResponse;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CimdLogoEndpointTest {
+
+    private static final String RAW_CLIENT_ID = "https://Example.COM/registry/meta";
+
+    @Mock
+    private RoutingContext routingContext;
+
+    @Mock
+    private HttpServerRequest request;
+
+    @Mock
+    private HttpServerResponse response;
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private CimdMetadataDocumentManager documentManager;
+
+    @Mock
+    private CimdLogoCacheService logoCacheService;
+
+    private CimdLogoEndpoint endpoint;
+    private CIMDSettings cimdSettings;
+    private OIDCSettings oidcSettings;
+
+    @Before
+    public void setUp() {
+        cimdSettings = new CIMDSettings();
+        cimdSettings.setEnabled(true);
+        cimdSettings.setAllowPrivateIpAddress(true);
+        oidcSettings = new OIDCSettings();
+        oidcSettings.setCimdSettings(cimdSettings);
+
+        when(domain.getOidc()).thenReturn(oidcSettings);
+
+        when(routingContext.request()).thenReturn(request);
+        when(routingContext.response()).thenReturn(response);
+        when(response.putHeader(anyString(), anyString())).thenReturn(response);
+        when(response.setStatusCode(anyInt())).thenReturn(response);
+
+        endpoint = new CimdLogoEndpoint(domain, documentManager, logoCacheService);
+    }
+
+    @Test
+    public void shouldReturn400WhenClientIdMissing() {
+        when(request.getParam("clientId")).thenReturn(" ");
+
+        endpoint.handle(routingContext);
+
+        verify(response).setStatusCode(400);
+        verify(response).end();
+    }
+
+    @Test
+    public void shouldServeLogoFromCache() {
+        final String canonical = ClientIds.canonicalize(RAW_CLIENT_ID);
+        when(request.getParam("clientId")).thenReturn(RAW_CLIENT_ID);
+        CachedLogo cached = new CachedLogo(new byte[]{9, 9, 9}, "image/svg+xml", 42L);
+        when(documentManager.getLogoByClientId(canonical)).thenReturn(Optional.of(cached));
+
+        endpoint.handle(routingContext);
+
+        verify(logoCacheService, never()).fetchAndCacheNow(anyString(), anyString(), anyLong(), any(CIMDSettings.class));
+        verify(response).setStatusCode(200);
+        verify(response).putHeader(eq("Content-Type"), eq("image/svg+xml"));
+        verify(response).putHeader(eq("Cache-Control"), eq("max-age=42"));
+        verify(response).end(any(Buffer.class));
+    }
+
+    @Test
+    public void shouldFetchAndServeLogoOnCacheMissWhenMetadataContainsLogoUri() {
+        final String canonical = ClientIds.canonicalize(RAW_CLIENT_ID);
+        when(request.getParam("clientId")).thenReturn(RAW_CLIENT_ID);
+        when(documentManager.getLogoByClientId(canonical)).thenReturn(Optional.empty());
+
+        CimdMetadataDocument doc = new CimdMetadataDocument();
+        doc.setExpiresAt(new Date(System.currentTimeMillis() + 120_000));
+        doc.setMetadata(new JsonObject().put("logo_uri", "https://example.com/logo.png").encode());
+        when(documentManager.resolve(canonical)).thenReturn(Single.just(Optional.of(doc)));
+
+        CachedLogo fetched = new CachedLogo(new byte[]{1, 2, 3}, "image/png", 90L);
+        when(logoCacheService.fetchAndCacheNow(eq(canonical), eq("https://example.com/logo.png"), anyLong(), eq(cimdSettings)))
+                .thenReturn(Single.just(Optional.of(fetched)));
+
+        endpoint.handle(routingContext);
+
+        verify(response).setStatusCode(200);
+        verify(response).putHeader(eq("Content-Type"), eq("image/png"));
+        verify(response).putHeader(eq("Cache-Control"), eq("max-age=90"));
+        verify(response).end(any(Buffer.class));
+    }
+
+    @Test
+    public void shouldReturn404WhenCimdDisabled() {
+        cimdSettings.setEnabled(false);
+
+        final String canonical = ClientIds.canonicalize(RAW_CLIENT_ID);
+        when(request.getParam("clientId")).thenReturn(RAW_CLIENT_ID);
+        when(documentManager.getLogoByClientId(canonical)).thenReturn(Optional.empty());
+
+        CimdMetadataDocument doc = new CimdMetadataDocument();
+        doc.setExpiresAt(new Date(System.currentTimeMillis() + 120_000));
+        doc.setMetadata(new JsonObject().put("logo_uri", "https://example.com/logo.png").encode());
+        when(documentManager.resolve(canonical)).thenReturn(Single.just(Optional.of(doc)));
+
+        endpoint.handle(routingContext);
+
+        verify(response).setStatusCode(404);
+        verify(response).end();
+    }
+
+    @Test
+    public void shouldReturn404WhenClientMetadataNotFound() {
+        final String canonical = ClientIds.canonicalize(RAW_CLIENT_ID);
+        when(request.getParam("clientId")).thenReturn(RAW_CLIENT_ID);
+        when(documentManager.getLogoByClientId(canonical)).thenReturn(Optional.empty());
+        when(documentManager.resolve(canonical)).thenReturn(Single.just(Optional.empty()));
+
+        endpoint.handle(routingContext);
+
+        verify(logoCacheService, never()).fetchAndCacheNow(anyString(), anyString(), anyLong(), any(CIMDSettings.class));
+        verify(response).setStatusCode(404);
+        verify(response).end();
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdLogoCacheService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdLogoCacheService.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.client.cimd;
+
+import io.gravitee.am.model.oidc.CIMDSettings;
+import io.gravitee.am.service.utils.RetryAtMostWithDelay;
+import io.gravitee.am.service.utils.vertx.BoundedBufferWriteStream;
+import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.rxjava3.core.streams.WriteStream;
+import io.vertx.rxjava3.ext.web.codec.BodyCodec;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Fetches CIMD client logos with the same trust and size bounds as metadata pre-fetch, and stores
+ * them in {@link CimdMetadataDocumentManager}.
+ */
+@Slf4j
+public class CimdLogoCacheService {
+
+    private static final int FETCH_RETRY_ATTEMPTS = 3;
+    private static final int FETCH_RETRY_DELAY_MS = 100;
+    static final long MAX_LOGO_SIZE_BYTES = 256L * 1024L;
+
+    private final WebClient webClient;
+    private final CimdMetadataDocumentManager cimdMetadataDocumentManager;
+    private final CimdUriTrustValidator cimdUriTrustValidator;
+
+    public CimdLogoCacheService(
+            WebClient webClient,
+            CimdMetadataDocumentManager cimdMetadataDocumentManager,
+            CimdUriTrustValidator cimdUriTrustValidator) {
+        this.webClient = webClient;
+        this.cimdMetadataDocumentManager = cimdMetadataDocumentManager;
+        this.cimdUriTrustValidator = cimdUriTrustValidator;
+    }
+
+    /**
+     * Fire-and-forget logo download when not already cached.
+     */
+    public void prefetchLogoAsync(String clientId, String logoUri, long metadataTtlSeconds, CIMDSettings settings) {
+        if (logoUri == null || logoUri.isBlank()) {
+            return;
+        }
+        if (cimdMetadataDocumentManager.getLogoByClientId(clientId).isPresent()) {
+            return;
+        }
+
+        final URI uri;
+        try {
+            uri = cimdUriTrustValidator.parseHttpUrl(logoUri, "logo_uri");
+        } catch (Exception ex) {
+            log.debug("CIMD logo pre-fetch skipped — invalid URI: {}", logoUri);
+            return;
+        }
+        try {
+            cimdUriTrustValidator.validateTrust(uri, settings, "logo_uri");
+        } catch (Exception ex) {
+            log.debug("CIMD logo pre-fetch skipped — URI not trusted: {}", logoUri);
+            return;
+        }
+
+        cimdUriTrustValidator.validateResolvableHost(uri.getHost(), "logo_uri", settings).subscribe(
+                () -> fetchLogoSingle(logoUri, metadataTtlSeconds, settings)
+                        .subscribe(
+                                opt -> opt.ifPresent(logo -> {
+                                    cimdMetadataDocumentManager.putLogo(clientId, logo);
+                                    log.debug("CIMD logo cached for clientId {}", clientId);
+                                }),
+                                err -> log.debug(
+                                        "CIMD logo pre-fetch failed for uri {}: {}",
+                                        logoUri,
+                                        err.getMessage())),
+                err -> log.debug("CIMD logo pre-fetch skipped — {}", err.getMessage()));
+    }
+
+    /**
+     * Synchronously (reactively) fetch and cache the logo; returns empty when the URI is invalid,
+     * untrusted, fetch fails, or the response is not a usable image.
+     */
+    public Single<Optional<CachedLogo>> fetchAndCacheNow(
+            String clientId, String logoUri, long metadataTtlSeconds, CIMDSettings settings) {
+        if (logoUri == null || logoUri.isBlank()) {
+            return Single.just(Optional.empty());
+        }
+        Optional<CachedLogo> existing = cimdMetadataDocumentManager.getLogoByClientId(clientId);
+        if (existing.isPresent()) {
+            return Single.just(existing);
+        }
+
+        final URI uri;
+        try {
+            uri = cimdUriTrustValidator.parseHttpUrl(logoUri, "logo_uri");
+        } catch (Exception ex) {
+            log.debug("CIMD logo fetch skipped — invalid URI: {}", logoUri);
+            return Single.just(Optional.empty());
+        }
+        try {
+            cimdUriTrustValidator.validateTrust(uri, settings, "logo_uri");
+        } catch (Exception ex) {
+            log.debug("CIMD logo fetch skipped — URI not trusted: {}", logoUri);
+            return Single.just(Optional.empty());
+        }
+
+        return cimdUriTrustValidator.validateResolvableHost(uri.getHost(), "logo_uri", settings)
+                .andThen(fetchLogoSingle(logoUri, metadataTtlSeconds, settings))
+                .flatMap(opt -> {
+                    opt.ifPresent(logo -> cimdMetadataDocumentManager.putLogo(clientId, logo));
+                    return Single.just(opt);
+                })
+                .onErrorResumeNext(e -> Single.just(Optional.empty()));
+    }
+
+    private Single<Optional<CachedLogo>> fetchLogoSingle(
+            String logoUri, long metadataTtlSeconds, CIMDSettings settings) {
+        final long timeoutMs = resolveTimeoutMs(settings);
+
+        return Single.defer(() -> {
+                    final var logoCollector = new BoundedBufferWriteStream(MAX_LOGO_SIZE_BYTES);
+                    return webClient.getAbs(logoUri)
+                        .timeout(timeoutMs)
+                        .followRedirects(true)
+                        .as(BodyCodec.pipe(WriteStream.newInstance(logoCollector), false))
+                        .rxSend()
+                        .map(response -> {
+                            if (response.statusCode() != HttpStatusCode.OK_200) {
+                                log.debug(
+                                        "CIMD logo fetch returned {} for uri {}",
+                                        response.statusCode(),
+                                        logoUri);
+                                return Optional.<CachedLogo>empty();
+                            }
+                            final Buffer body =
+                                    logoCollector.body().length() > 0 ? logoCollector.body() : response.bodyAsBuffer();
+                            if (body == null || body.length() <= 0 || body.length() > MAX_LOGO_SIZE_BYTES) {
+                                return Optional.<CachedLogo>empty();
+                            }
+                            final byte[] bytes = body.getBytes();
+                            final String contentType = resolveContentType(response.getHeader("Content-Type"), bytes);
+                            return Optional.of(new CachedLogo(bytes, contentType, metadataTtlSeconds));
+                        });
+                })
+                .retryWhen(new RetryAtMostWithDelay(FETCH_RETRY_ATTEMPTS, FETCH_RETRY_DELAY_MS))
+                .onErrorResumeNext(throwable -> {
+                    if (throwable instanceof TimeoutException) {
+                        log.debug("CIMD logo fetch timed out for uri {}", logoUri);
+                    } else if (throwable instanceof BoundedBufferWriteStream.MaxResponseSizeExceededException) {
+                        log.debug("CIMD logo fetch exceeded max size for uri {}", logoUri);
+                    } else {
+                        log.debug("CIMD logo fetch failed for uri {}: {}", logoUri, throwable.getMessage());
+                    }
+                    return Single.just(Optional.empty());
+                });
+    }
+
+    private static String resolveContentType(String headerValue, byte[] bytes) {
+        if (headerValue != null && !headerValue.isBlank()) {
+            return headerValue.trim();
+        }
+        return CimdMetadataDocumentManager.detectMimeType(bytes);
+    }
+
+    private static long resolveTimeoutMs(CIMDSettings settings) {
+        return Math.max(1L, settings.getFetchTimeoutMs());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdMetadataDocumentManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdMetadataDocumentManager.java
@@ -28,6 +28,7 @@ import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
+import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.json.JsonObject;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
@@ -158,6 +159,33 @@ public class CimdMetadataDocumentManager extends AbstractService<CimdMetadataDoc
                 (entry.document().getExpiresAt().getTime() - System.currentTimeMillis()) / 1000);
         CachedLogo logo = entry.logo();
         return Optional.of(new CachedLogo(logo.bytes(), logo.contentType(), remainingSeconds));
+    }
+
+    /**
+     * Returns a non-expired document from the local cache, falling back and warming from the DB on a miss.
+     */
+    public Single<Optional<CimdMetadataDocument>> resolve(String clientId) {
+        Optional<CimdMetadataDocument> local = get(clientId);
+        if (local.isPresent()) {
+            log.debug("CIMD local cache hit for domain={}, clientId={}", domain.getId(), clientId);
+            return Single.just(local);
+        }
+        log.debug("CIMD local cache miss, checking DB for domain={}, clientId={}", domain.getId(), clientId);
+        return cimdMetadataDocumentService.findByDomainAndClientId(domain.getId(), clientId)
+                .filter(doc -> !doc.isExpired())
+                .doOnSuccess(doc -> {
+                    log.debug("CIMD DB cache hit (restored) for domain={}, clientId={}", domain.getId(), clientId);
+                    put(clientId, doc);
+                })
+                .map(Optional::of)
+                .defaultIfEmpty(Optional.empty());
+    }
+
+    public static long remainingTtlSeconds(CimdMetadataDocument doc) {
+        if (doc.getExpiresAt() == null) {
+            return 0L;
+        }
+        return Math.max(0L, (doc.getExpiresAt().getTime() - System.currentTimeMillis()) / 1000L);
     }
 
     public static String detectMimeType(byte[] bytes) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdUriTrustValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdUriTrustValidator.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.client.cimd;
+
+import io.gravitee.am.common.web.PrivateOrReservedHostException;
+import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
+import io.gravitee.am.model.oidc.CIMDSettings;
+import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.reactivex.rxjava3.core.Completable;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Validates CIMD HTTP(S) URLs for metadata and logo fetching: parses URLs, applies domain trust policy
+ * (scheme, allowed host patterns, private or reserved IP literals in the authority), and optionally
+ * verifies DNS resolution does not map to private addresses via {@link HostSsrfGuard}.
+ */
+public class CimdUriTrustValidator {
+
+    private final HostSsrfGuard hostSsrfGuard;
+
+    public CimdUriTrustValidator(HostSsrfGuard hostSsrfGuard) {
+        this.hostSsrfGuard = hostSsrfGuard;
+    }
+
+    /**
+     * Parses {@code value} as an HTTP(S) URL suitable for Vert.x HTTP client use.
+     *
+     * @throws InvalidClientMetadataException when the string is not a valid HTTP(S) URL
+     */
+    public URI parseHttpUrl(String value, String fieldName) {
+        try {
+            return UriBuilder.fromHttpUrl(value).build();
+        } catch (IllegalArgumentException | URISyntaxException ex) {
+            throw new InvalidClientMetadataException(fieldName + " is not a valid URL.");
+        }
+    }
+
+    /**
+     * Validates scheme, host presence, allowed-domain patterns, and private/reserved IP literals in the host part.
+     */
+    public void validateTrust(URI uri, CIMDSettings settings, String fieldName) {
+        if (!settings.isAllowUnsecuredHttpUri() && "http".equalsIgnoreCase(uri.getScheme())) {
+            throw new InvalidClientMetadataException("Unsecured HTTP " + fieldName + " is not allowed.");
+        }
+
+        final String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new InvalidClientMetadataException(fieldName + " host is missing.");
+        }
+
+        if (!isAllowedDomain(host, settings.getAllowedDomains())) {
+            throw new InvalidClientMetadataException(fieldName + " host is not in allowed domains.");
+        }
+
+        if (!settings.isAllowPrivateIpAddress() && UriBuilder.isPrivateOrReservedIpLiteral(host)) {
+            throw new InvalidClientMetadataException(fieldName + " resolves to a private or reserved IP address.");
+        }
+    }
+
+    /**
+     * When private IPs are disallowed, resolves {@code host} and rejects private/reserved targets (DNS rebinding protection).
+     */
+    public Completable validateResolvableHost(String host, String fieldName, CIMDSettings settings) {
+        if (settings.isAllowPrivateIpAddress()) {
+            return Completable.complete();
+        }
+        return hostSsrfGuard.assertNotPrivateHost(host)
+                .onErrorResumeNext(e -> e instanceof PrivateOrReservedHostException
+                        ? Completable.error(new InvalidClientMetadataException(
+                                fieldName + " resolves to a private or reserved IP address."))
+                        : Completable.error(e));
+    }
+
+    private static boolean isAllowedDomain(String host, List<String> allowedDomains) {
+        if (allowedDomains == null || allowedDomains.isEmpty()) {
+            return true;
+        }
+
+        final String normalizedHost = host.toLowerCase(Locale.ROOT);
+
+        return allowedDomains.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(pattern -> !pattern.isEmpty())
+                .map(pattern -> pattern.toLowerCase(Locale.ROOT))
+                .anyMatch(pattern -> {
+                    if (pattern.startsWith("*.")) {
+                        final String suffix = pattern.substring(2);
+                        if (suffix.isEmpty() || !normalizedHost.endsWith("." + suffix)) {
+                            return false;
+                        }
+                        final String subdomain = normalizedHost.substring(0, normalizedHost.length() - suffix.length() - 1);
+                        return !subdomain.isEmpty();
+                    }
+                    return normalizedHost.equals(pattern);
+                });
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
@@ -19,13 +19,11 @@ import io.gravitee.am.common.oauth2.GrantType;
 import io.gravitee.am.common.oauth2.ResponseType;
 import io.gravitee.am.common.oidc.ClientAuthenticationMethod;
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.am.common.web.UriBuilder;
-import io.gravitee.am.common.web.PrivateOrReservedHostException;
-import io.gravitee.am.gateway.handler.common.client.cimd.CachedLogo;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
 import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
-import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdUriTrustValidator;
 import lombok.extern.slf4j.Slf4j;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.application.ApplicationScopeSettings;
@@ -36,8 +34,6 @@ import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.gravitee.am.service.utils.RetryAtMostWithDelay;
 import io.gravitee.am.service.utils.jwk.converter.JWKConverter;
-import io.gravitee.am.service.utils.vertx.BoundedBufferWriteStream;
-import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.buffer.Buffer;
@@ -47,16 +43,14 @@ import io.vertx.rxjava3.core.streams.WriteStream;
 import io.vertx.rxjava3.ext.web.codec.BodyCodec;
 import io.vertx.rxjava3.ext.web.client.HttpResponse;
 import io.vertx.rxjava3.ext.web.client.WebClient;
+import io.gravitee.am.service.utils.vertx.BoundedBufferWriteStream;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -74,7 +68,6 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
     );
     private static final int FETCH_RETRY_ATTEMPTS = 3;
     private static final int FETCH_RETRY_DELAY_MS = 100;
-    private static final long MAX_LOGO_SIZE_BYTES = 256L * 1024L;
     private static final String DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD = ClientAuthenticationMethod.NONE;
     private static final List<String> DEFAULT_GRANT_TYPES = List.of(GrantType.AUTHORIZATION_CODE);
     private static final List<String> DEFAULT_RESPONSE_TYPES = List.of(ResponseType.CODE);
@@ -83,18 +76,21 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
     private final WebClient webClient;
     private final CimdMetadataDocumentService cimdMetadataDocumentService;
     private final CimdMetadataDocumentManager cimdMetadataDocumentManager;
-    private final HostSsrfGuard hostSsrfGuard;
+    private final CimdUriTrustValidator cimdUriTrustValidator;
+    private final CimdLogoCacheService cimdLogoCacheService;
 
     public CimdMetadataServiceImpl(Domain domain,
                                    WebClient webClient,
                                    CimdMetadataDocumentService cimdMetadataDocumentService,
                                    CimdMetadataDocumentManager cimdMetadataDocumentManager,
-                                   HostSsrfGuard hostSsrfGuard) {
+                                   CimdUriTrustValidator cimdUriTrustValidator,
+                                   CimdLogoCacheService cimdLogoCacheService) {
         this.domain = domain;
         this.webClient = webClient;
         this.cimdMetadataDocumentService = cimdMetadataDocumentService;
         this.cimdMetadataDocumentManager = cimdMetadataDocumentManager;
-        this.hostSsrfGuard = hostSsrfGuard;
+        this.cimdUriTrustValidator = cimdUriTrustValidator;
+        this.cimdLogoCacheService = cimdLogoCacheService;
     }
 
     @Override
@@ -110,47 +106,30 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
 
             final String canonicalId = ClientIds.canonicalize(clientId);
             final CIMDSettings settings = getCimdSettings();
-            final URI clientIdUri = toUri(canonicalId, "client_id");
-            validateUrlTrust(clientIdUri, settings, "client_id");
+            final URI clientIdUri = cimdUriTrustValidator.parseHttpUrl(canonicalId, "client_id");
+            cimdUriTrustValidator.validateTrust(clientIdUri, settings, "client_id");
 
-            // [1] Local in-memory cache hit
-            var cached = cimdMetadataDocumentManager.get(canonicalId);
-            if (cached.isPresent()) {
-                log.debug("CIMD local cache hit for domain={}, clientId={}", domain.getId(), canonicalId);
-                return Maybe.just(synthesizeClient(canonicalId, templateClient, new JsonObject(cached.get().getMetadata())));
-            }
-
-            // [2] Shared DB hit
-            log.debug("CIMD local cache miss, checking DB for domain={}, clientId={}", domain.getId(), canonicalId);
-            return cimdMetadataDocumentService.findByDomainAndClientId(domain.getId(), canonicalId)
-                    .flatMap(doc -> {
-                        if (!doc.isExpired()) {
-                            log.debug("CIMD DB cache hit (restored) for domain={}, clientId={}", domain.getId(), canonicalId);
-                            cimdMetadataDocumentManager.put(canonicalId, doc);
-                            // Pre-fetch logo if not yet cached locally (e.g. after gateway restart)
-                            final JsonObject docMetadata = new JsonObject(doc.getMetadata());
-                            final long remainingTtlSeconds = doc.getExpiresAt() != null
-                                    ? Math.max(0L, (doc.getExpiresAt().getTime() - System.currentTimeMillis()) / 1000L)
-                                    : 0L;
-                            prefetchLogoAsync(canonicalId, docMetadata.getString("logo_uri"), remainingTtlSeconds, settings);
-                            return Maybe.just(synthesizeClient(canonicalId, templateClient, docMetadata));
+            return cimdMetadataDocumentManager.resolve(canonicalId)
+                    .flatMapMaybe(opt -> {
+                        if (opt.isEmpty()) {
+                            return Maybe.empty();
                         }
-                        return Maybe.empty();
+                        final var doc = opt.get();
+                        final JsonObject docMetadata = new JsonObject(doc.getMetadata());
+                        cimdLogoCacheService.prefetchLogoAsync(canonicalId, doc.getLogoUri(),
+                                CimdMetadataDocumentManager.remainingTtlSeconds(doc), settings);
+                        return Maybe.just(synthesizeClient(canonicalId, templateClient, docMetadata));
                     })
-                    // [3] Origin fetch on miss or expiry
                     .switchIfEmpty(
                             Maybe.defer(() -> {
                                 log.debug("CIMD cache miss, fetching from origin for domain={}, clientId={}", domain.getId(), canonicalId);
-                                return validateNotPrivateHost(clientIdUri.getHost(), "client_id", settings)
+                                return cimdUriTrustValidator.validateResolvableHost(clientIdUri.getHost(), "client_id", settings)
                                         .andThen(fetchMetadataWithTtl(canonicalId, settings))
                                         .flatMap(fetchResult -> {
                                             final FetchResult.CacheRequirements cache = fetchResult.cacheRequirements();
                                             if (!cache.noCache()) {
-                                                // Populate local cache immediately
                                                 cimdMetadataDocumentManager.put(canonicalId, fetchResult.json(), cache.ttl());
-                                                // Kick off background logo pre-fetch using the metadata TTL
-                                                prefetchLogoAsync(canonicalId, fetchResult.json().getString("logo_uri"), cache.ttl().toSeconds(), settings);
-                                                // [4] Persist to DB asynchronously; update local cache with DB-assigned entry when done
+                                                cimdLogoCacheService.prefetchLogoAsync(canonicalId, fetchResult.json().getString("logo_uri"), cache.ttl().toSeconds(), settings);
                                                 cimdMetadataDocumentService
                                                         .upsert(domain, canonicalId, fetchResult.json().encode(), cache.ttl())
                                                         .subscribe(
@@ -171,69 +150,6 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
             throw new InvalidClientMetadataException("CIMD settings are not configured for this domain.");
         }
         return domain.getOidc().getCimdSettings();
-    }
-
-    private URI toUri(String value, String fieldName) {
-        try {
-            return UriBuilder.fromHttpUrl(value).build();
-        } catch (IllegalArgumentException | URISyntaxException ex) {
-            throw new InvalidClientMetadataException(fieldName + " is not a valid URL.");
-        }
-    }
-
-    private void validateUrlTrust(URI uri, CIMDSettings settings, String fieldName) {
-        if (!settings.isAllowUnsecuredHttpUri() && "http".equalsIgnoreCase(uri.getScheme())) {
-            throw new InvalidClientMetadataException("Unsecured HTTP " + fieldName + " is not allowed.");
-        }
-
-        final String host = uri.getHost();
-        if (host == null || host.isBlank()) {
-            throw new InvalidClientMetadataException(fieldName + " host is missing.");
-        }
-
-        if (!isAllowedDomain(host, settings.getAllowedDomains())) {
-            throw new InvalidClientMetadataException(fieldName + " host is not in allowed domains.");
-        }
-
-        if (!settings.isAllowPrivateIpAddress() && UriBuilder.isPrivateOrReservedIpLiteral(host)) {
-            throw new InvalidClientMetadataException(fieldName + " resolves to a private or reserved IP address.");
-        }
-    }
-
-    private boolean isAllowedDomain(String host, List<String> allowedDomains) {
-        if (allowedDomains == null || allowedDomains.isEmpty()) {
-            return true;
-        }
-
-        final String normalizedHost = host.toLowerCase(Locale.ROOT);
-
-        return allowedDomains.stream()
-                .filter(Objects::nonNull)
-                .map(String::trim)
-                .filter(pattern -> !pattern.isEmpty())
-                .map(pattern -> pattern.toLowerCase(Locale.ROOT))
-                .anyMatch(pattern -> {
-                    if (pattern.startsWith("*.")) {
-                        final String suffix = pattern.substring(2);
-                        if (suffix.isEmpty() || !normalizedHost.endsWith("." + suffix)) {
-                            return false;
-                        }
-                        final String subdomain = normalizedHost.substring(0, normalizedHost.length() - suffix.length() - 1);
-                        return !subdomain.isEmpty();
-                    }
-                    return normalizedHost.equals(pattern);
-                });
-    }
-
-    private Completable validateNotPrivateHost(String host, String fieldName, CIMDSettings settings) {
-        if (settings.isAllowPrivateIpAddress()) {
-            return Completable.complete();
-        }
-        return hostSsrfGuard.assertNotPrivateHost(host)
-                .onErrorResumeNext(e -> e instanceof PrivateOrReservedHostException
-                        ? Completable.error(new InvalidClientMetadataException(
-                                fieldName + " resolves to a private or reserved IP address."))
-                        : Completable.error(e));
     }
 
     private Single<FetchResult> fetchMetadataWithTtl(String clientId, CIMDSettings settings) {
@@ -438,68 +354,6 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
         } catch (ParseException ex) {
             throw new InvalidClientMetadataException("Unable to parse jwks content.");
         }
-    }
-
-    private void prefetchLogoAsync(String clientId, String logoUri, long metadataTtlSeconds, CIMDSettings settings) {
-        if (logoUri == null || logoUri.isBlank()) {
-            return;
-        }
-        if (cimdMetadataDocumentManager.getLogoByClientId(clientId).isPresent()) {
-            return;
-        }
-
-        final URI uri;
-        try {
-            uri = toUri(logoUri, "logo_uri");
-        } catch (Exception ex) {
-            log.debug("CIMD logo pre-fetch skipped — invalid URI: {}", logoUri);
-            return;
-        }
-        try {
-            validateUrlTrust(uri, settings, "logo_uri");
-        } catch (Exception ex) {
-            log.debug("CIMD logo pre-fetch skipped — URI not trusted: {}", logoUri);
-            return;
-        }
-
-        validateNotPrivateHost(uri.getHost(), "logo_uri", settings).subscribe(
-                () -> sendLogoPrefetchRequest(clientId, logoUri, metadataTtlSeconds, settings),
-                err -> log.debug("CIMD logo pre-fetch skipped — {}", err.getMessage()));
-    }
-
-    private void sendLogoPrefetchRequest(String clientId, String logoUri, long metadataTtlSeconds, CIMDSettings settings) {
-        final long timeoutMs = resolveTimeoutMs(settings);
-        final var logoCollector = new BoundedBufferWriteStream(MAX_LOGO_SIZE_BYTES);
-
-        webClient.getAbs(logoUri)
-                .timeout(timeoutMs)
-                .followRedirects(true)
-                .as(BodyCodec.pipe(WriteStream.newInstance(logoCollector), false))
-                .rxSend()
-                .subscribe(
-                        response -> {
-                            if (response.statusCode() == HttpStatusCode.OK_200) {
-                                final Buffer body = logoCollector.body().length() > 0 ? logoCollector.body() : response.bodyAsBuffer();
-                                if (body != null && body.length() > 0 && body.length() <= MAX_LOGO_SIZE_BYTES) {
-                                    final byte[] bytes = body.getBytes();
-                                    final String contentType = resolveContentType(response.getHeader("Content-Type"), bytes);
-                                    cimdMetadataDocumentManager.putLogo(clientId, new CachedLogo(bytes, contentType, metadataTtlSeconds));
-                                    log.debug("CIMD logo cached for clientId {}", clientId);
-                                }
-                            }
-                            else {
-                                log.debug("CIMD logo pre-fetch returned {} status code for uri {}", response.statusCode(), logoUri);
-                            }
-                        },
-                        err -> log.debug("CIMD logo pre-fetch failed for uri {}: {}", logoUri, err.getMessage())
-                );
-    }
-
-    private static String resolveContentType(String headerValue, byte[] bytes) {
-        if (headerValue != null && !headerValue.isBlank()) {
-            return headerValue.trim();
-        }
-        return CimdMetadataDocumentManager.detectMimeType(bytes);
     }
 
     private static long resolveTimeoutMs(CIMDSettings settings) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -35,8 +35,10 @@ import io.gravitee.am.gateway.handler.common.certificate.impl.CertificateManager
 import io.gravitee.am.gateway.handler.common.client.ClientManager;
 import io.gravitee.am.gateway.handler.common.client.ClientLookupService;
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdUriTrustValidator;
 import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
 import io.gravitee.am.gateway.handler.common.client.cimd.impl.CimdMetadataServiceImpl;
 import io.gravitee.am.service.CimdMetadataDocumentService;
@@ -259,12 +261,32 @@ public class CommonConfiguration {
     }
 
     @Bean
+    public CimdUriTrustValidator cimdUriTrustValidator(HostSsrfGuard hostSsrfGuard) {
+        return new CimdUriTrustValidator(hostSsrfGuard);
+    }
+
+    @Bean
+    public CimdLogoCacheService cimdLogoCacheService(
+            @Qualifier("oidcWebClient") WebClient webClient,
+            CimdMetadataDocumentManager cimdMetadataDocumentManager,
+            CimdUriTrustValidator cimdUriTrustValidator) {
+        return new CimdLogoCacheService(webClient, cimdMetadataDocumentManager, cimdUriTrustValidator);
+    }
+
+    @Bean
     public CimdMetadataService cimdMetadataService(Domain domain,
                                                    @Qualifier("oidcWebClient") WebClient webClient,
                                                    CimdMetadataDocumentService cimdMetadataDocumentService,
                                                    CimdMetadataDocumentManager cimdMetadataDocumentManager,
-                                                   HostSsrfGuard hostSsrfGuard) {
-        return new CimdMetadataServiceImpl(domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, hostSsrfGuard);
+                                                   CimdUriTrustValidator cimdUriTrustValidator,
+                                                   CimdLogoCacheService cimdLogoCacheService) {
+        return new CimdMetadataServiceImpl(
+                domain,
+                webClient,
+                cimdMetadataDocumentService,
+                cimdMetadataDocumentManager,
+                cimdUriTrustValidator,
+                cimdLogoCacheService);
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdLogoCacheServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdLogoCacheServiceTest.java
@@ -1,0 +1,262 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.client.cimd;
+
+import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.model.oidc.CIMDSettings;
+import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.rxjava3.ext.web.client.HttpRequest;
+import io.vertx.rxjava3.ext.web.client.HttpResponse;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CimdLogoCacheServiceTest {
+
+    @BeforeClass
+    public static void setupSchedulers() {
+        RxJavaPlugins.setIoSchedulerHandler(s -> Schedulers.trampoline());
+    }
+
+    @AfterClass
+    public static void resetSchedulers() {
+        RxJavaPlugins.reset();
+    }
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private HttpRequest<Buffer> request;
+
+    @Mock
+    private HttpResponse<Buffer> response;
+
+    @Mock
+    private CimdMetadataDocumentManager cimdMetadataDocumentManager;
+
+    @Mock
+    private CimdUriTrustValidator cimdUriTrustValidator;
+
+    private CIMDSettings settings;
+    private CimdLogoCacheService cacheService;
+
+    @Before
+    public void setUp() throws Exception {
+        settings = new CIMDSettings();
+        settings.setAllowPrivateIpAddress(true);
+        settings.setFetchTimeoutMs(1500);
+
+        lenient()
+                .when(cimdUriTrustValidator.parseHttpUrl(anyString(), eq("logo_uri")))
+                .thenAnswer(inv -> UriBuilder.fromHttpUrl(inv.getArgument(0)).build());
+        lenient().doNothing().when(cimdUriTrustValidator).validateTrust(any(), any(), eq("logo_uri"));
+        lenient()
+                .when(cimdUriTrustValidator.validateResolvableHost(anyString(), eq("logo_uri"), any()))
+                .thenReturn(Completable.complete());
+
+        cacheService = new CimdLogoCacheService(webClient, cimdMetadataDocumentManager, cimdUriTrustValidator);
+    }
+
+    @Test
+    public void fetchAndCacheNowReturnsEmptyWhenLogoUriBlank() {
+        cacheService.fetchAndCacheNow("cid", "", 60L, settings).test().assertResult(Optional.empty());
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void fetchAndCacheNowReturnsExistingCachedLogoWithoutHttp() {
+        CachedLogo existing = new CachedLogo(new byte[]{1}, "image/png", 120L);
+        when(cimdMetadataDocumentManager.getLogoByClientId("cid")).thenReturn(Optional.of(existing));
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertResult(Optional.of(existing));
+
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void fetchAndCacheNowReturnsEmptyWhenParseFails() {
+        when(cimdUriTrustValidator.parseHttpUrl(anyString(), eq("logo_uri")))
+                .thenThrow(new InvalidClientMetadataException("bad"));
+
+        cacheService.fetchAndCacheNow("cid", "not-a-url", 60L, settings).test().assertResult(Optional.empty());
+
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void fetchAndCacheNowReturnsEmptyWhenTrustRejected() {
+        doThrow(new InvalidClientMetadataException("untrusted"))
+                .when(cimdUriTrustValidator)
+                .validateTrust(any(URI.class), any(CIMDSettings.class), eq("logo_uri"));
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertResult(Optional.empty());
+
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void fetchAndCacheNowReturnsEmptyWhenResolvableHostRejected() {
+        when(cimdUriTrustValidator.validateResolvableHost(anyString(), eq("logo_uri"), any()))
+                .thenReturn(Completable.error(new InvalidClientMetadataException("private")));
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertResult(Optional.empty());
+
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void prefetchLogoAsyncDoesNotPutLogoWhenTrustRejected() {
+        doThrow(new InvalidClientMetadataException("untrusted"))
+                .when(cimdUriTrustValidator)
+                .validateTrust(any(URI.class), any(CIMDSettings.class), eq("logo_uri"));
+
+        cacheService.prefetchLogoAsync("cid", "http://bad/logo.png", 60L, settings);
+
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void prefetchLogoAsyncDoesNotPutLogoWhenResolvableHostRejected() {
+        when(cimdUriTrustValidator.validateResolvableHost(anyString(), eq("logo_uri"), any()))
+                .thenReturn(Completable.error(new InvalidClientMetadataException("blocked")));
+
+        cacheService.prefetchLogoAsync("cid", "https://branding.vendor.example/logo.png", 60L, settings);
+
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void fetchAndCacheNowUsesFollowRedirectsTrue() {
+        mockLogoPipeline();
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer(new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47}));
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertValue(Optional::isPresent);
+
+        verify(request).followRedirects(true);
+    }
+
+    @Test
+    public void fetchAndCacheNowDoesNotPutLogoWhenResponseNotOk() {
+        mockLogoPipeline();
+        when(response.statusCode()).thenReturn(404);
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertResult(Optional.empty());
+
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+    }
+
+    @Test
+    public void fetchAndCacheNowDoesNotPutLogoWhenBodyEmpty() {
+        mockLogoPipeline();
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer());
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertResult(Optional.empty());
+
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+    }
+
+    @Test
+    public void fetchAndCacheNowDoesNotPutLogoWhenBodyExceedsMaxSize() {
+        mockLogoPipeline();
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer(new byte[(int) CimdLogoCacheService.MAX_LOGO_SIZE_BYTES + 1]));
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertResult(Optional.empty());
+
+        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+    }
+
+    @Test
+    public void fetchAndCacheNowUsesContentTypeHeaderWhenPresent() {
+        mockLogoPipeline();
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer(new byte[]{1, 2, 3}));
+        when(response.getHeader("Content-Type")).thenReturn("image/jpeg");
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertValue(Optional::isPresent);
+
+        ArgumentCaptor<CachedLogo> captor = ArgumentCaptor.forClass(CachedLogo.class);
+        verify(cimdMetadataDocumentManager).putLogo(eq("cid"), captor.capture());
+        assertEquals("image/jpeg", captor.getValue().contentType());
+    }
+
+    @Test
+    public void fetchAndCacheNowDetectsMimeFromMagicBytesWhenContentTypeAbsent() {
+        mockLogoPipeline();
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer(new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47}));
+        when(response.getHeader("Content-Type")).thenReturn(null);
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 60L, settings).test().assertValue(Optional::isPresent);
+
+        ArgumentCaptor<CachedLogo> captor = ArgumentCaptor.forClass(CachedLogo.class);
+        verify(cimdMetadataDocumentManager).putLogo(eq("cid"), captor.capture());
+        assertEquals("image/png", captor.getValue().contentType());
+    }
+
+    @Test
+    public void fetchAndCacheNowPassesMetadataTtlAsLogoMaxAge() {
+        mockLogoPipeline();
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer(new byte[]{1, 2, 3}));
+
+        cacheService.fetchAndCacheNow("cid", "https://localhost/logo.png", 900L, settings).test().assertComplete();
+
+        ArgumentCaptor<CachedLogo> captor = ArgumentCaptor.forClass(CachedLogo.class);
+        verify(cimdMetadataDocumentManager).putLogo(eq("cid"), captor.capture());
+        assertEquals(900L, captor.getValue().maxAgeSeconds());
+    }
+
+    private void mockLogoPipeline() {
+        when(webClient.getAbs(anyString())).thenReturn(request);
+        when(request.timeout(anyLong())).thenReturn(request);
+        when(request.followRedirects(true)).thenReturn(request);
+        when(request.as(any())).thenReturn((HttpRequest) request);
+        when(request.rxSend()).thenReturn(Single.just(response));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdMetadataDocumentManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdMetadataDocumentManagerTest.java
@@ -25,6 +25,7 @@ import io.gravitee.am.model.oidc.CIMDSettings;
 import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.common.event.impl.SimpleEvent;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,6 +42,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -158,6 +161,53 @@ public class CimdMetadataDocumentManagerTest {
         manager.afterPropertiesSet();
 
         assertFalse(manager.get(CLIENT_URL).isPresent());
+    }
+
+    // --- resolve() tests ---
+
+    @Test
+    public void resolve_shouldReturnLocalDocWithoutHittingDb() {
+        manager.put(CLIENT_URL, validDocument());
+
+        Optional<CimdMetadataDocument> result = manager.resolve(CLIENT_URL).blockingGet();
+
+        assertTrue(result.isPresent());
+        verify(cimdMetadataDocumentService, never()).findByDomainAndClientId(anyString(), anyString());
+    }
+
+    @Test
+    public void resolve_shouldFallBackToDbAndRestoreLocalCacheOnLocalMiss() {
+        CimdMetadataDocument dbDoc = validDocument();
+        when(cimdMetadataDocumentService.findByDomainAndClientId(DOMAIN_ID, CLIENT_URL))
+                .thenReturn(Maybe.just(dbDoc));
+
+        Optional<CimdMetadataDocument> result = manager.resolve(CLIENT_URL).blockingGet();
+
+        assertTrue(result.isPresent());
+        // local cache should have been restored
+        assertTrue(manager.get(CLIENT_URL).isPresent());
+    }
+
+    @Test
+    public void resolve_shouldReturnEmptyWhenDbDocIsExpired() {
+        CimdMetadataDocument expired = expiredDocument();
+        when(cimdMetadataDocumentService.findByDomainAndClientId(DOMAIN_ID, CLIENT_URL))
+                .thenReturn(Maybe.just(expired));
+
+        Optional<CimdMetadataDocument> result = manager.resolve(CLIENT_URL).blockingGet();
+
+        assertFalse(result.isPresent());
+        assertFalse(manager.get(CLIENT_URL).isPresent());
+    }
+
+    @Test
+    public void resolve_shouldReturnEmptyWhenDbAlsoMisses() {
+        when(cimdMetadataDocumentService.findByDomainAndClientId(DOMAIN_ID, CLIENT_URL))
+                .thenReturn(Maybe.empty());
+
+        Optional<CimdMetadataDocument> result = manager.resolve(CLIENT_URL).blockingGet();
+
+        assertFalse(result.isPresent());
     }
 
     // --- logo cache tests ---

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdUriTrustValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdUriTrustValidatorTest.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.client.cimd;
+
+import io.gravitee.am.common.web.PrivateOrReservedHostException;
+import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
+import io.gravitee.am.model.oidc.CIMDSettings;
+import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.reactivex.rxjava3.core.Completable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CimdUriTrustValidatorTest {
+
+    @Mock
+    private HostSsrfGuard hostSsrfGuard;
+
+    private CimdUriTrustValidator validator;
+
+    @Before
+    public void setUp() {
+        validator = new CimdUriTrustValidator(hostSsrfGuard);
+        when(hostSsrfGuard.assertNotPrivateHost(anyString())).thenReturn(Completable.complete());
+    }
+
+    @Test
+    public void parseHttpUrlBuildsUriForHttps() throws Exception {
+        URI uri = validator.parseHttpUrl("https://registry.example.com/app", "client_id");
+        assertEquals("registry.example.com", uri.getHost());
+    }
+
+    @Test
+    public void parseHttpUrlRejectsMalformedValue() {
+        assertThrows(InvalidClientMetadataException.class, () -> validator.parseHttpUrl("not-a-url", "logo_uri"));
+    }
+
+    @Test
+    public void validateTrustAcceptsHttpsByDefault() throws Exception {
+        CIMDSettings settings = settingsAllowPrivateLiterals();
+        URI uri = UriBuilder.fromHttpUrl("https://registry.example.com/app").build();
+        validator.validateTrust(uri, settings, "client_id");
+    }
+
+    @Test
+    public void validateTrustRejectsHttpWhenUnsecuredDisabled() throws Exception {
+        CIMDSettings settings = settingsAllowPrivateLiterals();
+        settings.setAllowUnsecuredHttpUri(false);
+        URI uri = UriBuilder.fromHttpUrl("http://registry.example.com/app").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "logo_uri"));
+    }
+
+    @Test
+    public void validateTrustAcceptsHttpWhenUnsecuredEnabled() throws Exception {
+        CIMDSettings settings = settingsAllowPrivateLiterals();
+        settings.setAllowUnsecuredHttpUri(true);
+        URI uri = UriBuilder.fromHttpUrl("http://registry.example.com/app").build();
+        validator.validateTrust(uri, settings, "client_id");
+    }
+
+    @Test
+    public void validateTrustRejectsHostOutsideAllowedDomains() throws Exception {
+        CIMDSettings settings = settingsAllowPrivateLiterals();
+        settings.setAllowedDomains(List.of("*.vendor.example"));
+        URI uri = UriBuilder.fromHttpUrl("https://evil.example/logo.png").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "logo_uri"));
+    }
+
+    @Test
+    public void validateTrustAllowsHostInsideAllowedDomains() throws Exception {
+        CIMDSettings settings = settingsAllowPrivateLiterals();
+        settings.setAllowedDomains(List.of("localhost"));
+        URI uri = UriBuilder.fromHttpUrl("https://localhost/metadata").build();
+        validator.validateTrust(uri, settings, "client_id");
+    }
+
+    @Test
+    public void validateTrustRejectsLoopbackIpv4LiteralWhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://127.0.0.1/metadata").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "client_id"));
+    }
+
+    @Test
+    public void validateTrustAllowsLoopbackIpv4WhenPrivateEnabled() throws Exception {
+        CIMDSettings settings = settingsAllowPrivateLiterals();
+        URI uri = UriBuilder.fromHttpUrl("https://127.0.0.1/metadata").build();
+        validator.validateTrust(uri, settings, "client_id");
+    }
+
+    @Test
+    public void validateTrustRejectsPrivateClassAIpLiteralWhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://10.0.0.1/metadata").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "client_id"));
+    }
+
+    @Test
+    public void validateTrustRejectsPrivateClassBIpLiteralWhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://172.16.0.1/metadata").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "client_id"));
+    }
+
+    @Test
+    public void validateTrustRejectsPrivateClassCIpLiteralWhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://192.168.1.1/metadata").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "client_id"));
+    }
+
+    @Test
+    public void validateTrustRejectsLinkLocalIpv4LiteralWhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://169.254.169.254/metadata").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "client_id"));
+    }
+
+    @Test
+    public void validateTrustRejectsLoopbackIpv6LiteralWhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://[::1]/metadata").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "client_id"));
+    }
+
+    @Test
+    public void validateTrustRejectsLinkLocalIpv6LiteralWhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://[fe80::1]/metadata").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "client_id"));
+    }
+
+    @Test
+    public void validateTrustAllowsPublicIpv4LiteralWhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://8.8.8.8/metadata").build();
+        validator.validateTrust(uri, settings, "client_id");
+    }
+
+    @Test
+    public void validateTrustAllowsPrivateLiteralsWhenPrivateEnabled() throws Exception {
+        CIMDSettings settings = settingsAllowPrivateLiterals();
+        validator.validateTrust(UriBuilder.fromHttpUrl("https://10.0.0.1/metadata").build(), settings, "client_id");
+    }
+
+    @Test
+    public void validateTrustRejectsLogoAuthorityPrivateIpv4WhenPrivateDisabled() throws Exception {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        URI uri = UriBuilder.fromHttpUrl("https://192.168.0.1/logo.png").build();
+        assertThrows(InvalidClientMetadataException.class, () -> validator.validateTrust(uri, settings, "logo_uri"));
+    }
+
+    @Test
+    public void validateResolvableHostSkipsDnsWhenPrivateIpsAllowed() {
+        CIMDSettings settings = settingsAllowPrivateLiterals();
+        validator.validateResolvableHost("host.example", "client_id", settings).test().assertComplete();
+        verifyNoInteractions(hostSsrfGuard);
+    }
+
+    @Test
+    public void validateResolvableHostCompletesWhenGuardAllows() {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        validator.validateResolvableHost("external.example.com", "client_id", settings).test().assertComplete();
+        verify(hostSsrfGuard).assertNotPrivateHost(eq("external.example.com"));
+    }
+
+    @Test
+    public void validateResolvableHostMapsPrivateDnsFailureToInvalidMetadata() {
+        when(hostSsrfGuard.assertNotPrivateHost(eq("vendor.example")))
+                .thenReturn(Completable.error(new PrivateOrReservedHostException("loopback")));
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(false);
+        validator.validateResolvableHost("vendor.example", "logo_uri", settings).test().assertFailure(InvalidClientMetadataException.class);
+    }
+
+    private static CIMDSettings baseSettings() {
+        CIMDSettings settings = new CIMDSettings();
+        settings.setAllowUnsecuredHttpUri(false);
+        return settings;
+    }
+
+    private static CIMDSettings settingsAllowPrivateLiterals() {
+        CIMDSettings settings = baseSettings();
+        settings.setAllowPrivateIpAddress(true);
+        return settings;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
@@ -15,10 +15,11 @@
  */
 package io.gravitee.am.gateway.handler.common.client.cimd.impl;
 
-import io.gravitee.am.gateway.handler.common.client.cimd.CachedLogo;
+import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
-import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
+import io.gravitee.am.gateway.handler.common.client.cimd.CimdUriTrustValidator;
 import io.gravitee.am.model.CimdMetadataDocument;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.application.ApplicationScopeSettings;
@@ -29,6 +30,7 @@ import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
@@ -40,12 +42,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.ext.web.client.HttpRequest;
 import io.vertx.rxjava3.ext.web.client.HttpResponse;
 import io.vertx.rxjava3.ext.web.client.WebClient;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -61,6 +63,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -93,6 +97,12 @@ public class CimdMetadataServiceImplTest {
     private HttpResponse<Buffer> response;
 
     @Mock
+    private CimdUriTrustValidator uriTrustValidator;
+
+    @Mock
+    private CimdLogoCacheService logoCacheService;
+
+    @Mock
     private CimdMetadataDocumentService cimdMetadataDocumentService;
 
     @Mock
@@ -114,16 +124,40 @@ public class CimdMetadataServiceImplTest {
         oidcSettings.setCimdSettings(cimdSettings);
         domain.setOidc(oidcSettings);
 
-        // Default: local cache miss, DB miss — falls through to HTTP fetch
-        when(cimdMetadataDocumentManager.get(anyString())).thenReturn(Optional.empty());
-        when(cimdMetadataDocumentManager.getLogoByClientId(anyString())).thenReturn(Optional.empty());
-        when(cimdMetadataDocumentService.findByDomainAndClientId(anyString(), anyString())).thenReturn(Maybe.empty());
+        // Default: cache miss — falls through to HTTP fetch
+        when(cimdMetadataDocumentManager.resolve(anyString())).thenReturn(Single.just(Optional.empty()));
+        lenient().when(cimdMetadataDocumentManager.getLogoByClientId(anyString())).thenReturn(Optional.empty());
         when(cimdMetadataDocumentService.upsert(any(), anyString(), anyString(), any(Duration.class)))
                 .thenReturn(Single.just(new CimdMetadataDocument()));
 
-        HostSsrfGuard hostSsrfGuard = new HostSsrfGuard(host -> new java.net.InetAddress[]{java.net.InetAddress.getByName("8.8.8.8")});
-        cimdMetadataService = new CimdMetadataServiceImpl(domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager,
-                hostSsrfGuard);
+        lenient()
+                .when(uriTrustValidator.parseHttpUrl(anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    try {
+                        return UriBuilder.fromHttpUrl(invocation.getArgument(0)).build();
+                    } catch (Exception ex) {
+                        throw new InvalidClientMetadataException(invocation.getArgument(1) + " is not a valid URL.");
+                    }
+                });
+        lenient().doNothing().when(uriTrustValidator).validateTrust(any(), any(), anyString());
+        lenient()
+                .when(uriTrustValidator.validateResolvableHost(anyString(), anyString(), any()))
+                .thenReturn(Completable.complete());
+
+        cimdMetadataService = new CimdMetadataServiceImpl(
+                domain,
+                webClient,
+                cimdMetadataDocumentService,
+                cimdMetadataDocumentManager,
+                uriTrustValidator,
+                logoCacheService);
+    }
+
+    @After
+    public void resetCimdTrustPolicy() {
+        cimdSettings.setAllowPrivateIpAddress(true);
+        cimdSettings.setAllowUnsecuredHttpUri(false);
+        cimdSettings.setAllowedDomains(null);
     }
 
     @Test
@@ -137,255 +171,15 @@ public class CimdMetadataServiceImplTest {
     }
 
     @Test
-    public void shouldRejectHttpWhenUnsecuredHttpIsDisabled() {
-        cimdSettings.setAllowUnsecuredHttpUri(false);
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("http://localhost/metadata", templateClient()).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldAcceptHttpWhenUnsecuredHttpIsEnabled() {
-        cimdSettings.setAllowUnsecuredHttpUri(true);
-        mockFetchSuccess(metadataPayload("http://localhost/metadata"));
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("http://localhost/metadata", templateClient()).test();
-
-        testObserver.assertComplete();
-        testObserver.assertNoErrors();
-        testObserver.assertValue(client -> "http://localhost/metadata".equals(client.getClientId()));
-    }
-
-    @Test
-    public void shouldRejectLoopbackIpLiteralWhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://127.0.0.1/metadata", templateClient()).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldAllowUnresolvableHostnameWhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-        mockFetchSuccess(metadataPayload("https://non-resolvable.example.invalid/metadata"));
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://non-resolvable.example.invalid/metadata", templateClient()).test();
-
-        testObserver.assertComplete();
-        testObserver.assertNoErrors();
-        testObserver.assertValue(client -> "https://non-resolvable.example.invalid/metadata".equals(client.getClientId()));
-    }
-
-    @Test
-    public void shouldAllowPrivateIpWhenPrivateIpIsEnabled() {
-        cimdSettings.setAllowPrivateIpAddress(true);
-        mockFetchSuccess(metadataPayload("https://127.0.0.1/metadata"));
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://127.0.0.1/metadata", templateClient()).test();
-
-        testObserver.assertComplete();
-        testObserver.assertNoErrors();
-        testObserver.assertValue(client -> "https://127.0.0.1/metadata".equals(client.getClientId()));
-    }
-
-    @Test
-    public void shouldRejectPrivateClassAIpWhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://10.0.0.1/metadata", templateClient()).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldRejectPrivateClassBIpWhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://172.16.0.1/metadata", templateClient()).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldRejectPrivateClassCIpWhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://192.168.1.1/metadata", templateClient()).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldRejectLinkLocalIpv4WhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://169.254.169.254/metadata", templateClient()).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldRejectLoopbackIpv6WhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://[::1]/metadata", templateClient()).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldRejectLinkLocalIpv6WhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://[fe80::1]/metadata", templateClient()).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldAllowPublicIpWhenPrivateIpIsDisabled() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-        mockFetchSuccess(metadataPayload("https://8.8.8.8/metadata"));
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://8.8.8.8/metadata", templateClient()).test();
-
-        testObserver.assertComplete();
-        testObserver.assertNoErrors();
-        testObserver.assertValue(client -> "https://8.8.8.8/metadata".equals(client.getClientId()));
-    }
-
-    @Test
-    public void shouldAllowPrivateIpRangesWhenPrivateIpIsEnabled() {
-        cimdSettings.setAllowPrivateIpAddress(true);
-        mockFetchSuccess(metadataPayload("https://10.0.0.1/metadata"));
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient("https://10.0.0.1/metadata", templateClient()).test();
-
-        testObserver.assertComplete();
-        testObserver.assertNoErrors();
-    }
-
-    @Test
-    public void shouldRejectLogoUriWithPrivateIpWhenPrivateIpIsDisabled() {
-        // Use a non-private client_id URL so Phase 1 does not block the main request.
-        // The logo_uri has a private IP — prefetchLogoAsync must not fetch it.
-        cimdSettings.setAllowPrivateIpAddress(false);
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://192.168.0.1/logo.png");
-        dbDoc.setClientId(EXTERNAL_URL);
-        dbDoc.setMetadata(metadataPayloadWithLogo(EXTERNAL_URL, "https://192.168.0.1/logo.png"));
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", EXTERNAL_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        when(cimdMetadataDocumentManager.get(EXTERNAL_URL)).thenReturn(Optional.empty());
-        when(cimdMetadataDocumentManager.getLogoByClientId(EXTERNAL_URL)).thenReturn(Optional.empty());
-
-        cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test().assertComplete();
-
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldSkipLogoPrefetchWhenLogoHostnameResolvesToPrivateIp() {
-        cimdSettings.setAllowPrivateIpAddress(false);
-        HostSsrfGuard rejectingGuard = new HostSsrfGuard(host ->
-                new java.net.InetAddress[]{java.net.InetAddress.getLoopbackAddress()});
-        cimdMetadataService = new CimdMetadataServiceImpl(
-                domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, rejectingGuard);
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://branding.vendor.example/logo.png");
-        dbDoc.setClientId(EXTERNAL_URL);
-        dbDoc.setMetadata(metadataPayloadWithLogo(EXTERNAL_URL, "https://branding.vendor.example/logo.png"));
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", EXTERNAL_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        when(cimdMetadataDocumentManager.get(EXTERNAL_URL)).thenReturn(Optional.empty());
-        when(cimdMetadataDocumentManager.getLogoByClientId(EXTERNAL_URL)).thenReturn(Optional.empty());
-
-        cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test().assertComplete();
-
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldSkipLogoPrefetchAfterOriginFetchWhenLogoHostnameResolvesToPrivateIp() throws Exception {
-        cimdSettings.setAllowPrivateIpAddress(false);
-        HostSsrfGuard selectiveGuard = new HostSsrfGuard(host -> {
-            if ("external.example.com".equalsIgnoreCase(host)) {
-                return new java.net.InetAddress[]{java.net.InetAddress.getByName("8.8.8.8")};
-            }
-            return new java.net.InetAddress[]{java.net.InetAddress.getLoopbackAddress()};
-        });
-        cimdMetadataService = new CimdMetadataServiceImpl(
-                domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, selectiveGuard);
-        mockFetchSuccess(metadataPayloadWithLogo(EXTERNAL_URL, "https://branding.vendor.example/logo.png"));
-
-        cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test().assertComplete();
-
-        verify(request, times(1)).rxSend();
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
-    }
-
-    @Test
-    public void shouldRejectWhenHostSsrfGuardRejectsHostname() {
-        HostSsrfGuard rejectingGuard = new HostSsrfGuard(host ->
-                new java.net.InetAddress[]{java.net.InetAddress.getLoopbackAddress()});
-        cimdMetadataService = new CimdMetadataServiceImpl(
-                domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, rejectingGuard);
+    public void shouldRejectWhenResolvableHostRejectedForClientId() {
+        when(uriTrustValidator.validateResolvableHost(eq("external.example.com"), eq("client_id"), eq(cimdSettings)))
+                .thenReturn(Completable.error(new InvalidClientMetadataException("private")));
         cimdSettings.setAllowPrivateIpAddress(false);
 
         TestObserver<Client> testObserver = cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test();
 
         testObserver.assertError(InvalidClientMetadataException.class);
         verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldAllowWhenHostSsrfGuardAllowsHostname() throws Exception {
-        java.net.InetAddress publicIp = java.net.InetAddress.getByName("8.8.8.8");
-        HostSsrfGuard allowingGuard = new HostSsrfGuard(host -> new java.net.InetAddress[]{publicIp});
-        cimdMetadataService = new CimdMetadataServiceImpl(
-                domain, webClient, cimdMetadataDocumentService, cimdMetadataDocumentManager, allowingGuard);
-        cimdSettings.setAllowPrivateIpAddress(false);
-        mockFetchSuccess(metadataPayload(EXTERNAL_URL));
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test();
-
-        testObserver.assertComplete();
-        testObserver.assertNoErrors();
-        testObserver.assertValueCount(1);
-    }
-
-    @Test
-    public void shouldRejectHostOutsideAllowedDomains() {
-        cimdSettings.setAllowedDomains(List.of("*.example.com"));
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
-
-        testObserver.assertError(e -> e instanceof InvalidClientMetadataException
-                && e.getMessage().contains("client_id")
-                && e.getMessage().contains("allowed domains"));
-        verifyNoInteractions(webClient);
-    }
-
-    @Test
-    public void shouldAllowHostInsideAllowedDomains() {
-        cimdSettings.setAllowedDomains(List.of("localhost"));
-        mockFetchSuccess(metadataPayload(CLIENT_URL));
-
-        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
-
-        testObserver.assertComplete();
-        testObserver.assertNoErrors();
-        testObserver.assertValue(client -> CLIENT_URL.equals(client.getClientId()));
     }
 
     @Test
@@ -834,7 +628,7 @@ public class CimdMetadataServiceImplTest {
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
         verify(request).followRedirects(false);
-        verify(request).followRedirects(true);
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq("https://localhost/logo.png"), anyLong(), eq(cimdSettings));
     }
 
     @Test
@@ -859,7 +653,7 @@ public class CimdMetadataServiceImplTest {
         when(webClient.getAbs(anyString())).thenReturn(request);
         when(request.timeout(anyLong())).thenReturn(request);
         when(request.followRedirects(false)).thenReturn(request);
-        when(request.followRedirects(true)).thenReturn(request);
+        lenient().when(request.followRedirects(true)).thenReturn(request);
         when(request.as(any())).thenReturn((HttpRequest) request);
     }
 
@@ -877,7 +671,7 @@ public class CimdMetadataServiceImplTest {
     @Test
     public void shouldReturnFromLocalCacheWithoutHttpOrDbCall() {
         CimdMetadataDocument cached = cachedDocument(false);
-        when(cimdMetadataDocumentManager.get(CLIENT_URL)).thenReturn(Optional.of(cached));
+        when(cimdMetadataDocumentManager.resolve(CLIENT_URL)).thenReturn(Single.just(Optional.of(cached)));
 
         TestObserver<Client> obs = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
 
@@ -885,14 +679,12 @@ public class CimdMetadataServiceImplTest {
         obs.assertNoErrors();
         obs.assertValueCount(1);
         verifyNoInteractions(webClient);
-        verify(cimdMetadataDocumentService, never()).findByDomainAndClientId(anyString(), anyString());
     }
 
     @Test
     public void shouldReturnFromDbCacheWithoutHttpCall() {
         CimdMetadataDocument dbDoc = cachedDocument(false);
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
+        when(cimdMetadataDocumentManager.resolve(CLIENT_URL)).thenReturn(Single.just(Optional.of(dbDoc)));
 
         TestObserver<Client> obs = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
 
@@ -900,23 +692,6 @@ public class CimdMetadataServiceImplTest {
         obs.assertNoErrors();
         obs.assertValueCount(1);
         verifyNoInteractions(webClient);
-        verify(cimdMetadataDocumentManager).put(CLIENT_URL, dbDoc);
-    }
-
-    @Test
-    public void shouldFetchFromOriginWhenDbDocumentIsExpired() {
-        CimdMetadataDocument expiredDoc = cachedDocument(true);
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(expiredDoc));
-        mockFetchSuccess(metadataPayload(CLIENT_URL));
-
-        TestObserver<Client> obs = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
-
-        obs.assertComplete();
-        obs.assertNoErrors();
-        obs.assertValueCount(1);
-        verify(request).as(any());
-        verify(cimdMetadataDocumentService).upsert(any(), anyString(), anyString(), any(Duration.class));
     }
 
     @Test
@@ -1037,7 +812,7 @@ public class CimdMetadataServiceImplTest {
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager).putLogo(eq(CLIENT_URL), any(CachedLogo.class));
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq("https://localhost/logo.png"), anyLong(), eq(cimdSettings));
     }
 
     @Test
@@ -1046,46 +821,39 @@ public class CimdMetadataServiceImplTest {
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verify(logoCacheService, never()).prefetchLogoAsync(anyString(), any(), anyLong(), any());
     }
 
     @Test
-    public void shouldTriggerLogoPrefetchOnDbHitWhenLogoNotYetCached() {
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        when(cimdMetadataDocumentManager.getLogoByClientId(CLIENT_URL)).thenReturn(Optional.empty());
-        mockLogoFetch();
+    public void shouldTriggerLogoPrefetchOnCacheHitWhenLogoNotYetCached() {
+        CimdMetadataDocument doc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
+        when(cimdMetadataDocumentManager.resolve(CLIENT_URL)).thenReturn(Single.just(Optional.of(doc)));
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager).putLogo(eq(CLIENT_URL), any(CachedLogo.class));
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq("https://localhost/logo.png"), anyLong(), eq(cimdSettings));
     }
 
     @Test
-    public void shouldSkipLogoPrefetchOnDbHitWhenLogoAlreadyCached() {
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        when(cimdMetadataDocumentManager.getLogoByClientId(CLIENT_URL))
-                .thenReturn(Optional.of(new CachedLogo(new byte[]{1, 2, 3}, "image/png", 3600L)));
+    public void shouldSkipLogoPrefetchOnCacheHitWhenLogoAlreadyCached() {
+        CimdMetadataDocument doc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
+        when(cimdMetadataDocumentManager.resolve(CLIENT_URL)).thenReturn(Single.just(Optional.of(doc)));
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq("https://localhost/logo.png"), anyLong(), eq(cimdSettings));
     }
 
     // --- logo_uri validation and edge cases ---
 
     @Test
     public void shouldNotPrefetchLogoWhenLogoUriIsNull() {
-        CimdMetadataDocument dbDoc = cachedDocument(false);
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
+        CimdMetadataDocument doc = cachedDocument(false);
+        when(cimdMetadataDocumentManager.resolve(CLIENT_URL)).thenReturn(Single.just(Optional.of(doc)));
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), isNull(), anyLong(), eq(cimdSettings));
         verifyNoInteractions(webClient);
     }
 
@@ -1095,142 +863,53 @@ public class CimdMetadataServiceImplTest {
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq(""), anyLong(), eq(cimdSettings));
     }
 
     @Test
     public void shouldNotFetchLogoWhenLogoUriIsInvalid() {
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "not-a-url");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
+        CimdMetadataDocument doc = cachedDocumentWithLogo(false, "not-a-url");
+        when(cimdMetadataDocumentManager.resolve(CLIENT_URL)).thenReturn(Single.just(Optional.of(doc)));
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq("not-a-url"), anyLong(), eq(cimdSettings));
         verifyNoInteractions(webClient);
     }
 
     @Test
     public void shouldNotFetchLogoWhenLogoUriIsUntrusted() {
         cimdSettings.setAllowUnsecuredHttpUri(false);
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "http://localhost/logo.png");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
+        CimdMetadataDocument doc = cachedDocumentWithLogo(false, "http://localhost/logo.png");
+        when(cimdMetadataDocumentManager.resolve(CLIENT_URL)).thenReturn(Single.just(Optional.of(doc)));
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq("http://localhost/logo.png"), anyLong(), eq(cimdSettings));
         verifyNoInteractions(webClient);
     }
 
     @Test
     public void shouldNotFetchLogoWhenLogoHostOutsideAllowedDomains() {
         cimdSettings.setAllowedDomains(List.of("*.example.com"));
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://cdn.evil.net/logo.png");
-        dbDoc.setClientId(EXTERNAL_URL);
-        dbDoc.setMetadata(metadataPayloadWithLogo(EXTERNAL_URL, "https://cdn.evil.net/logo.png"));
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", EXTERNAL_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        when(cimdMetadataDocumentManager.get(EXTERNAL_URL)).thenReturn(Optional.empty());
-        when(cimdMetadataDocumentManager.getLogoByClientId(EXTERNAL_URL)).thenReturn(Optional.empty());
+        CimdMetadataDocument doc = cachedDocumentWithLogo(false, "https://cdn.evil.net/logo.png");
+        doc.setClientId(EXTERNAL_URL);
+        doc.setMetadata(metadataPayloadWithLogo(EXTERNAL_URL, "https://cdn.evil.net/logo.png"));
+        when(cimdMetadataDocumentManager.resolve(EXTERNAL_URL)).thenReturn(Single.just(Optional.of(doc)));
 
         cimdMetadataService.resolveClient(EXTERNAL_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
+        verify(logoCacheService).prefetchLogoAsync(eq(EXTERNAL_URL), eq("https://cdn.evil.net/logo.png"), anyLong(), eq(cimdSettings));
         verifyNoInteractions(webClient);
     }
 
     @Test
     public void shouldSkipLogoPrefetchOnFreshFetchWhenLogoAlreadyCached() {
-        when(cimdMetadataDocumentManager.getLogoByClientId(CLIENT_URL))
-                .thenReturn(Optional.of(new CachedLogo(new byte[]{1, 2, 3}, "image/png", 3600L)));
         mockFetchSuccess(metadataPayloadWithLogo(CLIENT_URL, "https://localhost/logo.png"));
 
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
-    }
-
-    @Test
-    public void shouldNotCacheLogoWhenResponseIsNotOk() {
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        mockLogoFetch();
-        when(response.statusCode()).thenReturn(404);
-
-        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
-
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
-    }
-
-    @Test
-    public void shouldNotCacheLogoWhenBodyIsEmpty() {
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        mockLogoFetch();
-        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer());
-
-        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
-
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
-    }
-
-    @Test
-    public void shouldNotCacheLogoWhenBodyExceedsMaxSize() {
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        mockLogoFetch();
-        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer(new byte[256 * 1024 + 1]));
-
-        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
-
-        verify(cimdMetadataDocumentManager, never()).putLogo(anyString(), any());
-    }
-
-    @Test
-    public void shouldUseContentTypeHeaderWhenPresentForLogo() {
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        mockLogoFetch();
-        when(response.getHeader("Content-Type")).thenReturn("image/jpeg");
-
-        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
-
-        ArgumentCaptor<CachedLogo> captor = ArgumentCaptor.forClass(CachedLogo.class);
-        verify(cimdMetadataDocumentManager).putLogo(eq(CLIENT_URL), captor.capture());
-        assertEquals("image/jpeg", captor.getValue().contentType());
-    }
-
-    @Test
-    public void shouldDetectMimeTypeFromMagicBytesWhenContentTypeHeaderAbsent() {
-        CimdMetadataDocument dbDoc = cachedDocumentWithLogo(false, "https://localhost/logo.png");
-        when(cimdMetadataDocumentService.findByDomainAndClientId("domain-id", CLIENT_URL))
-                .thenReturn(Maybe.just(dbDoc));
-        mockLogoFetch();
-        when(response.getHeader("Content-Type")).thenReturn(null);
-
-        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
-
-        ArgumentCaptor<CachedLogo> captor = ArgumentCaptor.forClass(CachedLogo.class);
-        verify(cimdMetadataDocumentManager).putLogo(eq(CLIENT_URL), captor.capture());
-        assertEquals("image/png", captor.getValue().contentType());
-    }
-
-    @Test
-    public void shouldUseMetadataTtlForLogoMaxAge() {
-        // Metadata Cache-Control resolves to 900s; logo server Cache-Control is irrelevant
-        cimdSettings.setCacheTtlSeconds(1800);
-        mockFetchSuccessWithCacheControl(metadataPayloadWithLogo(CLIENT_URL, "https://localhost/logo.png"), "max-age=900");
-
-        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
-
-        ArgumentCaptor<CachedLogo> captor = ArgumentCaptor.forClass(CachedLogo.class);
-        verify(cimdMetadataDocumentManager).putLogo(eq(CLIENT_URL), captor.capture());
-        assertEquals(900L, captor.getValue().maxAgeSeconds());
+        verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq("https://localhost/logo.png"), anyLong(), eq(cimdSettings));
     }
 
     // --- helpers ---
@@ -1244,17 +923,6 @@ public class CimdMetadataServiceImplTest {
         doc.setExpiresAt(expired ? new Date(System.currentTimeMillis() - 1000) : new Date(System.currentTimeMillis() + 86400_000));
         doc.setUpdatedAt(new Date());
         return doc;
-    }
-
-    private void mockLogoFetch() {
-        when(webClient.getAbs(anyString())).thenReturn(request);
-        when(request.timeout(anyLong())).thenReturn(request);
-        when(request.followRedirects(true)).thenReturn(request);
-        when(request.as(any())).thenReturn((HttpRequest) request);
-        when(request.rxSend()).thenReturn(Single.just(response));
-        when(response.statusCode()).thenReturn(200);
-        when(response.bodyAsBuffer()).thenReturn(Buffer.buffer(new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47}));
-        when(response.getHeader("Content-Type")).thenReturn("image/png");
     }
 
     private void mockFetchSuccessWithCacheControl(String payload, String cacheControlHeader) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/main.css
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/main.css
@@ -284,6 +284,10 @@ form div {
     text-align: center;
 }
 
+.header-description > * {
+    vertical-align: middle;
+}
+
 .input-field {
     box-sizing: border-box;
     display: flex;
@@ -715,4 +719,29 @@ div#passwordSettings > p {
 .invalid:before {
     padding-right: 10px;
     content: url("../images/invalid.svg");
+}
+
+.cimd-consent-client-logo {
+    width: 48px;
+    height: 48px;
+    max-width: 48px;
+    max-height: 48px;
+    object-fit: contain;
+    flex-shrink: 0;
+}
+
+.cimd-consent-host-verified {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    font-size: 14px;
+    line-height: 18px;
+    color: #1b5e20;
+}
+
+.cimd-consent-host-verified .icons {
+    font-size: 18px;
+    line-height: 18px;
+    color: #1b5e20;
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/oauth2_user_consent.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/oauth2_user_consent.html
@@ -27,6 +27,8 @@
             <span th:text="#{oauth.consent.title}"/>
         </div>
         <div class="header-description">
+            <img class="cimd-consent-client-logo" th:if="${cimdLogoUrl}" th:src="${cimdLogoUrl}"
+                 th:attr="alt=${client.clientName}" onerror="this.style.display='none'">
             <span class="deep-blue" th:text="${client.clientName}"/> <span th:text="#{oauth.consent.description}"/>
         </div>
     </div>
@@ -46,6 +48,12 @@
 
             <span class="header-description start" th:text="${client.clientName} + ' ' + #{oauth.disclaimer}"></span>
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+
+            <div class="cimd-consent-host-verified" th:if="${cimdClientIdHostname}">
+                <span class="icons">check_circle</span>
+                <strong class="cimd-consent-hostname" th:text="${cimdClientIdHostname}"></strong>
+                <span th:text="#{oauth.consent.cimd.verified}"></span>
+            </div>
 
             <div>
                 <button type="submit" name="user_oauth_approval" value="true" class="button primary" th:text="#{oauth.button.accept}"></button>

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/CimdConsentPageAttributes.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/CimdConsentPageAttributes.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oauth2.resources.endpoint.authorization.consent;
+
+import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.oidc.Client;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+
+import java.net.URI;
+import java.util.Map;
+
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+
+/**
+ * Adds optional consent template attributes for URL-shaped (CIMD) OAuth clients.
+ */
+public final class CimdConsentPageAttributes {
+
+    static final String CIMD_CLIENT_ID_HOSTNAME_KEY = "cimdClientIdHostname";
+    static final String CIMD_DOMAIN_VERIFIED_KEY = "cimdDomainVerified";
+    static final String CIMD_LOGO_URL_KEY = "cimdLogoUrl";
+
+    private CimdConsentPageAttributes() {}
+
+    /**
+     * When the client is resolved via CIMD (URL-shaped {@code client_id} and CIMD enabled on the domain),
+     * exposes hostname, verified-domain messaging context, and a same-origin logo URL when {@code logo_uri} is set.
+     */
+    public static void putIfApplicable(RoutingContext routingContext, Domain domain, Client client) {
+        if (client == null
+                || !ClientIds.isUrlShaped(client.getClientId())
+                || domain == null
+                || domain.getOidc() == null
+                || domain.getOidc().getCimdSettings() == null
+                || !domain.getOidc().getCimdSettings().isEnabled()) {
+            return;
+        }
+
+        final String canonicalClientId = ClientIds.canonicalize(client.getClientId());
+        final String host;
+        try {
+            URI uri = UriBuilder.fromHttpUrl(canonicalClientId).build();
+            host = uri.getHost();
+        } catch (Exception e) {
+            return;
+        }
+        if (host == null || host.isBlank()) {
+            return;
+        }
+
+        routingContext.put(CIMD_CLIENT_ID_HOSTNAME_KEY, host);
+        routingContext.put(CIMD_DOMAIN_VERIFIED_KEY, Boolean.TRUE);
+
+        if (client.getLogoUri() != null && !client.getLogoUri().isBlank()) {
+            final String contextPath = routingContext.get(CONTEXT_PATH) != null ? routingContext.get(CONTEXT_PATH) : "";
+            final String logoUrl = UriBuilderRequest.resolveProxyRequest(
+                    routingContext.request(),
+                    contextPath + "/cimd/logo",
+                    Map.of("clientId", canonicalClientId),
+                    true);
+            routingContext.put(CIMD_LOGO_URL_KEY, logoUrl);
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/UserConsentEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/UserConsentEndpoint.java
@@ -76,6 +76,7 @@ public class UserConsentEndpoint implements Handler<RoutingContext> {
             List<Scope> requestedScopes = h.result();
             routingContext.put(ConstantKeys.SCOPES_CONTEXT_KEY, requestedScopes);
             routingContext.put(ConstantKeys.ACTION_KEY, action);
+            CimdConsentPageAttributes.putIfApplicable(routingContext, domain, client);
             engine.render(generateData(routingContext, domain, client), getTemplateFileName(client))
                     .subscribe(
                             buffer -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -205,6 +205,7 @@ reset_password.error.description.label=Error description:
 
 oauth.consent.title=Permissions requested
 oauth.consent.description=would like to
+oauth.consent.cimd.verified=verified domain
 oauth.disclaimer=will be able to use your data in accordance to their terms of service and privacy policies.
 oauth.button.accept=Accept
 oauth.button.cancel=Cancel

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
@@ -205,6 +205,7 @@ reset_password.error.description.label=Description de l'erreur :
 
 oauth.consent.title=Autorisations demandées
 oauth.consent.description=souhaite
+oauth.consent.cimd.verified=domaine vérifié
 oauth.disclaimer=sera en mesure d'utiliser vos données conformément à ses conditions d'utilisation et à sa politique de confidentialité.
 oauth.button.accept=Accepter
 oauth.button.cancel=Annuler

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/assets/preview/css/main.css
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/assets/preview/css/main.css
@@ -281,6 +281,10 @@ form div {
     text-align: center;
 }
 
+.header-description > * {
+    vertical-align: middle;
+}
+
 .input-field {
     box-sizing: border-box;
     display: flex;
@@ -683,4 +687,29 @@ div#passwordSettings > p {
 .invalid:before {
     padding-right: 10px;
     content: url("../images/invalid.svg");
+}
+
+.cimd-consent-client-logo {
+    width: 48px;
+    height: 48px;
+    max-width: 48px;
+    max-height: 48px;
+    object-fit: contain;
+    flex-shrink: 0;
+}
+
+.cimd-consent-host-verified {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    font-size: 14px;
+    line-height: 18px;
+    color: #1b5e20;
+}
+
+.cimd-consent-host-verified .icons {
+    font-size: 18px;
+    line-height: 18px;
+    color: #1b5e20;
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/oauth2_user_consent.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/oauth2_user_consent.html
@@ -27,6 +27,8 @@
             <span th:text="#{oauth.consent.title}"/>
         </div>
         <div class="header-description">
+            <img class="cimd-consent-client-logo" th:if="${cimdLogoUrl}" th:src="${cimdLogoUrl}"
+                 th:attr="alt=${client.clientName}" onerror="this.style.display='none'">
             <span class="deep-blue" th:text="${client.clientName}"/> <span th:text="#{oauth.consent.description}"/>
         </div>
     </div>
@@ -46,6 +48,12 @@
 
             <span class="header-description start" th:text="${client.clientName} + ' ' + #{oauth.disclaimer}"></span>
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+
+            <div class="cimd-consent-host-verified" th:if="${cimdClientIdHostname}">
+                <span class="icons">check_circle</span>
+                <strong class="cimd-consent-hostname" th:text="${cimdClientIdHostname}"></strong>
+                <span th:text="#{oauth.consent.cimd.verified}"></span>
+            </div>
 
             <div>
                 <button type="submit" name="user_oauth_approval" value="true" class="button primary" th:text="#{oauth.button.accept}"></button>

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -197,6 +197,7 @@ reset_password.error.description.label=Error description:
 
 oauth.consent.title=Permissions requested
 oauth.consent.description=would like to
+oauth.consent.cimd.verified=verified domain
 oauth.disclaimer=will be able to use your data in accordance to their terms of service and privacy policies.
 oauth.button.accept=Accept
 oauth.button.cancel=Cancel

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
@@ -197,6 +197,7 @@ reset_password.error.description.label=Description de l'erreur :
 
 oauth.consent.title=Autorisations demandées
 oauth.consent.description=souhaite
+oauth.consent.cimd.verified=domaine vérifié
 oauth.disclaimer=sera en mesure d'utiliser vos données conformément à ses conditions d'utilisation et à sa politique de confidentialité.
 oauth.button.accept=Accepter
 oauth.button.cancel=Annuler

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/CimdMetadataDocument.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/CimdMetadataDocument.java
@@ -15,6 +15,10 @@
  */
 package io.gravitee.am.model;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.time.Duration;
 import java.util.Date;
 
@@ -24,7 +28,11 @@ import java.util.Date;
  * 
  * @author GraviteeSource Team
  */
+@Setter
+@Getter
 public class CimdMetadataDocument {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private String id;
     private String domainId;
@@ -37,26 +45,16 @@ public class CimdMetadataDocument {
     private Date expiresAt;
     private Date updatedAt;
 
-    public String getId() { return id; }
-    public void setId(String id) { this.id = id; }
-
-    public String getDomainId() { return domainId; }
-    public void setDomainId(String domainId) { this.domainId = domainId; }
-
-    public String getClientId() { return clientId; }
-    public void setClientId(String clientId) { this.clientId = clientId; }
-
-    public String getMetadata() { return metadata; }
-    public void setMetadata(String metadata) { this.metadata = metadata; }
-
-    public Date getFetchedAt() { return fetchedAt; }
-    public void setFetchedAt(Date fetchedAt) { this.fetchedAt = fetchedAt; }
-
-    public Date getExpiresAt() { return expiresAt; }
-    public void setExpiresAt(Date expiresAt) { this.expiresAt = expiresAt; }
-
-    public Date getUpdatedAt() { return updatedAt; }
-    public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
+    public String getLogoUri() {
+        if (metadata == null) {
+            return null;
+        }
+        try {
+            return MAPPER.readTree(metadata).path("logo_uri").asText(null);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
 
     public boolean isExpired() {
         return expiresAt != null && expiresAt.before(new Date());

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/ClientProperties.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/safe/ClientProperties.java
@@ -33,6 +33,7 @@ public class ClientProperties {
     private String clientId;
     private String clientName;
     private String name;
+    private String logoUri;
     private CookieSettings cookieSettings;
     private Map<String, Object> metadata;
 
@@ -45,6 +46,7 @@ public class ClientProperties {
         this.clientId = client.getClientId();
         this.clientName = client.getClientName();
         this.name = client.getClientName();
+        this.logoUri = client.getLogoUri();
         this.cookieSettings = client.getCookieSettings();
         this.metadata = client.getMetadata() == null ? new HashMap<>() : new HashMap<>(client.getMetadata());
     }
@@ -91,6 +93,14 @@ public class ClientProperties {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getLogoUri() {
+        return logoUri;
+    }
+
+    public void setLogoUri(String logoUri) {
+        this.logoUri = logoUri;
     }
 
     public CookieSettings getCookieSettings() {

--- a/gravitee-am-test/specs/gateway/cimd/cimd-logo.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-logo.jest.spec.ts
@@ -17,7 +17,11 @@
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { setup } from '../../test-fixture';
 import { CimdAuthorizeFixture, setupCimdAuthorizeFixture } from './fixtures/cimd-authorize-fixture';
-import { clearWireMockRequestJournal, waitForWireMockGetToPath } from './fixtures/cimd-wiremock-helpers';
+import {
+  clearWireMockRequestJournal,
+  countGetRequestsForPathSubstring,
+  fetchWireMockRequestJournal,
+} from './fixtures/cimd-wiremock-helpers';
 
 setup(120000);
 
@@ -38,17 +42,26 @@ describe('CIMD logo endpoint', () => {
     await fixture.fetchCimdLogo().expect(400);
   });
 
-  it('should return 404 when logo is not yet cached', async () => {
+  it('should return 404 when logo is not cached and metadata is absent from the gateway', async () => {
     await fixture.fetchCimdLogo(fixture.buildClientId('valid-none')).expect(404);
   });
 
-  it('should return 200 with image/png after authorize populates the logo cache', async () => {
+  it('should return 200 with image/png after authorize populates the logo cache then leverage the cache on subsequent requests', async () => {
     await clearWireMockRequestJournal();
     fixture.expectLoginRedirect(await fixture.authorize(fixture.buildClientId('valid-none')));
-    await waitForWireMockGetToPath('/cimd/logos/example.png');
 
-    const response = await fixture.fetchCimdLogo(fixture.buildClientId('valid-none')).expect(200);
-    expect(response.headers['content-type']).toContain('image/png');
-    expect(response.body.length).toBeGreaterThan(0);
+    const first = await fixture.fetchCimdLogo(fixture.buildClientId('valid-none')).expect(200);
+    expect(first.headers['content-type']).toContain('image/png');
+    expect(first.body.length).toBeGreaterThan(0);
+
+    const journalAfterFirst = await fetchWireMockRequestJournal();
+    expect(countGetRequestsForPathSubstring(journalAfterFirst, '/cimd/logos/example.png')).toBeGreaterThanOrEqual(1);
+
+    await clearWireMockRequestJournal();
+    const second = await fixture.fetchCimdLogo(fixture.buildClientId('valid-none')).expect(200);
+    expect(second.headers['content-type']).toContain('image/png');
+
+    const journalAfterSecond = await fetchWireMockRequestJournal();
+    expect(countGetRequestsForPathSubstring(journalAfterSecond, '/cimd/logos/example.png')).toBe(0);
   });
 });


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6662](https://gravitee.atlassian.net/browse/AM-6662)

## :pencil2: A description of the changes proposed in the pull request
Display client logo in OAuth 2.0 consent screen template.

- Update consent template resources to show client logo and "verified domain" checkmark for CIMD clients
- Extract logo cache management, domain trust and cache warming behaviours into `CimdLogoCacheService`, `CimdUriTrustValidatorTest` and `CimdMetadataDocumentManager` respectively, then reuse in `CimdLogoEndpoint` to provide resilience for retrieving logo resources.

## :memo: Test scenarios

1. Create a template application with scopes, assigned to an IdP with an active user 
2. Configure CIMD for a security domain, referencing template application
3. Authenticate with CIMD client
4. Observe OAuth consent page

## :computer: Add screenshots for UI
<img width="612" height="732" alt="image" src="https://github.com/user-attachments/assets/0fde905f-6d12-4034-bca8-e429260573dd" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6662]: https://gravitee.atlassian.net/browse/AM-6662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ