### PR TITLE
feat: add expends query parameter to applications list endpoint

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -1019,6 +1019,12 @@ paths:
         in: query
         schema:
           type: string
+      - name: expand
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
       responses:
         "200":
           description: List registered applications for a security domain
@@ -12377,18 +12383,33 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SAMLAssertionAttribute"
+        assertionValiditySeconds:
+          type: integer
+          format: int32
         attributeConsumeServiceUrl:
           type: string
+        audiences:
+          type: array
+          items:
+            type: string
         certificate:
           type: string
         dataEncryptionAlgorithm:
           type: string
         entityId:
           type: string
+        includeAssertionConditions:
+          type: boolean
         keyTransportEncryptionAlgorithm:
           type: string
         nameIdMapping:
           type: string
+        notBeforeTimeSkewSeconds:
+          type: integer
+          format: int32
+        notOnOrAfterTimeSkewSeconds:
+          type: integer
+          format: int32
         responseBinding:
           type: string
         singleLogoutServiceUrl:
@@ -13496,6 +13517,8 @@ components:
     FilteredApplication:
       type: object
       properties:
+        clientId:
+          type: string
         description:
           type: string
         enabled:
@@ -15193,18 +15216,33 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SAMLAssertionAttribute"
+        assertionValiditySeconds:
+          type: integer
+          format: int32
         attributeConsumeServiceUrl:
           type: string
+        audiences:
+          type: array
+          items:
+            type: string
         certificate:
           type: string
         dataEncryptionAlgorithm:
           type: string
         entityId:
           type: string
+        includeAssertionConditions:
+          type: boolean
         keyTransportEncryptionAlgorithm:
           type: string
         nameIdMapping:
           type: string
+        notBeforeTimeSkewSeconds:
+          type: integer
+          format: int32
+        notOnOrAfterTimeSkewSeconds:
+          type: integer
+          format: int32
         responseBinding:
           type: string
         singleLogoutServiceUrl:

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/model/ApplicationExpand.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/model/ApplicationExpand.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.resources.model;
+
+import java.util.Arrays;
+
+public enum ApplicationExpand {
+    CLIENT_ID("clientId");
+
+    private final String paramValue;
+
+    ApplicationExpand(String paramValue) {
+        this.paramValue = paramValue;
+    }
+
+    public static ApplicationExpand fromString(String value) {
+        if (value == null) {
+            return null;
+        }
+        return Arrays.stream(values())
+                .filter(e -> e.paramValue.equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/model/FilteredApplication.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/model/FilteredApplication.java
@@ -19,6 +19,7 @@ import io.gravitee.am.model.Application;
 import io.gravitee.am.model.application.ApplicationType;
 
 import java.util.Date;
+import java.util.Set;
 
 public record FilteredApplication(
         String id,
@@ -27,9 +28,14 @@ public record FilteredApplication(
         ApplicationType type,
         boolean enabled,
         boolean template,
-        Date updatedAt) {
+        Date updatedAt,
+        String clientId) {
 
     public static FilteredApplication of(Application application) {
+        return of(application, Set.of());
+    }
+
+    public static FilteredApplication of(Application application, Set<ApplicationExpand> expands) {
         return new FilteredApplication(
                 application.getId(),
                 application.getName(),
@@ -37,7 +43,9 @@ public record FilteredApplication(
                 application.getType(),
                 application.isEnabled(),
                 application.isTemplate(),
-                application.getUpdatedAt()
+                application.getUpdatedAt(),
+                expands.contains(ApplicationExpand.CLIENT_ID) ? application.clientId() : null
         );
     }
+
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationsResource.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
+import io.gravitee.am.management.handlers.management.api.resources.model.ApplicationExpand;
 import io.gravitee.am.management.handlers.management.api.resources.model.FilteredApplication;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Application;
@@ -60,6 +61,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -101,8 +104,10 @@ public class ApplicationsResource extends AbstractDomainResource {
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue(MAX_APPLICATIONS_SIZE_PER_PAGE_STRING) int size,
             @QueryParam("q") String query,
+            @QueryParam("expand") List<String> expandsParam,
             @Suspended final AsyncResponse response) {
         User authenticatedUser = getAuthenticatedUser();
+        final Set<ApplicationExpand> expands = convertToApplicationExpands(expandsParam);
         checkAnyPermission(organizationId, environmentId, domain, Permission.APPLICATION, Acl.LIST)
                 .andThen(checkDomainExists(domain).ignoreElement())
                 .andThen(hasAnyPermission(authenticatedUser, organizationId, environmentId, domain, Permission.APPLICATION, Acl.READ)
@@ -114,11 +119,19 @@ public class ApplicationsResource extends AbstractDomainResource {
                                         .flatMap(ids -> listApplicationsByIds(domain, ids, page, size, query))))
                 .map(apps ->
                         new ApplicationPage(
-                                apps.getData().stream().map(FilteredApplication::of).toList(),
+                                apps.getData().stream().map(app -> FilteredApplication.of(app, expands)).toList(),
                                 apps.getCurrentPage(),
                                 apps.getTotalCount())
                 )
                 .subscribe(response::resume, response::resume);
+    }
+
+    private Set<ApplicationExpand> convertToApplicationExpands(List<String> expandsParam) {
+        return expandsParam == null ? Set.of() :
+                expandsParam.stream()
+                        .map(ApplicationExpand::fromString)
+                        .filter(e -> e != null)
+                        .collect(Collectors.toSet());
     }
 
     private Single<Page<Application>> listApplications(String domain, int page, int size, String query) {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceTest.java
@@ -23,6 +23,8 @@ import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.application.ApplicationOAuthSettings;
+import io.gravitee.am.model.application.ApplicationSettings;
 import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.permissions.Permission;
@@ -46,6 +48,7 @@ import java.util.Set;
 
 import static io.gravitee.am.model.ReferenceType.APPLICATION;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -136,5 +139,95 @@ public class ApplicationsResourceTest extends JerseySpringTest {
         assertEquals(result.getDescription(), application.getDescription());
 
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
+    }
+
+    @Test
+    public void shouldGetApps_withClientIdExpand() {
+        final String domainId = "domain-1";
+        final Domain mockDomain = new Domain();
+        mockDomain.setId(domainId);
+
+        final Application mockClient = new Application();
+        mockClient.setId("client-1-id");
+        mockClient.setName("client-1-name");
+        mockClient.setDomain(domainId);
+        mockClient.setUpdatedAt(new Date());
+        ApplicationSettings settings = new ApplicationSettings();
+        ApplicationOAuthSettings oauthSettings = new ApplicationOAuthSettings();
+        oauthSettings.setClientId("oauth-client-id");
+        settings.setOauth(oauthSettings);
+        mockClient.setSettings(settings);
+
+        final Page<Application> applicationPage = new Page(List.of(mockClient), 0, 1);
+
+        doReturn(Flowable.just("client-1-id"))
+                .when(permissionService).getReferenceIdsWithPermission(Mockito.any(), eq(APPLICATION), eq(Permission.APPLICATION), eq(Set.of(Acl.READ)));
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
+        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(domainId, 0, 50);
+
+        final Response response = target("domains").path(domainId).path("applications")
+                .queryParam("expand", "clientId")
+                .request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final Map responseEntity = readEntity(response, Map.class);
+        final Map firstApp = (Map) ((List) responseEntity.get("data")).get(0);
+        assertEquals("oauth-client-id", firstApp.get("clientId"));
+    }
+
+    @Test
+    public void shouldGetApps_withoutExpand_doesNotIncludeClientId() {
+        final String domainId = "domain-1";
+        final Domain mockDomain = new Domain();
+        mockDomain.setId(domainId);
+
+        final Application mockClient = new Application();
+        mockClient.setId("client-1-id");
+        mockClient.setName("client-1-name");
+        mockClient.setDomain(domainId);
+        mockClient.setUpdatedAt(new Date());
+        ApplicationSettings settings = new ApplicationSettings();
+        ApplicationOAuthSettings oauthSettings = new ApplicationOAuthSettings();
+        oauthSettings.setClientId("oauth-client-id");
+        settings.setOauth(oauthSettings);
+        mockClient.setSettings(settings);
+
+        final Page<Application> applicationPage = new Page(List.of(mockClient), 0, 1);
+
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
+        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(domainId, 0, 50);
+
+        final Response response = target("domains").path(domainId).path("applications").request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final Map responseEntity = readEntity(response, Map.class);
+        final Map firstApp = (Map) ((List) responseEntity.get("data")).get(0);
+        assertNull(firstApp.get("clientId"));
+    }
+
+    @Test
+    public void shouldGetApps_unknownExpandValueIsIgnored() {
+        final String domainId = "domain-1";
+        final Domain mockDomain = new Domain();
+        mockDomain.setId(domainId);
+
+        final Application mockClient = new Application();
+        mockClient.setId("client-1-id");
+        mockClient.setName("client-1-name");
+        mockClient.setDomain(domainId);
+        mockClient.setUpdatedAt(new Date());
+
+        final Page<Application> applicationPage = new Page(List.of(mockClient), 0, 1);
+
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
+        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(domainId, 0, 50);
+
+        final Response response = target("domains").path(domainId).path("applications")
+                .queryParam("expand", "unknownValue")
+                .request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final Map responseEntity = readEntity(response, Map.class);
+        assertEquals(1, ((List) responseEntity.get("data")).size());
     }
 }


### PR DESCRIPTION
Introduce an `expands` query parameter (repeatable) on GET /applications to request additional fields in the response. The first supported value is `clientId`, which exposes the OAuth client ID from the application settings. Unknown expand values are silently ignored.

fixes AM-6979
