### PR TITLE
AM-6669 private jwt client auth cimd

### DIFF
--- a/docker/local-stack/dev/docker-compose.yml
+++ b/docker/local-stack/dev/docker-compose.yml
@@ -95,6 +95,8 @@ services:
   wiremock:
     image: wiremock/wiremock:3.13.2
     command: ["--verbose", "--global-response-templating"]
+    volumes:
+      - ./wiremock/cimd-private-key-jwt-jwks.json:/home/wiremock/__files/cimd-private-key-jwt-jwks.json:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/mappings"]
       interval: 5s

--- a/docker/local-stack/dev/wiremock/cimd-private-key-jwt-jwks.json
+++ b/docker/local-stack/dev/wiremock/cimd-private-key-jwt-jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "n": "lOd-5KMvu9C0sulBE3-NbI-FfLavakLlt6GmoWgO27iUIDE6vcjvrLC_Qu8G4m0BGWqHy9ij9iprJ_ipAIMV5r8sf_3IXVeR0_4DN8U7VOgs8Je1zKMGZUQH5LUuYVq9raQAZYX_70cL5K_8mR1sX07W2txvBzcbP_Sd4MXIT-pcmvLTDXslWQs5XJqqWotbN6SxCRCWNOjdycYi4miGycnTts2GTLkAWPyXEG8tkOIzuA33wfrimC89Zd3baXKSkAzXPhFyvq42m3uKvro_4njMuTyoQwnkXkLedJFSCa1oJom4Ggj7J2OzluKlmFFH45jALybC96XBs2nEGK0hxw",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "cimd-private-key-jwt"
+    }
+  ]
+}

--- a/docker/local-stack/dev/wiremock/request-cimd.json
+++ b/docker/local-stack/dev/wiremock/request-cimd.json
@@ -324,6 +324,19 @@
     {
       "request": {
         "method": "GET",
+        "urlPathPattern": "/cimd/ENABLED_BASE/private-key-jwt-with-jwks-uri-[A-Za-z0-9]+"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": "{\"client_id\":\"http://wiremock:8080{{request.path}}\",\"client_name\":\"CIMD PKJWT With JWKS URI\",\"redirect_uris\":[\"https://client.example.com/callback\"],\"token_endpoint_auth_method\":\"private_key_jwt\",\"jwks_uri\":\"http://wiremock:8080/jwks/cimd-private-key-jwt{{request.path}}\"}"
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
         "urlPath": "/cimd/ENABLED_BASE/invalid-json"
       },
       "response": {

--- a/docker/local-stack/dev/wiremock/request-jwks.json
+++ b/docker/local-stack/dev/wiremock/request-jwks.json
@@ -22,6 +22,19 @@
           ]
         }
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPathPattern": "/jwks/cimd-private-key-jwt/cimd/ENABLED_BASE/private-key-jwt-with-jwks-uri-[A-Za-z0-9]+"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "cimd-private-key-jwt-jwks.json"
+      }
     }
   ],
   "importOptions": {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
@@ -34,6 +34,7 @@ import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.gravitee.am.service.utils.RetryAtMostWithDelay;
 import io.gravitee.am.service.utils.jwk.converter.JWKConverter;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.buffer.Buffer;
@@ -130,6 +131,8 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
                                 log.debug("CIMD cache miss, fetching from origin for domain={}, clientId={}", domain.getId(), canonicalId);
                                 return cimdUriTrustValidator.validateResolvableHost(clientIdUri.getHost(), "client_id", settings)
                                         .andThen(fetchMetadataWithTtl(canonicalId, settings))
+                                        .flatMap(fetchResult -> validateJWKs(fetchResult, settings)
+                                                .andThen(Single.just(fetchResult)))
                                         .flatMap(fetchResult -> {
                                             final FetchResult.CacheRequirements cache = fetchResult.cacheRequirements();
                                             if (!cache.noCache()) {
@@ -148,6 +151,16 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
                             })
                     );
         });
+    }
+
+    private Completable validateJWKs(FetchResult fetchResult, CIMDSettings settings) {
+        String jwksUri = fetchResult.json().getString("jwks_uri");
+        if (jwksUri == null || jwksUri.trim().isEmpty()) {
+            return Completable.complete();
+        }
+        final URI jwksURI = cimdUriTrustValidator.parseHttpUrl(jwksUri, "jwks_uri");
+        cimdUriTrustValidator.validateTrust(jwksURI, settings, "jwks_uri");
+        return cimdUriTrustValidator.validateResolvableHost(jwksURI.getHost(), "jwks_uri", settings);
     }
 
     private CIMDSettings getCimdSettings() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
@@ -31,7 +31,6 @@ import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
@@ -51,6 +50,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Duration;
@@ -61,12 +61,12 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -358,6 +358,123 @@ public class CimdMetadataServiceImplTest {
         TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
 
         testObserver.assertError(InvalidClientMetadataException.class);
+    }
+
+    @Test
+    public void shouldRejectWhenValidateTrustRejectsJwksUri() {
+        doThrow(new InvalidClientMetadataException("jwks_uri host is not in allowed domains."))
+                .when(uriTrustValidator).validateTrust(any(URI.class), eq(cimdSettings), eq("jwks_uri"));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "private_key_jwt")
+                .put("jwks_uri", "https://idp.example.com/jwks");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verify(uriTrustValidator).validateTrust(any(URI.class), eq(cimdSettings), eq("jwks_uri"));
+        verify(cimdMetadataDocumentManager, never()).put(anyString(), any(JsonObject.class), any(Duration.class));
+        verify(cimdMetadataDocumentService, never()).upsert(any(), anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    public void shouldRejectWhenValidateResolvableHostRejectsJwksUri() {
+        when(uriTrustValidator.validateResolvableHost(eq("idp.example.com"), eq("jwks_uri"), eq(cimdSettings)))
+                .thenReturn(Completable.error(new InvalidClientMetadataException("jwks_uri resolves to a private or reserved IP address.")));
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "private_key_jwt")
+                .put("jwks_uri", "https://idp.example.com/jwks");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verify(cimdMetadataDocumentService, never()).upsert(any(), anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    public void shouldRejectMetadataWithMalformedJwksUri() {
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "private_key_jwt")
+                .put("jwks_uri", "not a url");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        verify(uriTrustValidator).parseHttpUrl("not a url", "jwks_uri");
+        verify(cimdMetadataDocumentService, never()).upsert(any(), anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    public void shouldValidateJWKsUriWithRightFieldName() {
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "private_key_jwt")
+                .put("jwks_uri", "https://idp.example.com/jwks");
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(uriTrustValidator).parseHttpUrl("https://idp.example.com/jwks", "jwks_uri");
+        verify(uriTrustValidator).validateTrust(any(URI.class), eq(cimdSettings), eq("jwks_uri"));
+        verify(uriTrustValidator).validateResolvableHost(eq("idp.example.com"), eq("jwks_uri"), eq(cimdSettings));
+    }
+
+    @Test
+    public void shouldSkipJwksUriValidationWhenAbsent() {
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"));
+        mockFetchSuccess(metadata.encode());
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(client -> client.getJwksUri() == null);
+        verify(uriTrustValidator, never()).validateTrust(any(URI.class), any(), eq("jwks_uri"));
+        verify(uriTrustValidator, never()).validateResolvableHost(anyString(), eq("jwks_uri"), any());
+    }
+
+    @Test
+    public void shouldNotRevalidateJWKsUriOnLocalCacheHit() {
+        // On a cache hit, validateMetadata is not invoked — so the validator must not be called for jwks_uri,
+        // even if the cached metadata contains a now-untrusted jwks_uri.
+        String cachedPayload = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "private_key_jwt")
+                .put("jwks_uri", "https://disallowed.example.org/jwks")
+                .encode();
+        CimdMetadataDocument cached = new CimdMetadataDocument();
+        cached.setDomainId("domain-id");
+        cached.setClientId(CLIENT_URL);
+        cached.setMetadata(cachedPayload);
+        cached.setFetchedAt(new Date());
+        cached.setExpiresAt(new Date(System.currentTimeMillis() + 86400_000));
+        cached.setUpdatedAt(new Date());
+
+        when(cimdMetadataDocumentManager.resolve(CLIENT_URL))
+                .thenReturn(Single.just(Optional.of(cached)));
+
+        TestObserver<Client> testObserver = cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValueCount(1);
+        verifyNoInteractions(webClient);
+        verify(uriTrustValidator, never()).validateTrust(any(URI.class), any(), eq("jwks_uri"));
+        verify(uriTrustValidator, never()).validateResolvableHost(anyString(), eq("jwks_uri"), any());
     }
 
     @Test
@@ -684,7 +801,7 @@ public class CimdMetadataServiceImplTest {
                 .put("client_id", clientId)
                 .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
                 .put("token_endpoint_auth_method", "private_key_jwt")
-                .put("jwks_uri", "https://localhost/jwks")
+                .put("jwks_uri", "https://idp.example.com/jwks")
                 .encode();
     }
 
@@ -960,7 +1077,7 @@ public class CimdMetadataServiceImplTest {
                 .put("client_id", clientId)
                 .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
                 .put("token_endpoint_auth_method", "private_key_jwt")
-                .put("jwks_uri", "https://localhost/jwks")
+                .put("jwks_uri", "https://idp.example.com/jwks")
                 .put("logo_uri", logoUri)
                 .encode();
     }
@@ -976,7 +1093,7 @@ public class CimdMetadataServiceImplTest {
                 .put("client_id", clientId)
                 .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
                 .put("token_endpoint_auth_method", "private_key_jwt")
-                .put("jwks_uri", "https://localhost/jwks")
+                .put("jwks_uri", "https://idp.example.com/jwks")
                 .put("logo_uri", "")
                 .encode();
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/ClientAssertionServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/ClientAssertionServiceImpl.java
@@ -81,9 +81,6 @@ public class ClientAssertionServiceImpl implements ClientAssertionService {
     @Autowired
     private Domain domain;
 
-    @Autowired
-    private SecretService appSecretService;
-
     @Override
     public Maybe<Client> assertClient(String assertionType, String assertion, String basePath) {
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/jwk/impl/JWKServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/jwk/impl/JWKServiceImpl.java
@@ -15,24 +15,19 @@
  */
 package io.gravitee.am.gateway.handler.oidc.service.jwk.impl;
 
-import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
 import io.gravitee.am.gateway.handler.oidc.service.jwk.JWKService;
-import io.gravitee.am.service.utils.jwk.converter.JWKSetDeserializer;
+import io.gravitee.am.service.jwk.JWKSetFetcher;
 import io.gravitee.am.model.jose.JWK;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.JWKSet;
-import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.gravitee.am.service.jwk.JWKSetFetcher.JWKSetFetchResponse;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import io.vertx.rxjava3.ext.web.client.HttpResponse;
-import io.vertx.rxjava3.ext.web.client.WebClient;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
-import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -49,8 +44,7 @@ public class JWKServiceImpl implements JWKService {
     private CertificateManager certificateManager;
 
     @Autowired
-    @Qualifier("oidcWebClient")
-    public WebClient client;
+    private JWKSetFetcher jwkSetFetcher;
 
     @Override
     public Single<JWKSet> getKeys() {
@@ -93,23 +87,8 @@ public class JWKServiceImpl implements JWKService {
 
     @Override
     public Maybe<JWKSet> getKeys(String jwksUri) {
-        try {
-            return client.getAbs(UriBuilder.fromHttpUrl(jwksUri).build().toString())
-                    .rxSend()
-                    .map(HttpResponse::bodyAsString)
-                    .map(new JWKSetDeserializer()::convert)
-                    .flatMapMaybe(jwkSet -> {
-                        if (jwkSet != null && jwkSet.isPresent()) {
-                            return Maybe.just(jwkSet.get());
-                        }
-                        return Maybe.empty();
-                    })
-                    .onErrorResumeNext(exception -> Maybe.error(new InvalidClientMetadataException("Unable to parse jwks from : " + jwksUri)));
-        } catch (IllegalArgumentException | URISyntaxException ex) {
-            return Maybe.error(new InvalidClientMetadataException(jwksUri + " is not valid."));
-        } catch (InvalidClientMetadataException ex) {
-            return Maybe.error(ex);
-        }
+        return jwkSetFetcher.getKeys(jwksUri)
+                .map(JWKSetFetchResponse::jwkSet);
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/jwk/JWKServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/jwk/JWKServiceTest.java
@@ -20,6 +20,8 @@ import com.nimbusds.jose.JWEAlgorithm;
 import io.gravitee.am.certificate.api.CertificateProvider;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
 import io.gravitee.am.gateway.handler.oidc.service.jwk.impl.JWKServiceImpl;
+import io.gravitee.am.service.jwk.JWKSetFetcher;
+import io.gravitee.am.service.jwk.JWKSetFetcher.JWKSetFetchResponse;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.jose.ECKey;
 import io.gravitee.am.model.jose.JWK;
@@ -29,12 +31,8 @@ import io.gravitee.am.model.jose.RSAKey;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.rxjava3.ext.web.client.HttpRequest;
-import io.vertx.rxjava3.ext.web.client.HttpResponse;
-import io.vertx.rxjava3.ext.web.client.WebClient;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,7 +64,7 @@ public class JWKServiceTest {
     private JWKService jwkService = new JWKServiceImpl();
 
     @Mock
-    public WebClient webClient;
+    private JWKSetFetcher jwkSetFetcher;
 
     @Mock
     private CertificateManager certificateManager;
@@ -137,63 +135,42 @@ public class JWKServiceTest {
     }
 
     @Test
-    public void testGetKeys_UriException() {
-        TestObserver testObserver = jwkService.getKeys("blabla").test();
+    public void testGetKeys_delegatesToFetcher() {
+        JWK jwk = Mockito.mock(JWK.class);
+        when(jwk.getKid()).thenReturn("KID");
+        JWKSet jwkSet = new JWKSet();
+        jwkSet.setKeys(Arrays.asList(jwk));
 
-        testObserver.assertError(InvalidClientMetadataException.class);
-        testObserver.assertNotComplete();
-    }
-
-    @Test
-    public void testGetKeys_errorResponse() {
-
-        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
-        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
-
-
-        when(webClient.getAbs(anyString())).thenReturn(request);
-        when(request.rxSend()).thenReturn(Single.just(response));
-
-        TestObserver testObserver = jwkService.getKeys(JWKS_URI).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        testObserver.assertNotComplete();
-    }
-
-    @Test
-    public void testGetKeys_parseException() {
-
-        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
-        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
-
-
-        when(webClient.getAbs(anyString())).thenReturn(request);
-        when(request.rxSend()).thenReturn(Single.just(response));
-        when(response.bodyAsString()).thenReturn("{\"unknown\":[]}");
-
-        TestObserver testObserver = jwkService.getKeys(JWKS_URI).test();
-
-        testObserver.assertError(InvalidClientMetadataException.class);
-        testObserver.assertNotComplete();
-    }
-
-    @Test
-    public void testGetKeys() {
-
-        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
-        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
-
-        String bodyAsString = "{\"keys\":[{\"kty\": \"RSA\",\"use\": \"enc\",\"kid\": \"KID\",\"n\": \"modulus\",\"e\": \"exponent\"}]}";
-
-        when(webClient.getAbs(anyString())).thenReturn(request);
-        when(request.rxSend()).thenReturn(Single.just(response));
-        when(response.bodyAsString()).thenReturn(bodyAsString);
+        when(jwkSetFetcher.getKeys(JWKS_URI)).thenReturn(Maybe.just(new JWKSetFetchResponse(jwkSet, null)));
 
         TestObserver testObserver = jwkService.getKeys(JWKS_URI).test();
 
         testObserver.assertNoErrors();
         testObserver.assertComplete();
-        testObserver.assertValue(jwkSet -> ((JWKSet)jwkSet).getKeys().get(0).getKid().equals("KID"));
+        testObserver.assertValue(value -> ((JWKSet) value).getKeys().get(0).getKid().equals("KID"));
+        verify(jwkSetFetcher).getKeys(JWKS_URI);
+    }
+
+    @Test
+    public void testGetKeys_fetcherEmpty_emitsEmpty() {
+        when(jwkSetFetcher.getKeys(JWKS_URI)).thenReturn(Maybe.empty());
+
+        TestObserver testObserver = jwkService.getKeys(JWKS_URI).test();
+
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+        testObserver.assertNoValues();
+    }
+
+    @Test
+    public void testGetKeys_fetcherError_propagates() {
+        when(jwkSetFetcher.getKeys(JWKS_URI))
+                .thenReturn(Maybe.error(new InvalidClientMetadataException("boom")));
+
+        TestObserver testObserver = jwkService.getKeys(JWKS_URI).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        testObserver.assertNotComplete();
     }
 
     @Test
@@ -269,19 +246,17 @@ public class JWKServiceTest {
         Client client = new Client();
         client.setJwksUri(JWKS_URI);
 
-        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
-        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
+        JWK jwk = Mockito.mock(JWK.class);
+        when(jwk.getKid()).thenReturn("KID");
+        JWKSet jwkSet = new JWKSet();
+        jwkSet.setKeys(Arrays.asList(jwk));
 
-        String bodyAsString = "{\"keys\":[{\"kty\": \"RSA\",\"use\": \"enc\",\"kid\": \"KID\",\"n\": \"modulus\",\"e\": \"exponent\"}]}";
-
-        when(webClient.getAbs(anyString())).thenReturn(request);
-        when(request.rxSend()).thenReturn(Single.just(response));
-        when(response.bodyAsString()).thenReturn(bodyAsString);
+        when(jwkSetFetcher.getKeys(JWKS_URI)).thenReturn(Maybe.just(new JWKSetFetchResponse(jwkSet, null)));
 
         TestObserver testObserver = jwkService.getKeys(client).test();
         testObserver.assertNoErrors();
         testObserver.assertComplete();
-        testObserver.assertValue(jwkSet -> ((JWKSet)jwkSet).getKeys().get(0).getKid().equals("KID"));
+        testObserver.assertValue(value -> ((JWKSet) value).getKeys().get(0).getKid().equals("KID"));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -200,6 +200,9 @@ services:
 # JWT used to generate signed token for OAuth 2.0/OpenID Connect protocols and to verify emails
 jwt:
   jwks:
+#    cache:
+#      ttlAfterWriteSeconds: 3600
+#      maximumSize: 100
     retriever:
       type: JOSE # JOSE | WEBCLIENT
   secret: s3cR3t4grAv1t3310AMS1g1ingDftK3y # jwt secret used to sign JWT tokens (HMAC algorithm)

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/jwk/JWKSetFetcher.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/jwk/JWKSetFetcher.java
@@ -13,26 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.service.nimbusds;
+package io.gravitee.am.service.jwk;
 
 import com.nimbusds.jose.util.Resource;
-import com.nimbusds.jose.util.ResourceRetriever;
-import io.gravitee.am.service.jwk.JWKSetFetcher;
-import io.gravitee.am.service.jwk.JWKSetFetcher.JWKSetFetchResponse;
-import lombok.RequiredArgsConstructor;
+import io.gravitee.am.model.oidc.JWKSet;
+import io.reactivex.rxjava3.core.Maybe;
 
-import java.io.IOException;
-import java.net.URL;
+public interface JWKSetFetcher {
+    Maybe<JWKSetFetchResponse> getKeys(String jwksUri);
 
-@RequiredArgsConstructor
-public class WebClientResourceRetriever implements ResourceRetriever {
-    private final JWKSetFetcher jwkSetFetcher;
-
-    @Override
-    public Resource retrieveResource(URL url) throws IOException {
-        return jwkSetFetcher.getKeys(url.toExternalForm())
-                .map(JWKSetFetchResponse::resource)
-                .blockingGet();
-    }
-
+    record JWKSetFetchResponse(JWKSet jwkSet, Resource resource) {}
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/jwk/impl/CachedJWKSetFetcher.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/jwk/impl/CachedJWKSetFetcher.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.jwk.impl;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.gravitee.am.service.jwk.JWKSetFetcher;
+import io.reactivex.rxjava3.core.Maybe;
+
+import java.time.Duration;
+
+public class CachedJWKSetFetcher implements JWKSetFetcher {
+    private final JWKSetFetcher jwkSetFetcher;
+    private final Cache<String, JWKSetFetchResponse> cache;
+
+    public CachedJWKSetFetcher(JWKSetFetcher jwkSetFetcher,
+                               long maximumSize,
+                               Duration expireAfterWrite) {
+        this.cache = CacheBuilder.newBuilder()
+                .maximumSize(maximumSize)
+                .expireAfterWrite(expireAfterWrite)
+                .build();
+        this.jwkSetFetcher = jwkSetFetcher;
+    }
+
+    @Override
+    public Maybe<JWKSetFetchResponse> getKeys(String jwksUri) {
+        return Maybe.fromCallable(() -> cache.getIfPresent(jwksUri))
+                .switchIfEmpty(Maybe.defer(() -> this.jwkSetFetcher.getKeys(jwksUri)).doAfterSuccess(value -> cache.put(jwksUri, value)));
+    }
+
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/jwk/impl/WebClientJWKSetFetcher.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/jwk/impl/WebClientJWKSetFetcher.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.jwk.impl;
+
+import com.nimbusds.jose.util.Resource;
+import io.gravitee.am.common.web.UriBuilder;
+import io.gravitee.am.model.oidc.JWKSet;
+import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.gravitee.am.service.jwk.JWKSetFetcher;
+import io.gravitee.am.service.utils.jwk.converter.JWKSetDeserializer;
+import io.reactivex.rxjava3.core.Maybe;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.rxjava3.ext.web.client.HttpResponse;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Slf4j
+public class WebClientJWKSetFetcher implements JWKSetFetcher {
+    private final WebClient client;
+
+    private final static JWKSetDeserializer JWK_SET_DESERIALIZER = new JWKSetDeserializer();
+
+    @Override
+    public Maybe<JWKSetFetchResponse> getKeys(String jwksUri) {
+        return fetch(jwksUri);
+    }
+
+    private Maybe<JWKSetFetchResponse> fetch(String jwksUri) {
+        try {
+            String url = UriBuilder.fromHttpUrl(jwksUri).build().toString();
+            return client.getAbs(url)
+                    .rxSend()
+                    .flatMapMaybe(res -> {
+                        if (res.statusCode() == 200) {
+                            return Maybe.just(res);
+                        }
+                        String errorMessage = String.format(
+                                "HTTP status %s retrieving JWK set from %s. Body: %s",
+                                res.statusCode(),
+                                url,
+                                res.bodyAsString());
+                        return Maybe.error(new IOException(errorMessage));
+                    })
+                    .flatMap(this::toResponse)
+                    .onErrorResumeNext(exception -> Maybe.error(new InvalidClientMetadataException("Unable to parse jwks from : " + jwksUri)));
+        } catch (IllegalArgumentException | URISyntaxException ex) {
+            log.debug("Unable to parse jwks from : {}", jwksUri, ex);
+            return Maybe.error(new InvalidClientMetadataException(jwksUri + " is not valid."));
+        } catch (InvalidClientMetadataException ex) {
+            log.debug("Unable to parse jwks from : {}", jwksUri, ex);
+            return Maybe.error(ex);
+        }
+    }
+
+    private Maybe<JWKSetFetchResponse> toResponse(HttpResponse response) {
+        String raw = response.bodyAsString();
+        Optional<JWKSet> jwkSet = JWK_SET_DESERIALIZER.convert(raw);
+        return Maybe.fromOptional(jwkSet)
+                .map(res -> new JWKSetFetchResponse(res, new Resource(raw, response.getHeader(HttpHeaders.CONTENT_TYPE))));
+    }
+
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/spring/JWTConfiguration.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/spring/JWTConfiguration.java
@@ -24,9 +24,11 @@ import io.gravitee.am.jwt.DefaultJWTParser;
 import io.gravitee.am.jwt.JWTBuilder;
 import io.gravitee.am.jwt.JWTParser;
 import io.gravitee.am.service.http.WebClientBuilder;
+import io.gravitee.am.service.jwk.JWKSetFetcher;
+import io.gravitee.am.service.jwk.impl.CachedJWKSetFetcher;
+import io.gravitee.am.service.jwk.impl.WebClientJWKSetFetcher;
 import io.gravitee.am.service.nimbusds.WebClientResourceRetriever;
 import io.vertx.rxjava3.core.Vertx;
-import io.vertx.rxjava3.ext.web.client.WebClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.security.InvalidKeyException;
 import java.security.Key;
+import java.time.Duration;
 
 import static io.gravitee.am.common.utils.ConstantKeys.DEFAULT_JWT_OR_CSRF_SECRET;
 
@@ -48,6 +51,17 @@ public class JWTConfiguration {
     public enum RetrieverType {
         JOSE,
         WEBCLIENT
+    }
+
+    @Bean
+    public JWKSetFetcher jwkSetFetcher(Vertx vertx,
+                                       WebClientBuilder webClient,
+                                       @Value("${jwt.jwks.cache.maximumSize:100}") long maximumSize,
+                                       @Value("${jwt.jwks.cache.ttlAfterWriteSeconds:3600}") long expireAfterWriteSeconds){
+        return new CachedJWKSetFetcher(
+                new WebClientJWKSetFetcher(webClient.createWebClient(vertx)),
+                maximumSize,
+                Duration.ofSeconds(expireAfterWriteSeconds));
     }
 
     @Bean("managementSecretKey")
@@ -67,21 +81,14 @@ public class JWTConfiguration {
     }
 
     @Bean("defaultResourceRetriever")
-    protected ResourceRetriever defaultResourceRetriever(Vertx vertx,
+    protected ResourceRetriever defaultResourceRetriever(JWKSetFetcher jwkSetFetcher,
                                                          @Value("${jwt.jwks.retriever.type:JOSE}") RetrieverType type,
-                                                         WebClientBuilder webClientBuilder,
                                                          @Value("${httpClient.timeout:10000}") int connectionTimeout,
                                                          @Value("${httpClient.readTimeout:5000}") int readTimeout) {
         return switch (type) {
             case JOSE -> createJoseResourceRetriever(connectionTimeout, readTimeout);
-            case WEBCLIENT -> createWebClientResourceRetriever(vertx, webClientBuilder);
+            case WEBCLIENT -> new WebClientResourceRetriever(jwkSetFetcher);
         };
-    }
-
-    private ResourceRetriever createWebClientResourceRetriever(Vertx vertx, WebClientBuilder webClientBuilder) {
-        log.info("Creating WebClient for all JWKs retrievers");
-        WebClient webClient = webClientBuilder.createWebClient(vertx);
-        return new WebClientResourceRetriever(webClient);
     }
 
     private ResourceRetriever createJoseResourceRetriever(@Value("${httpClient.timeout:10000}") int connectionTimeout,

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/jwk/impl/CachedJWKSetFetcherTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/jwk/impl/CachedJWKSetFetcherTest.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.jwk.impl;
+
+import io.gravitee.am.service.jwk.JWKSetFetcher;
+import io.gravitee.am.service.jwk.JWKSetFetcher.JWKSetFetchResponse;
+import io.gravitee.am.model.jose.RSAKey;
+import io.gravitee.am.model.oidc.JWKSet;
+import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CachedJWKSetFetcherTest {
+
+    private static final String JWKS_URI_A = "https://idp-a.example.com/jwks";
+    private static final String JWKS_URI_B = "https://idp-b.example.com/jwks";
+
+    @Mock
+    private JWKSetFetcher delegate;
+
+    private CachedJWKSetFetcher cache;
+
+    @Before
+    public void setUp() {
+        cache = new CachedJWKSetFetcher(delegate, 100L, Duration.ofMinutes(5));
+    }
+
+    @Test
+    public void getKeys_firstCall_delegatesToWrappedFetcher() {
+        JWKSetFetchResponse response = response("key-a");
+        when(delegate.getKeys(JWKS_URI_A)).thenReturn(Maybe.just(response));
+
+        TestObserver<JWKSetFetchResponse> testObserver = cache.getKeys(JWKS_URI_A).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(response);
+        verify(delegate, times(1)).getKeys(JWKS_URI_A);
+    }
+
+    @Test
+    public void getKeys_secondCallSameUri_servesFromCache() {
+        JWKSetFetchResponse response = response("key-a");
+        when(delegate.getKeys(JWKS_URI_A)).thenReturn(Maybe.just(response));
+
+        cache.getKeys(JWKS_URI_A).test().assertComplete();
+        TestObserver<JWKSetFetchResponse> secondCall = cache.getKeys(JWKS_URI_A).test();
+
+        secondCall.assertComplete();
+        secondCall.assertValue(response);
+        verify(delegate, times(1)).getKeys(JWKS_URI_A);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void getKeys_distinctUris_areCachedSeparately() {
+        JWKSetFetchResponse responseA = response("key-a");
+        JWKSetFetchResponse responseB = response("key-b");
+        when(delegate.getKeys(JWKS_URI_A)).thenReturn(Maybe.just(responseA));
+        when(delegate.getKeys(JWKS_URI_B)).thenReturn(Maybe.just(responseB));
+
+        cache.getKeys(JWKS_URI_A).test().assertValue(responseA);
+        cache.getKeys(JWKS_URI_B).test().assertValue(responseB);
+        cache.getKeys(JWKS_URI_A).test().assertValue(responseA);
+        cache.getKeys(JWKS_URI_B).test().assertValue(responseB);
+
+        verify(delegate, times(1)).getKeys(JWKS_URI_A);
+        verify(delegate, times(1)).getKeys(JWKS_URI_B);
+    }
+
+    @Test
+    public void getKeys_delegateEmpty_notCached() {
+        when(delegate.getKeys(JWKS_URI_A)).thenReturn(Maybe.empty());
+
+        cache.getKeys(JWKS_URI_A).test().assertComplete().assertNoValues();
+        cache.getKeys(JWKS_URI_A).test().assertComplete().assertNoValues();
+
+        verify(delegate, times(2)).getKeys(JWKS_URI_A);
+    }
+
+    @Test
+    public void getKeys_delegateError_propagatesAndDoesNotCache() {
+        when(delegate.getKeys(JWKS_URI_A))
+                .thenReturn(Maybe.error(new InvalidClientMetadataException("boom")));
+
+        cache.getKeys(JWKS_URI_A).test().assertError(InvalidClientMetadataException.class);
+        cache.getKeys(JWKS_URI_A).test().assertError(InvalidClientMetadataException.class);
+
+        verify(delegate, times(2)).getKeys(JWKS_URI_A);
+    }
+
+    @Test
+    public void getKeys_expiresAfterWrite() {
+        CachedJWKSetFetcher shortLived = new CachedJWKSetFetcher(delegate, 100L, Duration.ofMillis(50));
+        JWKSetFetchResponse response = response("key-a");
+        when(delegate.getKeys(JWKS_URI_A)).thenReturn(Maybe.just(response));
+
+        shortLived.getKeys(JWKS_URI_A).test().assertValue(response);
+
+        Awaitility.await()
+                .atMost(2, TimeUnit.SECONDS)
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    shortLived.getKeys(JWKS_URI_A).test().assertValue(response);
+                    verify(delegate, times(2)).getKeys(JWKS_URI_A);
+                });
+    }
+
+    @Test
+    public void getKeys_maximumSizeEnforced() {
+        CachedJWKSetFetcher tinyCache = new CachedJWKSetFetcher(delegate, 1L, Duration.ofMinutes(5));
+        JWKSetFetchResponse responseA = response("key-a");
+        JWKSetFetchResponse responseB = response("key-b");
+        when(delegate.getKeys(JWKS_URI_A)).thenReturn(Maybe.just(responseA));
+        when(delegate.getKeys(JWKS_URI_B)).thenReturn(Maybe.just(responseB));
+
+        tinyCache.getKeys(JWKS_URI_A).test().assertValue(responseA);
+        tinyCache.getKeys(JWKS_URI_B).test().assertValue(responseB);
+        // entry A should have been evicted by B (maximumSize = 1)
+        tinyCache.getKeys(JWKS_URI_A).test().assertValue(responseA);
+
+        verify(delegate, times(2)).getKeys(JWKS_URI_A);
+        verify(delegate, times(1)).getKeys(JWKS_URI_B);
+    }
+
+    private static JWKSetFetchResponse response(String kid) {
+        RSAKey key = new RSAKey();
+        key.setKty("RSA");
+        key.setKid(kid);
+        key.setUse("sig");
+        JWKSet set = new JWKSet();
+        set.setKeys(Collections.singletonList(key));
+        return new JWKSetFetchResponse(set, null);
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/jwk/impl/WebClientJWKSetFetcherTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/jwk/impl/WebClientJWKSetFetcherTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.jwk.impl;
+
+import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.gravitee.am.service.jwk.JWKSetFetcher.JWKSetFetchResponse;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.rxjava3.ext.web.client.HttpRequest;
+import io.vertx.rxjava3.ext.web.client.HttpResponse;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WebClientJWKSetFetcherTest {
+
+    private static final String JWKS_URI = "http://client/jwk/uri";
+
+    @Mock
+    private WebClient webClient;
+
+    private WebClientJWKSetFetcher fetcher;
+
+    @Before
+    public void setUp() {
+        fetcher = new WebClientJWKSetFetcher(webClient);
+    }
+
+    @Test
+    public void getKeys_invalidUriString_returnsInvalidClientMetadataException() {
+        TestObserver<JWKSetFetchResponse> testObserver = fetcher.getKeys("blabla").test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        testObserver.assertNotComplete();
+        verifyNoInteractions(webClient);
+    }
+
+    @Test
+    public void getKeys_nonOkStatus_returnsInvalidClientMetadataException() {
+        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
+
+        when(webClient.getAbs(anyString())).thenReturn(request);
+        when(request.rxSend()).thenReturn(Single.just(response));
+        when(response.statusCode()).thenReturn(404);
+        when(response.bodyAsString()).thenReturn("not found");
+
+        TestObserver<JWKSetFetchResponse> testObserver = fetcher.getKeys(JWKS_URI).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        testObserver.assertNotComplete();
+    }
+
+    @Test
+    public void getKeys_nullBody_returnsInvalidClientMetadataException() {
+        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
+
+        when(webClient.getAbs(anyString())).thenReturn(request);
+        when(request.rxSend()).thenReturn(Single.just(response));
+        when(response.statusCode()).thenReturn(200);
+
+        TestObserver<JWKSetFetchResponse> testObserver = fetcher.getKeys(JWKS_URI).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        testObserver.assertNotComplete();
+    }
+
+    @Test
+    public void getKeys_unparseableBody_returnsInvalidClientMetadataException() {
+        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
+
+        when(webClient.getAbs(anyString())).thenReturn(request);
+        when(request.rxSend()).thenReturn(Single.just(response));
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsString()).thenReturn("{\"unknown\":[]}");
+
+        TestObserver<JWKSetFetchResponse> testObserver = fetcher.getKeys(JWKS_URI).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        testObserver.assertNotComplete();
+    }
+
+    @Test
+    public void getKeys_validBody_returnsJWKSet() {
+        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
+
+        String bodyAsString = "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"enc\",\"kid\":\"KID\",\"n\":\"modulus\",\"e\":\"exponent\"}]}";
+
+        when(webClient.getAbs(anyString())).thenReturn(request);
+        when(request.rxSend()).thenReturn(Single.just(response));
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsString()).thenReturn(bodyAsString);
+
+        TestObserver<JWKSetFetchResponse> testObserver = fetcher.getKeys(JWKS_URI).test();
+
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+        testObserver.assertValue(r -> r.jwkSet().getKeys().size() == 1
+                && "KID".equals(r.jwkSet().getKeys().get(0).getKid()));
+    }
+
+    @Test
+    public void getKeys_emptyKeysArray_emitsJWKSetWithNoKeys() {
+        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
+
+        when(webClient.getAbs(anyString())).thenReturn(request);
+        when(request.rxSend()).thenReturn(Single.just(response));
+        when(response.statusCode()).thenReturn(200);
+        when(response.bodyAsString()).thenReturn("{\"keys\":[]}");
+
+        TestObserver<JWKSetFetchResponse> testObserver = fetcher.getKeys(JWKS_URI).test();
+
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+        testObserver.assertValue(r -> r.jwkSet().getKeys() != null && r.jwkSet().getKeys().isEmpty());
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/nimbusds/WebClientResourceRetrieverTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/nimbusds/WebClientResourceRetrieverTest.java
@@ -16,92 +16,63 @@
 package io.gravitee.am.service.nimbusds;
 
 import com.nimbusds.jose.util.Resource;
-import io.reactivex.rxjava3.core.Single;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.rxjava3.ext.web.client.HttpResponse;
-import io.vertx.rxjava3.ext.web.client.HttpRequest;
-import io.vertx.rxjava3.ext.web.client.WebClient;
+import io.gravitee.am.model.oidc.JWKSet;
+import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.gravitee.am.service.jwk.JWKSetFetcher;
+import io.gravitee.am.service.jwk.JWKSetFetcher.JWKSetFetchResponse;
+import io.reactivex.rxjava3.core.Maybe;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.IOException;
 import java.net.URL;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WebClientResourceRetrieverTest {
 
     @Mock
-    private WebClient webClient;
-
-    @Mock
-    private HttpRequest<Buffer> httpRequest;
-
-    @Mock
-    private HttpResponse<Buffer> httpResponse;
+    private JWKSetFetcher jwkSetFetcher;
 
     private WebClientResourceRetriever retriever;
 
     @BeforeEach
     void setUp() {
-        retriever = new WebClientResourceRetriever(webClient);
+        retriever = new WebClientResourceRetriever(jwkSetFetcher);
     }
 
     @Test
-    void shouldRetrieveResourceSuccessfully_whenHttp200() throws Exception {
-        // given
+    void shouldReturnResourceFromFetcher() throws Exception {
         URL url = new URL("https://example.com/jwks");
-        String body = "{\"keys\":[]}";
-        String contentType = "application/json";
+        Resource resource = new Resource("{\"keys\":[]}", "application/json");
+        when(jwkSetFetcher.getKeys(url.toExternalForm()))
+                .thenReturn(Maybe.just(new JWKSetFetchResponse(new JWKSet(), resource)));
 
-        when(webClient.getAbs(url.toExternalForm())).thenReturn(httpRequest);
-        when(httpRequest.rxSend()).thenReturn(Single.just(httpResponse));
-        when(httpResponse.statusCode()).thenReturn(200);
-        when(httpResponse.bodyAsString()).thenReturn(body);
-        when(httpResponse.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn(contentType);
+        Resource result = retriever.retrieveResource(url);
 
-        // when
-        Resource resource = retriever.retrieveResource(url);
-
-        // then
-        assertThat(resource).isNotNull();
-        assertThat(resource.getContent()).isEqualTo(body);
-        assertThat(resource.getContentType()).isEqualTo(contentType);
+        assertThat(result).isSameAs(resource);
     }
 
     @Test
-    void shouldThrowIOException_whenHttpStatusIsNot200() throws Exception {
-        // given
+    void shouldReturnNullWhenFetcherEmpty() throws Exception {
         URL url = new URL("https://example.com/jwks");
+        when(jwkSetFetcher.getKeys(url.toExternalForm())).thenReturn(Maybe.empty());
 
-        when(webClient.getAbs(url.toExternalForm())).thenReturn(httpRequest);
-        when(httpRequest.rxSend()).thenReturn(Single.just(httpResponse));
-        when(httpResponse.statusCode()).thenReturn(404);
-        when(httpResponse.bodyAsString()).thenReturn("Not Found");
+        assertThat(retriever.retrieveResource(url)).isNull();
+    }
 
-        // when / then
+    @Test
+    void shouldPropagateFetcherError() throws Exception {
+        URL url = new URL("https://example.com/jwks");
+        when(jwkSetFetcher.getKeys(url.toExternalForm()))
+                .thenReturn(Maybe.error(new InvalidClientMetadataException("boom")));
+
         assertThatThrownBy(() -> retriever.retrieveResource(url))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining(url.toString());
-    }
-
-    @Test
-    void shouldWrapExceptionInIOException_whenWebClientFails() throws Exception {
-        // given
-        URL url = new URL("https://example.com/jwks");
-
-        when(webClient.getAbs(url.toExternalForm())).thenReturn(httpRequest);
-        when(httpRequest.rxSend()).thenReturn(Single.error(new RuntimeException("Boom")));
-
-        // when / then
-        assertThatThrownBy(() -> retriever.retrieveResource(url))
-                .isInstanceOf(IOException.class)
-                .hasCauseInstanceOf(RuntimeException.class);
+                .isInstanceOf(InvalidClientMetadataException.class);
     }
 }

--- a/gravitee-am-test/api/fixtures/cimd-private-key-jwt.ts
+++ b/gravitee-am-test/api/fixtures/cimd-private-key-jwt.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const CIMD_PRIVATE_KEY_JWT_KID = 'cimd-private-key-jwt';
+
+export const cimdPrivateKeyJwtPrivateJwk = {
+  kty: 'RSA',
+  n: 'lOd-5KMvu9C0sulBE3-NbI-FfLavakLlt6GmoWgO27iUIDE6vcjvrLC_Qu8G4m0BGWqHy9ij9iprJ_ipAIMV5r8sf_3IXVeR0_4DN8U7VOgs8Je1zKMGZUQH5LUuYVq9raQAZYX_70cL5K_8mR1sX07W2txvBzcbP_Sd4MXIT-pcmvLTDXslWQs5XJqqWotbN6SxCRCWNOjdycYi4miGycnTts2GTLkAWPyXEG8tkOIzuA33wfrimC89Zd3baXKSkAzXPhFyvq42m3uKvro_4njMuTyoQwnkXkLedJFSCa1oJom4Ggj7J2OzluKlmFFH45jALybC96XBs2nEGK0hxw',
+  e: 'AQAB',
+  d: 'E8wxpWGDA7QsiksUAW0olwIADARYD0dEtqUR_AzTSOhiHWOePUR9hVbcnyAbqLg4eLIeyv4LUrvyElbv1WcYXt0VJBFQdgSiGW8A64XYLSJPc0-gdsxIGeexKvnh6ETBylfvS5BE5oHqNWYmrg7o7UUUsPW0918eyuKRqSRyzRkWa-0fDbJSwveDStgK-83_JaBLipcObMmcpvzegogzvypWfcNLAiINo9UqCmP2GfW2x2KFXeFbsuYlEDz9sERVRerzFksvgbahi93-tFtPJr4fWTXIcJu3cXgBDMsm8x6U0CRa2-WkRjS8yrn-pvxiWWyOFI3il1Q1lA6dolQhWQ',
+  p: 'zMFysVKDyGQCQqlw1VyD-46BZKdLcmdJt_GwECsLy0z2s8qgSzU7_uLRDBbFCgNfLa-iawggrcz6u98Ex2RnRnXSRzroPNPosa08ZOA9ixWUsghSK8jkgt-y7r17TSQqoJ8X2xwLItoejxqzsCxI3RnCYem5cF0LWRZNpNNxK38',
+  q: 'uiuwX7KNdxi5KSnoAwjmXfP7_4NoLprWeLimOYPaeCN2wBVBfq6SU80y0W0Y7hHBWHgr8zDKGpRbmMT_xf6M8t5zADTN_hV8T-Z9PWRTcTX5Yx3wrlKvOpcYiWgE8T-LRaoMk6Np-Mzdo025yAQo7j0kDExzJnglifdumZvwzbk',
+  dp: 'N-l7UECgC9CDbYCndxvUTpUTcFDeoVbjIn-0_DVE-zcBBweFzgOzZl65hvuQwrM5Ali7mU6W3d7jePnlbC1Wpj72NM05LaMQH7SWkVVKePhjqlnrVll9TN-ZFOhZCy-dFE9dTE_UGqhFP_6iorD1FKs8EVCpeq1ts94LRb8XYDE',
+  dq: 'Cqq0KVeGqXs-KLCg_YOGB34SQzqZPopanYIe7A609ss5Y5oULZj9A1YvgjZZBlL4HASOqBl0iv9THDa1XPfPxZ6fQjTEVLmQbNeM93aHHWZ1SouNnb9ZEOdVXZIbLmNwrGYo4FCtorbCQDgU2_P5EGVqalX7Bwo9RGFr8dsweek',
+  qi: 'wbllD3ylf5VmnhR8IPVjrXXXBM9KKg6fly61aVIwipu2wihnUMmMZmIu1a42FxVpHXfHv6teGUC6lM2bcmiYpEfcY4iOO4nyHjXAKfeJnLDoIHarCSNTJV20kD03D4iIDTxCfiO6PK5g3RZ_iRumt0FZjAaJdgzCaRU1GIkP5YY',
+  use: 'sig',
+  kid: CIMD_PRIVATE_KEY_JWT_KID,
+};

--- a/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-authorize-enabled-base.jest.spec.ts
@@ -23,7 +23,6 @@ import {
   fetchWireMockRequestJournal,
 } from './fixtures/cimd-wiremock-helpers';
 import { decodeJwt } from '@utils-commands/jwt';
-import { delay } from '@utils-commands/misc';
 
 setup(200000);
 
@@ -142,6 +141,52 @@ describe('CIMD authorize - ENABLED_BASE', () => {
   it('should continue authorization when private_key_jwt metadata includes jwks', async () => {
     const response = await fixture.authorize(fixture.buildClientId('private-key-jwt-with-jwks'));
     fixture.expectLoginRedirect(response);
+  });
+
+  it('should authenticate private_key_jwt CIMD client with public keys exposed by jwks_uri', async () => {
+    await clearWireMockRequestJournal();
+    const scenario = `private-key-jwt-with-jwks-uri-${Date.now()}`;
+    const clientId = fixture.buildClientId(scenario);
+    const jwksPath = `/jwks/cimd-private-key-jwt${new URL(clientId).pathname}`;
+
+    const code = await fixture.completeAuthorizationCodeFlow(clientId);
+    const tokenResponse = await fixture.exchangeAuthCodeForTokenWithPrivateKeyJwt(code, clientId);
+    const accessToken = tokenResponse.body.access_token;
+    expect(accessToken).toBeDefined();
+    expect(decodeJwt(accessToken).aud).toBe(clientId);
+
+    const introspection = await fixture.introspectTokenWithPrivateKeyJwt(accessToken, clientId);
+    expect(introspection.active).toBe(true);
+    expect(introspection.client_id).toBe(clientId);
+    expect(introspection.aud).toBe(clientId);
+    expect(introspection.token_type).toBe('bearer');
+    expect(introspection.iss).toContain(fixture.domain.hrid);
+    expect(introspection.domain).toBe(fixture.domain.id);
+    expect(introspection.jti).toBeDefined();
+    expect(introspection.exp).toBeGreaterThan(introspection.iat);
+
+    const journal = await fetchWireMockRequestJournal();
+    expect(countGetRequestsForPathSubstring(journal, jwksPath)).toBe(1);
+  });
+
+  it('should fetch jwks_uri from source server only once for repeated private_key_jwt client authentication', async () => {
+    await clearWireMockRequestJournal();
+    const scenario = `private-key-jwt-with-jwks-uri-cache${Date.now()}`;
+    const clientId = fixture.buildClientId(scenario);
+    const jwksPath = `/jwks/cimd-private-key-jwt${new URL(clientId).pathname}`;
+
+    const code = await fixture.completeAuthorizationCodeFlow(clientId);
+    const tokenResponse = await fixture.exchangeAuthCodeForTokenWithPrivateKeyJwt(code, clientId);
+    const accessToken = tokenResponse.body.access_token;
+    expect(accessToken).toBeDefined();
+
+    const firstIntrospection = await fixture.introspectTokenWithPrivateKeyJwt(accessToken, clientId);
+    expect(firstIntrospection.active).toBe(true);
+    const secondIntrospection = await fixture.introspectTokenWithPrivateKeyJwt(accessToken, clientId);
+    expect(secondIntrospection.active).toBe(true);
+
+    const journal = await fetchWireMockRequestJournal();
+    expect(countGetRequestsForPathSubstring(journal, jwksPath)).toBe(1);
   });
 
   it('should enforce exact redirect_uri matching for CIMD clients', async () => {

--- a/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-authorize-fixture.ts
+++ b/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-authorize-fixture.ts
@@ -30,14 +30,18 @@ import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
 import { login } from '@gateway-commands/login-commands';
 import { getBase64BasicAuth } from '@gateway-commands/utils';
 import { uniqueName } from '@utils-commands/misc';
+import * as jose from 'jose';
+import crypto from 'crypto';
 import { Application } from '@management-models/Application';
 import { Domain } from '@management-models/Domain';
 import { IdentityProvider } from '@management-models/IdentityProvider';
 import { PatchCIMDSettings } from '@management-models/PatchCIMDSettings';
 import { Fixture } from '../../../test-fixture';
+import { CIMD_PRIVATE_KEY_JWT_KID, cimdPrivateKeyJwtPrivateJwk } from '@api-fixtures/cimd-private-key-jwt';
 
 export const CIMD_REDIRECT_URI = 'https://client.example.com/callback';
 const PRE_REGISTERED_URL_CLIENT_ID = 'http://wiremock:8080/cimd/static-one';
+const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
 const CIMD_TEST_USER = {
   username: 'cimd-user',
   password: 'CimdP@ssw0rd123!',
@@ -116,8 +120,10 @@ export interface CimdAuthorizeFixture extends Fixture {
   expectLoginRedirect: (response: any) => void;
   completeAuthorizationCodeFlow: (clientId: string, redirectUri?: string) => Promise<string>;
   exchangeAuthCodeForToken: (code: string, clientId: string, redirectUri?: string) => Promise<any>;
+  exchangeAuthCodeForTokenWithPrivateKeyJwt: (code: string, clientId: string, redirectUri?: string) => Promise<any>;
   revokeAccessToken: (token: string, clientId: string) => Promise<void>;
   introspectToken: (token: string) => Promise<any>;
+  introspectTokenWithPrivateKeyJwt: (token: string, clientId: string) => Promise<any>;
 }
 
 const buildClientId = (profile: CimdAuthorizeProfile, scenario: string): string => `http://wiremock:8080/cimd/${profile}/${scenario}`;
@@ -132,6 +138,20 @@ const buildAuthorizeUrl = (endpoint: string, clientId: string, redirectUri: stri
   });
 
   return `${endpoint}?${params.toString()}`;
+};
+
+const createPrivateKeyJwtAssertion = async (clientId: string, audience: string): Promise<string> => {
+  const privateKey = await jose.importJWK(cimdPrivateKeyJwtPrivateJwk as jose.JWK, 'RS256');
+  const now = Math.floor(Date.now() / 1000);
+  return new jose.SignJWT({})
+    .setProtectedHeader({ alg: 'RS256', kid: CIMD_PRIVATE_KEY_JWT_KID })
+    .setIssuer(clientId)
+    .setSubject(clientId)
+    .setAudience(audience)
+    .setJti(crypto.randomUUID())
+    .setIssuedAt(now)
+    .setExpirationTime(now + 300)
+    .sign(privateKey);
 };
 
 const readOAuthError = (response: any): OAuthAuthorizeError => {
@@ -173,7 +193,7 @@ async function createOAuthApplication(
         },
         advanced: { skipConsent: true },
       },
-      ...(identityProviderId ? { identityProviders: [{ identity: identityProviderId, priority: 0 }] } : {}),
+      ...(identityProviderId ? { identityProviders: new Set([{ identity: identityProviderId, priority: 0 }]) } : {}),
     },
     created.id,
   );
@@ -291,6 +311,32 @@ export const setupCimdAuthorizeFixture = async (profile: CimdAuthorizeProfile): 
       }).expect(200);
     };
 
+    const appendPrivateKeyJwtAuthentication = async (params: URLSearchParams, clientId: string): Promise<URLSearchParams> => {
+      params.set('client_id', clientId);
+      params.set('client_assertion_type', CLIENT_ASSERTION_TYPE);
+      params.set('client_assertion', await createPrivateKeyJwtAssertion(clientId, startedDomain.oidcConfig.token_endpoint));
+      return params;
+    };
+
+    const exchangeAuthCodeForTokenWithPrivateKeyJwt = async (
+      code: string,
+      clientId: string,
+      redirectUri = CIMD_REDIRECT_URI,
+    ): Promise<any> => {
+      const params = await appendPrivateKeyJwtAuthentication(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: redirectUri,
+        }),
+        clientId,
+      );
+
+      return performPost(startedDomain.oidcConfig.token_endpoint, '', params.toString(), {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      }).expect(200);
+    };
+
     const revokeAccessToken = async (token: string, clientId: string): Promise<void> => {
       const params = new URLSearchParams({
         token,
@@ -318,6 +364,20 @@ export const setupCimdAuthorizeFixture = async (profile: CimdAuthorizeProfile): 
       return response.body;
     };
 
+    const introspectTokenWithPrivateKeyJwt = async (token: string, clientId: string): Promise<any> => {
+      const params = await appendPrivateKeyJwtAuthentication(
+        new URLSearchParams({
+          token,
+          token_type_hint: 'access_token',
+        }),
+        clientId,
+      );
+      const response = await performPost(startedDomain.oidcConfig.introspection_endpoint, '', params.toString(), {
+        'Content-type': 'application/x-www-form-urlencoded',
+      }).expect(200);
+      return response.body;
+    };
+
     return {
       profile,
       accessToken,
@@ -340,8 +400,10 @@ export const setupCimdAuthorizeFixture = async (profile: CimdAuthorizeProfile): 
       expectLoginRedirect,
       completeAuthorizationCodeFlow,
       exchangeAuthCodeForToken,
+      exchangeAuthCodeForTokenWithPrivateKeyJwt,
       revokeAccessToken,
       introspectToken,
+      introspectTokenWithPrivateKeyJwt,
       cleanUp: async () => {
         await safeDeleteDomain(domain?.id, accessToken);
       },

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -194,6 +194,10 @@ data:
       {{- end }}
       # Allows to define if cookie secure only (default false)
       cookie-secure: {{ .Values.gateway.jwt.cookie.secure | default false }}
+      {{- if .Values.gateway.jwt.jwks }}
+      jwks:
+        {{- .Values.gateway.jwt.jwks | toYaml | nindent 8 }}
+      {{- end }}
 
     {{- if .Values.smtp }}
     # SMTP configuration used to send mails

--- a/helm/tests/gateway-configmap_test.yaml
+++ b/helm/tests/gateway-configmap_test.yaml
@@ -156,6 +156,26 @@ tests:
                 introspect:
                   offlineVerificationTimerSeconds: 25
 
+  - it: should set gateway jwt jwks
+    set:
+      gateway.jwt.jwks.cache.maximumSize: 100
+      gateway.jwt.jwks.cache.ttlAfterWriteSeconds: 3600
+      gateway.jwt.jwks.retriever.type: JOSE
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |2-
+              jwks:
+                cache:
+                  maximumSize: 100
+                  ttlAfterWriteSeconds: 3600
+                retriever:
+                  type: JOSE
+
   - it: should set default alert engine values disabled
     asserts:
       - hasDocuments:


### PR DESCRIPTION
How to test:
CIMD wire mock
<img width="311" height="157" alt="image" src="https://github.com/user-attachments/assets/982ef074-43d2-4b42-a8b9-471df7d07f7f" />

cimd-card.json:
```
{
  "client_id": "http://localhost:9999",
  "client_name": "My AI Agent",
  "client_uri": "https://example.com",
  "logo_uri": "https://example.com/logo.png",
  "redirect_uris": [
    "https://callback.com"
  ],
  "grant_types": ["client_credentials", "refresh_token", "authorization_code"],
  "token_endpoint_auth_method": "private_key_jwt",
  "jwks_uri": "http://localhost:9999/jwks.json"
}
```
root-get.json:
```
{
  "request": {
    "method": "GET",
    "urlPath": "/"
  },
  "response": {
    "status": 200,
    "headers": {
      "Content-Type": "application/json"
    },
    "bodyFileName": "cimd-card.json"
  }
}
```
jwks-get.json:
```
{
  "request": {
    "method": "GET",
    "urlPath": "/jwks.json"
  },
  "response": {
    "status": 200,
    "headers": {
      "Content-Type": "application/json"
    },
    "bodyFileName": "jwks.json"
  }
}
```
jwks.json:
```
1. Create a completely new domain
2. Load any JKS Certificate
3. Setup the Certificate on Application
4. Setup Application Custom Token Claim to override : sub -> http://localhost:9999
5. Copy response body of oidc/.well-known/jwks.json to jwks.json
6. Generate access_token

The token, should contain claim sub -> http://localhost:9999
The token's kid should be present in jwks.json

```

Configure CIMD in a completly new Domain
Now, token's endpoint can be queired with 
```
client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
client_assertion=<token acquired from domainA>
```