### PR TITLE
fix: AM-7012 map domain master value

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/AbstractDomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/AbstractDomainResource.java
@@ -47,6 +47,7 @@ public class AbstractDomainResource extends AbstractResource {
         filteredDomain.setName(domain.getName());
         filteredDomain.setDescription(domain.getDescription());
         filteredDomain.setEnabled(domain.isEnabled());
+        filteredDomain.setMaster(domain.isMaster());
         filteredDomain.setCreatedAt(domain.getCreatedAt());
         filteredDomain.setUpdatedAt(domain.getUpdatedAt());
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainsResourceTest.java
@@ -55,6 +55,7 @@ public class DomainsResourceTest extends JerseySpringTest {
         final Domain mockDomain = new Domain();
         mockDomain.setId("domain-id-1");
         mockDomain.setName("domain-name-1");
+        mockDomain.setMaster(true);
 
         final Domain mockDomain2 = new Domain();
         mockDomain2.setId("domain-id-2");
@@ -67,7 +68,10 @@ public class DomainsResourceTest extends JerseySpringTest {
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         final Map responseEntity = readEntity(response, Map.class);
-        assertEquals(2, ((List) responseEntity.get("data")).size());
+        List<Map<String, Object>> data = (List<Map<String, Object>>) responseEntity.get("data");
+        assertEquals(2, data.size());
+        assertEquals(Boolean.TRUE, data.get(0).get("master"));
+        assertEquals(Boolean.FALSE, data.get(1).get("master"));
     }
 
     @Test


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7012](https://gravitee.atlassian.net/browse/AM-7012)

## :pencil2: A description of the changes proposed in the pull request
Complete mapping of domain `master` property during `listDomains` management API request handling.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7012]: https://gravitee.atlassian.net/browse/AM-7012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ