### PR TITLE
fix: redact Authorization header in logger to hide JIRA_TOKEN

### DIFF
--- a/release/helpers/logger.mjs
+++ b/release/helpers/logger.mjs
@@ -9,7 +9,11 @@ const logger = pino({
     },
   },
   redact: {
-    paths: ['init.headers["Circle-Token"]'],
+    paths: [
+      'init.headers["Circle-Token"]',
+      'init.headers.Authorization',
+      '*.headers.Authorization',
+    ],
     censor: '*****',
   },
 });


### PR DESCRIPTION
The JIRA_TOKEN is passed in the Authorization header during fetch requests to the Jira API. The logger configuration was only redacting Circle-Token, allowing the JIRA_TOKEN to be exposed in stdout/logs if fetch requests were logged. Added Authorization header paths to the redaction list to prevent token leakage.
