### PR TITLE
fix: AM-7010 calculate audit actor links for applications

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/audit/AuditActorAttributes.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/audit/AuditActorAttributes.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.audit;
+
+public interface AuditActorAttributes {
+    String CIMD_METADATA_DOCUMENT_HASH = "metadataDocumentHash";
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientAuthAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientAuthAuditBuilder.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.service.reporter.builder;
 
 import com.google.common.collect.ImmutableMap;
+import io.gravitee.am.common.audit.AuditActorAttributes;
 import io.gravitee.am.common.audit.EntityType;
 import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.common.oauth2.ClientIds;
@@ -28,8 +29,6 @@ import io.gravitee.am.service.reporter.builder.gateway.GatewayAuditBuilder;
 import java.util.HashMap;
 
 public class ClientAuthAuditBuilder extends GatewayAuditBuilder<ClientAuthAuditBuilder> {
-
-    private static final String CIMD_METADATA_DOCUMENT_HASH_KEY = "metadataDocumentHash";
 
     private String metadataDocumentHash;
 
@@ -58,7 +57,7 @@ public class ClientAuthAuditBuilder extends GatewayAuditBuilder<ClientAuthAuditB
         if (metadataDocumentHash != null) {
             HashMap<String, Object> attributes =
                     actor.getAttributes() == null ? new HashMap<>() : new HashMap<>(actor.getAttributes());
-            attributes.put(CIMD_METADATA_DOCUMENT_HASH_KEY, metadataDocumentHash);
+            attributes.put(AuditActorAttributes.CIMD_METADATA_DOCUMENT_HASH, metadataDocumentHash);
             actor.setAttributes(ImmutableMap.copyOf(attributes));
         }
         return actor;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilder.java
@@ -17,6 +17,7 @@ package io.gravitee.am.service.reporter.builder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.gravitee.am.common.audit.AuditActorAttributes;
 import io.gravitee.am.common.audit.EntityType;
 import io.gravitee.am.common.oauth2.ClientIds;
 import io.gravitee.am.common.oauth2.TokenTypeHint;
@@ -44,6 +45,7 @@ public class ClientTokenAuditBuilder extends GatewayAuditBuilder<ClientTokenAudi
     private static final String ACCESS_TOKEN_SUB_ATTRIBUTE_KEY = "accessTokenSubject";
     private final Map<String, Object> tokenNewValue;
     private String accessTokenSubject;
+    private String metadataDocumentHash;
 
     public ClientTokenAuditBuilder() {
         super();
@@ -121,7 +123,7 @@ public class ClientTokenAuditBuilder extends GatewayAuditBuilder<ClientTokenAudi
             if(client.getDomain() != null){
                 reference(Reference.domain(client.getDomain()));
             }
-
+            this.metadataDocumentHash = client.getCimdMetadataHash();
         }
         return this;
     }
@@ -167,6 +169,17 @@ public class ClientTokenAuditBuilder extends GatewayAuditBuilder<ClientTokenAudi
             setNewValue(tokenNewValue);
         }
         return super.build(mapper);
+    }
+
+    @Override
+    protected AuditEntity createActor() {
+        AuditEntity actor = super.createActor();
+        if (metadataDocumentHash != null) {
+            HashMap<String, Object> attributes = actor.getAttributes() == null ? new HashMap<>() : new HashMap<>(actor.getAttributes());
+            attributes.put(AuditActorAttributes.CIMD_METADATA_DOCUMENT_HASH, metadataDocumentHash);
+            actor.setAttributes(ImmutableMap.copyOf(attributes));
+        }
+        return actor;
     }
 
     @Override

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/ClientAuthAuditBuilderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/ClientAuthAuditBuilderTest.java
@@ -24,6 +24,7 @@ import static io.gravitee.am.common.audit.EventType.CLIENT_AUTHENTICATION;
 import static io.gravitee.am.common.audit.Status.FAILURE;
 import static io.gravitee.am.common.audit.Status.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -132,5 +133,6 @@ class ClientAuthAuditBuilderTest {
         var audit = AuditBuilder.builder(ClientAuthAuditBuilder.class).clientActor(client).build(objectMapper);
 
         assertNull(audit.getTarget());
+        assertFalse(audit.getActor().getAttributes() != null && audit.getActor().getAttributes().containsKey("metadataDocumentHash"));
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilderTest.java
@@ -27,6 +27,8 @@ import static io.gravitee.am.common.audit.EventType.TOKEN_REVOKED;
 import static io.gravitee.am.common.audit.Status.FAILURE;
 import static io.gravitee.am.common.audit.Status.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -191,6 +193,7 @@ class ClientTokenAuditBuilderTest {
         assertEquals(clientName, audit.getActor().getAlternativeId());
         assertEquals(SUCCESS, audit.getOutcome().getStatus());
         assertEquals(TOKEN_CREATED, audit.getType());
+        assertFalse(audit.getActor().getAttributes() != null && audit.getActor().getAttributes().containsKey("metadataDocumentHash"));
     }
 
     @Test
@@ -199,11 +202,13 @@ class ClientTokenAuditBuilderTest {
         var clientId = "https://client.example.com/metadata";
         var clientName = "CIMD Client";
         var domainId = "domainId";
+        var metadataHash = "abc123";
         var client = new Client();
         client.setId(applicationId);
         client.setClientId(clientId);
         client.setClientName(clientName);
         client.setDomain(domainId);
+        client.setCimdMetadataHash(metadataHash);
 
         var audit = AuditBuilder.builder(ClientTokenAuditBuilder.class).tokenActor(client).build(objectMapper);
 
@@ -211,6 +216,8 @@ class ClientTokenAuditBuilderTest {
         assertEquals(clientName, audit.getActor().getDisplayName());
         assertEquals(clientId, audit.getActor().getAlternativeId());
         assertEquals(TOKEN_CREATED, audit.getType());
+        assertNotNull(audit.getActor().getAttributes());
+        assertEquals(metadataHash, audit.getActor().getAttributes().get("metadataDocumentHash"));
     }
 
     @Test

--- a/gravitee-am-ui/src/app/domain/settings/audits/audits.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/audits.component.ts
@@ -118,15 +118,25 @@ export class AuditsComponent implements OnInit {
   getActorUrl(row) {
     const routerLink = [];
 
-    if ('organization' === row.actor.referenceType) {
-      routerLink.push('/settings');
-    } else if ('domain' === row.actor.referenceType) {
-      routerLink.push('..');
+    if (row.actor.type === 'USER') {
+      if ('organization' === row.actor.referenceType) {
+        routerLink.push('/settings');
+      } else if ('domain' === row.actor.referenceType) {
+        routerLink.push('..');
+      }
+      if (routerLink.length > 0) {
+        routerLink.push('users');
+        routerLink.push(row.actor.id);
+      }
+      return routerLink;
     }
 
-    if (routerLink.length > 0) {
-      routerLink.push('users');
-      routerLink.push(row.actor.id);
+    if (row.actor.type === 'APPLICATION' && !row.actor.attributes?.metadataDocumentHash && !this.organizationContext) {
+      const envHrid = this.route.snapshot.paramMap.get('envHrid');
+      const domainId = this.route.snapshot.paramMap.get('domainId');
+      if (envHrid && domainId) {
+        return ['/environments', envHrid, 'domains', domainId, 'applications', row.actor.id];
+      }
     }
 
     return routerLink;


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7010](https://gravitee.atlassian.net/browse/AM-7010)

## :pencil2: A description of the changes proposed in the pull request
Calculate application links when rendered in the console UI audit log actor column.
- Pre-registered applications actors are rendered as links
- CIMD client actors are rendered as plain text

## :memo: Test scenarios
- To generate successful `CLIENT_AUTHENTICATION` audit events, set `reporters.audits.exclude.clientAuthentication.success` to false.
- Complete OAuth `/authorize` flows to generate `CLIENT_AUTHENTICATION` events.
- Exchange OAuth code token exchanges with `/token` to generate `TOKEN_CREATED` events.
- To view or revoke user consent to scopes, navigate to User settings > Authorized Apps tab.

## :computer: Add screenshots for UI
<img width="1396" height="450" alt="image" src="https://github.com/user-attachments/assets/0c82d569-681e-400a-a367-88c9a1d2e4e6" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7010]: https://gravitee.atlassian.net/browse/AM-7010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ