### PR TITLE
feat: AM-6679 CIMD automatic token revocation

### DIFF
--- a/docker/local-stack/dev/wiremock/request-cimd.json
+++ b/docker/local-stack/dev/wiremock/request-cimd.json
@@ -410,6 +410,51 @@
       }
     },
     {
+      "scenarioName": "cimd-revoke-on-change",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "Changed",
+      "request": {
+        "method": "GET",
+        "urlPath": "/cimd/ENABLED_BASE/revoke-on-change"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "client_id": "http://wiremock:8080/cimd/ENABLED_BASE/revoke-on-change",
+          "client_name": "CIMD Revoke On Change V1",
+          "redirect_uris": [
+            "https://client.example.com/callback"
+          ],
+          "token_endpoint_auth_method": "none"
+        }
+      }
+    },
+    {
+      "scenarioName": "cimd-revoke-on-change",
+      "requiredScenarioState": "Changed",
+      "request": {
+        "method": "GET",
+        "urlPath": "/cimd/ENABLED_BASE/revoke-on-change"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "client_id": "http://wiremock:8080/cimd/ENABLED_BASE/revoke-on-change",
+          "client_name": "CIMD Revoke On Change V2",
+          "redirect_uris": [
+            "https://client.example.com/callback"
+          ],
+          "token_endpoint_auth_method": "none"
+        }
+      }
+    },
+    {
       "request": {
         "method": "GET",
         "urlPath": "/cimd/DISABLED_BASE/valid-none"

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -12893,6 +12893,8 @@ components:
         maxResponseSizeKb:
           type: integer
           format: int32
+        revokeOnDocumentChange:
+          type: boolean
         templateId:
           type: string
     Certificate:
@@ -15624,6 +15626,8 @@ components:
         maxResponseSizeKb:
           type: integer
           format: int32
+        revokeOnDocumentChange:
+          type: boolean
         templateId:
           type: string
     PatchChallengeSettings:

--- a/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/DataPlaneProvider.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/DataPlaneProvider.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.dataplane.api;
 
 import io.gravitee.am.dataplane.api.repository.AccessPolicyRepository;
+import io.gravitee.am.dataplane.api.repository.CimdClientStateRepository;
 import io.gravitee.am.dataplane.api.repository.CredentialRepository;
 import io.gravitee.am.dataplane.api.repository.CertificateCredentialRepository;
 import io.gravitee.am.dataplane.api.repository.DeviceRepository;
@@ -35,6 +36,8 @@ public interface DataPlaneProvider {
     void stop();
 
     DataPlaneDescription getDataPlaneDescription();
+
+    CimdClientStateRepository getCimdClientStateRepository();
 
     CredentialRepository getCredentialRepository();
 

--- a/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/CimdClientStateRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/CimdClientStateRepository.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.dataplane.api.repository;
+
+import io.gravitee.am.model.CimdClientState;
+import io.gravitee.am.repository.common.CrudRepository;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface CimdClientStateRepository extends CrudRepository<CimdClientState, String> {
+
+    Maybe<CimdClientState> findByDomainAndClientId(String domainId, String clientId);
+
+    Single<CimdClientState> upsert(CimdClientState state);
+
+    Completable deleteByDomain(String domainId);
+}

--- a/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/ScopeApprovalRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/ScopeApprovalRepository.java
@@ -34,6 +34,8 @@ public interface ScopeApprovalRepository extends CrudRepository<ScopeApproval, S
 
     Flowable<ScopeApproval> findByDomainAndUser(String domain, UserId userId);
 
+    Flowable<ScopeApproval> findByDomainAndClient(String domain, String clientId);
+
     Single<ScopeApproval> upsert(ScopeApproval scopeApproval);
 
     Completable deleteByDomainAndScopeKey(String domain, String scope);
@@ -41,5 +43,7 @@ public interface ScopeApprovalRepository extends CrudRepository<ScopeApproval, S
     Completable deleteByDomainAndUserAndClient(String domain, UserId userId, String client);
 
     Completable deleteByDomainAndUser(String domain, UserId userId);
+
+    Completable deleteByDomainAndClient(String domain, String clientId);
 
 }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/provider/JdbcDataPlaneProvider.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/provider/JdbcDataPlaneProvider.java
@@ -18,6 +18,7 @@ package io.gravitee.am.dataplane.jdbc.provider;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.dataplane.api.DataPlaneProvider;
 import io.gravitee.am.dataplane.api.repository.AccessPolicyRepository;
+import io.gravitee.am.dataplane.api.repository.CimdClientStateRepository;
 import io.gravitee.am.dataplane.api.repository.CredentialRepository;
 import io.gravitee.am.dataplane.api.repository.CertificateCredentialRepository;
 import io.gravitee.am.dataplane.api.repository.DeviceRepository;
@@ -52,6 +53,9 @@ public class JdbcDataPlaneProvider implements DataPlaneProvider, InitializingBea
 
     @Autowired
     private R2DBCPoolWrapper clientWrapper;
+
+    @Autowired
+    private CimdClientStateRepository cimdClientStateRepository;
 
     @Autowired
     private CredentialRepository credentialRepository;
@@ -111,6 +115,11 @@ public class JdbcDataPlaneProvider implements DataPlaneProvider, InitializingBea
     @Override
     public ClientWrapper<ConnectionFactory> getClientWrapper() {
         return this.clientWrapper;
+    }
+
+    @Override
+    public CimdClientStateRepository getCimdClientStateRepository() {
+        return cimdClientStateRepository;
     }
 
     @Override

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcCimdClientStateRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcCimdClientStateRepository.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.dataplane.jdbc.repository;
+
+import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.dataplane.api.repository.CimdClientStateRepository;
+import io.gravitee.am.dataplane.jdbc.repository.model.JdbcCimdClientState;
+import io.gravitee.am.dataplane.jdbc.repository.spring.SpringCimdClientStateRepository;
+import io.gravitee.am.model.CimdClientState;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.relational.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+import static org.springframework.data.relational.core.query.Criteria.where;
+import static reactor.adapter.rxjava.RxJava3Adapter.monoToCompletable;
+import static reactor.adapter.rxjava.RxJava3Adapter.monoToSingle;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Repository
+public class JdbcCimdClientStateRepository extends AbstractJdbcRepository implements CimdClientStateRepository {
+
+    private static final String COL_ID = "id";
+    private static final String COL_DOMAIN_ID = "domain_id";
+    private static final String COL_CLIENT_ID = "client_id";
+
+    @Autowired
+    private SpringCimdClientStateRepository springRepo;
+
+    @Override
+    public Maybe<CimdClientState> findById(String id) {
+        LOGGER.debug("findById({})", id);
+        return springRepo.findById(id).map(this::toEntity).observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Maybe<CimdClientState> findByDomainAndClientId(String domainId, String clientId) {
+        LOGGER.debug("findByDomainAndClientId({}, {})", domainId, clientId);
+        return springRepo.findByDomainAndClientId(domainId, clientId)
+                .map(this::toEntity)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<CimdClientState> upsert(CimdClientState state) {
+        LOGGER.debug("upsert CimdClientState for domain={}, clientId={}", state.getDomainId(), state.getClientId());
+        return springRepo.findByDomainAndClientId(state.getDomainId(), state.getClientId())
+                .flatMapSingle(existing -> {
+                    state.setId(existing.getId());
+                    return update(state);
+                })
+                .switchIfEmpty(create(state))
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<CimdClientState> create(CimdClientState item) {
+        item.setId(item.getId() == null ? RandomString.generate() : item.getId());
+        item.setUpdatedAt(new Date());
+        LOGGER.debug("create CimdClientState with id {}", item.getId());
+        return monoToSingle(getTemplate().insert(toJdbcEntity(item))).map(this::toEntity)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<CimdClientState> update(CimdClientState item) {
+        item.setUpdatedAt(new Date());
+        LOGGER.debug("update CimdClientState with id {}", item.getId());
+        return monoToSingle(getTemplate().update(toJdbcEntity(item))).map(this::toEntity)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable delete(String id) {
+        LOGGER.debug("delete({})", id);
+        return monoToCompletable(getTemplate().delete(JdbcCimdClientState.class)
+                .matching(Query.query(where(COL_ID).is(id))).all())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable deleteByDomain(String domainId) {
+        LOGGER.debug("deleteByDomain({})", domainId);
+        return monoToCompletable(getTemplate().delete(JdbcCimdClientState.class)
+                .matching(Query.query(where(COL_DOMAIN_ID).is(domainId))).all())
+                .observeOn(Schedulers.computation());
+    }
+
+    private CimdClientState toEntity(JdbcCimdClientState jdbc) {
+        if (jdbc == null) return null;
+        CimdClientState state = new CimdClientState();
+        state.setId(jdbc.getId());
+        state.setDomainId(jdbc.getDomainId());
+        state.setClientId(jdbc.getClientId());
+        state.setMonitoredPropertiesHash(jdbc.getMonitoredPropertiesHash());
+        state.setUpdatedAt(toDate(jdbc.getUpdatedAt()));
+        return state;
+    }
+
+    private JdbcCimdClientState toJdbcEntity(CimdClientState state) {
+        if (state == null) return null;
+        JdbcCimdClientState jdbc = new JdbcCimdClientState();
+        jdbc.setId(state.getId());
+        jdbc.setDomainId(state.getDomainId());
+        jdbc.setClientId(state.getClientId());
+        jdbc.setMonitoredPropertiesHash(state.getMonitoredPropertiesHash());
+        jdbc.setUpdatedAt(toLocalDateTime(state.getUpdatedAt()));
+        return jdbc;
+    }
+}

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcScopeApprovalRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcScopeApprovalRepository.java
@@ -67,12 +67,12 @@ public class JdbcScopeApprovalRepository extends AbstractJdbcRepository implemen
     public Flowable<ScopeApproval> findByDomainAndUserAndClient(String domain, UserId userId, String clientId) {
         LOGGER.debug("findByDomainAndUserAndClient({}, {}, {})", domain, userId, clientId);
         LocalDateTime now = LocalDateTime.now(UTC);
-            return findAll(Query.query(userIdMatches(userId)
+        return findAll(Query.query(userIdMatches(userId)
                 .and(client(clientId))
-                .and(domain(domain))))
-                .filter(bean -> bean.getExpiresAt() == null || bean.getExpiresAt().isAfter(now))
+                .and(domain(domain))
+                .and(notExpiredAt(now))))
                 .map(this::toEntity)
-                    .observeOn(Schedulers.computation());
+                .observeOn(Schedulers.computation());
     }
 
     private Flowable<JdbcScopeApproval> findAll(Query query) {
@@ -92,12 +92,24 @@ public class JdbcScopeApprovalRepository extends AbstractJdbcRepository implemen
         return where("domain").is(domain);
     }
 
+    private Criteria notExpiredAt(LocalDateTime now) {
+        return where("expires_at").isNull().or(where("expires_at").greaterThan(now));
+    }
+
     @Override
     public Flowable<ScopeApproval> findByDomainAndUser(String domain, UserId userId) {
         LOGGER.debug("findByDomainAndUser({}, {})", domain, userId);
         LocalDateTime now = LocalDateTime.now(UTC);
-        return findAll(Query.query(userIdMatches(userId).and(domain(domain))))
-                .filter(bean -> bean.getExpiresAt() == null || bean.getExpiresAt().isAfter(now))
+        return findAll(Query.query(userIdMatches(userId).and(domain(domain)).and(notExpiredAt(now))))
+                .map(this::toEntity)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Flowable<ScopeApproval> findByDomainAndClient(String domain, String clientId) {
+        LOGGER.debug("findByDomainAndClient({}, {})", domain, clientId);
+        LocalDateTime now = LocalDateTime.now(UTC);
+        return findAll(Query.query(domain(domain).and(client(clientId)).and(notExpiredAt(now))))
                 .map(this::toEntity)
                 .observeOn(Schedulers.computation());
     }
@@ -156,6 +168,14 @@ public class JdbcScopeApprovalRepository extends AbstractJdbcRepository implemen
                 .matching(Query.query(domain(domain)
                         .and(userIdMatches(userId))))
                 .all())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable deleteByDomainAndClient(String domain, String clientId) {
+        LOGGER.debug("deleteByDomainAndClient({}, {})", domain, clientId);
+        return monoToCompletable(getTemplate().delete(JdbcScopeApproval.class)
+                .matching(Query.query(domain(domain).and(client(clientId)))).all())
                 .observeOn(Schedulers.computation());
     }
 

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/model/JdbcCimdClientState.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/model/JdbcCimdClientState.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.dataplane.jdbc.repository.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Table("cimd_client_states")
+public class JdbcCimdClientState {
+
+    @Id
+    private String id;
+
+    @Column("domain_id")
+    private String domainId;
+
+    @Column("client_id")
+    private String clientId;
+
+    @Column("monitored_properties_hash")
+    private String monitoredPropertiesHash;
+
+    @Column("updated_at")
+    private LocalDateTime updatedAt;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getDomainId() { return domainId; }
+    public void setDomainId(String domainId) { this.domainId = domainId; }
+
+    public String getClientId() { return clientId; }
+    public void setClientId(String clientId) { this.clientId = clientId; }
+
+    public String getMonitoredPropertiesHash() { return monitoredPropertiesHash; }
+    public void setMonitoredPropertiesHash(String monitoredPropertiesHash) { this.monitoredPropertiesHash = monitoredPropertiesHash; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/spring/SpringCimdClientStateRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/spring/SpringCimdClientStateRepository.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.dataplane.jdbc.repository.spring;
+
+import io.gravitee.am.dataplane.jdbc.repository.model.JdbcCimdClientState;
+import io.reactivex.rxjava3.core.Maybe;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.reactive.RxJava3CrudRepository;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface SpringCimdClientStateRepository extends RxJava3CrudRepository<JdbcCimdClientState, String> {
+
+    @Query("SELECT * FROM cimd_client_states WHERE domain_id = :domainId AND client_id = :clientId")
+    Maybe<JdbcCimdClientState> findByDomainAndClientId(
+            @Param("domainId") String domainId,
+            @Param("clientId") String clientId);
+}

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/4.12.0-dataplane-cimd-client-states.yml
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/4.12.0-dataplane-cimd-client-states.yml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0-dataplane-cimd-client-states-table
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: cimd_client_states
+            columns:
+              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: domain_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: client_id, type: nvarchar(2048), constraints: { nullable: false } }
+              - column: { name: monitored_properties_hash, type: nvarchar(64), constraints: { nullable: true } }
+              - column: { name: updated_at, type: timestamp(6), constraints: { nullable: true } }
+
+        - addPrimaryKey:
+            constraintName: pk_cimd_client_states
+            columnNames: id
+            tableName: cimd_client_states
+
+        - createIndex:
+            columns:
+              - column:
+                  name: domain_id
+              - column:
+                  name: client_id
+            indexName: idx_cimd_client_states_domain_client
+            tableName: cimd_client_states
+            unique: true

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/resources/liquibase/dp-master.yml
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/resources/liquibase/dp-master.yml
@@ -37,3 +37,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_9_0/4.9.0-dataplane-sweep-redundant-indexes-webauth.yml
   - include:
       - file: liquibase/changelogs/v4_10_0/4.10.0-dataplane-cert-credentials-table.yml
+  - include:
+      - file: liquibase/changelogs/v4_12_0/4.12.0-dataplane-cimd-client-states.yml

--- a/gravitee-am-dataplane/gravitee-am-dataplane-junit/src/main/java/io/gravitee/am/dataplane/junit/gateway/MemoryCimdClientStateRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-junit/src/main/java/io/gravitee/am/dataplane/junit/gateway/MemoryCimdClientStateRepository.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.dataplane.junit.gateway;
+
+import io.gravitee.am.dataplane.api.repository.CimdClientStateRepository;
+import io.gravitee.am.dataplane.junit.MemoryRepository;
+import io.gravitee.am.model.CimdClientState;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+
+import java.util.Date;
+import java.util.UUID;
+
+public class MemoryCimdClientStateRepository extends MemoryRepository<CimdClientState, String> implements CimdClientStateRepository {
+
+    @Override
+    public Maybe<CimdClientState> findByDomainAndClientId(String domainId, String clientId) {
+        return findOne(s -> s.getDomainId().equals(domainId) && s.getClientId().equals(clientId));
+    }
+
+    @Override
+    public Single<CimdClientState> upsert(CimdClientState state) {
+        return findByDomainAndClientId(state.getDomainId(), state.getClientId())
+                .flatMapSingle(existing -> {
+                    state.setId(existing.getId());
+                    state.setUpdatedAt(new Date());
+                    return update(state);
+                })
+                .switchIfEmpty(create(state));
+    }
+
+    @Override
+    public Completable deleteByDomain(String domainId) {
+        return findMany(s -> s.getDomainId().equals(domainId))
+                .flatMapCompletable(s -> delete(s.getId()));
+    }
+
+    @Override
+    protected String getId(CimdClientState item) {
+        return item.getId();
+    }
+
+    @Override
+    protected String generateAndSetId(CimdClientState item) {
+        var id = UUID.randomUUID().toString();
+        item.setId(id);
+        return id;
+    }
+}

--- a/gravitee-am-dataplane/gravitee-am-dataplane-junit/src/main/java/io/gravitee/am/dataplane/junit/gateway/MemoryScopeApprovalRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-junit/src/main/java/io/gravitee/am/dataplane/junit/gateway/MemoryScopeApprovalRepository.java
@@ -45,6 +45,11 @@ public class MemoryScopeApprovalRepository extends MemoryRepository<ScopeApprova
     }
 
     @Override
+    public Flowable<ScopeApproval> findByDomainAndClient(String domain, String clientId) {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    @Override
     public Single<ScopeApproval> upsert(ScopeApproval scopeApproval) {
         throw new UnsupportedOperationException("not implemented yet");
     }
@@ -61,6 +66,11 @@ public class MemoryScopeApprovalRepository extends MemoryRepository<ScopeApprova
 
     @Override
     public Completable deleteByDomainAndUser(String domain, UserId userId) {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    @Override
+    public Completable deleteByDomainAndClient(String domain, String clientId) {
         throw new UnsupportedOperationException("not implemented yet");
     }
 

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/provider/MongoDataPlaneProvider.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/provider/MongoDataPlaneProvider.java
@@ -19,6 +19,7 @@ import com.mongodb.reactivestreams.client.MongoClient;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.dataplane.api.DataPlaneProvider;
 import io.gravitee.am.dataplane.api.repository.AccessPolicyRepository;
+import io.gravitee.am.dataplane.api.repository.CimdClientStateRepository;
 import io.gravitee.am.dataplane.api.repository.CredentialRepository;
 import io.gravitee.am.dataplane.api.repository.CertificateCredentialRepository;
 import io.gravitee.am.dataplane.api.repository.DeviceRepository;
@@ -51,6 +52,9 @@ public class MongoDataPlaneProvider implements DataPlaneProvider, InitializingBe
 
     @Autowired
     private ClientWrapper<MongoClient> mongoClientWrapper;
+
+    @Autowired
+    private CimdClientStateRepository cimdClientStateRepository;
 
     @Autowired
     private CredentialRepository credentialRepository;
@@ -117,6 +121,11 @@ public class MongoDataPlaneProvider implements DataPlaneProvider, InitializingBe
     @Override
     public ClientWrapper<MongoClient> getClientWrapper() {
         return this.mongoClientWrapper;
+    }
+
+    @Override
+    public CimdClientStateRepository getCimdClientStateRepository() {
+        return cimdClientStateRepository;
     }
 
     @Override

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoCimdClientStateRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoCimdClientStateRepository.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.dataplane.mongodb.repository;
+
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.ReturnDocument;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.dataplane.api.repository.CimdClientStateRepository;
+import io.gravitee.am.dataplane.mongodb.repository.model.CimdClientStateMongo;
+import io.gravitee.am.model.CimdClientState;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import jakarta.annotation.PostConstruct;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.Map;
+
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+import static io.gravitee.am.repository.mongodb.common.MongoUtils.FIELD_ID;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+public class MongoCimdClientStateRepository extends AbstractDataPlaneMongoRepository implements CimdClientStateRepository {
+
+    private static final String COLLECTION = "cimd_client_states";
+    private static final String FIELD_DOMAIN_ID = "domainId";
+    private static final String FIELD_CLIENT_ID = "clientId";
+    private static final String FIELD_MONITORED_PROPERTIES_HASH = "monitoredPropertiesHash";
+    private static final String FIELD_UPDATED_AT = "updatedAt";
+
+    private MongoCollection<CimdClientStateMongo> collection;
+
+    @PostConstruct
+    public void init() {
+        collection = mongoDatabase.getCollection(COLLECTION, CimdClientStateMongo.class);
+        super.createIndex(collection, Map.of(
+                new Document(FIELD_DOMAIN_ID, 1).append(FIELD_CLIENT_ID, 1),
+                new IndexOptions().name("di1ci1").unique(true)
+        ));
+    }
+
+    @Override
+    public Maybe<CimdClientState> findById(String id) {
+        return Observable.fromPublisher(collection.find(eq(FIELD_ID, id)).first())
+                .firstElement()
+                .map(this::convert)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Maybe<CimdClientState> findByDomainAndClientId(String domainId, String clientId) {
+        return Observable.fromPublisher(
+                        collection.find(and(eq(FIELD_DOMAIN_ID, domainId), eq(FIELD_CLIENT_ID, clientId))).first())
+                .firstElement()
+                .map(this::convert)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<CimdClientState> upsert(CimdClientState state) {
+        final Document updateDoc = new Document("$set",
+                new Document(FIELD_MONITORED_PROPERTIES_HASH, state.getMonitoredPropertiesHash())
+                        .append(FIELD_UPDATED_AT, new Date()))
+                .append("$setOnInsert",
+                        new Document(FIELD_ID, RandomString.generate())
+                                .append(FIELD_DOMAIN_ID, state.getDomainId())
+                                .append(FIELD_CLIENT_ID, state.getClientId()));
+        return Single.fromPublisher(collection.findOneAndUpdate(
+                        and(eq(FIELD_DOMAIN_ID, state.getDomainId()), eq(FIELD_CLIENT_ID, state.getClientId())),
+                        updateDoc,
+                        new FindOneAndUpdateOptions().upsert(true).returnDocument(ReturnDocument.AFTER)))
+                .map(this::convert)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<CimdClientState> create(CimdClientState item) {
+        item.setId(item.getId() == null ? RandomString.generate() : item.getId());
+        item.setUpdatedAt(new Date());
+        return Single.fromPublisher(collection.insertOne(convert(item)))
+                .flatMap(success -> Single.just(item))
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<CimdClientState> update(CimdClientState item) {
+        item.setUpdatedAt(new Date());
+        return Single.fromPublisher(collection.replaceOne(eq(FIELD_ID, item.getId()), convert(item)))
+                .flatMap(result -> Single.just(item))
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable delete(String id) {
+        return Completable.fromPublisher(collection.deleteOne(eq(FIELD_ID, id)))
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable deleteByDomain(String domainId) {
+        return Completable.fromPublisher(collection.deleteMany(eq(FIELD_DOMAIN_ID, domainId)))
+                .observeOn(Schedulers.computation());
+    }
+
+    private CimdClientState convert(CimdClientStateMongo mongo) {
+        if (mongo == null) return null;
+        CimdClientState state = new CimdClientState();
+        state.setId(mongo.getId());
+        state.setDomainId(mongo.getDomainId());
+        state.setClientId(mongo.getClientId());
+        state.setMonitoredPropertiesHash(mongo.getMonitoredPropertiesHash());
+        state.setUpdatedAt(mongo.getUpdatedAt());
+        return state;
+    }
+
+    private CimdClientStateMongo convert(CimdClientState state) {
+        if (state == null) return null;
+        CimdClientStateMongo mongo = new CimdClientStateMongo();
+        mongo.setId(state.getId());
+        mongo.setDomainId(state.getDomainId());
+        mongo.setClientId(state.getClientId());
+        mongo.setMonitoredPropertiesHash(state.getMonitoredPropertiesHash());
+        mongo.setUpdatedAt(state.getUpdatedAt());
+        return mongo;
+    }
+}

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoScopeApprovalRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoScopeApprovalRepository.java
@@ -107,6 +107,13 @@ public class MongoScopeApprovalRepository extends AbstractDataPlaneMongoReposito
     }
 
     @Override
+    public Flowable<ScopeApproval> findByDomainAndClient(String domain, String clientId) {
+        return Flowable.fromPublisher(scopeApprovalsCollection.find(
+                and(eq(FIELD_DOMAIN, domain), eq(FIELD_CLIENT_ID, clientId), gte(FIELD_EXPIRES_AT, new Date())))).map(this::convert)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
     public Maybe<ScopeApproval> findById(String id) {
         return Observable.fromPublisher(scopeApprovalsCollection.find(and(eq(FIELD_ID, id), gte(FIELD_EXPIRES_AT, new Date()))).first()).firstElement().map(this::convert)
                 .observeOn(Schedulers.computation());
@@ -181,6 +188,13 @@ public class MongoScopeApprovalRepository extends AbstractDataPlaneMongoReposito
     public Completable deleteByDomainAndUser(String domain, UserId userId) {
         return Completable.fromPublisher(scopeApprovalsCollection.deleteMany(
                 and(eq(FIELD_DOMAIN, domain), userIdMatches(userId, DEFAULT_USER_FIELDS))))
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable deleteByDomainAndClient(String domain, String clientId) {
+        return Completable.fromPublisher(scopeApprovalsCollection.deleteMany(
+                and(eq(FIELD_DOMAIN, domain), eq(FIELD_CLIENT_ID, clientId))))
                 .observeOn(Schedulers.computation());
     }
 

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/model/CimdClientStateMongo.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/model/CimdClientStateMongo.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.dataplane.mongodb.repository.model;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+import java.util.Date;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CimdClientStateMongo {
+
+    @BsonId
+    private String id;
+    private String domainId;
+    private String clientId;
+    private String monitoredPropertiesHash;
+    private Date updatedAt;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getDomainId() { return domainId; }
+    public void setDomainId(String domainId) { this.domainId = domainId; }
+
+    public String getClientId() { return clientId; }
+    public void setClientId(String clientId) { this.clientId = clientId; }
+
+    public String getMonitoredPropertiesHash() { return monitoredPropertiesHash; }
+    public void setMonitoredPropertiesHash(String monitoredPropertiesHash) { this.monitoredPropertiesHash = monitoredPropertiesHash; }
+
+    public Date getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImpl.java
@@ -25,13 +25,17 @@ import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataDocumentMan
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdUriTrustValidator;
 import lombok.extern.slf4j.Slf4j;
+import io.gravitee.am.model.CimdClientState;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.application.ApplicationScopeSettings;
 import io.gravitee.am.model.oidc.CIMDSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.JWKSet;
+import io.gravitee.am.gateway.handler.common.service.RevokeTokenGatewayService;
+import io.gravitee.am.service.CimdClientStateService;
 import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.service.cimd.CimdValidationRules;
+import io.gravitee.am.service.ScopeApprovalService;
 import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.gravitee.am.service.utils.RetryAtMostWithDelay;
 import io.gravitee.am.service.utils.jwk.converter.JWKConverter;
@@ -58,10 +62,13 @@ import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 public class CimdMetadataServiceImpl implements CimdMetadataService {
@@ -74,25 +81,45 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
     private static final List<String> DEFAULT_GRANT_TYPES = List.of(GrantType.AUTHORIZATION_CODE);
     private static final List<String> DEFAULT_RESPONSE_TYPES = List.of(ResponseType.CODE);
 
+    private static final List<String> MONITORED_PROPERTIES = List.of(
+            "client_name",
+            "grant_types",
+            "jwks",
+            "jwks_uri",
+            "logo_uri",
+            "redirect_uris",
+            "scope",
+            "token_endpoint_auth_method"
+        );
+
     private final Domain domain;
     private final WebClient webClient;
     private final CimdMetadataDocumentService cimdMetadataDocumentService;
     private final CimdMetadataDocumentManager cimdMetadataDocumentManager;
     private final CimdUriTrustValidator cimdUriTrustValidator;
     private final CimdLogoCacheService cimdLogoCacheService;
+    private final CimdClientStateService cimdClientStateService;
+    private final ScopeApprovalService scopeApprovalService;
+    private final RevokeTokenGatewayService revokeTokenGatewayService;
 
     public CimdMetadataServiceImpl(Domain domain,
                                    WebClient webClient,
                                    CimdMetadataDocumentService cimdMetadataDocumentService,
                                    CimdMetadataDocumentManager cimdMetadataDocumentManager,
                                    CimdUriTrustValidator cimdUriTrustValidator,
-                                   CimdLogoCacheService cimdLogoCacheService) {
+                                   CimdLogoCacheService cimdLogoCacheService,
+                                   CimdClientStateService cimdClientStateService,
+                                   ScopeApprovalService scopeApprovalService,
+                                   RevokeTokenGatewayService revokeTokenGatewayService) {
         this.domain = domain;
         this.webClient = webClient;
         this.cimdMetadataDocumentService = cimdMetadataDocumentService;
         this.cimdMetadataDocumentManager = cimdMetadataDocumentManager;
         this.cimdUriTrustValidator = cimdUriTrustValidator;
         this.cimdLogoCacheService = cimdLogoCacheService;
+        this.cimdClientStateService = cimdClientStateService;
+        this.scopeApprovalService = scopeApprovalService;
+        this.revokeTokenGatewayService = revokeTokenGatewayService;
     }
 
     @Override
@@ -141,7 +168,10 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
                                                                 err -> log.warn("CIMD failed to persist metadata for domain={}, clientId={}: {}", domain.getId(), canonicalId, err.getMessage())
                                                         );
                                             }
-                                            return Single.just(synthesizeClient(canonicalId, templateClient, fetchResult.json()));
+                                            return (settings.isRevokeOnDocumentChange()
+                                                    ? detectAndRevokeOnChange(canonicalId, fetchResult.json())
+                                                    : Completable.complete())
+                                                    .andThen(Single.fromCallable(() -> synthesizeClient(canonicalId, templateClient, fetchResult.json())));
                                         })
                                         .toMaybe();
                             })
@@ -436,6 +466,33 @@ public class CimdMetadataServiceImpl implements CimdMetadataService {
 
     private static long resolveCacheTtlSeconds(CIMDSettings settings) {
         return Math.max(1L, settings.getCacheTtlSeconds());
+    }
+
+    private Completable detectAndRevokeOnChange(String clientId, JsonObject metadata) {
+        final String newHash = calculateMonitoredPropertiesHash(metadata);
+        return cimdClientStateService.findByDomainAndClientId(domain, clientId)
+                .defaultIfEmpty(new CimdClientState())
+                .flatMapCompletable(existing -> {
+                    if (newHash.equals(existing.getMonitoredPropertiesHash())) {
+                        return Completable.complete(); // unchanged — skip DB write
+                    }
+                    if (existing.getId() != null) {
+                        log.info("CIMD monitored properties changed for domain={}, clientId={} — revoking tokens and consents", domain.getId(), clientId);
+                        return scopeApprovalService.revokeByClient(domain, clientId, revokeTokenGatewayService::process)
+                                .andThen(cimdClientStateService.upsert(domain, clientId, newHash).ignoreElement());
+                    }
+                    return cimdClientStateService.upsert(domain, clientId, newHash).ignoreElement();
+                })
+                .doOnComplete(() -> log.debug("CIMD client state updated for domain={}, clientId={}", domain.getId(), clientId))
+                .doOnError(err -> log.warn("CIMD failed to check/update client state for domain={}, clientId={}: {}", domain.getId(), clientId, err.getMessage()))
+                .onErrorComplete();
+    }
+
+    static String calculateMonitoredPropertiesHash(JsonObject metadata) {
+        final String canonical = MONITORED_PROPERTIES.stream()
+                .map(k -> k + "=" + Optional.ofNullable(metadata.getValue(k)).map(Object::toString).orElse(""))
+                .collect(Collectors.joining("|"));
+        return calculateMetadataHash(canonical);
     }
 
     private static String calculateMetadataHash(String metadataJson) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -41,7 +41,9 @@ import io.gravitee.am.gateway.handler.common.client.cimd.CimdMetadataService;
 import io.gravitee.am.gateway.handler.common.client.cimd.CimdUriTrustValidator;
 import io.gravitee.am.gateway.handler.common.web.HostSsrfGuard;
 import io.gravitee.am.gateway.handler.common.client.cimd.impl.CimdMetadataServiceImpl;
+import io.gravitee.am.service.CimdClientStateService;
 import io.gravitee.am.service.CimdMetadataDocumentService;
+import io.gravitee.am.service.ScopeApprovalService;
 import io.gravitee.am.gateway.handler.common.client.impl.ClientManagerImpl;
 import io.gravitee.am.gateway.handler.common.client.impl.ClientSyncServiceImpl;
 import io.gravitee.am.gateway.handler.common.client.impl.CimdAwareClientLookupServiceImpl;
@@ -279,14 +281,20 @@ public class CommonConfiguration {
                                                    CimdMetadataDocumentService cimdMetadataDocumentService,
                                                    CimdMetadataDocumentManager cimdMetadataDocumentManager,
                                                    CimdUriTrustValidator cimdUriTrustValidator,
-                                                   CimdLogoCacheService cimdLogoCacheService) {
+                                                   CimdLogoCacheService cimdLogoCacheService,
+                                                   CimdClientStateService cimdClientStateService,
+                                                   ScopeApprovalService scopeApprovalService,
+                                                   RevokeTokenGatewayService revokeTokenGatewayService) {
         return new CimdMetadataServiceImpl(
                 domain,
                 webClient,
                 cimdMetadataDocumentService,
                 cimdMetadataDocumentManager,
                 cimdUriTrustValidator,
-                cimdLogoCacheService);
+                cimdLogoCacheService,
+                cimdClientStateService,
+                scopeApprovalService,
+                revokeTokenGatewayService);
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/cimd/impl/CimdMetadataServiceImplTest.java
@@ -28,9 +28,14 @@ import io.gravitee.am.model.application.ClientSecret;
 import io.gravitee.am.model.oidc.CIMDSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.OIDCSettings;
+import io.gravitee.am.gateway.handler.common.service.RevokeTokenGatewayService;
+import io.gravitee.am.model.CimdClientState;
+import io.gravitee.am.service.CimdClientStateService;
 import io.gravitee.am.service.CimdMetadataDocumentService;
+import io.gravitee.am.service.ScopeApprovalService;
 import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
@@ -111,6 +116,15 @@ public class CimdMetadataServiceImplTest {
     @Mock
     private CimdMetadataDocumentManager cimdMetadataDocumentManager;
 
+    @Mock
+    private CimdClientStateService cimdClientStateService;
+
+    @Mock
+    private ScopeApprovalService scopeApprovalService;
+
+    @Mock
+    private RevokeTokenGatewayService revokeTokenGatewayService;
+
     private CimdMetadataService cimdMetadataService;
     private CIMDSettings cimdSettings;
     private Domain domain;
@@ -146,6 +160,10 @@ public class CimdMetadataServiceImplTest {
         lenient()
                 .when(uriTrustValidator.validateResolvableHost(anyString(), anyString(), any()))
                 .thenReturn(Completable.complete());
+        lenient().when(cimdClientStateService.findByDomainAndClientId(any(Domain.class), anyString()))
+                .thenReturn(Maybe.empty());
+        lenient().when(cimdClientStateService.upsert(any(Domain.class), anyString(), anyString()))
+                .thenReturn(Single.just(new CimdClientState()));
 
         cimdMetadataService = new CimdMetadataServiceImpl(
                 domain,
@@ -153,7 +171,10 @@ public class CimdMetadataServiceImplTest {
                 cimdMetadataDocumentService,
                 cimdMetadataDocumentManager,
                 uriTrustValidator,
-                logoCacheService);
+                logoCacheService,
+                cimdClientStateService,
+                scopeApprovalService,
+                revokeTokenGatewayService);
     }
 
     @After
@@ -1049,6 +1070,81 @@ public class CimdMetadataServiceImplTest {
         cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test().assertComplete();
 
         verify(logoCacheService).prefetchLogoAsync(eq(CLIENT_URL), eq("https://localhost/logo.png"), anyLong(), eq(cimdSettings));
+    }
+
+    // --- detectAndRevokeOnChange tests ---
+
+    @Test
+    public void shouldNotCheckClientStateWhenRevokeOnDocumentChangeDisabled() {
+        // revokeOnDocumentChange is false by default — cimdClientStateService must never be called
+        mockFetchSuccess(metadataPayload(CLIENT_URL));
+
+        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test()
+                .awaitDone(2, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(cimdClientStateService, never()).findByDomainAndClientId(any(Domain.class), anyString());
+        verify(cimdClientStateService, never()).upsert(any(Domain.class), anyString(), anyString());
+        verify(scopeApprovalService, never()).revokeByClient(any(), anyString(), any());
+    }
+
+    @Test
+    public void shouldStoreHashOnFirstFetchWithoutRevocation() {
+        cimdSettings.setRevokeOnDocumentChange(true);
+        // default stub: findByDomainAndClientId returns Maybe.empty() (no prior state)
+        mockFetchSuccess(metadataPayload(CLIENT_URL));
+
+        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test()
+                .awaitDone(2, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(cimdClientStateService).upsert(eq(domain), eq(CLIENT_URL), anyString());
+        verify(scopeApprovalService, never()).revokeByClient(any(), anyString(), any());
+        verify(revokeTokenGatewayService, never()).process(any(), any());
+    }
+
+    @Test
+    public void shouldNotRevokeWhenMonitoredPropertiesHashUnchanged() {
+        cimdSettings.setRevokeOnDocumentChange(true);
+        JsonObject metadata = new JsonObject()
+                .put("client_id", CLIENT_URL)
+                .put("redirect_uris", new JsonArray().add("https://callback.example.com/cb"))
+                .put("token_endpoint_auth_method", "private_key_jwt")
+                .put("jwks_uri", "https://localhost/jwks");
+        String sameHash = CimdMetadataServiceImpl.calculateMonitoredPropertiesHash(metadata);
+        CimdClientState existingState = new CimdClientState();
+        existingState.setMonitoredPropertiesHash(sameHash);
+        when(cimdClientStateService.findByDomainAndClientId(domain, CLIENT_URL))
+                .thenReturn(Maybe.just(existingState));
+        mockFetchSuccess(metadata.encode());
+
+        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test()
+                .awaitDone(2, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(cimdClientStateService, never()).upsert(any(Domain.class), anyString(), anyString());
+        verify(scopeApprovalService, never()).revokeByClient(any(), anyString(), any());
+        verify(revokeTokenGatewayService, never()).process(any(), any());
+    }
+
+    @Test
+    public void shouldRevokeWhenMonitoredPropertiesHashChanged() {
+        cimdSettings.setRevokeOnDocumentChange(true);
+        CimdClientState existingState = new CimdClientState();
+        existingState.setId("existing-state-id");
+        existingState.setMonitoredPropertiesHash("old-hash-that-will-not-match");
+        when(cimdClientStateService.findByDomainAndClientId(domain, CLIENT_URL))
+                .thenReturn(Maybe.just(existingState));
+        when(scopeApprovalService.revokeByClient(eq(domain), eq(CLIENT_URL), any()))
+                .thenReturn(Completable.complete());
+        mockFetchSuccess(metadataPayload(CLIENT_URL));
+
+        cimdMetadataService.resolveClient(CLIENT_URL, templateClient()).test()
+                .awaitDone(2, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(scopeApprovalService).revokeByClient(eq(domain), eq(CLIENT_URL), any());
+        verify(cimdClientStateService).upsert(eq(domain), eq(CLIENT_URL), anyString());
     }
 
     // --- helpers ---

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainCIMDSettingsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainCIMDSettingsResourceTest.java
@@ -121,6 +121,8 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         assertEquals("cacheMaxEntries must be 500", Integer.valueOf(500), capturedCimd.getCacheMaxEntries().get());
         assertTrue("templateId must be present", capturedCimd.getTemplateId().isPresent());
         assertEquals("templateId must match", "my-template-id", capturedCimd.getTemplateId().get());
+        assertTrue("revokeOnDocumentChange must be present", capturedCimd.getRevokeOnDocumentChange().isPresent());
+        assertTrue("revokeOnDocumentChange must be true", capturedCimd.getRevokeOnDocumentChange().get());
     }
 
     @Test
@@ -154,6 +156,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         assertEquals("cacheTtlSeconds must be 7200", 7200, cimd.getCacheTtlSeconds());
         assertEquals("cacheMaxEntries must be 500", 500, cimd.getCacheMaxEntries());
         assertEquals("templateId must match", "my-template-id", cimd.getTemplateId());
+        assertTrue("revokeOnDocumentChange must be true", cimd.isRevokeOnDocumentChange());
     }
 
     // -------------------------------------------------------------------------
@@ -189,6 +192,8 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         assertEquals("templateId must match", "my-template-id", capturedCimd.getTemplateId().get());
         assertEquals("fetchTimeoutMs must be 3000", Integer.valueOf(3000), capturedCimd.getFetchTimeoutMs().get());
         assertEquals("cacheTtlSeconds must be 7200", Integer.valueOf(7200), capturedCimd.getCacheTtlSeconds().get());
+        assertTrue("revokeOnDocumentChange must be present", capturedCimd.getRevokeOnDocumentChange().isPresent());
+        assertTrue("revokeOnDocumentChange must be true", capturedCimd.getRevokeOnDocumentChange().get());
     }
 
     @Test
@@ -217,6 +222,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         assertEquals("templateId must match", "my-template-id", cimd.getTemplateId());
         assertEquals("fetchTimeoutMs must be 3000", 3000, cimd.getFetchTimeoutMs());
         assertEquals("cacheTtlSeconds must be 7200", 7200, cimd.getCacheTtlSeconds());
+        assertTrue("revokeOnDocumentChange must be true", cimd.isRevokeOnDocumentChange());
     }
 
     @Test
@@ -280,6 +286,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         cimdSettings.setCacheTtlSeconds(7200);
         cimdSettings.setCacheMaxEntries(500);
         cimdSettings.setTemplateId("my-template-id");
+        cimdSettings.setRevokeOnDocumentChange(true);
 
         OIDCSettings oidcSettings = new OIDCSettings();
         oidcSettings.setCimdSettings(cimdSettings);
@@ -299,6 +306,7 @@ public class DomainCIMDSettingsResourceTest extends JerseySpringTest {
         patchCimd.setCacheTtlSeconds(Optional.of(7200));
         patchCimd.setCacheMaxEntries(Optional.of(500));
         patchCimd.setTemplateId(Optional.of("my-template-id"));
+        patchCimd.setRevokeOnDocumentChange(Optional.of(true));
 
         PatchOIDCSettings patchOidc = new PatchOIDCSettings();
         patchOidc.setCimdSettings(Optional.of(patchCimd));

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -60,6 +60,7 @@ import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.AuthenticationDeviceNotifierService;
 import io.gravitee.am.service.AuthorizationEngineService;
 import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.CimdClientStateService;
 import io.gravitee.am.service.DeviceIdentifierService;
 import io.gravitee.am.service.DomainReadService;
 import io.gravitee.am.service.EmailTemplateService;
@@ -287,6 +288,8 @@ public class DomainServiceImpl implements DomainService {
     private ServiceResourceService serviceResourceService;
     @Autowired
     private AuthorizationEngineService authorizationEngineService;
+    @Autowired
+    private CimdClientStateService cimdClientStateService;
 
     @Override
     public Maybe<Domain> findById(String id) {
@@ -519,7 +522,9 @@ public class DomainServiceImpl implements DomainService {
                             // create event for sync process
                             .flatMap(domain1 -> {
                                 Event event = new Event(Type.DOMAIN, new Payload(domain1.getId(), DOMAIN, domain1.getId(), Action.UPDATE));
-                                return eventService.create(event, domain1).flatMap(__ -> Single.just(domain1));
+                                return eventService.create(event, domain1)
+                                        .flatMap(__ -> cleanUpCimdClientState(oldDomain, domain1)
+                                                .andThen(Single.just(domain1)));
                             })
                             .doOnSuccess(domain1 -> {
                                 auditService.report(AuditBuilder.builder(DomainAuditBuilder.class).principal(principal).type(EventType.DOMAIN_UPDATED).oldValue(oldDomain).domain(domain1));
@@ -715,6 +720,7 @@ public class DomainServiceImpl implements DomainService {
                             // delete certificate credentials
                             .andThen(certificateCredentialService.deleteByDomain(domain))
                             .andThen(authorizationEngineService.deleteByDomain(domainId))
+                            .andThen(cimdClientStateService.deleteByDomain(domain))
                             .andThen(domainRepository.delete(domainId))
                             .andThen(Completable.fromSingle(eventService.create(new Event(Type.DOMAIN, new Payload(domainId, DOMAIN, domainId, Action.DELETE), domain.getDataPlaneId(), domain.getReferenceId()), domain)))
                             .doOnComplete(() -> auditService.report(AuditBuilder.builder(DomainAuditBuilder.class)
@@ -882,6 +888,26 @@ public class DomainServiceImpl implements DomainService {
                         }));
     }
 
+
+    private static boolean isCimdRevokeOnDocumentChangeEnabled(Domain domain) {
+        return Optional.ofNullable(domain.getOidc())
+                .map(OIDCSettings::getCimdSettings)
+                .map(CIMDSettings::isRevokeOnDocumentChange)
+                .orElse(false);
+    }
+
+    /**
+     * When {@code revokeOnDocumentChange} is turned off for the domain, drops persisted CIMD client state records.
+     */
+    private Completable cleanUpCimdClientState(Domain domainBeforePatch, Domain domainAfterPatch) {
+        if (!isCimdRevokeOnDocumentChangeEnabled(domainBeforePatch)
+                || isCimdRevokeOnDocumentChangeEnabled(domainAfterPatch)) {
+            return Completable.complete();
+        }
+        return cimdClientStateService.deleteByDomain(domainAfterPatch)
+                .doOnError(e -> LOGGER.warn("Failed to clean up CIMD client state for domain {}: {}", domainAfterPatch.getId(), e.getMessage()))
+                .onErrorComplete();
+    }
 
     private Completable validateCIMDSettings(Domain domain) {
         Optional<CIMDSettings> optCIMDSettings = Optional.ofNullable(domain.getOidc()).map(OIDCSettings::getCimdSettings);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -114,6 +114,7 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -346,6 +347,14 @@ public class DomainServiceTest {
 
     @Mock
     private AuthorizationEngineService authorizationEngineService;
+
+    @Mock
+    private io.gravitee.am.service.CimdClientStateService cimdClientStateService;
+
+    @BeforeEach
+    void stubCimdClientStateServiceDefaults() {
+        Mockito.lenient().when(cimdClientStateService.deleteByDomain(any(Domain.class))).thenReturn(Completable.complete());
+    }
 
     @Test
     public void shouldDelegateFindById() {
@@ -1930,5 +1939,102 @@ public class DomainServiceTest {
         corsSettings.setAllowedMethods(Set.of("GET", "POST"));
         corsSettings.setAllowedOrigins(allowedOrigins);
         return corsSettings;
+    }
+
+    // ---- CIMD revokeOnDocumentChange cleanup tests ----
+
+    @Test
+    public void shouldPatch_deletesCimdClientState_whenRevokeOnDocumentChangeBecomesDisabled() {
+        Domain oldDomain = buildCimdPatchDomain(true);
+        Domain newDomain = buildCimdPatchDomain(false);
+        PatchDomain patchDomain = stubCimdPatch(oldDomain, newDomain);
+
+        domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, DOMAIN_ID), DOMAIN_ID, patchDomain, null)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertNoErrors();
+
+        verify(cimdClientStateService, times(1)).deleteByDomain(any(Domain.class));
+    }
+
+    @Test
+    public void shouldPatch_doesNotDeleteCimdClientState_whenRevokeOnDocumentChangeRemainsEnabled() {
+        Domain oldDomain = buildCimdPatchDomain(true);
+        Domain newDomain = buildCimdPatchDomain(true);
+        PatchDomain patchDomain = stubCimdPatch(oldDomain, newDomain);
+
+        domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, DOMAIN_ID), DOMAIN_ID, patchDomain, null)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertNoErrors();
+
+        verify(cimdClientStateService, never()).deleteByDomain(any(Domain.class));
+    }
+
+    @Test
+    public void shouldPatch_doesNotDeleteCimdClientState_whenRevokeOnDocumentChangeRemainsDisabled() {
+        Domain oldDomain = buildCimdPatchDomain(false);
+        Domain newDomain = buildCimdPatchDomain(false);
+        PatchDomain patchDomain = stubCimdPatch(oldDomain, newDomain);
+
+        domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, DOMAIN_ID), DOMAIN_ID, patchDomain, null)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertNoErrors();
+
+        verify(cimdClientStateService, never()).deleteByDomain(any(Domain.class));
+    }
+
+    @Test
+    public void shouldPatch_doesNotDeleteCimdClientState_whenRevokeOnDocumentChangeBecomesEnabled() {
+        Domain oldDomain = buildCimdPatchDomain(false);
+        Domain newDomain = buildCimdPatchDomain(true);
+        PatchDomain patchDomain = stubCimdPatch(oldDomain, newDomain);
+
+        domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, DOMAIN_ID), DOMAIN_ID, patchDomain, null)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertNoErrors();
+
+        verify(cimdClientStateService, never()).deleteByDomain(any(Domain.class));
+    }
+
+    private Domain buildCimdPatchDomain(boolean revokeOnDocumentChange) {
+        CIMDSettings cimdSettings = new CIMDSettings();
+        cimdSettings.setEnabled(false);
+        cimdSettings.setRevokeOnDocumentChange(revokeOnDocumentChange);
+        OIDCSettings oidc = new OIDCSettings();
+        oidc.setCimdSettings(cimdSettings);
+
+        Domain d = new Domain();
+        d.setId(DOMAIN_ID);
+        d.setHrid(DOMAIN_ID);
+        d.setName(DOMAIN_ID);
+        d.setPath("/cimd-test");
+        d.setReferenceType(ReferenceType.ENVIRONMENT);
+        d.setReferenceId(ENVIRONMENT_ID);
+        d.setVersion(DomainVersion.V2_0);
+        d.setOidc(oidc);
+        return d;
+    }
+
+    private PatchDomain stubCimdPatch(Domain oldDomain, Domain newDomain) {
+        PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
+        when(patchDomain.patch(any())).thenReturn(newDomain);
+        when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(oldDomain));
+        when(domainRepository.findByHrid(any(), anyString(), anyString())).thenReturn(Maybe.just(oldDomain));
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
+        when(domainReadService.listAll()).thenReturn(Flowable.empty());
+        when(domainRepository.update(any(Domain.class))).thenReturn(Single.just(newDomain));
+        when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
+        doReturn(Completable.complete()).when(domainValidator).validate(any(), any());
+        doReturn(Completable.complete()).when(virtualHostValidator).validateDomainVhosts(any(), any());
+        doReturn(true).when(accountSettingsValidator).validate(any());
+        doReturn(Completable.complete()).when(tokenExchangeSettingsValidator).validate(any());
+        return patchDomain;
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/CimdClientState.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/CimdClientState.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+/**
+ * Persists the hash of the monitored properties of a CIMD client's last-seen metadata document.
+ * Unlike {@link CimdMetadataDocument}, this record never expires — it is used to detect
+ * changes in monitored properties across cache TTL boundaries and gateway restarts.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class CimdClientState {
+
+    private String id;
+    /** The AM domain that owns this CIMD client. */
+    private String domainId;
+    /** The URL-shaped client_id — unique within a domain. */
+    private String clientId;
+    /** SHA-256 hash of the canonical representation of the monitored metadata properties. */
+    private String monitoredPropertiesHash;
+    private Date updatedAt;
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIMDSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIMDSettings.java
@@ -83,6 +83,12 @@ public class CIMDSettings {
      */
     private String templateId;
 
+    /**
+     * When true, all active tokens and user consents for a CIMD client are revoked whenever a re-fetch
+     * of its metadata document reveals that any of the monitored properties have changed.
+     */
+    private boolean revokeOnDocumentChange;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -153,6 +159,14 @@ public class CIMDSettings {
 
     public void setTemplateId(String templateId) {
         this.templateId = templateId;
+    }
+
+    public boolean isRevokeOnDocumentChange() {
+        return revokeOnDocumentChange;
+    }
+
+    public void setRevokeOnDocumentChange(boolean revokeOnDocumentChange) {
+        this.revokeOnDocumentChange = revokeOnDocumentChange;
     }
 
     public static CIMDSettings defaultSettings() {

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/token/RevokeToken.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/token/RevokeToken.java
@@ -114,6 +114,19 @@ public class RevokeToken extends RevokeTokenDeprecated {
         return request;
     }
 
+    public static RevokeToken byClientId(Domain domain, String clientId) {
+        final var request = new RevokeToken();
+        request.setRevokeType(RevokeType.BY_CLIENT);
+        request.setDomainId(domain.getId());
+        request.setApplication(ApplicationData.builder()
+                .clientId(clientId)
+                .build());
+
+        // For backward compatibility MAPI in newer version may sent an event which is read by GW in older version
+        request.setClientId(clientId);
+        return request;
+    }
+
     public static RevokeToken byUserAndClientId(Domain domain, String clientId, String userId, String username, String principalId, String principalUsername) {
         final var request = new RevokeToken();
         request.setRevokeType(RevokeType.BY_USER_AND_CLIENT);

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistry.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistry.java
@@ -20,6 +20,7 @@ package io.gravitee.am.plugins.dataplane.core;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.dataplane.api.DataPlaneProvider;
 import io.gravitee.am.dataplane.api.repository.AccessPolicyRepository;
+import io.gravitee.am.dataplane.api.repository.CimdClientStateRepository;
 import io.gravitee.am.dataplane.api.repository.CredentialRepository;
 import io.gravitee.am.dataplane.api.repository.CertificateCredentialRepository;
 import io.gravitee.am.dataplane.api.repository.DeviceRepository;
@@ -51,6 +52,8 @@ public interface DataPlaneRegistry {
     DataPlaneDescription getDescription(Domain domain);
 
     DataPlaneProvider getProviderById(String id);
+
+    CimdClientStateRepository getCimdClientStateRepository(Domain domain);
 
     CredentialRepository getCredentialRepository(Domain domain);
 

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImpl.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.am.plugins.dataplane.core;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.dataplane.api.DataPlaneProvider;
 import io.gravitee.am.dataplane.api.repository.AccessPolicyRepository;
+import io.gravitee.am.dataplane.api.repository.CimdClientStateRepository;
 import io.gravitee.am.dataplane.api.repository.CredentialRepository;
 import io.gravitee.am.dataplane.api.repository.CertificateCredentialRepository;
 import io.gravitee.am.dataplane.api.repository.DeviceRepository;
@@ -103,6 +104,11 @@ public class DataPlaneRegistryImpl extends AbstractService<DataPlaneRegistryImpl
             dataPlaneId = DEFAULT_DATA_PLANE_ID;
         }
         return dataPlaneId;
+    }
+
+    @Override
+    public CimdClientStateRepository getCimdClientStateRepository(Domain domain) {
+        return getProvider(domain).getCimdClientStateRepository();
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
@@ -458,6 +458,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         result.setCacheTtlSeconds(cimdSettings.getCacheTtlSeconds());
         result.setCacheMaxEntries(cimdSettings.getCacheMaxEntries());
         result.setTemplateId(cimdSettings.getTemplateId());
+        result.setRevokeOnDocumentChange(cimdSettings.isRevokeOnDocumentChange());
 
         return result;
     }
@@ -477,6 +478,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         result.setCacheTtlSeconds(cimdSettings.getCacheTtlSeconds());
         result.setCacheMaxEntries(cimdSettings.getCacheMaxEntries());
         result.setTemplateId(cimdSettings.getTemplateId());
+        result.setRevokeOnDocumentChange(cimdSettings.isRevokeOnDocumentChange());
 
         return result;
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/CIMDSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/CIMDSettingsMongo.java
@@ -31,6 +31,7 @@ public class CIMDSettingsMongo {
     private int cacheTtlSeconds;
     private int cacheMaxEntries;
     private String templateId;
+    private boolean revokeOnDocumentChange;
 
     public boolean isEnabled() {
         return enabled;
@@ -102,5 +103,13 @@ public class CIMDSettingsMongo {
 
     public void setTemplateId(String templateId) {
         this.templateId = templateId;
+    }
+
+    public boolean isRevokeOnDocumentChange() {
+        return revokeOnDocumentChange;
+    }
+
+    public void setRevokeOnDocumentChange(boolean revokeOnDocumentChange) {
+        this.revokeOnDocumentChange = revokeOnDocumentChange;
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/CimdClientStateService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/CimdClientStateService.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service;
+
+import io.gravitee.am.model.CimdClientState;
+import io.gravitee.am.model.Domain;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface CimdClientStateService {
+
+    Maybe<CimdClientState> findByDomainAndClientId(Domain domain, String clientId);
+
+    Single<CimdClientState> upsert(Domain domain, String clientId, String monitoredPropertiesHash);
+
+    Completable deleteByDomain(Domain domain);
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/ScopeApprovalService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/ScopeApprovalService.java
@@ -49,4 +49,6 @@ public interface ScopeApprovalService {
 
     Completable revokeByUserAndClient(Domain domain, UserId userId, String clientId, BiFunction<Domain, RevokeToken, Completable> revokeTokenProcessor, User principal);
 
+    Completable revokeByClient(Domain domain, String clientId, BiFunction<Domain, RevokeToken, Completable> revokeTokenProcessor);
+
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CimdClientStateServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CimdClientStateServiceImpl.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.impl;
+
+import io.gravitee.am.model.CimdClientState;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.service.CimdClientStateService;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+public class CimdClientStateServiceImpl implements CimdClientStateService {
+
+    @Autowired
+    private DataPlaneRegistry dataPlaneRegistry;
+
+    @Override
+    public Maybe<CimdClientState> findByDomainAndClientId(Domain domain, String clientId) {
+        return dataPlaneRegistry.getCimdClientStateRepository(domain).findByDomainAndClientId(domain.getId(), clientId);
+    }
+
+    @Override
+    public Single<CimdClientState> upsert(Domain domain, String clientId, String monitoredPropertiesHash) {
+        final CimdClientState state = new CimdClientState();
+        state.setDomainId(domain.getId());
+        state.setClientId(clientId);
+        state.setMonitoredPropertiesHash(monitoredPropertiesHash);
+        return dataPlaneRegistry.getCimdClientStateRepository(domain).upsert(state);
+    }
+
+    @Override
+    public Completable deleteByDomain(Domain domain) {
+        return dataPlaneRegistry.getCimdClientStateRepository(domain).deleteByDomain(domain.getId());
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ScopeApprovalServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ScopeApprovalServiceImpl.java
@@ -223,4 +223,27 @@ public class ScopeApprovalServiceImpl implements ScopeApprovalService {
                 });
 
     }
+
+    @Override
+    public Completable revokeByClient(Domain domain, String clientId, BiFunction<Domain, RevokeToken, Completable> revokeTokenProcessor) {
+        LOGGER.debug("Revoke approvals for domain: {}, client: {}", domain, clientId);
+        final var scopeApprovalRepository = dataPlaneRegistry.getScopeApprovalRepository(domain);
+        return scopeApprovalRepository.deleteByDomainAndClient(domain.getId(), clientId)
+                .doOnComplete(() -> auditService.report(AuditBuilder.builder(UserConsentAuditBuilder.class)
+                        .type(EventType.USER_CONSENT_REVOKED)
+                        .reference(domain.asReference())
+                        .client(clientId)
+                        .approvals(Collections.emptySet())))
+                .doOnError(throwable -> auditService.report(AuditBuilder.builder(UserConsentAuditBuilder.class)
+                        .type(EventType.USER_CONSENT_REVOKED)
+                        .reference(domain.asReference())
+                        .client(clientId)
+                        .throwable(throwable)))
+                .andThen(revokeTokenProcessor.apply(domain, RevokeToken.byClientId(domain, clientId)))
+                .onErrorResumeNext(ex -> {
+                    LOGGER.error("An error occurs while revoking scope approvals for domain: {}, client: {}", domain, clientId, ex);
+                    return Completable.error(new TechnicalManagementException(
+                            String.format("An error occurs while revoking scope approvals for domain: %s, client: %s", domain, clientId), ex));
+                });
+    }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIMDSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIMDSettings.java
@@ -48,6 +48,8 @@ public class PatchCIMDSettings {
     // Security Policy
     private Optional<String> templateId;
 
+    private Optional<Boolean> revokeOnDocumentChange;
+
     public Optional<Boolean> getEnabled() {
         return enabled;
     }
@@ -120,6 +122,14 @@ public class PatchCIMDSettings {
         this.templateId = templateId;
     }
 
+    public Optional<Boolean> getRevokeOnDocumentChange() {
+        return revokeOnDocumentChange;
+    }
+
+    public void setRevokeOnDocumentChange(Optional<Boolean> revokeOnDocumentChange) {
+        this.revokeOnDocumentChange = revokeOnDocumentChange;
+    }
+
     public CIMDSettings patch(CIMDSettings toPatch) {
         CIMDSettings result = toPatch != null ? toPatch : CIMDSettings.defaultSettings();
 
@@ -136,6 +146,7 @@ public class PatchCIMDSettings {
         Optional.ofNullable(getCacheMaxEntries())
                 .ifPresent(opt -> result.setCacheMaxEntries(opt.orElse(CIMDSettings.DEFAULT_CACHE_MAX_ENTRIES)));
         SetterUtils.safeSet(result::setTemplateId, this.getTemplateId(), String.class);
+        SetterUtils.safeSet(result::setRevokeOnDocumentChange, this.getRevokeOnDocumentChange(), boolean.class);
 
         return result;
     }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ScopeApprovalServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ScopeApprovalServiceTest.java
@@ -40,12 +40,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -253,5 +257,32 @@ public class ScopeApprovalServiceTest {
 
         TestObserver<Void> testObserver = scopeApprovalService.revokeByUserAndClient(new Domain(DOMAIN_ID), UserId.internal("user-id"), "client-id", (Domain, RevokeToken) -> Completable.complete(), new DefaultUser("user-id")).test();
         testObserver.assertError(UserNotFoundException.class);
+    }
+
+    @Test
+    public void shouldRevokeByClient() {
+        when(scopeApprovalRepository.deleteByDomainAndClient(DOMAIN_ID, "client-id")).thenReturn(Completable.complete());
+
+        TestObserver<Void> testObserver = scopeApprovalService.revokeByClient(DOMAIN, "client-id", (d, t) -> Completable.complete()).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(scopeApprovalRepository, never()).findByDomainAndClient(anyString(), anyString());
+        verify(scopeApprovalRepository).deleteByDomainAndClient(DOMAIN_ID, "client-id");
+        verify(auditService, timeout(3_000).times(1)).report(any(UserConsentAuditBuilder.class));
+    }
+
+    @Test
+    public void shouldRevokeByClient_technicalException() {
+        when(scopeApprovalRepository.deleteByDomainAndClient(DOMAIN_ID, "client-id"))
+                .thenReturn(Completable.error(new TechnicalException()));
+
+        TestObserver<Void> testObserver = scopeApprovalService.revokeByClient(DOMAIN, "client-id", (d, t) -> Completable.complete()).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertError(TechnicalManagementException.class);
+        testObserver.assertNotComplete();
+        verify(auditService, timeout(3_000).times(1)).report(any(UserConsentAuditBuilder.class));
     }
 }

--- a/gravitee-am-test/api/management/models/ApplicationSAMLSettings.ts
+++ b/gravitee-am-test/api/management/models/ApplicationSAMLSettings.ts
@@ -48,10 +48,22 @@ export interface ApplicationSAMLSettings {
   assertionAttributes?: Array<SAMLAssertionAttribute>;
   /**
    *
+   * @type {number}
+   * @memberof ApplicationSAMLSettings
+   */
+  assertionValiditySeconds?: number;
+  /**
+   *
    * @type {string}
    * @memberof ApplicationSAMLSettings
    */
   attributeConsumeServiceUrl?: string;
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof ApplicationSAMLSettings
+   */
+  audiences?: Array<string>;
   /**
    *
    * @type {string}
@@ -63,7 +75,25 @@ export interface ApplicationSAMLSettings {
    * @type {string}
    * @memberof ApplicationSAMLSettings
    */
+  dataEncryptionAlgorithm?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ApplicationSAMLSettings
+   */
   entityId?: string;
+  /**
+   *
+   * @type {boolean}
+   * @memberof ApplicationSAMLSettings
+   */
+  includeAssertionConditions?: boolean;
+  /**
+   *
+   * @type {string}
+   * @memberof ApplicationSAMLSettings
+   */
+  keyTransportEncryptionAlgorithm?: string;
   /**
    *
    * @type {string}
@@ -72,16 +102,16 @@ export interface ApplicationSAMLSettings {
   nameIdMapping?: string;
   /**
    *
-   * @type {string}
+   * @type {number}
    * @memberof ApplicationSAMLSettings
    */
-  dataEncryptionAlgorithm?: string;
+  notBeforeTimeSkewSeconds?: number;
   /**
    *
-   * @type {string}
+   * @type {number}
    * @memberof ApplicationSAMLSettings
    */
-  keyTransportEncryptionAlgorithm?: string;
+  notOnOrAfterTimeSkewSeconds?: number;
   /**
    *
    * @type {string}
@@ -99,13 +129,13 @@ export interface ApplicationSAMLSettings {
    * @type {boolean}
    * @memberof ApplicationSAMLSettings
    */
-  wantAssertionsSigned?: boolean;
+  wantAssertionsEncrypted?: boolean;
   /**
    *
    * @type {boolean}
    * @memberof ApplicationSAMLSettings
    */
-  wantAssertionsEncrypted?: boolean;
+  wantAssertionsSigned?: boolean;
   /**
    *
    * @type {boolean}
@@ -132,18 +162,21 @@ export function ApplicationSAMLSettingsFromJSONTyped(json: any, ignoreDiscrimina
   return {
     assertionAttributes:
       json['assertionAttributes'] == null ? undefined : (json['assertionAttributes'] as Array<any>).map(SAMLAssertionAttributeFromJSON),
+    assertionValiditySeconds: json['assertionValiditySeconds'] == null ? undefined : json['assertionValiditySeconds'],
     attributeConsumeServiceUrl: json['attributeConsumeServiceUrl'] == null ? undefined : json['attributeConsumeServiceUrl'],
+    audiences: json['audiences'] == null ? undefined : json['audiences'],
     certificate: json['certificate'] == null ? undefined : json['certificate'],
+    dataEncryptionAlgorithm: json['dataEncryptionAlgorithm'] == null ? undefined : json['dataEncryptionAlgorithm'],
     entityId: json['entityId'] == null ? undefined : json['entityId'],
+    includeAssertionConditions: json['includeAssertionConditions'] == null ? undefined : json['includeAssertionConditions'],
+    keyTransportEncryptionAlgorithm: json['keyTransportEncryptionAlgorithm'] == null ? undefined : json['keyTransportEncryptionAlgorithm'],
     nameIdMapping: json['nameIdMapping'] == null ? undefined : json['nameIdMapping'],
-    dataEncryptionAlgorithm:
-      json['dataEncryptionAlgorithm'] == null ? undefined : json['dataEncryptionAlgorithm'],
-    keyTransportEncryptionAlgorithm:
-      json['keyTransportEncryptionAlgorithm'] == null ? undefined : json['keyTransportEncryptionAlgorithm'],
+    notBeforeTimeSkewSeconds: json['notBeforeTimeSkewSeconds'] == null ? undefined : json['notBeforeTimeSkewSeconds'],
+    notOnOrAfterTimeSkewSeconds: json['notOnOrAfterTimeSkewSeconds'] == null ? undefined : json['notOnOrAfterTimeSkewSeconds'],
     responseBinding: json['responseBinding'] == null ? undefined : json['responseBinding'],
     singleLogoutServiceUrl: json['singleLogoutServiceUrl'] == null ? undefined : json['singleLogoutServiceUrl'],
-    wantAssertionsSigned: json['wantAssertionsSigned'] == null ? undefined : json['wantAssertionsSigned'],
     wantAssertionsEncrypted: json['wantAssertionsEncrypted'] == null ? undefined : json['wantAssertionsEncrypted'],
+    wantAssertionsSigned: json['wantAssertionsSigned'] == null ? undefined : json['wantAssertionsSigned'],
     wantResponseSigned: json['wantResponseSigned'] == null ? undefined : json['wantResponseSigned'],
   };
 }
@@ -160,16 +193,21 @@ export function ApplicationSAMLSettingsToJSONTyped(value?: ApplicationSAMLSettin
   return {
     assertionAttributes:
       value['assertionAttributes'] == null ? undefined : (value['assertionAttributes'] as Array<any>).map(SAMLAssertionAttributeToJSON),
+    assertionValiditySeconds: value['assertionValiditySeconds'],
     attributeConsumeServiceUrl: value['attributeConsumeServiceUrl'],
+    audiences: value['audiences'],
     certificate: value['certificate'],
-    entityId: value['entityId'],
-    nameIdMapping: value['nameIdMapping'],
     dataEncryptionAlgorithm: value['dataEncryptionAlgorithm'],
+    entityId: value['entityId'],
+    includeAssertionConditions: value['includeAssertionConditions'],
     keyTransportEncryptionAlgorithm: value['keyTransportEncryptionAlgorithm'],
+    nameIdMapping: value['nameIdMapping'],
+    notBeforeTimeSkewSeconds: value['notBeforeTimeSkewSeconds'],
+    notOnOrAfterTimeSkewSeconds: value['notOnOrAfterTimeSkewSeconds'],
     responseBinding: value['responseBinding'],
     singleLogoutServiceUrl: value['singleLogoutServiceUrl'],
-    wantAssertionsSigned: value['wantAssertionsSigned'],
     wantAssertionsEncrypted: value['wantAssertionsEncrypted'],
+    wantAssertionsSigned: value['wantAssertionsSigned'],
     wantResponseSigned: value['wantResponseSigned'],
   };
 }

--- a/gravitee-am-test/api/management/models/CIMDSettings.ts
+++ b/gravitee-am-test/api/management/models/CIMDSettings.ts
@@ -82,6 +82,12 @@ export interface CIMDSettings {
   maxResponseSizeKb?: number;
   /**
    *
+   * @type {boolean}
+   * @memberof CIMDSettings
+   */
+  revokeOnDocumentChange?: boolean;
+  /**
+   *
    * @type {string}
    * @memberof CIMDSettings
    */
@@ -112,6 +118,7 @@ export function CIMDSettingsFromJSONTyped(json: any, ignoreDiscriminator: boolea
     enabled: json['enabled'] == null ? undefined : json['enabled'],
     fetchTimeoutMs: json['fetchTimeoutMs'] == null ? undefined : json['fetchTimeoutMs'],
     maxResponseSizeKb: json['maxResponseSizeKb'] == null ? undefined : json['maxResponseSizeKb'],
+    revokeOnDocumentChange: json['revokeOnDocumentChange'] == null ? undefined : json['revokeOnDocumentChange'],
     templateId: json['templateId'] == null ? undefined : json['templateId'],
   };
 }
@@ -134,6 +141,7 @@ export function CIMDSettingsToJSONTyped(value?: CIMDSettings | null, ignoreDiscr
     enabled: value['enabled'],
     fetchTimeoutMs: value['fetchTimeoutMs'],
     maxResponseSizeKb: value['maxResponseSizeKb'],
+    revokeOnDocumentChange: value['revokeOnDocumentChange'],
     templateId: value['templateId'],
   };
 }

--- a/gravitee-am-test/api/management/models/PatchApplicationSAMLSettings.ts
+++ b/gravitee-am-test/api/management/models/PatchApplicationSAMLSettings.ts
@@ -48,10 +48,22 @@ export interface PatchApplicationSAMLSettings {
   assertionAttributes?: Array<SAMLAssertionAttribute>;
   /**
    *
+   * @type {number}
+   * @memberof PatchApplicationSAMLSettings
+   */
+  assertionValiditySeconds?: number;
+  /**
+   *
    * @type {string}
    * @memberof PatchApplicationSAMLSettings
    */
   attributeConsumeServiceUrl?: string;
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PatchApplicationSAMLSettings
+   */
+  audiences?: Array<string>;
   /**
    *
    * @type {string}
@@ -63,7 +75,25 @@ export interface PatchApplicationSAMLSettings {
    * @type {string}
    * @memberof PatchApplicationSAMLSettings
    */
+  dataEncryptionAlgorithm?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof PatchApplicationSAMLSettings
+   */
   entityId?: string;
+  /**
+   *
+   * @type {boolean}
+   * @memberof PatchApplicationSAMLSettings
+   */
+  includeAssertionConditions?: boolean;
+  /**
+   *
+   * @type {string}
+   * @memberof PatchApplicationSAMLSettings
+   */
+  keyTransportEncryptionAlgorithm?: string;
   /**
    *
    * @type {string}
@@ -72,16 +102,16 @@ export interface PatchApplicationSAMLSettings {
   nameIdMapping?: string;
   /**
    *
-   * @type {string}
+   * @type {number}
    * @memberof PatchApplicationSAMLSettings
    */
-  dataEncryptionAlgorithm?: string;
+  notBeforeTimeSkewSeconds?: number;
   /**
    *
-   * @type {string}
+   * @type {number}
    * @memberof PatchApplicationSAMLSettings
    */
-  keyTransportEncryptionAlgorithm?: string;
+  notOnOrAfterTimeSkewSeconds?: number;
   /**
    *
    * @type {string}
@@ -99,13 +129,13 @@ export interface PatchApplicationSAMLSettings {
    * @type {boolean}
    * @memberof PatchApplicationSAMLSettings
    */
-  wantAssertionsSigned?: boolean;
+  wantAssertionsEncrypted?: boolean;
   /**
    *
    * @type {boolean}
    * @memberof PatchApplicationSAMLSettings
    */
-  wantAssertionsEncrypted?: boolean;
+  wantAssertionsSigned?: boolean;
   /**
    *
    * @type {boolean}
@@ -132,18 +162,21 @@ export function PatchApplicationSAMLSettingsFromJSONTyped(json: any, ignoreDiscr
   return {
     assertionAttributes:
       json['assertionAttributes'] == null ? undefined : (json['assertionAttributes'] as Array<any>).map(SAMLAssertionAttributeFromJSON),
+    assertionValiditySeconds: json['assertionValiditySeconds'] == null ? undefined : json['assertionValiditySeconds'],
     attributeConsumeServiceUrl: json['attributeConsumeServiceUrl'] == null ? undefined : json['attributeConsumeServiceUrl'],
+    audiences: json['audiences'] == null ? undefined : json['audiences'],
     certificate: json['certificate'] == null ? undefined : json['certificate'],
+    dataEncryptionAlgorithm: json['dataEncryptionAlgorithm'] == null ? undefined : json['dataEncryptionAlgorithm'],
     entityId: json['entityId'] == null ? undefined : json['entityId'],
+    includeAssertionConditions: json['includeAssertionConditions'] == null ? undefined : json['includeAssertionConditions'],
+    keyTransportEncryptionAlgorithm: json['keyTransportEncryptionAlgorithm'] == null ? undefined : json['keyTransportEncryptionAlgorithm'],
     nameIdMapping: json['nameIdMapping'] == null ? undefined : json['nameIdMapping'],
-    dataEncryptionAlgorithm:
-      json['dataEncryptionAlgorithm'] == null ? undefined : json['dataEncryptionAlgorithm'],
-    keyTransportEncryptionAlgorithm:
-      json['keyTransportEncryptionAlgorithm'] == null ? undefined : json['keyTransportEncryptionAlgorithm'],
+    notBeforeTimeSkewSeconds: json['notBeforeTimeSkewSeconds'] == null ? undefined : json['notBeforeTimeSkewSeconds'],
+    notOnOrAfterTimeSkewSeconds: json['notOnOrAfterTimeSkewSeconds'] == null ? undefined : json['notOnOrAfterTimeSkewSeconds'],
     responseBinding: json['responseBinding'] == null ? undefined : json['responseBinding'],
     singleLogoutServiceUrl: json['singleLogoutServiceUrl'] == null ? undefined : json['singleLogoutServiceUrl'],
-    wantAssertionsSigned: json['wantAssertionsSigned'] == null ? undefined : json['wantAssertionsSigned'],
     wantAssertionsEncrypted: json['wantAssertionsEncrypted'] == null ? undefined : json['wantAssertionsEncrypted'],
+    wantAssertionsSigned: json['wantAssertionsSigned'] == null ? undefined : json['wantAssertionsSigned'],
     wantResponseSigned: json['wantResponseSigned'] == null ? undefined : json['wantResponseSigned'],
   };
 }
@@ -163,16 +196,21 @@ export function PatchApplicationSAMLSettingsToJSONTyped(
   return {
     assertionAttributes:
       value['assertionAttributes'] == null ? undefined : (value['assertionAttributes'] as Array<any>).map(SAMLAssertionAttributeToJSON),
+    assertionValiditySeconds: value['assertionValiditySeconds'],
     attributeConsumeServiceUrl: value['attributeConsumeServiceUrl'],
+    audiences: value['audiences'],
     certificate: value['certificate'],
-    entityId: value['entityId'],
-    nameIdMapping: value['nameIdMapping'],
     dataEncryptionAlgorithm: value['dataEncryptionAlgorithm'],
+    entityId: value['entityId'],
+    includeAssertionConditions: value['includeAssertionConditions'],
     keyTransportEncryptionAlgorithm: value['keyTransportEncryptionAlgorithm'],
+    nameIdMapping: value['nameIdMapping'],
+    notBeforeTimeSkewSeconds: value['notBeforeTimeSkewSeconds'],
+    notOnOrAfterTimeSkewSeconds: value['notOnOrAfterTimeSkewSeconds'],
     responseBinding: value['responseBinding'],
     singleLogoutServiceUrl: value['singleLogoutServiceUrl'],
-    wantAssertionsSigned: value['wantAssertionsSigned'],
     wantAssertionsEncrypted: value['wantAssertionsEncrypted'],
+    wantAssertionsSigned: value['wantAssertionsSigned'],
     wantResponseSigned: value['wantResponseSigned'],
   };
 }

--- a/gravitee-am-test/api/management/models/PatchCIMDSettings.ts
+++ b/gravitee-am-test/api/management/models/PatchCIMDSettings.ts
@@ -82,6 +82,12 @@ export interface PatchCIMDSettings {
   maxResponseSizeKb?: number;
   /**
    *
+   * @type {boolean}
+   * @memberof PatchCIMDSettings
+   */
+  revokeOnDocumentChange?: boolean;
+  /**
+   *
    * @type {string}
    * @memberof PatchCIMDSettings
    */
@@ -112,6 +118,7 @@ export function PatchCIMDSettingsFromJSONTyped(json: any, ignoreDiscriminator: b
     enabled: json['enabled'] == null ? undefined : json['enabled'],
     fetchTimeoutMs: json['fetchTimeoutMs'] == null ? undefined : json['fetchTimeoutMs'],
     maxResponseSizeKb: json['maxResponseSizeKb'] == null ? undefined : json['maxResponseSizeKb'],
+    revokeOnDocumentChange: json['revokeOnDocumentChange'] == null ? undefined : json['revokeOnDocumentChange'],
     templateId: json['templateId'] == null ? undefined : json['templateId'],
   };
 }
@@ -134,6 +141,7 @@ export function PatchCIMDSettingsToJSONTyped(value?: PatchCIMDSettings | null, i
     enabled: value['enabled'],
     fetchTimeoutMs: value['fetchTimeoutMs'],
     maxResponseSizeKb: value['maxResponseSizeKb'],
+    revokeOnDocumentChange: value['revokeOnDocumentChange'],
     templateId: value['templateId'],
   };
 }

--- a/gravitee-am-test/specs/gateway/cimd/cimd-refresh-token.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-refresh-token.jest.spec.ts
@@ -15,79 +15,14 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import {
-  extractXsrfTokenAndActionResponse,
-  performFormPost,
-  performGet,
-  performPost,
-} from '@gateway-commands/oauth-oidc-commands';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
 import { getBase64BasicAuth } from '@gateway-commands/utils';
 import { JWT_FORMAT } from '@specs-utils/jwt-format';
 import { setup } from '../../test-fixture';
 import { CimdRefreshTokenFixture, setupCimdRefreshTokenFixture } from './fixtures/cimd-refresh-token-fixture';
+import { executeCimdAuthCodeFlow } from './fixtures/cimd-auth-flow-helpers';
 
 setup(200000);
-
-/**
- * Browser login for a URL-shaped CIMD client; returns the authorization code.
- */
-async function executeCimdAuthCodeFlow(fixture: CimdRefreshTokenFixture): Promise<string> {
-  const params = new URLSearchParams({
-    response_type: 'code',
-    client_id: fixture.clientId,
-    redirect_uri: fixture.redirectUri,
-    scope: 'openid',
-    state: 'cimd-refresh-state',
-  });
-  const authorizeUrl = `${fixture.oidc.authorization_endpoint}?${params.toString()}`;
-
-  const authResponse = await performGet(authorizeUrl).expect(302);
-  const { headers, token, action } = await extractXsrfTokenAndActionResponse(authResponse);
-
-  const postLogin = await performFormPost(
-    action,
-    '',
-    {
-      'X-XSRF-TOKEN': token,
-      username: fixture.user.username,
-      password: fixture.user.password,
-      client_id: fixture.clientId,
-    },
-    {
-      Cookie: headers['set-cookie'],
-      'Content-type': 'application/x-www-form-urlencoded',
-    },
-  ).expect(302);
-
-  let redirectResponse = await performGet(postLogin.headers['location'], '', {
-    Cookie: postLogin.headers['set-cookie'],
-  }).expect(302);
-
-  if (redirectResponse.headers['location']?.includes('/oauth/consent')) {
-    const consentResult = await extractXsrfTokenAndActionResponse(redirectResponse);
-    const postConsent = await performFormPost(
-      consentResult.action,
-      '',
-      {
-        'X-XSRF-TOKEN': consentResult.token,
-        'scope.openid': true,
-        user_oauth_approval: true,
-      },
-      {
-        Cookie: consentResult.headers['set-cookie'],
-        'Content-type': 'application/x-www-form-urlencoded',
-      },
-    ).expect(302);
-
-    redirectResponse = await performGet(postConsent.headers['location'], '', {
-      Cookie: postLogin.headers['set-cookie'],
-    }).expect(302);
-  }
-
-  const codePattern = /code=([-_a-zA-Z0-9]+)&?/;
-  expect(redirectResponse.headers['location']).toMatch(codePattern);
-  return redirectResponse.headers['location'].match(codePattern)![1];
-}
 
 let fixture: CimdRefreshTokenFixture;
 

--- a/gravitee-am-test/specs/gateway/cimd/cimd-revoke-on-document-change.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-revoke-on-document-change.jest.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { retryUntil } from '@utils-commands/retry';
+import { setup } from '../../test-fixture';
+import {
+  CimdRevokeOnDocumentChangeFixture,
+  setupCimdRevokeOnDocumentChangeFixture,
+} from './fixtures/cimd-revoke-on-document-change-fixture';
+import { resetAllWireMockScenarios } from './fixtures/cimd-wiremock-helpers';
+import { executeCimdAuthCodeFlow } from './fixtures/cimd-auth-flow-helpers';
+import { waitFor } from '@management-commands/domain-management-commands';
+
+setup(200000);
+
+let fixture: CimdRevokeOnDocumentChangeFixture;
+
+beforeAll(async () => {
+  await resetAllWireMockScenarios();
+  fixture = await setupCimdRevokeOnDocumentChangeFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('CIMD revoke on document change', () => {
+  it('should revoke an access token when the CIMD metadata document changes after cache TTL expires', async () => {
+    // Obtain an access token — this triggers the first CIMD metadata fetch (WireMock returns V1
+    // and advances the scenario state to "Changed" via newScenarioState).
+    const code = await executeCimdAuthCodeFlow(fixture);
+
+    const tokenResponse = await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: fixture.redirectUri,
+        client_id: fixture.clientId,
+      }).toString(),
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+    ).expect(200);
+
+    const accessToken: string = tokenResponse.body.access_token;
+    expect(accessToken).toBeDefined();
+
+    // Baseline: token should be active.
+    const baseline = await fixture.introspectToken(accessToken);
+    expect(baseline.active).toBe(true);
+
+    // Wait for the 1-second cache TTL to expire (plus a buffer).
+    await waitFor(2500);
+
+    // Trigger a new CIMD metadata fetch by initiating an authorization request.
+    // The gateway will re-fetch the document (cache expired), receive V2 from WireMock
+    // (scenario is now in "Changed" state), detect the hash difference, and asynchronously
+    // revoke all tokens for this client.
+    const triggerParams = new URLSearchParams({
+      response_type: 'code',
+      client_id: fixture.clientId,
+      redirect_uri: fixture.redirectUri,
+      scope: 'openid',
+      state: 'cimd-revoke-trigger',
+    });
+    await performGet(`${fixture.oidc.authorization_endpoint}?${triggerParams.toString()}`);
+
+    // Poll until the token becomes inactive (revocation is asynchronous).
+    await retryUntil(
+      () => fixture.introspectToken(accessToken).then((body) => ({ active: body.active })),
+      (response) => response.active === false,
+      { timeoutMillis: 15000, intervalMillis: 300 },
+    );
+
+    const revoked = await fixture.introspectToken(accessToken);
+    expect(revoked.active).toBe(false);
+  });
+});

--- a/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-auth-flow-helpers.ts
+++ b/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-auth-flow-helpers.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from '@jest/globals';
+import { extractXsrfTokenAndActionResponse, performFormPost, performGet } from '@gateway-commands/oauth-oidc-commands';
+
+/** Minimal fixture shape required to execute the CIMD authorization code flow. */
+export interface CimdAuthCodeFlowFixture {
+  clientId: string;
+  redirectUri: string;
+  oidc: { authorization_endpoint: string };
+  user: { username: string; password: string };
+}
+
+/**
+ * Simulates a full browser-based authorization code flow for a URL-shaped CIMD client.
+ * Handles the login form and, if present, the consent screen.
+ * Returns the authorization code extracted from the final redirect location.
+ */
+export async function executeCimdAuthCodeFlow(fixture: CimdAuthCodeFlowFixture): Promise<string> {
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: fixture.clientId,
+    redirect_uri: fixture.redirectUri,
+    scope: 'openid',
+    state: 'cimd-state',
+  });
+
+  const authResponse = await performGet(`${fixture.oidc.authorization_endpoint}?${params.toString()}`).expect(302);
+  const { headers, token, action } = await extractXsrfTokenAndActionResponse(authResponse);
+
+  const postLogin = await performFormPost(
+    action,
+    '',
+    {
+      'X-XSRF-TOKEN': token,
+      username: fixture.user.username,
+      password: fixture.user.password,
+      client_id: fixture.clientId,
+    },
+    {
+      Cookie: headers['set-cookie'],
+      'Content-type': 'application/x-www-form-urlencoded',
+    },
+  ).expect(302);
+
+  let redirectResponse = await performGet(postLogin.headers['location'], '', {
+    Cookie: postLogin.headers['set-cookie'],
+  }).expect(302);
+
+  if (redirectResponse.headers['location']?.includes('/oauth/consent')) {
+    const consentResult = await extractXsrfTokenAndActionResponse(redirectResponse);
+    const postConsent = await performFormPost(
+      consentResult.action,
+      '',
+      {
+        'X-XSRF-TOKEN': consentResult.token,
+        'scope.openid': true,
+        user_oauth_approval: true,
+      },
+      {
+        Cookie: consentResult.headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
+    ).expect(302);
+
+    redirectResponse = await performGet(postConsent.headers['location'], '', {
+      Cookie: postLogin.headers['set-cookie'],
+    }).expect(302);
+  }
+
+  const codePattern = /code=([-_a-zA-Z0-9]+)&?/;
+  expect(redirectResponse.headers['location']).toMatch(codePattern);
+  return redirectResponse.headers['location'].match(codePattern)![1];
+}

--- a/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-revoke-on-document-change-fixture.ts
+++ b/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-revoke-on-document-change-fixture.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import {
+  createDomain,
+  DomainOidcConfig,
+  patchDomain,
+  safeDeleteDomain,
+  startDomain,
+  waitForDomainStart,
+} from '@management-commands/domain-management-commands';
+import { createApplication, patchApplication, updateApplication } from '@management-commands/application-management-commands';
+import { getAllIdps } from '@management-commands/idp-management-commands';
+import { buildCreateAndTestUser } from '@management-commands/user-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { getBase64BasicAuth } from '@gateway-commands/utils';
+import { Application } from '@management-models/Application';
+import { Domain } from '@management-models/Domain';
+import { Fixture } from '../../../test-fixture';
+import { CIMD_REDIRECT_URI } from './cimd-authorize-fixture';
+
+export const CIMD_REVOKE_ON_CHANGE_SCENARIO = 'revoke-on-change';
+
+export interface CimdRevokeOnDocumentChangeFixture extends Fixture {
+  accessToken: string;
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  templateApplication: Application;
+  preRegisteredApplication: Application;
+  clientId: string;
+  redirectUri: string;
+  user: { username: string; password: string; id: string };
+  introspectToken: (token: string) => Promise<{ active: boolean }>;
+}
+
+export const setupCimdRevokeOnDocumentChangeFixture = async (): Promise<CimdRevokeOnDocumentChangeFixture> => {
+  let domain: Domain | null = null;
+  let accessToken: string | null = null;
+
+  try {
+    accessToken = await requestAdminAccessToken();
+    expect(accessToken).toBeDefined();
+
+    domain = await createDomain(
+      accessToken,
+      uniqueName('cimd-revoke-doc-change', true),
+      'CIMD revoke on document change',
+    );
+    expect(domain.id).toBeDefined();
+
+    const idpSet = await getAllIdps(domain.id, accessToken);
+    const defaultIdp = idpSet.values().next().value;
+    expect(defaultIdp?.id).toBeDefined();
+
+    const user = await buildCreateAndTestUser(domain.id, accessToken, 0);
+    expect(user.username).toBeDefined();
+    expect(user.id).toBeDefined();
+    const userPassword = user.password;
+    expect(userPassword).toBeDefined();
+
+    const createdTemplate = await createApplication(domain.id, accessToken, {
+      name: uniqueName('cimd-template-revoke', true),
+      type: 'WEB',
+      redirectUris: [CIMD_REDIRECT_URI],
+    });
+
+    const templateApplication = await updateApplication(
+      domain.id,
+      accessToken,
+      {
+        identityProviders: new Set([{ identity: defaultIdp.id, priority: 0 }]),
+        settings: {
+          oauth: {
+            redirectUris: [CIMD_REDIRECT_URI],
+            grantTypes: ['authorization_code'],
+            responseTypes: ['code'],
+            scopeSettings: [{ scope: 'openid', defaultScope: true }],
+          },
+          advanced: { skipConsent: true },
+        },
+      },
+      createdTemplate.id,
+    );
+
+    await patchApplication(domain.id, accessToken, { template: true }, templateApplication.id);
+
+    const createdPreRegistered = await createApplication(domain.id, accessToken, {
+      name: uniqueName('cimd-pre-registered-revoke', true),
+      type: 'WEB',
+      redirectUris: [CIMD_REDIRECT_URI],
+    });
+
+    const preRegisteredApplication = await updateApplication(
+      domain.id,
+      accessToken,
+      {
+        identityProviders: new Set([{ identity: defaultIdp.id, priority: 0 }]),
+        settings: {
+          oauth: {
+            redirectUris: [CIMD_REDIRECT_URI],
+            grantTypes: ['authorization_code'],
+            responseTypes: ['code'],
+            scopeSettings: [{ scope: 'openid', defaultScope: true }],
+          },
+        },
+      },
+      createdPreRegistered.id,
+    );
+    preRegisteredApplication.settings.oauth.clientSecret = createdPreRegistered.settings.oauth.clientSecret;
+
+    await patchDomain(domain.id, accessToken, {
+      oidc: {
+        cimdSettings: {
+          enabled: true,
+          allowUnsecuredHttpUri: true,
+          allowPrivateIpAddress: true,
+          allowedDomains: [],
+          fetchTimeoutMs: 1500,
+          maxResponseSizeKb: 10,
+          cacheTtlSeconds: 1,
+          cacheMaxEntries: 500,
+          revokeOnDocumentChange: true,
+          templateId: templateApplication.id,
+        },
+      },
+    });
+
+    await startDomain(domain.id, accessToken);
+    const startedDomain = await waitForDomainStart(domain);
+
+    const clientId = `http://wiremock:8080/cimd/ENABLED_BASE/${CIMD_REVOKE_ON_CHANGE_SCENARIO}`;
+
+    const introspectToken = async (token: string): Promise<{ active: boolean }> => {
+      const callerClientId = preRegisteredApplication.settings.oauth.clientId;
+      const callerClientSecret = preRegisteredApplication.settings.oauth.clientSecret;
+      const response = await performPost(
+        startedDomain.oidcConfig.introspection_endpoint,
+        '',
+        `token=${token}&token_type_hint=access_token`,
+        {
+          'Content-type': 'application/x-www-form-urlencoded',
+          Authorization: 'Basic ' + getBase64BasicAuth(callerClientId, callerClientSecret),
+        },
+      ).expect(200);
+      return response.body;
+    };
+
+    return {
+      accessToken,
+      domain: startedDomain.domain,
+      oidc: startedDomain.oidcConfig,
+      templateApplication,
+      preRegisteredApplication,
+      clientId,
+      redirectUri: CIMD_REDIRECT_URI,
+      user: { username: user.username, password: userPassword as string, id: user.id },
+      introspectToken,
+      cleanUp: async () => {
+        await safeDeleteDomain(domain?.id, accessToken);
+      },
+    };
+  } catch (error) {
+    if (domain?.id && accessToken) {
+      await safeDeleteDomain(domain.id, accessToken);
+    }
+    throw error;
+  }
+};

--- a/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-wiremock-helpers.ts
+++ b/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-wiremock-helpers.ts
@@ -20,6 +20,15 @@ import { expect } from '@jest/globals';
 export const getWireMockAdminBase = (): string => process.env.SFR_URL ?? 'http://localhost:8181';
 
 /**
+ * Resets all WireMock scenarios to their initial "Started" state.
+ * Call in `beforeAll` for tests that rely on scenario-based stub behaviour.
+ */
+export const resetAllWireMockScenarios = async (): Promise<void> => {
+  const res = await fetch(`${getWireMockAdminBase()}/__admin/scenarios/reset`, { method: 'POST' });
+  expect(res.ok).toBe(true);
+};
+
+/**
  * Clears the WireMock request journal (best-effort). Use between tests that assert on request counts.
  */
 export const clearWireMockRequestJournal = async (): Promise<void> => {

--- a/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
@@ -130,6 +130,26 @@
 
           <div class="gv-form-section" fxLayout="column">
             <div class="gv-form-section-title">
+              <h5>Security Policy</h5>
+              <mat-divider></mat-divider>
+            </div>
+            <mat-slide-toggle
+              name="revokeOnDocumentChange"
+              (change)="cimdSettings.revokeOnDocumentChange = $event.checked; onFormChange()"
+              [checked]="cimdSettings.revokeOnDocumentChange"
+              [disabled]="!editMode"
+            >
+              Revoke tokens and consents when client metadata changes
+            </mat-slide-toggle>
+            <mat-hint style="font-size: 75%"
+              >When enabled, all active tokens and user consents for a CIMD client are automatically revoked when any of the monitored
+              metadata properties change (redirect_uris, scope, grant_types, token_endpoint_auth_method, jwks, jwks_uri, client_name,
+              logo_uri).</mat-hint
+            >
+          </div>
+
+          <div class="gv-form-section" fxLayout="column">
+            <div class="gv-form-section-title">
               <h5>Cache Settings</h5>
               <mat-divider></mat-divider>
             </div>


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6679](https://gravitee.atlassian.net/browse/AM-6679)

## :pencil2: A description of the changes proposed in the pull request
Add CIMD option for automatically revoking tokens and user consent when aspects of metadata documents change.
- The feature requires a persistence of metadata "thumbprints" that are compared when CIMD documents are fetched.
- The records that have been persisted for a given domain are removed when the CIMD option is disabled.
- The Domain API and the console UI expose the new option as a boolean and toggle respectively. 

## :memo: Test scenarios 

1. Configure a short CIMD cache TTL - for example, 30 seconds - and enable **Revoke tokens and consents when client metadata changes** option
2. Authenticate as a user using CIMD client that offers scopes - for example, make an authorization code request, then exchange the code for an access token with one or more scopes
3. Consent to any scopes
4. Modify values of one or more observed properties in the hosted CIMD metadata document - for example, `client_name`
5. Wait for the CIMD cache entry to expire, then repeat step 2
6. Observe that (a) consent is required again and (b) the previous access token is inactive

## :computer: Add screenshots for UI
<img width="996" height="524" alt="image" src="https://github.com/user-attachments/assets/55472bda-5e77-4513-bd0a-c2142040cb55" />

## :books: Any other comments that will help with documentation
https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/ section 6.3 outlines revocations as a security consideration. 

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6679]: https://gravitee.atlassian.net/browse/AM-6679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ