### PR TITLE
fix: AM-6990 enable template toggle when CIMD is disabled

### DIFF
--- a/gravitee-am-ui/src/app/domain/applications/application/advanced/general/general.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/application/advanced/general/general.component.ts
@@ -107,7 +107,7 @@ export class ApplicationGeneralComponent implements OnInit {
     this.editMode = this.authService.hasPermissions(['application_settings_update']);
     this.deleteMode = this.authService.hasPermissions(['application_settings_delete']);
     this.isTemplate = this.application.template || false;
-    this.isCimdTemplate = this.domain?.oidc?.cimdSettings?.templateId === this.application.id;
+    this.isCimdTemplate = !!this.domain?.oidc?.cimdSettings?.enabled && this.domain?.oidc?.cimdSettings?.templateId === this.application.id;
     if (!this.domain.uma || !this.domain.uma.enabled) {
       remove(this.applicationTypes, { type: 'RESOURCE_SERVER' });
     }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6990](https://gravitee.atlassian.net/browse/AM-6990)

## :pencil2: A description of the changes proposed in the pull request
Ensure that Template toggle in the console UI is enabled when CIMD is disabled. Any reference to the current application is ignored, allowing the application mode to be reset.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6990]: https://gravitee.atlassian.net/browse/AM-6990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ