### PR TITLE
fix: AM-7013 correct CIMD specification name

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/cimd/cimd.component.html
@@ -22,9 +22,9 @@
       <form #cimdSettingsForm="ngForm" (ngSubmit)="save()" (keydown.enter)="(false)">
         <div class="gv-form-section" fxLayout="column">
           <mat-slide-toggle (change)="enableCIMD($event)" [checked]="isCIMDEnabled()" [disabled]="!editMode">
-            Client-Initiated Metadata Document (CIMD) support
+            Client ID Metadata Document (CIMD) support
           </mat-slide-toggle>
-          <mat-hint style="font-size: 75%">Enable support for Client-Initiated Metadata Document (CIMD).</mat-hint>
+          <mat-hint style="font-size: 75%">Enable support for Client ID Metadata Document (CIMD).</mat-hint>
         </div>
 
         <div *ngIf="cimdSettings.enabled">
@@ -193,8 +193,8 @@
       <h3>What is CIMD?</h3>
       <div class="gv-page-description-content">
         <p>
-          Client-Initiated Metadata Document (CIMD) allows OAuth 2.0 clients to retrieve their own metadata from a well-known URI, enabling
-          dynamic configuration of client parameters without prior registration.
+          Client ID Metadata Document (CIMD) allows OAuth 2.0 clients to retrieve their own metadata from a well-known URI, enabling dynamic
+          configuration of client parameters without prior registration.
         </p>
         <h4>Template Application</h4>
         <p>


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7013](https://gravitee.atlassian.net/browse/AM-7013)

## :pencil2: A description of the changes proposed in the pull request
Correct specification name used for CIMD in the console UI: "Client-Initiated Metadata Document" -> "Client ID Metadata Document”.

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
**Before**
<img width="1023" height="419" alt="image" src="https://github.com/user-attachments/assets/bef99a57-3ab6-44cb-aa37-dbe2d1936694" />

**After**
<img width="981" height="200" alt="image" src="https://github.com/user-attachments/assets/9e39162f-a1e5-43a3-84ea-7e6135a3d722" />

## :books: Any other comments that will help with documentation
https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7013]: https://gravitee.atlassian.net/browse/AM-7013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ