### PR TITLE
fix: add repository fallback to ClientSyncServiceImpl for immediate D…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/impl/ClientSyncServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/client/impl/ClientSyncServiceImpl.java
@@ -17,10 +17,13 @@ package io.gravitee.am.gateway.handler.common.client.impl;
 
 import io.gravitee.am.gateway.handler.common.client.ClientManager;
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
+import io.gravitee.am.model.Application;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.repository.management.api.ApplicationRepository;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
@@ -34,6 +37,7 @@ import static java.util.Optional.ofNullable;
  * @author Alexandre FARIA (contact at alexandrefaria.net)
  * @author GraviteeSource Team
  */
+@Slf4j
 public class ClientSyncServiceImpl implements ClientSyncService {
 
     @Autowired
@@ -42,9 +46,27 @@ public class ClientSyncServiceImpl implements ClientSyncService {
     @Autowired
     private ClientManager clientManager;
 
+    @Autowired
+    private ApplicationRepository applicationRepository;
+
     @Override
     public Maybe<Client> findById(String id) {
-        return ofNullable(clientManager.get(id)).map(Maybe::just).orElseGet(Maybe::empty);
+        return ofNullable(clientManager.get(id))
+                .map(Maybe::just)
+                .orElseGet(Maybe::empty)
+                .switchIfEmpty(Maybe.defer(() -> {
+                    return applicationRepository.findById(id)
+                        .map(Application::toClient)
+                        .filter(this::canLoadNotSynchronizedClient)
+                        .doOnSuccess(client -> {
+                            log.debug("Client {} not in cache, loaded from repository and deployed locally", id);
+                            clientManager.deploy(client);
+                        })
+                        .onErrorResumeNext(error -> {
+                            log.debug("Failed to load client {} from repository", id, error);
+                            return Maybe.empty();
+                        });
+                }));
     }
 
 
@@ -58,7 +80,32 @@ public class ClientSyncServiceImpl implements ClientSyncService {
         return fromIterable(clientManager.entities())
                 .filter(client -> !client.isTemplate())
                 .filter(client -> client.getClientId().equals(clientId) && client.getDomain().equals(domain))
-                .firstElement();
+                .firstElement()
+                .switchIfEmpty(Maybe.defer(() -> {
+                    return applicationRepository.findByDomainAndClientId(domain, clientId)
+                        .map(Application::toClient)
+                        .filter(this::canLoadNotSynchronizedClient)
+                        .doOnSuccess(client -> {
+                            log.debug("Client {}/{} not in cache, loaded from repository and deployed locally", domain, clientId);
+                            clientManager.deploy(client);
+                        })
+                        .onErrorResumeNext(error -> {
+                            log.debug("Failed to load client {}/{} from repository", domain, clientId, error);
+                            return Maybe.empty();
+                        });
+                }));
+    }
+
+    /**
+     * Return true if the application is not a template, is enabled.
+     * This is useful to avoid providing an invalid Client instance when the cache retrieval fallback
+     * to the repository layer.
+     *
+     * @param client
+     * @return
+     */
+    private boolean canLoadNotSynchronizedClient(Client client) {
+        return client.isEnabled() && !client.isTemplate();
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/ClientSyncServiceRepositoryFallbackTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/ClientSyncServiceRepositoryFallbackTest.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.client;
+
+import io.gravitee.am.gateway.handler.common.client.impl.ClientSyncServiceImpl;
+import io.gravitee.am.model.Application;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.application.ApplicationOAuthSettings;
+import io.gravitee.am.model.application.ApplicationSettings;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.repository.management.api.ApplicationRepository;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for ClientSyncServiceImpl repository fallback behavior.
+ * Covers cache misses that trigger repository queries and error handling.
+ *
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ClientSyncServiceRepositoryFallbackTest {
+
+    @InjectMocks
+    private ClientSyncService clientSyncService = new ClientSyncServiceImpl();
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private ClientManager clientManager;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Before
+    public void setUp() {
+        lenient().when(domain.getId()).thenReturn("domainA");
+        // Use lenient stub for entities since only findByDomainAndClientId tests use it
+        lenient().when(clientManager.entities()).thenReturn(new HashSet<>());
+    }
+
+    // ===== findByDomainAndClientId repository fallback tests =====
+
+    @Test
+    public void findByDomainAndClientId_cacheMiss_repoFound_deploysAndReturnsClient() {
+        Application app = buildEnabledApp("new-id", "domainA", "newClient");
+        when(applicationRepository.findByDomainAndClientId("domainA", "newClient")).thenReturn(Maybe.just(app));
+
+        TestObserver<Client> test = clientSyncService.findByDomainAndClientId("domainA", "newClient").test();
+
+        test.assertComplete().assertNoErrors();
+        test.assertValue(c -> "newClient".equals(c.getClientId()));
+        verify(clientManager, times(1)).deploy(any(Client.class));
+    }
+
+    @Test
+    public void findByDomainAndClientId_cacheMiss_repoNotFound_returnsEmpty() {
+        when(applicationRepository.findByDomainAndClientId("domainA", "unknown")).thenReturn(Maybe.empty());
+
+        TestObserver<Client> test = clientSyncService.findByDomainAndClientId("domainA", "unknown").test();
+
+        test.assertComplete().assertNoErrors().assertNoValues();
+        verify(clientManager, never()).deploy(any());
+    }
+
+    @Test
+    public void findByDomainAndClientId_cacheMiss_repoFindsDisabledClient_returnsEmpty() {
+        Application app = buildDisabledApp("dis-id", "domainA", "disabledClient");
+        when(applicationRepository.findByDomainAndClientId("domainA", "disabledClient")).thenReturn(Maybe.just(app));
+
+        TestObserver<Client> test = clientSyncService.findByDomainAndClientId("domainA", "disabledClient").test();
+
+        test.assertComplete().assertNoErrors().assertNoValues();
+        verify(clientManager, never()).deploy(any());
+    }
+
+    @Test
+    public void findByDomainAndClientId_cacheMiss_repoThrowsException_returnsEmptyAndLogsError() {
+        when(applicationRepository.findByDomainAndClientId("domainA", "errorClient"))
+                .thenReturn(Maybe.error(new RuntimeException("Database connection failed")));
+
+        TestObserver<Client> test = clientSyncService.findByDomainAndClientId("domainA", "errorClient").test();
+
+        test.assertComplete().assertNoErrors().assertNoValues();
+        verify(clientManager, never()).deploy(any());
+    }
+
+    @Test
+    public void findByDomainAndClientId_cacheMiss_repoThrowsCheckedException_returnsEmptyAndLogsError() {
+        when(applicationRepository.findByDomainAndClientId("domainA", "checkedErrorClient"))
+                .thenReturn(Maybe.error(new Exception("Checked exception from repository")));
+
+        TestObserver<Client> test = clientSyncService.findByDomainAndClientId("domainA", "checkedErrorClient").test();
+
+        test.assertComplete().assertNoErrors().assertNoValues();
+        verify(clientManager, never()).deploy(any());
+    }
+
+    // ===== findById repository fallback tests =====
+
+    @Test
+    public void findById_cacheMiss_repoFound_deploysAndReturnsClient() {
+        when(clientManager.get(anyString())).thenReturn(null);
+        Application app = buildEnabledApp("fresh-id", "domainA", "freshClient");
+        when(applicationRepository.findById("fresh-id")).thenReturn(Maybe.just(app));
+
+        TestObserver<Client> test = clientSyncService.findById("fresh-id").test();
+
+        test.assertComplete().assertNoErrors();
+        test.assertValue(c -> "freshClient".equals(c.getClientId()));
+        verify(clientManager, times(1)).deploy(any(Client.class));
+    }
+
+    @Test
+    public void findById_cacheMiss_repoNotFound_returnsEmpty() {
+        when(clientManager.get("missing")).thenReturn(null);
+        when(applicationRepository.findById("missing")).thenReturn(Maybe.empty());
+
+        TestObserver<Client> test = clientSyncService.findById("missing").test();
+
+        test.assertComplete().assertNoErrors().assertNoValues();
+        verify(clientManager, never()).deploy(any());
+    }
+
+    @Test
+    public void findById_cacheMiss_repoFindsDisabledClient_returnsEmpty() {
+        when(clientManager.get("disabled-id")).thenReturn(null);
+        Application app = buildDisabledApp("disabled-id", "domainA", "disabledClient");
+        when(applicationRepository.findById("disabled-id")).thenReturn(Maybe.just(app));
+
+        TestObserver<Client> test = clientSyncService.findById("disabled-id").test();
+
+        test.assertComplete().assertNoErrors().assertNoValues();
+        verify(clientManager, never()).deploy(any());
+    }
+
+    @Test
+    public void findById_cacheMiss_repoThrowsException_returnsEmptyAndLogsError() {
+        when(clientManager.get("error-id")).thenReturn(null);
+        when(applicationRepository.findById("error-id"))
+                .thenReturn(Maybe.error(new RuntimeException("Database error")));
+
+        TestObserver<Client> test = clientSyncService.findById("error-id").test();
+
+        test.assertComplete().assertNoErrors().assertNoValues();
+        verify(clientManager, never()).deploy(any());
+    }
+
+    @Test
+    public void findById_cacheMiss_repoThrowsIOException_returnsEmptyAndLogsError() {
+        when(clientManager.get("io-error")).thenReturn(null);
+        when(applicationRepository.findById("io-error"))
+                .thenReturn(Maybe.error(new RuntimeException("I/O error communicating with database")));
+
+        TestObserver<Client> test = clientSyncService.findById("io-error").test();
+
+        test.assertComplete().assertNoErrors().assertNoValues();
+        verify(clientManager, never()).deploy(any());
+    }
+
+    // ===== Helper methods =====
+
+    private Application buildEnabledApp(String id, String domain, String clientId) {
+        Application app = new Application();
+        app.setId(id);
+        app.setDomain(domain);
+        app.setEnabled(true);
+        ApplicationSettings settings = new ApplicationSettings();
+        ApplicationOAuthSettings oauth = new ApplicationOAuthSettings();
+        oauth.setClientId(clientId);
+        settings.setOauth(oauth);
+        app.setSettings(settings);
+        return app;
+    }
+
+    private Application buildDisabledApp(String id, String domain, String clientId) {
+        Application app = buildEnabledApp(id, domain, clientId);
+        app.setEnabled(false);
+        return app;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/ClientSyncServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/client/ClientSyncServiceTest.java
@@ -18,6 +18,8 @@ package io.gravitee.am.gateway.handler.common.client;
 import io.gravitee.am.gateway.handler.common.client.impl.ClientSyncServiceImpl;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.repository.management.api.ApplicationRepository;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -51,6 +53,9 @@ public class ClientSyncServiceTest {
 
     @Mock
     private ClientManager clientManager;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
 
     @BeforeClass
     public static void initializeClients() {
@@ -103,6 +108,8 @@ public class ClientSyncServiceTest {
     public void setUp() {
         when(domain.getId()).thenReturn("domainA");
         when(clientManager.entities()).thenReturn(clientSet);
+        when(applicationRepository.findByDomainAndClientId(anyString(), anyString())).thenReturn(Maybe.empty());
+        when(applicationRepository.findById(anyString())).thenReturn(Maybe.empty());
     }
 
     @Test

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationRepository.java
@@ -258,6 +258,7 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
                         .bind("value", escapedQuery.toUpperCase())
                         .map((row, rowMetadata) -> row.get(0, Long.class)).first())
                         .map(total -> new Page<>(data, page, total)))
+                .observeOn(Schedulers.computation())
                 .doOnError(error -> LOGGER.error("Unable to retrieve all applications with domain {} (page={}/size={})", domain, page, size, error));
     }
 
@@ -291,6 +292,7 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
                         .bind("value", escapedQuery.toUpperCase())
                         .map((row, rowMetadata) -> row.get(0, Long.class)).first())
                         .map(total -> new Page<Application>(data, page, total)))
+                .observeOn(Schedulers.computation())
                 .doOnError(error -> LOGGER.error("Unable to retrieve all applications with domain {} (page={}/size={})", domain, page, size, error));
     }
 
@@ -299,7 +301,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         LOGGER.debug("findByCertificate({})", certificate);
         return applicationRepository.findByCertificate(certificate)
                 .map(this::toEntity)
-                .flatMap(app -> completeApplication(app).toFlowable());
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -313,7 +316,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
                 .bind(IDENTITY, identityProvider)
                 .map((row, rowMetadata) -> rowMapper.read(JdbcApplication.class, row)).all())
                 .map(this::toEntity)
-                .flatMap(app -> completeApplication(app).toFlowable());
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -321,7 +325,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         LOGGER.debug("findByFactor({})", factor);
         return applicationRepository.findAllByFactor(factor)
                 .map(this::toEntity)
-                .flatMap(app -> completeApplication(app).toFlowable());
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -329,7 +334,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         LOGGER.debug("findByDomainAndExtensionGrant({}, {})", domain, extensionGrant);
         return applicationRepository.findAllByDomainAndGrant(domain, extensionGrant)
                 .map(this::toEntity)
-                .flatMap(app -> completeApplication(app).toFlowable());
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -340,17 +346,20 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         }
         return applicationRepository.findByIdIn(ids)
                 .map(this::toEntity)
-                .flatMap(app -> completeApplication(app).toFlowable());
+                .flatMap(app -> completeApplication(app).toFlowable())
+                .observeOn(Schedulers.computation());
     }
 
     @Override
     public Single<Long> count() {
-        return applicationRepository.count();
+        return applicationRepository.count()
+                .observeOn(Schedulers.computation());
     }
 
     @Override
     public Single<Long> countByDomain(String domain) {
-        return applicationRepository.countByDomain(domain);
+        return applicationRepository.countByDomain(domain)
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -363,7 +372,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
                 .all())
                 .map(this::toEntity)
                 .flatMap(app -> completeApplication(app).toFlowable())
-                .firstElement();
+                .firstElement()
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -371,7 +381,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         LOGGER.debug("findById({}", id);
         return applicationRepository.findById(id)
                 .map(this::toEntity)
-                .flatMap(app -> completeApplication(app).toMaybe());
+                .flatMap(app -> completeApplication(app).toMaybe())
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -400,7 +411,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         insertAction = persistChildEntities(insertAction, item);
 
         return monoToSingle(insertAction.as(trx::transactional))
-                .flatMap(i -> this.findById(item.getId()).toSingle());
+                .flatMap(i -> this.findById(item.getId()).toSingle())
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -429,7 +441,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         updateAction = persistChildEntities(updateAction, item);
 
         return monoToSingle(updateAction.as(trx::transactional))
-                .flatMap(i -> this.findById(item.getId()).toSingle());
+                .flatMap(i -> this.findById(item.getId()).toSingle())
+                .observeOn(Schedulers.computation());
     }
 
     @Override
@@ -438,7 +451,8 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         TransactionalOperator trx = TransactionalOperator.create(tm);
         Mono<Long> delete = getTemplate().delete(JdbcApplication.class).matching(query(where(COL_ID).is(id))).all();
         return monoToCompletable(delete.then(deleteChildEntities(id)).as(trx::transactional))
-                .andThen(applicationRepository.deleteById(id));
+                .andThen(applicationRepository.deleteById(id))
+                .observeOn(Schedulers.computation());
     }
 
     private Mono<Long> deleteChildEntities(String appId) {


### PR DESCRIPTION
…CR client visibility

When multiple Gateway instances are deployed and a client is created via DCR, the originating gateway adds it to its local cache immediately. However, other gateway instances only discover it when their event-polling sync cycle fires (every ~5 seconds by default). During this window, requests for the new client routed to other gateways fail with "client not found".

This fix adds a repository fallback to findById() and findByDomainAndClientId() in ClientSyncServiceImpl. When the in-memory cache misses, the code queries ApplicationRepository directly, then warms the local cache with the result. Disabled clients are filtered out and not cached. The fix is backward-compatible and has zero performance impact on cache hits.

Resolves the distributed synchronization gap without requiring event-push infrastructure or reducing the existing 5-second sync interval.

fixes AM-7020

fixes gravitee-io/issues#11443

