### PR TITLE
fix: SCIM update operation changes the internal property to false

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/ProvisioningUserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/ProvisioningUserServiceImpl.java
@@ -449,6 +449,7 @@ public class ProvisioningUserServiceImpl implements ProvisioningUserService, Ini
                                                     userToUpdate.setPassword(null);
                                                     // set external id
                                                     userToUpdate.setExternalId(idpUser.getId());
+                                                    userToUpdate.setInternal(existingUser.isInternal());
                                                     // if password has been changed, update last update date
                                                     if (scimUser.getPassword() != null) {
                                                         userToUpdate.setLastPasswordReset(new Date());
@@ -463,6 +464,7 @@ public class ProvisioningUserServiceImpl implements ProvisioningUserService, Ini
                                                         // idp user does not exist, only update AM user
                                                         // clear password
                                                         userToUpdate.setPassword(null);
+                                                        userToUpdate.setInternal(existingUser.isInternal());
                                                         return updateUser(userToUpdate, UpdateActions.build(existingUser, userToUpdate));
                                                     }
                                                     return Single.error(ex);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -447,6 +447,42 @@ public class ProvisioningUserServiceTest {
     }
 
     @Test
+    public void shouldUpdateUser_preserveInternalFlag() {
+        io.gravitee.am.model.User existingUser = mock(io.gravitee.am.model.User.class);
+        when(existingUser.getId()).thenReturn("user-id");
+        when(existingUser.getSource()).thenReturn("user-idp");
+        when(existingUser.getUsername()).thenReturn("username");
+        when(existingUser.getReferenceType()).thenReturn(ReferenceType.DOMAIN);
+        when(existingUser.getReferenceId()).thenReturn(DOMAIN_ID);
+        when(existingUser.isInternal()).thenReturn(true);
+
+        User scimUser = mock(User.class);
+        when(scimUser.getPassword()).thenReturn(PASSWORD);
+        when(scimUser.isActive()).thenReturn(true);
+
+        io.gravitee.am.identityprovider.api.User idpUser = mock(io.gravitee.am.identityprovider.api.User.class);
+
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.create(any())).thenReturn(Single.just(idpUser));
+
+        when(userRepository.findById(existingUser.getId())).thenReturn(Maybe.just(existingUser));
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        ArgumentCaptor<io.gravitee.am.model.User> userCaptor = ArgumentCaptor.forClass(io.gravitee.am.model.User.class);
+        when(userRepository.update(any(), any())).thenReturn(Single.just(existingUser));
+        when(groupService.findByMember(existingUser.getId())).thenReturn(Flowable.empty());
+        when(passwordService.isValid(eq(PASSWORD), any(), any())).thenReturn(true);
+        when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
+
+        TestObserver<User> testObserver = userService.update(existingUser.getId(), scimUser, null, "/", null, null).test();
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+
+        verify(userRepository, times(1)).update(userCaptor.capture(), any());
+        assertTrue(userCaptor.getValue().isInternal());
+    }
+
+    @Test
     public void shouldUpdateUser_status_disabled_and_tokens_revoked() {
         io.gravitee.am.model.User existingUser = mock(io.gravitee.am.model.User.class);
         when(existingUser.getId()).thenReturn("user-id");


### PR DESCRIPTION
How to test:
Create a user by SCIM API (bulk and regular POST)
Check the database, **users** collection, the property **internal** should be true
Update email (or anything else) by SCIM API (bulk and regular, POST and PUT)
Check the database, **users** collection, the property **internal** should remain the same