### PR TITLE
feat: AM-6663 identify CIMD clients in user consent and audit events

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/oauth2/ClientIds.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/oauth2/ClientIds.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.gateway.handler.common.client.cimd;
+package io.gravitee.am.common.oauth2;
 
 import io.gravitee.am.common.web.UriBuilder;
 
@@ -22,7 +22,7 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
- * Utilities for client_id values that can be URLs.
+ * Utilities for client_id values that can be URLs (e.g. OAuth Client ID Metadata Document).
  */
 public final class ClientIds {
 

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/oauth2/ClientIdsTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/oauth2/ClientIdsTest.java
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.gateway.handler.common.client.cimd;
+package io.gravitee.am.common.oauth2;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author GraviteeSource Team
  */
-public class ClientIdsTest {
+class ClientIdsTest {
 
     @Test
-    public void isUrlShaped_acceptsHttpAndHttpsAtStart() {
+    void isUrlShaped_acceptsHttpAndHttpsAtStart() {
         assertTrue(ClientIds.isUrlShaped("http://example.com"));
         assertTrue(ClientIds.isUrlShaped("https://example.com"));
         assertTrue(ClientIds.isUrlShaped("HTTP://EXAMPLE.COM/p"));
@@ -36,7 +36,7 @@ public class ClientIdsTest {
     }
 
     @Test
-    public void isUrlShaped_rejectsNullEmptyAndNonUrl() {
+    void isUrlShaped_rejectsNullEmptyAndNonUrl() {
         assertFalse(ClientIds.isUrlShaped(null));
         assertFalse(ClientIds.isUrlShaped(""));
         assertFalse(ClientIds.isUrlShaped("opaque-client"));
@@ -44,99 +44,98 @@ public class ClientIdsTest {
     }
 
     @Test
-    public void isUrlShaped_rejectsFtpAndRequiresSchemeAtStart() {
+    void isUrlShaped_rejectsFtpAndRequiresSchemeAtStart() {
         assertFalse(ClientIds.isUrlShaped("ftp://files.example/"));
         assertFalse(ClientIds.isUrlShaped(" not-http://trailing"));
         assertFalse(ClientIds.isUrlShaped("prefix-https://host"));
     }
 
     @Test
-    public void isUrlShaped_rejectsHttpWithoutSlashSlash() {
+    void isUrlShaped_rejectsHttpWithoutSlashSlash() {
         assertFalse(ClientIds.isUrlShaped("http:"));
         assertFalse(ClientIds.isUrlShaped("https"));
     }
 
     @Test
-    public void canonicalize_returnsNullWhenInputNull() {
+    void canonicalize_returnsNullWhenInputNull() {
         assertNull(ClientIds.canonicalize(null));
     }
 
     @Test
-    public void canonicalize_nonUrl_returnsUnchanged() {
+    void canonicalize_nonUrl_returnsUnchanged() {
         assertEquals("my-app", ClientIds.canonicalize("my-app"));
         assertEquals("", ClientIds.canonicalize(""));
     }
 
     @Test
-    public void canonicalize_lowercasesSchemeAndHost_preservesPathAndQuery() {
+    void canonicalize_lowercasesSchemeAndHost_preservesPathAndQuery() {
         assertEquals(
                 "https://client.example.com/metadata?x=1&y=a+b",
                 ClientIds.canonicalize("HTTPS://CLIENT.EXAMPLE.COM/metadata?x=1&y=a+b"));
     }
 
     @Test
-    public void canonicalize_includesPortWhenNotDefault() {
+    void canonicalize_includesPortWhenNotDefault() {
         assertEquals("http://example.com:8080/oauth", ClientIds.canonicalize("HTTP://EXAMPLE.COM:8080/oauth"));
     }
 
     @Test
-    public void canonicalize_emptyPath_usesEmptyPathString() {
+    void canonicalize_emptyPath_usesEmptyPathString() {
         assertEquals("https://h.example", ClientIds.canonicalize("https://H.EXAMPLE"));
     }
 
     @Test
-    public void sameForLookup_bothUrl_equivalentWhenHostsDifferInCase() {
+    void sameForLookup_bothUrl_equivalentWhenHostsDifferInCase() {
         assertTrue(ClientIds.sameForLookup(
                 "https://a.example.com/r",
                 "HTTPS://A.EXAMPLE.COM/r"));
     }
 
     @Test
-    public void sameForLookup_httpAndHttps_notEqual() {
+    void sameForLookup_httpAndHttps_notEqual() {
         assertFalse(ClientIds.sameForLookup("http://x.example/p", "https://x.example/p"));
     }
 
     @Test
-    public void sameForLookup_pathsMustMatch() {
+    void sameForLookup_pathsMustMatch() {
         assertFalse(ClientIds.sameForLookup("https://x.example/a", "https://x.example/b"));
     }
 
     @Test
-    public void sameForLookup_trailingPathSlashMatters() {
+    void sameForLookup_trailingPathSlashMatters() {
         assertFalse(ClientIds.sameForLookup("https://x.example", "https://x.example/"));
     }
 
     @Test
-    public void sameForLookup_opaque_usesStringEquality() {
+    void sameForLookup_opaque_usesStringEquality() {
         assertTrue(ClientIds.sameForLookup("opaque-id", "opaque-id"));
         assertFalse(ClientIds.sameForLookup("opaque-id", "Opaque-Id"));
     }
 
     @Test
-    public void sameForLookup_nullHandling() {
+    void sameForLookup_nullHandling() {
         assertTrue(ClientIds.sameForLookup(null, null));
         assertFalse(ClientIds.sameForLookup(null, "a"));
         assertFalse(ClientIds.sameForLookup("a", null));
     }
 
     @Test
-    public void sameForLookup_mixedUrlAndOpaque_doesNotMatch() {
+    void sameForLookup_mixedUrlAndOpaque_doesNotMatch() {
         assertFalse(ClientIds.sameForLookup("https://x.example.com/", "not-a-url"));
     }
 
     @Test
-    public void sameForLookup_bothUrl_oneOpaqueButLooksLikePath_stillUrlBranch() {
-        // If one side is URL-shaped, we compare via canonicalize on both; opaque string unchanged.
+    void sameForLookup_bothUrl_oneOpaqueButLooksLikePath_stillUrlBranch() {
         assertFalse(ClientIds.sameForLookup("https://a.example.com/", "a.example.com"));
     }
 
     @Test
-    public void canonicalize_urnStyle_notUrlShaped_unchanged() {
+    void canonicalize_urnStyle_notUrlShaped_unchanged() {
         assertEquals("urn:acme:client", ClientIds.canonicalize("urn:acme:client"));
     }
 
     @Test
-    public void canonicalize_rawPathPercentEncoding_stableUnderCaseOnlyChange() {
+    void canonicalize_rawPathPercentEncoding_stableUnderCaseOnlyChange() {
         String lowerHost = "https://ns.example/oidc%2Freg";
         String upperHost = "HTTPS://ns.example/oidc%2Freg";
         assertEquals(ClientIds.canonicalize(lowerHost), ClientIds.canonicalize(upperHost));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/main/java/io/gravitee/am/gateway/handler/cimd/resources/endpoint/CimdLogoEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/main/java/io/gravitee/am/gateway/handler/cimd/resources/endpoint/CimdLogoEndpoint.java
@@ -18,7 +18,7 @@ package io.gravitee.am.gateway.handler.cimd.resources.endpoint;
 import io.gravitee.am.gateway.handler.common.client.cimd.CachedLogo;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
-import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.CIMDSettings;
 import io.reactivex.rxjava3.core.Single;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/test/java/io/gravitee/am/gateway/handler/cimd/resources/endpoint/CimdLogoEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-cimd/src/test/java/io/gravitee/am/gateway/handler/cimd/resources/endpoint/CimdLogoEndpointTest.java
@@ -18,7 +18,7 @@ package io.gravitee.am.gateway.handler.cimd.resources.endpoint;
 import io.gravitee.am.gateway.handler.common.client.cimd.CachedLogo;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
-import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.model.CimdMetadataDocument;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.CIMDSettings;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
@@ -20,7 +20,7 @@ import io.gravitee.am.common.oauth2.ResponseType;
 import io.gravitee.am.common.oidc.ClientAuthenticationMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdLogoCacheService;
-import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentManager;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdUriTrustValidator;
@@ -46,11 +46,16 @@ import io.vertx.rxjava3.ext.web.client.WebClient;
 import io.gravitee.am.service.utils.vertx.BoundedBufferWriteStream;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -294,6 +299,9 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
         synthesizedClient.setSecretSettings(List.of());
         synthesizedClient.setTemplate(false);
         synthesizedClient.setDomain(domain.getId());
+
+        synthesizedClient.setCimdMetadataHash(calculateMetadataHash(metadata.encode()));
+
         return synthesizedClient;
     }
 
@@ -362,6 +370,16 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
 
     private static long resolveCacheTtlSeconds(CIMDSettings settings) {
         return Math.max(1L, settings.getCacheTtlSeconds());
+    }
+
+    private static String calculateMetadataHash(String metadataJson) {
+        try {
+            byte[] hashBytes = MessageDigest.getInstance("SHA-256")
+                    .digest(metadataJson.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
     }
 
     private record FetchResult(JsonObject json, CacheRequirements cacheRequirements) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/impl/ClientSyncServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/impl/ClientSyncServiceImpl.java
@@ -17,7 +17,7 @@ package io.gravitee.am.gateway.handler.common.client.impl;
 
 import io.gravitee.am.gateway.handler.common.client.ClientManager;
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
-import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.Client;
 import io.reactivex.rxjava3.core.Maybe;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/protectedresource/impl/ProtectedResourceSyncServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/protectedresource/impl/ProtectedResourceSyncServiceImpl.java
@@ -16,7 +16,7 @@
 
 package io.gravitee.am.gateway.handler.common.protectedresource.impl;
 
-import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceManager;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceSyncService;
 import io.gravitee.am.model.Domain;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdClientIdsTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/CimdClientIdsTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.common.client.cimd;
 
+import io.gravitee.am.common.oauth2.ClientIds;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
@@ -51,8 +51,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Date;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -268,6 +271,25 @@ public class CimdMetadataServiceImplTest {
                 && client.getSecretSettings().isEmpty()
                 && !client.isTemplate()
                 && "domain-id".equals(client.getDomain()));
+    }
+
+    @Test
+    public void shouldStoreMetadataDocumentHashInSynthesizedClientMetadata() throws Exception {
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "none");
+        String metadataJson = metadata.encode();
+        mockFetchSuccess(metadataJson);
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        String expectedHash = HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(metadataJson.getBytes(StandardCharsets.UTF_8)));
+        testObserver.assertValue(client -> expectedHash.equals(client.getCimdMetadataHash()));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/common/RedirectUriValidationHandler.java
@@ -19,7 +19,7 @@ import io.gravitee.am.common.exception.oauth2.RedirectMismatchException;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.jwt.TokenPurpose;
 import io.gravitee.am.common.utils.ConstantKeys;
-import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.gateway.handler.root.service.RedirectUriValidator;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.gateway.handler.root.service.user.model.UserToken;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/CimdConsentPageAttributes.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/CimdConsentPageAttributes.java
@@ -16,7 +16,7 @@
 package io.gravitee.am.gateway.handler.oauth2.resources.endpoint.authorization.consent;
 
 import io.gravitee.am.common.web.UriBuilder;
-import io.gravitee.am.gateway.handler.common.client.cimd.ClientIds;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.Client;

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/pom.xml
@@ -31,6 +31,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.gravitee.am.common</groupId>
+            <artifactId>gravitee-am-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.gravitee.am.management</groupId>
             <artifactId>gravitee-am-management-api-service</artifactId>
             <version>${project.version}</version>

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/adapter/ConsentApplicationEntityFactory.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/adapter/ConsentApplicationEntityFactory.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.adapter;
+
+import io.gravitee.am.common.oauth2.ClientIds;
+import io.gravitee.am.management.handlers.management.api.model.ApplicationEntity;
+import io.gravitee.am.service.ApplicationService;
+import io.gravitee.am.service.CimdMetadataDocumentService;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Builds {@link ApplicationEntity} for user consent payloads, including URL-shaped (CIMD) clients
+ * that are not persisted as domain applications.
+ */
+@RequiredArgsConstructor
+public class ConsentApplicationEntityFactory {
+
+    public static final String CIMD_CLIENT = "cimd-client";
+
+    private final ApplicationService applicationService;
+    private final CimdMetadataDocumentService cimdMetadataDocumentService;
+
+    public Single<ApplicationEntity> resolve(String domainId, String clientId) {
+        return applicationService.findByDomainAndClientId(domainId, clientId)
+                .map(ApplicationEntity::new)
+                .switchIfEmpty(Single.defer(() -> {
+                    if (ClientIds.isUrlShaped(clientId)) {
+                        return resolveCimdDocument(domainId, clientId);
+                    }
+                    return Single.just(new ApplicationEntity(ScopeApprovalAdapterImpl.UNKNOWN_ID, clientId, "unknown-client-name"));
+                }));
+    }
+
+    private Single<ApplicationEntity> resolveCimdDocument(String domainId, String clientId) {
+        String canonical = ClientIds.canonicalize(clientId);
+        return cimdMetadataDocumentService.findByDomainAndClientId(domainId, canonical)
+                .map(doc -> {
+                    String displayName = doc.getClientName();
+                    if (displayName == null) {
+                        displayName = canonical;
+                    }
+                    return new ApplicationEntity(CIMD_CLIENT, clientId, displayName);
+                })
+                .switchIfEmpty(Maybe.just(new ApplicationEntity(CIMD_CLIENT, clientId, canonical)))
+                .toSingle();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/adapter/ScopeApprovalAdapterImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/adapter/ScopeApprovalAdapterImpl.java
@@ -23,7 +23,6 @@ import io.gravitee.am.management.service.RevokeTokenManagementService;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.UserId;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
-import io.gravitee.am.service.ApplicationService;
 import io.gravitee.am.service.ScopeApprovalService;
 import io.gravitee.am.service.ScopeService;
 import io.gravitee.am.service.exception.UserNotFoundException;
@@ -40,7 +39,7 @@ public class ScopeApprovalAdapterImpl implements ScopeApprovalAdapter {
 
     private final ScopeApprovalService scopeApprovalService;
     private final RevokeTokenManagementService revokeTokenManagementService;
-    private final ApplicationService applicationService;
+    private final ConsentApplicationEntityFactory consentApplicationEntityFactory;
     private final ScopeService scopeService;
     private final DataPlaneRegistry dataPlaneRegistry;
 
@@ -93,9 +92,6 @@ public class ScopeApprovalAdapterImpl implements ScopeApprovalAdapter {
     }
 
     private Single<ApplicationEntity> getClient(String domain, String clientId) {
-        return applicationService.findByDomainAndClientId(domain, clientId)
-                .map(ApplicationEntity::new)
-                .defaultIfEmpty(new ApplicationEntity(UNKNOWN_ID, clientId, "unknown-client-name"))
-                .cache();
+        return consentApplicationEntityFactory.resolve(domain, clientId);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserConsentResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/UserConsentResource.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.model.ApplicationEntity;
+import io.gravitee.am.management.handlers.management.api.adapter.ConsentApplicationEntityFactory;
 import io.gravitee.am.management.handlers.management.api.model.ScopeApprovalEntity;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
 import io.gravitee.am.management.service.DomainService;
@@ -24,7 +25,6 @@ import io.gravitee.am.management.service.RevokeTokenManagementService;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.UserId;
 import io.gravitee.am.model.permissions.Permission;
-import io.gravitee.am.service.ApplicationService;
 import io.gravitee.am.service.ScopeApprovalService;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.ScopeApprovalNotFoundException;
@@ -58,7 +58,7 @@ public class UserConsentResource extends AbstractResource {
     private ScopeApprovalService scopeApprovalService;
 
     @Autowired
-    private ApplicationService applicationService;
+    private ConsentApplicationEntityFactory consentApplicationEntityFactory;
 
     @Autowired
     private RevokeTokenManagementService revokeTokenManagementService;
@@ -126,8 +126,6 @@ public class UserConsentResource extends AbstractResource {
 
 
     private Single<ApplicationEntity> getClient(String domain, String clientId) {
-        return applicationService.findByDomainAndClientId(domain, clientId)
-                .map(ApplicationEntity::new)
-                .defaultIfEmpty(new ApplicationEntity("unknown-id", clientId, "unknown-client-name"));
+        return consentApplicationEntityFactory.resolve(domain, clientId);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/spring/ManagementConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/spring/ManagementConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.spring;
 
+import io.gravitee.am.management.handlers.management.api.adapter.ConsentApplicationEntityFactory;
 import io.gravitee.am.management.handlers.management.api.adapter.ScopeApprovalAdapter;
 import io.gravitee.am.management.handlers.management.api.adapter.ScopeApprovalAdapterImpl;
 import io.gravitee.am.management.handlers.management.api.adapter.UMAResourceManagementAdapter;
@@ -30,6 +31,7 @@ import io.gravitee.am.management.service.RevokeTokenManagementService;
 import io.gravitee.am.management.service.dataplane.UMAResourceManagementService;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.ApplicationService;
+import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.service.ScopeApprovalService;
 import io.gravitee.am.service.ScopeService;
 import org.springframework.beans.factory.annotation.Value;
@@ -61,12 +63,19 @@ public class ManagementConfiguration {
     }
 
     @Bean
+    ConsentApplicationEntityFactory consentApplicationEntityFactory(
+            ApplicationService applicationService,
+            CimdMetadataDocumentService cimdMetadataDocumentService) {
+        return new ConsentApplicationEntityFactory(applicationService, cimdMetadataDocumentService);
+    }
+
+    @Bean
     ScopeApprovalAdapter scopeApprovalAdapter(ScopeApprovalService scopeApprovalService,
         RevokeTokenManagementService revokeTokenManagementService,
-        ApplicationService applicationService,
+        ConsentApplicationEntityFactory consentApplicationEntityFactory,
         ScopeService scopeService,
         DataPlaneRegistry dataPlaneRegistry) {
-        return new ScopeApprovalAdapterImpl(scopeApprovalService, revokeTokenManagementService, applicationService, scopeService, dataPlaneRegistry);
+        return new ScopeApprovalAdapterImpl(scopeApprovalService, revokeTokenManagementService, consentApplicationEntityFactory, scopeService, dataPlaneRegistry);
     }
 
     @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/JerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/JerseySpringTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.management.api.adapter.ConsentApplicationEntityFactory;
 import io.gravitee.am.management.handlers.management.api.adapter.ScopeApprovalAdapter;
 import io.gravitee.am.management.handlers.management.api.authentication.view.TemplateResolver;
 import io.gravitee.am.management.handlers.management.api.mapper.ObjectMapperResolver;
@@ -279,6 +280,9 @@ public abstract class JerseySpringTest {
 
     @Autowired
     protected PasswordPolicyService passwordPolicyService;
+
+    @Autowired
+    protected ConsentApplicationEntityFactory consentApplicationEntityFactory;
 
     @Autowired
     protected ScopeApprovalAdapter scopeApprovalAdapter;
@@ -683,6 +687,11 @@ public abstract class JerseySpringTest {
         @Bean
         public AuthorizationEnginePluginService authorizationEnginePluginService() {
             return mock(AuthorizationEnginePluginService.class);
+        }
+
+        @Bean
+        public ConsentApplicationEntityFactory consentApplicationEntityFactory() {
+            return mock(ConsentApplicationEntityFactory.class);
         }
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/adapter/ConsentApplicationEntityFactoryTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/adapter/ConsentApplicationEntityFactoryTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.adapter;
+
+import io.gravitee.am.model.Application;
+import io.gravitee.am.model.CimdMetadataDocument;
+import io.gravitee.am.model.application.ApplicationOAuthSettings;
+import io.gravitee.am.model.application.ApplicationSettings;
+import io.gravitee.am.service.ApplicationService;
+import io.gravitee.am.service.CimdMetadataDocumentService;
+import io.reactivex.rxjava3.core.Maybe;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConsentApplicationEntityFactoryTest {
+
+    private static final String DOMAIN = "domain-1";
+    private static final String CLIENT_URL = "https://CLIENT.EXAMPLE.COM/metadata";
+
+    @Mock
+    private ApplicationService applicationService;
+
+    @Mock
+    private CimdMetadataDocumentService cimdMetadataDocumentService;
+
+    @InjectMocks
+    private ConsentApplicationEntityFactory factory;
+
+    @Test
+    void shouldUseRegisteredApplicationWhenPresent() {
+        Application app = new Application();
+        app.setId("app-id");
+        app.setName("My Application");
+        ApplicationOAuthSettings oauth = new ApplicationOAuthSettings();
+        oauth.setClientId("regular-id");
+        ApplicationSettings settings = new ApplicationSettings();
+        settings.setOauth(oauth);
+        app.setSettings(settings);
+
+        when(applicationService.findByDomainAndClientId(DOMAIN, "regular-id")).thenReturn(Maybe.just(app));
+
+        factory.resolve(DOMAIN, "regular-id")
+                .test()
+                .assertValue(e -> "app-id".equals(e.getId()) && "My Application".equals(e.getName()) && "regular-id".equals(e.getClientId()));
+    }
+
+    @Test
+    void shouldUseCimdClientEntityIdWhenMetadataDocumentFound() {
+        when(applicationService.findByDomainAndClientId(DOMAIN, CLIENT_URL)).thenReturn(Maybe.empty());
+
+        CimdMetadataDocument doc = new CimdMetadataDocument();
+        doc.setMetadata("{\"client_name\":\"CIMD display\"}");
+        when(cimdMetadataDocumentService.findByDomainAndClientId(DOMAIN, "https://client.example.com/metadata"))
+                .thenReturn(Maybe.just(doc));
+
+        factory.resolve(DOMAIN, CLIENT_URL)
+                .test()
+                .assertValue(e -> ConsentApplicationEntityFactory.CIMD_CLIENT.equals(e.getId())
+                        && CLIENT_URL.equals(e.getClientId())
+                        && "CIMD display".equals(e.getName()));
+    }
+
+    @Test
+    void shouldFallbackToCanonicalUrlAsNameWhenClientNameMissingInMetadata() {
+        when(applicationService.findByDomainAndClientId(DOMAIN, CLIENT_URL)).thenReturn(Maybe.empty());
+
+        CimdMetadataDocument doc = new CimdMetadataDocument();
+        doc.setMetadata("{\"client_id\":\"" + CLIENT_URL + "\"}");
+        when(cimdMetadataDocumentService.findByDomainAndClientId(DOMAIN, "https://client.example.com/metadata"))
+                .thenReturn(Maybe.just(doc));
+
+        factory.resolve(DOMAIN, CLIENT_URL)
+                .test()
+                .assertValue(e -> ConsentApplicationEntityFactory.CIMD_CLIENT.equals(e.getId())
+                        && CLIENT_URL.equals(e.getClientId())
+                        && "https://client.example.com/metadata".equals(e.getName()));
+    }
+
+    @Test
+    void shouldUseCimdClientAndCanonicalUrlAsNameWhenUrlShapedButNoCachedMetadata() {
+        when(applicationService.findByDomainAndClientId(DOMAIN, CLIENT_URL)).thenReturn(Maybe.empty());
+        when(cimdMetadataDocumentService.findByDomainAndClientId(anyString(), anyString())).thenReturn(Maybe.empty());
+
+        factory.resolve(DOMAIN, CLIENT_URL)
+                .test()
+                .assertValue(e -> ConsentApplicationEntityFactory.CIMD_CLIENT.equals(e.getId())
+                        && CLIENT_URL.equals(e.getClientId())
+                        && "https://client.example.com/metadata".equals(e.getName()));
+    }
+
+    @Test
+    void shouldUseUnknownWhenOpaqueClientAndNoApplication() {
+        when(applicationService.findByDomainAndClientId(DOMAIN, "opaque")).thenReturn(Maybe.empty());
+
+        factory.resolve(DOMAIN, "opaque")
+                .test()
+                .assertValue(e -> ScopeApprovalAdapterImpl.UNKNOWN_ID.equals(e.getId())
+                        && "unknown-client-name".equals(e.getName()));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/adapter/ScopeApprovalAdapterImplTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/adapter/ScopeApprovalAdapterImplTest.java
@@ -28,6 +28,7 @@ import io.gravitee.am.model.oauth2.Scope;
 import io.gravitee.am.model.oauth2.ScopeApproval;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.ApplicationService;
+import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.service.ScopeApprovalService;
 import io.gravitee.am.service.ScopeService;
 import io.gravitee.am.service.impl.ScopeApprovalServiceImpl;
@@ -58,9 +59,13 @@ class ScopeApprovalAdapterImplTest {
     private final ScopeApprovalService scopeApprovalService = new ScopeApprovalServiceImpl(dataPlaneRegistry, mock());
     private final RevokeTokenManagementService revokeTokenManagementService = mock(RevokeTokenManagementService.class);
     private final ApplicationService appService = mock();
+    private final CimdMetadataDocumentService cimdMetadataDocumentService = mock();
+    private final ConsentApplicationEntityFactory consentApplicationEntityFactory =
+            new ConsentApplicationEntityFactory(appService, cimdMetadataDocumentService);
     private final ScopeService scopeService = mock();
 
-    private final ScopeApprovalAdapterImpl underTest = new ScopeApprovalAdapterImpl(scopeApprovalService, revokeTokenManagementService, appService, scopeService, dataPlaneRegistry);
+    private final ScopeApprovalAdapterImpl underTest = new ScopeApprovalAdapterImpl(scopeApprovalService,
+            revokeTokenManagementService, consentApplicationEntityFactory, scopeService, dataPlaneRegistry);
 
     @BeforeEach
     void setUp() {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/UserConsentResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/UserConsentResourceTest.java
@@ -16,15 +16,16 @@
 package io.gravitee.am.management.handlers.management.api.resources;
 
 import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
+import io.gravitee.am.management.handlers.management.api.model.ApplicationEntity;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.User;
-import io.gravitee.am.model.oauth2.Scope;
 import io.gravitee.am.model.oauth2.ScopeApproval;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
@@ -51,21 +52,15 @@ public class UserConsentResourceTest extends JerseySpringTest {
         final Application mockClient = new Application();
         mockClient.setId("client-id-1");
 
-        final Scope mockScope = new Scope();
-        mockScope.setId("scope-id-1");
-        mockScope.setKey("scope");
-
         final ScopeApproval scopeApproval = new ScopeApproval();
         scopeApproval.setId("consent-id");
         scopeApproval.setClientId("clientId");
         scopeApproval.setScope("scope");
         scopeApproval.setDomain(domainId);
 
-
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
-        doReturn(Maybe.just(mockClient)).when(applicationService).findByDomainAndClientId(domainId, scopeApproval.getClientId());
-        doReturn(Maybe.just(mockScope)).when(scopeService).findByDomainAndKey(domainId, scopeApproval.getScope());
         doReturn(Maybe.just(scopeApproval)).when(scopeApprovalService).findById(mockDomain, scopeApproval.getId());
+        doReturn(Single.just(new ApplicationEntity(mockClient))).when(consentApplicationEntityFactory).resolve(domainId, scopeApproval.getClientId());
 
         final Response response = target("domains")
                 .path(domainId)

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/CimdMetadataDocument.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/CimdMetadataDocument.java
@@ -46,11 +46,19 @@ public class CimdMetadataDocument {
     private Date updatedAt;
 
     public String getLogoUri() {
+        return getStringFromMetadata("logo_uri");
+    }
+
+    public String getClientName() {
+        return getStringFromMetadata("client_name");
+    }
+
+    private String getStringFromMetadata(String key) {
         if (metadata == null) {
             return null;
         }
         try {
-            return MAPPER.readTree(metadata).path("logo_uri").asText(null);
+            return MAPPER.readTree(metadata).path(key).asText(null);
         } catch (Exception ignored) {
             return null;
         }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
@@ -238,6 +238,9 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     private Map<String, Object> metadata;
 
+    /** Thumbprint of the CIMD metadata document used at authentication time. */
+    private transient String cimdMetadataHash;
+
     private boolean forcePKCE;
 
     private boolean forceS256CodeChallengeMethod;
@@ -905,6 +908,14 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     public void setMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
+    }
+
+    public String getCimdMetadataHash() {
+        return cimdMetadataHash;
+    }
+
+    public void setCimdMetadataHash(String cimdMetadataHash) {
+        this.cimdMetadataHash = cimdMetadataHash;
     }
 
     public String getTlsClientAuthSubjectDn() {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientAuthAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientAuthAuditBuilder.java
@@ -15,14 +15,24 @@
  */
 package io.gravitee.am.service.reporter.builder;
 
+import com.google.common.collect.ImmutableMap;
 import io.gravitee.am.common.audit.EntityType;
 import io.gravitee.am.common.audit.EventType;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.reporter.api.audit.model.AuditEntity;
 import io.gravitee.am.service.reporter.builder.gateway.GatewayAuditBuilder;
 
+import java.util.HashMap;
+
 public class ClientAuthAuditBuilder extends GatewayAuditBuilder<ClientAuthAuditBuilder> {
+
+    private static final String CIMD_METADATA_DOCUMENT_HASH_KEY = "metadataDocumentHash";
+
+    private String metadataDocumentHash;
+
     public ClientAuthAuditBuilder() {
         super();
         type(EventType.CLIENT_AUTHENTICATION);
@@ -31,12 +41,26 @@ public class ClientAuthAuditBuilder extends GatewayAuditBuilder<ClientAuthAuditB
     public ClientAuthAuditBuilder clientActor(Client client) {
         if (client != null) {
             var domainId = client.getDomain();
-            setActor(client.getId(), EntityType.APPLICATION, client.getClientName(), client.getClientName(), ReferenceType.DOMAIN, domainId);
+            var alternativeId = ClientIds.isUrlShaped(client.getClientId()) ? client.getClientId() : client.getClientName();
+            setActor(client.getId(), EntityType.APPLICATION, alternativeId, client.getClientName(), ReferenceType.DOMAIN, domainId);
             super.client(client);
-            if(domainId != null){
+            if (domainId != null) {
                 reference(Reference.domain(domainId));
             }
+            this.metadataDocumentHash = client.getCimdMetadataHash();
         }
         return this;
+    }
+
+    @Override
+    protected AuditEntity createActor() {
+        AuditEntity actor = super.createActor();
+        if (metadataDocumentHash != null) {
+            HashMap<String, Object> attributes =
+                    actor.getAttributes() == null ? new HashMap<>() : new HashMap<>(actor.getAttributes());
+            attributes.put(CIMD_METADATA_DOCUMENT_HASH_KEY, metadataDocumentHash);
+            actor.setAttributes(ImmutableMap.copyOf(attributes));
+        }
+        return actor;
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilder.java
@@ -18,6 +18,7 @@ package io.gravitee.am.service.reporter.builder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.gravitee.am.common.audit.EntityType;
+import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.common.oauth2.TokenTypeHint;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
@@ -114,7 +115,8 @@ public class ClientTokenAuditBuilder extends GatewayAuditBuilder<ClientTokenAudi
 
     public ClientTokenAuditBuilder tokenActor(Client client) {
         if (client != null) {
-            setActor(client.getId(), EntityType.APPLICATION, client.getClientName(), client.getClientName(), ReferenceType.DOMAIN, client.getDomain());
+            var alternativeId = ClientIds.isUrlShaped(client.getClientId()) ? client.getClientId() : client.getClientName();
+            setActor(client.getId(), EntityType.APPLICATION, alternativeId, client.getClientName(), ReferenceType.DOMAIN, client.getDomain());
             super.client(client);
             if(client.getDomain() != null){
                 reference(Reference.domain(client.getDomain()));

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/ClientAuthAuditBuilderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/ClientAuthAuditBuilderTest.java
@@ -24,6 +24,7 @@ import static io.gravitee.am.common.audit.EventType.CLIENT_AUTHENTICATION;
 import static io.gravitee.am.common.audit.Status.FAILURE;
 import static io.gravitee.am.common.audit.Status.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ClientAuthAuditBuilderTest {
@@ -64,6 +65,7 @@ class ClientAuthAuditBuilderTest {
         assertEquals(clientName, audit.getActor().getAlternativeId());
         assertEquals(SUCCESS, audit.getOutcome().getStatus());
         assertEquals(CLIENT_AUTHENTICATION, audit.getType());
+        assertNull(audit.getTarget());
     }
 
     @Test
@@ -92,5 +94,43 @@ class ClientAuthAuditBuilderTest {
         assertEquals(FAILURE, audit.getOutcome().getStatus());
         assertEquals(errorMessage, audit.getOutcome().getMessage());
         assertEquals(CLIENT_AUTHENTICATION, audit.getType());
+    }
+
+    @Test
+    void shouldStoreMetadataHashInActorAttributesForCimdClient() {
+        var applicationId = "client-applicationId";
+        var clientId = "https://example.com/client";
+        var clientName = "CIMD Client";
+        var domainId = "domainId";
+        var metadataHash = "abc123def456";
+
+        var client = new Client();
+        client.setId(applicationId);
+        client.setClientId(clientId);
+        client.setClientName(clientName);
+        client.setDomain(domainId);
+        client.setCimdMetadataHash(metadataHash);
+
+        var audit = AuditBuilder.builder(ClientAuthAuditBuilder.class).clientActor(client).build(objectMapper);
+
+        assertEquals(applicationId, audit.getActor().getId());
+        assertEquals(clientName, audit.getActor().getDisplayName());
+        assertEquals(clientId, audit.getActor().getAlternativeId());
+        assertNull(audit.getTarget());
+        assertNotNull(audit.getActor().getAttributes());
+        assertEquals(metadataHash, audit.getActor().getAttributes().get("metadataDocumentHash"));
+    }
+
+    @Test
+    void shouldNotSetTargetWhenNoMetadataHash() {
+        var client = new Client();
+        client.setId("id");
+        client.setClientId("regular-client-id");
+        client.setClientName("Regular Client");
+        client.setDomain("domainId");
+
+        var audit = AuditBuilder.builder(ClientAuthAuditBuilder.class).clientActor(client).build(objectMapper);
+
+        assertNull(audit.getTarget());
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilderTest.java
@@ -194,6 +194,26 @@ class ClientTokenAuditBuilderTest {
     }
 
     @Test
+    void shouldBuildTokenActorCimdClient() {
+        var applicationId = "client-applicationId";
+        var clientId = "https://client.example.com/metadata";
+        var clientName = "CIMD Client";
+        var domainId = "domainId";
+        var client = new Client();
+        client.setId(applicationId);
+        client.setClientId(clientId);
+        client.setClientName(clientName);
+        client.setDomain(domainId);
+
+        var audit = AuditBuilder.builder(ClientTokenAuditBuilder.class).tokenActor(client).build(objectMapper);
+
+        assertEquals(applicationId, audit.getActor().getId());
+        assertEquals(clientName, audit.getActor().getDisplayName());
+        assertEquals(clientId, audit.getActor().getAlternativeId());
+        assertEquals(TOKEN_CREATED, audit.getType());
+    }
+
+    @Test
     void shouldBuildError() {
         var message = "message-error-1";
         var audit = AuditBuilder.builder(ClientTokenAuditBuilder.class).throwable(new Exception(message)).build(objectMapper);

--- a/gravitee-am-ui/src/app/domain/settings/audits/audit/audit.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/audits/audit/audit.component.html
@@ -62,6 +62,11 @@
           <input matInput placeholder="User Agent" disabled [value]="audit.accessPoint?.userAgent" />
           <mat-hint>Remote Client User Agent</mat-hint>
         </mat-form-field>
+        <mat-form-field *ngIf="audit.actor?.attributes?.metadataDocumentHash" appearance="outline" floatLabel="always">
+          <mat-label>Metadata Document Hash</mat-label>
+          <input matInput placeholder="Metadata Document Hash" disabled [value]="audit.actor.attributes.metadataDocumentHash" />
+          <mat-hint>SHA-256 hash of the CIMD metadata document</mat-hint>
+        </mat-form-field>
       </div>
       <div class="gv-form-section">
         <div class="gv-form-section-title">

--- a/gravitee-am-ui/src/app/domain/settings/users/user/applications/application/application.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/applications/application/application.component.html
@@ -19,7 +19,7 @@
   <a [routerLink]="['..']" class="gv-back-link"><small><< Back to authorized apps</small></a>
   <div>
     <div fxLayout="row" style="align-items: center">
-      <h1>{{ application.name }}</h1>
+      <h1>{{ applicationDisplayName }}</h1>
       <div fxFlex fxLayoutAlign="end">
         <button
           *ngIf="canRevokeAccess() && canRevoke"

--- a/gravitee-am-ui/src/app/domain/settings/users/user/applications/application/application.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/applications/application/application.component.ts
@@ -33,6 +33,7 @@ export class UserApplicationComponent implements OnInit {
   private domainId: string;
   private userId: string;
   application: any;
+  applicationDisplayName: string;
   clientId: string;
   consents: any[];
   canRevoke: boolean;
@@ -53,6 +54,18 @@ export class UserApplicationComponent implements OnInit {
     this.consents = this.route.snapshot.data['consents'];
     this.clientId = this.route.snapshot.queryParamMap.get('clientId');
     this.canRevoke = this.authService.hasPermissions(['domain_user_update']);
+    this.applicationDisplayName = this.resolveApplicationDisplayName();
+  }
+
+  private resolveApplicationDisplayName(): string {
+    const fromConsent = this.consents?.[0]?.clientEntity?.name;
+    if (fromConsent) {
+      return fromConsent;
+    }
+    if (this.application?.name) {
+      return this.application.name;
+    }
+    return this.clientId ?? '';
   }
 
   revokeApplication(event) {
@@ -63,7 +76,7 @@ export class UserApplicationComponent implements OnInit {
         filter((res) => res),
         switchMap(() => this.userService.revokeConsents(this.domainId, this.userId, this.clientId)),
         tap(() => {
-          this.snackbarService.open('Access for application ' + this.application.name + ' revoked');
+          this.snackbarService.open('Access for application ' + this.applicationDisplayName + ' revoked');
           this.router.navigate(['..'], { relativeTo: this.route });
         }),
       )
@@ -93,6 +106,7 @@ export class UserApplicationComponent implements OnInit {
     this.userService.consents(this.domainId, this.userId, null).subscribe((consents) => {
       this.consents = consents.filter((consent) => consent.clientId === this.clientId);
       this.consents = [...this.consents];
+      this.applicationDisplayName = this.resolveApplicationDisplayName();
     });
   }
 

--- a/gravitee-am-ui/src/app/domain/settings/users/user/applications/user-consent-application.constants.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/applications/user-consent-application.constants.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Matches {@link io.gravitee.am.management.handlers.management.api.adapter.ScopeApprovalAdapterImpl#UNKNOWN_ID}. */
+export const USER_CONSENT_UNKNOWN_APPLICATION_ENTITY_ID = 'unknown-id';
+
+/** Matches {@link io.gravitee.am.management.handlers.management.api.adapter.ConsentApplicationEntityFactory#CIMD_CLIENT}. */
+export const USER_CONSENT_CIMD_CLIENT_ENTITY_ID = 'cimd-client';
+
+export function isUserConsentSyntheticApplicationId(appId: string | null | undefined): boolean {
+  return appId === USER_CONSENT_UNKNOWN_APPLICATION_ENTITY_ID || appId === USER_CONSENT_CIMD_CLIENT_ENTITY_ID;
+}

--- a/gravitee-am-ui/src/app/resolvers/application.resolver.ts
+++ b/gravitee-am-ui/src/app/resolvers/application.resolver.ts
@@ -15,8 +15,9 @@
  */
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
+import { isUserConsentSyntheticApplicationId } from '../domain/settings/users/user/applications/user-consent-application.constants';
 import { ApplicationService } from '../services/application.service';
 
 @Injectable()
@@ -26,6 +27,14 @@ export class ApplicationResolver {
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
     const domainId = route.parent.data['domain'].id;
     const appId = route.paramMap.get('appId');
+    const clientId = route.queryParamMap.get('clientId');
+    if (clientId && isUserConsentSyntheticApplicationId(appId)) {
+      return of({
+        id: appId,
+        name: clientId,
+        settings: { oauth: { clientId } },
+      });
+    }
     return this.applicationService.get(domainId, appId);
   }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6663](https://gravitee.atlassian.net/browse/AM-6663)

## :pencil2: A description of the changes proposed in the pull request
Identify CIMD clients in audit events and user OAuth consent lists:
- Use CIMD `client_id` URL as alternative ID in the audit events
   - `CLIENT_AUTHENTICATION`
   - `TOKEN_CREATED`
- Include "Metadata Document Hash" target attribute for `CLIENT_AUTHENTICATION` events relating to CIMD clients and display this in the UI when available
- Resolve CIMD `client_name` value from the cache for the user consent endpoint (falling back to `client_id` URL on cache miss)
   - Prevent request to applications API when client is identified as CIMD-generated

## :memo: Test scenarios 
- To generate successful `CLIENT_AUTHENTICATION` audit events, set `reporters.audits.exclude.clientAuthentication.success` to false.
- Complete OAuth `/authorize` flows with scopes to generate `CLIENT_AUTHENTICATION` and `USER_CONSENT_CONSENTED` events.
- Exchange OAuth code token exchanges with `/token` to generate `TOKEN_CREATED` events.
- To view or revoke user consent to scopes, navigate to User settings > Authorized Apps tab.

## :computer: Add screenshots for UI
<img width="1395" height="137" alt="image" src="https://github.com/user-attachments/assets/abc42732-2e42-40ca-8195-8c47ccf7eda2" />

<img width="988" height="792" alt="image" src="https://github.com/user-attachments/assets/9c7e9759-964e-4221-a1a4-ddbe5e2ab055" />


## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6663]: https://gravitee.atlassian.net/browse/AM-6663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ