### PR TITLE
ci: add release-gamma-version workflow for non-snapshot gamma artifacts

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1945,6 +1945,8 @@ workflows:
 
   # Publishes a non-SNAPSHOT gamma artifact to Gravitee's private Artifactory only.
   # Intentionally omits Docker Hub, Maven Central, Aqua and Slack notify jobs.
+  # rc_requested is hardcoded true: gamma always uses qualifier-style versions
+  # (4.12.0-gamma.N), so the pre-release branch in the release job must run.
   release-gamma-version:
     when:
       and:
@@ -1957,7 +1959,7 @@ workflows:
           name: release_dist <<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
           context: cicd-orchestrator
           dry_run: << pipeline.parameters.dry_run >>
-          rc_requested: << pipeline.parameters.rc_requested >>
+          rc_requested: true
           graviteeio_version: << pipeline.parameters.graviteeio_version >>
           create_maintenance_version_branch: << pipeline.parameters.create_maintenance_version_branch >>
           qualifier_label: gamma

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -65,7 +65,7 @@ executors:
 parameters:
   gio_action:
     type: enum
-    enum: [ release, publish_maven_central, publish_rpms, publish_docker_images, pull_requests, release_notes_am, release_helm , publish-images-azure-registry, release-version, release-alpha-version, release-hotfix-version ]
+    enum: [ release, publish_maven_central, publish_rpms, publish_docker_images, pull_requests, release_notes_am, release_helm , publish-images-azure-registry, release-version, release-alpha-version, release-gamma-version, release-hotfix-version ]
     default: pull_requests
   gio_product:
     type: enum
@@ -1202,6 +1202,10 @@ jobs:
         type: boolean
         default: false
         description: "Create maintenance version branch"
+      qualifier_label:
+        type: string
+        default: "alpha"
+        description: "Pre-release qualifier label used in versions like 4.12.0-<qualifier>.N (e.g. alpha, gamma)"
     executor:
       name: openjdk
       class: xlarge
@@ -1212,6 +1216,7 @@ jobs:
       GIO_VERSION: << parameters.graviteeio_version >>
       HOTFIX_VERSION: << parameters.hotfix_version >>
       CREATE_MAINT_VER_BRANCH: << parameters.create_maintenance_version_branch >>
+      QUALIFIER_LABEL: << parameters.qualifier_label >>
     steps:
       - checkout
       - restore-maven-job-cache:
@@ -1233,7 +1238,7 @@ jobs:
             export MVN_PRJ_VERSION_MAJOR=$(cat /tmp/gio.maven.project.release.version | awk -F '.' '{print $1}')
             export MVN_PRJ_VERSION_MINOR=$(cat /tmp/gio.maven.project.release.version | awk -F '.' '{print $2}')
             export MVN_PRJ_VERSION_PATCH=$(cat /tmp/gio.maven.project.release.version | awk -F '.' '{print $3}' | awk -F '-' '{print $1}')
-            export MVN_PRJ_VERSION_QUALIFIER=$(cat /tmp/gio.maven.project.release.version | awk -F '-' '{print $2}' | awk -F 'alpha.' '{print $2}')
+            export MVN_PRJ_VERSION_QUALIFIER=$(cat /tmp/gio.maven.project.release.version | awk -F '-' '{print $2}' | awk -F "${QUALIFIER_LABEL}." '{print $2}')
             export MVN_PRJ_VERSION_HOTFIX=$(cat /tmp/gio.maven.project.release.version | awk -F '-' '{print $2}' | awk -F 'hotfix.' '{print $2}')
 
             if [ "${RC_REQUESTED}" == "true" ]; then
@@ -1241,7 +1246,7 @@ jobs:
                 export MVN_PRJ_VERSION_QUALIFIER="1"
               fi;
 
-              export MVN_PRJ_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${MVN_PRJ_VERSION_PATCH}-alpha.${MVN_PRJ_VERSION_QUALIFIER}"
+              export MVN_PRJ_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${MVN_PRJ_VERSION_PATCH}-${QUALIFIER_LABEL}.${MVN_PRJ_VERSION_QUALIFIER}"
               echo "${MVN_PRJ_VERSION}" > /tmp/gio.maven.project.release.version
 
             elif [ "${HOTFIX_VERSION}" == "true" ]; then
@@ -1298,7 +1303,7 @@ jobs:
             export MVN_PRJ_VERSION_MAJOR=$(cat /tmp/gio.maven.project.release.version | awk -F '.' '{print $1}')
             export MVN_PRJ_VERSION_MINOR=$(cat /tmp/gio.maven.project.release.version | awk -F '.' '{print $2}')
             export MVN_PRJ_VERSION_PATCH=$(cat /tmp/gio.maven.project.release.version | awk -F '.' '{print $3}' | awk -F '-' '{print $1}')
-            export MVN_PRJ_VERSION_QUALIFIER=$(cat /tmp/gio.maven.project.release.version | awk -F '-' '{print $2}' | awk -F 'alpha.' '{print $2}')
+            export MVN_PRJ_VERSION_QUALIFIER=$(cat /tmp/gio.maven.project.release.version | awk -F '-' '{print $2}' | awk -F "${QUALIFIER_LABEL}." '{print $2}')
             export MVN_PRJ_VERSION_HOTFIX=$(cat /tmp/gio.maven.project.release.version | awk -F '-' '{print $2}' | awk -F 'hotfix.' '{print $2}')
 
             export CURRENT_GIT_BRANCH=$(git status | grep 'On branch' | awk '{print $3}')
@@ -1312,7 +1317,7 @@ jobs:
             
             if [ "${RC_REQUESTED}" == "true" ]; then
               export NEXT_QUALIFIER=$((${MVN_PRJ_VERSION_QUALIFIER}+1))
-              export NEXT_PATCH_SNAPSHOT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${MVN_PRJ_VERSION_PATCH}-alpha.${NEXT_QUALIFIER}-SNAPSHOT"
+              export NEXT_PATCH_SNAPSHOT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${MVN_PRJ_VERSION_PATCH}-${QUALIFIER_LABEL}.${NEXT_QUALIFIER}-SNAPSHOT"
             elif [ "${HOTFIX_VERSION}" == "true" ]; then
               export NEXT_HOTFIX_PATCH=$((${MVN_PRJ_VERSION_HOTFIX}+1))
               export NEXT_PATCH_SNAPSHOT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${MVN_PRJ_VERSION_PATCH}-hotfix.${NEXT_HOTFIX_PATCH}-SNAPSHOT"
@@ -1353,7 +1358,7 @@ jobs:
 
             export NEXT_SNAPSHOT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${NEXT_MINOR_VERSION}.${MVN_PRJ_VERSION_PATCH}-SNAPSHOT"
             export NEXT_SNAPSHOT_MAINT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${NEXT_PATCH_VERSION}-SNAPSHOT"
-            export NEXT_SNAPSHOT_RC_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${MVN_PRJ_VERSION_PATCH}-alpha.${NEXT_QUALIFIER_VERSION}-SNAPSHOT"
+            export NEXT_SNAPSHOT_RC_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${MVN_PRJ_VERSION_PATCH}-${QUALIFIER_LABEL}.${NEXT_QUALIFIER_VERSION}-SNAPSHOT"
             export NEXT_SNAPSHOT_HOTFIX_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${MVN_PRJ_VERSION_PATCH}-hotfix.${NEXT_HOTFIX_VERSION}-SNAPSHOT"
 
             if [ "${RC_REQUESTED}" == "true" -a "${MVN_PRJ_VERSION_PATCH}" == "0" -a "${CREATE_MAINT_VER_BRANCH}" == "true" ]; then
@@ -1937,6 +1942,27 @@ workflows:
           requires:
             - publish docker images
             - publish maven packages
+
+  # Publishes a non-SNAPSHOT gamma artifact to Gravitee's private Artifactory only.
+  # Intentionally omits Docker Hub, Maven Central, Aqua and Slack notify jobs.
+  release-gamma-version:
+    when:
+      and:
+        - equal: [ release-gamma-version, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - setup:
+          name: setup
+          context: cicd-orchestrator
+      - release:
+          name: release_dist <<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
+          context: cicd-orchestrator
+          dry_run: << pipeline.parameters.dry_run >>
+          rc_requested: << pipeline.parameters.rc_requested >>
+          graviteeio_version: << pipeline.parameters.graviteeio_version >>
+          create_maintenance_version_branch: << pipeline.parameters.create_maintenance_version_branch >>
+          qualifier_label: gamma
+          requires:
+            - setup
 
   release-hotfix-version:
     when:

--- a/release/steps/am-release-gamma-pipeline.mjs
+++ b/release/steps/am-release-gamma-pipeline.mjs
@@ -1,0 +1,23 @@
+import { AbstractStepRelease } from './abstract-step-release.mjs';
+
+export class ReleaseGammaVersion extends AbstractStepRelease {
+    buildCommand(program) {
+        super.buildCommand(program, 'release-gamma-version');
+        this.command
+                .description('trigger pipeline release gamma version on CircleCI (Artifactory only, no Docker Hub / Maven Central)')
+                .usage('npm run am-release -- --branch="gamma" --gio-version="4.12.0-gamma.1" --dry-run release-gamma-version')
+                .option('--create-maint-branch', 'creates maintenance version branch - false by default', false);
+    }
+
+    computePipelineParameters(options) {
+        return {
+            dry_run: options.dryRun,
+            graviteeio_version: options.gioVersion,
+            gio_action: 'release-gamma-version',
+            rc_requested: true,
+            tag_latest: false,
+            tag_latest_support: false,
+            create_maintenance_version_branch: options.createMaintBranch
+        };
+    }
+}

--- a/release/steps/am-release.mjs
+++ b/release/steps/am-release.mjs
@@ -10,6 +10,7 @@ import { ReleaseHelm } from './5-step-release-helm.mjs';
 import { ReleaseNotes } from './6-step-release-notes.mjs';
 import { ReleaseVersion } from "./am-release-pipeline.mjs";
 import { ReleaseAlphaVersion } from "./am-release-alpha-pipeline.mjs";
+import { ReleaseGammaVersion } from "./am-release-gamma-pipeline.mjs";
 import { ReleaseHotfix } from './am-release-hotfix.mjs';
 
 function changeLogLevel(newLevel) {
@@ -60,6 +61,7 @@ async function main() {
   new ReleaseNotes().buildCommand(program);
   new ReleaseVersion().buildCommand(program);
   new ReleaseAlphaVersion().buildCommand(program);
+  new ReleaseGammaVersion().buildCommand(program);
   new ReleaseHotfix().buildCommand(program);
 
   await checkCircleCIToken();


### PR DESCRIPTION
## :id: Reference related issue.
N/A — internal CI tooling change.

## :pencil2: A description of the changes proposed in the pull request

Adds a way to publish a **non-SNAPSHOT** release of the `gamma` branch to Gravitee's private Artifactory **only** — no Docker Hub, no Maven Central, no Aqua, no Slack. This makes gamma artifacts referenceable as fixed dependencies from other projects (today `gamma` only produces `-SNAPSHOT` builds via `build_branch`).

Three pieces:

1. **New `gio_action` value `release-gamma-version`** (`.circleci/workflows.yml`) — added to the enum and a matching workflow that runs `setup` + `release` only. Intentionally omits `build_n_push_am_ce_job`, `add-docker-images-in-aqua`, `publish_maven_packages_to_maven_central`, and `notify-release-complete` so nothing leaves Gravitee infra.
2. **`release` job generalized** with a new `qualifier_label` parameter (default `alpha`). The alpha-hardcoded `awk -F 'alpha.'` parsing and `-alpha.${N}` string-building are now driven by `${QUALIFIER_LABEL}`, so the same job handles `4.12.0-alpha.N` and `4.12.0-gamma.N` without behavioural change for the existing alpha flow.
3. **New `am-release` subcommand** `release-gamma-version` (`release/steps/am-release-gamma-pipeline.mjs`) wired into `am-release.mjs`, mirroring `release-alpha-version`.

## :memo: Test scenarios

- `circleci config validate .circleci/workflows.yml` passes locally.
- Existing `release-alpha-version` flow is unchanged: `qualifier_label` defaults to `alpha`, all alpha-flow string templates resolve to the same values as before.
- Dry-run on `gamma`:
  ```
  npm run am-release -- --branch gamma --gio-version 4.12.0-gamma.1 --dry-run release-gamma-version
  ```
  Expect: pipeline picks `release-gamma-version` workflow, `release` job parses pom version `4.12.0-gamma.1-SNAPSHOT` correctly, runs `mvn ... install` (no deploy), no git tag/push.
- Real run (after merge):
  ```
  npm run am-release -- --branch gamma --gio-version 4.12.0-gamma.1 release-gamma-version
  ```
  Expect: `4.12.0-gamma.1` published to Gravitee Artifactory, tag `4.12.0-gamma.1` pushed, `gamma` bumped to `4.12.0-gamma.2-SNAPSHOT`. **No** Docker Hub or Maven Central uploads.

## :computer: Add screenshots for UI
N/A.

## :books: Any other comments that will help with documentation

The release is **manually triggered** — merging this PR does not publish anything. Use the `am-release` subcommand above (or trigger CircleCI directly with `gio_action=release-gamma-version`, `rc_requested=true`, `graviteeio_version=4.12.0-gamma.N`).

## :man: :woman: @mentions of the person or team responsible for reviewing proposed changes