### PR TITLE
fix: AM-7017 allow introspection of multiple client aud values

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/oauth2/impl/BaseIntrospectionTokenService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/oauth2/impl/BaseIntrospectionTokenService.java
@@ -24,11 +24,12 @@ import io.gravitee.am.gateway.handler.common.jwt.JWTService;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService.TokenType;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceManager;
 import io.gravitee.am.model.ProtectedResource;
+import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.repository.oauth2.model.Token;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +37,7 @@ import org.springframework.core.env.Environment;
 
 import java.time.Instant;
 import java.util.Date;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -129,60 +130,59 @@ abstract class BaseIntrospectionTokenService {
             return Single.error(new InvalidTokenException("The token is invalid", "Token has no audience claim", jwt));
         }
 
-        // Single-audience: check if the audience is a client ID
-        if (audiences.size() == 1) {
-            return clientService.findByDomainAndClientId(jwt.getDomain(), audiences.getFirst())
-                    .flatMapSingle(client -> {
-                        String certificateId = client.getCertificate();
-                        // If the client's certificate is null, assume the token is signed with an HMAC key
-                        return Single.just(Objects.requireNonNullElse(certificateId, ""));
-                    })
-                    .switchIfEmpty(Single.defer(() -> validateProtectedResourcesAndGetCertificateId(jwt, callerClientId)));
-        }
-
-        return validateProtectedResourcesAndGetCertificateId(jwt, callerClientId);
+        return Observable.fromIterable(audiences)
+                .concatMapSingle(audience -> resolveAudience(jwt.getDomain(), audience))
+                .toList()
+                .flatMap(matches -> resolveCertificateIdFromAudMatches(matches, jwt, callerClientId));
     }
 
-    private Single<String> validateProtectedResourcesAndGetCertificateId(JWT jwt, String callerClientId) {
-        return validateResourcesBelongToDomain(jwt)
-                .flatMapCompletable(matchedResources -> {
-                    if (isLegacyRfc8707Enabled && callerClientId != null) {
-                        return validateResourcesBelongToAuthorizedClient(matchedResources, jwt, callerClientId);
+    private Single<AudienceMatch> resolveAudience(String domain, String audience) {
+        return clientService.findByDomainAndClientId(domain, audience)
+                .<AudienceMatch>map(client -> new ClientMatch(audience, client))
+                .switchIfEmpty(Single.fromCallable(() -> {
+                    Set<ProtectedResource> resources = protectedResourceManager.getByIdentifier(audience);
+                    if (!resources.isEmpty()) {
+                        return new ResourceMatch(audience, resources);
                     }
-                    return Completable.complete();
-                })
-                .toSingle(() -> {
-                    // Protected resources currently do not have a configurable certificate ID
-                    return "";
-                });
+                    return new UnmatchedAudience(audience);
+                }));
     }
 
-    private Single<Set<ProtectedResource>> validateResourcesBelongToDomain(JWT jwt) {
-        List<String> audiences = jwt.getAudList();
-        String domainId = jwt.getDomain();
-        Set<ProtectedResource> matchedResources = new HashSet<>();
-        Set<String> unmatchedAudiences = new HashSet<>();
+    private Single<String> resolveCertificateIdFromAudMatches(List<AudienceMatch> matches, JWT jwt, String callerClientId) {
+        Set<String> unmatched = matches.stream()
+                .filter(UnmatchedAudience.class::isInstance)
+                .map(AudienceMatch::audience)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        for (String audience : audiences) {
-            Set<ProtectedResource> resources = protectedResourceManager.getByIdentifier(audience);
-            if (!resources.isEmpty()) {
-                matchedResources.addAll(resources);
-            } else {
-                unmatchedAudiences.add(audience);
-            }
-        }
-
-        if (!unmatchedAudiences.isEmpty()) {
+        if (!unmatched.isEmpty()) {
             String details = String.format("Token audience values [%s] do not match any client or protected resource identifiers in domain [%s]",
-                    String.join(", ", unmatchedAudiences), domainId);
+                    String.join(", ", unmatched), jwt.getDomain());
             return Single.error(new InvalidTokenException("The token is invalid", details, jwt));
         }
 
-        return Single.just(matchedResources);
+        // Use first matched client's certificate.
+        // Protected-resource-only tokens fall back to "" (HMAC/default certificate).
+        String certificateId = matches.stream()
+                .filter(ClientMatch.class::isInstance)
+                .map(ClientMatch.class::cast)
+                .map(cm -> cm.client().getCertificate())
+                .map(cert -> Objects.requireNonNullElse(cert, ""))
+                .findFirst()
+                .orElse("");
+
+        return validateResourcesBelongToAuthorizedClient(matches, jwt, callerClientId)
+                .toSingleDefault(certificateId);
     }
 
-    private Completable validateResourcesBelongToAuthorizedClient(Set<ProtectedResource> matchedResources, JWT jwt, @NotNull String callerClientId) {
-        Set<String> mismatchedClientIds = matchedResources.stream()
+    private Completable validateResourcesBelongToAuthorizedClient(List<AudienceMatch> matches, JWT jwt, String callerClientId) {
+        if (!isLegacyRfc8707Enabled || callerClientId == null) {
+            return Completable.complete();
+        }
+
+        Set<String> mismatchedClientIds = matches.stream()
+                .filter(ResourceMatch.class::isInstance)
+                .map(ResourceMatch.class::cast)
+                .flatMap(rm -> rm.resources().stream())
                 .map(ProtectedResource::getClientId)
                 .filter(clientId -> !callerClientId.equals(clientId))
                 .collect(Collectors.toSet());
@@ -195,4 +195,12 @@ abstract class BaseIntrospectionTokenService {
 
         return Completable.complete();
     }
+
+    private sealed interface AudienceMatch permits ClientMatch, ResourceMatch, UnmatchedAudience {
+        String audience();
+    }
+
+    private record ClientMatch(String audience, Client client) implements AudienceMatch { }
+    private record ResourceMatch(String audience, Set<ProtectedResource> resources) implements AudienceMatch { }
+    private record UnmatchedAudience(String audience) implements AudienceMatch { }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/provider/impl/OAuth2AuthProviderImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/provider/impl/OAuth2AuthProviderImpl.java
@@ -16,11 +16,14 @@
 package io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.impl;
 
 import io.gravitee.am.common.exception.oauth2.InvalidTokenException;
+import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
 import io.gravitee.am.gateway.handler.common.oauth2.IntrospectionTokenService;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthResponse;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
+import io.gravitee.am.model.oidc.Client;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -43,11 +46,19 @@ public class OAuth2AuthProviderImpl implements OAuth2AuthProvider {
     @Override
     public void decodeToken(String token, boolean offlineVerification, Handler<AsyncResult<OAuth2AuthResponse>> handler) {
         introspectionTokenService.introspect(token, offlineVerification)
-                .flatMap(jwt -> clientSyncService.findByDomainAndClientId(jwt.getDomain(), jwt.getAud())
+                .flatMap(jwt -> findClientByAudience(jwt)
                         .switchIfEmpty(Maybe.error(new InvalidTokenException("The token is invalid", "Client not found")))
                         .map(client -> new OAuth2AuthResponse(jwt, client)))
                 .subscribe(
                         accessToken -> handler.handle(Future.succeededFuture(accessToken)),
                         error -> handler.handle(Future.failedFuture(error)));
+    }
+
+    private Maybe<Client> findClientByAudience(JWT jwt) {
+        // Return the first registered client that resolves.
+        // RFC 8707 resource indicators return nothing here.
+        return Observable.fromIterable(jwt.getAudList())
+                .concatMapMaybe(audience -> clientSyncService.findByDomainAndClientId(jwt.getDomain(), audience))
+                .firstElement();
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/oauth2/impl/BaseIntrospectionTokenServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/oauth2/impl/BaseIntrospectionTokenServiceTest.java
@@ -29,6 +29,7 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.Environment;
@@ -123,6 +124,8 @@ public class BaseIntrospectionTokenServiceTest {
         ProtectedResource resourceTwo = buildProtectedResource("resource-two", DOMAIN, backendClient.getClientId());
 
         mockDecode(jwt);
+        when(clientService.findByDomainAndClientId(DOMAIN, "resource-one")).thenReturn(Maybe.empty());
+        when(clientService.findByDomainAndClientId(DOMAIN, "resource-two")).thenReturn(Maybe.empty());
         when(protectedResourceManager.getByIdentifier("resource-one")).thenReturn(Set.of(resourceOne));
         when(protectedResourceManager.getByIdentifier("resource-two")).thenReturn(Set.of(resourceTwo));
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Supplier<String>>any(), eq(ACCESS_TOKEN))).thenReturn(Single.just(jwt));
@@ -130,7 +133,116 @@ public class BaseIntrospectionTokenServiceTest {
         TestObserver<JWT> observer = introspectionTokenService.introspect(TOKEN, true, null).test();
 
         observer.assertResult(jwt);
-        verify(clientService, never()).findByDomainAndClientId(DOMAIN, "resource-one");
+        verify(protectedResourceManager).getByIdentifier("resource-one");
+        verify(protectedResourceManager).getByIdentifier("resource-two");
+    }
+
+    @Test
+    public void shouldValidateMultipleAudiencesAllClients() {
+        JWT jwt = buildJwtWithAudiences(Arrays.asList("client-one", "client-two"));
+        Client clientOne = buildClient("client-one");
+        clientOne.setCertificate("cert-one");
+        Client clientTwo = buildClient("client-two");
+        clientTwo.setCertificate("cert-two");
+
+        mockDecode(jwt);
+        when(clientService.findByDomainAndClientId(DOMAIN, "client-one")).thenReturn(Maybe.just(clientOne));
+        when(clientService.findByDomainAndClientId(DOMAIN, "client-two")).thenReturn(Maybe.just(clientTwo));
+        when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Supplier<String>>any(), eq(ACCESS_TOKEN))).thenReturn(Single.just(jwt));
+
+        TestObserver<JWT> observer = introspectionTokenService.introspect(TOKEN, true, null).test();
+
+        observer.assertResult(jwt);
+        // Client lookup short-circuits the protected-resource manager once a client match is found.
+        verify(protectedResourceManager, never()).getByIdentifier(anyString());
+        // First matched client's certificate should be used.
+        ArgumentCaptor<Supplier<String>> captor = ArgumentCaptor.forClass(Supplier.class);
+        verify(jwtService).decodeAndVerify(eq(TOKEN), captor.capture(), eq(ACCESS_TOKEN));
+        org.junit.Assert.assertEquals("cert-one", captor.getValue().get());
+    }
+
+    @Test
+    public void shouldValidateMixedAudiencesClientThenProtectedResource() {
+        JWT jwt = buildJwtWithAudiences(Arrays.asList("client-id", "resource-id"));
+        Client client = buildClient("client-id");
+        client.setCertificate("cert-from-client");
+        Client backendClient = buildClient("backend-client");
+        ProtectedResource resource = buildProtectedResource("resource-id", DOMAIN, backendClient.getClientId());
+
+        mockDecode(jwt);
+        when(clientService.findByDomainAndClientId(DOMAIN, "client-id")).thenReturn(Maybe.just(client));
+        when(clientService.findByDomainAndClientId(DOMAIN, "resource-id")).thenReturn(Maybe.empty());
+        when(protectedResourceManager.getByIdentifier("resource-id")).thenReturn(Set.of(resource));
+        when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Supplier<String>>any(), eq(ACCESS_TOKEN))).thenReturn(Single.just(jwt));
+
+        TestObserver<JWT> observer = introspectionTokenService.introspect(TOKEN, true, null).test();
+
+        observer.assertResult(jwt);
+        ArgumentCaptor<Supplier<String>> captor = ArgumentCaptor.forClass(Supplier.class);
+        verify(jwtService).decodeAndVerify(eq(TOKEN), captor.capture(), eq(ACCESS_TOKEN));
+        org.junit.Assert.assertEquals("cert-from-client", captor.getValue().get());
+    }
+
+    @Test
+    public void shouldValidateMixedAudiencesProtectedResourceThenClient() {
+        JWT jwt = buildJwtWithAudiences(Arrays.asList("resource-id", "client-id"));
+        Client client = buildClient("client-id");
+        client.setCertificate("cert-from-client");
+        Client backendClient = buildClient("backend-client");
+        ProtectedResource resource = buildProtectedResource("resource-id", DOMAIN, backendClient.getClientId());
+
+        mockDecode(jwt);
+        when(clientService.findByDomainAndClientId(DOMAIN, "resource-id")).thenReturn(Maybe.empty());
+        when(clientService.findByDomainAndClientId(DOMAIN, "client-id")).thenReturn(Maybe.just(client));
+        when(protectedResourceManager.getByIdentifier("resource-id")).thenReturn(Set.of(resource));
+        when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Supplier<String>>any(), eq(ACCESS_TOKEN))).thenReturn(Single.just(jwt));
+
+        TestObserver<JWT> observer = introspectionTokenService.introspect(TOKEN, true, null).test();
+
+        observer.assertResult(jwt);
+        // Even when the client aud appears second, its certificate must still be picked up.
+        ArgumentCaptor<Supplier<String>> captor = ArgumentCaptor.forClass(Supplier.class);
+        verify(jwtService).decodeAndVerify(eq(TOKEN), captor.capture(), eq(ACCESS_TOKEN));
+        org.junit.Assert.assertEquals("cert-from-client", captor.getValue().get());
+    }
+
+    @Test
+    public void shouldFailWhenAnyAudienceInMixedSetUnmatched() {
+        JWT jwt = buildJwtWithAudiences(Arrays.asList("client-id", "resource-id", "unknown"));
+        Client client = buildClient("client-id");
+        Client backendClient = buildClient("backend-client");
+        ProtectedResource resource = buildProtectedResource("resource-id", DOMAIN, backendClient.getClientId());
+
+        mockDecode(jwt);
+        when(clientService.findByDomainAndClientId(DOMAIN, "client-id")).thenReturn(Maybe.just(client));
+        when(clientService.findByDomainAndClientId(DOMAIN, "resource-id")).thenReturn(Maybe.empty());
+        when(clientService.findByDomainAndClientId(DOMAIN, "unknown")).thenReturn(Maybe.empty());
+        when(protectedResourceManager.getByIdentifier("resource-id")).thenReturn(Set.of(resource));
+        when(protectedResourceManager.getByIdentifier("unknown")).thenReturn(Set.of());
+
+        TestObserver<JWT> observer = introspectionTokenService.introspect(TOKEN, true, null).test();
+
+        observer.assertError(throwable -> throwable instanceof InvalidTokenException e
+                && e.getMessage().equals("The token is invalid")
+                && e.getDetails().equals("Token audience values [unknown] do not match any client or protected resource identifiers in domain [" + DOMAIN + "]"));
+    }
+
+    @Test
+    public void shouldFailWhenLegacyFlagRejectsMixedAudienceProtectedResource() {
+        JWT jwt = buildJwtWithAudiences(Arrays.asList("client-id", "resource-id"));
+        Client client = buildClient("client-id");
+        ProtectedResource resource = buildProtectedResource("resource-id", DOMAIN, "backend-client");
+
+        mockDecode(jwt);
+        when(clientService.findByDomainAndClientId(DOMAIN, "client-id")).thenReturn(Maybe.just(client));
+        when(clientService.findByDomainAndClientId(DOMAIN, "resource-id")).thenReturn(Maybe.empty());
+        when(protectedResourceManager.getByIdentifier("resource-id")).thenReturn(Set.of(resource));
+
+        TestObserver<JWT> observer = introspectionTokenService.introspect(TOKEN, true, "caller-client").test();
+
+        observer.assertError(throwable -> throwable instanceof InvalidTokenException e
+                && e.getMessage().equals("The token is invalid")
+                && e.getDetails().equals("Protected resources matched by token audience have client IDs [backend-client] that do not match the introspecting client ID [caller-client]"));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/provider/impl/OAuth2AuthProviderImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/provider/impl/OAuth2AuthProviderImplTest.java
@@ -31,6 +31,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -139,6 +140,81 @@ public class OAuth2AuthProviderImplTest {
 
         verify(introspectionTokenService).introspect(TOKEN, false);
         verify(clientSyncService).findByDomainAndClientId(DOMAIN, CLIENT_ID);
+    }
+
+    @Test
+    public void shouldDecodeMultiAudienceTokenAndAttachFirstMatchingClient() throws InterruptedException {
+        // Given - aud is [resource-id, client-id]; only the second audience resolves to a client
+        JWT jwt = new JWT(Map.of(
+                Claims.SUB, "test-sub",
+                Claims.AUD, List.of("resource-id", CLIENT_ID),
+                Claims.DOMAIN, DOMAIN
+        ));
+        Client client = new Client();
+        client.setClientId(CLIENT_ID);
+        client.setDomain(DOMAIN);
+
+        when(introspectionTokenService.introspect(TOKEN, false))
+                .thenReturn(Maybe.just(jwt));
+        when(clientSyncService.findByDomainAndClientId(DOMAIN, "resource-id"))
+                .thenReturn(Maybe.empty());
+        when(clientSyncService.findByDomainAndClientId(DOMAIN, CLIENT_ID))
+                .thenReturn(Maybe.just(client));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        @SuppressWarnings("unchecked")
+        AsyncResult<OAuth2AuthResponse>[] result = new AsyncResult[1];
+
+        // When
+        oAuth2AuthProvider.decodeToken(TOKEN, false, handler -> {
+            result[0] = handler;
+            latch.countDown();
+        });
+
+        // Then
+        assertTrue("Handler should be called", latch.await(1, TimeUnit.SECONDS));
+        assertTrue("Result should be successful", result[0].succeeded());
+        assertEquals("Client should match", client, result[0].result().getClient());
+        verify(clientSyncService).findByDomainAndClientId(DOMAIN, "resource-id");
+        verify(clientSyncService).findByDomainAndClientId(DOMAIN, CLIENT_ID);
+    }
+
+    @Test
+    public void shouldFailWhenNoAudienceResolvesToClient() throws InterruptedException {
+        // Given - both audiences are protected-resource identifiers; none resolves to a client
+        JWT jwt = new JWT(Map.of(
+                Claims.SUB, "test-sub",
+                Claims.AUD, List.of("resource-one", "resource-two"),
+                Claims.DOMAIN, DOMAIN
+        ));
+
+        when(introspectionTokenService.introspect(TOKEN, false))
+                .thenReturn(Maybe.just(jwt));
+        when(clientSyncService.findByDomainAndClientId(DOMAIN, "resource-one"))
+                .thenReturn(Maybe.empty());
+        when(clientSyncService.findByDomainAndClientId(DOMAIN, "resource-two"))
+                .thenReturn(Maybe.empty());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        @SuppressWarnings("unchecked")
+        AsyncResult<OAuth2AuthResponse>[] result = new AsyncResult[1];
+
+        // When
+        oAuth2AuthProvider.decodeToken(TOKEN, false, handler -> {
+            result[0] = handler;
+            latch.countDown();
+        });
+
+        // Then
+        assertTrue("Handler should be called", latch.await(1, TimeUnit.SECONDS));
+        assertTrue("Result should be failed", result[0].failed());
+        assertTrue("Failure should be InvalidTokenException",
+                result[0].cause() instanceof InvalidTokenException);
+        InvalidTokenException exception = (InvalidTokenException) result[0].cause();
+        assertEquals("The token is invalid", exception.getMessage());
+        assertEquals("Client not found", exception.getDetails());
+        verify(clientSyncService).findByDomainAndClientId(DOMAIN, "resource-one");
+        verify(clientSyncService).findByDomainAndClientId(DOMAIN, "resource-two");
     }
 
     @Test

--- a/gravitee-am-test/specs/gateway/protected-resources/fixtures/protected-resources-fixture.ts
+++ b/gravitee-am-test/specs/gateway/protected-resources/fixtures/protected-resources-fixture.ts
@@ -33,7 +33,7 @@ import { IdentityProvider } from '@management-models/IdentityProvider';
 import { uniqueName } from '@utils-commands/misc';
 import { performGet, performPost, getWellKnownOpenIdConfiguration } from '@gateway-commands/oauth-oidc-commands';
 import { login } from '@gateway-commands/login-commands';
-import { applicationBase64Token } from '@gateway-commands/utils';
+import { applicationBase64Token, getBase64BasicAuth } from '@gateway-commands/utils';
 
 export interface ProtectedResourcesFixture {
   domain: Domain;
@@ -50,6 +50,11 @@ export interface ProtectedResourcesFixture {
   exchangeAuthCodeForToken: (authCode: string, resources?: string[]) => any;
   exchangeAuthCodeForTokenWithoutResources: (authCode: string) => any;
   exchangeRefreshToken: (refreshToken: string, resources?: string[]) => any;
+  requestClientCredentialsToken: (resources?: string[]) => any;
+  introspectToken: (
+    accessToken: string,
+    introspectingResource: { clientId?: string; clientSecret?: string },
+  ) => any;
 }
 
 // Test constants
@@ -188,6 +193,14 @@ async function createTestUser(domain: Domain, application: Application, defaultI
   return testUser;
 }
 
+// A single protected resource exposing multiple resource identifiers is the
+// natural way to mint multi-aud tokens that pass the legacy RFC 8707 caller-client
+// check on introspection: every matched resource shares this one backing client.
+export const MULTI_AUD_RESOURCE_IDENTIFIERS = [
+  'https://api.example.com/multi-aud/photos',
+  'https://api.example.com/multi-aud/albums',
+] as const;
+
 async function createTestProtectedResources(domain: Domain, accessToken: string) {
   const resources = [
     {
@@ -206,6 +219,12 @@ async function createTestProtectedResources(domain: Domain, accessToken: string)
       name: 'Meta API',
       resourceIdentifiers: ['https://api.example.com/meta?foo=bar'],
       description: 'Meta API with query',
+      type: 'MCP_SERVER',
+    },
+    {
+      name: 'Multi-Audience API',
+      resourceIdentifiers: [...MULTI_AUD_RESOURCE_IDENTIFIERS],
+      description: 'Single protected resource exposing two identifiers',
       type: 'MCP_SERVER',
     },
   ];
@@ -287,6 +306,32 @@ export const setupProtectedResourcesFixture = async (): Promise<ProtectedResourc
     });
   };
 
+  const requestClientCredentialsToken = (resources?: string[]) => {
+    const tokenParams = new URLSearchParams({ grant_type: 'client_credentials' });
+    for (const r of resources || []) {
+      tokenParams.append('resource', r);
+    }
+    return performPost(openIdConfiguration.token_endpoint, '', tokenParams.toString(), {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${applicationBase64Token(serviceApplication)}`,
+    });
+  };
+
+  const introspectToken = (
+    accessToken: string,
+    introspectingResource: { clientId?: string; clientSecret?: string },
+  ) => {
+    return performPost(
+      openIdConfiguration.introspection_endpoint,
+      '',
+      `token=${accessToken}&token_type_hint=access_token`,
+      {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: 'Basic ' + getBase64BasicAuth(introspectingResource.clientId, introspectingResource.clientSecret),
+      },
+    );
+  };
+
     const cleanup = async () => {
       // Delete domain (this will cascade delete applications, users, protected resources, etc.)
       await safeDeleteDomain(domain?.id, accessToken);
@@ -307,6 +352,8 @@ export const setupProtectedResourcesFixture = async (): Promise<ProtectedResourc
       exchangeAuthCodeForToken: exchangeCodeForTokenWithResources,
       exchangeAuthCodeForTokenWithoutResources: exchangeCodeForTokenWithoutResources,
       exchangeRefreshToken: exchangeRefreshForTokenWithResources,
+      requestClientCredentialsToken,
+      introspectToken,
     };
   } catch (error) {
     // Cleanup domain if setup fails partway through

--- a/gravitee-am-test/specs/gateway/protected-resources/introspection-resource-indicators.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/protected-resources/introspection-resource-indicators.jest.spec.ts
@@ -16,10 +16,13 @@
 
 import fetch from 'cross-fetch';
 import { afterAll, beforeAll, expect, jest } from '@jest/globals';
-import { performPost } from '@gateway-commands/oauth-oidc-commands';
-import { getBase64BasicAuth } from '@gateway-commands/utils';
-import { setupProtectedResourcesFixture, ProtectedResourcesFixture } from './fixtures/protected-resources-fixture';
+import {
+  MULTI_AUD_RESOURCE_IDENTIFIERS,
+  ProtectedResourcesFixture,
+  setupProtectedResourcesFixture,
+} from './fixtures/protected-resources-fixture';
 import { delay } from '@utils-commands/misc';
+import { requestClientCredentialsToken } from '@gateway-commands/oauth-oidc-commands';
 
 // RFC 8707 Introspection: Protected Resource can introspect tokens obtained via authorization_code grant with resource indicators
 
@@ -64,15 +67,7 @@ describe('Protected Resource Introspection with Resource Indicators (RFC 8707)',
 
     // Step 4: Introspect the token using the Protected Resource credentials
     // Note that the client ID of the resources indicated in the token exchange must match the client ID of the Authorization header
-    const introspectionResponse = await performPost(
-      fixture.openIdConfiguration.introspection_endpoint,
-      '',
-      `token=${accessToken}&token_type_hint=access_token`,
-      {
-        'Content-type': 'application/x-www-form-urlencoded',
-        Authorization: 'Basic ' + getBase64BasicAuth(protectedResource.clientId, protectedResource.clientSecret),
-      },
-    ).expect(200);
+    const introspectionResponse = await fixture.introspectToken(accessToken, protectedResource).expect(200);
 
     // Verify introspection response
     expect(introspectionResponse.body).toBeDefined();
@@ -92,6 +87,27 @@ describe('Protected Resource Introspection with Resource Indicators (RFC 8707)',
     expect(introspectionResponse.body.exp).toBeDefined();
     expect(introspectionResponse.body.iat).toBeDefined();
     expect(introspectionResponse.body.exp).toBeGreaterThan(introspectionResponse.body.iat);
+  });
+
+  it('Protected Resource can introspect token with multiple aud values (RFC 8707 multi-resource)', async () => {
+    const resourceIdentifiers = [...MULTI_AUD_RESOURCE_IDENTIFIERS];
+    const multiAudResource = fixture.protectedResources.find((r) => r.name === 'Multi-Audience API');
+    expect(multiAudResource).toBeDefined();
+    expect(multiAudResource.clientId).toBeDefined();
+    expect(multiAudResource.clientSecret).toBeDefined();
+
+    // Mint a token via client_credentials carrying both resources -> aud is a 2-element array.
+    const tokenResponse = await fixture.requestClientCredentialsToken(resourceIdentifiers).expect(200);
+    expect(tokenResponse.body.access_token).toBeDefined();
+
+    // No offline-verification wait: exercise with the offline path
+    const introspectionResponse = await fixture
+    .introspectToken(tokenResponse.body.access_token, multiAudResource)
+    .expect(200);
+
+    expect(introspectionResponse.body.active).toBe(true);
+    expect(Array.isArray(introspectionResponse.body.aud)).toBe(true);
+    expect(introspectionResponse.body.aud).toEqual(expect.arrayContaining(resourceIdentifiers));
   });
 });
 


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7017](https://gravitee.atlassian.net/browse/AM-7017)

## :pencil2: A description of the changes proposed in the pull request
Allow introspection to resolve multiple clients from token `aud` claim values. This fixes a regression introduced with validation of protected resources audiences.

The default certificate is resolved from the _first_ valid client referenced in the `aud` claim (leveraged only when `kid` header is omitted from token). Audience values must reference protected resources or clients in the domain (unchanged).

## :memo: Test scenarios 
See Jira.

Note that you can generate an access token using an application in AM with a custom `aud` claim but it needs to be in List format, e.g. using EL `{T(java.lang.String).valueOf('audience-one,audience-two').split(',')}`.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7017]: https://gravitee.atlassian.net/browse/AM-7017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ