### PR TITLE
feat(applications): add status and owner.email filter on application …

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -1025,6 +1025,14 @@ paths:
           type: array
           items:
             type: string
+      - name: status
+        in: query
+        schema:
+          type: string
+      - name: owner.email
+        in: query
+        schema:
+          type: string
       responses:
         "200":
           description: List registered applications for a security domain

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationsResource.java
@@ -16,22 +16,17 @@
 package io.gravitee.am.management.handlers.management.api.resources.organizations.environments.domains;
 
 import io.gravitee.am.identityprovider.api.User;
-import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
 import io.gravitee.am.management.handlers.management.api.resources.model.ApplicationExpand;
 import io.gravitee.am.management.handlers.management.api.resources.model.FilteredApplication;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Application;
-import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.ApplicationService;
-import io.gravitee.am.management.service.DomainService;
-import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.gravitee.am.service.model.ApplicationFilter;
 import io.gravitee.am.service.model.NewApplication;
 import io.gravitee.common.http.MediaType;
-import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -44,7 +39,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -105,18 +99,29 @@ public class ApplicationsResource extends AbstractDomainResource {
             @QueryParam("size") @DefaultValue(MAX_APPLICATIONS_SIZE_PER_PAGE_STRING) int size,
             @QueryParam("q") String query,
             @QueryParam("expand") List<String> expandsParam,
+            @QueryParam("status") String status,
+            @QueryParam("owner.email") String ownerEmail,
             @Suspended final AsyncResponse response) {
         User authenticatedUser = getAuthenticatedUser();
+        ApplicationFilter filter = new ApplicationFilter(status, ownerEmail);
+
+        // owner.email filter requires ORGANIZATION_USER[READ] — checked here, resolved in service
+        io.reactivex.rxjava3.core.Completable ownerPermissionCheck = filter.hasOwnerEmailFilter()
+                ? checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_USER, Acl.READ)
+                : io.reactivex.rxjava3.core.Completable.complete();
+
         final Set<ApplicationExpand> expands = convertToApplicationExpands(expandsParam);
-        checkAnyPermission(organizationId, environmentId, domain, Permission.APPLICATION, Acl.LIST)
+
+        ownerPermissionCheck
+                .andThen(checkAnyPermission(organizationId, environmentId, domain, Permission.APPLICATION, Acl.LIST))
                 .andThen(checkDomainExists(domain).ignoreElement())
                 .andThen(hasAnyPermission(authenticatedUser, organizationId, environmentId, domain, Permission.APPLICATION, Acl.READ)
                         .filter(hasPermission -> hasPermission)
-                        .flatMapSingle(__ -> listApplications(domain, page, size, query))
+                        .flatMapSingle(__ -> listApplications(domain, organizationId, filter, page, size, query))
                         .switchIfEmpty(
                                 getResourceIdsWithPermission(authenticatedUser, ReferenceType.APPLICATION, Permission.APPLICATION, Acl.READ)
                                         .toList()
-                                        .flatMap(ids -> listApplicationsByIds(domain, ids, page, size, query))))
+                                        .flatMap(ids -> listApplicationsByIds(domain, organizationId, ids, filter, page, size, query))))
                 .map(apps ->
                         new ApplicationPage(
                                 apps.getData().stream().map(app -> FilteredApplication.of(app, expands)).toList(),
@@ -134,20 +139,30 @@ public class ApplicationsResource extends AbstractDomainResource {
                         .collect(Collectors.toSet());
     }
 
-    private Single<Page<Application>> listApplications(String domain, int page, int size, String query) {
+    private Single<Page<Application>> listApplications(String domain, String organizationId, ApplicationFilter filter, int page, int size, String query) {
+        if (filter.hasStatusFilter() || filter.hasOwnerEmailFilter()) {
+            return query != null
+                    ? applicationService.search(domain, organizationId, filter, query, page, size)
+                    : applicationService.findByDomain(domain, organizationId, filter, page, size);
+        }
         if (query != null) {
             return applicationService.search(domain, query, page, size);
-        } else {
-            return applicationService.findByDomain(domain, page, size);
         }
+        return applicationService.findByDomain(domain, page, size);
     }
 
-    private Single<Page<Application>> listApplicationsByIds(String domain, List<String> applicationIds, int page, int size, String query) {
+    private Single<Page<Application>> listApplicationsByIds(String domain, String organizationId, List<String> applicationIds, ApplicationFilter filter, int page, int size, String query) {
+        if (filter.hasStatusFilter() || filter.hasOwnerEmailFilter()) {
+            // Intersect permission-scoped IDs with any owner/status filter resolution in the service layer
+            ApplicationFilter filterWithScope = new ApplicationFilter(filter.status(), filter.ownerEmail(), applicationIds);
+            return query != null
+                    ? applicationService.search(domain, organizationId, filterWithScope, query, page, size)
+                    : applicationService.findByDomain(domain, organizationId, filterWithScope, page, size);
+        }
         if (query != null) {
             return applicationService.search(domain, applicationIds, query, page, size);
-        } else {
-            return applicationService.findByDomain(domain, applicationIds, page, size);
         }
+        return applicationService.findByDomain(domain, applicationIds, page, size);
     }
 
     @POST

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceFilterTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceFilterTest.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.resources;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
+import io.gravitee.am.management.service.permissions.PermissionAcls;
+import io.gravitee.am.model.Application;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.common.Page;
+import io.gravitee.am.service.model.ApplicationFilter;
+import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * Tests for the status and owner.email filter parameters on the application list endpoint.
+ */
+public class ApplicationsResourceFilterTest extends JerseySpringTest {
+
+    @BeforeEach
+    public void setUpPermissionStubs() {
+        // getReferenceIdsWithPermission is evaluated eagerly during Rx chain construction;
+        // stub it to prevent NPE even when the switchIfEmpty branch is not subscribed to.
+        doReturn(Flowable.empty()).when(permissionService)
+                .getReferenceIdsWithPermission(any(), any(), any(), any());
+        // Shared Spring mock beans accumulate invocations across tests; clear before each test
+        // so verify() counts only the invocations from the current test.
+        Mockito.clearInvocations(applicationService);
+    }
+
+    @Test
+    public void shouldGetApps_withStatusFilter_callsFilteredService() {
+        final String domainId = "domain-1";
+        final Domain mockDomain = new Domain();
+        mockDomain.setId(domainId);
+
+        final Application mockClient = new Application();
+        mockClient.setId("client-1-id");
+        mockClient.setName("client-1-name");
+        mockClient.setDomain(domainId);
+        mockClient.setUpdatedAt(new Date());
+
+        final Page<Application> applicationPage = new Page<>(List.of(mockClient), 0, 1);
+
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
+        doReturn(Single.just(applicationPage)).when(applicationService)
+                .findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
+
+        final Response response = target("domains").path(domainId).path("applications")
+                .queryParam("status", "enabled")
+                .request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        assertEquals(1, ((List) ((Map) readEntity(response, Map.class)).get("data")).size());
+        Mockito.verify(applicationService).findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
+        Mockito.verify(applicationService, Mockito.never()).findByDomain(domainId, 0, 50);
+    }
+
+    @Test
+    public void shouldGetApps_withOwnerEmailFilter_callsFilteredService() {
+        final String domainId = "domain-1";
+        final Domain mockDomain = new Domain();
+        mockDomain.setId(domainId);
+
+        final Application mockClient = new Application();
+        mockClient.setId("client-1-id");
+        mockClient.setName("client-1-name");
+        mockClient.setDomain(domainId);
+        mockClient.setUpdatedAt(new Date());
+
+        final Page<Application> applicationPage = new Page<>(List.of(mockClient), 0, 1);
+
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
+        doReturn(Single.just(applicationPage)).when(applicationService)
+                .findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
+
+        final Response response = target("domains").path(domainId).path("applications")
+                .queryParam("owner.email", "owner@example.com")
+                .request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        assertEquals(1, ((List) ((Map) readEntity(response, Map.class)).get("data")).size());
+        Mockito.verify(applicationService).findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
+        Mockito.verify(applicationService, Mockito.never()).findByDomain(domainId, 0, 50);
+    }
+
+    @Test
+    public void shouldGetApps_withOwnerEmailFilter_forbidden_whenNoOrgUserReadPermission() {
+        final String domainId = "domain-1";
+
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = target("domains").path(domainId).path("applications")
+                .queryParam("owner.email", "owner@example.com")
+                .request().get();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void shouldGetApps_withStatusAndOwnerEmailFilter_callsFilteredService() {
+        final String domainId = "domain-1";
+        final Domain mockDomain = new Domain();
+        mockDomain.setId(domainId);
+
+        final Application mockClient = new Application();
+        mockClient.setId("client-1-id");
+        mockClient.setName("client-1-name");
+        mockClient.setDomain(domainId);
+        mockClient.setUpdatedAt(new Date());
+
+        final Page<Application> applicationPage = new Page<>(List.of(mockClient), 0, 1);
+
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
+        doReturn(Single.just(applicationPage)).when(applicationService)
+                .findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
+
+        final Response response = target("domains").path(domainId).path("applications")
+                .queryParam("status", "enabled")
+                .queryParam("owner.email", "owner@example.com")
+                .request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        assertEquals(1, ((List) ((Map) readEntity(response, Map.class)).get("data")).size());
+        Mockito.verify(applicationService).findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
+    }
+
+    @Test
+    public void shouldGetApps_withStatusFilterAndQuery_callsFilteredSearch() {
+        final String domainId = "domain-1";
+        final Domain mockDomain = new Domain();
+        mockDomain.setId(domainId);
+
+        final Application mockClient = new Application();
+        mockClient.setId("client-1-id");
+        mockClient.setName("client-1-name");
+        mockClient.setDomain(domainId);
+        mockClient.setUpdatedAt(new Date());
+
+        final Page<Application> applicationPage = new Page<>(List.of(mockClient), 0, 1);
+
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
+        doReturn(Single.just(applicationPage)).when(applicationService)
+                .search(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq("myapp"), eq(0), eq(50));
+
+        final Response response = target("domains").path(domainId).path("applications")
+                .queryParam("status", "enabled")
+                .queryParam("q", "myapp")
+                .request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        assertEquals(1, ((List) ((Map) readEntity(response, Map.class)).get("data")).size());
+        Mockito.verify(applicationService).search(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq("myapp"), eq(0), eq(50));
+        Mockito.verify(applicationService, Mockito.never()).search(domainId, "myapp", 0, 50);
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/ApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/ApplicationRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.am.repository.management.api;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.repository.common.CrudRepository;
+import io.gravitee.am.repository.management.api.search.ApplicationCriteria;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -43,6 +44,10 @@ public interface ApplicationRepository extends CrudRepository<Application, Strin
     Single<Page<Application>> search(String domain, String query, int page, int size);
 
     Single<Page<Application>> search(String domain, List<String> applicationIds, String query, int page, int size);
+
+    Single<Page<Application>> findByDomain(String domain, ApplicationCriteria criteria, int page, int size);
+
+    Single<Page<Application>> search(String domain, ApplicationCriteria criteria, String query, int page, int size);
 
     Flowable<Application> findByCertificate(String certificate);
 

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/OrganizationUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/OrganizationUserRepository.java
@@ -15,10 +15,15 @@
  */
 package io.gravitee.am.repository.management.api;
 
+import io.gravitee.am.model.User;
+import io.reactivex.rxjava3.core.Flowable;
+
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface OrganizationUserRepository extends CommonUserRepository {
+
+    Flowable<User> findByEmail(String organizationId, String email);
 
 }

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/search/ApplicationCriteria.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/search/ApplicationCriteria.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.management.api.search;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApplicationCriteria {
+
+    /** null means "no status filter". */
+    private Boolean enabled;
+
+    /**
+     * null means "no owner filter".
+     * An empty list means the owner filter resolved to zero matches — callers
+     * should short-circuit before reaching the repository, but implementations
+     * must still return an empty page when this list is empty.
+     */
+    private List<String> applicationIds;
+
+    public Optional<Boolean> getEnabled() {
+        return Optional.ofNullable(enabled);
+    }
+
+    public Optional<List<String>> getApplicationIds() {
+        return Optional.ofNullable(applicationIds);
+    }
+
+    public ApplicationCriteria setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public ApplicationCriteria setApplicationIds(List<String> applicationIds) {
+        this.applicationIds = applicationIds;
+        return this;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/AbstractDialectHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/AbstractDialectHelper.java
@@ -18,6 +18,7 @@ package io.gravitee.am.repository.jdbc.common.dialect;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.repository.jdbc.provider.common.JSONMapper;
 import io.gravitee.am.repository.jdbc.exceptions.RepositoryInitializationException;
+import io.gravitee.am.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
 import org.springframework.data.r2dbc.dialect.R2dbcDialect;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
@@ -423,6 +424,55 @@ public abstract class AbstractDialectHelper implements DatabaseDialectHelper {
         return new StringBuilder("SELECT * FROM applications a WHERE ")
                 .append(" a.domain = :domain ")
                 .append(" AND a.settings_client_id = :clientId").toString();
+    }
+
+    @Override
+    public String buildSearchApplicationsQuery(boolean wildcard, ApplicationCriteria criteria, int page, int size, String sort, boolean asc) {
+        StringBuilder builder = new StringBuilder("SELECT * FROM applications a WHERE ");
+        return buildSearchApplicationsWithCriteria(wildcard, criteria, builder)
+                .append(buildPagingClause(sort, asc, page, size))
+                .toString();
+    }
+
+    @Override
+    public String buildCountApplicationsQuery(boolean wildcard, ApplicationCriteria criteria) {
+        StringBuilder builder = new StringBuilder("SELECT COUNT(DISTINCT a.id) FROM applications a WHERE ");
+        return buildSearchApplicationsWithCriteria(wildcard, criteria, builder).toString();
+    }
+
+    @Override
+    public String buildFindApplicationsByDomainAndCriteria(ApplicationCriteria criteria, int page, int size) {
+        StringBuilder builder = new StringBuilder("SELECT * FROM applications a WHERE a.domain = :domain");
+        appendCriteriaFilters(criteria, builder);
+        builder.append(buildPagingClause("updated_at", false, page, size));
+        return builder.toString();
+    }
+
+    @Override
+    public String buildCountApplicationsByDomainAndCriteria(ApplicationCriteria criteria) {
+        StringBuilder builder = new StringBuilder("SELECT COUNT(DISTINCT a.id) FROM applications a WHERE a.domain = :domain");
+        appendCriteriaFilters(criteria, builder);
+        return builder.toString();
+    }
+
+    protected StringBuilder buildSearchApplicationsWithCriteria(boolean wildcard, ApplicationCriteria criteria, StringBuilder builder) {
+        String escapeSuffix = wildcard ? getLikeEscapeClause() : "";
+        builder.append("a.domain = :domain");
+        appendCriteriaFilters(criteria, builder);
+        builder.append(" AND (")
+                .append(" upper(a.name) ").append(wildcard ? LIKE : "= ")
+                .append(VALUE)
+                .append(escapeSuffix)
+                .append(" OR upper(a.settings_client_id) ").append(wildcard ? LIKE : "= ")
+                .append(VALUE)
+                .append(escapeSuffix)
+                .append(" ) ");
+        return builder;
+    }
+
+    protected void appendCriteriaFilters(ApplicationCriteria criteria, StringBuilder builder) {
+        criteria.getApplicationIds().filter(ids -> !ids.isEmpty()).ifPresent(ids -> builder.append(" AND a.id IN (:applicationIds)"));
+        criteria.getEnabled().ifPresent(enabled -> builder.append(" AND a.enabled = :enabled"));
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/DatabaseDialectHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/DatabaseDialectHelper.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.jdbc.common.dialect;
 
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.r2dbc.core.DatabaseClient;
@@ -55,6 +56,14 @@ public interface DatabaseDialectHelper {
     String buildSearchApplicationsQuery(boolean wildcard, boolean withIds, int page, int size, String sort, boolean asc);
 
     String buildCountApplicationsQuery(boolean wildcard, boolean withIds);
+
+    String buildSearchApplicationsQuery(boolean wildcard, ApplicationCriteria criteria, int page, int size, String sort, boolean asc);
+
+    String buildCountApplicationsQuery(boolean wildcard, ApplicationCriteria criteria);
+
+    String buildFindApplicationsByDomainAndCriteria(ApplicationCriteria criteria, int page, int size);
+
+    String buildCountApplicationsByDomainAndCriteria(ApplicationCriteria criteria);
 
     String buildSearchProtectedResourceQuery(boolean wildcard, int page, int size, String sort, boolean asc);
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/PostgresqlHelper.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/common/dialect/PostgresqlHelper.java
@@ -17,6 +17,7 @@ package io.gravitee.am.repository.jdbc.common.dialect;
 
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.repository.jdbc.provider.common.JSONMapper;
+import io.gravitee.am.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
 import io.r2dbc.postgresql.codec.Json;
 import org.springframework.data.r2dbc.dialect.R2dbcDialect;
@@ -32,9 +33,8 @@ import java.util.Map;
  */
 public class PostgresqlHelper extends AbstractDialectHelper {
 
-    public static final String SQL_LIKE = "LIKE ";
     public static final String VALUE_PARAM = ":value";
-    public static final String SQL_LIKE_2 = "' like ";
+    public static final String LIKE_2 = "' like ";
     public static final String ARROW = " ->> '";
 
     public PostgresqlHelper(R2dbcDialect dialect, String collation) {
@@ -85,15 +85,15 @@ public class PostgresqlHelper extends AbstractDialectHelper {
                 queryBuilder.append(path[0] + " ? '" + path[1] + "'");
                 break;
             case "co":
-                queryBuilder.append(path[0] + ARROW + path[1] + SQL_LIKE_2 + bindValueName + " ");
+                queryBuilder.append(path[0] + ARROW + path[1] + LIKE_2 + bindValueName + " ");
                 search.addBinding(bindValueKey, "%" + value + "%");
                 break;
             case "sw":
-                queryBuilder.append(path[0] + ARROW + path[1] + SQL_LIKE_2 + bindValueName + " ");
+                queryBuilder.append(path[0] + ARROW + path[1] + LIKE_2 + bindValueName + " ");
                 search.addBinding(bindValueKey, value + "%");
                 break;
             case "ew":
-                queryBuilder.append(path[0] + ARROW + path[1] + SQL_LIKE_2 + bindValueName + " ");
+                queryBuilder.append(path[0] + ARROW + path[1] + LIKE_2 + bindValueName + " ");
                 search.addBinding(bindValueKey, "%" + value);
                 break;
             default:
@@ -109,17 +109,17 @@ public class PostgresqlHelper extends AbstractDialectHelper {
         return builder.append("u.reference_id = :refId")
                 .append(" AND u.reference_type = :refType")
                 .append(" AND (")
-                .append(" u.username ").append(wildcard ? SQL_LIKE : "= ")
+                .append(" u.username ").append(wildcard ? LIKE : "= ")
                 .append(VALUE_PARAM)
-                .append(" OR u.email ").append(wildcard ? SQL_LIKE : "= ")
+                .append(" OR u.email ").append(wildcard ? LIKE : "= ")
                 .append(VALUE_PARAM)
-                .append(" OR  u.additional_information->>email ").append(wildcard ? SQL_LIKE : "= ")
+                .append(" OR  u.additional_information->>email ").append(wildcard ? LIKE : "= ")
                 .append(VALUE_PARAM)
-                .append(" OR u.display_name ").append(wildcard ? SQL_LIKE : "= ")
+                .append(" OR u.display_name ").append(wildcard ? LIKE : "= ")
                 .append(VALUE_PARAM)
-                .append(" OR u.first_name ").append(wildcard ? SQL_LIKE : "= ")
+                .append(" OR u.first_name ").append(wildcard ? LIKE : "= ")
                 .append(VALUE_PARAM)
-                .append(" OR u.last_name ").append(wildcard ? SQL_LIKE : "= ")
+                .append(" OR u.last_name ").append(wildcard ? LIKE : "= ")
                 .append(VALUE_PARAM)
                 .append(" ) ");
     }
@@ -129,9 +129,9 @@ public class PostgresqlHelper extends AbstractDialectHelper {
         return builder.append("a.domain = :domain")
                 .append(withIds ? " AND a.id IN (:applicationIds)": "")
                 .append(" AND (")
-                .append(" upper(a.name) ").append(wildcard ? SQL_LIKE : "= ")
+                .append(" upper(a.name) ").append(wildcard ? LIKE : "= ")
                 .append(VALUE_PARAM)
-                .append(" OR upper(a.settings->'oauth'->>'clientId') ").append(wildcard ? SQL_LIKE : "= ")
+                .append(" OR upper(a.settings->'oauth'->>'clientId') ").append(wildcard ? LIKE : "= ")
                 .append(VALUE_PARAM)
                 .append(" ) ");
     }
@@ -169,5 +169,21 @@ public class PostgresqlHelper extends AbstractDialectHelper {
     @Override
     public String buildAuthorizationCodeDeleteAndReturnQuery() {
         return "DELETE FROM authorization_codes c where c.code = :code and c.client_id = :clientId and (c.expire_at > :now or c.expire_at is null) RETURNING *";
+    }
+
+
+    protected StringBuilder buildSearchApplicationsWithCriteria(boolean wildcard, ApplicationCriteria criteria, StringBuilder builder) {
+        String escapeSuffix = wildcard ? getLikeEscapeClause() : "";
+        builder.append("a.domain = :domain");
+        appendCriteriaFilters(criteria, builder);
+        builder.append(" AND (")
+                .append(" upper(a.name) ").append(wildcard ? LIKE : "= ")
+                .append(VALUE)
+                .append(escapeSuffix)
+                .append(" OR upper(a.settings->'oauth'->>'clientId') ").append(wildcard ? LIKE : "= ")
+                .append(VALUE)
+                .append(escapeSuffix)
+                .append(" ) ");
+        return builder;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.am.model.application.ClientSecret;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.idp.ApplicationIdentityProvider;
 import io.gravitee.am.repository.jdbc.management.AbstractJdbcRepository;
+import io.gravitee.am.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.am.repository.jdbc.management.api.model.JdbcApplication;
 import io.gravitee.am.repository.jdbc.management.api.model.JdbcApplication.Identity;
 import io.gravitee.am.repository.jdbc.management.api.spring.application.SpringApplicationClientSecretRepository;
@@ -292,6 +293,84 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
                         .map((row, rowMetadata) -> row.get(0, Long.class)).first())
                         .map(total -> new Page<Application>(data, page, total)))
                 .doOnError(error -> LOGGER.error("Unable to retrieve all applications with domain {} (page={}/size={})", domain, page, size, error));
+    }
+
+    @Override
+    public Single<Page<Application>> findByDomain(String domain, ApplicationCriteria criteria, int page, int size) {
+        LOGGER.debug("findByDomain({}, criteria, {}, {})", domain, page, size);
+
+        if (skipSearchDueToEmptyAppIds(criteria)) {
+            return Single.just(new Page<>(Collections.emptyList(), page, 0));
+        }
+
+        String search = databaseDialectHelper.buildFindApplicationsByDomainAndCriteria(criteria, page, size);
+        String count = databaseDialectHelper.buildCountApplicationsByDomainAndCriteria(criteria);
+
+        final var searchSpec = bindCriteriaParams(
+                getTemplate().getDatabaseClient().sql(search).bind(COL_DOMAIN, domain), criteria);
+        final var countSpec = bindCriteriaParams(
+                getTemplate().getDatabaseClient().sql(count).bind(COL_DOMAIN, domain), criteria);
+
+        return fluxToFlowable(searchSpec
+                .map((row, rowMetadata) -> rowMapper.read(JdbcApplication.class, row))
+                .all()).map(this::toEntity)
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .toList()
+                .flatMap(data -> monoToSingle(countSpec
+                        .map((row, rowMetadata) -> row.get(0, Long.class)).first())
+                        .map(total -> new Page<>(data, page, total)))
+                .doOnError(error -> LOGGER.error("Unable to retrieve applications with domain {} and criteria (page={}/size={})", domain, page, size, error))
+                .observeOn(Schedulers.computation());
+    }
+
+    private static boolean skipSearchDueToEmptyAppIds(ApplicationCriteria criteria) {
+        return criteria.getApplicationIds().isPresent() && criteria.getApplicationIds().get().isEmpty();
+    }
+
+    @Override
+    public Single<Page<Application>> search(String domain, ApplicationCriteria criteria, String query, int page, int size) {
+        LOGGER.debug("search({}, criteria, {}, {}, {})", domain, query, page, size);
+
+        if (skipSearchDueToEmptyAppIds(criteria)) {
+            return Single.just(new Page<>(Collections.emptyList(), page, 0));
+        }
+
+        boolean wildcardMatch = query.contains("*");
+        String wildcardQuery = query.replaceAll("\\*+", "%");
+        String escapedQuery = databaseDialectHelper.escapeLikePatternValue(wildcardMatch ? wildcardQuery : query);
+
+        String search = databaseDialectHelper.buildSearchApplicationsQuery(wildcardMatch, criteria, page, size, COL_UPDATED_AT, false);
+        String count = databaseDialectHelper.buildCountApplicationsQuery(wildcardMatch, criteria);
+
+        final var searchSpec = bindCriteriaParams(
+                getTemplate().getDatabaseClient().sql(search)
+                        .bind(COL_DOMAIN, domain)
+                        .bind("value", escapedQuery.toUpperCase()), criteria);
+        final var countSpec = bindCriteriaParams(
+                getTemplate().getDatabaseClient().sql(count)
+                        .bind(COL_DOMAIN, domain)
+                        .bind("value", escapedQuery.toUpperCase()), criteria);
+
+        return fluxToFlowable(searchSpec
+                .map((row, rowMetadata) -> rowMapper.read(JdbcApplication.class, row))
+                .all())
+                .map(this::toEntity)
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .toList()
+                .flatMap(data -> monoToSingle(countSpec
+                        .map((row, rowMetadata) -> row.get(0, Long.class)).first())
+                        .map(total -> new Page<>(data, page, total)))
+                .doOnError(error -> LOGGER.error("Unable to search applications with domain {} and criteria (page={}/size={})", domain, page, size, error));
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindCriteriaParams(DatabaseClient.GenericExecuteSpec spec, ApplicationCriteria criteria) {
+        if (criteria.getApplicationIds().filter(ids -> !ids.isEmpty()).isPresent()) {
+            spec = spec.bind("applicationIds", criteria.getApplicationIds().get());
+        }
+        if (criteria.getEnabled().isPresent()) {
+            spec = spec.bind("enabled", criteria.getEnabled().get());
+        }
+        return spec;
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcMembershipRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcMembershipRepository.java
@@ -116,7 +116,8 @@ public class JdbcMembershipRepository extends AbstractJdbcRepository implements 
         }
 
         if (criteria.getRoleId().isPresent()) {
-            userClause = where("role_id").is(criteria.getRoleId().get());
+            Criteria roleClause = where("role_id").is(criteria.getRoleId().get());
+            userClause = criteria.getUserId().isPresent() ? userClause.and(roleClause) : roleClause;
         }
 
         whereClause = whereClause.and(referenceClause.and(criteria.isLogicalOR() ? userClause.or(groupClause) : userClause.and(groupClause)));
@@ -147,7 +148,8 @@ public class JdbcMembershipRepository extends AbstractJdbcRepository implements 
         }
 
         if (criteria.getRoleId().isPresent()) {
-            userClause = where("role_id").is(criteria.getRoleId().get());
+            Criteria roleClause = where("role_id").is(criteria.getRoleId().get());
+            userClause = criteria.getUserId().isPresent() ? userClause.and(roleClause) : roleClause;
         }
 
         whereClause = whereClause.and(referenceClause.and(criteria.isLogicalOR() ? userClause.or(groupClause) : userClause.and(groupClause)));

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcOrganizationUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcOrganizationUserRepository.java
@@ -346,6 +346,21 @@ public class JdbcOrganizationUserRepository extends AbstractJdbcRepository imple
     }
 
     @Override
+    public Flowable<User> findByEmail(String organizationId, String email) {
+        LOGGER.debug("findByEmail({}, {})", organizationId, email);
+        return fluxToFlowable(getTemplate().getDatabaseClient()
+                .sql(databaseDialectHelper.buildFindUserByReferenceAndEmail(ReferenceType.ORGANIZATION, organizationId, email, true))
+                .bind(REF_ID, organizationId)
+                .bind(REF_TYPE, ReferenceType.ORGANIZATION.name())
+                .bind("email", email)
+                .map((row, rowMetadata) -> rowMapper.read(JdbcOrganizationUser.class, row))
+                .all())
+                .map(this::toEntity)
+                .concatMap(user -> completeUser(user).toFlowable())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
     public Maybe<User> findByUsernameAndSource(ReferenceType referenceType, String referenceId, String username, String source) {
         LOGGER.debug("findByUsernameAndSource({},{},{},{})", referenceType, referenceId, username, source);
         return userRepository.findByUsernameAndSource(referenceType.name(), referenceId, username, source)

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -49,6 +49,7 @@ import io.gravitee.am.model.jose.RSAKey;
 import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.repository.management.api.ApplicationRepository;
+import io.gravitee.am.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.am.repository.mongodb.management.internal.model.AccountSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.ApplicationAdvancedSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.ApplicationIdentityProviderMongo;
@@ -106,6 +107,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -116,6 +118,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
     private static final String FIELD_CLIENT_ID = "settings.oauth.clientId";
     private static final String FIELD_APPLICATION_IDENTITY_PROVIDERS = "identityProviders";
     private static final String FIELD_IDENTITY = "identity";
+    private static final String FIELD_ENABLED = "enabled";
     // Kept for retro-compatibility
     private static final String FIELD_IDENTITIES = "identities";
     private static final String FIELD_FACTORS = "factors";
@@ -337,6 +340,36 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
     public Single<Long> countByDomain(String domain) {
         return Single.fromPublisher(applicationsCollection.countDocuments(eq(FIELD_DOMAIN, domain), countOptions()))
                 .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<Page<Application>> findByDomain(String domain, ApplicationCriteria criteria, int page, int size) {
+        Bson query = buildCriteriaQuery(domain, criteria);
+        return queryApplications(query, page, size).observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<Page<Application>> search(String domain, ApplicationCriteria criteria, String query, int page, int size) {
+        Bson textQuery = buildSearchQuery(query, domain, FIELD_DOMAIN, FIELD_CLIENT_ID);
+        List<Bson> criteriaFilters = buildCriteriaFilters(criteria);
+        Bson mongoQuery = criteriaFilters.isEmpty() ? textQuery : and(textQuery, and(criteriaFilters));
+        boolean useCollation = !isWildcardQuery(query);
+        return findPage(applicationsCollection, mongoQuery, page, size, MongoApplicationRepository::convert, useCollation)
+                .observeOn(Schedulers.computation());
+    }
+
+    private Bson buildCriteriaQuery(String domain, ApplicationCriteria criteria) {
+        List<Bson> filters = new ArrayList<>();
+        filters.add(eq(FIELD_DOMAIN, domain));
+        filters.addAll(buildCriteriaFilters(criteria));
+        return filters.size() == 1 ? filters.get(0) : and(filters);
+    }
+
+    private List<Bson> buildCriteriaFilters(ApplicationCriteria criteria) {
+        List<Bson> filters = new ArrayList<>();
+        criteria.getEnabled().ifPresent(enabled -> filters.add(eq(FIELD_ENABLED, enabled)));
+        criteria.getApplicationIds().ifPresent(ids -> filters.add(in(FIELD_ID, ids)));
+        return filters;
     }
 
     private ApplicationMongo convert(Application other) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoMembershipRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoMembershipRepository.java
@@ -123,7 +123,8 @@ public class MongoMembershipRepository extends AbstractManagementMongoRepository
         }
 
         if (criteria.getRoleId().isPresent()) {
-            eqUserId = eq(FIELD_ROLE, criteria.getRoleId().get());
+            Bson roleFilter = eq(FIELD_ROLE, criteria.getRoleId().get());
+            eqUserId = eqUserId != null ? and(eqUserId, roleFilter) : roleFilter;
         }
 
         return toBsonFilter(criteria.isLogicalOR(), eqGroupId, eqUserId)

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoOrganizationUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoOrganizationUserRepository.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.am.repository.mongodb.management;
 
+import com.mongodb.BasicDBObject;
 import com.mongodb.client.model.Updates;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.User;
 import io.gravitee.am.repository.management.api.OrganizationUserRepository;
 import io.gravitee.am.repository.mongodb.management.internal.model.OrganizationUserMongo;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -32,6 +34,7 @@ import java.util.regex.Pattern;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Filters.regex;
 
 /**
@@ -83,6 +86,16 @@ public class MongoOrganizationUserRepository extends AbstractUserRepository<Orga
             updates.add(Updates.set("password", item.getPassword()));
         }
         return updates;
+    }
+
+    @Override
+    public Flowable<User> findByEmail(String organizationId, String email) {
+        Bson mongoQuery = and(
+                eq(FIELD_REFERENCE_TYPE, ReferenceType.ORGANIZATION.name()),
+                eq(FIELD_REFERENCE_ID, organizationId),
+                or(new BasicDBObject(FIELD_EMAIL, email), new BasicDBObject(FIELD_ADDITIONAL_INFO_EMAIL, email)));
+        return Flowable.fromPublisher(usersCollection.find(mongoQuery)).map(this::convert)
+                .observeOn(Schedulers.computation());
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryCriteriaTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryCriteriaTest.java
@@ -1,0 +1,280 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.management.api;
+
+import io.gravitee.am.model.Application;
+import io.gravitee.am.model.application.ApplicationOAuthSettings;
+import io.gravitee.am.model.application.ApplicationSettings;
+import io.gravitee.am.model.common.Page;
+import io.gravitee.am.repository.management.AbstractManagementTest;
+import io.gravitee.am.repository.management.api.search.ApplicationCriteria;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for the criteria-based application query methods:
+ * {@link ApplicationRepository#findByDomain(String, ApplicationCriteria, int, int)} and
+ * {@link ApplicationRepository#search(String, ApplicationCriteria, String, int, int)}.
+ *
+ * @author GraviteeSource Team
+ */
+public class ApplicationRepositoryCriteriaTest extends AbstractManagementTest {
+
+    @Autowired
+    private ApplicationRepository applicationRepository;
+
+    // -------------------------------------------------------------------------
+    // findByDomain with ApplicationCriteria
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void findByDomain_criteria_emptyFilters_returnsAll() {
+        String domain = "crit-domain-" + UUID.randomUUID();
+        createApp(domain, "app1", true, "clientA");
+        createApp(domain, "app2", false, "clientB");
+
+        ApplicationCriteria criteria = new ApplicationCriteria();
+
+        TestObserver<Page<Application>> observer = applicationRepository.findByDomain(domain, criteria, 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 2 && page.getData().size() == 2);
+    }
+
+    @Test
+    public void findByDomain_criteria_filterByEnabled_returnsOnlyEnabled() {
+        String domain = "crit-enabled-" + UUID.randomUUID();
+        createApp(domain, "enabledApp", true, "clientEn");
+        createApp(domain, "disabledApp", false, "clientDis");
+
+        ApplicationCriteria criteria = new ApplicationCriteria().setEnabled(true);
+
+        TestObserver<Page<Application>> observer = applicationRepository.findByDomain(domain, criteria, 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 1
+                && page.getData().stream().allMatch(Application::isEnabled));
+    }
+
+    @Test
+    public void findByDomain_criteria_filterByDisabled_returnsOnlyDisabled() {
+        String domain = "crit-disabled-" + UUID.randomUUID();
+        createApp(domain, "enabledApp2", true, "clientEn2");
+        createApp(domain, "disabledApp2", false, "clientDis2");
+
+        ApplicationCriteria criteria = new ApplicationCriteria().setEnabled(false);
+
+        TestObserver<Page<Application>> observer = applicationRepository.findByDomain(domain, criteria, 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 1
+                && page.getData().stream().noneMatch(Application::isEnabled));
+    }
+
+    @Test
+    public void findByDomain_criteria_filterByApplicationIds_returnsMatchingApps() {
+        String domain = "crit-ids-" + UUID.randomUUID();
+        Application a = createApp(domain, "appX", true, "clientX");
+        createApp(domain, "appY", true, "clientY");
+
+        ApplicationCriteria criteria = new ApplicationCriteria().setApplicationIds(List.of(a.getId()));
+
+        TestObserver<Page<Application>> observer = applicationRepository.findByDomain(domain, criteria, 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 1
+                && page.getData().iterator().next().getId().equals(a.getId()));
+    }
+
+    @Test
+    public void findByDomain_criteria_filterByEmptyApplicationIds_returnsNoApps() {
+        String domain = "crit-empty-ids-" + UUID.randomUUID();
+        createApp(domain, "appZ", true, "clientZ");
+
+        ApplicationCriteria criteria = new ApplicationCriteria().setApplicationIds(List.of());
+
+        TestObserver<Page<Application>> observer = applicationRepository.findByDomain(domain, criteria, 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 0 && page.getData().isEmpty());
+    }
+
+    @Test
+    public void findByDomain_criteria_combinedFilters_enabledAndApplicationIds() {
+        String domain = "crit-combo-" + UUID.randomUUID();
+        Application enabledA = createApp(domain, "enabledA", true, "clientEA");
+        Application disabledB = createApp(domain, "disabledB", false, "clientDB");
+
+        // restrict to both IDs but filter by enabled=true
+        ApplicationCriteria criteria = new ApplicationCriteria()
+                .setApplicationIds(List.of(enabledA.getId(), disabledB.getId()))
+                .setEnabled(true);
+
+        TestObserver<Page<Application>> observer = applicationRepository.findByDomain(domain, criteria, 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 1
+                && page.getData().iterator().next().getId().equals(enabledA.getId()));
+    }
+
+    @Test
+    public void findByDomain_criteria_pagination_respectsPageAndSize() {
+        String domain = "crit-page-" + UUID.randomUUID();
+        createApp(domain, "p1", true, "cP1");
+        createApp(domain, "p2", true, "cP2");
+        createApp(domain, "p3", true, "cP3");
+
+        ApplicationCriteria criteria = new ApplicationCriteria().setEnabled(true);
+
+        TestObserver<Page<Application>> page0 = applicationRepository.findByDomain(domain, criteria, 0, 2).test();
+        page0.awaitDone(10, TimeUnit.SECONDS);
+        page0.assertComplete();
+        page0.assertNoErrors();
+        page0.assertValue(page -> page.getTotalCount() == 3 && page.getData().size() == 2);
+
+        TestObserver<Page<Application>> page1 = applicationRepository.findByDomain(domain, criteria, 1, 2).test();
+        page1.awaitDone(10, TimeUnit.SECONDS);
+        page1.assertComplete();
+        page1.assertNoErrors();
+        page1.assertValue(page -> page.getTotalCount() == 3 && page.getData().size() == 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // search with ApplicationCriteria
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void search_criteria_noFilters_matchesQuery() {
+        String domain = "crit-search-" + UUID.randomUUID();
+        createApp(domain, "searchMe", true, "clientSM");
+        createApp(domain, "other", true, "clientO");
+
+        ApplicationCriteria criteria = new ApplicationCriteria();
+
+        TestObserver<Page<Application>> observer = applicationRepository.search(domain, criteria, "searchMe", 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 1
+                && page.getData().iterator().next().getName().equals("searchMe"));
+    }
+
+    @Test
+    public void search_criteria_filterByEnabled_narrowsResults() {
+        String domain = "crit-search-en-" + UUID.randomUUID();
+        createApp(domain, "targetEnabled", true, "clientTE");
+        createApp(domain, "targetDisabled", false, "clientTD");
+
+        ApplicationCriteria criteria = new ApplicationCriteria().setEnabled(true);
+
+        TestObserver<Page<Application>> observer = applicationRepository.search(domain, criteria, "target*", 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 1
+                && page.getData().stream().allMatch(Application::isEnabled));
+    }
+
+    @Test
+    public void search_criteria_filterByApplicationIds_narrowsResults() {
+        String domain = "crit-search-ids-" + UUID.randomUUID();
+        Application included = createApp(domain, "included", true, "clientInc");
+        createApp(domain, "excluded", true, "clientExc");
+
+        ApplicationCriteria criteria = new ApplicationCriteria()
+                .setApplicationIds(List.of(included.getId()));
+
+        TestObserver<Page<Application>> observer = applicationRepository.search(domain, criteria, "inc*", 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 1
+                && page.getData().iterator().next().getId().equals(included.getId()));
+    }
+
+    @Test
+    public void search_criteria_emptyApplicationIds_returnsEmpty() {
+        String domain = "crit-search-empty-" + UUID.randomUUID();
+        createApp(domain, "anyApp", true, "clientAny");
+
+        ApplicationCriteria criteria = new ApplicationCriteria().setApplicationIds(List.of());
+
+        TestObserver<Page<Application>> observer = applicationRepository.search(domain, criteria, "any*", 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 0 && page.getData().isEmpty());
+    }
+
+    @Test
+    public void search_criteria_combinedEnabledAndIds() {
+        String domain = "crit-search-combo-" + UUID.randomUUID();
+        Application enabledApp = createApp(domain, "comboEnabled", true, "clientCE");
+        Application disabledApp = createApp(domain, "comboDisabled", false, "clientCD");
+
+        ApplicationCriteria criteria = new ApplicationCriteria()
+                .setApplicationIds(List.of(enabledApp.getId(), disabledApp.getId()))
+                .setEnabled(true);
+
+        TestObserver<Page<Application>> observer = applicationRepository.search(domain, criteria, "combo*", 0, 10).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(page -> page.getTotalCount() == 1
+                && page.getData().iterator().next().getId().equals(enabledApp.getId()));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private Application createApp(String domain, String name, boolean enabled, String clientId) {
+        Application app = new Application();
+        app.setDomain(domain);
+        app.setName(name);
+        app.setEnabled(enabled);
+
+        ApplicationSettings settings = new ApplicationSettings();
+        ApplicationOAuthSettings oauth = new ApplicationOAuthSettings();
+        oauth.setClientId(clientId);
+        settings.setOauth(oauth);
+        app.setSettings(settings);
+
+        return applicationRepository.create(app).blockingGet();
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/MembershipRepositoryCriteriaTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/MembershipRepositoryCriteriaTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.management.api;
+
+import io.gravitee.am.model.Membership;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.membership.MemberType;
+import io.gravitee.am.repository.management.AbstractManagementTest;
+import io.gravitee.am.repository.management.api.search.MembershipCriteria;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for the AND combination of userId + roleId in {@link MembershipCriteria}.
+ *
+ * Covers both {@link MembershipRepository#findByCriteria(ReferenceType, String, MembershipCriteria)}
+ * and {@link MembershipRepository#findByCriteria(ReferenceType, MembershipCriteria)}.
+ *
+ * @author GraviteeSource Team
+ */
+public class MembershipRepositoryCriteriaTest extends AbstractManagementTest {
+
+    @Autowired
+    private MembershipRepository membershipRepository;
+
+    // -------------------------------------------------------------------------
+    // findByCriteria(referenceType, referenceId, criteria)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void findByCriteria_withReferenceId_userIdAndRoleId_returnsMatch() {
+        String refId = "ref-and-" + UUID.randomUUID();
+        String userId = "user-" + UUID.randomUUID();
+        String roleId = "role-" + UUID.randomUUID();
+        String otherRoleId = "role-other-" + UUID.randomUUID();
+
+        create(refId, userId, MemberType.USER, roleId);
+        create(refId, userId, MemberType.USER, otherRoleId);  // same user, different role
+
+        MembershipCriteria criteria = new MembershipCriteria(userId).setRoleId(roleId);
+        TestSubscriber<Membership> obs = membershipRepository.findByCriteria(ReferenceType.APPLICATION, refId, criteria).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValueCount(1);
+        obs.assertValue(m -> roleId.equals(m.getRoleId()) && userId.equals(m.getMemberId()));
+    }
+
+    @Test
+    public void findByCriteria_withReferenceId_userIdAndRoleId_noMatch_wrongRole() {
+        String refId = "ref-nomatch-" + UUID.randomUUID();
+        String userId = "user-" + UUID.randomUUID();
+        String roleId = "role-" + UUID.randomUUID();
+        String otherRoleId = "role-other-" + UUID.randomUUID();
+
+        create(refId, userId, MemberType.USER, otherRoleId);  // user exists but with a different role
+
+        MembershipCriteria criteria = new MembershipCriteria(userId).setRoleId(roleId);
+        TestSubscriber<Membership> obs = membershipRepository.findByCriteria(ReferenceType.APPLICATION, refId, criteria).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValueCount(0);
+    }
+
+    @Test
+    public void findByCriteria_withReferenceId_userIdAndRoleId_noMatch_wrongUser() {
+        String refId = "ref-wronguser-" + UUID.randomUUID();
+        String userId = "user-" + UUID.randomUUID();
+        String otherUserId = "user-other-" + UUID.randomUUID();
+        String roleId = "role-" + UUID.randomUUID();
+
+        create(refId, otherUserId, MemberType.USER, roleId);  // role matches but user differs
+
+        MembershipCriteria criteria = new MembershipCriteria(userId).setRoleId(roleId);
+        TestSubscriber<Membership> obs = membershipRepository.findByCriteria(ReferenceType.APPLICATION, refId, criteria).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValueCount(0);
+    }
+
+    @Test
+    public void findByCriteria_withReferenceId_roleIdOnly_returnsAllWithRole() {
+        String refId = "ref-roleid-" + UUID.randomUUID();
+        String userId1 = "user-a-" + UUID.randomUUID();
+        String userId2 = "user-b-" + UUID.randomUUID();
+        String roleId = "role-" + UUID.randomUUID();
+
+        create(refId, userId1, MemberType.USER, roleId);
+        create(refId, userId2, MemberType.USER, roleId);
+
+        MembershipCriteria criteria = new MembershipCriteria().setRoleId(roleId);
+        TestSubscriber<Membership> obs = membershipRepository.findByCriteria(ReferenceType.APPLICATION, refId, criteria).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValueCount(2);
+    }
+
+    @Test
+    public void findByCriteria_withReferenceId_userIdOnly_returnsAllRolesForUser() {
+        String refId = "ref-userid-" + UUID.randomUUID();
+        String userId = "user-" + UUID.randomUUID();
+        String roleId1 = "role-1-" + UUID.randomUUID();
+        String roleId2 = "role-2-" + UUID.randomUUID();
+
+        create(refId, userId, MemberType.USER, roleId1);
+        create(refId, userId, MemberType.USER, roleId2);
+
+        MembershipCriteria criteria = new MembershipCriteria(userId);
+        TestSubscriber<Membership> obs = membershipRepository.findByCriteria(ReferenceType.APPLICATION, refId, criteria).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValueCount(2);
+    }
+
+    // -------------------------------------------------------------------------
+    // findByCriteria(referenceType, criteria) — no referenceId scoping
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void findByCriteria_noReferenceId_userIdAndRoleId_returnsOnlyMatchAcrossRefs() {
+        String refId1 = "ref-multi-a-" + UUID.randomUUID();
+        String refId2 = "ref-multi-b-" + UUID.randomUUID();
+        String userId = "user-" + UUID.randomUUID();
+        String roleId = "role-" + UUID.randomUUID();
+        String otherRoleId = "role-other-" + UUID.randomUUID();
+
+        create(refId1, userId, MemberType.USER, roleId);       // should match
+        create(refId2, userId, MemberType.USER, otherRoleId);  // same user, wrong role
+
+        MembershipCriteria criteria = new MembershipCriteria(userId).setRoleId(roleId);
+        TestSubscriber<Membership> obs = membershipRepository.findByCriteria(ReferenceType.APPLICATION, criteria).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValueCount(1);
+        obs.assertValue(m -> roleId.equals(m.getRoleId()) && userId.equals(m.getMemberId()) && refId1.equals(m.getReferenceId()));
+    }
+
+    @Test
+    public void findByCriteria_noReferenceId_userIdAndRoleId_multipleRefs_allMatch() {
+        String refId1 = "ref-all-a-" + UUID.randomUUID();
+        String refId2 = "ref-all-b-" + UUID.randomUUID();
+        String refId3 = "ref-all-c-" + UUID.randomUUID();
+        String userId = "user-" + UUID.randomUUID();
+        String roleId = "role-" + UUID.randomUUID();
+        String otherRoleId = "role-" + UUID.randomUUID();
+
+        create(refId1, userId, MemberType.USER, roleId);
+        create(refId2, userId, MemberType.USER, roleId);
+        create(refId3, userId, MemberType.USER, otherRoleId);
+
+        MembershipCriteria criteria = new MembershipCriteria(userId).setRoleId(roleId);
+        TestSubscriber<Membership> obs = membershipRepository.findByCriteria(ReferenceType.APPLICATION, criteria).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValueCount(2);
+        obs.values().forEach( m ->
+            Assert.assertTrue(refId1.equals(m.getReferenceId()) || refId2.equals(m.getReferenceId()))
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // helper
+    // -------------------------------------------------------------------------
+
+    private Membership create(String referenceId, String memberId, MemberType memberType, String roleId) {
+        Membership m = new Membership();
+        m.setReferenceType(ReferenceType.APPLICATION);
+        m.setReferenceId(referenceId);
+        m.setMemberType(memberType);
+        m.setMemberId(memberId);
+        m.setRoleId(roleId);
+        return membershipRepository.create(m).blockingGet();
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/ApplicationService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/ApplicationService.java
@@ -20,6 +20,7 @@ import io.gravitee.am.model.Application;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.common.Page;
+import io.gravitee.am.service.model.ApplicationFilter;
 import io.gravitee.am.service.model.NewApplication;
 import io.gravitee.am.service.model.NewCimdApplication;
 import io.gravitee.am.service.model.PatchApplication;
@@ -51,6 +52,10 @@ public interface ApplicationService {
     Single<Page<Application>> search(String domain, String query, int page, int size);
 
     Single<Page<Application>> search(String domain, List<String> applicationIds, String query, int page, int size);
+
+    Single<Page<Application>> findByDomain(String domain, String organizationId, ApplicationFilter filter, int page, int size);
+
+    Single<Page<Application>> search(String domain, String organizationId, ApplicationFilter filter, String query, int page, int size);
 
     Flowable<Application> findByCertificate(String certificate);
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -44,8 +44,11 @@ import io.gravitee.am.model.common.event.Event;
 import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.model.membership.MemberType;
 import io.gravitee.am.model.permissions.SystemRole;
-import io.gravitee.am.model.idp.ApplicationIdentityProvider;
 import io.gravitee.am.repository.management.api.ApplicationRepository;
+import io.gravitee.am.repository.management.api.OrganizationUserRepository;
+import io.gravitee.am.repository.management.api.search.ApplicationCriteria;
+import io.gravitee.am.repository.management.api.search.MembershipCriteria;
+import io.gravitee.am.service.model.ApplicationFilter;
 import io.gravitee.am.service.ApplicationService;
 import io.gravitee.am.service.CimdMetadataDocumentService;
 import io.gravitee.am.service.model.CimdClientMetadata;
@@ -157,6 +160,10 @@ public class ApplicationServiceImpl implements ApplicationService {
     @Autowired
     private ApplicationTemplateManager applicationTemplateManager;
 
+    @Lazy
+    @Autowired
+    private OrganizationUserRepository organizationUserRepository;
+
     @Autowired
     private AccountSettingsValidator accountSettingsValidator;
 
@@ -257,6 +264,70 @@ public class ApplicationServiceImpl implements ApplicationService {
                     return Single.error(new TechnicalManagementException(
                             String.format("An error occurs while trying to search applications with query %s by domain %s", query, domain), ex));
                 });
+    }
+
+    @Override
+    public Single<Page<Application>> findByDomain(String domain, String organizationId, ApplicationFilter filter, int page, int size) {
+        LOGGER.debug("Find applications by domain {} with filter", domain);
+        return buildCriteria(filter, organizationId)
+                .flatMap(criteria ->applicationRepository.findByDomain(domain, criteria, page, size))
+                .onErrorResumeNext(ex -> {
+                    LOGGER.error("An error occurs while trying to find applications by domain {} with filter", domain, ex);
+                    return Single.error(new TechnicalManagementException(
+                            String.format("An error occurs while trying to find applications by domain %s with filter", domain), ex));
+                });
+    }
+
+    @Override
+    public Single<Page<Application>> search(String domain, String organizationId, ApplicationFilter filter, String query, int page, int size) {
+        LOGGER.debug("Search applications with query {} for domain {} with filter", query, domain);
+        return buildCriteria(filter, organizationId)
+                .flatMap(criteria -> applicationRepository.search(domain, criteria, query, page, size))
+                .onErrorResumeNext(ex -> {
+                    LOGGER.error("An error occurs while trying to search applications with query {} for domain {} with filter", query, domain, ex);
+                    return Single.error(new TechnicalManagementException(
+                            String.format("An error occurs while trying to search applications with query %s for domain %s with filter", query, domain), ex));
+                });
+    }
+
+    private Single<ApplicationCriteria> buildCriteria(ApplicationFilter filter, String organizationId) {
+        ApplicationCriteria criteria = new ApplicationCriteria();
+
+        if (filter.hasStatusFilter()) {
+            criteria.setEnabled(ApplicationFilter.STATUS_ENABLED.equalsIgnoreCase(filter.status()));
+        }
+
+        if (!filter.hasOwnerEmailFilter()) {
+            if (filter.hasPermissionScopedIds()) {
+                criteria.setApplicationIds(filter.permissionScopedIds());
+            }
+            return Single.just(criteria);
+        }
+
+        return retrieveOwnerApplicationIds(filter, organizationId)
+                .map(ids -> {
+                    List<String> finalIds = filter.hasPermissionScopedIds()
+                            ? ids.stream().filter(filter.permissionScopedIds()::contains).collect(Collectors.toList())
+                            : ids;
+                    criteria.setApplicationIds(finalIds);
+                    return criteria;
+                }).switchIfEmpty(Single.fromCallable(() -> {
+                    criteria.setApplicationIds(List.of());
+                    return criteria;
+                }));
+    }
+
+    private Maybe<List<String>> retrieveOwnerApplicationIds(ApplicationFilter filter, String organizationId) {
+        return organizationUserRepository.findByEmail(organizationId, filter.ownerEmail())
+                .firstElement()
+                .flatMap(user ->
+                        roleService.findSystemRole(SystemRole.APPLICATION_PRIMARY_OWNER, ReferenceType.APPLICATION)
+                                .flatMap(role -> membershipService
+                                        .findByCriteria(ReferenceType.APPLICATION, new MembershipCriteria(user.getId()).setRoleId(role.getId()))
+                                        .map(Membership::getReferenceId)
+                                        .toList()
+                                        .toMaybe())
+                );
     }
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/ApplicationFilter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/ApplicationFilter.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.model;
+
+import java.util.List;
+
+/**
+ * Raw filter parameters for application list/search endpoints.
+ * Resolution of ownerEmail into application IDs is performed by the service layer.
+ * <p>
+ * {@code permissionScopedIds} — when non-null, the result is restricted to this set of
+ * application IDs (derived from the caller's READ permissions). The service intersects
+ * this with any owner-resolved IDs so the final query always respects both constraints.
+ *
+ * @author GraviteeSource Team
+ */
+public record ApplicationFilter(String status, String ownerEmail, List<String> permissionScopedIds) {
+
+    public static final String STATUS_ENABLED = "enabled";
+    public static final String STATUS_DISABLED = "disabled";
+
+    public ApplicationFilter(String status, String ownerEmail) {
+        this(status, ownerEmail, null);
+    }
+
+    public boolean hasStatusFilter() {
+        return status != null && !status.isBlank();
+    }
+
+    public boolean hasOwnerEmailFilter() {
+        return ownerEmail != null && !ownerEmail.isBlank();
+    }
+
+    public boolean hasPermissionScopedIds() {
+        return permissionScopedIds != null;
+    }
+
+    public static ApplicationFilter empty() {
+        return new ApplicationFilter(null, null, null);
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ApplicationServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ApplicationServiceTest.java
@@ -267,7 +267,7 @@ public class ApplicationServiceTest {
 
     @Test
     public void shouldFindByDomainAndApplicationIds() {
-        when(applicationRepository.findByDomain(eq(DOMAIN.getId()), any(), eq(0), eq(10)))
+        when(applicationRepository.findByDomain(eq(DOMAIN.getId()), any(List.class), eq(0), eq(10)))
                 .thenReturn(Single.just(new Page<>(Collections.singleton(new Application()), 0, 1)));
         TestObserver<Page<Application>> testObserver = applicationService.findByDomain(DOMAIN.getId(), List.of("id1"),0, 10).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
@@ -279,7 +279,7 @@ public class ApplicationServiceTest {
 
     @Test
     public void shouldSearchByDomainAndApplicationIds() {
-        when(applicationRepository.search(eq(DOMAIN.getId()), any(), eq("query"), eq(0), eq(10)))
+        when(applicationRepository.search(eq(DOMAIN.getId()), any(List.class), eq("query"), eq(0), eq(10)))
                 .thenReturn(Single.just(new Page<>(Collections.singleton(new Application()), 0, 1)));
         TestObserver<Page<Application>> testObserver = applicationService.search(DOMAIN.getId(), List.of("id1"), "query", 0, 10).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);


### PR DESCRIPTION
…list endpoint

Introduce backend filtering for the application list/search API:
- New `status` query parameter filters by enabled/disabled state
- New `owner.email` query parameter filters by primary owner email; requires ORGANIZATION_USER[READ] permission on the caller
- Filters combine with AND logic and are additive over pagination/search
- Resolution of owner email to application IDs is performed in the service layer via OrganizationUserRepository and MembershipService
- Permission-scoped application IDs (callers with per-app READ only) are intersected with owner-resolved IDs in the service layer

Repository changes:
- New ApplicationCriteria carries enabled and applicationIds filters
- ApplicationRepository gains two new criteria-based query methods implemented for both MongoDB and JDBC
- OrganizationUserRepository gains findByEmail, implemented for both MongoDB and JDBC
- Fix MembershipCriteria AND logic: setting both userId and roleId now produces member_id = :u AND role_id = :r instead of roleId silently overwriting the userId filter (no existing caller used both together)

fixes AM-6978