### PR TITLE
fix: replace in-place splice with new array assignment in devices com…

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/users/user/devices/devices.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/devices/devices.component.ts
@@ -81,11 +81,8 @@ export class UserDevicesComponent implements OnInit {
           filter((res) => res),
           switchMap(() => this.userService.removeDevice(this.domainId, this.user.id, device.id)),
           tap(() => {
-            this.snackbarService.open('Device has been deleted deleted');
-            const index = this.devices.indexOf(device);
-            if (index > -1) {
-              this.devices.splice(index, 1);
-            }
+            this.snackbarService.open('Device has been deleted');
+            this.devices = this.devices.filter((d) => d !== device);
           }),
         )
         .subscribe();


### PR DESCRIPTION
…ponent

ngx-datatable keeps an internal copy of [rows] and only re-renders when the input reference changes. Using splice() mutated the array in-place, leaving the table stale after deletion — the deleted device remained visible while the remaining one disappeared, and retrying deletion without a page refresh resulted in a 404. Reassigning via filter() produces a new reference and triggers correct re-rendering.

fixes AM-7024

fixes gravitee-io/issues#11446