### PR TITLE
chore: use vertx5 flag

### DIFF
--- a/gravitee-am-management-api-sdk-java/pom.xml
+++ b/gravitee-am-management-api-sdk-java/pom.xml
@@ -32,7 +32,7 @@
     <description>Java client SDK generated from the Access Management Management API OpenAPI specification.</description>
 
     <properties>
-        <openapi-generator.version>7.11.0</openapi-generator.version>
+        <openapi-generator.version>7.22.0</openapi-generator.version>
         <jackson.version>2.18.2</jackson.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
@@ -40,31 +40,29 @@
     </properties>
 
     <dependencies>
-        <!-- okhttp-gson generator runtime deps -->
+        <!-- vertx generator runtime deps -->
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>4.12.0</version>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>logging-interceptor</artifactId>
-            <version>4.12.0</version>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.gsonfire</groupId>
-            <artifactId>gson-fire</artifactId>
-            <version>1.9.0</version>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.2.25</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
@@ -135,9 +133,9 @@
                         Post-generation fix. Even with the spec reshaped, openapi-generator
                         hard-codes `this.type = getClass().getSimpleName()` into the
                         discriminator subclass constructors. Parent `type` is now a typed
-                        enum, so the String assignment won't compile. Gson populates `type`
-                        from the JSON payload during deserialization, so the assignment is
-                        redundant — strip it.
+                        enum, so the String assignment won't compile. Jackson populates
+                        `type` from the JSON payload during deserialization, so the
+                        assignment is redundant — strip it.
                     -->
                     <execution>
                         <id>patch-discriminator-subclass-constructors</id>
@@ -157,6 +155,24 @@
                                         <include name="UpdateMcpTool.java"/>
                                     </fileset>
                                 </replaceregexp>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Vert.x 5 dropped vertx-rx-java (RxJava 1 EOL). The vertx generator
+                        still emits an api/rxjava/* wrapper layer compiled against rx.Single.
+                        Delete it so only the standard WebClient-based api/* survives.
+                    -->
+                    <execution>
+                        <id>strip-rxjava1-wrappers</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                        <configuration>
+                            <target>
+                                <delete dir="${project.build.directory}/generated-sources/openapi/src/main/java/io/gravitee/am/sdk/management/api/rxjava"/>
                             </target>
                         </configuration>
                     </execution>
@@ -187,7 +203,8 @@
                             <generateModelDocumentation>false</generateModelDocumentation>
                             <skipValidateSpec>true</skipValidateSpec>
                             <configOptions>
-                                <library>okhttp-gson</library>
+                                <library>vertx</library>
+                                <useVertx5>true</useVertx5>
                                 <dateLibrary>java8</dateLibrary>
                                 <openApiNullable>false</openApiNullable>
                                 <hideGenerationTimestamp>true</hideGenerationTimestamp>


### PR DESCRIPTION
## :id: Reference related issue.
N/A

## :pencil2: A description of the changes proposed in the pull request

Switch the generated Java SDK (`gravitee-am-management-api-sdk-java`) from the `okhttp-gson` openapi-generator library to the `vertx` library so the SDK aligns with the project's Vert.x 5 / Future-based stack.

### Changes
- **openapi-generator**: bumped `7.11.0` → `7.22.0`. `useVertx5` was introduced in 7.22.0 (PR [#23563](https://github.com/OpenAPITools/openapi-generator/pull/23563)) — it's the flag that makes the `vertx` template emit Vert.x 5 `Future`-returning APIs instead of the legacy `Handler<AsyncResult<...>>` callback API.
- **Generator config**: `<library>okhttp-gson</library>` → `<library>vertx</library>`, added `<useVertx5>true</useVertx5>`.
- **Runtime deps**: removed okhttp / okhttp logging-interceptor / gson / gson-fire / commons-lang3; added `vertx-core`, `vertx-web-client`, `jackson-databind`, `jackson-datatype-jsr310`, `swagger-annotations` (versions inherited from the gravitee BOM where possible).
- **Strip RxJava 1 wrappers**: even with `useVertx5=true`, `JavaClientCodegen` still unconditionally writes `rxApiImpl.mustache` into `api/rxjava/*` against `rx.Single`. Vert.x 5 dropped `vertx-rx-java`, so those files don't compile. Added an Ant `delete` execution in `process-sources` to remove the `api/rxjava` directory before compilation.
- **Discriminator patch**: existing post-gen regex (strips `this.type = this.getClass().getSimpleName()` from MCP discriminator subclass constructors) is unchanged; comment updated from "Gson populates" to "Jackson populates" to match the new generator runtime.

### Why not simpler alternatives
- Keeping 7.11.0 and overriding `ApiClient.mustache` with custom Vert.x 5 templates: viable but high-maintenance — bumping the plugin gets the upstream Vert.x 5 support for free.
- Pinning Vert.x 4 in the SDK module only: would create classpath conflicts for callers running on Vert.x 5.

## :memo: Test scenarios
- [x] `mvn -pl gravitee-am-management-api-sdk-java install -DskipTests` produces a green build with the new dependency set.
- [x] Generated `ApiClient.java` uses `Future<HttpResponse<Buffer>>` / `WebClient` (Vert.x 5 API) — no `Handler<AsyncResult<...>>` callback overloads.
- [x] No `api/rxjava/*` files remain in the generated sources after `process-sources`.

## :computer: Add screenshots for UI
N/A

## :books: Any other comments that will help with documentation
The committed `docs/mapi/openapi.yaml` is the input spec — the OAS staleness check in CI continues to gate it. No changes to the spec itself.

## :man: :woman: @mentions of the person or team responsible for reviewing proposed changes