### PR TITLE
AM-7008 custom claims

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -11197,6 +11197,10 @@ components:
           type: string
         tosUri:
           type: string
+        userinfoCustomClaims:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserInfoClaim'
         userinfoEncryptedResponseAlg:
           type: string
         userinfoEncryptedResponseEnc:
@@ -13733,6 +13737,10 @@ components:
           type: string
         tosUri:
           type: string
+        userinfoCustomClaims:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserInfoClaim'
         userinfoEncryptedResponseAlg:
           type: string
         userinfoEncryptedResponseEnc:
@@ -15801,6 +15809,13 @@ components:
         userId:
           type: string
         username:
+          type: string
+    UserInfoClaim:
+      type: object
+      properties:
+        claimName:
+          type: string
+        claimValue:
           type: string
     UserNotificationContent:
       type: object

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/EvaluableJWT.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/EvaluableJWT.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.jwt;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class EvaluableJWT extends JWT {
+
+    public EvaluableJWT(JWT jwt){
+        super(jwt);
+        put("scopes", getScopes());
+    }
+
+    private Set<String> getScopes() {
+        String scopes = getScope();
+        if(scopes == null || scopes.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(scopes.split("\\s+")).collect(Collectors.toSet());
+    }
+}

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/jwt/EvaluableJWTTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/jwt/EvaluableJWTTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.jwt;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class EvaluableJWTTest {
+
+    @Test
+    public void shouldExposeScopesAsSet() {
+        JWT jwt = new JWT();
+        jwt.setSub("user");
+        jwt.setScope("openid profile email");
+
+        EvaluableJWT evaluable = new EvaluableJWT(jwt);
+
+        assertEquals("user", evaluable.getSub());
+        assertEquals("openid profile email", evaluable.getScope());
+        assertTrue(evaluable.get("scopes") instanceof Set);
+        assertEquals(Set.of("openid", "profile", "email"), evaluable.get("scopes"));
+    }
+
+    @Test
+    public void shouldExposeEmptyScopesWhenScopeMissing() {
+        JWT jwt = new JWT();
+        jwt.setSub("user");
+
+        EvaluableJWT evaluable = new EvaluableJWT(jwt);
+
+        assertEquals(Set.of(), evaluable.get("scopes"));
+    }
+
+    @Test
+    public void shouldExposeEmptyScopesWhenScopeIsEmpty() {
+        JWT jwt = new JWT();
+        jwt.setScope("");
+
+        EvaluableJWT evaluable = new EvaluableJWT(jwt);
+
+        assertEquals(Set.of(), evaluable.get("scopes"));
+    }
+
+    @Test
+    public void shouldDeduplicateScopes() {
+        JWT jwt = new JWT();
+        jwt.setScope("openid openid profile");
+
+        EvaluableJWT evaluable = new EvaluableJWT(jwt);
+
+        assertEquals(Set.of("openid", "profile"), evaluable.get("scopes"));
+    }
+
+    @Test
+    public void shouldCopyAllJwtClaims() {
+        JWT jwt = new JWT();
+        jwt.setSub("user");
+        jwt.setAud("client-id");
+        jwt.setIss("https://example.com");
+        jwt.setScope("openid");
+        jwt.put("custom", "value");
+
+        EvaluableJWT evaluable = new EvaluableJWT(jwt);
+
+        assertEquals("user", evaluable.get(Claims.SUB));
+        assertEquals("client-id", evaluable.get(Claims.AUD));
+        assertEquals("https://example.com", evaluable.get(Claims.ISS));
+        assertEquals("value", evaluable.get("custom"));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/el/ExecutionContextTokenEnhancer.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/el/ExecutionContextTokenEnhancer.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oauth2.service.el;
+
+import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.oauth2.TokenTypeHint;
+import io.gravitee.am.model.TokenClaim;
+import io.gravitee.am.model.UserInfoClaim;
+import io.gravitee.gateway.api.ExecutionContext;
+import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONArray;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+
+@Slf4j
+public class ExecutionContextTokenEnhancer {
+
+    public void enhanceToken(JWT jwt, TokenTypeHint hint, List<TokenClaim> customClaims, ExecutionContext executionContext) {
+        if (customClaims != null && !customClaims.isEmpty()) {
+            customClaims
+                    .stream()
+                    .filter(tokenClaim -> hint.equals(tokenClaim.getTokenType()))
+                    .forEach(tokenClaim -> {
+                            String claimName = tokenClaim.getClaimName();
+                            String claimExpression = tokenClaim.getClaimValue();
+                            evaluateAndUpdate(jwt, executionContext, claimName, claimExpression);
+                    });
+        }
+    }
+
+    public void enhanceToken(JWT jwt, List<UserInfoClaim> customClaims, ExecutionContext executionContext) {
+        if (customClaims != null && !customClaims.isEmpty()) {
+            customClaims
+                    .forEach(tokenClaim -> {
+                        String claimName = tokenClaim.getClaimName();
+                        String claimExpression = tokenClaim.getClaimValue();
+                        evaluateAndUpdate(jwt, executionContext, claimName, claimExpression);
+                    });
+        }
+    }
+
+    private void evaluateAndUpdate(JWT jwt, ExecutionContext executionContext, String claimName, String claimExpression){
+        try {
+            Object extValue = (claimExpression != null) ? executionContext.getTemplateEngine().getValue(claimExpression, Object.class) : null;
+            if (extValue != null) {
+                if (Claims.AUD.equals(claimName) && (extValue instanceof String[] || extValue instanceof List)) {
+                    var audiences = new LinkedHashSet<>();
+                    audiences.add(jwt.getAud()); // make sure the client_id is the first entry of the aud array
+                    audiences.addAll(extValue instanceof List ? (List) extValue : List.of((String[]) extValue)); // Set will remove duplicate client_id if any
+                    var jsonArray = new JSONArray();
+                    jsonArray.addAll(audiences);
+                    jwt.put(claimName, jsonArray);
+                } else {
+                    jwt.put(claimName, extValue);
+                }
+            }
+        } catch (Exception ex) {
+            log.debug("An error occurs while parsing expression language : {}", claimExpression, ex);
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -29,6 +29,7 @@ import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.oauth2.IntrospectionTokenFacade;
 import io.gravitee.am.gateway.handler.context.ExecutionContextFactory;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidGrantException;
+import io.gravitee.am.gateway.handler.oauth2.service.el.ExecutionContextTokenEnhancer;
 import io.gravitee.am.gateway.handler.oauth2.service.request.OAuth2Request;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequest;
 import io.gravitee.am.gateway.handler.oauth2.service.token.Token;
@@ -410,30 +411,8 @@ public class TokenServiceImpl implements TokenService {
 
     private void enhanceJWT(JWT jwt, List<TokenClaim> customClaims, TokenTypeHint tokenTypeHint, ExecutionContext executionContext) {
         if (customClaims != null && !customClaims.isEmpty()) {
-            customClaims
-                    .stream()
-                    .filter(tokenClaim -> tokenTypeHint.equals(tokenClaim.getTokenType()))
-                    .forEach(tokenClaim -> {
-                        try {
-                            String claimName = tokenClaim.getClaimName();
-                            String claimExpression = tokenClaim.getClaimValue();
-                            Object extValue = (claimExpression != null) ? executionContext.getTemplateEngine().getValue(claimExpression, Object.class) : null;
-                            if (extValue != null) {
-                                if (Claims.AUD.equals(claimName) && (extValue instanceof String[] || extValue instanceof List)) {
-                                    var audiences = new LinkedHashSet<>();
-                                    audiences.add(jwt.getAud()); // make sure the client_id is the first entry of the aud array
-                                    audiences.addAll(extValue instanceof List ? (List) extValue : List.of((String[]) extValue)); // Set will remove duplicate client_id if any
-                                    var jsonArray = new JSONArray();
-                                    jsonArray.addAll(audiences);
-                                    jwt.put(claimName, jsonArray);
-                                } else {
-                                    jwt.put(claimName, extValue);
-                                }
-                            }
-                        } catch (Exception ex) {
-                            logger.debug("An error occurs while parsing expression language : {}", tokenClaim.getClaimValue(), ex);
-                        }
-                    });
+            ExecutionContextTokenEnhancer enhancer = new ExecutionContextTokenEnhancer();
+            enhancer.enhanceToken(jwt, tokenTypeHint, customClaims, executionContext);
         }
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/OIDCProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/OIDCProvider.java
@@ -24,6 +24,7 @@ import io.gravitee.am.gateway.handler.common.jwt.JWTService;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
+import io.gravitee.am.gateway.handler.context.ExecutionContextFactory;
 import io.gravitee.am.gateway.handler.oauth2.OAuth2Provider;
 import io.gravitee.am.gateway.handler.oauth2.resources.auth.handler.ClientAuthHandler;
 import io.gravitee.am.gateway.handler.oauth2.resources.handler.ExceptionHandler;
@@ -135,6 +136,9 @@ public class OIDCProvider extends AbstractProtocolProvider {
     @Autowired
     private SubjectManager subjectManager;
 
+    @Autowired
+    private ExecutionContextFactory executionContextFactory;
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -198,7 +202,7 @@ public class OIDCProvider extends AbstractProtocolProvider {
         userInfoAuthHandler.extractClient(true);
         userInfoAuthHandler.forceEndUserToken(true);
 
-        Handler<RoutingContext> userInfoEndpoint = new UserInfoEndpoint(userEnhancer, jwtService, jweService, discoveryService, environment, subjectManager);
+        Handler<RoutingContext> userInfoEndpoint = new UserInfoEndpoint(userEnhancer, jwtService, jweService, discoveryService, environment, subjectManager, executionContextFactory);
         oidcRouter.route("/userinfo").handler(corsHandler);
         oidcRouter
                 .route(HttpMethod.GET, "/userinfo")

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpoint.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.oidc.resources.endpoint;
 
 import io.gravitee.am.common.exception.oauth2.InvalidTokenException;
+import io.gravitee.am.common.jwt.EvaluableJWT;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.oidc.CustomClaims;
 import io.gravitee.am.common.oidc.Scope;
@@ -24,16 +25,27 @@ import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.utils.Tuple;
+import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
+import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerResponse;
 import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
+import io.gravitee.am.gateway.handler.context.ExecutionContextFactory;
+import io.gravitee.am.gateway.handler.oauth2.service.el.ExecutionContextTokenEnhancer;
 import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryService;
 import io.gravitee.am.gateway.handler.oidc.service.jwe.JWEService;
 import io.gravitee.am.gateway.handler.oidc.service.request.ClaimsRequest;
 import io.gravitee.am.model.Role;
 import io.gravitee.am.model.User;
+import io.gravitee.am.model.UserInfoClaim;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.model.safe.ClientProperties;
+import io.gravitee.am.model.safe.UserProperties;
 import io.gravitee.am.service.impl.user.UserEnhancer;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.Handler;
 import io.vertx.core.json.Json;
@@ -50,6 +62,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.gravitee.am.common.utils.ConstantKeys.ID_TOKEN_EXCLUDED_CLAIMS;
+import static io.gravitee.am.gateway.handler.common.utils.RoutingContextUtils.getEvaluableAttributes;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -76,6 +89,7 @@ public class UserInfoEndpoint implements Handler<RoutingContext> {
     private final JWEService jweService;
     private final OpenIDDiscoveryService openIDDiscoveryService;
     private final SubjectManager subjectManager;
+    private final ExecutionContextFactory executionContextFactory;
 
     private final boolean legacyOpenidScope;
 
@@ -84,13 +98,15 @@ public class UserInfoEndpoint implements Handler<RoutingContext> {
                             JWEService jweService,
                             OpenIDDiscoveryService openIDDiscoveryService,
                             Environment environment,
-                            SubjectManager subjectManager) {
+                            SubjectManager subjectManager,
+                            ExecutionContextFactory executionContextFactory) {
         this.userEnhancer = userEnhancer;
         this.jwtService = jwtService;
         this.jweService = jweService;
         this.openIDDiscoveryService = openIDDiscoveryService;
         this.legacyOpenidScope = environment.getProperty("legacy.openid.openid_scope_full_profile", boolean.class, false);
         this.subjectManager = subjectManager;
+        this.executionContextFactory = executionContextFactory;
     }
 
     @Override
@@ -102,13 +118,13 @@ public class UserInfoEndpoint implements Handler<RoutingContext> {
                 // enhance user information
                 .flatMap(user -> enhance(user, accessToken))
                 // process user claims
-                .map(user -> Tuple.of(user, processClaims(user, accessToken)))
+                .map(user -> {
+                    var claims = processClaims(user, accessToken);
+                    var jwt = createJWT(Tuple.of(user, claims));
+                    return processCustomClaims(jwt, accessToken, user, client, context);
+                })
                 // encode response
-                .flatMap(tuple -> {
-                            final var user = tuple.getT1();
-                            final var claims = tuple.getT2();
-                            final var jwt = new JWT(claims);
-                            subjectManager.updateJWT(jwt, user);
+                .flatMap(jwt -> {
                             if (!expectSignedOrEncryptedUserInfo(client)) {
                                 context.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
                                 return Single.just(Json.encodePrettily(jwt));
@@ -135,6 +151,47 @@ public class UserInfoEndpoint implements Handler<RoutingContext> {
                 );
     }
 
+    private JWT createJWT(Tuple<User, Map<String, Object>> tuple) {
+        final var user = tuple.getT1();
+        final var claims = tuple.getT2();
+        final var jwt = new JWT(claims);
+        subjectManager.updateJWT(jwt, user);
+        return jwt;
+    }
+
+    private JWT processCustomClaims(JWT userInfoJwt,
+                                    JWT accessToken,
+                                    User user,
+                                    Client client,
+                                    RoutingContext context) {
+        List<UserInfoClaim> customClaims = client.getUserinfoCustomClaims();
+        if (customClaims == null || customClaims.isEmpty()) {
+            return userInfoJwt;
+        }
+        ExecutionContextTokenEnhancer executionContextTokenEnhancer = new ExecutionContextTokenEnhancer();
+        ExecutionContext executionContext = prepareContext(context, client, user, accessToken);
+        executionContextTokenEnhancer.enhanceToken(userInfoJwt, customClaims, executionContext);
+        return userInfoJwt;
+    }
+
+    private ExecutionContext prepareContext(RoutingContext routingContext, Client client, User user, JWT accessToken) {
+        io.vertx.core.http.HttpServerRequest request = routingContext.request().getDelegate();
+        Request serverRequest = new VertxHttpServerRequest(request);
+        Response serverResponse = new VertxHttpServerResponse(request, serverRequest.metrics());
+        ExecutionContext simpleExecutionContext = new SimpleExecutionContext(serverRequest, serverResponse);
+        ExecutionContext executionContext = executionContextFactory.create(simpleExecutionContext);
+        executionContext.getAttributes().putAll(getEvaluableAttributes(routingContext));
+        // add current context attributes
+        executionContext.setAttribute(ConstantKeys.CLIENT_CONTEXT_KEY, new ClientProperties(client));
+        if (user != null) {
+            executionContext.setAttribute(ConstantKeys.USER_CONTEXT_KEY, new UserProperties(user, false));
+        }
+        if(executionContext.getAttributes().get(ConstantKeys.TOKEN_CONTEXT_KEY) instanceof JWT jwt){
+            executionContext.getAttributes().put(ConstantKeys.TOKEN_CONTEXT_KEY, new EvaluableJWT(jwt));
+        }
+        return executionContext;
+    }
+
     /**
      * Process user claims against user data and access token information
      * @param user the end user
@@ -142,8 +199,7 @@ public class UserInfoEndpoint implements Handler<RoutingContext> {
      * @return user claims
      */
     private Map<String, Object> processClaims(User user, JWT accessToken) {
-        final Map<String, Object> additionalInfos = ofNullable(user.getAdditionalInformation()).orElse(Map.of());
-        final Map<String, Object> fullProfileClaims = new HashMap<>(additionalInfos);
+        final Map<String, Object> fullProfileClaims = new HashMap<>(ofNullable(user.getAdditionalInformation()).orElse(Map.of()));
 
         // to be sure that this sub value coming from the IDP will not override the one provided by AM
         // we explicitly remove it from the additional info.

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/impl/IDTokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idtoken/impl/IDTokenServiceImpl.java
@@ -29,6 +29,7 @@ import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.context.ExecutionContextFactory;
+import io.gravitee.am.gateway.handler.oauth2.service.el.ExecutionContextTokenEnhancer;
 import io.gravitee.am.gateway.handler.oauth2.service.request.OAuth2Request;
 import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryService;
 import io.gravitee.am.gateway.handler.oidc.service.idtoken.IDTokenService;
@@ -314,30 +315,8 @@ public class IDTokenServiceImpl implements IDTokenService {
 
     private void enhanceIDToken(JWT jwt, List<TokenClaim> customClaims, ExecutionContext executionContext) {
         if (customClaims != null && !customClaims.isEmpty()) {
-            customClaims
-                    .stream()
-                    .filter(tokenClaim -> TokenTypeHint.ID_TOKEN.equals(tokenClaim.getTokenType()))
-                    .forEach(tokenClaim -> {
-                        try {
-                            String claimName = tokenClaim.getClaimName();
-                            String claimExpression = tokenClaim.getClaimValue();
-                            Object extValue = (claimExpression != null) ? executionContext.getTemplateEngine().getValue(claimExpression, Object.class) : null;
-                            if (extValue != null) {
-                                if (Claims.AUD.equals(claimName) && (extValue instanceof String[] || extValue instanceof List)) {
-                                    var audiences = new LinkedHashSet<>();
-                                    audiences.add(jwt.getAud()); // make sure the client_id is the first entry of the aud array
-                                    audiences.addAll(extValue instanceof List ? (List)extValue : List.of((String[]) extValue)); // Set will remove duplicate client_id if any
-                                    var jsonArray = new JSONArray();
-                                    jsonArray.addAll(audiences);
-                                    jwt.put(claimName, jsonArray);
-                                } else {
-                                    jwt.put(claimName, extValue);
-                                }
-                            }
-                        } catch (Exception ex) {
-                            log.debug("An error occurs while parsing expression language : {}", tokenClaim.getClaimValue(), ex);
-                        }
-                    });
+            ExecutionContextTokenEnhancer enhancer = new ExecutionContextTokenEnhancer();
+            enhancer.enhanceToken(jwt, TokenTypeHint.ID_TOKEN, customClaims, executionContext);
         }
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/el/ExecutionContextTokenEnhancerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/el/ExecutionContextTokenEnhancerTest.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oauth2.service.el;
+
+import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.oauth2.TokenTypeHint;
+import io.gravitee.am.model.TokenClaim;
+import io.gravitee.am.model.UserInfoClaim;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.api.ExecutionContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ExecutionContextTokenEnhancerTest {
+
+    @Mock
+    private ExecutionContext executionContext;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    private ExecutionContextTokenEnhancer enhancer;
+
+    @Before
+    public void setUp() {
+        enhancer = new ExecutionContextTokenEnhancer();
+        when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
+    }
+
+    // ---- TokenClaim overload --------------------------------------------------
+
+    @Test
+    public void shouldEnhance_tokenClaim_addsClaimWithEvaluatedValue() {
+        JWT jwt = new JWT();
+        TokenClaim claim = TokenClaim.of(TokenTypeHint.ACCESS_TOKEN, "iss", "https://custom-iss");
+        when(templateEngine.getValue("https://custom-iss", Object.class)).thenReturn("https://custom-iss");
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, List.of(claim), executionContext);
+
+        assertEquals("https://custom-iss", jwt.get("iss"));
+    }
+
+    @Test
+    public void shouldEnhance_tokenClaim_ignoresClaimsWithDifferentTokenType() {
+        JWT jwt = new JWT();
+        TokenClaim idTokenClaim = TokenClaim.of(TokenTypeHint.ID_TOKEN, "iss", "https://custom-iss");
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, List.of(idTokenClaim), executionContext);
+
+        assertFalse(jwt.containsKey("iss"));
+        verify(templateEngine, never()).getValue(any(String.class), eq(Object.class));
+    }
+
+    @Test
+    public void shouldEnhance_tokenClaim_audWithStringArray_mergesPreservingClientIdFirst() {
+        JWT jwt = new JWT();
+        jwt.setAud("client-id");
+        String expr = "{T(java.lang.String).valueOf(\"a,b,client-id\").split(\",\")}";
+        TokenClaim claim = TokenClaim.of(TokenTypeHint.ACCESS_TOKEN, Claims.AUD, expr);
+        when(templateEngine.getValue(expr, Object.class)).thenReturn(new String[]{"a", "b", "client-id"});
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, List.of(claim), executionContext);
+
+        Object aud = jwt.get(Claims.AUD);
+        assertTrue(aud instanceof List);
+        List<?> audList = (List<?>) aud;
+        assertEquals(3, audList.size());
+        assertEquals("client-id", audList.get(0));
+        assertTrue(audList.containsAll(Arrays.asList("a", "b", "client-id")));
+    }
+
+    @Test
+    public void shouldEnhance_tokenClaim_audWithList_mergesPreservingClientIdFirst() {
+        JWT jwt = new JWT();
+        jwt.setAud("client-id");
+        TokenClaim claim = TokenClaim.of(TokenTypeHint.ACCESS_TOKEN, Claims.AUD, "#values");
+        when(templateEngine.getValue("#values", Object.class)).thenReturn(Arrays.asList("a", "b", "client-id"));
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, List.of(claim), executionContext);
+
+        Object aud = jwt.get(Claims.AUD);
+        assertTrue(aud instanceof List);
+        List<?> audList = (List<?>) aud;
+        assertEquals(3, audList.size());
+        assertEquals("client-id", audList.get(0));
+    }
+
+    @Test
+    public void shouldEnhance_tokenClaim_nullList_isNoOp() {
+        JWT jwt = new JWT();
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, null, executionContext);
+
+        assertTrue(jwt.isEmpty());
+        verify(executionContext, never()).getTemplateEngine();
+    }
+
+    @Test
+    public void shouldEnhance_tokenClaim_emptyList_isNoOp() {
+        JWT jwt = new JWT();
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, Collections.emptyList(), executionContext);
+
+        assertTrue(jwt.isEmpty());
+        verify(executionContext, never()).getTemplateEngine();
+    }
+
+    @Test
+    public void shouldEnhance_tokenClaim_nullClaimExpression_doesNotAddClaim() {
+        JWT jwt = new JWT();
+        TokenClaim claim = TokenClaim.of(TokenTypeHint.ACCESS_TOKEN, "iss", null);
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, List.of(claim), executionContext);
+
+        assertFalse(jwt.containsKey("iss"));
+        verify(templateEngine, never()).getValue(any(String.class), eq(Object.class));
+    }
+
+    @Test
+    public void shouldEnhance_tokenClaim_evaluationReturningNull_doesNotAddClaim() {
+        JWT jwt = new JWT();
+        TokenClaim claim = TokenClaim.of(TokenTypeHint.ACCESS_TOKEN, "iss", "#missing");
+        when(templateEngine.getValue("#missing", Object.class)).thenReturn(null);
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, List.of(claim), executionContext);
+
+        assertFalse(jwt.containsKey("iss"));
+    }
+
+    @Test
+    public void shouldEnhance_tokenClaim_evaluationThrowing_isSwallowedAndClaimSkipped() {
+        JWT jwt = new JWT();
+        TokenClaim claim = TokenClaim.of(TokenTypeHint.ACCESS_TOKEN, "iss", "#broken");
+        when(templateEngine.getValue("#broken", Object.class)).thenThrow(new RuntimeException("boom"));
+
+        enhancer.enhanceToken(jwt, TokenTypeHint.ACCESS_TOKEN, List.of(claim), executionContext);
+
+        assertFalse(jwt.containsKey("iss"));
+    }
+
+    // ---- UserInfoClaim overload ----------------------------------------------
+
+    @Test
+    public void shouldEnhance_userInfoClaim_addsClaimWithEvaluatedValue() {
+        JWT jwt = new JWT();
+        UserInfoClaim claim = UserInfoClaim.of("custom_claim", "#{'value'}");
+        when(templateEngine.getValue("#{'value'}", Object.class)).thenReturn("value");
+
+        enhancer.enhanceToken(jwt, List.of(claim), executionContext);
+
+        assertEquals("value", jwt.get("custom_claim"));
+    }
+
+    @Test
+    public void shouldEnhance_userInfoClaim_appliesAllClaims() {
+        JWT jwt = new JWT();
+        UserInfoClaim c1 = UserInfoClaim.of("a", "#a");
+        UserInfoClaim c2 = UserInfoClaim.of("b", "#b");
+        when(templateEngine.getValue("#a", Object.class)).thenReturn("1");
+        when(templateEngine.getValue("#b", Object.class)).thenReturn("2");
+
+        enhancer.enhanceToken(jwt, List.of(c1, c2), executionContext);
+
+        assertEquals("1", jwt.get("a"));
+        assertEquals("2", jwt.get("b"));
+    }
+
+    @Test
+    public void shouldEnhance_userInfoClaim_nullList_isNoOp() {
+        JWT jwt = new JWT();
+
+        enhancer.enhanceToken(jwt, (List<UserInfoClaim>) null, executionContext);
+
+        assertTrue(jwt.isEmpty());
+        verify(executionContext, never()).getTemplateEngine();
+    }
+
+    @Test
+    public void shouldEnhance_userInfoClaim_emptyList_isNoOp() {
+        JWT jwt = new JWT();
+
+        enhancer.enhanceToken(jwt, Collections.<UserInfoClaim>emptyList(), executionContext);
+
+        assertTrue(jwt.isEmpty());
+        verify(executionContext, never()).getTemplateEngine();
+    }
+
+    @Test
+    public void shouldEnhance_userInfoClaim_audWithList_mergesPreservingClientIdFirst() {
+        JWT jwt = new JWT();
+        jwt.setAud("client-id");
+        UserInfoClaim claim = UserInfoClaim.of(Claims.AUD, "#values");
+        when(templateEngine.getValue("#values", Object.class)).thenReturn(Arrays.asList("other", "client-id"));
+
+        enhancer.enhanceToken(jwt, List.of(claim), executionContext);
+
+        Object aud = jwt.get(Claims.AUD);
+        assertTrue(aud instanceof List);
+        List<?> audList = (List<?>) aud;
+        assertEquals(2, audList.size());
+        assertEquals("client-id", audList.get(0));
+        assertTrue(audList.contains("other"));
+    }
+
+    @Test
+    public void shouldEnhance_userInfoClaim_evaluationThrowing_isSwallowedAndClaimSkipped() {
+        JWT jwt = new JWT();
+        UserInfoClaim claim = UserInfoClaim.of("custom_claim", "#broken");
+        when(templateEngine.getValue("#broken", Object.class)).thenThrow(new RuntimeException("boom"));
+
+        enhancer.enhanceToken(jwt, List.of(claim), executionContext);
+
+        assertNull(jwt.get("custom_claim"));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/resources/endpoint/UserInfoEndpointHandlerTest.java
@@ -26,6 +26,7 @@ import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthResponse;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
+import io.gravitee.am.gateway.handler.context.ExecutionContextFactory;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidClientException;
 import io.gravitee.am.gateway.handler.oauth2.exception.ServerErrorException;
 import io.gravitee.am.gateway.handler.oauth2.resources.handler.ExceptionHandler;
@@ -33,11 +34,14 @@ import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryServ
 import io.gravitee.am.gateway.handler.oidc.service.jwe.JWEService;
 import io.gravitee.am.model.Role;
 import io.gravitee.am.model.User;
+import io.gravitee.am.model.UserInfoClaim;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.impl.user.UserEnhancer;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.api.ExecutionContext;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.AsyncResult;
@@ -61,6 +65,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -88,6 +95,9 @@ public class UserInfoEndpointHandlerTest extends RxWebTestBase {
     @Mock
     private Environment env;
 
+    @Mock
+    private ExecutionContextFactory executionContextFactory;
+
     private UserInfoEndpoint userInfoEndpoint;
 
     @Override
@@ -95,7 +105,7 @@ public class UserInfoEndpointHandlerTest extends RxWebTestBase {
         super.setUp();
 
         when(env.getProperty("legacy.openid.openid_scope_full_profile", boolean.class, false)).thenReturn(false);
-        userInfoEndpoint = new UserInfoEndpoint(userEnhancer, jwtService, jweService, openIDDiscoveryService, env, subjectManager);
+        userInfoEndpoint = new UserInfoEndpoint(userEnhancer, jwtService, jweService, openIDDiscoveryService, env, subjectManager, executionContextFactory);
 
         router.route(HttpMethod.GET, "/userinfo")
                 .handler(userInfoEndpoint);
@@ -764,6 +774,76 @@ public class UserInfoEndpointHandlerTest extends RxWebTestBase {
                     assertEquals(MediaType.APPLICATION_JWT,resp.getHeader(HttpHeaders.CONTENT_TYPE));
                     resp.bodyHandler(body -> assertEquals("signedJwtBearer",body.toString()));
                 },
+                HttpStatusCode.OK_200, "OK", null);
+    }
+
+    @Test
+    public void shouldInvokeUserEndpoint_userinfoCustomClaims_emptyList_skipsEnhancement() throws Exception {
+        JWT jwt = new JWT();
+        jwt.setJti("id-token");
+        jwt.setAud("client-id");
+        jwt.setSub("id-subject");
+        jwt.setScope("openid");
+
+        Client client = new Client();
+        client.setId("client-id");
+        client.setClientId("client-id");
+        client.setUserinfoCustomClaims(Collections.emptyList());
+
+        router.route().order(-1).handler(createOAuth2AuthHandler(oAuth2AuthProvider(jwt, client)));
+
+        User user = createUser();
+        when(subjectManager.findUserBySub(any())).thenReturn(Maybe.just(user));
+
+        testRequest(
+                HttpMethod.GET,
+                "/userinfo",
+                req -> req.putHeader(HttpHeaders.AUTHORIZATION, "Bearer test-token"),
+                resp -> resp.bodyHandler(body -> {
+                    final Map<String, Object> claims = Json.decodeValue(body.toString(), Map.class);
+                    assertNotNull(claims);
+                    assertFalse(claims.containsKey("custom_userinfo"));
+                }),
+                HttpStatusCode.OK_200, "OK", null);
+
+        verify(executionContextFactory, never()).create(any());
+    }
+
+    @Test
+    public void shouldInvokeUserEndpoint_userinfoCustomClaims_evaluatesAndAddsClaim() throws Exception {
+        JWT jwt = new JWT();
+        jwt.setJti("id-token");
+        jwt.setAud("client-id");
+        jwt.setSub("id-subject");
+        jwt.setScope("openid");
+
+        Client client = new Client();
+        client.setId("client-id");
+        client.setClientId("client-id");
+        client.setUserinfoCustomClaims(List.of(UserInfoClaim.of("custom_userinfo", "#{'evaluated'}")));
+
+        router.route().order(-1).handler(createOAuth2AuthHandler(oAuth2AuthProvider(jwt, client)));
+
+        User user = createUser();
+        when(subjectManager.findUserBySub(any())).thenReturn(Maybe.just(user));
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        TemplateEngine templateEngine = mock(TemplateEngine.class);
+        when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
+        when(executionContext.getAttributes()).thenReturn(new HashMap<>());
+        when(templateEngine.getValue("#{'evaluated'}", Object.class)).thenReturn("evaluated");
+        when(executionContextFactory.create(any())).thenReturn(executionContext);
+
+        testRequest(
+                HttpMethod.GET,
+                "/userinfo",
+                req -> req.putHeader(HttpHeaders.AUTHORIZATION, "Bearer test-token"),
+                resp -> resp.bodyHandler(body -> {
+                    final Map<String, Object> claims = Json.decodeValue(body.toString(), Map.class);
+                    assertNotNull(claims);
+                    assertTrue(claims.containsKey("custom_userinfo"));
+                    assertEquals("evaluated", claims.get("custom_userinfo"));
+                }),
                 HttpStatusCode.OK_200, "OK", null);
     }
 

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/UserInfoClaim.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/UserInfoClaim.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class UserInfoClaim {
+
+    private String claimName;
+    private String claimValue;
+
+    public static UserInfoClaim of(String claimName, String claimValue) {
+        UserInfoClaim claim = new UserInfoClaim();
+        claim.setClaimName(claimName);
+        claim.setClaimValue(claimValue);
+        return claim;
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationOAuthSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationOAuthSettings.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.model.application;
 
 import io.gravitee.am.model.TokenClaim;
+import io.gravitee.am.model.UserInfoClaim;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -245,6 +246,11 @@ public class ApplicationOAuthSettings {
      */
     private List<TokenClaim> tokenCustomClaims;
 
+    /**
+     * UserInfo claims mapping settings
+     */
+    private List<UserInfoClaim> userinfoCustomClaims;
+
     private String tlsClientAuthSubjectDn;
 
     private String tlsClientAuthSanDns;
@@ -368,6 +374,7 @@ public class ApplicationOAuthSettings {
         this.refreshTokenValiditySeconds = other.refreshTokenValiditySeconds;
         this.idTokenValiditySeconds = other.idTokenValiditySeconds;
         this.tokenCustomClaims = other.tokenCustomClaims != null ? new ArrayList<>(other.tokenCustomClaims) : null;
+        this.userinfoCustomClaims = other.userinfoCustomClaims != null ? new ArrayList<>(other.userinfoCustomClaims) : null;
         this.tlsClientAuthSubjectDn = other.tlsClientAuthSubjectDn;
         this.tlsClientAuthSanDns = other.tlsClientAuthSanDns;
         this.tlsClientAuthSanEmail = other.tlsClientAuthSanEmail;
@@ -807,6 +814,14 @@ public class ApplicationOAuthSettings {
         this.tokenCustomClaims = tokenCustomClaims;
     }
 
+    public List<UserInfoClaim> getUserinfoCustomClaims() {
+        return userinfoCustomClaims;
+    }
+
+    public void setUserinfoCustomClaims(List<UserInfoClaim> userinfoCustomClaims) {
+        this.userinfoCustomClaims = userinfoCustomClaims;
+    }
+
     public String getTlsClientAuthSubjectDn() {
         return tlsClientAuthSubjectDn;
     }
@@ -1013,6 +1028,7 @@ public class ApplicationOAuthSettings {
         client.setEnhanceScopesWithUserPermissions(this.enhanceScopesWithUserPermissions);
         client.setScopeSettings(this.scopeSettings);
         client.setTokenCustomClaims(this.tokenCustomClaims);
+        client.setUserinfoCustomClaims(this.userinfoCustomClaims);
         client.setTlsClientAuthSubjectDn(this.tlsClientAuthSubjectDn);
         client.setTlsClientAuthSanDns(this.tlsClientAuthSanDns);
         client.setTlsClientAuthSanEmail(this.tlsClientAuthSanEmail);

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
@@ -29,6 +29,7 @@ import io.gravitee.am.model.PasswordSettingsAware;
 import io.gravitee.am.model.Resource;
 import io.gravitee.am.model.SecretExpirationSettings;
 import io.gravitee.am.model.TokenClaim;
+import io.gravitee.am.model.UserInfoClaim;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.application.ApplicationScopeSettings;
 import io.gravitee.am.model.application.ApplicationSecretSettings;
@@ -229,6 +230,8 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     private List<TokenClaim> tokenCustomClaims;
 
+    private List<UserInfoClaim> userinfoCustomClaims;
+
     private boolean template;
 
     private Map<String, Object> metadata;
@@ -343,6 +346,7 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
         this.loginSettings = other.loginSettings;
         this.passwordSettings = other.passwordSettings;
         this.tokenCustomClaims = other.tokenCustomClaims != null ? new ArrayList<>(other.tokenCustomClaims) : null;
+        this.userinfoCustomClaims = other.userinfoCustomClaims != null ? new ArrayList<>(other.userinfoCustomClaims) : null;
         this.template = other.template;
         this.metadata = other.metadata != null ? new HashMap<>(other.metadata) : null;
         this.authorizationSignedResponseAlg = other.authorizationSignedResponseAlg;
@@ -847,6 +851,14 @@ public class Client implements Cloneable, Resource, PasswordSettingsAware {
 
     public void setTokenCustomClaims(List<TokenClaim> tokenCustomClaims) {
         this.tokenCustomClaims = tokenCustomClaims;
+    }
+
+    public List<UserInfoClaim> getUserinfoCustomClaims() {
+        return userinfoCustomClaims;
+    }
+
+    public void setUserinfoCustomClaims(List<UserInfoClaim> userinfoCustomClaims) {
+        this.userinfoCustomClaims = userinfoCustomClaims;
     }
 
     public boolean isTemplate() {

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/application/ApplicationOAuthSettingsTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/application/ApplicationOAuthSettingsTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.application;
+
+import io.gravitee.am.model.UserInfoClaim;
+import io.gravitee.am.model.oidc.Client;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApplicationOAuthSettingsTest {
+
+    @Test
+    public void copyConstructor_copies_userinfoCustomClaims_independently() {
+        ApplicationOAuthSettings source = new ApplicationOAuthSettings();
+        List<UserInfoClaim> claims = new ArrayList<>();
+        claims.add(UserInfoClaim.of("a", "#a"));
+        source.setUserinfoCustomClaims(claims);
+
+        ApplicationOAuthSettings copy = new ApplicationOAuthSettings(source);
+
+        assertEquals(1, copy.getUserinfoCustomClaims().size());
+        assertEquals("a", copy.getUserinfoCustomClaims().get(0).getClaimName());
+        assertNotSame(source.getUserinfoCustomClaims(), copy.getUserinfoCustomClaims());
+
+        // mutating source must not affect copy
+        source.getUserinfoCustomClaims().add(UserInfoClaim.of("b", "#b"));
+        assertEquals(1, copy.getUserinfoCustomClaims().size());
+    }
+
+    @Test
+    public void copyConstructor_handles_null_userinfoCustomClaims() {
+        ApplicationOAuthSettings source = new ApplicationOAuthSettings();
+        source.setUserinfoCustomClaims(null);
+
+        ApplicationOAuthSettings copy = new ApplicationOAuthSettings(source);
+
+        assertNull(copy.getUserinfoCustomClaims());
+    }
+
+    @Test
+    public void copyTo_propagates_userinfoCustomClaims_to_client() {
+        ApplicationOAuthSettings settings = new ApplicationOAuthSettings();
+        List<UserInfoClaim> claims = List.of(UserInfoClaim.of("custom", "#expr"));
+        settings.setUserinfoCustomClaims(claims);
+
+        Client client = new Client();
+        settings.copyTo(client);
+
+        assertEquals(claims, client.getUserinfoCustomClaims());
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -26,6 +26,7 @@ import io.gravitee.am.model.MFASettings;
 import io.gravitee.am.model.PasswordSettings;
 import io.gravitee.am.model.SecretExpirationSettings;
 import io.gravitee.am.model.TokenClaim;
+import io.gravitee.am.model.UserInfoClaim;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.application.ApplicationAdvancedSettings;
 import io.gravitee.am.model.application.ApplicationOAuthSettings;
@@ -63,6 +64,7 @@ import io.gravitee.am.repository.mongodb.management.internal.model.MFASettingsMo
 import io.gravitee.am.repository.mongodb.management.internal.model.PasswordSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.SecretSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.TokenClaimMongo;
+import io.gravitee.am.repository.mongodb.management.internal.model.UserInfoClaimMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.risk.RiskAssessmentSettingsMongo;
 import io.gravitee.risk.assessment.api.assessment.settings.RiskAssessmentSettings;
 import io.reactivex.rxjava3.core.Completable;
@@ -534,6 +536,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationOAuthSettingsMongo.setRefreshTokenValiditySeconds(other.getRefreshTokenValiditySeconds());
         applicationOAuthSettingsMongo.setIdTokenValiditySeconds(other.getIdTokenValiditySeconds());
         applicationOAuthSettingsMongo.setTokenCustomClaims(getMongoTokenClaims(other.getTokenCustomClaims()));
+        applicationOAuthSettingsMongo.setUserinfoCustomClaims(getMongoUserInfoClaims(other.getUserinfoCustomClaims()));
         applicationOAuthSettingsMongo.setTlsClientAuthSubjectDn(other.getTlsClientAuthSubjectDn());
         applicationOAuthSettingsMongo.setTlsClientAuthSanDns(other.getTlsClientAuthSanDns());
         applicationOAuthSettingsMongo.setTlsClientAuthSanEmail(other.getTlsClientAuthSanEmail());
@@ -615,6 +618,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationOAuthSettings.setRefreshTokenValiditySeconds(other.getRefreshTokenValiditySeconds());
         applicationOAuthSettings.setIdTokenValiditySeconds(other.getIdTokenValiditySeconds());
         applicationOAuthSettings.setTokenCustomClaims(getTokenClaims(other.getTokenCustomClaims()));
+        applicationOAuthSettings.setUserinfoCustomClaims(getUserInfoClaims(other.getUserinfoCustomClaims()));
         applicationOAuthSettings.setTlsClientAuthSubjectDn(other.getTlsClientAuthSubjectDn());
         applicationOAuthSettings.setTlsClientAuthSanDns(other.getTlsClientAuthSanDns());
         applicationOAuthSettings.setTlsClientAuthSanEmail(other.getTlsClientAuthSanEmail());
@@ -790,6 +794,34 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         mongoTokenClaim.setClaimName(tokenClaim.getClaimName());
         mongoTokenClaim.setClaimValue(tokenClaim.getClaimValue());
         return mongoTokenClaim;
+    }
+
+    private static List<UserInfoClaim> getUserInfoClaims(List<UserInfoClaimMongo> mongoUserInfoClaims) {
+        if (mongoUserInfoClaims == null) {
+            return null;
+        }
+        return mongoUserInfoClaims.stream().map(MongoApplicationRepository::convert).collect(Collectors.toList());
+    }
+
+    private static List<UserInfoClaimMongo> getMongoUserInfoClaims(List<UserInfoClaim> userInfoClaims) {
+        if (userInfoClaims == null) {
+            return null;
+        }
+        return userInfoClaims.stream().map(MongoApplicationRepository::convert).collect(Collectors.toList());
+    }
+
+    private static UserInfoClaim convert(UserInfoClaimMongo mongoUserInfoClaim) {
+        UserInfoClaim userInfoClaim = new UserInfoClaim();
+        userInfoClaim.setClaimName(mongoUserInfoClaim.getClaimName());
+        userInfoClaim.setClaimValue(mongoUserInfoClaim.getClaimValue());
+        return userInfoClaim;
+    }
+
+    private static UserInfoClaimMongo convert(UserInfoClaim userInfoClaim) {
+        UserInfoClaimMongo mongoUserInfoClaim = new UserInfoClaimMongo();
+        mongoUserInfoClaim.setClaimName(userInfoClaim.getClaimName());
+        mongoUserInfoClaim.setClaimValue(userInfoClaim.getClaimValue());
+        return mongoUserInfoClaim;
     }
 
     private static JWKSet convert(List<JWKMongo> jwksMongo) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationOAuthSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationOAuthSettingsMongo.java
@@ -74,6 +74,7 @@ public class ApplicationOAuthSettingsMongo {
     private int refreshTokenValiditySeconds;
     private int idTokenValiditySeconds;
     private List<TokenClaimMongo> tokenCustomClaims;
+    private List<UserInfoClaimMongo> userinfoCustomClaims;
     private String tlsClientAuthSubjectDn;
     private String tlsClientAuthSanDns;
     private String tlsClientAuthSanUri;
@@ -479,6 +480,14 @@ public class ApplicationOAuthSettingsMongo {
 
     public void setTokenCustomClaims(List<TokenClaimMongo> tokenCustomClaims) {
         this.tokenCustomClaims = tokenCustomClaims;
+    }
+
+    public List<UserInfoClaimMongo> getUserinfoCustomClaims() {
+        return userinfoCustomClaims;
+    }
+
+    public void setUserinfoCustomClaims(List<UserInfoClaimMongo> userinfoCustomClaims) {
+        this.userinfoCustomClaims = userinfoCustomClaims;
     }
 
     public String getTlsClientAuthSubjectDn() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ClientMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ClientMongo.java
@@ -156,6 +156,8 @@ public class ClientMongo extends Auditable {
 
     private List<TokenClaimMongo> tokenCustomClaims;
 
+    private List<UserInfoClaimMongo> userinfoCustomClaims;
+
     private boolean template;
 
     private Document metadata;
@@ -582,6 +584,14 @@ public class ClientMongo extends Auditable {
 
     public void setTokenCustomClaims(List<TokenClaimMongo> tokenCustomClaims) {
         this.tokenCustomClaims = tokenCustomClaims;
+    }
+
+    public List<UserInfoClaimMongo> getUserinfoCustomClaims() {
+        return userinfoCustomClaims;
+    }
+
+    public void setUserinfoCustomClaims(List<UserInfoClaimMongo> userinfoCustomClaims) {
+        this.userinfoCustomClaims = userinfoCustomClaims;
     }
 
     public boolean isTemplate() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/UserInfoClaimMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/UserInfoClaimMongo.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.management.internal.model;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class UserInfoClaimMongo {
+
+    private String claimName;
+    private String claimValue;
+
+    public String getClaimName() {
+        return claimName;
+    }
+
+    public void setClaimName(String claimName) {
+        this.claimName = claimName;
+    }
+
+    public String getClaimValue() {
+        return claimValue;
+    }
+
+    public void setClaimValue(String claimValue) {
+        this.claimValue = claimValue;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationOAuthSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationOAuthSettings.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.service.model;
 
 import io.gravitee.am.model.TokenClaim;
+import io.gravitee.am.model.UserInfoClaim;
 import io.gravitee.am.model.application.ApplicationOAuthSettings;
 import io.gravitee.am.model.application.ApplicationScopeSettings;
 import io.gravitee.am.model.oidc.JWKSet;
@@ -76,6 +77,7 @@ public class PatchApplicationOAuthSettings {
     private Optional<Integer> refreshTokenValiditySeconds;
     private Optional<Integer> idTokenValiditySeconds;
     private Optional<List<TokenClaim>> tokenCustomClaims;
+    private Optional<List<UserInfoClaim>> userinfoCustomClaims;
     private Optional<String> tlsClientAuthSubjectDn;
     private Optional<String> tlsClientAuthSanDns;
     private Optional<String> tlsClientAuthSanUri;
@@ -438,6 +440,14 @@ public class PatchApplicationOAuthSettings {
         this.tokenCustomClaims = tokenCustomClaims;
     }
 
+    public Optional<List<UserInfoClaim>> getUserinfoCustomClaims() {
+        return userinfoCustomClaims;
+    }
+
+    public void setUserinfoCustomClaims(Optional<List<UserInfoClaim>> userinfoCustomClaims) {
+        this.userinfoCustomClaims = userinfoCustomClaims;
+    }
+
     public Optional<String> getTlsClientAuthSubjectDn() {
         return tlsClientAuthSubjectDn;
     }
@@ -606,6 +616,7 @@ public class PatchApplicationOAuthSettings {
         SetterUtils.safeSet(toPatch::setRefreshTokenValiditySeconds, this.getRefreshTokenValiditySeconds());
         SetterUtils.safeSet(toPatch::setIdTokenValiditySeconds, this.getIdTokenValiditySeconds());
         SetterUtils.safeSet(toPatch::setTokenCustomClaims, this.getTokenCustomClaims());
+        SetterUtils.safeSet(toPatch::setUserinfoCustomClaims, this.getUserinfoCustomClaims());
         SetterUtils.safeSet(toPatch::setTlsClientAuthSubjectDn, this.getTlsClientAuthSubjectDn());
         SetterUtils.safeSet(toPatch::setTlsClientAuthSanDns, this.getTlsClientAuthSanDns());
         SetterUtils.safeSet(toPatch::setTlsClientAuthSanEmail, this.getTlsClientAuthSanEmail());

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/model/PatchApplicationTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/model/PatchApplicationTest.java
@@ -17,6 +17,7 @@ package io.gravitee.am.service.model;
 
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.PasswordSettings;
+import io.gravitee.am.model.UserInfoClaim;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.application.ApplicationOAuthSettings;
 import io.gravitee.am.model.application.ApplicationSettings;
@@ -27,6 +28,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -237,6 +239,53 @@ public class PatchApplicationTest {
 
         //apply patch
         patch.patch(toPatch);
+    }
+
+    @Test
+    public void patch_applies_userinfoCustomClaims_when_present() {
+        List<UserInfoClaim> patchedClaims = List.of(UserInfoClaim.of("custom", "#expr"));
+
+        PatchApplicationOAuthSettings oauthPatch = new PatchApplicationOAuthSettings();
+        oauthPatch.setUserinfoCustomClaims(Optional.of(patchedClaims));
+
+        PatchApplicationSettings settingsPatch = new PatchApplicationSettings();
+        settingsPatch.setOauth(Optional.of(oauthPatch));
+
+        PatchApplication patch = new PatchApplication();
+        patch.setSettings(Optional.of(settingsPatch));
+
+        Application toPatch = new Application();
+        ApplicationSettings appSettings = new ApplicationSettings();
+        appSettings.setOauth(new ApplicationOAuthSettings());
+        toPatch.setSettings(appSettings);
+
+        Application result = patch.patch(toPatch);
+
+        assertEquals(patchedClaims, result.getSettings().getOauth().getUserinfoCustomClaims());
+    }
+
+    @Test
+    public void patch_leaves_userinfoCustomClaims_untouched_when_optional_empty() {
+        List<UserInfoClaim> existing = List.of(UserInfoClaim.of("kept", "#kept"));
+
+        PatchApplicationOAuthSettings oauthPatch = new PatchApplicationOAuthSettings();
+        // not setting userinfoCustomClaims — Optional remains null
+        PatchApplicationSettings settingsPatch = new PatchApplicationSettings();
+        settingsPatch.setOauth(Optional.of(oauthPatch));
+
+        PatchApplication patch = new PatchApplication();
+        patch.setSettings(Optional.of(settingsPatch));
+
+        Application toPatch = new Application();
+        ApplicationSettings appSettings = new ApplicationSettings();
+        ApplicationOAuthSettings existingOauth = new ApplicationOAuthSettings();
+        existingOauth.setUserinfoCustomClaims(existing);
+        appSettings.setOauth(existingOauth);
+        toPatch.setSettings(appSettings);
+
+        Application result = patch.patch(toPatch);
+
+        assertEquals(existing, result.getSettings().getOauth().getUserinfoCustomClaims());
     }
 
 }

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -288,6 +288,7 @@ import {
   ApplicationTokensComponent,
   ClaimsInfoDialogComponent,
   CreateClaimComponent,
+  CreateUserinfoClaimComponent,
 } from './domain/applications/application/advanced/oauth2/tokens/application-tokens.component';
 import { ApplicationGrantFlowsComponent } from './domain/applications/application/advanced/oauth2/grantFlows/application-grant-flows.component';
 import { ApplicationSecretsCertificatesComponent } from './domain/applications/application/advanced/secrets-certificates/secrets-certificates.component';
@@ -516,6 +517,7 @@ import { DomainStoreService } from './stores/domain.store';
     LogoutCallbackComponent,
     BreadcrumbComponent,
     CreateClaimComponent,
+    CreateUserinfoClaimComponent,
     CertificateCreationComponent,
     CertificateComponent,
     CertificateCreationStep1Component,

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/oauth2.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/oauth2.component.ts
@@ -30,7 +30,7 @@ export class ApplicationOAuth2Component implements OnDestroy {
   navLinks: any = [
     { href: 'grantFlows', label: 'Grant flows', icon: 'more_vert' },
     { href: 'scopes', label: 'Scopes', icon: 'transform' },
-    { href: 'tokens', label: 'Tokens', icon: 'swap_horiz' },
+    { href: 'tokens', label: 'Tokens & User Profile', icon: 'swap_horiz' },
   ];
   constructor(
     private router: Router,

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/application-tokens.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/application-tokens.component.html
@@ -20,7 +20,7 @@
     <form (keydown.enter)="(false)" (ngSubmit)="patch()">
       <div class="gv-form-section">
         <div class="gv-form-section-title">
-          <h5>Tokens</h5>
+          <h5>Tokens & User Profile</h5>
           <mat-divider></mat-divider>
         </div>
 
@@ -78,9 +78,7 @@
             <h5 style="margin: 0">Custom claims</h5>
             <button mat-icon-button (click)="openDialog($event)"><mat-icon>info_outline</mat-icon></button>
           </div>
-          <small
-            >You can add custom claims to the tokens (ID Token and Access Token) by picking attributes from the execution context.</small
-          >
+          <small>You can add custom claims to the tokens (ID Token, Access Token) by picking attributes from the execution context.</small>
           <mat-divider></mat-divider>
         </div>
         <div class="token-custom-claims">
@@ -93,7 +91,7 @@
             class="material"
             [columnMode]="'flex'"
             [headerHeight]="40"
-            [rowHeight]="55"
+            [rowHeight]="'auto'"
             [messages]="{ emptyMessage: 'There is no custom claims' }"
             [rows]="applicationOauthSettings.tokenCustomClaims"
             [groupRowsBy]="'tokenType'"
@@ -117,7 +115,7 @@
               </ng-template>
             </ngx-datatable-group-header>
 
-            <ngx-datatable-column name="Claims" [flexGrow]="2">
+            <ngx-datatable-column name="Claims" [flexGrow]="1">
               <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
                 <span (dblclick)="editing[row.id + '-claimName'] = true" *ngIf="!editing[row.id + '-claimName']">
                   {{ row.claimName }}
@@ -139,12 +137,11 @@
             <ngx-datatable-column name="" [flexGrow]="4">
               <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
                 <pre
-                  style="margin: 0; white-space: normal; font-size: 12px"
+                  style="margin: 0; white-space: normal; word-break: break-all; font-size: 12px"
                   (dblclick)="editing[row.id + '-claimValue'] = true"
                   *ngIf="!editing[row.id + '-claimValue']"
+                  >{{ row.claimValue }}</pre
                 >
-                  {{ row.claimValue }}
-                </pre>
                 <mat-form-field *ngIf="editing[row.id + '-claimValue']" class="datatable-input">
                   <input
                     matInput
@@ -161,8 +158,86 @@
             </ngx-datatable-column>
             <ngx-datatable-column name="" [flexGrow]="1">
               <ng-template let-row="row" ngx-datatable-cell-template>
-                <div fxLayout="row" class="gv-table-cell-actions" *ngIf="!readonly">
+                <div fxLayout="row" fxLayoutAlign="end center" class="gv-table-cell-actions" *ngIf="!readonly">
                   <button mat-icon-button (click)="deleteClaim(row.tokenType, row.claimName, $event)"><mat-icon>close</mat-icon></button>
+                </div>
+              </ng-template>
+            </ngx-datatable-column>
+          </ngx-datatable>
+        </div>
+      </div>
+
+      <div class="gv-form-section">
+        <div class="gv-form-section-title">
+          <div fxLayout="row" style="align-items: center">
+            <h5 style="margin: 0">Userinfo claims</h5>
+            <button mat-icon-button (click)="openDialog($event)"><mat-icon>info_outline</mat-icon></button>
+          </div>
+          <small
+            >Claims returned from the OIDC <span class="code">/userinfo</span> endpoint. Use these to expose user-profile attributes from
+            the execution context.</small
+          >
+          <mat-divider></mat-divider>
+        </div>
+        <div class="token-custom-claims">
+          <app-create-userinfo-claim *ngIf="!readonly" (addClaimChange)="addUserInfoClaim($event)"></app-create-userinfo-claim>
+          <p *ngIf="!userInfoClaimsIsEmpty() && !readonly">
+            <small><i>Double click to edit and press enter to save changes</i></small>
+          </p>
+          <ngx-datatable
+            #userinfoClaimsTable
+            class="material"
+            [columnMode]="'flex'"
+            [headerHeight]="40"
+            [rowHeight]="'auto'"
+            [messages]="{ emptyMessage: 'There is no userinfo claims' }"
+            [rows]="applicationOauthSettings.userinfoCustomClaims"
+          >
+            <ngx-datatable-column name="Claims" [flexGrow]="1">
+              <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
+                <span (dblclick)="editing[row.id + '-userinfo-claimName'] = true" *ngIf="!editing[row.id + '-userinfo-claimName']">
+                  {{ row.claimName }}
+                </span>
+                <mat-form-field *ngIf="editing[row.id + '-userinfo-claimName']" class="datatable-input">
+                  <input
+                    matInput
+                    type="text"
+                    required
+                    autofocus
+                    placeholder="Claim name"
+                    (keyup.enter)="updateUserInfoClaim($event, 'claimName', row.id)"
+                    (blur)="editing[row.id + '-userinfo-claimName'] = false"
+                    [value]="row.claimName"
+                  />
+                </mat-form-field>
+              </ng-template>
+            </ngx-datatable-column>
+            <ngx-datatable-column name="" [flexGrow]="4">
+              <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
+                <pre
+                  style="margin: 0; white-space: normal; word-break: break-all; font-size: 12px"
+                  (dblclick)="editing[row.id + '-userinfo-claimValue'] = true"
+                  *ngIf="!editing[row.id + '-userinfo-claimValue']"
+                  >{{ row.claimValue }}</pre
+                >
+                <mat-form-field *ngIf="editing[row.id + '-userinfo-claimValue']" class="datatable-input">
+                  <input
+                    matInput
+                    type="text"
+                    required
+                    autofocus
+                    placeholder="Claim value"
+                    (keyup.enter)="updateUserInfoClaim($event, 'claimValue', row.id)"
+                    (blur)="editing[row.id + '-userinfo-claimValue'] = false"
+                    [value]="row.claimValue"
+                  />
+                </mat-form-field>
+              </ng-template>
+            </ngx-datatable-column>
+            <ngx-datatable-column name="" [flexGrow]="1">
+              <ng-template let-row="row" ngx-datatable-cell-template>
+                <div fxLayout="row" fxLayoutAlign="end center" class="gv-table-cell-actions" *ngIf="!readonly">
+                  <button mat-icon-button (click)="deleteUserInfoClaim(row.claimName, $event)"><mat-icon>close</mat-icon></button>
                 </div>
               </ng-template>
             </ngx-datatable-column>
@@ -178,7 +253,7 @@
   <div class="gv-page-description" fxFlex>
     <h3>OAuth 2.0 / OpenID Connect</h3>
     <div class="gv-page-description-content">
-      <h4>Tokens</h4>
+      <h4>Tokens & User Profile</h4>
       <p>The ID Token is a JSON Web Token (JWT) that contains claims (user profile information) about the End-User.</p>
       <p>
         You must provide the OAuth 2 scope <span class="code">openid</span> in order to get the <span class="code">id_token</span> which
@@ -191,6 +266,10 @@
         <b><i>exp:</i></b> Expiration time on or after which the ID Token MUST NOT be accepted for processing.<br />
         <b><i>iat:</i></b> Time at which the JWT was issued.<br />
       </small>
+      <p>
+        Use the <b>Userinfo claims</b> section to expose claims returned from the OIDC <span class="code">/userinfo</span> endpoint instead
+        of embedding them in a token.
+      </p>
     </div>
   </div>
 </div>

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/application-tokens.component.scss
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/application-tokens.component.scss
@@ -1,3 +1,22 @@
 .datatable-input {
   align-self: center;
 }
+
+:host ::ng-deep ngx-datatable.material {
+  .datatable-body-cell {
+    display: flex;
+    align-items: center;
+  }
+
+  .datatable-body-cell-label {
+    width: 100%;
+  }
+
+  .gv-table-cell-actions {
+    margin-left: 0;
+
+    button {
+      top: auto;
+    }
+  }
+}

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/application-tokens.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/application-tokens.component.ts
@@ -30,6 +30,7 @@ import { AuthService } from '../../../../../../services/auth.service';
 })
 export class ApplicationTokensComponent implements OnInit {
   @ViewChild('claimsTable') table: any;
+  @ViewChild('userinfoClaimsTable') userinfoTable: any;
   private domainId: string;
   formChanged: boolean;
   application: any;
@@ -51,22 +52,29 @@ export class ApplicationTokensComponent implements OnInit {
     this.application = structuredClone(this.route.snapshot.data['application']);
     this.applicationOauthSettings = this.application.settings == null ? {} : this.application.settings.oauth || {};
     this.applicationOauthSettings.tokenCustomClaims = this.applicationOauthSettings.tokenCustomClaims || [];
+    this.applicationOauthSettings.userinfoCustomClaims = this.applicationOauthSettings.userinfoCustomClaims || [];
+    this.migrateLegacyUserProfileClaims();
     this.readonly = !this.authService.hasPermissions(['application_openid_update']);
     this.initCustomClaims();
+    this.initUserInfoCustomClaims();
   }
 
   patch() {
     this.cleanCustomClaims();
+    this.cleanUserInfoCustomClaims();
     const oauthSettings: any = {};
     oauthSettings.tokenCustomClaims = this.applicationOauthSettings.tokenCustomClaims;
+    oauthSettings.userinfoCustomClaims = this.applicationOauthSettings.userinfoCustomClaims;
     oauthSettings.accessTokenValiditySeconds = this.applicationOauthSettings.accessTokenValiditySeconds;
     oauthSettings.refreshTokenValiditySeconds = this.applicationOauthSettings.refreshTokenValiditySeconds;
     oauthSettings.idTokenValiditySeconds = this.applicationOauthSettings.idTokenValiditySeconds;
     this.applicationService.patch(this.domainId, this.application.id, { settings: { oauth: oauthSettings } }).subscribe(() => {
+      this.clearLegacyUserProfileStorage();
       this.snackbarService.open('Application updated');
       this.router.navigate(['.'], { relativeTo: this.route, queryParams: { reload: true } });
       this.formChanged = false;
       this.initCustomClaims();
+      this.initUserInfoCustomClaims();
     });
   }
 
@@ -118,6 +126,49 @@ export class ApplicationTokensComponent implements OnInit {
     this.table.groupHeader.toggleExpandGroup(group);
   }
 
+  addUserInfoClaim(claim) {
+    if (claim) {
+      if (!this.userInfoClaimExists(claim)) {
+        claim.id = Math.random().toString(36).substring(7);
+        this.applicationOauthSettings.userinfoCustomClaims.push(claim);
+        this.applicationOauthSettings.userinfoCustomClaims = [...this.applicationOauthSettings.userinfoCustomClaims];
+        this.formChanged = true;
+      } else {
+        this.snackbarService.open('Claim already exists');
+      }
+    }
+  }
+
+  userInfoClaimExists(claim): boolean {
+    return find(this.applicationOauthSettings.userinfoCustomClaims, function (el) {
+      return el.claimName === claim.claimName;
+    });
+  }
+
+  updateUserInfoClaim(event, cell, rowIndex) {
+    const claim = event.target.value;
+    if (claim) {
+      this.editing[rowIndex + '-userinfo-' + cell] = false;
+      const index = findIndex(this.applicationOauthSettings.userinfoCustomClaims, { id: rowIndex });
+      this.applicationOauthSettings.userinfoCustomClaims[index][cell] = claim;
+      this.applicationOauthSettings.userinfoCustomClaims = [...this.applicationOauthSettings.userinfoCustomClaims];
+      this.formChanged = true;
+    }
+  }
+
+  deleteUserInfoClaim(key, event) {
+    event.preventDefault();
+    remove(this.applicationOauthSettings.userinfoCustomClaims, function (el: any) {
+      return el.claimName === key;
+    });
+    this.applicationOauthSettings.userinfoCustomClaims = [...this.applicationOauthSettings.userinfoCustomClaims];
+    this.formChanged = true;
+  }
+
+  userInfoClaimsIsEmpty() {
+    return this.applicationOauthSettings.userinfoCustomClaims.length === 0;
+  }
+
   openDialog(event) {
     event.preventDefault();
     this.dialog.open(ClaimsInfoDialogComponent, {});
@@ -142,6 +193,55 @@ export class ApplicationTokensComponent implements OnInit {
       });
     }
   }
+
+  private cleanUserInfoCustomClaims() {
+    if (this.applicationOauthSettings.userinfoCustomClaims.length > 0) {
+      this.applicationOauthSettings.userinfoCustomClaims.forEach((claim) => {
+        delete claim.id;
+      });
+    }
+  }
+
+  private initUserInfoCustomClaims() {
+    if (this.applicationOauthSettings.userinfoCustomClaims.length > 0) {
+      this.applicationOauthSettings.userinfoCustomClaims.forEach((claim) => {
+        claim.id = Math.random().toString(36).substring(7);
+      });
+    }
+  }
+
+  private legacyUserProfileStorageKey(): string {
+    return `am.tokenCustomClaims.userProfile:${this.domainId}:${this.application.id}`;
+  }
+
+  private migrateLegacyUserProfileClaims(): void {
+    let legacy: any[];
+    try {
+      const raw = window.localStorage.getItem(this.legacyUserProfileStorageKey());
+      legacy = raw ? JSON.parse(raw) : [];
+    } catch {
+      return;
+    }
+    if (!legacy || legacy.length === 0) {
+      return;
+    }
+    const existingNames = new Set(this.applicationOauthSettings.userinfoCustomClaims.map((c: any) => c.claimName));
+    const migrated = legacy
+      .filter((c: any) => c && c.claimName && !existingNames.has(c.claimName))
+      .map((c: any) => ({ claimName: c.claimName, claimValue: c.claimValue }));
+    if (migrated.length > 0) {
+      this.applicationOauthSettings.userinfoCustomClaims = [...this.applicationOauthSettings.userinfoCustomClaims, ...migrated];
+      this.formChanged = true;
+    }
+  }
+
+  private clearLegacyUserProfileStorage(): void {
+    try {
+      window.localStorage.removeItem(this.legacyUserProfileStorageKey());
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 @Component({
@@ -151,6 +251,22 @@ export class ApplicationTokensComponent implements OnInit {
 export class CreateClaimComponent {
   claim: any = {};
   tokenTypes: any[] = ['id_token', 'access_token'];
+  @Output() addClaimChange = new EventEmitter();
+  @ViewChild('claimForm', { static: true }) form: NgForm;
+
+  addClaim() {
+    this.addClaimChange.emit(this.claim);
+    this.claim = {};
+    this.form.reset(this.claim);
+  }
+}
+
+@Component({
+  selector: 'app-create-userinfo-claim',
+  templateUrl: './claims/add-userinfo-claim.component.html',
+})
+export class CreateUserinfoClaimComponent {
+  claim: any = {};
   @Output() addClaimChange = new EventEmitter();
   @ViewChild('claimForm', { static: true }) form: NgForm;
 

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/claims/add-userinfo-claim.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/claims/add-userinfo-claim.component.html
@@ -17,13 +17,6 @@
 -->
 <form #claimForm="ngForm" style="padding: 15px; border: 1px solid rgba(0, 0, 0, 0.12); border-radius: 4px">
   <div fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="flex-start flex-start">
-    <mat-form-field appearance="outline" fxFlex="2 1 0">
-      <mat-select placeholder="Token Type" name="tokenType" required [(ngModel)]="claim.tokenType">
-        <mat-option *ngFor="let tokenType of tokenTypes" [value]="tokenType">
-          {{ tokenType | uppercase }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
     <mat-form-field appearance="outline" fxFlex="3 1 0">
       <input matInput name="claimName" placeholder="Claim name" required [(ngModel)]="claim.claimName" />
       <mat-hint>The claim's name.</mat-hint>

--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/dialog/claims-info.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/oauth2/tokens/dialog/claims-info.component.html
@@ -20,16 +20,14 @@
   <mat-dialog-content>
     <h5>Information</h5>
     <mat-divider></mat-divider>
-    <mat-list dense>
-      <mat-list-item>
-        <mat-icon matListIcon>info</mat-icon>
-        <h3 matLine>Tokens claims are statements about the subject or the application, for example name, role, or email address.</h3>
-      </mat-list-item>
-      <mat-list-item>
-        <mat-icon matListIcon>info</mat-icon>
-        <h3 matLine>You can use <b>Expression Language</b> or <b>raw value</b> to set the claim values.</h3>
-      </mat-list-item>
-    </mat-list>
+    <div style="display: flex; align-items: center; gap: 8px; padding: 8px 0">
+      <mat-icon>info</mat-icon>
+      <span>Tokens claims are statements about the subject or the application, for example name, role, or email address.</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; padding: 8px 0">
+      <mat-icon>info</mat-icon>
+      <span>You can use <b>Expression Language</b> or <b>raw value</b> to set the claim values.</span>
+    </div>
 
     <h5>Execution Context</h5>
     <mat-divider></mat-divider>
@@ -41,6 +39,7 @@
       {#context.attributes['user']} : Authenticated User (if available) with username, firstName, lastName, email, roles, groups and claims
       {#context.attributes['authorizationRequest']} : OAuth 2.0 Authorization Request (if available)
       {#context.attributes['tokenRequest']} : OAuth 2.0 Token Request (if available)
+      {#context.attributes['token']} : OAuth 2.0 AccessToken (if available)
       {#context.attributes['authFlow']} : Attributes coming from the Enrich Authentication Flow policy (if available)
       {#context.attributes['authFlow']['requestParameters']} : Params provided to the authentication flow using PAR uri (if available)
       ]]>


### PR DESCRIPTION
Nominal test case scenario:
Create a user and put additionalInformation property `test` -> `value`
Create a custom scope "test"
Update Application -> Settings -> OAuth -> Scopes -> Scope "test" default
Update Application -> Settings -> OAuth -> Tokens&UserProfile -> User Profile claims
```
new1 -> 
{#context.attributes['token'].scopes.contains('test') ? #context.attributes['user'].additionalInformation['test'] : null }
```

Get the access_token 
```
curl http://localhost:8092/a1/oauth/token -u 'test:test' -d 'grant_type=password&username=u1&password=Password123!'
```

Call the userinfo endpoint
```
curl http://localhost:8092/a1/oidc/userinfo -H 'Authorization: Bearer <token>'
```

The result should contain extra claim called "new1"


Screenshots:

<img width="963" height="472" alt="image" src="https://github.com/user-attachments/assets/6d78cd16-6ed4-48b0-abab-f98cc67754ef" />

