### PR TITLE
fix: avoid single eventbus address for reporter

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/impl/AuditReporterVerticle.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/impl/AuditReporterVerticle.java
@@ -15,18 +15,15 @@
  */
 package io.gravitee.am.service.reporter.impl;
 
+import io.gravitee.am.model.Reference;
 import io.gravitee.am.reporter.api.Reportable;
 import io.gravitee.am.service.reporter.AuditReporterService;
-import io.gravitee.am.service.reporter.vertx.EventBusReporterWrapper;
 import io.gravitee.node.reporter.vertx.eventbus.ReportableMessageCodec;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.rxjava3.core.AbstractVerticle;
-import io.vertx.rxjava3.core.eventbus.MessageProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -37,31 +34,31 @@ public class AuditReporterVerticle extends AbstractVerticle implements AuditRepo
 
     public static final Logger LOGGER = LoggerFactory.getLogger(AuditReporterVerticle.class);
     public static final String EVENT_BUS_ADDRESS = "node:audits";
-    private MessageProducer<Reportable> producer;
+    public static final String EVENT_BUS_ADDRESS_PREFIX = "node:audits.";
+
+    private DeliveryOptions deliveryOptions;
 
     @Override
     public void start() throws Exception {
-        producer = vertx.eventBus()
-                .<Reportable>publisher(
-                        EVENT_BUS_ADDRESS,
-                        new DeliveryOptions()
-                                .setCodecName(ReportableMessageCodec.CODEC_NAME));
-
+        deliveryOptions = new DeliveryOptions().setCodecName(ReportableMessageCodec.CODEC_NAME);
         vertx.eventBus().consumer(EVENT_BUS_ADDRESS, new ReportableHandlerLogger<>());
     }
 
     @Override
     public void stop() throws Exception {
-        if (producer != null) {
-            producer.close();
-        }
+        // nothing to close
     }
 
     public void report(Reportable reportable) {
-        if (producer != null) {
-            producer.write(reportable)
-                    .doOnError(throwable -> LOGGER.error("Unexpected error while sending a reportable element", throwable))
-                    .subscribe();
+        if (deliveryOptions != null) {
+            String address = (reportable.getReferenceType() != null && reportable.getReferenceId() != null)
+                    ? addressFor(new Reference(reportable.getReferenceType(), reportable.getReferenceId()))
+                    : EVENT_BUS_ADDRESS;
+            vertx.eventBus().publish(address, reportable, deliveryOptions);
         }
+    }
+
+    public static String addressFor(Reference reference) {
+        return EVENT_BUS_ADDRESS_PREFIX + reference.type().name() + "." + reference.id();
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/vertx/EventBusReporterWrapper.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/vertx/EventBusReporterWrapper.java
@@ -24,7 +24,6 @@ import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.reporter.api.Reportable;
 import io.gravitee.am.reporter.api.provider.ReportableCriteria;
 import io.gravitee.am.reporter.api.provider.Reporter;
-import io.gravitee.am.service.reporter.impl.AuditReporterVerticle;
 import io.gravitee.common.component.Lifecycle;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -36,14 +35,18 @@ import io.vertx.rxjava3.core.eventbus.MessageConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
 import static io.gravitee.am.service.reporter.impl.AuditReporterVerticle.EVENT_BUS_ADDRESS;
+import static io.gravitee.am.service.reporter.impl.AuditReporterVerticle.EVENT_BUS_ADDRESS_PREFIX;
+import static io.gravitee.am.service.reporter.impl.AuditReporterVerticle.addressFor;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -54,7 +57,7 @@ public class EventBusReporterWrapper<R extends Reportable,C extends ReportableCr
     public static final Logger logger = LoggerFactory.getLogger(EventBusReporterWrapper.class);
     private final Vertx vertx;
     private final Reporter<R,C> reporter;
-    private MessageConsumer<Reportable> messageConsumer;
+    private final List<MessageConsumer<Reportable>> messageConsumers = Collections.synchronizedList(new ArrayList<>());
     private Set<Reference> referenceFilter;
 
 
@@ -126,7 +129,6 @@ public class EventBusReporterWrapper<R extends Reportable,C extends ReportableCr
 
     @Override
     public Reporter<R,C> start() throws Exception {
-        // start the delegate reporter
         vertx.rxExecuteBlocking(event -> {
                     try {
                         event.complete(reporter);
@@ -135,7 +137,15 @@ public class EventBusReporterWrapper<R extends Reportable,C extends ReportableCr
                         event.fail(ex);
                     }
                 })
-                .doOnSuccess(o -> messageConsumer = vertx.eventBus().consumer(EVENT_BUS_ADDRESS, EventBusReporterWrapper.this))
+                .doOnSuccess(o -> {
+                    if (referenceFilter == null) {
+                        messageConsumers.add(vertx.eventBus().consumer(EVENT_BUS_ADDRESS, EventBusReporterWrapper.this));
+                    } else {
+                        for (Reference ref : referenceFilter) {
+                            messageConsumers.add(vertx.eventBus().consumer(addressFor(ref), EventBusReporterWrapper.this));
+                        }
+                    }
+                })
                 .doOnError(ex -> logger.error("Error while starting reporter", ex))
                 .subscribe();
 
@@ -144,25 +154,35 @@ public class EventBusReporterWrapper<R extends Reportable,C extends ReportableCr
 
     @Override
     public Reporter<R,C> stop() throws Exception {
-        if (messageConsumer != null) {
-            messageConsumer.unregister();
-        }
+        unregister();
         return (Reporter<R, C>) reporter.stop();
     }
 
     public void unregister() {
-        if (messageConsumer != null) {
-            messageConsumer.unregister();
-        }
+        messageConsumers.forEach(MessageConsumer::unregister);
+        messageConsumers.clear();
     }
 
     public void updateReferences(ChildReporterAction referenceChange) {
         switch (referenceChange.op()) {
-            case CREATE -> referenceFilter.add(referenceChange.reference());
-            case DELETE -> referenceFilter.remove(referenceChange.reference);
+            case CREATE -> {
+                referenceFilter.add(referenceChange.reference());
+                messageConsumers.add(vertx.eventBus().consumer(addressFor(referenceChange.reference()), EventBusReporterWrapper.this));
+            }
+            case DELETE -> {
+                referenceFilter.remove(referenceChange.reference());
+                String removedAddress = addressFor(referenceChange.reference());
+                messageConsumers.removeIf(c -> {
+                    if (removedAddress.equals(c.address())) {
+                        c.unregister();
+                        return true;
+                    }
+                    return false;
+                });
+            }
             default -> logger.debug("Ignoring {}", referenceChange);
         }
-        logger.info("Reporter {}: updated reference list to {}", reporter ,referenceFilter);
+        logger.info("Reporter {}: updated reference list to {}", reporter, referenceFilter);
     }
 
     public record ChildReporterAction(Action op, Reference reference) {


### PR DESCRIPTION
 this change create one address per domain/organization so when an event an audit is published

 only relevant reporter instances are used

 this change avoid high CPU usage when the number of domain is important

fixes AM-6989