### PR TITLE
test: AM-6665 CIMD automation

### DIFF
--- a/docker/local-stack/dev/wiremock/request-cimd.json
+++ b/docker/local-stack/dev/wiremock/request-cimd.json
@@ -556,6 +556,50 @@
           "request_object_signing_alg": "RS256"
         }
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/cimd/ENABLED_BASE/scope-intersection"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "client_id": "http://wiremock:8080/cimd/ENABLED_BASE/scope-intersection",
+          "client_name": "CIMD Scope Intersection",
+          "redirect_uris": [
+            "https://client.example.com/callback"
+          ],
+          "token_endpoint_auth_method": "none",
+          "scope": "openid profile email"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/cimd/ENABLED_BASE/grant-types-intersection"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "client_id": "http://wiremock:8080/cimd/ENABLED_BASE/grant-types-intersection",
+          "client_name": "CIMD Grant Types Intersection",
+          "redirect_uris": [
+            "https://client.example.com/callback"
+          ],
+          "token_endpoint_auth_method": "none",
+          "grant_types": [
+            "client_credentials"
+          ]
+        }
+      }
     }
   ],
   "importOptions": {

--- a/gravitee-am-test/api/commands/utils/pkce.ts
+++ b/gravitee-am-test/api/commands/utils/pkce.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import crypto from 'crypto';
+
+/** A PKCE (RFC 7636) verifier/challenge pair using the S256 challenge method. */
+export interface PkcePair {
+  codeVerifier: string;
+  codeChallenge: string;
+  codeChallengeMethod: 'S256';
+}
+
+/**
+ * Generates a fresh PKCE (RFC 7636) S256 verifier/challenge pair.
+ *
+ * The verifier is 32 random bytes base64url-encoded (a 43-character high-entropy
+ * string, well within the RFC 7636 §4.1 length bounds); the challenge is the
+ * base64url-encoded SHA-256 of the verifier.
+ */
+export const generatePkcePair = (): PkcePair => {
+  const codeVerifier = crypto.randomBytes(32).toString('base64url');
+  const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+  return { codeVerifier, codeChallenge, codeChallengeMethod: 'S256' };
+};

--- a/gravitee-am-test/specs/gateway/cimd/cimd-authorize-flows.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-authorize-flows.jest.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { CIMD_REDIRECT_URI, CimdAuthorizeFixture, setupCimdAuthorizeFixture } from './fixtures/cimd-authorize-fixture';
+import { decodeJwt } from '@utils-commands/jwt';
+import { generatePkcePair } from '@utils-commands/pkce';
+import crypto from 'crypto';
+
+setup(200000);
+
+let fixture: CimdAuthorizeFixture;
+
+beforeAll(async () => {
+  fixture = await setupCimdAuthorizeFixture('ENABLED_BASE');
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('CIMD authorize - ENABLED_BASE - OAuth/OIDC flows', () => {
+  describe('Authorization code flow with PKCE', () => {
+    it('should complete the authorization code flow with a valid S256 code_verifier', async () => {
+      const clientId = fixture.buildClientId('valid-none');
+      const pkce = generatePkcePair();
+
+      const code = await fixture.completeAuthorizationCodeFlow(clientId, CIMD_REDIRECT_URI, {
+        code_challenge: pkce.codeChallenge,
+        code_challenge_method: pkce.codeChallengeMethod,
+      });
+
+      const tokenResponse = await fixture.exchangeAuthCodeForToken(code, clientId, CIMD_REDIRECT_URI, {
+        code_verifier: pkce.codeVerifier,
+      });
+      const accessToken = tokenResponse.body.access_token;
+      expect(accessToken).toBeDefined();
+      expect(decodeJwt(accessToken).aud).toBe(clientId);
+
+      const introspection = await fixture.introspectToken(accessToken);
+      expect(introspection.active).toBe(true);
+    });
+
+    it('should reject the token exchange when the PKCE code_verifier does not match the challenge', async () => {
+      const clientId = fixture.buildClientId('valid-none');
+      const pkce = generatePkcePair();
+
+      const code = await fixture.completeAuthorizationCodeFlow(clientId, CIMD_REDIRECT_URI, {
+        code_challenge: pkce.codeChallenge,
+        code_challenge_method: pkce.codeChallengeMethod,
+      });
+
+      const tokenResponse = await fixture.exchangeAuthCodeForTokenExpectingError(code, clientId, CIMD_REDIRECT_URI, {
+        code_verifier: generatePkcePair().codeVerifier,
+      });
+      expect(tokenResponse.status).toBe(400);
+      expect(tokenResponse.body.error).toBe('invalid_grant');
+    });
+
+    it('should reject the token exchange when the PKCE code_verifier is missing', async () => {
+      const clientId = fixture.buildClientId('valid-none');
+      const pkce = generatePkcePair();
+
+      const code = await fixture.completeAuthorizationCodeFlow(clientId, CIMD_REDIRECT_URI, {
+        code_challenge: pkce.codeChallenge,
+        code_challenge_method: pkce.codeChallengeMethod,
+      });
+
+      const tokenResponse = await fixture.exchangeAuthCodeForTokenExpectingError(code, clientId);
+      expect(tokenResponse.status).toBe(400);
+      expect(tokenResponse.body.error).toBe('invalid_grant');
+    });
+  });
+
+  describe('OIDC id_token and userinfo on the authorization code path', () => {
+    it('should issue an id_token bound to the CIMD client and expose claims via userinfo', async () => {
+      const clientId = fixture.buildClientId('valid-none');
+      const nonce = `cimd-nonce-${crypto.randomUUID()}`;
+
+      const code = await fixture.completeAuthorizationCodeFlow(clientId, CIMD_REDIRECT_URI, { nonce });
+      const tokenResponse = await fixture.exchangeAuthCodeForToken(code, clientId);
+
+      const idToken = tokenResponse.body.id_token;
+      expect(idToken).toBeDefined();
+      const idTokenClaims = decodeJwt(idToken);
+      expect(idTokenClaims.aud).toBe(clientId);
+      expect(idTokenClaims.iss).toContain(fixture.domain.hrid);
+      expect(idTokenClaims.sub).toBeDefined();
+      expect(idTokenClaims.nonce).toBe(nonce);
+
+      const userInfo = await fixture.fetchUserInfo(tokenResponse.body.access_token);
+      expect(userInfo.sub).toBe(idTokenClaims.sub);
+    });
+  });
+
+  describe('Template intersection of metadata grant_types and scope', () => {
+    it('should restrict the synthesized client scopes to those allowed by the template', async () => {
+      const clientId = fixture.buildClientId('scope-intersection');
+
+      const callbackLocation = await fixture.loginAndGetCallbackLocation(clientId, CIMD_REDIRECT_URI, {
+        scope: 'openid profile email',
+      });
+      const callbackUrl = new URL(callbackLocation);
+      expect(callbackUrl.searchParams.get('error')).toBe('invalid_scope');
+      expect(callbackUrl.searchParams.get('error_description')).toContain('profile');
+      expect(callbackUrl.searchParams.get('error_description')).toContain('email');
+    });
+
+    it('should reject the code flow when metadata grant_types exclude authorization_code', async () => {
+      // Metadata declares only client_credentials; intersected against the template
+      // (authorization_code) this leaves the client with no usable grant for the code flow.
+      const response = await fixture.authorize(fixture.buildClientId('grant-types-intersection'));
+      const error = fixture.readOAuthError(response);
+      expect(error.error).toBeTruthy();
+      expect(error.location).not.toContain('/login');
+    });
+  });
+});

--- a/gravitee-am-test/specs/gateway/cimd/cimd-authorize-trust.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-authorize-trust.jest.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { CimdAuthorizeFixture, setupCimdAuthorizeFixture } from './fixtures/cimd-authorize-fixture';
+
+setup(200000);
+
+// Host of every CIMD client_id used in these tests; the trust policy keys off this host.
+const WIREMOCK_VALID_CLIENT_ID = 'http://wiremock:8080/cimd/ENABLED_BASE/valid-none';
+
+let denyFixture: CimdAuthorizeFixture;
+let httpsOnlyFixture: CimdAuthorizeFixture;
+let privateIpFixture: CimdAuthorizeFixture;
+
+beforeAll(async () => {
+  [denyFixture, httpsOnlyFixture, privateIpFixture] = await Promise.all([
+    setupCimdAuthorizeFixture('ENABLED_DOMAIN_DENY'),
+    setupCimdAuthorizeFixture('ENABLED_HTTPS_ONLY'),
+    setupCimdAuthorizeFixture('ENABLED_PRIVATE_IP_DENY'),
+  ]);
+});
+
+afterAll(async () => {
+  await Promise.all([denyFixture?.cleanUp(), httpsOnlyFixture?.cleanUp(), privateIpFixture?.cleanUp()]);
+});
+
+describe('CIMD authorize - URL trust policy', () => {
+  it('should reject CIMD resolution when the host is not in the allowed-domains allowlist', async () => {
+    const response = await denyFixture.authorize(WIREMOCK_VALID_CLIENT_ID);
+    denyFixture.expectInvalidClientMetadata(response, 'not in allowed domains');
+  });
+
+  it('should reject an unsecured http client_id when only https is allowed', async () => {
+    const response = await httpsOnlyFixture.authorize(WIREMOCK_VALID_CLIENT_ID);
+    httpsOnlyFixture.expectInvalidClientMetadata(response, 'Unsecured HTTP');
+  });
+
+  it('should reject CIMD resolution when the host resolves to a private IP and private addresses are disallowed', async () => {
+    const response = await privateIpFixture.authorize(WIREMOCK_VALID_CLIENT_ID);
+    privateIpFixture.expectInvalidClientMetadata(response, 'private or reserved IP');
+  });
+});

--- a/gravitee-am-test/specs/gateway/cimd/cimd-revoke-on-document-change.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/cimd/cimd-revoke-on-document-change.jest.spec.ts
@@ -26,6 +26,12 @@ import { resetAllWireMockScenarios } from './fixtures/cimd-wiremock-helpers';
 import { executeCimdAuthCodeFlow } from './fixtures/cimd-auth-flow-helpers';
 import { waitFor } from '@management-commands/domain-management-commands';
 
+// Cache TTL configured on the revoke fixture is 1s; wait it out plus a safety buffer.
+const CACHE_TTL_EXPIRY_WAIT_MS = 1500;
+// Window over which we confirm an erroneous asynchronous revocation does NOT occur.
+const NO_REVOCATION_OBSERVATION_MS = 3000;
+const REVOCATION_POLL_INTERVAL_MS = 300;
+
 setup(200000);
 
 let fixture: CimdRevokeOnDocumentChangeFixture;
@@ -67,7 +73,7 @@ describe('CIMD revoke on document change', () => {
     expect(baseline.active).toBe(true);
 
     // Wait for the 1-second cache TTL to expire (plus a buffer).
-    await waitFor(2500);
+    await waitFor(CACHE_TTL_EXPIRY_WAIT_MS);
 
     // Trigger a new CIMD metadata fetch by initiating an authorization request.
     // The gateway will re-fetch the document (cache expired), receive V2 from WireMock
@@ -91,5 +97,51 @@ describe('CIMD revoke on document change', () => {
 
     const revoked = await fixture.introspectToken(accessToken);
     expect(revoked.active).toBe(false);
+  });
+
+  it('should NOT revoke an access token when the CIMD metadata document is unchanged after cache TTL expires', async () => {
+    // valid-none is a static WireMock stub (no scenario state) so every fetch returns an identical
+    // document. The monitored-properties hash must match across refreshes and tokens must survive.
+    const stableClientId = 'http://wiremock:8080/cimd/ENABLED_BASE/valid-none';
+    const stableFlowFixture = { ...fixture, clientId: stableClientId };
+
+    const code = await executeCimdAuthCodeFlow(stableFlowFixture);
+    const tokenResponse = await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: fixture.redirectUri,
+        client_id: stableClientId,
+      }).toString(),
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+    ).expect(200);
+
+    const accessToken: string = tokenResponse.body.access_token;
+    expect(accessToken).toBeDefined();
+
+    const baseline = await fixture.introspectToken(accessToken);
+    expect(baseline.active).toBe(true);
+
+    // Let the 1-second cache TTL expire, then force a fresh fetch of the (unchanged) document.
+    await waitFor(CACHE_TTL_EXPIRY_WAIT_MS);
+    const triggerParams = new URLSearchParams({
+      response_type: 'code',
+      client_id: stableClientId,
+      redirect_uri: fixture.redirectUri,
+      scope: 'openid',
+      state: 'cimd-no-revoke-trigger',
+    });
+    await performGet(`${fixture.oidc.authorization_endpoint}?${triggerParams.toString()}`);
+
+    // Continuously assert the token stays active across the observation window. This catches an
+    // erroneous asynchronous revocation the moment it happens, rather than only at a single point.
+    const deadline = Date.now() + NO_REVOCATION_OBSERVATION_MS;
+    do {
+      const probe = await fixture.introspectToken(accessToken);
+      expect(probe.active).toBe(true);
+      await waitFor(REVOCATION_POLL_INTERVAL_MS);
+    } while (Date.now() < deadline);
   });
 });

--- a/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-authorize-fixture.ts
+++ b/gravitee-am-test/specs/gateway/cimd/fixtures/cimd-authorize-fixture.ts
@@ -50,7 +50,14 @@ const CIMD_TEST_USER = {
   email: 'cimd.user@test.com',
 };
 
-export type CimdAuthorizeProfile = 'ENABLED_BASE' | 'ENABLED_TIMEOUT' | 'ENABLED_MAXSIZE' | 'DISABLED_BASE';
+export type CimdAuthorizeProfile =
+  | 'ENABLED_BASE'
+  | 'ENABLED_TIMEOUT'
+  | 'ENABLED_MAXSIZE'
+  | 'DISABLED_BASE'
+  | 'ENABLED_DOMAIN_DENY'
+  | 'ENABLED_HTTPS_ONLY'
+  | 'ENABLED_PRIVATE_IP_DENY';
 
 const PROFILE_SETTINGS: Record<CimdAuthorizeProfile, PatchCIMDSettings> = {
   ENABLED_BASE: {
@@ -91,6 +98,39 @@ const PROFILE_SETTINGS: Record<CimdAuthorizeProfile, PatchCIMDSettings> = {
     fetchTimeoutMs: 1500,
     maxResponseSizeKb: 10,
   },
+  ENABLED_DOMAIN_DENY: {
+    enabled: true,
+    allowUnsecuredHttpUri: true,
+    allowPrivateIpAddress: true,
+    allowedDomains: ['trusted.example.com'],
+    fetchTimeoutMs: 1500,
+    maxResponseSizeKb: 10,
+    cacheTtlSeconds: 3600,
+    cacheMaxEntries: 500,
+  },
+  // Unsecured http client_id must be rejected when only https is allowed.
+  ENABLED_HTTPS_ONLY: {
+    enabled: true,
+    allowUnsecuredHttpUri: false,
+    allowPrivateIpAddress: true,
+    allowedDomains: [],
+    fetchTimeoutMs: 1500,
+    maxResponseSizeKb: 10,
+    cacheTtlSeconds: 3600,
+    cacheMaxEntries: 500,
+  },
+  // SSRF guard: the CIMD host ("wiremock") resolves to a private Docker IP, so with
+  // private addresses disallowed the metadata fetch must be rejected.
+  ENABLED_PRIVATE_IP_DENY: {
+    enabled: true,
+    allowUnsecuredHttpUri: true,
+    allowPrivateIpAddress: false,
+    allowedDomains: [],
+    fetchTimeoutMs: 1500,
+    maxResponseSizeKb: 10,
+    cacheTtlSeconds: 3600,
+    cacheMaxEntries: 500,
+  },
 };
 
 type OAuthAuthorizeError = {
@@ -112,23 +152,35 @@ export interface CimdAuthorizeFixture extends Fixture {
   user: any;
   buildClientId: (clientId: string) => string;
   buildAuthorizeUrl: (clientId: string, redirectUri?: string) => string;
-  authorize: (clientId: string, redirectUri?: string) => Promise<any>;
+  authorize: (clientId: string, redirectUri?: string, extraParams?: AuthorizeExtraParams) => Promise<any>;
   fetchCimdLogo: (clientId?: string) => ReturnType<typeof performGet>;
   readOAuthError: (response: any) => OAuthAuthorizeError;
   expectInvalidClientMetadata: (response: any, messagePart: string) => void;
   expectInvalidRequest: (response: any, messagePart: string) => void;
   expectLoginRedirect: (response: any) => void;
-  completeAuthorizationCodeFlow: (clientId: string, redirectUri?: string) => Promise<string>;
-  exchangeAuthCodeForToken: (code: string, clientId: string, redirectUri?: string) => Promise<any>;
+  loginAndGetCallbackLocation: (clientId: string, redirectUri?: string, extraParams?: AuthorizeExtraParams) => Promise<string>;
+  completeAuthorizationCodeFlow: (clientId: string, redirectUri?: string, extraParams?: AuthorizeExtraParams) => Promise<string>;
+  exchangeAuthCodeForToken: (code: string, clientId: string, redirectUri?: string, extraParams?: Record<string, string>) => Promise<any>;
+  exchangeAuthCodeForTokenExpectingError: (
+    code: string,
+    clientId: string,
+    redirectUri?: string,
+    extraParams?: Record<string, string>,
+  ) => Promise<any>;
   exchangeAuthCodeForTokenWithPrivateKeyJwt: (code: string, clientId: string, redirectUri?: string) => Promise<any>;
   revokeAccessToken: (token: string, clientId: string) => Promise<void>;
   introspectToken: (token: string) => Promise<any>;
   introspectTokenWithPrivateKeyJwt: (token: string, clientId: string) => Promise<any>;
+  fetchUserInfo: (accessToken: string) => Promise<any>;
 }
 
 const buildClientId = (profile: CimdAuthorizeProfile, scenario: string): string => `http://wiremock:8080/cimd/${profile}/${scenario}`;
 
-const buildAuthorizeUrl = (endpoint: string, clientId: string, redirectUri: string): string => {
+/** Extra query parameters that can be layered onto the base authorize request (PKCE, nonce, scope override...). */
+export type AuthorizeExtraParams = Partial<Record<'scope' | 'nonce' | 'state' | 'code_challenge' | 'code_challenge_method', string>> &
+  Record<string, string>;
+
+const buildAuthorizeUrl = (endpoint: string, clientId: string, redirectUri: string, extraParams: AuthorizeExtraParams = {}): string => {
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: clientId,
@@ -136,6 +188,12 @@ const buildAuthorizeUrl = (endpoint: string, clientId: string, redirectUri: stri
     scope: 'openid',
     state: 'cimd-state',
   });
+
+  for (const [key, value] of Object.entries(extraParams)) {
+    if (value !== undefined) {
+      params.set(key, value);
+    }
+  }
 
   return `${endpoint}?${params.toString()}`;
 };
@@ -256,8 +314,8 @@ export const setupCimdAuthorizeFixture = async (profile: CimdAuthorizeProfile): 
     await startDomain(domain.id, accessToken);
     const startedDomain = await waitForDomainStart(domain);
 
-    const authorize = async (clientId: string, redirectUri = CIMD_REDIRECT_URI) =>
-      performGet(buildAuthorizeUrl(startedDomain.oidcConfig.authorization_endpoint, clientId, redirectUri)).expect(302);
+    const authorize = async (clientId: string, redirectUri = CIMD_REDIRECT_URI, extraParams: AuthorizeExtraParams = {}) =>
+      performGet(buildAuthorizeUrl(startedDomain.oidcConfig.authorization_endpoint, clientId, redirectUri, extraParams)).expect(302);
 
     const fetchCimdLogo = (clientId?: string) => {
       const base = `${process.env.AM_GATEWAY_URL}/${startedDomain.domain.hrid}/cimd/logo`;
@@ -284,32 +342,61 @@ export const setupCimdAuthorizeFixture = async (profile: CimdAuthorizeProfile): 
       expect(location).not.toContain('error=');
     };
 
-    const completeAuthorizationCodeFlow = async (clientId: string, redirectUri = CIMD_REDIRECT_URI): Promise<string> => {
+    // Runs the authorize + login hops and returns the post-authentication callback location.
+    // OAuth validations such as invalid_scope surface here (after login), not on the initial GET.
+    const loginAndGetCallbackLocation = async (
+      clientId: string,
+      redirectUri = CIMD_REDIRECT_URI,
+      extraParams: AuthorizeExtraParams = {},
+    ): Promise<string> => {
       const authResponse = await performGet(
-        buildAuthorizeUrl(startedDomain.oidcConfig.authorization_endpoint, clientId, redirectUri),
+        buildAuthorizeUrl(startedDomain.oidcConfig.authorization_endpoint, clientId, redirectUri, extraParams),
       ).expect(302);
       const postLogin = await login(authResponse, CIMD_TEST_USER.username, clientId, CIMD_TEST_USER.password, false, false);
       const callbackResponse = await performGet(postLogin.headers['location'], '', {
         Cookie: postLogin.headers['set-cookie'],
       }).expect(302);
-      const callbackLocation = callbackResponse.headers['location'];
+      return callbackResponse.headers['location'];
+    };
+
+    const completeAuthorizationCodeFlow = async (
+      clientId: string,
+      redirectUri = CIMD_REDIRECT_URI,
+      extraParams: AuthorizeExtraParams = {},
+    ): Promise<string> => {
+      const callbackLocation = await loginAndGetCallbackLocation(clientId, redirectUri, extraParams);
       expect(callbackLocation).toContain(redirectUri);
       const codeMatch = /[?&]code=([-_a-zA-Z0-9]+)/.exec(callbackLocation);
       expect(codeMatch).toBeTruthy();
       return codeMatch![1];
     };
 
-    const exchangeAuthCodeForToken = async (code: string, clientId: string, redirectUri = CIMD_REDIRECT_URI): Promise<any> => {
+    const requestTokenRaw = (code: string, clientId: string, redirectUri: string, extraParams: Record<string, string>) => {
       const params = new URLSearchParams({
         grant_type: 'authorization_code',
         code,
         redirect_uri: redirectUri,
         client_id: clientId,
+        ...extraParams,
       });
       return performPost(startedDomain.oidcConfig.token_endpoint, '', params.toString(), {
         'Content-Type': 'application/x-www-form-urlencoded',
-      }).expect(200);
+      });
     };
+
+    const exchangeAuthCodeForToken = async (
+      code: string,
+      clientId: string,
+      redirectUri = CIMD_REDIRECT_URI,
+      extraParams: Record<string, string> = {},
+    ): Promise<any> => requestTokenRaw(code, clientId, redirectUri, extraParams).expect(200);
+
+    const exchangeAuthCodeForTokenExpectingError = async (
+      code: string,
+      clientId: string,
+      redirectUri = CIMD_REDIRECT_URI,
+      extraParams: Record<string, string> = {},
+    ): Promise<any> => requestTokenRaw(code, clientId, redirectUri, extraParams);
 
     const appendPrivateKeyJwtAuthentication = async (params: URLSearchParams, clientId: string): Promise<URLSearchParams> => {
       params.set('client_id', clientId);
@@ -378,6 +465,13 @@ export const setupCimdAuthorizeFixture = async (profile: CimdAuthorizeProfile): 
       return response.body;
     };
 
+    const fetchUserInfo = async (token: string): Promise<any> => {
+      const response = await performGet(startedDomain.oidcConfig.userinfo_endpoint, '', {
+        Authorization: 'Bearer ' + token,
+      }).expect(200);
+      return response.body;
+    };
+
     return {
       profile,
       accessToken,
@@ -398,12 +492,15 @@ export const setupCimdAuthorizeFixture = async (profile: CimdAuthorizeProfile): 
       expectInvalidClientMetadata,
       expectInvalidRequest,
       expectLoginRedirect,
+      loginAndGetCallbackLocation,
       completeAuthorizationCodeFlow,
       exchangeAuthCodeForToken,
+      exchangeAuthCodeForTokenExpectingError,
       exchangeAuthCodeForTokenWithPrivateKeyJwt,
       revokeAccessToken,
       introspectToken,
       introspectTokenWithPrivateKeyJwt,
+      fetchUserInfo,
       cleanUp: async () => {
         await safeDeleteDomain(domain?.id, accessToken);
       },

--- a/gravitee-am-test/specs/gateway/oauth-flows/oauth-flows.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/oauth-flows/oauth-flows.jest.spec.ts
@@ -25,7 +25,7 @@ import { applicationBase64Token } from '@gateway-commands/utils';
 import { jira } from '@specs-utils/jira';
 import { setup } from '../../test-fixture';
 import { OAuth2Fixture, setupFixture, assertGeneratedToken } from '../oauth2/fixture/oauth2-fixture';
-import crypto from 'crypto';
+import { generatePkcePair } from '@utils-commands/pkce';
 
 setup(200000);
 
@@ -153,14 +153,12 @@ describe('OAuth Grant Flows — Regression Suite', () => {
     });
 
     it(jira`should complete auth code + PKCE (S256) flow ${'AM-2238'}`, async () => {
-      // Generate PKCE code_verifier and code_challenge
-      const codeVerifier = crypto.randomBytes(32).toString('base64url');
-      const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+      const { codeVerifier, codeChallenge, codeChallengeMethod } = generatePkcePair();
 
       const { code, lastRedirect } = await executeAuthCodeFlow(
         fixture,
         user,
-        `code_challenge=${codeChallenge}&code_challenge_method=S256`,
+        `code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}`,
       );
 
       // Exchange code for token with code_verifier

--- a/gravitee-am-test/specs/gateway/openid-discovery.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/openid-discovery.jest.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { afterAll, beforeAll, expect } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import {
   createDomain,
@@ -27,7 +27,7 @@ import { createCertificate } from '@management-commands/certificate-management-c
 import { getWellKnownOpenIdConfiguration, performGet } from '@gateway-commands/oauth-oidc-commands';
 import { Domain } from 'api/management/models';
 import { delay, uniqueName } from '@utils-commands/misc';
-import { setup } from '../../test-fixture';
+import { setup } from '../test-fixture';
 
 let accessToken: any;
 let domain: Domain;


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6665](https://gravitee.atlassian.net/browse/AM-6665)

## :pencil2: A description of the changes proposed in the pull request
Add Jest automation to cover CIMD feature:
- OAuth 2.0 authorization code flow with PKCE
- URL trust / SSRF policy enforcement
- id_token / userinfo on the standard auth-code CIMD pat
- grant_types/response_types/scope intersection with template application settings
- Automatic toke/consent revocation negative case

Additionally, moved `openid-discovery.jest.spec.ts` from the management to the gateway folder for discoverability/consistency.

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-6665]: https://gravitee.atlassian.net/browse/AM-6665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ