### PR TITLE
feat: AM-6780 Automation API

### DIFF
--- a/.circleci/scripts/oas-automation-compat-check.sh
+++ b/.circleci/scripts/oas-automation-compat-check.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -euo pipefail
+
+# Disable git pager to prevent hanging in CI
+export GIT_PAGER=cat
+export PAGER=cat
+
+# ---------------------------------------------------------------------------
+# Automation OAS Breaking-Change Check
+#
+# Compares docs/automation/openapi.yaml at the merge-base against HEAD (or the
+# working tree when --use-head false) using oasdiff. Exits 1 if breaking
+# changes are detected, unless a version-boundary exemption applies.
+#
+# Usage:
+#   bash oas-automation-compat-check.sh [--base <ref>] [--use-head <true|false>]
+#
+#   --base <ref>         Any git ref to use as the comparison baseline.
+#                        When omitted, uses auto-detection: merge-base with the tracking
+#                        branch (@{u}), then GitHub API for PRs, with fallback to HEAD~1.
+#
+#   --use-head <bool>    true  (default): compare baseline → HEAD.
+#                        false: compare baseline → working tree (staged + unstaged).
+#                               Useful locally before committing.
+#
+# Exits 0 if: spec unchanged since merge-base, or no breaking changes, or the
+#             minor version bumped / patch is zero (version-boundary exemption).
+# Exits 1 if: breaking OAS changes detected on a non-exempt version boundary.
+#
+# Requires oasdiff on PATH. Install: https://github.com/tufin/oasdiff
+#
+# Shared CLI, merge-base, and POM version helpers: _compat_common.sh
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_compat_common.sh
+source "$SCRIPT_DIR/_compat_common.sh"
+
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+SPEC="docs/automation/openapi.yaml"
+
+compat_parse_args "$@"
+
+echo "=== Automation OpenAPI Spec Backward-Compatibility Check ==="
+if [[ "$USE_HEAD" == "false" ]]; then
+  echo "(comparing against working tree)"
+fi
+echo ""
+
+compat_resolve_merge_base
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Version-boundary exemption
+# ---------------------------------------------------------------------------
+
+if [[ "$USE_HEAD" == "true" ]]; then
+  read -r HEAD_MINOR HEAD_PATCH <<< "$(extract_version HEAD)"
+else
+  read -r HEAD_MINOR HEAD_PATCH <<< "$(parse_version_from_pom < "$REPO_ROOT/pom.xml" 2>/dev/null || true)"
+fi
+read -r BASE_MINOR BASE_PATCH <<< "$(extract_version "$MERGE_BASE")"
+
+compat_evaluate_minor_bump_allow_breaking
+
+# ---------------------------------------------------------------------------
+# Check for spec changes
+# ---------------------------------------------------------------------------
+
+if [[ "$USE_HEAD" == "true" ]]; then
+  GIT_DIFF_TARGET="HEAD"
+else
+  GIT_DIFF_TARGET=""
+fi
+
+if ! git diff --name-only "$MERGE_BASE" $GIT_DIFF_TARGET -- "$SPEC" 2>/dev/null | grep -q .; then
+  echo "✅  Spec unchanged since merge-base. Nothing to check."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Run oasdiff
+# ---------------------------------------------------------------------------
+
+TMPDIR_OAS="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_OAS"; }
+trap cleanup EXIT
+
+OLD_SPEC="$TMPDIR_OAS/old-openapi.yaml"
+
+if ! git show "${MERGE_BASE}:${SPEC}" > "$OLD_SPEC" 2>/dev/null; then
+  echo "ℹ️   Spec did not exist at merge-base — new file, skipping breaking-change check."
+  exit 0
+fi
+
+NEW_SPEC="$REPO_ROOT/$SPEC"
+if [[ "$USE_HEAD" == "false" && ! -f "$NEW_SPEC" ]]; then
+  echo "ℹ️   Spec removed in working tree — no forward-compat check needed."
+  exit 0
+fi
+
+if [[ -n "$ALLOW_BREAKING" ]]; then
+  # Version-boundary exemption: print findings but do not fail.
+  oasdiff breaking "$OLD_SPEC" "$NEW_SPEC" --fail-on ERR || true
+  echo ""
+  echo "✅  Breaking changes exempted (version boundary)."
+  exit 0
+fi
+
+if ! oasdiff breaking "$OLD_SPEC" "$NEW_SPEC" --fail-on ERR; then
+  echo ""
+  echo "❌  Breaking OAS changes detected."
+  echo "    To fix: keep backward compatibility or bump the minor version in pom.xml."
+  exit 1
+fi
+
+echo ""
+echo "✅  No breaking OAS changes."
+exit 0

--- a/.circleci/scripts/oas-automation-staleness-check.sh
+++ b/.circleci/scripts/oas-automation-staleness-check.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Automation OAS Staleness Check
+#
+# Regenerates docs/automation/openapi.yaml to a temp directory using
+# scripts/regen-automation-oas.sh and diffs the result against the committed
+# spec.
+#
+# Exits 1 if they differ — the committed spec must match what the source
+# generates.
+#
+# Exits 0 if the spec is up to date, or if regeneration itself fails (e.g.
+# the module is not compiled) — a build failure should not mask a compile
+# error as an OAS staleness failure.
+#
+# Pass --also-make to build upstream modules before generating. Locally,
+# use --also-make when the tree is not already compiled.
+#
+# Options forwarded to scripts/regen-automation-oas.sh:
+#   --also-make   Build upstream Maven modules before generating.
+#   --maven-settings <path>
+#                 Pass-through -s for CI (Artifactory).
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+SPEC="docs/automation/openapi.yaml"
+
+REGEN_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --also-make) REGEN_ARGS+=(--also-make); shift ;;
+    --maven-settings)
+      SETTINGS_PATH="${2:?--maven-settings requires a path}"
+      REGEN_ARGS+=(--maven-settings "$SETTINGS_PATH")
+      shift 2
+      ;;
+    *) echo "Error: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+echo "=== Automation OpenAPI Spec Staleness Check ==="
+echo ""
+
+TMPDIR_OAS="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_OAS"; }
+trap cleanup EXIT
+
+if ! bash "$REPO_ROOT/scripts/regen-automation-oas.sh" \
+      --output-dir "$TMPDIR_OAS" \
+      ${REGEN_ARGS[@]+"${REGEN_ARGS[@]}"} \
+      2>&1 | sed 's/^/  /'; then
+  echo ""
+  echo "⚠️   WARNING: could not regenerate spec — automation API module may not be compiled."
+  echo "    Staleness check skipped. Run locally with:"
+  echo "      bash .circleci/scripts/oas-automation-staleness-check.sh --also-make"
+  exit 0
+fi
+
+echo ""
+
+if diff -q "$TMPDIR_OAS/openapi.yaml" "$REPO_ROOT/$SPEC" > /dev/null 2>&1; then
+  echo "✅  Committed spec matches regenerated output — up to date."
+  exit 0
+else
+  echo "❌  Committed spec differs from what the current source would generate."
+  echo "    Regenerate and commit the updated spec:"
+  echo "      bash scripts/regen-automation-oas.sh"
+  echo ""
+  echo "    Diff (regenerated vs committed):"
+  diff --unified=3 "$TMPDIR_OAS/openapi.yaml" "$REPO_ROOT/$SPEC" | head -60 | sed 's/^/  /'
+  exit 1
+fi

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1074,8 +1074,14 @@ jobs:
           name: Check OAS staleness
           command: bash .circleci/scripts/oas-staleness-check.sh --also-make --maven-settings /tmp/.gravitee.settings.xml
       - run:
+          name: Check Automation OAS staleness
+          command: bash .circleci/scripts/oas-automation-staleness-check.sh --also-make --maven-settings /tmp/.gravitee.settings.xml
+      - run:
           name: Check OAS breaking changes
           command: bash .circleci/scripts/oas-compat-check.sh
+      - run:
+          name: Check Automation OAS breaking changes
+          command: bash .circleci/scripts/oas-automation-compat-check.sh
 
   ee-schema-compat-check:
     executor:
@@ -1309,6 +1315,7 @@ jobs:
             export CURRENT_GIT_BRANCH=$(git status | grep 'On branch' | awk '{print $3}')
 
             bash scripts/regen-oas.sh --maven-settings /tmp/.gravitee.settings.xml
+            bash scripts/regen-automation-oas.sh --maven-settings /tmp/.gravitee.settings.xml
             git add --update
             git commit -m "${MVN_PRJ_VERSION}"
             git tag ${MVN_PRJ_VERSION}
@@ -1333,6 +1340,7 @@ jobs:
               git checkout -b ${MAINTENANCE_GIT_BRANCH}
               mvn -s /tmp/.gravitee.settings.xml -B versions:set -DnewVersion=${NEXT_PATCH_SNAPSHOT_VERSION} -DgenerateBackupPoms=false
               bash scripts/regen-oas.sh --version-only --maven-settings /tmp/.gravitee.settings.xml
+              bash scripts/regen-automation-oas.sh --version-only --maven-settings /tmp/.gravitee.settings.xml
               git add --update
               git commit -m 'chore: prepare next version'
 
@@ -1392,6 +1400,7 @@ jobs:
             fi;
             
             bash scripts/regen-oas.sh --version-only --maven-settings /tmp/.gravitee.settings.xml
+            bash scripts/regen-automation-oas.sh --version-only --maven-settings /tmp/.gravitee.settings.xml
             git add --update
             git commit -m 'chore: prepare next version [skip ci]'
 

--- a/docker/local-stack/dev/docker-compose.yml
+++ b/docker/local-stack/dev/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - GRAVITEE_MFA_RATE_TIMEUNIT=Minutes
       - GIO_MAX_MEM=512m
       - GRAVITEE_SERVICES_CORE_HTTP_HOST=0.0.0.0
+      - GRAVITEE_HTTP_API_AUTOMATION_ENABLED=true
 
   am-wait:
     image: curlimages/curl:8.10.1

--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -1,0 +1,1225 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+openapi: 3.0.1
+info:
+  title: Gravitee.io AM - Automation API
+  description: "Declarative, GitOps-style management of Access Management resources."
+  version: 4.12.0-alpha.5
+servers:
+- url: /management/automation
+security:
+- BearerAuth: []
+- BasicAuth: []
+tags:
+- name: Certificates
+- name: Domains
+- name: Identity Providers
+- name: Reporters
+paths:
+  /organizations/{orgId}/environments/{envId}/domains:
+    get:
+      tags:
+      - Domains
+      summary: List all domains
+      description: Returns all security domains within the specified environment.
+      operationId: automationListDomains
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: List of domains
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AutomationDomain"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+    put:
+      tags:
+      - Domains
+      summary: Create or update a domain
+      description: Idempotent create-or-update. Uses the key field in the body to
+        identify the domain.
+      operationId: automationCreateOrUpdateDomain
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AutomationDomain"
+        required: true
+      responses:
+        "200":
+          description: The created or updated domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationDomain"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}:
+    get:
+      tags:
+      - Domains
+      summary: Get a domain
+      description: Retrieves a single security domain by its key.
+      operationId: automationGetDomain
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationDomain"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+    delete:
+      tags:
+      - Domains
+      summary: Delete a domain
+      operationId: automationDeleteDomain
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Domain deleted
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/certificates:
+    get:
+      tags:
+      - Certificates
+      - Domains
+      summary: List a domain's certificates
+      description: Returns all certificates managed by the Automation API under the
+        domain.
+      operationId: automationListCertificates
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: List of certificates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AutomationCertificate"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+    put:
+      tags:
+      - Certificates
+      - Domains
+      summary: Create or update a certificate
+      description: Idempotent create-or-update. Uses the key field in the body to
+        identify the certificate within the domain.
+      operationId: automationCreateOrUpdateCertificate
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AutomationCertificate"
+        required: true
+      responses:
+        "200":
+          description: The created or updated certificate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationCertificate"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/certificates/{certKey}:
+    get:
+      tags:
+      - Certificates
+      - Domains
+      summary: Get a certificate
+      description: Retrieves a single certificate by its key.
+      operationId: automationGetCertificate
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: certKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The certificate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationCertificate"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+    delete:
+      tags:
+      - Certificates
+      - Domains
+      summary: Delete a certificate
+      operationId: automationDeleteCertificate
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: certKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Certificate deleted
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identity-providers:
+    get:
+      tags:
+      - Identity Providers
+      - Domains
+      summary: List a domain's identity providers
+      description: Returns all identity providers managed by the Automation API under
+        the domain.
+      operationId: automationListIdentityProviders
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: List of identity providers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AutomationIdentityProvider"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+    put:
+      tags:
+      - Identity Providers
+      - Domains
+      summary: Create or update an identity provider
+      description: Idempotent create-or-update. Uses the key field in the body to
+        identify the identity provider within the domain.
+      operationId: automationCreateOrUpdateIdentityProvider
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AutomationIdentityProvider"
+        required: true
+      responses:
+        "200":
+          description: The created or updated identity provider
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationIdentityProvider"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identity-providers/{idpKey}:
+    get:
+      tags:
+      - Identity Providers
+      - Domains
+      summary: Get an identity provider
+      description: Retrieves a single identity provider by its key.
+      operationId: automationGetIdentityProvider
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: idpKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The identity provider
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationIdentityProvider"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+    delete:
+      tags:
+      - Identity Providers
+      - Domains
+      summary: Delete an identity provider
+      operationId: automationDeleteIdentityProvider
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: idpKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Identity provider deleted
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/reporters:
+    get:
+      tags:
+      - Reporters
+      - Domains
+      summary: List a domain's reporters
+      description: Returns all reporters managed by the Automation API under the domain.
+      operationId: automationListReporters
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: List of reporters
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AutomationReporter"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+    put:
+      tags:
+      - Reporters
+      - Domains
+      summary: Create or update a reporter
+      description: Idempotent create-or-update. Uses the key field in the body to
+        identify the reporter within the domain.
+      operationId: automationCreateOrUpdateReporter
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AutomationReporter"
+        required: true
+      responses:
+        "200":
+          description: The created or updated reporter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationReporter"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/reporters/{reporterKey}:
+    get:
+      tags:
+      - Reporters
+      - Domains
+      summary: Get a reporter
+      description: Retrieves a single reporter by its key.
+      operationId: automationGetReporter
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: reporterKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The reporter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationReporter"
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+    delete:
+      tags:
+      - Reporters
+      - Domains
+      summary: Delete a reporter
+      operationId: automationDeleteReporter
+      parameters:
+      - name: orgId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: envId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: domainKey
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: reporterKey
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Reporter deleted
+        "403":
+          description: Permission denied
+        default:
+          description: Unexpected error
+components:
+  schemas:
+    AutomationAccountSettings:
+      type: object
+      properties:
+        accountBlockedDuration:
+          type: integer
+          format: int32
+        autoLoginAfterRegistration:
+          type: boolean
+        autoLoginAfterResetPassword:
+          type: boolean
+        completeRegistrationWhenResetPassword:
+          type: boolean
+        defaultIdentityProviderForRegistration:
+          type: string
+          description: key of an identity provider that exists under this domain
+        deletePasswordlessDevicesAfterResetPassword:
+          type: boolean
+        dynamicUserRegistration:
+          type: boolean
+        inherited:
+          type: boolean
+        loginAttemptsDetectionEnabled:
+          type: boolean
+        loginAttemptsResetTime:
+          type: integer
+          format: int32
+        maxLoginAttempts:
+          type: integer
+          format: int32
+        mfaChallengeAttemptsDetectionEnabled:
+          type: boolean
+        mfaChallengeAttemptsResetTime:
+          type: integer
+          format: int32
+        mfaChallengeMaxAttempts:
+          type: integer
+          format: int32
+        mfaChallengeSendVerifyAlertEmail:
+          type: boolean
+        redirectUriAfterRegistration:
+          type: string
+        redirectUriAfterResetPassword:
+          type: string
+        rememberMe:
+          type: boolean
+        rememberMeDuration:
+          type: integer
+          format: int32
+        resetPasswordConfirmIdentity:
+          type: boolean
+        resetPasswordCustomForm:
+          type: boolean
+        resetPasswordCustomFormFields:
+          type: array
+          items:
+            $ref: "#/components/schemas/FormField"
+        resetPasswordInvalidateTokens:
+          type: boolean
+        sendRecoverAccountEmail:
+          type: boolean
+        sendVerifyRegistrationAccountEmail:
+          type: boolean
+    AutomationCIBASettings:
+      type: object
+      properties:
+        authReqExpiry:
+          type: integer
+          format: int32
+        bindingMessageLength:
+          type: integer
+          format: int32
+        enabled:
+          type: boolean
+        tokenReqInterval:
+          type: integer
+          format: int32
+    AutomationCertificate:
+      required:
+      - key
+      type: object
+      properties:
+        configuration:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        expiresAt:
+          type: string
+          format: date-time
+          readOnly: true
+        key:
+          maxLength: 255
+          minLength: 1
+          pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+          type: string
+        name:
+          maxLength: 255
+          minLength: 1
+          type: string
+        system:
+          type: boolean
+          description: "whether this is the domain's system certificate (immutable\
+            \ after creation; when true, only key is required and the certificate\
+            \ is built from domains.certificates.default.* system settings)"
+        type:
+          maxLength: 2147483647
+          minLength: 1
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+    AutomationCertificateSettings:
+      type: object
+      properties:
+        fallbackCertificate:
+          type: string
+    AutomationDomain:
+      required:
+      - dataPlaneId
+      - key
+      - name
+      - path
+      type: object
+      properties:
+        accountSettings:
+          $ref: "#/components/schemas/AutomationAccountSettings"
+        certificateSettings:
+          $ref: "#/components/schemas/AutomationCertificateSettings"
+        corsSettings:
+          $ref: "#/components/schemas/CorsSettings"
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        dataPlaneId:
+          maxLength: 255
+          minLength: 1
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+        key:
+          maxLength: 255
+          minLength: 1
+          pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+          type: string
+        loginSettings:
+          $ref: "#/components/schemas/LoginSettings"
+        name:
+          maxLength: 255
+          minLength: 1
+          type: string
+        oidc:
+          $ref: "#/components/schemas/AutomationOidcSettings"
+        passwordSettings:
+          $ref: "#/components/schemas/PasswordSettings"
+        path:
+          maxLength: 255
+          minLength: 1
+          type: string
+        saml:
+          $ref: "#/components/schemas/AutomationSamlSettings"
+        scim:
+          $ref: "#/components/schemas/SCIMSettings"
+        secretExpirationSettings:
+          $ref: "#/components/schemas/SecretExpirationSettings"
+        selfServiceAccountManagementSettings:
+          $ref: "#/components/schemas/SelfServiceAccountManagementSettings"
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        tokenExchangeSettings:
+          $ref: "#/components/schemas/TokenExchangeSettings"
+        uma:
+          $ref: "#/components/schemas/UMASettings"
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+        vhosts:
+          type: array
+          items:
+            $ref: "#/components/schemas/VirtualHost"
+        webAuthnSettings:
+          $ref: "#/components/schemas/WebAuthnSettings"
+    AutomationIdentityProvider:
+      required:
+      - key
+      type: object
+      properties:
+        configuration:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        domainWhitelist:
+          type: array
+          items:
+            type: string
+        groupMapper:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        key:
+          maxLength: 255
+          minLength: 1
+          pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+          type: string
+        mappers:
+          type: object
+          additionalProperties:
+            type: string
+        name:
+          maxLength: 255
+          minLength: 1
+          type: string
+        roleMapper:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        system:
+          type: boolean
+          description: "whether this is the domain's system identity provider (immutable\
+            \ after creation; when true, only key is required and the IDP is built\
+            \ from domains.identities.default.* system settings)"
+        type:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+    AutomationOidcSettings:
+      type: object
+      properties:
+        cibaSettings:
+          $ref: "#/components/schemas/AutomationCIBASettings"
+        clientRegistrationSettings:
+          $ref: "#/components/schemas/ClientRegistrationSettings"
+        postLogoutRedirectUris:
+          type: array
+          items:
+            type: string
+        redirectUriStrictMatching:
+          type: boolean
+        requestUris:
+          type: array
+          items:
+            type: string
+        securityProfileSettings:
+          $ref: "#/components/schemas/SecurityProfileSettings"
+    AutomationReporter:
+      required:
+      - key
+      type: object
+      properties:
+        configuration:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        dataType:
+          type: string
+          readOnly: true
+        enabled:
+          type: boolean
+        key:
+          maxLength: 255
+          minLength: 1
+          pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+          type: string
+        name:
+          maxLength: 255
+          minLength: 1
+          type: string
+        system:
+          type: boolean
+          description: "whether this is the domain's system reporter (immutable after\
+            \ creation; when true, only key is required and the reporter is built\
+            \ from domains.reporters.default.* and repository system settings)"
+        type:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+    AutomationSamlSettings:
+      type: object
+      properties:
+        certificate:
+          type: string
+        enabled:
+          type: boolean
+        entityId:
+          type: string
+    ClientRegistrationSettings:
+      type: object
+      properties:
+        allowHttpSchemeRedirectUri:
+          type: boolean
+        allowLocalhostRedirectUri:
+          type: boolean
+        allowRedirectUriParamsExpressionLanguage:
+          type: boolean
+        allowWildCardRedirectUri:
+          type: boolean
+        allowedScopes:
+          type: array
+          items:
+            type: string
+        allowedScopesEnabled:
+          type: boolean
+        clientTemplateEnabled:
+          type: boolean
+        defaultScopes:
+          type: array
+          items:
+            type: string
+        dynamicClientRegistrationEnabled:
+          type: boolean
+        openDynamicClientRegistrationEnabled:
+          type: boolean
+    CorsSettings:
+      type: object
+      properties:
+        allowCredentials:
+          type: boolean
+        allowedHeaders:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        allowedMethods:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        allowedOrigins:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        enabled:
+          type: boolean
+        maxAge:
+          type: integer
+          format: int32
+    FormField:
+      type: object
+      properties:
+        key:
+          type: string
+        label:
+          type: string
+        type:
+          type: string
+    LoginSettings:
+      type: object
+      properties:
+        certificateBasedAuthEnabled:
+          type: boolean
+        certificateBasedAuthUrl:
+          type: string
+        enforcePasswordPolicyEnabled:
+          type: boolean
+        forgotPasswordEnabled:
+          type: boolean
+        hideForm:
+          type: boolean
+        identifierFirstEnabled:
+          type: boolean
+        inherited:
+          type: boolean
+        magicLinkAuthEnabled:
+          type: boolean
+        passwordlessDeviceNamingEnabled:
+          type: boolean
+        passwordlessEnabled:
+          type: boolean
+        passwordlessEnforcePasswordEnabled:
+          type: boolean
+        passwordlessEnforcePasswordMaxAge:
+          type: integer
+          format: int32
+        passwordlessRememberDeviceEnabled:
+          type: boolean
+        registerEnabled:
+          type: boolean
+        rememberMeEnabled:
+          type: boolean
+        resetPasswordOnExpiration:
+          type: boolean
+    PasswordSettings:
+      type: object
+      properties:
+        excludePasswordsInDictionary:
+          type: boolean
+        excludeUserProfileInfoInPassword:
+          type: boolean
+        expiryDuration:
+          type: integer
+          format: int32
+        includeNumbers:
+          type: boolean
+        includeSpecialCharacters:
+          type: boolean
+        inherited:
+          type: boolean
+        lettersInMixedCase:
+          type: boolean
+        maxConsecutiveLetters:
+          type: integer
+          format: int32
+        maxLength:
+          type: integer
+          format: int32
+        minLength:
+          type: integer
+          format: int32
+        oldPasswords:
+          type: integer
+          format: int32
+        passwordHistoryEnabled:
+          type: boolean
+    ResetPasswordSettings:
+      type: object
+      properties:
+        oldPasswordRequired:
+          type: boolean
+        tokenAge:
+          type: integer
+          format: int32
+    SCIMSettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+        idpSelectionEnabled:
+          type: boolean
+        idpSelectionRule:
+          type: string
+    SecretExpirationSettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+        expiryTimeSeconds:
+          type: integer
+          format: int64
+    SecurityProfileSettings:
+      type: object
+      properties:
+        enableFapiBrazil:
+          type: boolean
+        enablePlainFapi:
+          type: boolean
+    SelfServiceAccountManagementSettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+        resetPassword:
+          $ref: "#/components/schemas/ResetPasswordSettings"
+    TokenExchangeOAuthSettings:
+      type: object
+      properties:
+        inherited:
+          type: boolean
+        scopeHandling:
+          type: string
+          enum:
+          - DOWNSCOPING
+          - PERMISSIVE
+    TokenExchangeSettings:
+      type: object
+      properties:
+        allowDelegation:
+          type: boolean
+        allowImpersonation:
+          type: boolean
+        allowedActorTokenTypes:
+          type: array
+          items:
+            type: string
+        allowedRequestedTokenTypes:
+          type: array
+          items:
+            type: string
+        allowedSubjectTokenTypes:
+          type: array
+          items:
+            type: string
+        enabled:
+          type: boolean
+        maxDelegationDepth:
+          type: integer
+          format: int32
+        tokenExchangeOAuthSettings:
+          $ref: "#/components/schemas/TokenExchangeOAuthSettings"
+        trustedIssuers:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrustedIssuer"
+    TrustedIssuer:
+      type: object
+      properties:
+        certificate:
+          type: string
+        issuer:
+          type: string
+        jwksUri:
+          type: string
+        keyResolutionMethod:
+          type: string
+          enum:
+          - JWKS_URL
+          - PEM
+        scopeMappings:
+          type: object
+          additionalProperties:
+            type: string
+        userBindingCriteria:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserBindingCriterion"
+        userBindingEnabled:
+          type: boolean
+    UMASettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+    UserBindingCriterion:
+      type: object
+      properties:
+        attribute:
+          type: string
+        expression:
+          type: string
+    VirtualHost:
+      type: object
+      properties:
+        host:
+          type: string
+        overrideEntrypoint:
+          type: boolean
+        path:
+          type: string
+    WebAuthnSettings:
+      type: object
+      properties:
+        attestationConveyancePreference:
+          type: string
+          enum:
+          - NONE
+          - INDIRECT
+          - DIRECT
+        authenticatorAttachment:
+          type: string
+          enum:
+          - CROSS_PLATFORM
+          - PLATFORM
+        certificates:
+          type: object
+          additionalProperties:
+            type: object
+        enforceAuthenticatorIntegrity:
+          type: boolean
+        enforceAuthenticatorIntegrityMaxAge:
+          type: integer
+          format: int32
+        forceRegistration:
+          type: boolean
+        origin:
+          type: string
+        relyingPartyId:
+          type: string
+        relyingPartyName:
+          type: string
+        requireResidentKey:
+          type: boolean
+        userVerification:
+          type: string
+          enum:
+          - REQUIRED
+          - PREFERRED
+          - DISCOURAGED
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    BasicAuth:
+      type: http
+      scheme: basic

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -13512,8 +13512,13 @@ components:
           type: array
           items:
             type: string
+        key:
+          type: string
+          readOnly: true
         loginSettings:
           $ref: "#/components/schemas/LoginSettings"
+        managedBy:
+          $ref: "#/components/schemas/ManagedBy"
         master:
           type: boolean
         name:
@@ -14157,6 +14162,11 @@ components:
               type: string
         id:
           type: string
+        key:
+          type: string
+          readOnly: true
+        managedBy:
+          $ref: "#/components/schemas/ManagedBy"
         mappers:
           type: object
           additionalProperties:
@@ -14295,6 +14305,13 @@ components:
           $ref: "#/components/schemas/StepUpAuthenticationSettings"
         stepUpAuthenticationRule:
           type: string
+    ManagedBy:
+      type: string
+      enum:
+      - NONE
+      - TERRAFORM
+      - GKO
+      - AUTOMATION_API
     McpTool:
       type: object
       allOf:
@@ -16584,6 +16601,11 @@ components:
           type: string
         inherited:
           type: boolean
+        key:
+          type: string
+          readOnly: true
+        managedBy:
+          $ref: "#/components/schemas/ManagedBy"
         name:
           type: string
         reference:

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/4.12.0-dataplane-cimd-client-states.yml
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/4.12.0-dataplane-cimd-client-states.yml
@@ -17,12 +17,26 @@ databaseChangeLog:
             columnNames: id
             tableName: cimd_client_states
 
-        - createIndex:
-            columns:
-              - column:
-                  name: domain_id
-              - column:
-                  name: client_id
-            indexName: idx_cimd_client_states_domain_client
-            tableName: cimd_client_states
-            unique: true
+        # PostgreSQL: use functional unique index (client_id is too long for a direct index)
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            sql: "CREATE UNIQUE INDEX uq_cimd_client_states_domain_client ON cimd_client_states(domain_id, md5(client_id))"
+
+        # SQL Server: add persisted computed column using HASHBYTES('SHA2_256', client_id)
+        - sql:
+            dbms: mssql
+            splitStatements: false
+            sql: "ALTER TABLE cimd_client_states ADD client_id_hash AS LOWER(CONVERT(VARCHAR(64), HASHBYTES('SHA2_256', client_id), 2)) PERSISTED"
+
+        # MySQL/MariaDB: add generated column using SHA2(client_id, 256)
+        - sql:
+            dbms: mysql, mariadb
+            splitStatements: false
+            sql: "ALTER TABLE cimd_client_states ADD COLUMN client_id_hash VARCHAR(64) GENERATED ALWAYS AS (SHA2(client_id, 256)) STORED"
+
+        # Unique constraint for MySQL/MariaDB/MSSQL (PostgreSQL uses functional index above)
+        - sql:
+            dbms: mysql, mariadb, mssql
+            splitStatements: false
+            sql: "ALTER TABLE cimd_client_states ADD CONSTRAINT uq_cimd_client_states_domain_client UNIQUE (domain_id, client_id_hash)"

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
@@ -238,7 +238,7 @@ public class UserServiceImpl implements UserService {
         final var rawPassword = user.getPassword();
         // validate user and then check user uniqueness
         return userValidator.validate(user)
-                .andThen(userService.findByUsernameAndSource(user.getUsername(), source).isEmpty()
+                .andThen(Single.defer(() -> userService.findByUsernameAndSource(user.getUsername(), source).isEmpty()
                         .flatMapMaybe(checkUserPresence(user, source))
                         .switchIfEmpty(Single.error(() -> new UserProviderNotFoundException(source)))
                         .flatMap(userProvider -> userProvider.create(convert(user)))
@@ -258,7 +258,7 @@ public class UserServiceImpl implements UserService {
                                 .client(user.getClient())
                                 .principal(principal)
                                 .type(EventType.USER_REGISTERED)
-                                .throwable(throwable))));
+                                .throwable(throwable)))));
     }
 
     private static RegistrationResponse buildRegistrationResponse(Optional<AccountSettings> accountSettings, User user) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
@@ -87,6 +87,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -1388,10 +1389,6 @@ public class UserServiceTest {
                 Completable.defer(() -> Completable.error(new IllegalArgumentException("User is not valid")))
         );
 
-        when(commonUserService.findByUsernameAndSource(anyString(), anyString())).thenReturn(
-                Maybe.empty()
-        );
-
         final User user = new User();
         user.setUsername("username");
         user.setPreRegistration(false);
@@ -1449,6 +1446,35 @@ public class UserServiceTest {
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertError(UserProviderNotFoundException.class);
 
+        verify(auditService, times(1)).report(any());
+    }
+
+    @Test
+    public void must_not_register_user_and_must_not_fallback_when_configured_idp_missing() {
+        when(userValidator.validate(any())).thenReturn(Completable.complete());
+
+        final User user = new User();
+        user.setId("user-id");
+        user.setUsername("username");
+        // A specific (non-default) registration provider is configured...
+        user.setSource("configured-idp");
+        user.setPreRegistration(false);
+        user.setRegistrationCompleted(true);
+
+        when(commonUserService.findByUsernameAndSource(anyString(), anyString())).thenReturn(Maybe.empty());
+        // ...but that provider does not exist.
+        when(identityProviderManager.getUserProvider("configured-idp")).thenReturn(Maybe.empty());
+
+        final Client client = new Client();
+        client.setId("clientId");
+
+        var testObserver = userService.register(client, user).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        // The configured provider being absent must fail registration
+        testObserver.assertError(UserProviderNotFoundException.class);
+        testObserver.assertError(throwable -> throwable.getMessage().contains("configured-idp"));
+        verify(identityProviderManager, times(1)).getUserProvider("configured-idp");
+        verify(identityProviderManager, never()).getUserProvider(startsWith("default-idp-"));
         verify(auditService, times(1)).report(any());
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/WALKTHROUGH.md
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/WALKTHROUGH.md
@@ -1,0 +1,409 @@
+# Automation API Walkthrough
+
+This guide walks through using the AM Automation API to declaratively provision
+Domains and the resources that live under them — Identity Providers, Certificates and
+Reporters — the kind of setup you'd drive from Terraform, a GKO CRD, or a CI/CD pipeline.
+
+## Prerequisites
+
+- Management API running with automation enabled:
+  ```yaml
+  # gravitee.yml
+  http:
+    api:
+      automation:
+        enabled: true
+  ```
+- An admin Bearer token (all examples below use `$TOKEN`)
+
+```bash
+TOKEN=$(curl -s http://localhost:8093/management/auth/token \
+  -u admin:adminadmin \
+  -d "grant_type=password&username=admin&password=adminadmin" | jq -r '.access_token')
+```
+
+> **Organizations and environments are a prerequisite, not part of this API.**
+> The Automation API operates *within* an existing organization and environment — it
+> does **not** create, update, or delete them. Every path is rooted at
+> `/organizations/{orgId}/environments/{envId}/…`; provision the organization and
+> environment via the standard Management API beforehand. The default install ships an
+> organization and environment both with the id `DEFAULT`, used throughout this guide.
+
+## Base URL
+
+```
+http://localhost:8093/management/automation
+```
+
+## API Pattern
+
+Every resource type (Domain, Identity Provider, Certificate, Reporter) is managed
+individually and follows the same convention:
+
+| Operation | Method | Path | Identifier |
+|-----------|--------|------|------------|
+| Create/Update | PUT | Collection (e.g. `/domains`) | `key` in request body |
+| Read one | GET | Resource (e.g. `/domains/{key}`) | `key` in path |
+| List all | GET | Collection (e.g. `/domains`) | — |
+| Delete | DELETE | Resource (e.g. `/domains/{key}`) | `key` in path |
+
+PUT is always on the **collection** endpoint. The `key` field in the body identifies
+which resource to create or update — no key in the PUT path. Each PUT manages a single
+resource; it never deletes sibling resources you didn't mention.
+
+### Addressing: the `key`
+
+Every Automation-API-managed resource (Domain, Identity Provider, Certificate, Reporter)
+carries a dedicated `key` — a stable, human-chosen identifier set on create and immutable
+thereafter (PUTting a different `key` creates a new resource). `key` is distinct from the
+mutable `name`: you can rename a resource freely without changing its identity.
+
+`key` format: lowercase alphanumeric and hyphens, starting and ending with an
+alphanumeric character (`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`).
+
+> **Deterministic IDs:** the internal resource id is a UUID derived from the resource's
+> scope (environment for domains, domain for identity providers, certificates and
+> reporters) folded with its `key`. The same inputs always produce the same id, which
+> gives idempotent create-or-update without exposing internal ids.
+
+### The `default` flag
+
+A Certificate, Identity Provider or Reporter may be declared the domain's **default** of
+its type with `"default": true`. This maps to the internal *system* flag the platform uses
+for special handling — the default certificate signs tokens for applications that don't
+pin one, the default identity provider backs user registration, the default reporter
+captures audit logs. A default identity provider additionally adopts the conventional
+`default-idp-<domainId>` id so the gateway's registration fallback resolves to it. There can
+be at most one default per type per domain. Unlike via the Management API, the Automation
+API can freely GET and DELETE its default resources — no system guard restricts it.
+
+> **`default` is immutable** — like `key`, it is an identity attribute fixed at creation
+> (for an identity provider it co-determines the internal id). A PUT that flips `default`
+> on an existing resource is **rejected with `400`**, not silently ignored; delete and
+> recreate the resource to change it. A `GET → PUT` round-trip of an unmodified document is
+> therefore still lossless.
+
+### Automation-managed scope
+
+Every resource created via this API is stamped `managedBy = AUTOMATION_API`. The
+Automation API only sees, mutates, or deletes its own resources:
+
+- Listing / fetching a domain, identity provider, certificate or reporter only succeeds
+  for an automation-managed one — UI-created resources are invisible.
+- Declaring a `key` whose deterministic id collides with a non-automation resource is
+  rejected.
+
+> **Automation domains start empty.** Unlike domains created via the UI, an
+> automation-managed domain is **not** seeded with a default identity provider, a default
+> reporter, or a default certificate. Declare what you need explicitly — including, if you
+> want them, the defaults themselves via the `default` flag (see above).
+
+This makes adoption safe in environments that already host UI-created resources.
+
+### PUT is full desired state (declarative)
+
+A PUT body is the **complete desired state** of the resource — there are no partial
+updates and no implicit/derived values. To change one thing: `GET`, edit the returned
+document, `PUT` the whole document back. Consequences:
+
+- **Required on every domain PUT:** `key`, `name`, `path`, `dataPlaneId`. `enabled`
+  defaults to `true` if omitted. `dataPlaneId` is immutable after creation — it is part
+  of the full document but is never re-applied on update.
+- **Strict settings reconciliation:** any settings block omitted from the payload is
+  reset to its domain-creation default — `null` (feature off) for every settings block
+  **except `oidc`**, which is reset to its standard default (it must never be null).
+- **References are eventually consistent:** the certificate / identity-provider keys a
+  domain references (`saml.certificate`, `certificateSettings.fallbackCertificate`,
+  `accountSettings.defaultIdentityProviderForRegistration`) need **not** already exist —
+  they may point to a resource you create later, in any order. The key is stored verbatim
+  so a `GET` echoes it back even before the target exists.
+- `GET` then `PUT` of the same payload is a lossless, idempotent round-trip.
+
+---
+
+## 1. Create Security Domains
+
+The `key` in the body is the unique identifier within the environment.
+
+```bash
+ORG="DEFAULT"
+ENV="DEFAULT"
+BASE="http://localhost:8093/management/automation"
+
+# Customer-facing auth domain
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "customer-auth",
+    "name": "Customer Authentication",
+    "description": "Handles customer login, registration, and MFA",
+    "path": "/customer-auth",
+    "enabled": true,
+    "dataPlaneId": "default"
+  }' | jq '{key, name}'
+
+# Internal admin domain
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "internal-admin",
+    "name": "Internal Admin",
+    "description": "Employee SSO for back-office applications",
+    "path": "/internal-admin",
+    "enabled": true,
+    "dataPlaneId": "default"
+  }' | jq '{key, name}'
+```
+
+List domains in the environment:
+```bash
+curl -s "$BASE/organizations/$ORG/environments/$ENV/domains" \
+  -H "Authorization: Bearer $TOKEN" | jq '.[].key'
+```
+
+Read a single domain:
+```bash
+curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth" \
+  -H "Authorization: Bearer $TOKEN" | jq '{key, name, enabled}'
+```
+
+---
+
+## 2. Identity Providers — a resource under the domain
+
+Identity providers are managed as their own resource under a domain, at
+`/domains/{domainKey}/identity-providers`. Each IdP is identified by its `key`. This
+keeps payloads small: manage one IdP at a time without re-sending the whole domain.
+
+### Inline IDP (test users)
+
+```bash
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "dev-test-users",
+    "name": "Dev Test Users",
+    "type": "inline-am-idp",
+    "configuration": "{\"users\":[{\"firstname\":\"Alice\",\"lastname\":\"Test\",\"username\":\"alice\",\"password\":\"P@ssword1\"},{\"firstname\":\"Bob\",\"lastname\":\"Test\",\"username\":\"bob\",\"password\":\"P@ssword1\"}]}"
+  }' | jq '{key, name}'
+```
+
+### LDAP IDP with mappers
+
+```bash
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/internal-admin/identity-providers" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "corporate-ldap",
+    "name": "Corporate LDAP",
+    "type": "ldap-am-idp",
+    "configuration": "{\"contextSourceUrl\":\"ldap://ldap.internal:389\",\"contextSourceBase\":\"dc=mycompany,dc=com\",\"contextSourceUsername\":\"cn=admin,dc=mycompany,dc=com\",\"contextSourcePassword\":\"secret\",\"userSearchFilter\":\"uid={0}\",\"userSearchBase\":\"ou=people\"}",
+    "mappers": {
+      "sub": "uid",
+      "email": "mail",
+      "name": "cn"
+    }
+  }' | jq '{key, name}'
+```
+
+List / read / delete identity providers under a domain:
+```bash
+curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers" \
+  -H "Authorization: Bearer $TOKEN" | jq '.[].key'
+
+curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers/dev-test-users" \
+  -H "Authorization: Bearer $TOKEN" | jq '{key, name, type}'
+
+curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers/dev-test-users" \
+  -H "Authorization: Bearer $TOKEN" -w "\nHTTP %{http_code}\n"
+```
+
+### Account settings referencing an identity provider
+
+`accountSettings.defaultIdentityProviderForRegistration` references an identity provider
+by its `key`. The reference is **eventually consistent**: it may be `null`, or it may name
+an IdP that does not exist yet — the request succeeds either way and the key round-trips on
+`GET`. The reference simply resolves once the IdP exists. (Equally, you can leave it unset
+and rely on a `default: true` identity provider, which the gateway uses for registration
+automatically.)
+
+```bash
+# the reference can be set before or after the IdP is created — either order works:
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "customer-auth",
+    "name": "Customer Authentication",
+    "path": "/customer-auth",
+    "dataPlaneId": "default",
+    "accountSettings": {
+      "defaultIdentityProviderForRegistration": "dev-test-users"
+    }
+  }' | jq '.accountSettings.defaultIdentityProviderForRegistration'
+```
+
+---
+
+## 3. Certificates — a resource under the domain, referenced by SAML
+
+Certificates are managed as their own resource under a domain, at
+`/domains/{domainKey}/certificates`, identified by `key`. Domain settings reference a
+certificate by its `key`.
+
+```bash
+# create a SAML signing certificate
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/certificates" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "saml-signing",
+    "name": "SAML signing certificate",
+    "type": "javakeystore-am-certificate",
+    "configuration": "{...}"
+  }' | jq '{key, name, default}'
+
+# mark a certificate the domain default (signs application tokens)
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/certificates" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "default-signing",
+    "name": "Default signing certificate",
+    "type": "javakeystore-am-certificate",
+    "configuration": "{...}",
+    "default": true
+  }' | jq '{key, default}'
+```
+
+Reference a certificate from the domain's SAML / fallback settings by `key`. The reference
+is eventually consistent — it may name a certificate you create before *or* after this PUT:
+
+```bash
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "customer-auth",
+    "name": "Customer Authentication",
+    "path": "/customer-auth",
+    "dataPlaneId": "default",
+    "saml": {
+      "enabled": true,
+      "entityId": "https://auth.mycompany.com",
+      "certificate": "saml-signing"
+    }
+  }' | jq '{key, saml}'
+```
+
+List / read / delete certificates under a domain:
+```bash
+curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/certificates" \
+  -H "Authorization: Bearer $TOKEN" | jq '.[].key'
+
+curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/certificates/saml-signing" \
+  -H "Authorization: Bearer $TOKEN" -w "\nHTTP %{http_code}\n"
+```
+
+---
+
+## 4. Reporters — a resource under the domain
+
+Reporters are managed as their own resource under a domain, at
+`/domains/{domainKey}/reporters`, identified by `key`. Mark one `default: true` to make it
+the domain's audit reporter.
+
+```bash
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/reporters" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "audit-kafka",
+    "name": "Audit Kafka reporter",
+    "type": "reporter-am-kafka",
+    "configuration": "{\"bootstrapServers\":\"kafka:9092\",\"topic\":\"am-audit\",\"acks\":\"1\"}",
+    "default": true
+  }' | jq '{key, name, default}'
+
+curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/reporters" \
+  -H "Authorization: Bearer $TOKEN" | jq '.[].key'
+
+curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/reporters/audit-kafka" \
+  -H "Authorization: Bearer $TOKEN" -w "\nHTTP %{http_code}\n"
+```
+
+---
+
+## 5. Update an Existing Resource
+
+PUT again to the collection with the same `key`. Because PUT carries the **full desired
+state**, send the complete document (not just the changed field) — re-include the
+required fields and any settings you want to keep, or they will be reset to their
+domain-creation default (see "PUT is full desired state" above).
+
+```bash
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "customer-auth",
+    "name": "Customer Authentication",
+    "description": "Updated: now includes social login",
+    "path": "/customer-auth",
+    "enabled": true,
+    "dataPlaneId": "default"
+  }' | jq '{key, description}'
+```
+
+> The robust pattern is **GET → edit → PUT**: fetch the current document, change what
+> you need, and PUT the whole thing back.
+
+---
+
+## 6. Tear Down a Resource
+
+DELETE uses the `key` in the path. Deleting a domain removes its identity providers,
+certificates and reporters.
+
+```bash
+# remove a single identity provider
+curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers/dev-test-users" \
+  -H "Authorization: Bearer $TOKEN" -w "\nHTTP %{http_code}\n"
+
+# remove a whole domain
+curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/internal-admin" \
+  -H "Authorization: Bearer $TOKEN" -w "\nHTTP %{http_code}\n"
+```
+
+---
+
+## 7. OpenAPI Spec
+
+Auto-generated from annotations, available without authentication:
+
+```bash
+curl -s http://localhost:8093/management/automation/openapi.json | jq .info
+curl -s http://localhost:8093/management/automation/openapi.yaml | head -20
+```
+
+---
+
+## Quick Reference
+
+| Resource | PUT (create/update) | GET one | GET list | DELETE |
+|----------|---------------------|---------|----------|--------|
+| Domain | `PUT .../domains` | `GET .../domains/{key}` | `GET .../domains` | `DELETE .../domains/{key}` |
+| Identity Provider | `PUT .../domains/{key}/identity-providers` | `GET .../domains/{key}/identity-providers/{key}` | `GET .../domains/{key}/identity-providers` | `DELETE .../domains/{key}/identity-providers/{key}` |
+| Certificate | `PUT .../domains/{key}/certificates` | `GET .../domains/{key}/certificates/{key}` | `GET .../domains/{key}/certificates` | `DELETE .../domains/{key}/certificates/{key}` |
+| Reporter | `PUT .../domains/{key}/reporters` | `GET .../domains/{key}/reporters/{key}` | `GET .../domains/{key}/reporters` | `DELETE .../domains/{key}/reporters/{key}` |
+
+All paths are prefixed with
+`http://{host}/management/automation/organizations/{orgId}/environments/{envId}`.
+
+Domains, identity providers, certificates and reporters are all addressed by their `key`.
+Only resources whose `managedBy = AUTOMATION_API` are visible to this API — UI-created
+resources are never read, mutated, or deleted by it.

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/pom.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.gravitee.am.management.automation</groupId>
+        <artifactId>gravitee-am-management-api-automation</artifactId>
+        <version>4.12.0-alpha.5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gravitee-am-management-api-automation-rest</artifactId>
+    <name>Gravitee IO - Access Management - Management API - Automation - Rest</name>
+
+    <dependencies>
+        <!-- AM Management API Service -->
+        <dependency>
+            <groupId>io.gravitee.am.management</groupId>
+            <artifactId>gravitee-am-management-api-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- AM Management API REST (for shared components) -->
+        <dependency>
+            <groupId>io.gravitee.am.management</groupId>
+            <artifactId>gravitee-am-management-api-rest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Spring Security -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+
+        <!-- Jakarta Servlet -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${jakarta.servlet-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jersey dependencies -->
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-bean-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-spring6</artifactId>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-jetty</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <!--
+            generate-oas: Regenerates docs/automation/openapi.yaml at build time by
+            scanning the Automation API JAX-RS annotations (no running server required).
+
+            Usage: bash scripts/regen-automation-oas.sh
+        -->
+        <profile>
+            <id>generate-oas</id>
+            <properties>
+                <!-- Override on the command line to redirect output, e.g. -Doas.outputPath=/tmp/oas-gen -->
+                <oas.outputPath>${project.basedir}/../../../docs/automation</oas.outputPath>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.swagger.core.v3</groupId>
+                        <artifactId>swagger-maven-plugin-jakarta</artifactId>
+                        <version>${swagger.version}</version>
+                        <configuration>
+                            <outputFileName>openapi</outputFileName>
+                            <outputPath>${oas.outputPath}</outputPath>
+                            <outputFormat>YAML</outputFormat>
+                            <resourcePackages>
+                                <resourcePackage>io.gravitee.am.management.handlers.automation</resourcePackage>
+                            </resourcePackages>
+                            <prettyPrint>TRUE</prettyPrint>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>resolve</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/AutomationApiApplication.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/AutomationApiApplication.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation;
+
+import io.gravitee.am.management.handlers.automation.resource.CertificateResource;
+import io.gravitee.am.management.handlers.automation.resource.CertificatesResource;
+import io.gravitee.am.management.handlers.automation.resource.DomainResource;
+import io.gravitee.am.management.handlers.automation.resource.DomainsResource;
+import io.gravitee.am.management.handlers.automation.resource.IdentityProviderResource;
+import io.gravitee.am.management.handlers.automation.resource.IdentityProvidersResource;
+import io.gravitee.am.management.handlers.automation.resource.OrganizationResource;
+import io.gravitee.am.management.handlers.automation.resource.ReporterResource;
+import io.gravitee.am.management.handlers.automation.resource.ReportersResource;
+import io.gravitee.am.management.handlers.automation.swagger.AutomationApiDefinition;
+import io.gravitee.am.management.handlers.management.api.mapper.ObjectMapperResolver;
+import io.gravitee.am.management.handlers.management.api.provider.ManagementExceptionMapper;
+import io.gravitee.am.management.handlers.management.api.provider.ThrowableMapper;
+import io.gravitee.am.management.handlers.management.api.provider.ValidationExceptionMapper;
+import io.gravitee.am.management.handlers.management.api.provider.WebApplicationExceptionMapper;
+import io.swagger.v3.jaxrs2.SwaggerSerializers;
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
+
+/**
+ * JAX-RS Application for the Automation API.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+public class AutomationApiApplication extends ResourceConfig {
+
+    public AutomationApiApplication() {
+        register(OrganizationResource.class);
+        register(DomainsResource.class);
+        register(DomainResource.class);
+        register(IdentityProvidersResource.class);
+        register(IdentityProviderResource.class);
+        register(CertificatesResource.class);
+        register(CertificateResource.class);
+        register(ReportersResource.class);
+        register(ReporterResource.class);
+
+        register(ObjectMapperResolver.class);
+        register(ManagementExceptionMapper.class);
+        register(ValidationExceptionMapper.class);
+        register(WebApplicationExceptionMapper.class);
+        register(ThrowableMapper.class);
+
+        // Swagger / OpenAPI auto-generation
+        register(AutomationApiDefinition.class);
+        register(OpenApiResource.class);
+        register(SwaggerSerializers.class);
+
+        property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true);
+        property(ServerProperties.BV_DISABLE_VALIDATE_ON_EXECUTABLE_OVERRIDE_CHECK, true);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationCertificateMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationCertificateMapper.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.mapper;
+
+import io.gravitee.am.management.handlers.automation.model.AutomationCertificate;
+import io.gravitee.am.model.Certificate;
+import io.gravitee.am.service.model.AutomationNewCertificate;
+import io.gravitee.am.service.model.UpdateCertificate;
+
+/**
+ * Maps between the shared {@link Certificate} model and the {@link AutomationCertificate} projection.
+ *
+ * @author GraviteeSource Team
+ */
+public final class AutomationCertificateMapper {
+
+    private AutomationCertificateMapper() {
+    }
+
+    public static AutomationCertificate toAutomationCertificate(Certificate certificate) {
+        AutomationCertificate out = new AutomationCertificate();
+        out.setAutomationKey(certificate.getAutomationKey());
+        out.setName(certificate.getName());
+        out.setType(certificate.getType());
+        out.setConfiguration(certificate.getConfiguration());
+        out.setSystem(certificate.isSystem());
+        out.setCreatedAt(certificate.getCreatedAt());
+        out.setUpdatedAt(certificate.getUpdatedAt());
+        out.setExpiresAt(certificate.getExpiresAt());
+        return out;
+    }
+
+    /**
+     * Build the create payload for a declared certificate. The deterministic id is set by the caller
+     * (the upsert path) before the certificate is persisted.
+     */
+    public static AutomationNewCertificate toNewCertificate(AutomationCertificate definition) {
+        AutomationNewCertificate newCertificate = new AutomationNewCertificate();
+        newCertificate.setAutomationKey(definition.getAutomationKey());
+        newCertificate.setName(definition.getName());
+        newCertificate.setType(definition.getType());
+        newCertificate.setConfiguration(definition.getConfiguration());
+        return newCertificate;
+    }
+
+    public static UpdateCertificate toUpdateCertificate(AutomationCertificate definition) {
+        UpdateCertificate updateCertificate = new UpdateCertificate();
+        updateCertificate.setName(definition.getName());
+        updateCertificate.setType(definition.getType());
+        updateCertificate.setConfiguration(definition.getConfiguration());
+        return updateCertificate;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapper.java
@@ -1,0 +1,304 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.mapper;
+
+import io.gravitee.am.management.handlers.automation.model.AutomationAccountSettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationCIBASettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationCertificateSettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
+import io.gravitee.am.management.handlers.automation.model.AutomationOidcSettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationSamlSettings;
+import io.gravitee.am.management.handlers.automation.resource.AutomationIds;
+import io.gravitee.am.model.CertificateSettings;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.SAMLSettings;
+import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.model.oidc.CIBASettings;
+import io.gravitee.am.model.oidc.OIDCSettings;
+
+import java.util.List;
+
+/**
+ * Maps between the shared {@link Domain} model and the symmetric {@link AutomationDomain} projection.
+ * <p>
+ * Settings blocks that don't carry cross-resource references are reused by reference. Certificates,
+ * identity providers and reporters are discrete resources with their own endpoints; the domain only
+ * <i>references</i> some of them by key:
+ * <ul>
+ *   <li>{@code saml.certificate} and {@code certificateSettings.fallbackCertificate} — certificate keys</li>
+ *   <li>{@code accountSettings.defaultIdentityProviderForRegistration} — an identity-provider key</li>
+ * </ul>
+ * Each reference is stored twice on the shared model: the internal-id field (read by the gateway and
+ * management API) and a parallel {@code *Key} field (owned by the Automation API). The key is stored
+ * verbatim so GET round-trips losslessly even when the referenced resource does not exist yet (eventual
+ * consistency); the internal id is computed deterministically from the key so no lookup or existence
+ * check is required at write time.
+ *
+ * @author GraviteeSource Team
+ */
+public final class AutomationDomainMapper {
+
+    private AutomationDomainMapper() {
+    }
+
+    // --- model -> Automation (response) -------------------------------------
+
+    public static AutomationDomain toAutomationDomain(Domain domain) {
+        AutomationDomain out = new AutomationDomain();
+        out.setAutomationKey(domain.getAutomationKey());
+        out.setName(domain.getName());
+        out.setDescription(domain.getDescription());
+        out.setEnabled(domain.isEnabled());
+        out.setPath(domain.getPath());
+        out.setTags(domain.getTags());
+        out.setVhosts(domain.getVhosts());
+        out.setDataPlaneId(domain.getDataPlaneId());
+        out.setCreatedAt(domain.getCreatedAt());
+        out.setUpdatedAt(domain.getUpdatedAt());
+
+        // unchanged settings: reuse the shared sub-models by reference
+        out.setUma(domain.getUma());
+        out.setLoginSettings(domain.getLoginSettings());
+        out.setWebAuthnSettings(domain.getWebAuthnSettings());
+        out.setScim(domain.getScim());
+        out.setPasswordSettings(domain.getPasswordSettings());
+        out.setSelfServiceAccountManagementSettings(domain.getSelfServiceAccountManagementSettings());
+        out.setCorsSettings(domain.getCorsSettings());
+        out.setSecretExpirationSettings(domain.getSecretExpirationSettings());
+        out.setTokenExchangeSettings(domain.getTokenExchangeSettings());
+
+        // Wrapped settings blocks (key-keyed references read from the parallel *Key fields)
+        out.setOidc(toAutomationOidc(domain.getOidc()));
+        out.setAccountSettings(toAutomationAccountSettings(domain.getAccountSettings()));
+
+        if (domain.getSaml() != null) {
+            AutomationSamlSettings saml = new AutomationSamlSettings();
+            saml.setEnabled(domain.getSaml().isEnabled());
+            saml.setEntityId(domain.getSaml().getEntityId());
+            saml.setCertificate(domain.getSaml().getCertificateKey());
+            out.setSaml(saml);
+        }
+        if (domain.getCertificateSettings() != null) {
+            AutomationCertificateSettings cs = new AutomationCertificateSettings();
+            cs.setFallbackCertificate(domain.getCertificateSettings().getFallbackCertificateKey());
+            out.setCertificateSettings(cs);
+        }
+        return out;
+    }
+
+    private static AutomationOidcSettings toAutomationOidc(OIDCSettings oidc) {
+        if (oidc == null) {
+            return null;
+        }
+        AutomationOidcSettings out = new AutomationOidcSettings();
+        out.setClientRegistrationSettings(oidc.getClientRegistrationSettings());
+        out.setSecurityProfileSettings(oidc.getSecurityProfileSettings());
+        out.setRedirectUriStrictMatching(oidc.isRedirectUriStrictMatching());
+        out.setPostLogoutRedirectUris(oidc.getPostLogoutRedirectUris());
+        out.setRequestUris(oidc.getRequestUris());
+        // cimdSettings is intentionally not surfaced — see AutomationOidcSettings javadoc.
+        out.setCibaSettings(toAutomationCiba(oidc.getCibaSettings()));
+        return out;
+    }
+
+    private static AutomationCIBASettings toAutomationCiba(CIBASettings ciba) {
+        if (ciba == null) {
+            return null;
+        }
+        AutomationCIBASettings out = new AutomationCIBASettings();
+        out.setEnabled(ciba.isEnabled());
+        out.setAuthReqExpiry(ciba.getAuthReqExpiry());
+        out.setTokenReqInterval(ciba.getTokenReqInterval());
+        out.setBindingMessageLength(ciba.getBindingMessageLength());
+        return out;
+    }
+
+    private static AutomationAccountSettings toAutomationAccountSettings(AccountSettings account) {
+        if (account == null) {
+            return null;
+        }
+        AutomationAccountSettings out = new AutomationAccountSettings();
+        out.setInherited(account.isInherited());
+        out.setLoginAttemptsDetectionEnabled(account.isLoginAttemptsDetectionEnabled());
+        out.setMaxLoginAttempts(account.getMaxLoginAttempts());
+        out.setLoginAttemptsResetTime(account.getLoginAttemptsResetTime());
+        out.setAccountBlockedDuration(account.getAccountBlockedDuration());
+        out.setSendRecoverAccountEmail(account.isSendRecoverAccountEmail());
+        out.setSendVerifyRegistrationAccountEmail(account.isSendVerifyRegistrationAccountEmail());
+        out.setCompleteRegistrationWhenResetPassword(account.isCompleteRegistrationWhenResetPassword());
+        out.setAutoLoginAfterRegistration(account.isAutoLoginAfterRegistration());
+        out.setRedirectUriAfterRegistration(account.getRedirectUriAfterRegistration());
+        out.setDynamicUserRegistration(account.isDynamicUserRegistration());
+        out.setDefaultIdentityProviderForRegistration(account.getDefaultIdentityProviderForRegistrationKey());
+        out.setAutoLoginAfterResetPassword(account.isAutoLoginAfterResetPassword());
+        out.setRedirectUriAfterResetPassword(account.getRedirectUriAfterResetPassword());
+        out.setDeletePasswordlessDevicesAfterResetPassword(account.isDeletePasswordlessDevicesAfterResetPassword());
+        out.setRememberMe(account.isRememberMe());
+        out.setRememberMeDuration(account.getRememberMeDuration());
+        out.setResetPasswordCustomForm(account.isResetPasswordCustomForm());
+        out.setResetPasswordCustomFormFields(account.getResetPasswordCustomFormFields());
+        out.setResetPasswordConfirmIdentity(account.isResetPasswordConfirmIdentity());
+        out.setResetPasswordInvalidateTokens(account.isResetPasswordInvalidateTokens());
+        out.setMfaChallengeAttemptsDetectionEnabled(account.isMfaChallengeAttemptsDetectionEnabled());
+        out.setMfaChallengeMaxAttempts(account.getMfaChallengeMaxAttempts());
+        out.setMfaChallengeAttemptsResetTime(account.getMfaChallengeAttemptsResetTime());
+        out.setMfaChallengeSendVerifyAlertEmail(account.isMfaChallengeSendVerifyAlertEmail());
+        return out;
+    }
+
+    // --- Automation (request) -> model -------------------------------------
+
+    /**
+     * Apply the writable fields of {@code in} onto {@code target} with <b>strict declarative</b>
+     * semantics: a settings block omitted from the payload is reset to its domain-creation default —
+     * {@code null} for every feature settings block (its state in a freshly created domain), and
+     * {@link OIDCSettings#defaultSettings()} for {@code oidc} (which must never be null). Each key
+     * reference is written to both the internal-id field (computed deterministically from the key, or
+     * resolved against {@code idps} for an identity provider so a default — which uses the conventional
+     * id — is honoured) and its parallel {@code *Key} field.
+     */
+    public static void applyTo(AutomationDomain in, Domain target, List<IdentityProvider> idps) {
+        target.setName(in.getName());
+        target.setDescription(in.getDescription());
+        target.setEnabled(in.isEnabled());
+        target.setPath(in.getPath());
+        target.setTags(in.getTags());
+        target.setVhosts(in.getVhosts());
+
+        // oidc must never be null — reset to the same default the domain is created with
+        target.setOidc(in.getOidc() != null
+                ? toModelOidc(in.getOidc())
+                : OIDCSettings.defaultSettings());
+        // every other settings block: omitted -> reset to its created-domain default (null)
+        target.setUma(in.getUma());
+        target.setLoginSettings(in.getLoginSettings());
+        target.setWebAuthnSettings(in.getWebAuthnSettings());
+        target.setScim(in.getScim());
+        target.setAccountSettings(toModelAccountSettings(in.getAccountSettings(), target.getId(), idps));
+        target.setPasswordSettings(in.getPasswordSettings());
+        target.setSelfServiceAccountManagementSettings(in.getSelfServiceAccountManagementSettings());
+        target.setCorsSettings(in.getCorsSettings());
+        target.setSecretExpirationSettings(in.getSecretExpirationSettings());
+        target.setTokenExchangeSettings(in.getTokenExchangeSettings());
+
+        if (in.getSaml() != null) {
+            SAMLSettings saml = new SAMLSettings();
+            saml.setEnabled(in.getSaml().isEnabled());
+            saml.setEntityId(in.getSaml().getEntityId());
+            saml.setCertificate(certificateKeyToId(target.getId(), in.getSaml().getCertificate()));
+            saml.setCertificateKey(in.getSaml().getCertificate());
+            target.setSaml(saml);
+        } else {
+            target.setSaml(null);
+        }
+        if (in.getCertificateSettings() != null) {
+            CertificateSettings cs = new CertificateSettings();
+            cs.setFallbackCertificate(certificateKeyToId(target.getId(), in.getCertificateSettings().getFallbackCertificate()));
+            cs.setFallbackCertificateKey(in.getCertificateSettings().getFallbackCertificate());
+            target.setCertificateSettings(cs);
+        } else {
+            target.setCertificateSettings(null);
+        }
+    }
+
+    private static OIDCSettings toModelOidc(AutomationOidcSettings in) {
+        OIDCSettings out = new OIDCSettings();
+        out.setClientRegistrationSettings(in.getClientRegistrationSettings());
+        out.setSecurityProfileSettings(in.getSecurityProfileSettings());
+        out.setRedirectUriStrictMatching(in.isRedirectUriStrictMatching());
+        out.setPostLogoutRedirectUris(in.getPostLogoutRedirectUris());
+        out.setRequestUris(in.getRequestUris());
+        out.setCibaSettings(toModelCiba(in.getCibaSettings()));
+        return out;
+    }
+
+    private static CIBASettings toModelCiba(AutomationCIBASettings in) {
+        if (in == null) {
+            return null;
+        }
+        CIBASettings out = new CIBASettings();
+        out.setEnabled(in.isEnabled());
+        out.setAuthReqExpiry(in.getAuthReqExpiry());
+        out.setTokenReqInterval(in.getTokenReqInterval());
+        out.setBindingMessageLength(in.getBindingMessageLength());
+        return out;
+    }
+
+    private static AccountSettings toModelAccountSettings(AutomationAccountSettings in, String domainId, List<IdentityProvider> idps) {
+        if (in == null) {
+            return null;
+        }
+        AccountSettings out = new AccountSettings();
+        out.setInherited(in.isInherited());
+        out.setLoginAttemptsDetectionEnabled(in.isLoginAttemptsDetectionEnabled());
+        out.setMaxLoginAttempts(in.getMaxLoginAttempts());
+        out.setLoginAttemptsResetTime(in.getLoginAttemptsResetTime());
+        out.setAccountBlockedDuration(in.getAccountBlockedDuration());
+        out.setSendRecoverAccountEmail(in.isSendRecoverAccountEmail());
+        out.setSendVerifyRegistrationAccountEmail(in.isSendVerifyRegistrationAccountEmail());
+        out.setCompleteRegistrationWhenResetPassword(in.isCompleteRegistrationWhenResetPassword());
+        out.setAutoLoginAfterRegistration(in.isAutoLoginAfterRegistration());
+        out.setRedirectUriAfterRegistration(in.getRedirectUriAfterRegistration());
+        out.setDynamicUserRegistration(in.isDynamicUserRegistration());
+        out.setDefaultIdentityProviderForRegistration(
+                identityProviderKeyToId(domainId, in.getDefaultIdentityProviderForRegistration(), idps));
+        out.setDefaultIdentityProviderForRegistrationKey(in.getDefaultIdentityProviderForRegistration());
+        out.setAutoLoginAfterResetPassword(in.isAutoLoginAfterResetPassword());
+        out.setRedirectUriAfterResetPassword(in.getRedirectUriAfterResetPassword());
+        out.setDeletePasswordlessDevicesAfterResetPassword(in.isDeletePasswordlessDevicesAfterResetPassword());
+        out.setRememberMe(in.isRememberMe());
+        out.setRememberMeDuration(in.getRememberMeDuration());
+        out.setResetPasswordCustomForm(in.isResetPasswordCustomForm());
+        out.setResetPasswordCustomFormFields(in.getResetPasswordCustomFormFields());
+        out.setResetPasswordConfirmIdentity(in.isResetPasswordConfirmIdentity());
+        out.setResetPasswordInvalidateTokens(in.isResetPasswordInvalidateTokens());
+        out.setMfaChallengeAttemptsDetectionEnabled(in.isMfaChallengeAttemptsDetectionEnabled());
+        out.setMfaChallengeMaxAttempts(in.getMfaChallengeMaxAttempts());
+        out.setMfaChallengeAttemptsResetTime(in.getMfaChallengeAttemptsResetTime());
+        out.setMfaChallengeSendVerifyAlertEmail(in.isMfaChallengeSendVerifyAlertEmail());
+        return out;
+    }
+
+    // --- key -> id helpers --------------------------------------------------
+
+    /**
+     * A certificate's internal id is always the deterministic key-based id (certificates have no
+     * conventional id, even when default), so it can be computed without a lookup or existence check.
+     */
+    private static String certificateKeyToId(String domainId, String key) {
+        return key == null ? null : AutomationIds.certificateId(domainId, key);
+    }
+
+    /**
+     * Resolve an identity-provider key to its internal id. A default provider adopts the conventional
+     * {@code default-idp-<domainId>} id, so we resolve against the domain's existing automation-managed
+     * providers when possible; if the provider does not exist yet (eventual consistency) we fall back to
+     * the deterministic key-based id.
+     */
+    private static String identityProviderKeyToId(String domainId, String key, List<IdentityProvider> idps) {
+        if (key == null) {
+            return null;
+        }
+        return idps.stream()
+                .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API))
+                .filter(idp -> key.equals(idp.getAutomationKey()))
+                .map(IdentityProvider::getId)
+                .findFirst()
+                .orElseGet(() -> AutomationIds.identityProviderId(domainId, key));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationIdentityProviderMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationIdentityProviderMapper.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.mapper;
+
+import io.gravitee.am.management.handlers.automation.model.AutomationIdentityProvider;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.service.model.AutomationNewIdentityProvider;
+import io.gravitee.am.service.model.UpdateIdentityProvider;
+
+/**
+ * Maps between the shared {@link IdentityProvider} model and the symmetric
+ * {@link AutomationIdentityProvider} projection used by both request and response
+ * bodies. Internal-id fields ({@code id}, {@code referenceId}, {@code referenceType}),
+ * operational flags ({@code system}, {@code external}, {@code managedBy},
+ * {@code dataPlaneId}) and the {@code passwordPolicy} reference are intentionally not
+ * surfaced.
+ *
+ * @author GraviteeSource Team
+ */
+public final class AutomationIdentityProviderMapper {
+
+    private AutomationIdentityProviderMapper() {
+    }
+
+    public static AutomationIdentityProvider toAutomationIdentityProvider(IdentityProvider idp) {
+        AutomationIdentityProvider out = new AutomationIdentityProvider();
+        out.setAutomationKey(idp.getAutomationKey());
+        out.setName(idp.getName());
+        out.setType(idp.getType());
+        out.setSystem(idp.isSystem());
+        out.setConfiguration(idp.getConfiguration());
+        out.setMappers(idp.getMappers());
+        out.setRoleMapper(idp.getRoleMapper());
+        out.setGroupMapper(idp.getGroupMapper());
+        out.setDomainWhitelist(idp.getDomainWhitelist());
+        out.setCreatedAt(idp.getCreatedAt());
+        out.setUpdatedAt(idp.getUpdatedAt());
+        return out;
+    }
+
+    public static AutomationNewIdentityProvider toNewIdentityProvider(AutomationIdentityProvider definition) {
+        AutomationNewIdentityProvider newIdp = new AutomationNewIdentityProvider();
+        newIdp.setAutomationKey(definition.getAutomationKey());
+        newIdp.setName(definition.getName());
+        newIdp.setType(definition.getType());
+        newIdp.setConfiguration(definition.getConfiguration());
+        newIdp.setDomainWhitelist(definition.getDomainWhitelist());
+        return newIdp;
+    }
+
+    public static UpdateIdentityProvider toUpdateIdentityProvider(AutomationIdentityProvider definition) {
+        UpdateIdentityProvider update = new UpdateIdentityProvider();
+        update.setName(definition.getName());
+        update.setType(definition.getType());
+        update.setConfiguration(definition.getConfiguration());
+        update.setMappers(definition.getMappers());
+        update.setRoleMapper(definition.getRoleMapper());
+        update.setGroupMapper(definition.getGroupMapper());
+        update.setDomainWhitelist(definition.getDomainWhitelist());
+        return update;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationReporterMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationReporterMapper.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.mapper;
+
+import io.gravitee.am.management.handlers.automation.model.AutomationReporter;
+import io.gravitee.am.model.Reporter;
+import io.gravitee.am.service.model.AutomationNewReporter;
+import io.gravitee.am.service.model.UpdateReporter;
+
+/**
+ * Maps between the shared {@link Reporter} model and the {@link AutomationReporter} projection.
+ *
+ * @author GraviteeSource Team
+ */
+public final class AutomationReporterMapper {
+
+    private AutomationReporterMapper() {
+    }
+
+    public static AutomationReporter toAutomationReporter(Reporter reporter) {
+        AutomationReporter out = new AutomationReporter();
+        out.setAutomationKey(reporter.getAutomationKey());
+        out.setName(reporter.getName());
+        out.setType(reporter.getType());
+        out.setConfiguration(reporter.getConfiguration());
+        out.setEnabled(reporter.isEnabled());
+        out.setSystem(reporter.isSystem());
+        out.setDataType(reporter.getDataType());
+        out.setCreatedAt(reporter.getCreatedAt());
+        out.setUpdatedAt(reporter.getUpdatedAt());
+        return out;
+    }
+
+    /**
+     * Build the create payload for a declared reporter. The deterministic id is set by the caller
+     * (the upsert path) before the reporter is persisted.
+     */
+    public static AutomationNewReporter toNewReporter(AutomationReporter definition) {
+        AutomationNewReporter newReporter = new AutomationNewReporter();
+        newReporter.setAutomationKey(definition.getAutomationKey());
+        newReporter.setName(definition.getName());
+        newReporter.setType(definition.getType());
+        newReporter.setConfiguration(definition.getConfiguration());
+        newReporter.setEnabled(definition.isEnabled());
+        return newReporter;
+    }
+
+    public static UpdateReporter toUpdateReporter(AutomationReporter definition) {
+        UpdateReporter updateReporter = new UpdateReporter();
+        updateReporter.setName(definition.getName());
+        updateReporter.setType(definition.getType());
+        updateReporter.setConfiguration(definition.getConfiguration());
+        updateReporter.setEnabled(definition.isEnabled());
+        return updateReporter;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationAccountSettings.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationAccountSettings.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import io.gravitee.am.model.account.FormField;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Automation API mirror of {@link io.gravitee.am.model.account.AccountSettings}, wrapped
+ * because {@link #defaultIdentityProviderForRegistration} is a cross-resource reference
+ * expressed in the key-only contract: the {@code key} of an identity provider that exists
+ * under this domain (created via the identity-providers endpoints, resolved against the IdP
+ * rows at apply time). A reference to an IdP that does not exist is rejected with {@code 400}.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationAccountSettings {
+
+    private boolean inherited = true;
+
+    private boolean loginAttemptsDetectionEnabled;
+    private Integer maxLoginAttempts;
+    private Integer loginAttemptsResetTime;
+    private Integer accountBlockedDuration;
+
+    private boolean sendRecoverAccountEmail;
+    private boolean sendVerifyRegistrationAccountEmail;
+    private boolean completeRegistrationWhenResetPassword;
+
+    private boolean autoLoginAfterRegistration;
+    private String redirectUriAfterRegistration;
+    private boolean dynamicUserRegistration;
+
+    /**
+     * The {@code key} of an identity provider that exists under this domain, to use as the
+     * default for user registration. Resolved against the domain's IdPs at apply time; a
+     * value that does not match any existing IdP is rejected with {@code 400}. May be null.
+     */
+    @Schema(description = "key of an identity provider that exists under this domain")
+    private String defaultIdentityProviderForRegistration;
+
+    private boolean autoLoginAfterResetPassword;
+    private String redirectUriAfterResetPassword;
+    private boolean deletePasswordlessDevicesAfterResetPassword;
+
+    private boolean rememberMe;
+    private Integer rememberMeDuration;
+
+    private boolean resetPasswordCustomForm;
+    private List<FormField> resetPasswordCustomFormFields;
+    private boolean resetPasswordConfirmIdentity;
+    private boolean resetPasswordInvalidateTokens;
+
+    private boolean mfaChallengeAttemptsDetectionEnabled;
+    private Integer mfaChallengeMaxAttempts;
+    private Integer mfaChallengeAttemptsResetTime;
+    private boolean mfaChallengeSendVerifyAlertEmail;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationCIBASettings.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationCIBASettings.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Automation API mirror of {@link io.gravitee.am.model.oidc.CIBASettings}. Device notifiers
+ * are out of scope for the Automation API and are intentionally not surfaced.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationCIBASettings {
+
+    private boolean enabled;
+
+    /** Validity (in sec) of the {@code auth_req_id}. */
+    private int authReqExpiry = io.gravitee.am.model.oidc.CIBASettings.DEFAULT_EXPIRY_IN_SEC;
+
+    /** Delay between two calls on the token endpoint using the same {@code auth_req_id}. */
+    private int tokenReqInterval = io.gravitee.am.model.oidc.CIBASettings.DEFAULT_INTERVAL_IN_SEC;
+
+    /** Max length of the {@code binding_message} parameter. */
+    private int bindingMessageLength = io.gravitee.am.model.oidc.CIBASettings.DEFAULT_MSG_LENGTH;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationCertificate.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationCertificate.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+/**
+ * The Automation API representation of a certificate.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationCertificate {
+
+    @NotNull
+    @Size(min = 1, max = 255)
+    @JsonProperty("key")
+    @Schema(name = "key")
+    @Pattern(regexp = "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+            message = "key must be lowercase alphanumeric and hyphens, starting and ending with an alphanumeric character")
+    private String automationKey;
+
+    @Size(min = 1, max = 255)
+    private String name;
+
+    @Size(min = 1)
+    private String type;
+
+    private String configuration;
+
+    /**
+     * Whether this is the domain's system certificate. Immutable: fixed at creation. When {@code true},
+     * only {@code key} is required; the certificate is built from {@code domains.certificates.default.*}
+     * settings in {@code gravitee.yaml} and the {@code name}, {@code type} and {@code configuration}
+     * fields of this payload are ignored.
+     */
+    @JsonProperty("system")
+    @Schema(name = "system", description = "whether this is the domain's system certificate (immutable after creation; when true, only key is required and the certificate is built from domains.certificates.default.* system settings)")
+    private boolean system;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date createdAt;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date updatedAt;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date expiresAt;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationCertificateSettings.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationCertificateSettings.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Domain certificate settings as exposed by the Automation API.
+ * <p>
+ * {@code fallbackCertificate} references — by {@code key} — one of the certificates
+ * declared in the same Domain request.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationCertificateSettings {
+
+    /**
+     * The {@code key} of one of the certificates declared on the domain.
+     */
+    private String fallbackCertificate;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import io.gravitee.am.model.CorsSettings;
+import io.gravitee.am.model.SecretExpirationSettings;
+import io.gravitee.am.model.SelfServiceAccountManagementSettings;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.VirtualHost;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.login.WebAuthnSettings;
+import io.gravitee.am.model.scim.SCIMSettings;
+import io.gravitee.am.model.uma.UMASettings;
+import io.gravitee.am.model.PasswordSettings;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The Automation API representation of a Domain.
+ * <p>
+ * Design:
+ * <ul>
+ *   <li>Unchanged domain settings reuse the shared {@code io.gravitee.am.model.*}
+ *       sub-models <i>by reference</i> — no per-field mapping, full symmetry, and the
+ *       shared schemas are never modified.</li>
+ *   <li>Certificates, identity providers and reporters are <b>not</b> embedded — they are managed via
+ *       their own {@code /domains/{domainKey}/...} endpoints. The domain only references some of them
+ *       by <b>key</b>: {@link #saml} and {@link #certificateSettings} reference certificates,
+ *       {@link #accountSettings} references an identity provider.</li>
+ *   <li>{@code createdAt}/{@code updatedAt} are read-only; the writable key is
+ *       {@code key}.</li>
+ * </ul>
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationDomain {
+
+    @NotNull
+    @Size(min = 1, max = 255)
+    @JsonProperty("key")
+    @Schema(name = "key")
+    @Pattern(regexp = "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+            message = "key must be lowercase alphanumeric and hyphens, starting and ending with an alphanumeric character")
+    private String automationKey;
+
+    @NotNull
+    @Size(min = 1, max = 255)
+    private String name;
+
+    private String description;
+
+    private boolean enabled = true;
+
+    @NotNull
+    @Size(min = 1, max = 255)
+    private String path;
+
+    private Set<String> tags;
+
+    private List<VirtualHost> vhosts;
+
+    /**
+     * Required and immutable after creation. The domain cannot be created without a
+     * valid data plane, and it cannot be changed afterwards; it is part of the full
+     * desired-state document but is never re-applied on update.
+     */
+    @NotNull
+    @Size(min = 1, max = 255)
+    private String dataPlaneId;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date createdAt;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date updatedAt;
+
+    // --- Shared settings reused by reference (full request/response symmetry) ---
+
+    private UMASettings uma;
+    private LoginSettings loginSettings;
+    private WebAuthnSettings webAuthnSettings;
+    private SCIMSettings scim;
+    private PasswordSettings passwordSettings;
+    private SelfServiceAccountManagementSettings selfServiceAccountManagementSettings;
+    private CorsSettings corsSettings;
+    private SecretExpirationSettings secretExpirationSettings;
+    private TokenExchangeSettings tokenExchangeSettings;
+
+    // --- Automation wrappers (key-keyed references) ---
+
+    /**
+     * OIDC settings. Wrapped (rather than reused by reference) because {@code cimdSettings}
+     * is intentionally not surfaced — see {@link AutomationOidcSettings}.
+     */
+    @Valid
+    private AutomationOidcSettings oidc;
+
+    /**
+     * Account settings. Wrapped because {@code defaultIdentityProviderForRegistration} is a
+     * cross-resource reference that must be expressed in the key-only contract — see
+     * {@link AutomationAccountSettings}.
+     */
+    @Valid
+    private AutomationAccountSettings accountSettings;
+
+    /**
+     * Domain SAML 2.0 IdP settings. {@code saml.certificate} references a certificate of this domain by
+     * its {@code key} (managed via the certificates endpoints).
+     */
+    @Valid
+    private AutomationSamlSettings saml;
+
+    /**
+     * Domain certificate settings. {@code certificateSettings.fallbackCertificate} references a
+     * certificate of this domain by its {@code key} (managed via the certificates endpoints).
+     */
+    @Valid
+    private AutomationCertificateSettings certificateSettings;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationIdentityProvider.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationIdentityProvider.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The Automation API representation of an Identity Provider.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationIdentityProvider {
+
+    @NotNull
+    @Size(min = 1, max = 255)
+    @JsonProperty("key")
+    @Schema(name = "key")
+    @Pattern(regexp = "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+            message = "key must be lowercase alphanumeric and hyphens, starting and ending with an alphanumeric character")
+    private String automationKey;
+
+    @Size(min = 1, max = 255)
+    private String name;
+
+    private String type;
+
+    /**
+     * Whether this is the domain's system identity provider. Immutable: fixed at creation. Drives the
+     * conventional {@code default-idp-<domainId>} id so the gateway's registration fallback resolves to
+     * it. When {@code true}, only {@code key} is required; the IDP is built from
+     * {@code domains.identities.default.*} settings in {@code gravitee.yaml} and the {@code name},
+     * {@code type} and {@code configuration} fields of this payload are ignored.
+     */
+    @JsonProperty("system")
+    @Schema(name = "system", description = "whether this is the domain's system identity provider (immutable after creation; when true, only key is required and the IDP is built from domains.identities.default.* system settings)")
+    private boolean system;
+
+    private String configuration;
+
+    private Map<String, String> mappers;
+
+    private Map<String, String[]> roleMapper;
+
+    private Map<String, String[]> groupMapper;
+
+    private List<String> domainWhitelist;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date createdAt;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date updatedAt;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationOidcSettings.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationOidcSettings.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import io.gravitee.am.model.oidc.ClientRegistrationSettings;
+import io.gravitee.am.model.oidc.SecurityProfileSettings;
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Automation API mirror of {@link io.gravitee.am.model.oidc.OIDCSettings}. All sub-blocks
+ * that don't carry internal references are reused by reference from the shared model;
+ * {@link #cibaSettings} is wrapped because it references authentication device notifiers
+ * by name rather than id.
+ * <p>
+ * <b>Not surfaced:</b> {@code cimdSettings}. CIMD requires {@code templateId} (an internal
+ * id of an {@link io.gravitee.am.model.Application}), and the Automation API does not yet
+ * model Applications. Any existing CIMD configuration is reset on PUT.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationOidcSettings {
+
+    private ClientRegistrationSettings clientRegistrationSettings;
+
+    private SecurityProfileSettings securityProfileSettings;
+
+    /** Enable redirect_uri strict matching during OIDC flow. */
+    private boolean redirectUriStrictMatching;
+
+    private List<String> postLogoutRedirectUris;
+
+    private List<String> requestUris;
+
+    /** CIBA settings. */
+    @Valid
+    private AutomationCIBASettings cibaSettings;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationReporter.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationReporter.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+/**
+ * The Automation API representation of a reporter.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationReporter {
+
+    @NotNull
+    @Size(min = 1, max = 255)
+    @JsonProperty("key")
+    @Schema(name = "key")
+    @Pattern(regexp = "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+            message = "key must be lowercase alphanumeric and hyphens, starting and ending with an alphanumeric character")
+    private String automationKey;
+
+    @Size(min = 1, max = 255)
+    private String name;
+
+    private String type;
+
+    private String configuration;
+
+    private boolean enabled = true;
+
+    /**
+     * Whether this is the domain's system reporter. Immutable: fixed at creation. When {@code true},
+     * only {@code key} is required; the reporter is built from {@code domains.reporters.default.*}
+     * settings (and the repository backend) in {@code gravitee.yaml} and the {@code name}, {@code type}
+     * and {@code configuration} fields of this payload are ignored.
+     */
+    @JsonProperty("system")
+    @Schema(name = "system", description = "whether this is the domain's system reporter (immutable after creation; when true, only key is required and the reporter is built from domains.reporters.default.* and repository system settings)")
+    private boolean system;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    private String dataType;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date createdAt;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    private Date updatedAt;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationSamlSettings.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationSamlSettings.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Domain SAML 2.0 IdP settings as exposed by the Automation API.
+ * <p>
+ * {@code certificate} references — by {@code key} — one of the certificates declared
+ * in the same Domain request, keeping the SAML signing certificate atomically
+ * consistent with the domain's certificates.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationSamlSettings {
+
+    private boolean enabled;
+
+    private String entityId;
+
+    /**
+     * The {@code key} of one of the certificates declared in the same Domain request.
+     */
+    private String certificate;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/AbstractAutomationResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/AbstractAutomationResource.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.service.PermissionService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.permissions.Permission;
+import io.reactivex.rxjava3.core.Completable;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import java.security.Principal;
+
+import static io.gravitee.am.management.service.permissions.Permissions.of;
+import static io.gravitee.am.management.service.permissions.Permissions.or;
+
+/**
+ * Base class for Automation API resources.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+public abstract class AbstractAutomationResource {
+
+    @Context
+    protected SecurityContext securityContext;
+
+    @Autowired
+    private PermissionService permissionService;
+
+    protected static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    protected static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    protected User getAuthenticatedUser() {
+        Principal principal = securityContext.getUserPrincipal();
+        if (!(principal instanceof UsernamePasswordAuthenticationToken token)) {
+            throw new NotAuthorizedException("Bearer");
+        }
+        if (!(token.getPrincipal() instanceof User user)) {
+            throw new NotAuthorizedException("Bearer");
+        }
+        return user;
+    }
+
+    protected Completable checkPermission(User user, ReferenceType referenceType, String referenceId, Permission permission, Acl... acls) {
+        return permissionService.hasPermission(user, of(referenceType, referenceId, permission, acls))
+                .flatMapCompletable(this::assertPermission);
+    }
+
+    protected Completable checkAnyPermission(User user, String organizationId, String environmentId, Permission permission, Acl... acls) {
+        return permissionService.hasPermission(user,
+                        or(of(ReferenceType.ENVIRONMENT, environmentId, permission, acls),
+                                of(ReferenceType.ORGANIZATION, organizationId, permission, acls)))
+                .flatMapCompletable(this::assertPermission);
+    }
+
+    protected Completable checkAnyPermission(User user, String organizationId, String environmentId, String domainId, Permission permission, Acl... acls) {
+        return permissionService.hasPermission(user,
+                        or(of(ReferenceType.DOMAIN, domainId, permission, acls),
+                                of(ReferenceType.ENVIRONMENT, environmentId, permission, acls),
+                                of(ReferenceType.ORGANIZATION, organizationId, permission, acls)))
+                .flatMapCompletable(this::assertPermission);
+    }
+
+    private Completable assertPermission(Boolean hasPermission) {
+        if (!hasPermission) {
+            return Completable.error(new ForbiddenException("Permission denied"));
+        }
+        return Completable.complete();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/AutomationIds.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/AutomationIds.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.service.impl.DefaultIdentityProviderServiceImpl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * Computes the deterministic internal UUID for an Automation-API-managed resource by folding
+ * the resource's external {@code key} with the id of its scope (environment for domains,
+ * domain for identity providers, certificates and reporters). The same {@code (scope, key)} pair
+ * always resolves to the same primary key, which gives idempotent upserts and uniqueness-within-scope
+ * without any database index or constraint.
+ *
+ * @author GraviteeSource Team
+ */
+public final class AutomationIds {
+
+    private AutomationIds() {
+    }
+
+    public static String domainId(String environmentId, String key) {
+        return deterministicId(environmentId, key);
+    }
+
+    public static String identityProviderId(String domainId, String key) {
+        return deterministicId(domainId, key);
+    }
+
+    public static String certificateId(String domainId, String key) {
+        return deterministicId(domainId, key);
+    }
+
+    public static String reporterId(String domainId, String key) {
+        return deterministicId(domainId, key);
+    }
+
+    /**
+     * The conventional id of a domain's system identity provider — the same id the platform assigns to
+     * the built-in default, and the one the gateway falls back to for user registration.
+     */
+    public static String systemIdentityProviderId(String domainId) {
+        return DefaultIdentityProviderServiceImpl.DEFAULT_IDP_PREFIX + domainId.toLowerCase();
+    }
+
+    private static String deterministicId(String scopeId, String key) {
+        return UUID.nameUUIDFromBytes((scopeId + "/" + key).getBytes(StandardCharsets.UTF_8)).toString();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/CertificateResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/CertificateResource.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.mapper.AutomationCertificateMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationCertificate;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Certificate;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.exception.CertificateNotFoundException;
+import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * A single certificate managed under a domain, addressed by its key.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Certificates")
+public class CertificateResource extends AbstractAutomationResource {
+
+    @Autowired
+    private DomainService domainService;
+
+    @Autowired
+    private CertificateService certificateService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationGetCertificate", summary = "Get a certificate",
+            description = "Retrieves a single certificate by its key.")
+    @ApiResponse(responseCode = "200", description = "The certificate",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationCertificate.class)))
+    public void get(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @PathParam("certKey") String certKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_CERTIFICATE, Acl.READ)
+                .andThen(resolveDomain(environmentId, domainKey))
+                .flatMap(domain -> resolveCertificate(domain, certKey)
+                        .map(AutomationCertificateMapper::toAutomationCertificate))
+                .subscribe(response::resume, response::resume);
+    }
+
+    @DELETE
+    @Operation(operationId = "automationDeleteCertificate", summary = "Delete a certificate")
+    @ApiResponse(responseCode = "204", description = "Certificate deleted")
+    public void delete(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @PathParam("certKey") String certKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_CERTIFICATE, Acl.DELETE)
+                .andThen(resolveDomainMaybe(environmentId, domainKey))
+                .flatMap(domain -> certificateService.findByDomain(domain.getId())
+                        .filter(certificate -> certificate.isManagedBy(ManagedBy.AUTOMATION_API) && certKey.equals(certificate.getAutomationKey()))
+                        .firstElement())
+                .flatMapCompletable(certificate -> certificateService.delete(certificate.getId(), principal))
+                .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
+    }
+
+    private Single<Domain> resolveDomain(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .switchIfEmpty(Single.error(() -> new DomainNotFoundException(domainKey)))
+                .flatMap(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API)
+                        ? Single.just(domain)
+                        : Single.error(new DomainNotFoundException(domainKey)));
+    }
+
+    private Maybe<Domain> resolveDomainMaybe(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .filter(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API));
+    }
+
+    private Single<Certificate> resolveCertificate(Domain domain, String certKey) {
+        return certificateService.findByDomain(domain.getId())
+                .filter(certificate -> certificate.isManagedBy(ManagedBy.AUTOMATION_API) && certKey.equals(certificate.getAutomationKey()))
+                .firstElement()
+                .switchIfEmpty(Maybe.error(() -> new CertificateNotFoundException(certKey)))
+                .toSingle();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/CertificatesResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/CertificatesResource.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.mapper.AutomationCertificateMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationCertificate;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Certificate;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.gravitee.am.service.exception.InvalidParameterException;
+import io.gravitee.am.service.model.AutomationNewCertificate;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+/**
+ * Certificates managed individually under a domain.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Certificates")
+public class CertificatesResource extends AbstractAutomationResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Autowired
+    private DomainService domainService;
+
+    @Autowired
+    private CertificateService certificateService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationListCertificates", summary = "List a domain's certificates",
+            description = "Returns all certificates managed by the Automation API under the domain.")
+    @ApiResponse(responseCode = "200", description = "List of certificates",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = AutomationCertificate.class))))
+    public void list(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_CERTIFICATE, Acl.LIST)
+                .andThen(resolveDomain(environmentId, domainKey))
+                .flatMap(domain -> certificateService.findByDomain(domain.getId())
+                        .filter(certificate -> certificate.isManagedBy(ManagedBy.AUTOMATION_API))
+                        .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(
+                                nullToEmpty(o1.getAutomationKey()), nullToEmpty(o2.getAutomationKey())))
+                        .map(AutomationCertificateMapper::toAutomationCertificate)
+                        .toList())
+                .subscribe(response::resume, response::resume);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationCreateOrUpdateCertificate",
+            summary = "Create or update a certificate",
+            description = "Idempotent create-or-update. Uses the key field in the body to identify the certificate within the domain.")
+    @ApiResponse(responseCode = "200", description = "The created or updated certificate",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationCertificate.class)))
+    public void createOrUpdate(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @Valid @NotNull AutomationCertificate definition,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        final String domainId = AutomationIds.domainId(environmentId, domainKey);
+        final String key = definition.getAutomationKey();
+        certificateService.findByDomain(domainId).toList().flatMap(allExisting -> {
+            Optional<Certificate> match = allExisting.stream()
+                    .filter(certificate -> certificate.isManagedBy(ManagedBy.AUTOMATION_API))
+                    .filter(certificate -> key.equals(certificate.getAutomationKey()))
+                    .findFirst();
+            // The ACL is chosen from a non-erroring lookup so the permission gate runs before any
+            // existence is revealed (domain 404 / conflict 400).
+            Acl requiredAcl = match.isPresent() ? Acl.UPDATE : Acl.CREATE;
+            return checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_CERTIFICATE, requiredAcl)
+                    .andThen(resolveDomain(environmentId, domainKey))
+                    .flatMap(domain -> {
+                        if (match.isPresent()) {
+                            Certificate existing = match.get();
+                            // 'system' is an immutable identity attribute; reject a change.
+                            if (definition.isSystem() != existing.isSystem()) {
+                                return Single.error(new InvalidParameterException(
+                                        "The 'system' flag is immutable for an existing certificate '" + key
+                                                + "'; delete and recreate it to change it"));
+                            }
+                            if (existing.isSystem()) {
+                                // re-PUT is an idempotent no-op
+                                return Single.just(AutomationCertificateMapper.toAutomationCertificate(existing));
+                            }
+                            return certificateService.update(domain, existing.getId(),
+                                            AutomationCertificateMapper.toUpdateCertificate(definition), principal)
+                                    .map(AutomationCertificateMapper::toAutomationCertificate);
+                        }
+
+                        final String certId = AutomationIds.certificateId(domain.getId(), key);
+                        Optional<Certificate> occupant = allExisting.stream()
+                                .filter(certificate -> certId.equals(certificate.getId()))
+                                .findFirst();
+                        if (occupant.isPresent()) {
+                            return Single.error(new InvalidParameterException(
+                                    "Certificate key '" + key + "' conflicts with an existing certificate"));
+                        }
+                        if (definition.isSystem() && allExisting.stream()
+                                .anyMatch(certificate -> certificate.isManagedBy(ManagedBy.AUTOMATION_API) && certificate.isSystem())) {
+                            return Single.error(new InvalidParameterException(
+                                    "The domain already has a system certificate"));
+                        }
+                        if (definition.isSystem()) {
+                            return certificateService.createSystem(domain, certId, key, principal)
+                                    .map(AutomationCertificateMapper::toAutomationCertificate);
+                        }
+                        Single<AutomationCertificate> rejection = rejectIfMissingCertificateFields(definition, key);
+                        if (rejection != null) {
+                            return rejection;
+                        }
+                        AutomationNewCertificate newCertificate = AutomationCertificateMapper.toNewCertificate(definition);
+                        newCertificate.setId(certId);
+                        return certificateService.create(domain, newCertificate, principal, false)
+                                .map(AutomationCertificateMapper::toAutomationCertificate);
+                    });
+        })
+                .subscribe(response::resume, response::resume);
+    }
+
+    private static Single<AutomationCertificate> rejectIfMissingCertificateFields(AutomationCertificate definition, String key) {
+        if (isBlank(definition.getName())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'name' is required for a non-system certificate '" + key + "'"));
+        }
+        if (isBlank(definition.getType())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'type' is required for a non-system certificate '" + key + "'"));
+        }
+        if (isBlank(definition.getConfiguration())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'configuration' is required for a non-system certificate '" + key + "'"));
+        }
+        return null;
+    }
+
+    @Path("/{certKey}")
+    public CertificateResource getCertificateResource() {
+        return resourceContext.getResource(CertificateResource.class);
+    }
+
+    private Single<Domain> resolveDomain(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .switchIfEmpty(Single.error(() -> new DomainNotFoundException(domainKey)))
+                .flatMap(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API)
+                        ? Single.just(domain)
+                        : Single.error(new DomainNotFoundException(domainKey)));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainResource.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.common.utils.GraviteeContext;
+import io.gravitee.am.management.handlers.automation.mapper.AutomationDomainMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Domains")
+public class DomainResource extends AbstractAutomationResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Autowired
+    private DomainService domainService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationGetDomain", summary = "Get a domain",
+            description = "Retrieves a single security domain by its key.")
+    @ApiResponse(responseCode = "200", description = "The domain",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationDomain.class)))
+    public void get(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        final String domainId = AutomationIds.domainId(environmentId, domainKey);
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN, Acl.READ)
+                .andThen(domainService.findById(domainId)
+                        .switchIfEmpty(Single.error(() -> new DomainNotFoundException(domainKey)))
+                        .flatMap(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API)
+                                ? Single.fromCallable(() -> AutomationDomainMapper.toAutomationDomain(domain))
+                                : Single.error(new DomainNotFoundException(domainKey))))
+                .subscribe(response::resume, response::resume);
+    }
+
+    @DELETE
+    @Operation(operationId = "automationDeleteDomain", summary = "Delete a domain")
+    @ApiResponse(responseCode = "204", description = "Domain deleted")
+    public void delete(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        final String domainId = AutomationIds.domainId(environmentId, domainKey);
+
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN, Acl.DELETE)
+                .andThen(domainService.findById(domainId)
+                        .filter(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API)))
+                .flatMapCompletable(domain -> domainService.delete(
+                        new GraviteeContext(organizationId, environmentId, domain.getId()), domain.getId(), principal))
+                .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
+    }
+
+    @Path("/identity-providers")
+    public IdentityProvidersResource getIdentityProvidersResource() {
+        return resourceContext.getResource(IdentityProvidersResource.class);
+    }
+
+    @Path("/certificates")
+    public CertificatesResource getCertificatesResource() {
+        return resourceContext.getResource(CertificatesResource.class);
+    }
+
+    @Path("/reporters")
+    public ReportersResource getReportersResource() {
+        return resourceContext.getResource(ReportersResource.class);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainsResource.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.automation.mapper.AutomationDomainMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.exception.InvalidParameterException;
+import io.gravitee.am.service.model.AutomationNewDomain;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+/**
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Domains")
+public class DomainsResource extends AbstractAutomationResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Autowired
+    private DomainService domainService;
+
+    @Autowired
+    private IdentityProviderService identityProviderService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationListDomains", summary = "List all domains",
+            description = "Returns all security domains within the specified environment.")
+    @ApiResponse(responseCode = "200", description = "List of domains",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = AutomationDomain.class))))
+    public void list(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN, Acl.LIST)
+                .andThen(domainService.findAllByEnvironment(organizationId, environmentId)
+                        .filter(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API))
+                        .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()))
+                        .map(AutomationDomainMapper::toAutomationDomain)
+                        .toList())
+                .subscribe(response::resume, response::resume);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationCreateOrUpdateDomain",
+            summary = "Create or update a domain",
+            description = "Idempotent create-or-update. Uses the key field in the body to identify the domain.")
+    @ApiResponse(responseCode = "200", description = "The created or updated domain",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationDomain.class)))
+    public void createOrUpdate(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @Valid @NotNull AutomationDomain definition,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        final String key = definition.getAutomationKey();
+        final String domainId = AutomationIds.domainId(environmentId, key);
+
+        Single.defer(() ->
+                domainService.findById(domainId)
+                        .flatMap(existing ->
+                                // Permission is checked before the non-automation guard so the existence of a
+                                // domain the caller may not touch is not revealed ahead of authorization.
+                                checkAnyPermission(principal, organizationId, environmentId, existing.getId(), Permission.DOMAIN, Acl.UPDATE)
+                                        .andThen(existing.isManagedBy(ManagedBy.AUTOMATION_API)
+                                                ? Maybe.just(existing)
+                                                : Maybe.<Domain>error(new InvalidParameterException(
+                                                        "Domain with key '" + key + "' already exists in this environment and is not managed by the Automation API"))))
+                        .switchIfEmpty(Single.defer(() ->
+                                checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN, Acl.CREATE)
+                                        .andThen(Single.defer(() -> {
+                                            AutomationNewDomain newDomain = new AutomationNewDomain();
+                                            newDomain.setId(domainId);
+                                            newDomain.setAutomationKey(key);
+                                            newDomain.setName(definition.getName());
+                                            newDomain.setPath(definition.getPath());
+                                            newDomain.setDescription(definition.getDescription());
+                                            newDomain.setDataPlaneId(definition.getDataPlaneId());
+                                            return domainService.create(organizationId, environmentId, newDomain, principal);
+                                        }))))
+                        .flatMap(domain -> applyAndRespond(domain, definition, principal)))
+                .subscribe(response::resume, response::resume);
+    }
+
+    @Path("/{domainKey}")
+    public DomainResource getDomainResource() {
+        return resourceContext.getResource(DomainResource.class);
+    }
+
+    /**
+     * Resolves the {@code accountSettings.defaultIdentityProviderForRegistration} key reference against
+     * the domain's existing identity providers, applies the full domain settings, then persists with a
+     * reference-lenient update — certificate / identity-provider references may point to resources that
+     * do not exist yet (eventual consistency), so they are not validated here.
+     */
+    private Single<AutomationDomain> applyAndRespond(Domain domain, AutomationDomain definition, User principal) {
+        return automationIdentityProviders(domain.getId())
+                .flatMap(idps -> {
+                    AutomationDomainMapper.applyTo(definition, domain, idps);
+                    return domainService.update(domain.getId(), domain, false);
+                })
+                .map(AutomationDomainMapper::toAutomationDomain);
+    }
+
+    private Single<List<IdentityProvider>> automationIdentityProviders(String domainId) {
+        return identityProviderService.findAll(ReferenceType.DOMAIN, domainId)
+                .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API))
+                .toList();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProviderResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProviderResource.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.mapper.AutomationIdentityProviderMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationIdentityProvider;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.gravitee.am.service.exception.IdentityProviderNotFoundException;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * A single identity provider managed under a domain, addressed by its key.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Identity Providers")
+public class IdentityProviderResource extends AbstractAutomationResource {
+
+    @Autowired
+    private DomainService domainService;
+
+    @Autowired
+    private IdentityProviderService identityProviderService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationGetIdentityProvider", summary = "Get an identity provider",
+            description = "Retrieves a single identity provider by its key.")
+    @ApiResponse(responseCode = "200", description = "The identity provider",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationIdentityProvider.class)))
+    public void get(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @PathParam("idpKey") String idpKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_IDENTITY_PROVIDER, Acl.READ)
+                .andThen(resolveDomain(environmentId, domainKey))
+                .flatMap(domain -> resolveIdentityProvider(domain, idpKey)
+                        .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider))
+                .subscribe(response::resume, response::resume);
+    }
+
+    @DELETE
+    @Operation(operationId = "automationDeleteIdentityProvider", summary = "Delete an identity provider")
+    @ApiResponse(responseCode = "204", description = "Identity provider deleted")
+    public void delete(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @PathParam("idpKey") String idpKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_IDENTITY_PROVIDER, Acl.DELETE)
+                .andThen(resolveDomainMaybe(environmentId, domainKey))
+                .flatMapCompletable(domain -> identityProviderService.findAll(ReferenceType.DOMAIN, domain.getId())
+                        .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && idpKey.equals(idp.getAutomationKey()))
+                        .firstElement()
+                        .flatMapCompletable(idp -> identityProviderService.delete(ReferenceType.DOMAIN, domain.getId(), idp.getId(), principal)))
+                .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
+    }
+
+    private Single<Domain> resolveDomain(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .switchIfEmpty(Single.error(() -> new DomainNotFoundException(domainKey)))
+                .flatMap(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API)
+                        ? Single.just(domain)
+                        : Single.error(new DomainNotFoundException(domainKey)));
+    }
+
+    private Maybe<Domain> resolveDomainMaybe(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .filter(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API));
+    }
+
+    /**
+     * Resolves an automation-managed identity provider by its {@code key} (not its internal id) so that a
+     * system provider — which adopts the conventional {@code default-idp-<domainId>} id rather than the
+     * deterministic key-based id — resolves like any other.
+     */
+    private Single<IdentityProvider> resolveIdentityProvider(Domain domain, String idpKey) {
+        return identityProviderService.findAll(ReferenceType.DOMAIN, domain.getId())
+                .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && idpKey.equals(idp.getAutomationKey()))
+                .firstElement()
+                .switchIfEmpty(Maybe.error(() -> new IdentityProviderNotFoundException(idpKey)))
+                .toSingle();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.automation.mapper.AutomationIdentityProviderMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationIdentityProvider;
+import io.gravitee.am.management.service.DefaultIdentityProviderService;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.gravitee.am.service.exception.InvalidParameterException;
+import io.gravitee.am.service.model.AutomationNewIdentityProvider;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+/**
+ * Identity providers managed individually under a domain.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Identity Providers")
+public class IdentityProvidersResource extends AbstractAutomationResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Autowired
+    private DomainService domainService;
+
+    @Autowired
+    private IdentityProviderService identityProviderService;
+
+    @Autowired
+    private DefaultIdentityProviderService defaultIdentityProviderService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationListIdentityProviders", summary = "List a domain's identity providers",
+            description = "Returns all identity providers managed by the Automation API under the domain.")
+    @ApiResponse(responseCode = "200", description = "List of identity providers",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = AutomationIdentityProvider.class))))
+    public void list(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_IDENTITY_PROVIDER, Acl.LIST)
+                .andThen(resolveDomain(environmentId, domainKey))
+                .flatMap(domain -> identityProviderService.findAll(ReferenceType.DOMAIN, domain.getId())
+                        .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API))
+                        .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(
+                                nullToEmpty(o1.getAutomationKey()), nullToEmpty(o2.getAutomationKey())))
+                        .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider)
+                        .toList())
+                .subscribe(response::resume, response::resume);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationCreateOrUpdateIdentityProvider",
+            summary = "Create or update an identity provider",
+            description = "Idempotent create-or-update. Uses the key field in the body to identify the identity provider within the domain.")
+    @ApiResponse(responseCode = "200", description = "The created or updated identity provider",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationIdentityProvider.class)))
+    public void createOrUpdate(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @Valid @NotNull AutomationIdentityProvider definition,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        final String domainId = AutomationIds.domainId(environmentId, domainKey);
+        final String key = definition.getAutomationKey();
+        identityProviderService.findAll(ReferenceType.DOMAIN, domainId).toList().flatMap(allExisting -> {
+            // A resource is addressed by its key; a system IDP adopts the conventional default-idp id.
+            Optional<IdentityProvider> match = allExisting.stream()
+                    .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API))
+                    .filter(idp -> key.equals(idp.getAutomationKey()))
+                    .findFirst();
+            // The ACL is chosen from a non-erroring lookup so the permission gate runs before any
+            // existence is revealed (domain 404 / conflict 400).
+            Acl requiredAcl = match.isPresent() ? Acl.UPDATE : Acl.CREATE;
+            return checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_IDENTITY_PROVIDER, requiredAcl)
+                    .andThen(resolveDomain(environmentId, domainKey))
+                    .flatMap(domain -> {
+                        if (match.isPresent()) {
+                            IdentityProvider existing = match.get();
+                            // 'system' is an immutable identity attribute (it co-determines the internal id and
+                            // the system flag); reject a change.
+                            if (definition.isSystem() != existing.isSystem()) {
+                                return Single.error(new InvalidParameterException(
+                                        "The 'system' flag is immutable for an existing identity provider '" + key
+                                                + "'; delete and recreate it to change it"));
+                            }
+                            if (existing.isSystem()) {
+                                // re-PUT is an idempotent no-op
+                                return Single.just(AutomationIdentityProviderMapper.toAutomationIdentityProvider(existing));
+                            }
+                            return identityProviderService.update(ReferenceType.DOMAIN, domain.getId(), existing.getId(),
+                                            AutomationIdentityProviderMapper.toUpdateIdentityProvider(definition), principal, false)
+                                    .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
+                        }
+
+                        final String idpId = definition.isSystem()
+                                ? AutomationIds.systemIdentityProviderId(domain.getId())
+                                : AutomationIds.identityProviderId(domain.getId(), key);
+                        Optional<IdentityProvider> occupant = allExisting.stream()
+                                .filter(idp -> idpId.equals(idp.getId()))
+                                .findFirst();
+                        if (occupant.isPresent()) {
+                            return Single.error(new InvalidParameterException(
+                                    "Identity provider key '" + key + "' conflicts with an existing identity provider"
+                                            + (definition.isSystem() ? " (the domain already has a system identity provider)" : "")));
+                        }
+                        if (definition.isSystem() && allExisting.stream()
+                                .anyMatch(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && idp.isSystem())) {
+                            return Single.error(new InvalidParameterException(
+                                    "The domain already has a system identity provider"));
+                        }
+                        if (definition.isSystem()) {
+                            return defaultIdentityProviderService.create(domain, key, principal)
+                                    .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
+                        }
+                        Single<AutomationIdentityProvider> rejection = rejectIfMissingIdentityProviderFields(definition, key);
+                        if (rejection != null) {
+                            return rejection;
+                        }
+                        AutomationNewIdentityProvider newIdp = AutomationIdentityProviderMapper.toNewIdentityProvider(definition);
+                        newIdp.setId(idpId);
+                        return identityProviderService.create(domain, newIdp, principal, false)
+                                .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
+                    });
+        })
+                .subscribe(response::resume, response::resume);
+    }
+
+    private static Single<AutomationIdentityProvider> rejectIfMissingIdentityProviderFields(AutomationIdentityProvider definition, String key) {
+        if (isBlank(definition.getName())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'name' is required for a non-system identity provider '" + key + "'"));
+        }
+        if (isBlank(definition.getType())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'type' is required for a non-system identity provider '" + key + "'"));
+        }
+        return null;
+    }
+
+    @Path("/{idpKey}")
+    public IdentityProviderResource getIdentityProviderResource() {
+        return resourceContext.getResource(IdentityProviderResource.class);
+    }
+
+    private Single<Domain> resolveDomain(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .switchIfEmpty(Single.error(() -> new DomainNotFoundException(domainKey)))
+                .flatMap(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API)
+                        ? Single.just(domain)
+                        : Single.error(new DomainNotFoundException(domainKey)));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/OrganizationResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/OrganizationResource.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+
+/**
+ * Entry point for Automation API organization-scoped resources.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Path("/organizations/{orgId}")
+public class OrganizationResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Path("/environments/{envId}/domains")
+    public DomainsResource getDomainsResource() {
+        return resourceContext.getResource(DomainsResource.class);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/ReporterResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/ReporterResource.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.mapper.AutomationReporterMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationReporter;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.Reference;
+import io.gravitee.am.model.Reporter;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.ReporterService;
+import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.gravitee.am.service.exception.ReporterNotFoundException;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * A single reporter managed under a domain, addressed by its key.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Reporters")
+public class ReporterResource extends AbstractAutomationResource {
+
+    @Autowired
+    private DomainService domainService;
+
+    @Autowired
+    private ReporterService reporterService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationGetReporter", summary = "Get a reporter",
+            description = "Retrieves a single reporter by its key.")
+    @ApiResponse(responseCode = "200", description = "The reporter",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationReporter.class)))
+    public void get(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @PathParam("reporterKey") String reporterKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_REPORTER, Acl.READ)
+                .andThen(resolveDomain(environmentId, domainKey))
+                .flatMap(domain -> resolveReporter(domain, reporterKey)
+                        .map(AutomationReporterMapper::toAutomationReporter))
+                .subscribe(response::resume, response::resume);
+    }
+
+    @DELETE
+    @Operation(operationId = "automationDeleteReporter", summary = "Delete a reporter")
+    @ApiResponse(responseCode = "204", description = "Reporter deleted")
+    public void delete(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @PathParam("reporterKey") String reporterKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_REPORTER, Acl.DELETE)
+                .andThen(resolveDomainMaybe(environmentId, domainKey))
+                .flatMap(domain -> reporterService.findByReference(Reference.domain(domain.getId()))
+                        .filter(reporter -> reporter.isManagedBy(ManagedBy.AUTOMATION_API) && reporterKey.equals(reporter.getAutomationKey()))
+                        .firstElement())
+                // removeSystemReporter=true: the Automation API owns the lifecycle of the resources
+                // it manages, including the default, so the system guard does not apply.
+                .flatMapCompletable(reporter -> reporterService.delete(reporter.getId(), principal, true))
+                .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
+    }
+
+    private Single<Domain> resolveDomain(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .switchIfEmpty(Single.error(() -> new DomainNotFoundException(domainKey)))
+                .flatMap(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API)
+                        ? Single.just(domain)
+                        : Single.error(new DomainNotFoundException(domainKey)));
+    }
+
+    private Maybe<Domain> resolveDomainMaybe(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .filter(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API));
+    }
+
+    private Single<Reporter> resolveReporter(Domain domain, String reporterKey) {
+        return reporterService.findByReference(Reference.domain(domain.getId()))
+                .filter(reporter -> reporter.isManagedBy(ManagedBy.AUTOMATION_API) && reporterKey.equals(reporter.getAutomationKey()))
+                .firstElement()
+                .switchIfEmpty(Maybe.error(() -> new ReporterNotFoundException(reporterKey)))
+                .toSingle();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/ReportersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/ReportersResource.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.mapper.AutomationReporterMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationReporter;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.Reference;
+import io.gravitee.am.model.Reporter;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.ReporterService;
+import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.gravitee.am.service.exception.InvalidParameterException;
+import io.gravitee.am.service.model.AutomationNewReporter;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+/**
+ * Reporters managed individually under a domain.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Reporters")
+public class ReportersResource extends AbstractAutomationResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Autowired
+    private DomainService domainService;
+
+    @Autowired
+    private ReporterService reporterService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationListReporters", summary = "List a domain's reporters",
+            description = "Returns all reporters managed by the Automation API under the domain.")
+    @ApiResponse(responseCode = "200", description = "List of reporters",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = AutomationReporter.class))))
+    public void list(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_REPORTER, Acl.LIST)
+                .andThen(resolveDomain(environmentId, domainKey))
+                .flatMap(domain -> reporterService.findByReference(Reference.domain(domain.getId()))
+                        .filter(reporter -> reporter.isManagedBy(ManagedBy.AUTOMATION_API))
+                        .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(
+                                nullToEmpty(o1.getAutomationKey()), nullToEmpty(o2.getAutomationKey())))
+                        .map(AutomationReporterMapper::toAutomationReporter)
+                        .toList())
+                .subscribe(response::resume, response::resume);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationCreateOrUpdateReporter",
+            summary = "Create or update a reporter",
+            description = "Idempotent create-or-update. Uses the key field in the body to identify the reporter within the domain.")
+    @ApiResponse(responseCode = "200", description = "The created or updated reporter",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationReporter.class)))
+    public void createOrUpdate(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("domainKey") String domainKey,
+            @Valid @NotNull AutomationReporter definition,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        final String domainId = AutomationIds.domainId(environmentId, domainKey);
+        final String key = definition.getAutomationKey();
+        final Reference reference = Reference.domain(domainId);
+        reporterService.findByReference(reference).toList().flatMap(allExisting -> {
+            Optional<Reporter> match = allExisting.stream()
+                    .filter(reporter -> reporter.isManagedBy(ManagedBy.AUTOMATION_API))
+                    .filter(reporter -> key.equals(reporter.getAutomationKey()))
+                    .findFirst();
+            // The ACL is chosen from a non-erroring lookup so the permission gate runs before any
+            // existence is revealed (domain 404 / conflict 400).
+            Acl requiredAcl = match.isPresent() ? Acl.UPDATE : Acl.CREATE;
+            return checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_REPORTER, requiredAcl)
+                    .andThen(resolveDomain(environmentId, domainKey))
+                    .flatMap(domain -> {
+                        if (match.isPresent()) {
+                            Reporter existing = match.get();
+                            // 'system' is an immutable identity attribute; reject a change.
+                            if (definition.isSystem() != existing.isSystem()) {
+                                return Single.error(new InvalidParameterException(
+                                        "The 'system' flag is immutable for an existing reporter '" + key
+                                                + "'; delete and recreate it to change it"));
+                            }
+                            if (existing.isSystem()) {
+                                // re-PUT is an idempotent no-op
+                                return Single.just(AutomationReporterMapper.toAutomationReporter(existing));
+                            }
+                            return reporterService.update(reference, existing.getId(),
+                                            AutomationReporterMapper.toUpdateReporter(definition), principal, false)
+                                    .map(AutomationReporterMapper::toAutomationReporter);
+                        }
+
+                        final String reporterId = AutomationIds.reporterId(domain.getId(), key);
+                        Optional<Reporter> occupant = allExisting.stream()
+                                .filter(reporter -> reporterId.equals(reporter.getId()))
+                                .findFirst();
+                        if (occupant.isPresent()) {
+                            return Single.error(new InvalidParameterException(
+                                    "Reporter key '" + key + "' conflicts with an existing reporter"));
+                        }
+                        if (definition.isSystem() && allExisting.stream()
+                                .anyMatch(reporter -> reporter.isManagedBy(ManagedBy.AUTOMATION_API) && reporter.isSystem())) {
+                            return Single.error(new InvalidParameterException(
+                                    "The domain already has a system reporter"));
+                        }
+                        if (definition.isSystem()) {
+                            return reporterService.createSystem(reference, reporterId, key, principal)
+                                    .map(AutomationReporterMapper::toAutomationReporter);
+                        }
+                        Single<AutomationReporter> rejection = rejectIfMissingReporterFields(definition, key);
+                        if (rejection != null) {
+                            return rejection;
+                        }
+                        AutomationNewReporter newReporter = AutomationReporterMapper.toNewReporter(definition);
+                        newReporter.setId(reporterId);
+                        return reporterService.create(reference, newReporter, principal, false)
+                                .map(AutomationReporterMapper::toAutomationReporter);
+                    });
+        })
+                .subscribe(response::resume, response::resume);
+    }
+
+    private static Single<AutomationReporter> rejectIfMissingReporterFields(AutomationReporter definition, String key) {
+        if (isBlank(definition.getName())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'name' is required for a non-system reporter '" + key + "'"));
+        }
+        if (isBlank(definition.getType())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'type' is required for a non-system reporter '" + key + "'"));
+        }
+        if (isBlank(definition.getConfiguration())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'configuration' is required for a non-system reporter '" + key + "'"));
+        }
+        return null;
+    }
+
+    @Path("/{reporterKey}")
+    public ReporterResource getReporterResource() {
+        return resourceContext.getResource(ReporterResource.class);
+    }
+
+    private Single<Domain> resolveDomain(String environmentId, String domainKey) {
+        return domainService.findById(AutomationIds.domainId(environmentId, domainKey))
+                .switchIfEmpty(Single.error(() -> new DomainNotFoundException(domainKey)))
+                .flatMap(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API)
+                        ? Single.just(domain)
+                        : Single.error(new DomainNotFoundException(domainKey)));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/spring/AutomationConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/spring/AutomationConfiguration.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.spring;
+
+import io.gravitee.am.management.handlers.automation.spring.security.AutomationSecurityConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+/**
+ * Root Spring configuration for the Automation API child context.
+ * <p>
+ * This context is created as a child of the management API's parent application context,
+ * inheriting shared service beans (DomainService, EnvironmentService, IdentityProviderService,
+ * PermissionService, etc.) while maintaining isolated security configuration.
+ * <p>
+ * Mirrors the APIM pattern where each API surface (Management, Portal, Automation)
+ * gets its own {@code AnnotationConfigWebApplicationContext} with dedicated security.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Configuration
+@EnableWebSecurity
+@Import(AutomationSecurityConfiguration.class)
+public class AutomationConfiguration {
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/spring/security/AutomationBearerTokenFilter.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/spring/security/AutomationBearerTokenFilter.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.spring.security;
+
+import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.oidc.CustomClaims;
+import io.gravitee.am.common.oidc.StandardClaims;
+import io.gravitee.am.identityprovider.api.DefaultUser;
+import io.gravitee.am.jwt.JWTParser;
+import io.gravitee.am.management.service.OrganizationUserService;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.User;
+import io.gravitee.common.http.HttpHeaders;
+import io.reactivex.rxjava3.core.Single;
+import lombok.extern.slf4j.Slf4j;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.session.SessionAuthenticationException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.gravitee.gateway.api.http.HttpHeaderNames.AUTHORIZATION;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Lightweight Bearer token filter for the Automation API.
+ * <p>
+ * Extends {@link OncePerRequestFilter} instead of {@code AbstractAuthenticationProcessingFilter}
+ * to avoid the complex request-matching, session management, and mutable state issues of the
+ * management REST {@link io.gravitee.am.management.handlers.management.api.authentication.filter.BearerAuthenticationFilter}.
+ * <p>
+ * Authentication is limited to JWT Bearer tokens in the {@code Authorization} header only.
+ * Cookie-based JWT and account access tokens (supported by the management REST filter) are
+ * intentionally out of scope for this machine-oriented API surface.
+ * <p>
+ * When no Bearer token is present, or when token validation fails (invalid JWT, expired session,
+ * or repository lookup timeout), the security context is left unauthenticated and the request
+ * continues; Spring Security's authorization layer ({@code .authenticated()}) returns 401 via
+ * the configured {@link io.gravitee.am.management.handlers.management.api.authentication.web.Http401UnauthorizedEntryPoint}.
+ * <p>
+ * Repository lookups honour {@code http.blockingGet.timeoutMillis}; set to {@code 0} to
+ * disable the timeout.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class AutomationBearerTokenFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JWTParser jwtParser;
+    private final OrganizationUserService userService;
+    private final long blockingGetTimeoutMillis;
+
+    public AutomationBearerTokenFilter(
+            JWTParser jwtParser,
+            OrganizationUserService userService,
+            long blockingGetTimeoutMillis
+    ) {
+        this.jwtParser = jwtParser;
+        this.userService = userService;
+        this.blockingGetTimeoutMillis = blockingGetTimeoutMillis;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        String token = extractBearerToken(request);
+        if (token != null) {
+            try {
+                var authentication = authenticate(token, request);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                SecurityContextHolder.clearContext();
+                log.debug("Automation API bearer authentication failed: {}", e.getMessage(), e);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String extractBearerToken(HttpServletRequest request) {
+        String authorization = request.getHeader(AUTHORIZATION);
+        if (authorization != null && authorization.startsWith(BEARER_PREFIX)) {
+            return authorization.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    private UsernamePasswordAuthenticationToken authenticate(String authToken, HttpServletRequest request) {
+        JWT jwt = jwtParser.parse(authToken);
+
+        Map<String, Object> claims = new HashMap<>(jwt);
+        claims.put(Claims.IP_ADDRESS, remoteAddress(request));
+        claims.put(Claims.USER_AGENT, request.getHeader(HttpHeaders.USER_AGENT));
+
+        var orgUser = userService.findById(
+                        ReferenceType.ORGANIZATION,
+                        (String) jwt.get("org"),
+                        (String) claims.get(StandardClaims.SUB))
+                .compose(this::applyTimeout)
+                .blockingGet();
+
+        var dates = List.of(
+                Optional.ofNullable(orgUser.getLastLogoutAt()),
+                Optional.ofNullable(orgUser.getLastUsernameReset())
+        );
+
+        boolean isSessionExpired = dates.stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .anyMatch(time -> time.after(new Date(jwt.getIat() * 1000)));
+
+        if (isSessionExpired) {
+            throw new SessionAuthenticationException("Session expired");
+        }
+
+        DefaultUser user = new DefaultUser((String) claims.get(StandardClaims.PREFERRED_USERNAME));
+        user.setId((String) claims.get(StandardClaims.SUB));
+        user.setAdditionalInformation(claims);
+        user.setRoles((List<String>) claims.get(CustomClaims.ROLES));
+        user.setGroups((List<String>) claims.get(CustomClaims.GROUPS));
+
+        return new UsernamePasswordAuthenticationToken(user, null, getAuthorities(user));
+    }
+
+    private Single<User> applyTimeout(Single<User> src) {
+        if (blockingGetTimeoutMillis > 0) {
+            return src.timeout(blockingGetTimeoutMillis, TimeUnit.MILLISECONDS);
+        }
+        return src;
+    }
+
+    private List<GrantedAuthority> getAuthorities(DefaultUser user) {
+        if (user.getRoles() == null) {
+            return AuthorityUtils.NO_AUTHORITIES;
+        }
+        return user.getRoles().stream().map(SimpleGrantedAuthority::new).collect(toList());
+    }
+
+    private String remoteAddress(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader(HttpHeaders.X_FORWARDED_FOR);
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            int idx = xForwardedFor.indexOf(',');
+            String remoteAddress = (idx != -1) ? xForwardedFor.substring(0, idx) : xForwardedFor;
+            idx = remoteAddress.indexOf(':');
+            return (idx != -1) ? remoteAddress.substring(0, idx).trim() : remoteAddress.trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/spring/security/AutomationSecurityConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/spring/security/AutomationSecurityConfiguration.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.spring.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.jwt.JWTParser;
+import io.gravitee.am.management.handlers.management.api.authentication.web.Http401UnauthorizedEntryPoint;
+import io.gravitee.am.management.service.OrganizationUserService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+/**
+ * Security configuration for the Automation API.
+ * <p>
+ * Lives in its own Spring child context (separate from the management API context),
+ * following the APIM pattern of isolated security per API surface.
+ * <p>
+ * Uses a lightweight {@link AutomationBearerTokenFilter} ({@code OncePerRequestFilter})
+ * for stateless JWT Bearer authentication with CSRF disabled.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class AutomationSecurityConfiguration {
+
+    @Bean
+    public Http401UnauthorizedEntryPoint automationEntryPoint(ObjectMapper objectMapper) {
+        return new Http401UnauthorizedEntryPoint(objectMapper);
+    }
+
+    @Bean
+    public AutomationBearerTokenFilter automationBearerTokenFilter(
+            @Qualifier("managementJwtParser") JWTParser jwtParser,
+            OrganizationUserService userService,
+            @Value("${http.blockingGet.timeoutMillis:120000}") long blockingGetTimeoutMillis
+    ) {
+        return new AutomationBearerTokenFilter(jwtParser, userService, blockingGetTimeoutMillis);
+    }
+
+    @Bean
+    public SecurityFilterChain automationSecurityFilterChain(
+            HttpSecurity http,
+            Http401UnauthorizedEntryPoint entryPoint,
+            AutomationBearerTokenFilter automationBearerTokenFilter
+    ) throws Exception {
+        http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                new AntPathRequestMatcher("/openapi.json", "GET"),
+                                new AntPathRequestMatcher("/openapi.yaml", "GET"),
+                                new AntPathRequestMatcher("/**", "OPTIONS")
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(entryPoint))
+                .addFilterBefore(automationBearerTokenFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.swagger;
+
+import io.gravitee.common.util.Version;
+import io.swagger.v3.jaxrs2.ReaderListener;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.integration.api.OpenApiReader;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.tags.Tag;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * OpenAPI definition for the Automation API.
+ * Filters the auto-generated spec to only include automation-specific paths and schemas.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@OpenAPIDefinition
+public class AutomationApiDefinition implements ReaderListener {
+
+    public static final String BEARER_AUTH_SCHEME = "BearerAuth";
+    public static final String BASIC_AUTH_SCHEME = "BasicAuth";
+
+    /**
+     * Default servlet path the Automation API is mounted at, shared with the runtime server
+     * configuration (see {@code http.api.automation.entrypoint}). The generated OAS is static, so the
+     * declared server url always reflects this default even when the runtime path is overridden.
+     */
+    public static final String DEFAULT_AUTOMATION_ENTRYPOINT = "/management/automation";
+
+    private static final Set<String> AUTOMATION_TAGS = Set.of("Domains", "Identity Providers", "Certificates", "Reporters");
+
+    @Override
+    public void beforeScan(OpenApiReader openApiReader, OpenAPI openAPI) {
+    }
+
+    @Override
+    public void afterScan(OpenApiReader openApiReader, OpenAPI openAPI) {
+
+        // Filter paths to only automation endpoints (those using {orgId} not {organizationId})
+        Paths filteredPaths = new Paths();
+        openAPI.getPaths().forEach((path, pathItem) -> {
+            if (path.startsWith("/organizations/{orgId}")) {
+                filteredPaths.put(path, pathItem);
+            }
+        });
+        filteredPaths.putAll(new TreeMap<>(filteredPaths));
+        openAPI.setPaths(filteredPaths);
+
+        // Document a generic failure case on every operation. OAS linters
+        // (e.g. Speakeasy's generator-missing-error-response) require a default
+        // or 4XX/5XX response so client error handling is predictable.
+        filteredPaths.values().stream()
+                .map(PathItem::readOperations)
+                .flatMap(Collection::stream)
+                .forEach(AutomationApiDefinition::addDefaultErrorResponse);
+
+        // Every Automation API operation is permission-gated, so document a shared 403 on each one.
+        // This lets clients distinguish an authorization failure from the generic error above.
+        filteredPaths.values().stream()
+                .map(PathItem::readOperations)
+                .flatMap(Collection::stream)
+                .forEach(AutomationApiDefinition::addForbiddenResponse);
+
+        // Collect schema names referenced by the filtered paths
+        Set<String> referencedSchemas = new HashSet<>();
+        filteredPaths.values().stream()
+                .map(PathItem::readOperations)
+                .flatMap(Collection::stream)
+                .forEach(op -> collectSchemaRefs(op, referencedSchemas));
+
+        // Filter schemas to only referenced ones, then resolve transitive refs
+        if (openAPI.getComponents() != null && openAPI.getComponents().getSchemas() != null) {
+            Map<String, Schema> allSchemas = openAPI.getComponents().getSchemas();
+            Set<String> resolved = new HashSet<>();
+            Set<String> toResolve = new HashSet<>(referencedSchemas);
+            while (!toResolve.isEmpty()) {
+                Set<String> next = new HashSet<>();
+                for (String name : toResolve) {
+                    if (resolved.add(name) && allSchemas.containsKey(name)) {
+                        collectSchemaRefsFromSchema(allSchemas.get(name), next);
+                    }
+                }
+                toResolve = next;
+            }
+            Map<String, Schema> filteredSchemas = new TreeMap<>();
+            for (String name : resolved) {
+                if (allSchemas.containsKey(name)) {
+                    filteredSchemas.put(name, allSchemas.get(name));
+                }
+            }
+            // sort properties within each schema for deterministic output
+            filteredSchemas.values().forEach(AutomationApiDefinition::sortSchemaProperties);
+            openAPI.getComponents().setSchemas(filteredSchemas);
+        }
+
+        // Filter tags to only automation ones
+        openAPI.tags(AUTOMATION_TAGS.stream()
+                .sorted()
+                .map(name -> new Tag().name(name))
+                .collect(ArrayList::new, ArrayList::add, ArrayList::addAll));
+
+        // The Automation API is mounted at the configurable http.api.automation.entrypoint
+        // (defaults to /management/automation), mirroring how the management API declares its
+        // /management server in GraviteeApiDefinition. The spec is static, so it always reflects the default.
+        openAPI.servers(List.of(new Server().url(DEFAULT_AUTOMATION_ENTRYPOINT)));
+        openAPI.info(new Info()
+                .version(Version.RUNTIME_VERSION.toString())
+                .title("Gravitee.io AM - Automation API")
+                .description("Declarative, GitOps-style management of Access Management resources.")
+        );
+
+        Components components = openAPI.getComponents() != null ? openAPI.getComponents() : new Components();
+        // Replace all security schemes — remove inherited ones (e.g. gravitee-auth from management API).
+        // Use an ordered map so the generated spec is deterministic.
+        Map<String, SecurityScheme> securitySchemes = new LinkedHashMap<>();
+        securitySchemes.put(BEARER_AUTH_SCHEME, new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT"));
+        securitySchemes.put(BASIC_AUTH_SCHEME, new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic"));
+        components.setSecuritySchemes(securitySchemes);
+        openAPI.components(components);
+        openAPI.security(List.of(
+                new SecurityRequirement().addList(BEARER_AUTH_SCHEME),
+                new SecurityRequirement().addList(BASIC_AUTH_SCHEME)
+        ));
+    }
+
+    private static void addDefaultErrorResponse(Operation operation) {
+        ApiResponses responses = operation.getResponses();
+        if (responses == null) {
+            responses = new ApiResponses();
+            operation.setResponses(responses);
+        }
+        boolean hasErrorResponse = responses.keySet().stream()
+                .anyMatch(code -> "default".equals(code) || code.startsWith("4") || code.startsWith("5"));
+        if (!hasErrorResponse) {
+            responses.addApiResponse("default", new ApiResponse().description("Unexpected error"));
+        }
+    }
+
+    private static void addForbiddenResponse(Operation operation) {
+        ApiResponses responses = operation.getResponses();
+        if (responses == null) {
+            responses = new ApiResponses();
+            operation.setResponses(responses);
+        }
+        responses.computeIfAbsent("403", code -> new ApiResponse().description("Permission denied"));
+        // Re-insert in sorted key order so the generated spec is deterministic (ApiResponses is a LinkedHashMap).
+        ApiResponses sorted = new ApiResponses();
+        new TreeMap<>(responses).forEach(sorted::addApiResponse);
+        operation.setResponses(sorted);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static void sortSchemaProperties(Schema schema) {
+        if (schema.getProperties() != null) {
+            schema.setProperties(new LinkedHashMap<>(new TreeMap<>(schema.getProperties())));
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void collectSchemaRefs(Operation operation, Set<String> refs) {
+        if (operation.getResponses() != null) {
+            operation.getResponses().values().forEach(resp -> {
+                if (resp.getContent() != null) {
+                    resp.getContent().values().forEach(media -> {
+                        if (media.getSchema() != null) {
+                            addSchemaRef(media.getSchema(), refs);
+                        }
+                        if (media.getSchema() != null && media.getSchema().getItems() != null) {
+                            addSchemaRef(media.getSchema().getItems(), refs);
+                        }
+                    });
+                }
+            });
+        }
+        if (operation.getRequestBody() != null && operation.getRequestBody().getContent() != null) {
+            operation.getRequestBody().getContent().values().forEach(media -> {
+                if (media.getSchema() != null) {
+                    addSchemaRef(media.getSchema(), refs);
+                }
+            });
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void addSchemaRef(Schema schema, Set<String> refs) {
+        if (schema.get$ref() != null) {
+            refs.add(schema.get$ref().replace("#/components/schemas/", ""));
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void collectSchemaRefsFromSchema(Schema schema, Set<String> refs) {
+        if (schema.get$ref() != null) {
+            refs.add(schema.get$ref().replace("#/components/schemas/", ""));
+        }
+        if (schema.getProperties() != null) {
+            ((Map<String, Schema>) schema.getProperties()).values().forEach(prop -> {
+                if (prop.get$ref() != null) {
+                    refs.add(prop.get$ref().replace("#/components/schemas/", ""));
+                }
+                if (prop.getItems() != null && prop.getItems().get$ref() != null) {
+                    refs.add(prop.getItems().get$ref().replace("#/components/schemas/", ""));
+                }
+            });
+        }
+        if (schema.getItems() != null && schema.getItems().get$ref() != null) {
+            refs.add(schema.getItems().get$ref().replace("#/components/schemas/", ""));
+        }
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.identityprovider.api.DefaultUser;
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.management.api.mapper.ObjectMapperResolver;
+import io.gravitee.am.management.service.DefaultIdentityProviderService;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.PermissionService;
+import io.gravitee.am.management.service.permissions.PermissionAcls;
+import io.gravitee.am.model.Organization;
+import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.ReporterService;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Jersey + Spring test harness for the Automation API, mirroring the management REST
+ * API's {@code JerseySpringTest} pattern but scoped to the (much smaller) set of beans
+ * the Automation resources require. Boots the real {@link AutomationApiApplication} so
+ * routing, providers and (de)serialization are exercised end-to-end against mocked
+ * services.
+ *
+ * @author GraviteeSource Team
+ */
+@SpringJUnitConfig(classes = AutomationJerseySpringTest.ContextConfiguration.class)
+public abstract class AutomationJerseySpringTest {
+
+    protected static final String USER_NAME = "UnitTests";
+    protected static final String ORG_ID = "DEFAULT";
+    protected static final String ENV_ID = "DEFAULT";
+
+    protected ObjectMapper objectMapper = new ObjectMapperResolver()
+            .getContext(ObjectMapper.class)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Autowired
+    protected PermissionService permissionService;
+
+    @Autowired
+    protected DomainService domainService;
+
+    @Autowired
+    protected CertificateService certificateService;
+
+    @Autowired
+    protected IdentityProviderService identityProviderService;
+
+    @Autowired
+    protected DefaultIdentityProviderService defaultIdentityProviderService;
+
+    @Autowired
+    protected ReporterService reporterService;
+
+    @BeforeEach
+    public void init() {
+        // The service mocks are Spring singletons shared across the cached context, so clear any
+        // invocations recorded by a previous test before each one runs — this keeps verify(...) checks
+        // (e.g. "delete was never called") scoped to the test at hand.
+        clearInvocations(permissionService, domainService, certificateService, identityProviderService,
+                defaultIdentityProviderService, reporterService);
+        when(permissionService.hasPermission(any(User.class), any(PermissionAcls.class)))
+                .thenReturn(Single.just(true));
+    }
+
+    /**
+     * Re-stubs the permission service to deny every check, so tests can assert that authorization is
+     * enforced (403) ahead of any resource lookup — i.e. without leaking existence as a 404.
+     */
+    protected void denyPermission() {
+        when(permissionService.hasPermission(any(User.class), any(PermissionAcls.class)))
+                .thenReturn(Single.just(false));
+    }
+
+    @Configuration
+    static class ContextConfiguration {
+
+        @Bean
+        public PermissionService permissionService() {
+            return mock(PermissionService.class);
+        }
+
+        @Bean
+        public DomainService domainService() {
+            return mock(DomainService.class);
+        }
+
+        @Bean
+        public CertificateService certificateService() {
+            return mock(CertificateService.class);
+        }
+
+        @Bean
+        public IdentityProviderService identityProviderService() {
+            return mock(IdentityProviderService.class);
+        }
+
+        @Bean
+        public DefaultIdentityProviderService defaultIdentityProviderService() {
+            return mock(DefaultIdentityProviderService.class);
+        }
+
+        @Bean
+        public ReporterService reporterService() {
+            return mock(ReporterService.class);
+        }
+    }
+
+    private JerseyTest jerseyTest;
+
+    /** Root of every Automation API path: {@code /organizations/{orgId}}. */
+    protected final WebTarget orgTarget() {
+        return jerseyTest.target("organizations").path(ORG_ID);
+    }
+
+    /** {@code /organizations/{orgId}/environments/{envId}/domains}. */
+    protected final WebTarget domainsTarget() {
+        return orgTarget().path("environments").path(ENV_ID).path("domains");
+    }
+
+    /** {@code /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identity-providers}. */
+    protected final WebTarget identityProvidersTarget(String domainKey) {
+        return domainsTarget().path(domainKey).path("identity-providers");
+    }
+
+    /** {@code /organizations/{orgId}/environments/{envId}/domains/{domainKey}/certificates}. */
+    protected final WebTarget certificatesTarget(String domainKey) {
+        return domainsTarget().path(domainKey).path("certificates");
+    }
+
+    /** {@code /organizations/{orgId}/environments/{envId}/domains/{domainKey}/reporters}. */
+    protected final WebTarget reportersTarget(String domainKey) {
+        return domainsTarget().path(domainKey).path("reporters");
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        jerseyTest.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        jerseyTest.tearDown();
+    }
+
+    @Autowired
+    public void setApplicationContext(final ApplicationContext context) {
+        jerseyTest = new JerseyTest() {
+            @Override
+            protected Application configure() {
+                ResourceConfig application = new AutomationApiApplication();
+                application.register(AuthenticationFilter.class);
+                application.property("contextConfig", context);
+                return application;
+            }
+        };
+    }
+
+    /**
+     * Stands in for {@code AutomationBearerTokenFilter}: sets a {@link SecurityContext}
+     * whose principal is the {@link UsernamePasswordAuthenticationToken} that
+     * {@code AbstractAutomationResource#getAuthenticatedUser()} expects.
+     */
+    @Priority(50)
+    public static class AuthenticationFilter implements ContainerRequestFilter {
+        @Override
+        public void filter(final ContainerRequestContext requestContext) {
+            requestContext.setSecurityContext(new SecurityContext() {
+                @Override
+                public Principal getUserPrincipal() {
+                    DefaultUser endUser = new DefaultUser(USER_NAME);
+                    endUser.setAdditionalInformation(Map.of(Claims.ORGANIZATION, Organization.DEFAULT));
+                    return new UsernamePasswordAuthenticationToken(endUser, null);
+                }
+
+                @Override
+                public boolean isUserInRole(String role) {
+                    return true;
+                }
+
+                @Override
+                public boolean isSecure() {
+                    return true;
+                }
+
+                @Override
+                public String getAuthenticationScheme() {
+                    return "BEARER";
+                }
+            });
+        }
+    }
+
+    protected <T> T readEntity(Response response, Class<T> clazz) {
+        try {
+            if (clazz == String.class) {
+                return (T) response.readEntity(String.class);
+            }
+            return objectMapper.readValue(response.readEntity(String.class), clazz);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected <T> T readEntity(Response response, TypeReference<T> typeReference) {
+        try {
+            return objectMapper.readValue(response.readEntity(String.class), typeReference);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected <T> List<T> readListEntity(Response response, Class<T> entityClazz) {
+        try {
+            return objectMapper.readValue(response.readEntity(String.class),
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, entityClazz));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected <T> Response put(WebTarget webTarget, T value) {
+        try {
+            return webTarget.request().put(Entity.entity(
+                    objectMapper.writeValueAsString(value), MediaType.APPLICATION_JSON_TYPE));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapperTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapperTest.java
@@ -1,0 +1,391 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.mapper;
+
+import io.gravitee.am.management.handlers.automation.model.AutomationAccountSettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationCertificateSettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
+import io.gravitee.am.management.handlers.automation.model.AutomationOidcSettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationSamlSettings;
+import io.gravitee.am.management.handlers.automation.resource.AutomationIds;
+import io.gravitee.am.model.CorsSettings;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.PasswordSettings;
+import io.gravitee.am.model.SecretExpirationSettings;
+import io.gravitee.am.model.SelfServiceAccountManagementSettings;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.login.WebAuthnSettings;
+import io.gravitee.am.model.oidc.CIMDSettings;
+import io.gravitee.am.model.oidc.ClientRegistrationSettings;
+import io.gravitee.am.model.oidc.OIDCSettings;
+import io.gravitee.am.model.oidc.SecurityProfileSettings;
+import io.gravitee.am.model.scim.SCIMSettings;
+import io.gravitee.am.model.uma.UMASettings;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author GraviteeSource Team
+ */
+class AutomationDomainMapperTest {
+
+    private static final String DOMAIN_ID = "domain-1";
+
+    /**
+     * Writable {@link Domain} fields that the Automation API intentionally does NOT
+     * surface. Adding to this set is a conscious decision and must be justified here —
+     * the drift guard below fails until a new {@code Domain} field is either surfaced
+     * on {@link AutomationDomain} (and mapped) or listed here.
+     */
+    private static final Set<String> INTENTIONALLY_NOT_SURFACED = Set.of(
+            "id",             // internal id; the Automation API addresses domains by key
+            "hrid",           // name-derived human id; the Automation API uses the dedicated key instead
+            "version",        // internal domain schema version, not declarative state
+            "referenceType",  // internal; always ENVIRONMENT
+            "referenceId",    // internal; the environment id is taken from the URL path
+            "alertEnabled",   // alerting is not exposed via the Automation API
+            "identities",     // legacy field, DefaultOrganizationUpgrader use only
+            "master",         // cross-domain token introspection toggle, not exposed
+            "vhostMode",      // not independently exposed (driven by the vhosts list)
+            "managedBy"       // set server-side to AUTOMATION_API; not a writable input
+    );
+
+    // --- drift guard --------------------------------------------------------
+
+    /**
+     * Fails when the core {@link Domain} model gains writable state that the
+     * {@link AutomationDomain} projection (and therefore {@link AutomationDomainMapper})
+     * silently drops. Either surface the new field on {@link AutomationDomain} and map
+     * it, or add it to {@link #INTENTIONALLY_NOT_SURFACED} with a rationale.
+     */
+    @Test
+    void domainWritableStateIsFullySurfacedByAutomationDomain() {
+        Set<String> automationFields = writableFieldNames(AutomationDomain.class);
+
+        Set<String> unsurfaced = new TreeSet<>();
+        for (String domainField : writableFieldNames(Domain.class)) {
+            if (INTENTIONALLY_NOT_SURFACED.contains(domainField)) {
+                continue;
+            }
+            if (!automationFields.contains(domainField)) {
+                unsurfaced.add(domainField);
+            }
+        }
+
+        assertTrue(unsurfaced.isEmpty(),
+                "Domain has writable state not surfaced by the Automation API: " + unsurfaced
+                        + ". Add a matching property to AutomationDomain and map it in "
+                        + "AutomationDomainMapper, or add the field to "
+                        + "INTENTIONALLY_NOT_SURFACED with a rationale.");
+    }
+
+    private static Set<String> writableFieldNames(Class<?> type) {
+        return java.util.Arrays.stream(type.getDeclaredFields())
+                .filter(f -> !f.isSynthetic())
+                .filter(f -> !Modifier.isStatic(f.getModifiers()))
+                .map(Field::getName)
+                .filter(name -> hasSetter(type, name))
+                .collect(Collectors.toSet());
+    }
+
+    private static boolean hasSetter(Class<?> type, String fieldName) {
+        String setter = "set" + Character.toUpperCase(fieldName.charAt(0)) + fieldName.substring(1);
+        return java.util.Arrays.stream(type.getMethods())
+                .anyMatch(m -> m.getName().equals(setter) && m.getParameterCount() == 1);
+    }
+
+    private static Domain newDomain() {
+        Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        return domain;
+    }
+
+    // --- settings reuse by reference ---------------------------------------
+
+    @Test
+    void sharedSettingsBlocksAreReusedByReferenceOnApply() {
+        UMASettings uma = new UMASettings();
+        LoginSettings login = new LoginSettings();
+        WebAuthnSettings webAuthn = new WebAuthnSettings();
+        SCIMSettings scim = new SCIMSettings();
+        PasswordSettings password = new PasswordSettings();
+        SelfServiceAccountManagementSettings selfService = new SelfServiceAccountManagementSettings();
+        CorsSettings cors = new CorsSettings();
+        SecretExpirationSettings secret = new SecretExpirationSettings();
+        TokenExchangeSettings tokenExchange = new TokenExchangeSettings();
+
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        in.setUma(uma);
+        in.setLoginSettings(login);
+        in.setWebAuthnSettings(webAuthn);
+        in.setScim(scim);
+        in.setPasswordSettings(password);
+        in.setSelfServiceAccountManagementSettings(selfService);
+        in.setCorsSettings(cors);
+        in.setSecretExpirationSettings(secret);
+        in.setTokenExchangeSettings(tokenExchange);
+
+        Domain target = newDomain();
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        assertSame(uma, target.getUma());
+        assertSame(login, target.getLoginSettings());
+        assertSame(webAuthn, target.getWebAuthnSettings());
+        assertSame(scim, target.getScim());
+        assertSame(password, target.getPasswordSettings());
+        assertSame(selfService, target.getSelfServiceAccountManagementSettings());
+        assertSame(cors, target.getCorsSettings());
+        assertSame(secret, target.getSecretExpirationSettings());
+        assertSame(tokenExchange, target.getTokenExchangeSettings());
+
+        // a GET of the same domain reuses the shared sub-models by reference too
+        AutomationDomain out = AutomationDomainMapper.toAutomationDomain(target);
+        assertSame(tokenExchange, out.getTokenExchangeSettings());
+    }
+
+    // --- strict declarative null-reset semantics ---------------------------
+
+    @Test
+    void omittedSettingsAreResetToCreationDefaultsOnApply() {
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        // every settings block omitted
+
+        // pre-populate the target so we prove they are actively reset, not just absent
+        Domain target = newDomain();
+        target.setUma(new UMASettings());
+        target.setLoginSettings(new LoginSettings());
+
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        // oidc must never be null — reset to the standard default
+        assertNotNull(target.getOidc(), "oidc must be reset to its default, never null");
+
+        assertNull(target.getUma());
+        assertNull(target.getLoginSettings());
+        assertNull(target.getWebAuthnSettings());
+        assertNull(target.getScim());
+        assertNull(target.getAccountSettings());
+        assertNull(target.getPasswordSettings());
+        assertNull(target.getSelfServiceAccountManagementSettings());
+        assertNull(target.getCorsSettings());
+        assertNull(target.getSecretExpirationSettings());
+        assertNull(target.getTokenExchangeSettings());
+        assertNull(target.getSaml());
+        assertNull(target.getCertificateSettings());
+    }
+
+    @Test
+    void providedOidcIsNotOverriddenByTheDefault() {
+        AutomationOidcSettings oidc = new AutomationOidcSettings();
+        oidc.setRedirectUriStrictMatching(true);
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        in.setOidc(oidc);
+
+        Domain target = newDomain();
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        assertNotNull(target.getOidc());
+        assertTrue(target.getOidc().isRedirectUriStrictMatching());
+    }
+
+    @Test
+    void oidcReusableSubBlocksAreReusedByReference() {
+        ClientRegistrationSettings clientReg = new ClientRegistrationSettings();
+        SecurityProfileSettings security = new SecurityProfileSettings();
+
+        AutomationOidcSettings oidc = new AutomationOidcSettings();
+        oidc.setClientRegistrationSettings(clientReg);
+        oidc.setSecurityProfileSettings(security);
+
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        in.setOidc(oidc);
+
+        Domain target = newDomain();
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        assertSame(clientReg, target.getOidc().getClientRegistrationSettings());
+        assertSame(security, target.getOidc().getSecurityProfileSettings());
+    }
+
+    @Test
+    void existingCimdSettingsAreWipedWhenOidcIsProvidedOnApply() {
+        CIMDSettings preExisting = new CIMDSettings();
+        preExisting.setEnabled(true);
+        preExisting.setTemplateId("template-id-123");
+
+        OIDCSettings existingOidc = new OIDCSettings();
+        existingOidc.setCimdSettings(preExisting);
+
+        Domain target = newDomain();
+        target.setOidc(existingOidc);
+
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        in.setOidc(new AutomationOidcSettings());
+
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        assertNull(target.getOidc().getCimdSettings(),
+                "CIMD must be wiped when oidc is replaced by an Automation API PUT");
+    }
+
+    @Test
+    void existingCimdSettingsAreResetToDefaultWhenOidcIsOmittedOnApply() {
+        CIMDSettings preExisting = new CIMDSettings();
+        preExisting.setEnabled(true);
+        preExisting.setTemplateId("template-id-123");
+
+        OIDCSettings existingOidc = new OIDCSettings();
+        existingOidc.setCimdSettings(preExisting);
+
+        Domain target = newDomain();
+        target.setOidc(existingOidc);
+
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        assertNotNull(target.getOidc().getCimdSettings());
+        assertFalse(target.getOidc().getCimdSettings().isEnabled());
+        assertNull(target.getOidc().getCimdSettings().getTemplateId());
+    }
+
+    // --- certificate key <-> id translation (parallel storage) --------------
+
+    @Test
+    void samlAndFallbackCertificateRoundTripByKey() {
+        // Automation -> model: the certificate id is computed deterministically from the key and the key
+        // is kept verbatim in the parallel *Key field; no existence check is required.
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        AutomationSamlSettings saml = new AutomationSamlSettings();
+        saml.setEnabled(true);
+        saml.setEntityId("https://idp.example.com");
+        saml.setCertificate("saml-signing");
+        in.setSaml(saml);
+        AutomationCertificateSettings cs = new AutomationCertificateSettings();
+        cs.setFallbackCertificate("saml-signing");
+        in.setCertificateSettings(cs);
+
+        Domain target = newDomain();
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        String expectedId = AutomationIds.certificateId(DOMAIN_ID, "saml-signing");
+        assertEquals(expectedId, target.getSaml().getCertificate());
+        assertEquals("saml-signing", target.getSaml().getCertificateKey());
+        assertEquals(expectedId, target.getCertificateSettings().getFallbackCertificate());
+        assertEquals("saml-signing", target.getCertificateSettings().getFallbackCertificateKey());
+
+        // model -> Automation: the key is read back from the parallel field
+        AutomationDomain out = AutomationDomainMapper.toAutomationDomain(target);
+        assertEquals("saml-signing", out.getSaml().getCertificate());
+        assertEquals("saml-signing", out.getCertificateSettings().getFallbackCertificate());
+    }
+
+    @Test
+    void certificateReferenceToNotYetCreatedCertificateIsAccepted() {
+        // eventual consistency: referencing a certificate that does not exist yet is allowed; the id is the
+        // deterministic key-based id and the key still round-trips on a GET.
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        AutomationSamlSettings saml = new AutomationSamlSettings();
+        saml.setEnabled(true);
+        saml.setCertificate("does-not-exist-yet");
+        in.setSaml(saml);
+
+        Domain target = newDomain();
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        assertEquals(AutomationIds.certificateId(DOMAIN_ID, "does-not-exist-yet"), target.getSaml().getCertificate());
+        assertEquals("does-not-exist-yet", AutomationDomainMapper.toAutomationDomain(target).getSaml().getCertificate());
+    }
+
+    // --- account settings: IdP key translation -----------------------------
+
+    @Test
+    void defaultIdentityProviderForRegistrationResolvesToExistingProviderId() {
+        IdentityProvider idp = new IdentityProvider();
+        idp.setId("idp-id-1");
+        idp.setAutomationKey("customer-users");
+        idp.setManagedBy(ManagedBy.AUTOMATION_API);
+
+        AutomationAccountSettings account = new AutomationAccountSettings();
+        account.setDefaultIdentityProviderForRegistration("customer-users");
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        in.setAccountSettings(account);
+
+        Domain target = newDomain();
+        AutomationDomainMapper.applyTo(in, target, List.of(idp));
+
+        // resolved to the provider's actual id, key kept verbatim in the parallel field
+        assertEquals("idp-id-1", target.getAccountSettings().getDefaultIdentityProviderForRegistration());
+        assertEquals("customer-users", target.getAccountSettings().getDefaultIdentityProviderForRegistrationKey());
+
+        // GET reads the key back from the parallel field
+        AutomationDomain out = AutomationDomainMapper.toAutomationDomain(target);
+        assertEquals("customer-users", out.getAccountSettings().getDefaultIdentityProviderForRegistration());
+    }
+
+    @Test
+    void defaultIdentityProviderForRegistrationToNotYetCreatedProviderFallsBackToDeterministicId() {
+        AutomationAccountSettings account = new AutomationAccountSettings();
+        account.setDefaultIdentityProviderForRegistration("not-created-yet");
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        in.setAccountSettings(account);
+
+        Domain target = newDomain();
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        assertEquals(AutomationIds.identityProviderId(DOMAIN_ID, "not-created-yet"),
+                target.getAccountSettings().getDefaultIdentityProviderForRegistration());
+        assertEquals("not-created-yet",
+                AutomationDomainMapper.toAutomationDomain(target).getAccountSettings().getDefaultIdentityProviderForRegistration());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/CertificateResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/CertificateResourceTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationCertificate;
+import io.gravitee.am.model.Certificate;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class CertificateResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DOMAIN_KEY = "customer-auth";
+    private static final String CERT_KEY = "saml-signing";
+    private final String domainId = AutomationIds.domainId(ENV_ID, DOMAIN_KEY);
+    private final String certId = AutomationIds.certificateId(domainId, CERT_KEY);
+
+    private Domain domain() {
+        Domain domain = new Domain();
+        domain.setId(domainId);
+        domain.setAutomationKey(DOMAIN_KEY);
+        domain.setReferenceId(ENV_ID);
+        domain.setManagedBy(ManagedBy.AUTOMATION_API);
+        return domain;
+    }
+
+    private Certificate cert(boolean system, ManagedBy managedBy) {
+        Certificate c = new Certificate();
+        c.setId(certId);
+        c.setAutomationKey(CERT_KEY);
+        c.setName("SAML signing");
+        c.setType("javakeystore-am-certificate");
+        c.setConfiguration("{}");
+        c.setSystem(system);
+        c.setDomain(domainId);
+        c.setManagedBy(managedBy);
+        return c;
+    }
+
+    private Response getRequest() {
+        return certificatesTarget(DOMAIN_KEY).path(CERT_KEY).request().get();
+    }
+
+    @Test
+    void get_returns_certificate_when_found() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(anyString())).thenReturn(Flowable.just(cert(true, ManagedBy.AUTOMATION_API)));
+
+        Response response = getRequest();
+
+        assertEquals(200, response.getStatus());
+        AutomationCertificate body = readEntity(response, AutomationCertificate.class);
+        assertEquals(CERT_KEY, body.getAutomationKey());
+        assertTrue(body.isSystem(), "system certificate must be projected as system:true");
+    }
+
+    @Test
+    void get_returns_404_when_certificate_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(anyString())).thenReturn(Flowable.empty());
+
+        assertEquals(404, getRequest().getStatus());
+    }
+
+    @Test
+    void get_returns_404_when_certificate_not_automation_managed() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(anyString())).thenReturn(Flowable.just(cert(false, null)));
+
+        assertEquals(404, getRequest().getStatus());
+    }
+
+    @Test
+    void get_returns_404_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        assertEquals(404, getRequest().getStatus());
+    }
+
+    @Test
+    void delete_returns_204() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(anyString())).thenReturn(Flowable.just(cert(true, ManagedBy.AUTOMATION_API)));
+        when(certificateService.delete(eq(certId), any())).thenReturn(Completable.complete());
+
+        Response response = certificatesTarget(DOMAIN_KEY).path(CERT_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    void delete_returns_204_when_certificate_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(anyString())).thenReturn(Flowable.empty());
+
+        Response response = certificatesTarget(DOMAIN_KEY).path(CERT_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+        verify(certificateService, never()).delete(anyString(), any());
+    }
+
+    @Test
+    void delete_returns_204_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = certificatesTarget(DOMAIN_KEY).path(CERT_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+        verify(certificateService, never()).delete(anyString(), any());
+    }
+
+    @Test
+    void get_returns_403_without_revealing_existence_when_not_permitted() {
+        denyPermission();
+        // domain stubbed absent: an unauthorized caller must still get 403, never a 404 that leaks existence.
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        assertEquals(403, getRequest().getStatus());
+    }
+
+    @Test
+    void delete_returns_403_when_not_permitted() {
+        denyPermission();
+
+        Response response = certificatesTarget(DOMAIN_KEY).path(CERT_KEY).request().delete();
+
+        assertEquals(403, response.getStatus());
+        verify(certificateService, never()).delete(anyString(), any());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/CertificatesResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/CertificatesResourceTest.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationCertificate;
+import io.gravitee.am.model.Certificate;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class CertificatesResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DOMAIN_KEY = "customer-auth";
+    private final String domainId = AutomationIds.domainId(ENV_ID, DOMAIN_KEY);
+
+    private Domain domain() {
+        Domain domain = new Domain();
+        domain.setId(domainId);
+        domain.setAutomationKey(DOMAIN_KEY);
+        domain.setReferenceId(ENV_ID);
+        domain.setManagedBy(ManagedBy.AUTOMATION_API);
+        return domain;
+    }
+
+    private Certificate cert(String id, String key, boolean system, ManagedBy managedBy) {
+        Certificate c = new Certificate();
+        c.setId(id);
+        c.setAutomationKey(key);
+        c.setName(key);
+        c.setType("javakeystore-am-certificate");
+        c.setConfiguration("{}");
+        c.setSystem(system);
+        c.setDomain(domainId);
+        c.setManagedBy(managedBy);
+        return c;
+    }
+
+    private AutomationCertificate definition(String key, boolean isSystem) {
+        AutomationCertificate in = new AutomationCertificate();
+        in.setAutomationKey(key);
+        in.setName(key);
+        in.setType("javakeystore-am-certificate");
+        in.setConfiguration("{}");
+        in.setSystem(isSystem);
+        return in;
+    }
+
+    /**
+     * A minimal payload — only {@code key} and {@code system:true} — the AAPI accepts on the system
+     * path. {@code name}/{@code type}/{@code configuration} are ignored when {@code system} is true,
+     * so this models the way a caller is meant to provision a system resource.
+     */
+    private AutomationCertificate systemDefinition(String key) {
+        AutomationCertificate in = new AutomationCertificate();
+        in.setAutomationKey(key);
+        in.setSystem(true);
+        return in;
+    }
+
+    @Test
+    void list_returns_only_automation_managed_sorted() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(
+                        cert("id-b", "beta", false, ManagedBy.AUTOMATION_API),
+                        cert("id-legacy", "legacy", true, null),
+                        cert("id-a", "alpha", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = certificatesTarget(DOMAIN_KEY).request().get();
+
+        assertEquals(200, response.getStatus());
+        List<AutomationCertificate> body = readListEntity(response, AutomationCertificate.class);
+        assertEquals(2, body.size());
+        assertEquals("alpha", body.get(0).getAutomationKey());
+        assertEquals("beta", body.get(1).getAutomationKey());
+    }
+
+    @Test
+    void put_creates_when_absent() {
+        String certId = AutomationIds.certificateId(domainId, "my-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId))).thenReturn(Flowable.empty());
+        when(certificateService.create(any(Domain.class), any(), any(), eq(false)))
+                .thenReturn(Single.just(cert(certId, "my-cert", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), definition("my-cert", false));
+
+        assertEquals(200, response.getStatus());
+        assertEquals("my-cert", readEntity(response, AutomationCertificate.class).getAutomationKey());
+    }
+
+    @Test
+    void put_creates_system_from_config() {
+        String certId = AutomationIds.certificateId(domainId, "sys-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId))).thenReturn(Flowable.empty());
+        when(certificateService.createSystem(any(Domain.class), eq(certId), eq("sys-cert"), any()))
+                .thenReturn(Single.just(cert(certId, "sys-cert", true, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), systemDefinition("sys-cert"));
+
+        assertEquals(200, response.getStatus());
+        assertTrue(readEntity(response, AutomationCertificate.class).isSystem());
+        // The payload path must never run for a system create.
+        verify(certificateService, never()).create(any(Domain.class), any(), any(), eq(true));
+    }
+
+    @Test
+    void put_existing_system_is_idempotent_noop() {
+        // Re-PUTting a system certificate must not touch the service; gravitee.yaml owns the config.
+        String certId = AutomationIds.certificateId(domainId, "sys-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert(certId, "sys-cert", true, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), systemDefinition("sys-cert"));
+
+        assertEquals(200, response.getStatus());
+        verify(certificateService, never()).update(any(Domain.class), anyString(), any(), any());
+        verify(certificateService, never()).create(any(Domain.class), any(), any(), eq(true));
+        verify(certificateService, never()).createSystem(any(Domain.class), anyString(), anyString(), any());
+    }
+
+    @Test
+    void put_rejects_non_system_missing_required_fields() {
+        // name/type/configuration are no longer @NotNull on the model so the system path can omit them;
+        // the resource enforces them programmatically for non-system creates.
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId))).thenReturn(Flowable.empty());
+
+        AutomationCertificate def = new AutomationCertificate();
+        def.setAutomationKey("incomplete");
+        // name, type, configuration intentionally left null
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(certificateService, never()).create(any(Domain.class), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_updates_when_present() {
+        String certId = AutomationIds.certificateId(domainId, "my-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert(certId, "my-cert", false, ManagedBy.AUTOMATION_API)));
+        when(certificateService.update(any(Domain.class), eq(certId), any(), any()))
+                .thenReturn(Single.just(cert(certId, "my-cert", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), definition("my-cert", false));
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_changing_system_on_existing() {
+        String certId = AutomationIds.certificateId(domainId, "my-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        // existing is non-system; the PUT flips system -> rejected (immutable)
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert(certId, "my-cert", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), definition("my-cert", true));
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_collision_with_non_automation_certificate() {
+        String certId = AutomationIds.certificateId(domainId, "my-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert(certId, "my-cert", false, null)));
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), definition("my-cert", false));
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_second_system() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert("existing-system", "primary", true, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), systemDefinition("second-system"));
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_returns_404_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), definition("my-cert", false));
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_invalid_key_pattern() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(anyString())).thenReturn(Flowable.empty());
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), definition("Bad Key!", false));
+
+        assertEquals(400, response.getStatus());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainResourceTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class DomainResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DOMAIN_KEY = "customer-auth";
+    private final String domainId = AutomationIds.domainId(ENV_ID, DOMAIN_KEY);
+
+    private Domain domain() {
+        Domain domain = new Domain();
+        domain.setId(domainId);
+        domain.setAutomationKey(DOMAIN_KEY);
+        domain.setHrid(DOMAIN_KEY);
+        domain.setName("Customer Auth");
+        domain.setPath("/customer-auth");
+        domain.setReferenceId(ENV_ID);
+        domain.setDataPlaneId("default");
+        domain.setManagedBy(ManagedBy.AUTOMATION_API);
+        return domain;
+    }
+
+    private Domain managementDomain() {
+        Domain domain = domain();
+        domain.setManagedBy(null);
+        return domain;
+    }
+
+    @Test
+    void get_returns_domain_when_found() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+
+        Response response = domainsTarget().path(DOMAIN_KEY).request().get();
+
+        assertEquals(200, response.getStatus());
+        assertEquals(DOMAIN_KEY, readEntity(response, AutomationDomain.class).getAutomationKey());
+    }
+
+    @Test
+    void get_returns_404_when_absent() {
+        when(domainService.findById(eq(AutomationIds.domainId(ENV_ID, "missing")))).thenReturn(Maybe.empty());
+
+        Response response = domainsTarget().path("missing").request().get();
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void delete_returns_204() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(domainService.delete(any(), eq(domainId), any())).thenReturn(Completable.complete());
+
+        Response response = domainsTarget().path(DOMAIN_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    void get_returns_404_when_domain_is_not_automation_managed() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(managementDomain()));
+
+        Response response = domainsTarget().path(DOMAIN_KEY).request().get();
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void delete_returns_204_when_domain_is_not_automation_managed() {
+        // A domain the Automation API does not manage is treated as "nothing to delete" — an
+        // idempotent no-op (204), and it is never actually deleted.
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(managementDomain()));
+
+        Response response = domainsTarget().path(DOMAIN_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+        verify(domainService, never()).delete(any(), any(), any());
+    }
+
+    @Test
+    void delete_returns_204_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = domainsTarget().path(DOMAIN_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+        verify(domainService, never()).delete(any(), any(), any());
+    }
+
+    @Test
+    void get_returns_403_without_revealing_existence_when_not_permitted() {
+        denyPermission();
+        // findById is stubbed empty: even for an absent domain the caller must get 403, not 404.
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = domainsTarget().path(DOMAIN_KEY).request().get();
+
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    void delete_returns_403_when_not_permitted() {
+        denyPermission();
+
+        Response response = domainsTarget().path(DOMAIN_KEY).request().delete();
+
+        assertEquals(403, response.getStatus());
+        verify(domainService, never()).delete(any(), any(), any());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.ReferenceType;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class DomainsResourceTest extends AutomationJerseySpringTest {
+
+    private Domain domain(String id, String key) {
+        Domain domain = new Domain();
+        domain.setId(id);
+        domain.setAutomationKey(key);
+        domain.setHrid(key);
+        domain.setName(key);
+        domain.setPath("/" + key);
+        domain.setReferenceId(ENV_ID);
+        domain.setDataPlaneId("default");
+        domain.setManagedBy(ManagedBy.AUTOMATION_API);
+        return domain;
+    }
+
+    private Domain managementDomain(String id, String key) {
+        Domain domain = domain(id, key);
+        domain.setManagedBy(null);
+        return domain;
+    }
+
+    private AutomationDomain definition(String key) {
+        AutomationDomain in = new AutomationDomain();
+        in.setAutomationKey(key);
+        in.setName(key);
+        in.setPath("/" + key);
+        in.setDataPlaneId("default");
+        return in;
+    }
+
+    @Test
+    void list_returns_domains_sorted() {
+        when(domainService.findAllByEnvironment(ORG_ID, ENV_ID))
+                .thenReturn(Flowable.just(domain("id-b", "beta"), domain("id-a", "alpha")));
+
+        Response response = domainsTarget().request().get();
+
+        assertEquals(200, response.getStatus());
+        List<AutomationDomain> body = readListEntity(response, AutomationDomain.class);
+        assertEquals(2, body.size());
+        assertEquals("alpha", body.get(0).getAutomationKey());
+        assertEquals("beta", body.get(1).getAutomationKey());
+    }
+
+    @Test
+    void put_creates_when_domain_absent() {
+        String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
+        Domain created = domain(domainId, "customer-auth");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+        when(domainService.create(eq(ORG_ID), eq(ENV_ID), any(), any()))
+                .thenReturn(Single.just(created));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+        when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(created));
+
+        Response response = put(domainsTarget(), definition("customer-auth"));
+
+        assertEquals(200, response.getStatus());
+        assertEquals("customer-auth", readEntity(response, AutomationDomain.class).getAutomationKey());
+    }
+
+    @Test
+    void put_updates_when_domain_present() {
+        String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
+        Domain existing = domain(domainId, "customer-auth");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(existing));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+        when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(existing));
+
+        Response response = put(domainsTarget(), definition("customer-auth"));
+
+        assertEquals(200, response.getStatus());
+        assertEquals("customer-auth", readEntity(response, AutomationDomain.class).getAutomationKey());
+    }
+
+    @Test
+    void put_is_rejected_when_required_fields_missing() {
+        AutomationDomain invalid = new AutomationDomain();
+        invalid.setAutomationKey("customer-auth"); // name, path, dataPlaneId missing
+
+        Response response = put(domainsTarget(), invalid);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void list_filters_out_non_automation_managed_domains() {
+        Domain managed = domain("id-a", "alpha");
+        Domain management = managementDomain("id-b", "beta");
+        when(domainService.findAllByEnvironment(ORG_ID, ENV_ID))
+                .thenReturn(Flowable.just(managed, management));
+
+        Response response = domainsTarget().request().get();
+
+        assertEquals(200, response.getStatus());
+        List<AutomationDomain> body = readListEntity(response, AutomationDomain.class);
+        assertEquals(1, body.size());
+        assertEquals("alpha", body.get(0).getAutomationKey());
+    }
+
+    @Test
+    void put_rejects_when_existing_domain_is_not_automation_managed() {
+        String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
+        when(domainService.findById(eq(domainId)))
+                .thenReturn(Maybe.just(managementDomain(domainId, "customer-auth")));
+
+        Response response = put(domainsTarget(), definition("customer-auth"));
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_invalid_key_pattern() {
+        AutomationDomain invalid = definition("Customer Auth!"); // uppercase + space + bang
+
+        Response response = put(domainsTarget(), invalid);
+
+        assertEquals(400, response.getStatus());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProviderResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProviderResourceTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationIdentityProvider;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.ReferenceType;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class IdentityProviderResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DOMAIN_KEY = "customer-auth";
+    private static final String IDP_KEY = "dev-users";
+    private final String domainId = AutomationIds.domainId(ENV_ID, DOMAIN_KEY);
+    private final String idpId = AutomationIds.identityProviderId(domainId, IDP_KEY);
+
+    private Domain domain() {
+        Domain domain = new Domain();
+        domain.setId(domainId);
+        domain.setAutomationKey(DOMAIN_KEY);
+        domain.setReferenceId(ENV_ID);
+        domain.setManagedBy(ManagedBy.AUTOMATION_API);
+        return domain;
+    }
+
+    private IdentityProvider idp(ManagedBy managedBy) {
+        IdentityProvider idp = new IdentityProvider();
+        idp.setId(idpId);
+        idp.setAutomationKey(IDP_KEY);
+        idp.setName("Dev Users");
+        idp.setType("inline-am-idp");
+        idp.setReferenceType(ReferenceType.DOMAIN);
+        idp.setReferenceId(domainId);
+        idp.setManagedBy(managedBy);
+        return idp;
+    }
+
+    private Response getRequest() {
+        return identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().get();
+    }
+
+    @Test
+    void get_returns_idp_when_found() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString()))
+                .thenReturn(Flowable.just(idp(ManagedBy.AUTOMATION_API)));
+
+        Response response = getRequest();
+
+        assertEquals(200, response.getStatus());
+        assertEquals(IDP_KEY, readEntity(response, AutomationIdentityProvider.class).getAutomationKey());
+    }
+
+    @Test
+    void get_returns_404_when_idp_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+
+        Response response = getRequest();
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void get_returns_404_when_idp_not_automation_managed() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString()))
+                .thenReturn(Flowable.just(idp(null)));
+
+        Response response = getRequest();
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void get_returns_404_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = getRequest();
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void delete_returns_204() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString()))
+                .thenReturn(Flowable.just(idp(ManagedBy.AUTOMATION_API)));
+        when(identityProviderService.delete(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any()))
+                .thenReturn(Completable.complete());
+
+        Response response = identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    void delete_returns_204_when_idp_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+
+        Response response = identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+        verify(identityProviderService, never()).delete(any(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void delete_returns_204_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+        verify(identityProviderService, never()).delete(any(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void get_returns_403_without_revealing_existence_when_not_permitted() {
+        denyPermission();
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        assertEquals(403, getRequest().getStatus());
+    }
+
+    @Test
+    void delete_returns_403_when_not_permitted() {
+        denyPermission();
+
+        Response response = identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
+
+        assertEquals(403, response.getStatus());
+        verify(identityProviderService, never()).delete(any(), anyString(), anyString(), any());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
@@ -1,0 +1,252 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationIdentityProvider;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.ReferenceType;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DOMAIN_KEY = "customer-auth";
+    private final String domainId = AutomationIds.domainId(ENV_ID, DOMAIN_KEY);
+
+    private Domain domain() {
+        Domain domain = new Domain();
+        domain.setId(domainId);
+        domain.setAutomationKey(DOMAIN_KEY);
+        domain.setReferenceId(ENV_ID);
+        domain.setManagedBy(ManagedBy.AUTOMATION_API);
+        return domain;
+    }
+
+    private IdentityProvider idp(String id, String key, ManagedBy managedBy) {
+        return idp(id, key, managedBy, false);
+    }
+
+    private IdentityProvider idp(String id, String key, ManagedBy managedBy, boolean system) {
+        IdentityProvider idp = new IdentityProvider();
+        idp.setId(id);
+        idp.setAutomationKey(key);
+        idp.setName(key);
+        idp.setType("inline-am-idp");
+        idp.setReferenceType(ReferenceType.DOMAIN);
+        idp.setReferenceId(domainId);
+        idp.setManagedBy(managedBy);
+        idp.setSystem(system);
+        return idp;
+    }
+
+    private AutomationIdentityProvider definition(String key) {
+        AutomationIdentityProvider in = new AutomationIdentityProvider();
+        in.setAutomationKey(key);
+        in.setName(key);
+        in.setType("inline-am-idp");
+        in.setConfiguration("{}");
+        return in;
+    }
+
+    /**
+     * A minimal payload — only {@code key} and {@code system:true} — the AAPI accepts on the system
+     * path. {@code name}/{@code type}/{@code configuration} are ignored when {@code system} is true,
+     * so this models the way a caller is meant to provision a system IDP.
+     */
+    private AutomationIdentityProvider systemDefinition(String key) {
+        AutomationIdentityProvider in = new AutomationIdentityProvider();
+        in.setAutomationKey(key);
+        in.setSystem(true);
+        return in;
+    }
+
+    @Test
+    void list_returns_only_automation_managed_sorted() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(
+                        idp("id-b", "beta", ManagedBy.AUTOMATION_API),
+                        idp("id-legacy", "legacy", null),
+                        idp("id-a", "alpha", ManagedBy.AUTOMATION_API)));
+
+        Response response = identityProvidersTarget(DOMAIN_KEY).request().get();
+
+        assertEquals(200, response.getStatus());
+        List<AutomationIdentityProvider> body = readListEntity(response, AutomationIdentityProvider.class);
+        assertEquals(2, body.size());
+        assertEquals("alpha", body.get(0).getAutomationKey());
+        assertEquals("beta", body.get(1).getAutomationKey());
+    }
+
+    @Test
+    void put_creates_when_absent() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+        when(identityProviderService.create(any(Domain.class), any(), any(), eq(false)))
+                .thenReturn(Single.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+
+        assertEquals(200, response.getStatus());
+        assertEquals("dev-users", readEntity(response, AutomationIdentityProvider.class).getAutomationKey());
+    }
+
+    @Test
+    void put_updates_when_present() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+        when(identityProviderService.update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false)))
+                .thenReturn(Single.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+
+        assertEquals(200, response.getStatus());
+        assertEquals("dev-users", readEntity(response, AutomationIdentityProvider.class).getAutomationKey());
+    }
+
+    @Test
+    void put_creates_system_from_config() {
+        String systemIdpId = AutomationIds.systemIdentityProviderId(domainId);
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+        when(defaultIdentityProviderService.create(any(Domain.class), eq("sys-idp"), any()))
+                .thenReturn(Single.just(idp(systemIdpId, "sys-idp", ManagedBy.AUTOMATION_API, true)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
+
+        assertEquals(200, response.getStatus());
+        assertTrue(readEntity(response, AutomationIdentityProvider.class).isSystem());
+        // The payload path must never run for a system create.
+        verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(true));
+    }
+
+    @Test
+    void put_existing_system_is_idempotent_noop() {
+        // Re-PUTting a system IDP must not touch either service; gravitee.yaml owns the config.
+        String systemIdpId = AutomationIds.systemIdentityProviderId(domainId);
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(systemIdpId, "sys-idp", ManagedBy.AUTOMATION_API, true)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
+
+        assertEquals(200, response.getStatus());
+        verify(identityProviderService, never())
+                .update(eq(ReferenceType.DOMAIN), anyString(), anyString(), any(), any(), anyBoolean());
+        verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(true));
+        verify(defaultIdentityProviderService, never()).create(any(Domain.class), anyString(), any());
+    }
+
+    @Test
+    void put_rejects_second_system() {
+        String existingSystemId = AutomationIds.systemIdentityProviderId(domainId);
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(existingSystemId, "primary", ManagedBy.AUTOMATION_API, true)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("second-system"));
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_non_system_missing_required_fields() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+
+        AutomationIdentityProvider def = new AutomationIdentityProvider();
+        def.setAutomationKey("incomplete");
+        // name, type intentionally left null
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_rejects_changing_system_on_existing() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        // existing is non-system; the PUT flips system -> rejected (immutable)
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+        AutomationIdentityProvider def = definition("dev-users");
+        def.setSystem(true);
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_collision_with_non_automation_idp() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(idpId, "dev-users", null)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_returns_404_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_invalid_key_pattern() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("Dev Users!"));
+
+        assertEquals(400, response.getStatus());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/OrganizationResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/OrganizationResourceTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.reactivex.rxjava3.core.Flowable;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises the {@code OrganizationResource} entry point and its sub-resource locator
+ * chain ({@code /organizations/{orgId}} -> domains).
+ *
+ * @author GraviteeSource Team
+ */
+class OrganizationResourceTest extends AutomationJerseySpringTest {
+
+    @Test
+    void domains_collection_is_reachable_through_organization_entry_point() {
+        when(domainService.findAllByEnvironment(eq(ORG_ID), eq(ENV_ID)))
+                .thenReturn(Flowable.empty());
+
+        Response response = domainsTarget().request().get();
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void unknown_organization_sub_path_is_404() {
+        Response response = orgTarget().path("not-a-resource").request().get();
+
+        assertEquals(404, response.getStatus());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReporterResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReporterResourceTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationReporter;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.Reference;
+import io.gravitee.am.model.Reporter;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class ReporterResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DOMAIN_KEY = "customer-auth";
+    private static final String REPORTER_KEY = "audit-log";
+    private final String domainId = AutomationIds.domainId(ENV_ID, DOMAIN_KEY);
+    private final String reporterId = AutomationIds.reporterId(domainId, REPORTER_KEY);
+
+    private Domain domain() {
+        Domain domain = new Domain();
+        domain.setId(domainId);
+        domain.setAutomationKey(DOMAIN_KEY);
+        domain.setReferenceId(ENV_ID);
+        domain.setManagedBy(ManagedBy.AUTOMATION_API);
+        return domain;
+    }
+
+    private Reporter reporter(boolean system, ManagedBy managedBy) {
+        return Reporter.builder()
+                .id(reporterId)
+                .automationKey(REPORTER_KEY)
+                .name("Audit log")
+                .type("reporter-am-file")
+                .configuration("{}")
+                .enabled(true)
+                .system(system)
+                .dataType("AUDIT")
+                .reference(Reference.domain(domainId))
+                .managedBy(managedBy)
+                .build();
+    }
+
+    private Response getRequest() {
+        return reportersTarget(DOMAIN_KEY).path(REPORTER_KEY).request().get();
+    }
+
+    @Test
+    void get_returns_reporter_when_found() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(Reference.domain(domainId))))
+                .thenReturn(Flowable.just(reporter(true, ManagedBy.AUTOMATION_API)));
+
+        Response response = getRequest();
+
+        assertEquals(200, response.getStatus());
+        AutomationReporter body = readEntity(response, AutomationReporter.class);
+        assertEquals(REPORTER_KEY, body.getAutomationKey());
+        assertTrue(body.isSystem(), "system reporter must be projected as system:true");
+    }
+
+    @Test
+    void get_returns_404_when_reporter_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(Reference.domain(domainId)))).thenReturn(Flowable.empty());
+
+        assertEquals(404, getRequest().getStatus());
+    }
+
+    @Test
+    void get_returns_404_when_reporter_not_automation_managed() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(Reference.domain(domainId))))
+                .thenReturn(Flowable.just(reporter(true, null)));
+
+        assertEquals(404, getRequest().getStatus());
+    }
+
+    @Test
+    void get_returns_404_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        assertEquals(404, getRequest().getStatus());
+    }
+
+    @Test
+    void delete_returns_204_and_bypasses_system_guard() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(Reference.domain(domainId))))
+                .thenReturn(Flowable.just(reporter(true, ManagedBy.AUTOMATION_API)));
+        when(reporterService.delete(eq(reporterId), any(), eq(true))).thenReturn(Completable.complete());
+
+        Response response = reportersTarget(DOMAIN_KEY).path(REPORTER_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    void delete_returns_204_when_reporter_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(Reference.domain(domainId)))).thenReturn(Flowable.empty());
+
+        Response response = reportersTarget(DOMAIN_KEY).path(REPORTER_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+        verify(reporterService, never()).delete(anyString(), any(), anyBoolean());
+    }
+
+    @Test
+    void delete_returns_204_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = reportersTarget(DOMAIN_KEY).path(REPORTER_KEY).request().delete();
+
+        assertEquals(204, response.getStatus());
+        verify(reporterService, never()).delete(anyString(), any(), anyBoolean());
+    }
+
+    @Test
+    void get_returns_403_without_revealing_existence_when_not_permitted() {
+        denyPermission();
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        assertEquals(403, getRequest().getStatus());
+    }
+
+    @Test
+    void delete_returns_403_when_not_permitted() {
+        denyPermission();
+
+        Response response = reportersTarget(DOMAIN_KEY).path(REPORTER_KEY).request().delete();
+
+        assertEquals(403, response.getStatus());
+        verify(reporterService, never()).delete(anyString(), any(), anyBoolean());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReportersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReportersResourceTest.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationReporter;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.Reference;
+import io.gravitee.am.model.Reporter;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class ReportersResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DOMAIN_KEY = "customer-auth";
+    private final String domainId = AutomationIds.domainId(ENV_ID, DOMAIN_KEY);
+    private final Reference reference = Reference.domain(domainId);
+
+    private Domain domain() {
+        Domain domain = new Domain();
+        domain.setId(domainId);
+        domain.setAutomationKey(DOMAIN_KEY);
+        domain.setReferenceId(ENV_ID);
+        domain.setManagedBy(ManagedBy.AUTOMATION_API);
+        return domain;
+    }
+
+    private Reporter reporter(String id, String key, boolean system, ManagedBy managedBy) {
+        return Reporter.builder()
+                .id(id)
+                .automationKey(key)
+                .name(key)
+                .type("reporter-am-file")
+                .configuration("{}")
+                .enabled(true)
+                .system(system)
+                .dataType("AUDIT")
+                .reference(reference)
+                .managedBy(managedBy)
+                .build();
+    }
+
+    private AutomationReporter definition(String key, boolean isSystem) {
+        AutomationReporter in = new AutomationReporter();
+        in.setAutomationKey(key);
+        in.setName(key);
+        in.setType("reporter-am-file");
+        in.setConfiguration("{}");
+        in.setSystem(isSystem);
+        return in;
+    }
+
+    /**
+     * A minimal payload — only {@code key} and {@code system:true} — the AAPI accepts on the system
+     * path. {@code name}/{@code type}/{@code configuration} are ignored when {@code system} is true,
+     * so this models the way a caller is meant to provision a system reporter.
+     */
+    private AutomationReporter systemDefinition(String key) {
+        AutomationReporter in = new AutomationReporter();
+        in.setAutomationKey(key);
+        in.setSystem(true);
+        return in;
+    }
+
+    @Test
+    void list_returns_only_automation_managed_sorted() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(
+                        reporter("id-b", "beta", false, ManagedBy.AUTOMATION_API),
+                        reporter("id-legacy", "legacy", true, null),
+                        reporter("id-a", "alpha", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = reportersTarget(DOMAIN_KEY).request().get();
+
+        assertEquals(200, response.getStatus());
+        List<AutomationReporter> body = readListEntity(response, AutomationReporter.class);
+        assertEquals(2, body.size());
+        assertEquals("alpha", body.get(0).getAutomationKey());
+        assertEquals("beta", body.get(1).getAutomationKey());
+    }
+
+    @Test
+    void put_creates_when_absent() {
+        String reporterId = AutomationIds.reporterId(domainId, "audit-log");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
+        when(reporterService.create(eq(reference), any(), any(), eq(false)))
+                .thenReturn(Single.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(reportersTarget(DOMAIN_KEY), definition("audit-log", false));
+
+        assertEquals(200, response.getStatus());
+        assertEquals("audit-log", readEntity(response, AutomationReporter.class).getAutomationKey());
+    }
+
+    @Test
+    void put_creates_system_from_config() {
+        String reporterId = AutomationIds.reporterId(domainId, "sys-reporter");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
+        when(reporterService.createSystem(eq(reference), eq(reporterId), eq("sys-reporter"), any()))
+                .thenReturn(Single.just(reporter(reporterId, "sys-reporter", true, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(reportersTarget(DOMAIN_KEY), systemDefinition("sys-reporter"));
+
+        assertEquals(200, response.getStatus());
+        assertTrue(readEntity(response, AutomationReporter.class).isSystem());
+        // The payload path must never run for a system create.
+        verify(reporterService, never()).create(eq(reference), any(), any(), eq(true));
+    }
+
+    @Test
+    void put_existing_system_is_idempotent_noop() {
+        // Re-PUTting a system reporter must not touch the service; gravitee.yaml owns the config.
+        String reporterId = AutomationIds.reporterId(domainId, "sys-reporter");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(reporter(reporterId, "sys-reporter", true, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(reportersTarget(DOMAIN_KEY), systemDefinition("sys-reporter"));
+
+        assertEquals(200, response.getStatus());
+        verify(reporterService, never()).update(eq(reference), anyString(), any(), any(), anyBoolean());
+        verify(reporterService, never()).create(eq(reference), any(), any(), eq(true));
+        verify(reporterService, never()).createSystem(eq(reference), anyString(), anyString(), any());
+    }
+
+    @Test
+    void put_rejects_non_system_missing_required_fields() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
+
+        AutomationReporter def = new AutomationReporter();
+        def.setAutomationKey("incomplete");
+        // name, type, configuration intentionally left null
+
+        Response response = put(reportersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(reporterService, never()).create(eq(reference), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_updates_when_present() {
+        String reporterId = AutomationIds.reporterId(domainId, "audit-log");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+        when(reporterService.update(eq(reference), eq(reporterId), any(), any(), eq(false)))
+                .thenReturn(Single.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(reportersTarget(DOMAIN_KEY), definition("audit-log", false));
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_changing_system_on_existing() {
+        String reporterId = AutomationIds.reporterId(domainId, "audit-log");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        // existing is non-system; the PUT flips system -> rejected (immutable)
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(reportersTarget(DOMAIN_KEY), definition("audit-log", true));
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_second_system() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(reporter("existing-system", "primary", true, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(reportersTarget(DOMAIN_KEY), systemDefinition("second-system"));
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_returns_404_when_domain_absent() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+
+        Response response = put(reportersTarget(DOMAIN_KEY), definition("audit-log", false));
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_invalid_key_pattern() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
+
+        Response response = put(reportersTarget(DOMAIN_KEY), definition("Bad Key!", false));
+
+        assertEquals(400, response.getStatus());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/spring/security/AutomationBearerTokenFilterTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/spring/security/AutomationBearerTokenFilterTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.spring.security;
+
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.oidc.StandardClaims;
+import io.gravitee.am.jwt.JWTParser;
+import io.gravitee.am.management.service.OrganizationUserService;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.User;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Date;
+
+import static io.gravitee.gateway.api.http.HttpHeaderNames.AUTHORIZATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AutomationBearerTokenFilterTest {
+
+    private static final String ORG_ID = "DEFAULT";
+    private static final String USER_ID = "user-123";
+    private static final String USERNAME = "admin";
+    private static final long BLOCKING_GET_TIMEOUT_MILLIS = 120_000L;
+
+    @Mock
+    private JWTParser jwtParser;
+
+    @Mock
+    private OrganizationUserService userService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    private AutomationBearerTokenFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new AutomationBearerTokenFilter(jwtParser, userService, BLOCKING_GET_TIMEOUT_MILLIS);
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shouldAuthenticateWithValidBearerToken() throws Exception {
+        String token = "valid.jwt.token";
+        when(request.getHeader(AUTHORIZATION)).thenReturn("Bearer " + token);
+
+        JWT jwt = new JWT();
+        jwt.put("org", ORG_ID);
+        jwt.put(StandardClaims.SUB, USER_ID);
+        jwt.put(StandardClaims.PREFERRED_USERNAME, USERNAME);
+        jwt.setIat(System.currentTimeMillis() / 1000);
+        when(jwtParser.parse(token)).thenReturn(jwt);
+
+        User orgUser = new User();
+        orgUser.setId(USER_ID);
+        orgUser.setUsername(USERNAME);
+        when(userService.findById(eq(ReferenceType.ORGANIZATION), eq(ORG_ID), eq(USER_ID)))
+                .thenReturn(Single.just(orgUser));
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth);
+        assertEquals(USERNAME, ((io.gravitee.am.identityprovider.api.User) auth.getPrincipal()).getUsername());
+    }
+
+    @Test
+    void shouldContinueChainWithoutAuthWhenNoAuthorizationHeader() throws Exception {
+        when(request.getHeader(AUTHORIZATION)).thenReturn(null);
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldContinueChainWithoutAuthWhenNonBearerHeader() throws Exception {
+        when(request.getHeader(AUTHORIZATION)).thenReturn("Basic dXNlcjpwYXNz");
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldClearContextOnInvalidToken() throws Exception {
+        when(request.getHeader(AUTHORIZATION)).thenReturn("Bearer invalid.token");
+        when(jwtParser.parse("invalid.token")).thenThrow(new RuntimeException("Invalid JWT"));
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldClearContextOnExpiredSession() throws Exception {
+        String token = "valid.jwt.token";
+        when(request.getHeader(AUTHORIZATION)).thenReturn("Bearer " + token);
+
+        JWT jwt = new JWT();
+        jwt.put("org", ORG_ID);
+        jwt.put(StandardClaims.SUB, USER_ID);
+        jwt.put(StandardClaims.PREFERRED_USERNAME, USERNAME);
+        jwt.setIat(1000L); // very old token
+        when(jwtParser.parse(token)).thenReturn(jwt);
+
+        User orgUser = new User();
+        orgUser.setId(USER_ID);
+        orgUser.setUsername(USERNAME);
+        orgUser.setLastLogoutAt(new Date()); // logged out after token issued
+        when(userService.findById(eq(ReferenceType.ORGANIZATION), eq(ORG_ID), eq(USER_ID)))
+                .thenReturn(Single.just(orgUser));
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldClearContextWhenUserLookupExceedsBlockingGetTimeout() throws Exception {
+        String token = "valid.jwt.token";
+        when(request.getHeader(AUTHORIZATION)).thenReturn("Bearer " + token);
+
+        JWT jwt = new JWT();
+        jwt.put("org", ORG_ID);
+        jwt.put(StandardClaims.SUB, USER_ID);
+        jwt.put(StandardClaims.PREFERRED_USERNAME, USERNAME);
+        jwt.setIat(System.currentTimeMillis() / 1000);
+        when(jwtParser.parse(token)).thenReturn(jwt);
+
+        when(userService.findById(eq(ReferenceType.ORGANIZATION), eq(ORG_ID), eq(USER_ID)))
+                .thenReturn(Single.<User>never().subscribeOn(Schedulers.io()));
+
+        var filterWithShortTimeout = new AutomationBearerTokenFilter(jwtParser, userService, 50L);
+
+        filterWithShortTimeout.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldAuthenticateRegardlessOfHttpMethod() throws Exception {
+        // OncePerRequestFilter processes ALL methods — no method-based filtering.
+        // This is the key difference from AbstractAuthenticationProcessingFilter.
+        assertAuthenticatesSuccessfully();
+    }
+
+    private void assertAuthenticatesSuccessfully() throws Exception {
+        String token = "valid.jwt.token";
+        when(request.getHeader(AUTHORIZATION)).thenReturn("Bearer " + token);
+
+        JWT jwt = new JWT();
+        jwt.put("org", ORG_ID);
+        jwt.put(StandardClaims.SUB, USER_ID);
+        jwt.put(StandardClaims.PREFERRED_USERNAME, USERNAME);
+        jwt.setIat(System.currentTimeMillis() / 1000);
+        when(jwtParser.parse(token)).thenReturn(jwt);
+
+        User orgUser = new User();
+        orgUser.setId(USER_ID);
+        orgUser.setUsername(USERNAME);
+        when(userService.findById(eq(ReferenceType.ORGANIZATION), eq(ORG_ID), eq(USER_ID)))
+                .thenReturn(Single.just(orgUser));
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.gravitee.am.management</groupId>
+        <artifactId>gravitee-am-management-api</artifactId>
+        <version>4.12.0-alpha.5-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.gravitee.am.management.automation</groupId>
+    <artifactId>gravitee-am-management-api-automation</artifactId>
+    <packaging>pom</packaging>
+    <name>Gravitee IO - Access Management - Management API - Automation</name>
+
+    <modules>
+        <module>gravitee-am-management-api-automation-rest</module>
+    </modules>
+</project>

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DefaultIdentityProviderService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DefaultIdentityProviderService.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.service;
 
 import java.util.Map;
 
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.service.model.NewIdentityProvider;
@@ -24,6 +25,12 @@ import io.reactivex.rxjava3.core.Single;
 
 public interface DefaultIdentityProviderService {
     Single<IdentityProvider> create(Domain domain);
+
+    /**
+     * Create the domain's system identity provider from {@code gravitee.yaml} repository settings on
+     * behalf of the Automation API.
+     */
+    Single<IdentityProvider> create(Domain domain, String automationKey, User principal);
 
     Map<String, Object> createProviderConfiguration(String referenceId, NewIdentityProvider identityProvider);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DomainService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DomainService.java
@@ -56,7 +56,15 @@ public interface DomainService extends DomainReadService {
 
     Single<Domain> create(String organizationId, String environmentId, NewDomain domain, User principal);
 
-    Single<Domain> update(String domainId, Domain domain);
+    Single<Domain> update(String domainId, Domain domain, boolean validateReferences);
+
+    /**
+     * Update a domain, validating that the certificate/identity-provider references it carries point to
+     * existing resources.
+     */
+    default Single<Domain> update(String domainId, Domain domain) {
+        return update(domainId, domain, true);
+    }
 
     Single<Domain> patch(GraviteeContext graviteeContext, String domainId, PatchDomain domain, User principal);
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
@@ -19,12 +19,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
 import io.gravitee.am.common.env.RepositoriesEnvironment;
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.repository.Scope;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.authentication.crypto.password.PasswordEncoderOptions;
+import io.gravitee.am.service.model.AutomationNewIdentityProvider;
 import io.gravitee.am.service.model.NewIdentityProvider;
 import io.reactivex.rxjava3.core.Single;
 import lombok.extern.slf4j.Slf4j;
@@ -76,18 +78,33 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
     @Override
     public Single<IdentityProvider> create(Domain domain) {
         NewIdentityProvider newIdentityProvider = new NewIdentityProvider();
-        newIdentityProvider.setId(DEFAULT_IDP_PREFIX + domain.getId().toLowerCase());
-        newIdentityProvider.setName(DEFAULT_IDP_NAME);
+        return populateDefault(domain, newIdentityProvider)
+                .flatMap(populated -> identityProviderService.create(domain, populated, null, true));
+    }
+
+    @Override
+    public Single<IdentityProvider> create(Domain domain, String automationKey, User principal) {
+        AutomationNewIdentityProvider auto = new AutomationNewIdentityProvider();
+        auto.setAutomationKey(automationKey);
+        return populateDefault(domain, auto)
+                .flatMap(populated -> identityProviderService.create(domain, populated, principal, true));
+    }
+
+    private <T extends NewIdentityProvider> Single<T> populateDefault(Domain domain, T target) {
+        target.setId(DEFAULT_IDP_PREFIX + domain.getId().toLowerCase());
+        target.setName(DEFAULT_IDP_NAME);
         if (useMongoRepositories()) {
-            newIdentityProvider.setType(DEFAULT_MONGO_IDP_TYPE);
-            newIdentityProvider.setConfiguration(createProviderConfig(domain.getId(), null));
+            target.setType(DEFAULT_MONGO_IDP_TYPE);
+            target.setConfiguration(createProviderConfig(domain.getId(), null));
         } else if (useJdbcRepositories()) {
-            newIdentityProvider.setType(DEFAULT_JDBC_IDP_TYPE);
-            newIdentityProvider.setConfiguration(createProviderConfig(domain.getId(), newIdentityProvider));
+            target.setType(DEFAULT_JDBC_IDP_TYPE);
+            // createProviderConfig may rewrite the id when the JDBC table name would exceed the platform
+            // limit; the passed instance is mutated in place.
+            target.setConfiguration(createProviderConfig(domain.getId(), target));
         } else {
             return Single.error(new IllegalStateException("Unable to create Default IdentityProvider with " + managementBackend() + " backend"));
         }
-        return identityProviderService.create(domain, newIdentityProvider, null, true);
+        return Single.just(target);
     }
 
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -37,6 +37,7 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.DomainVersion;
 import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.Environment;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Membership;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
@@ -94,6 +95,7 @@ import io.gravitee.am.service.exception.InvalidWebAuthnConfigurationException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.I18nDictionaryService;
 import io.gravitee.am.service.impl.PasswordHistoryService;
+import io.gravitee.am.service.model.AutomationNewDomain;
 import io.gravitee.am.service.model.NewDomain;
 import io.gravitee.am.service.model.NewSystemScope;
 import io.gravitee.am.service.model.PatchDomain;
@@ -366,7 +368,7 @@ public class DomainServiceImpl implements DomainService {
     @Override
     public Single<Domain> create(String organizationId, String environmentId, NewDomain newDomain, User principal) {
         LOGGER.debug("Create a new domain: {}", newDomain);
-        // generate hrid
+        var automationDomain = newDomain instanceof AutomationNewDomain auto ? auto : null;
         String hrid = IdGenerator.generate(newDomain.getName());
         if (dataPlaneRegistry.getDataPlanes().stream().map(DataPlaneDescription::id).noneMatch(id -> id.equals(newDomain.getDataPlaneId()))) {
             return Single.error(new InvalidDataPlaneException("An error occurred while trying to create a domain. Data Plane with provided Id doesn't exist."));
@@ -379,9 +381,11 @@ public class DomainServiceImpl implements DomainService {
                     } else {
                         Domain domain = new Domain();
                         domain.setVersion(DomainVersion.V2_0);
-                        domain.setId(RandomString.generate());
+                        domain.setId(automationDomain != null && automationDomain.getId() != null
+                                ? automationDomain.getId() : RandomString.generate());
                         domain.setHrid(hrid);
-                        domain.setPath(generateContextPath(newDomain.getName()));
+                        domain.setPath(automationDomain != null && automationDomain.getPath() != null
+                                ? automationDomain.getPath() : generateContextPath(newDomain.getName()));
                         domain.setName(newDomain.getName());
                         domain.setDescription(newDomain.getDescription());
                         domain.setEnabled(false);
@@ -392,6 +396,10 @@ public class DomainServiceImpl implements DomainService {
                         domain.setCreatedAt(new Date());
                         domain.setUpdatedAt(domain.getCreatedAt());
                         domain.setDataPlaneId(newDomain.getDataPlaneId());
+                        if (automationDomain != null) {
+                            domain.setManagedBy(ManagedBy.AUTOMATION_API);
+                            domain.setAutomationKey(automationDomain.getAutomationKey());
+                        }
 
                         return environmentService.findById(domain.getReferenceId())
                                 .doOnSuccess(environment -> setDeployMode(domain, environment))
@@ -401,8 +409,13 @@ public class DomainServiceImpl implements DomainService {
                 })
                 // create default system scopes
                 .flatMap(this::createSystemScopes)
-                // create default certificate
-                .flatMap(this::createDefaultCertificate)
+                // create default certificate (skipped for automation domains)
+                .flatMap(domain -> {
+                    if (automationDomain != null) {
+                        return Single.just(domain);
+                    }
+                    return createDefaultCertificate(domain);
+                })
                 // create owner
                 .flatMap(domain -> {
                     if (principal == null) {
@@ -422,16 +435,16 @@ public class DomainServiceImpl implements DomainService {
                                         .map(__ -> domain);
                             });
                 })
-                //create default IdP
+                // create default IdP (always skipped for automation domains)
                 .flatMap(domain -> {
-                    if (!createDefaultIdentityProvider) {
+                    if (!createDefaultIdentityProvider || automationDomain != null) {
                         return Single.just(domain);
                     }
                     return defaultIdentityProviderService.create(domain).map(__ -> domain);
                 })
-                // create default reporter
+                // create default reporter (always skipped for automation domains)
                 .flatMap(domain -> {
-                    if (!createDefaultReporters) {
+                    if (!createDefaultReporters || automationDomain != null) {
                         return Single.just(domain);
                     }
                     //default behaviour
@@ -465,7 +478,7 @@ public class DomainServiceImpl implements DomainService {
     }
 
     @Override
-    public Single<Domain> update(String domainId, Domain domain) {
+    public Single<Domain> update(String domainId, Domain domain, boolean validateReferences) {
         LOGGER.debug("Update an existing domain: {}", domain);
         return domainRepository.findById(domainId)
                 .switchIfEmpty(Single.error(new DomainNotFoundException(domainId)))
@@ -480,8 +493,13 @@ public class DomainServiceImpl implements DomainService {
                     domain.setReferenceType(existingDomain.getReferenceType());
                     domain.setHrid(IdGenerator.generate(domain.getName()));
                     domain.setUpdatedAt(new Date());
+                    // The Automation API references certificates / identity providers that may not exist yet
+                    // (eventual consistency), so reference validation is skipped for it.
+                    Completable referenceValidation = validateReferences
+                            ? validateCertificateSettings(domain)
+                            : Completable.complete();
                     return validateDomain(domain)
-                            .andThen(validateCertificateSettings(domain))
+                            .andThen(referenceValidation)
                             .andThen(Single.defer(() -> domainRepository.update(domain)));
                 })
                 // create event for sync process

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ReporterServiceProxyImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ReporterServiceProxyImpl.java
@@ -95,6 +95,14 @@ public class ReporterServiceProxyImpl extends AbstractSensitiveProxy implements 
     }
 
     @Override
+    public Single<Reporter> createSystem(Reference reference, String id, String automationKey, User principal) {
+        return reporterService.createSystem(reference, id, automationKey, principal)
+                .flatMap(this::filterSensitiveData)
+                .doOnSuccess(reporter1 -> auditService.report(AuditBuilder.builder(ReporterAuditBuilder.class).principal(principal).type(EventType.REPORTER_CREATED).reporter(reporter1)))
+                .doOnError(throwable -> auditService.report(AuditBuilder.builder(ReporterAuditBuilder.class).principal(principal).type(EventType.REPORTER_CREATED).reference(reference).throwable(throwable)));
+    }
+
+    @Override
     public Single<Reporter> update(Reference domain, String id, UpdateReporter updateReporter, User principal, boolean isUpgrader) {
 
         Supplier<ReporterAuditBuilder> baseAudit = () ->

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -103,6 +103,7 @@ import io.gravitee.am.service.exception.InvalidWebAuthnConfigurationException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.I18nDictionaryService;
 import io.gravitee.am.service.impl.PasswordHistoryService;
+import io.gravitee.am.service.model.AutomationNewDomain;
 import io.gravitee.am.service.model.NewDomain;
 import io.gravitee.am.service.model.NewSystemScope;
 import io.gravitee.am.service.model.PatchDomain;
@@ -544,6 +545,44 @@ public class DomainServiceTest {
             var audit = builder.build(OBJECT_MAPPER);
             return audit.getReferenceType().equals(ORGANIZATION) && audit.getReferenceId().equals(ORGANIZATION_ID);
         }));
+    }
+
+    @Test
+    public void shouldCreate_automationDomain_withoutDefaultEntities() {
+        AutomationNewDomain newDomain = new AutomationNewDomain();
+        newDomain.setName("automation-domain");
+        newDomain.setAutomationKey("automation-domain");
+        newDomain.setId("domain-id");
+        newDomain.setPath("/automation-domain");
+        newDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
+        when(domainReadService.listAll()).thenReturn(Flowable.empty());
+        Domain domain = new Domain();
+        domain.setReferenceType(ReferenceType.ENVIRONMENT);
+        domain.setReferenceId(ENVIRONMENT_ID);
+        domain.setId("domain-id");
+        domain.setVersion(DomainVersion.V2_0);
+        domain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(new DataPlaneDescription(DataPlaneDescription.DEFAULT_DATA_PLANE_ID,"default","mongodb","test", "http://localhost:8092")));
+        when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, "automation-domain")).thenReturn(Maybe.empty());
+        when(domainRepository.create(any(Domain.class))).thenReturn(Single.just(domain));
+        when(scopeService.create(any(), any(NewSystemScope.class))).thenReturn(Single.just(new Scope()));
+        when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
+        when(membershipService.addOrUpdate(eq(ORGANIZATION_ID), any())).thenReturn(Single.just(new Membership()));
+        when(roleService.findSystemRole(SystemRole.DOMAIN_PRIMARY_OWNER, DOMAIN)).thenReturn(Maybe.just(new Role()));
+        when(reporterService.notifyInheritedReporters(any(),any(),any())).thenReturn(Completable.complete());
+        doReturn(Single.just(List.of()).ignoreElement()).when(domainValidator).validate(any(), any());
+        doReturn(Single.just(List.of()).ignoreElement()).when(virtualHostValidator).validateDomainVhosts(any(), any());
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain, new DefaultUser("username"))
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertNoErrors();
+
+        verify(certificateService, never()).create(any());
+        verify(reporterService, never()).createDefault(any());
+        verify(defaultIdentityProviderService, never()).create(any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/pom.xml
@@ -84,6 +84,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.am.management.automation</groupId>
+            <artifactId>gravitee-am-management-api-automation-rest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.am</groupId>
             <artifactId>gravitee-am-monitoring</artifactId>
             <version>${project.version}</version>

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/server/ManagementApiServer.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/server/ManagementApiServer.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.am.management.standalone.server;
 
+import io.gravitee.am.management.handlers.automation.AutomationApiApplication;
+import io.gravitee.am.management.handlers.automation.spring.AutomationConfiguration;
+import io.gravitee.am.management.handlers.automation.swagger.AutomationApiDefinition;
 import io.gravitee.am.management.handlers.management.api.ManagementApplication;
 import io.gravitee.am.management.handlers.management.api.spring.ManagementConfiguration;
 import io.gravitee.node.jetty.JettyHttpServer;
@@ -22,7 +25,11 @@ import jakarta.servlet.DispatcherType;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.glassfish.jersey.servlet.ServletContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -33,16 +40,31 @@ import org.springframework.web.filter.DelegatingFilterProxy;
 import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.DispatcherServlet;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
 
 /**
+ * Configures and starts the Management API server.
+ * <p>
+ * Each API surface (Management, Automation) gets its own {@link ServletContextHandler}
+ * with an isolated Spring child context and security filter chain, following the APIM
+ * pattern of per-API context isolation via {@link ContextHandlerCollection}.
+ *
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class ManagementApiServer extends JettyHttpServer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManagementApiServer.class);
+
     @Value("${http.api.entrypoint:/management}")
     private String entrypoint;
+
+    @Value("${http.api.automation.enabled:false}")
+    private boolean startAutomationAPI;
+
+    @Value("${http.api.automation.entrypoint:" + AutomationApiDefinition.DEFAULT_AUTOMATION_ENTRYPOINT + "}")
+    private String automationEntrypoint;
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -52,36 +74,88 @@ public class ManagementApiServer extends JettyHttpServer {
     }
 
     public void attachHandlers() {
+        var contexts = new ArrayList<ContextHandler>();
 
-        // Use a custom ServletContextHandler that tolerates InnocuousThread.
-        // JDK InnocuousThread (used by ForkJoinPool compensation threads, MongoDB async driver, etc.)
-        // blocks Thread.setContextClassLoader() with a SecurityException. Jetty's ContextHandler calls
-        // setContextClassLoader in both enterScope() and exitScope() during request dispatch.
-        // When async responses (AsyncResponse.resume()) complete on an InnocuousThread, this causes
-        // the response to fail. This subclass catches and ignores the SecurityException.
+        if (startAutomationAPI) {
+            LOGGER.info("Automation API is enabled, registering at {}", automationEntrypoint);
+            contexts.add(configureAutomationAPI());
+        }
+
+        contexts.add(configureManagementAPI());
+
+        server.setHandler(new ContextHandlerCollection(contexts.toArray(new ContextHandler[0])));
+    }
+
+    private ServletContextHandler configureManagementAPI() {
         final ServletContextHandler context = new SafeClassLoaderServletContextHandler(entrypoint, ServletContextHandler.NO_SESSIONS);
-        // REST configuration
-        final ServletHolder servletHolder = new ServletHolder(ServletContainer.class);
-        servletHolder.setInitParameter("jakarta.ws.rs.Application", ManagementApplication.class.getName());
-        servletHolder.setInitOrder(1);
-        servletHolder.setAsyncSupported(true);
+
+        final ServletHolder servletHolder = createServletHolder(
+                "gravitee-am-management-api",
+                ManagementApplication.class.getName(),
+                "management-api",
+                "io.gravitee.am.management.handlers.management.api.resources"
+            );
 
         AnnotationConfigWebApplicationContext webApplicationContext = new AnnotationConfigWebApplicationContext();
         webApplicationContext.setEnvironment((ConfigurableEnvironment) applicationContext.getEnvironment());
         webApplicationContext.setParent(applicationContext);
         webApplicationContext.setServletContext(context.getServletContext());
-
         webApplicationContext.register(ManagementConfiguration.class);
 
         context.addEventListener(new ContextLoaderListener(webApplicationContext));
         context.addServlet(servletHolder, "/*");
         context.addServlet(new ServletHolder(new DispatcherServlet(webApplicationContext)), "/auth/*");
 
-        // X-Forwarded-* support
         context.addFilter(ForwardedHeaderFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
-
-        // Spring Security filter
         context.addFilter(new FilterHolder(new DelegatingFilterProxy("springSecurityFilterChain")), "/*", EnumSet.allOf(DispatcherType.class));
-        server.setHandler(context);
+
+        return context;
+    }
+
+    private ServletContextHandler configureAutomationAPI() {
+        final ServletContextHandler context = new SafeClassLoaderServletContextHandler(automationEntrypoint, ServletContextHandler.NO_SESSIONS);
+
+        final ServletHolder servletHolder = createServletHolder(
+            "gravitee-am-automation-api",
+            AutomationApiApplication.class.getName(),
+            "automation-api",
+            "io.gravitee.am.management.handlers.automation"
+        );
+
+        AnnotationConfigWebApplicationContext webApplicationContext = new AnnotationConfigWebApplicationContext();
+        webApplicationContext.setEnvironment((ConfigurableEnvironment) applicationContext.getEnvironment());
+        webApplicationContext.setParent(applicationContext);
+        webApplicationContext.setServletContext(context.getServletContext());
+        webApplicationContext.register(AutomationConfiguration.class);
+
+        context.addEventListener(new ContextLoaderListener(webApplicationContext));
+        context.addServlet(servletHolder, "/*");
+
+        context.addFilter(ForwardedHeaderFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
+        context.addFilter(new FilterHolder(new DelegatingFilterProxy("springSecurityFilterChain")), "/*", EnumSet.allOf(DispatcherType.class));
+
+        return context;
+    }
+
+    private static ServletHolder createServletHolder(
+            String name,
+            String applicationClass,
+            String openApiContextId,
+            String resourcePackages
+    ) {
+        ServletHolder servletHolder = new ServletHolder(ServletContainer.class);
+        servletHolder.setName(name);
+        servletHolder.setInitParameter("jakarta.ws.rs.Application", applicationClass);
+
+        // Identifies the OpenAPI context for this API.
+        servletHolder.setInitParameter("openapi.context.id", openApiContextId);
+
+        // Limits classpath scanning to the API's JAX-RS resources. Required when using a dedicated openapi.context.id.
+        servletHolder.setInitParameter("openApi.configuration.resourcePackages", resourcePackages);
+
+        servletHolder.setInitOrder(1);
+        servletHolder.setAsyncSupported(true);
+
+        return servletHolder;
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/server/SafeClassLoaderServletContextHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/server/SafeClassLoaderServletContextHandler.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.standalone.server;
 
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Request;
@@ -31,11 +32,12 @@ import org.eclipse.jetty.server.Request;
  * call throws a {@code SecurityException}, which breaks the response.
  *
  * <p>This subclass catches and ignores the {@code SecurityException} in both
- * methods. This is safe because the management API runs as a single webapp
+ * methods. This is safe because the management API runs as one or two webapps
  * with no classloader isolation between contexts.
  *
  * @author GraviteeSource Team
  */
+@Slf4j
 class SafeClassLoaderServletContextHandler extends ServletContextHandler {
 
     SafeClassLoaderServletContextHandler(String contextPath, int options) {
@@ -47,9 +49,8 @@ class SafeClassLoaderServletContextHandler extends ServletContextHandler {
         try {
             return super.enterScope(request);
         } catch (SecurityException e) {
-            // InnocuousThread blocks setContextClassLoader — return current
-            // classloader so exitScope has something to restore (even though
-            // that restore will also be caught).
+            log.debug("SecurityException in enterScope on thread {} ({}): {}",
+                    Thread.currentThread().getName(), Thread.currentThread().getClass().getSimpleName(), e.getMessage());
             return Thread.currentThread().getContextClassLoader();
         }
     }
@@ -59,8 +60,8 @@ class SafeClassLoaderServletContextHandler extends ServletContextHandler {
         try {
             super.exitScope(request, previousContext, previousClassLoader);
         } catch (SecurityException e) {
-            // InnocuousThread blocks setContextClassLoader — safe to ignore
-            // since the thread doesn't allow classloader changes anyway.
+            log.debug("SecurityException in exitScope on thread {} ({}): {}",
+                    Thread.currentThread().getName(), Thread.currentThread().getClass().getSimpleName(), e.getMessage());
         }
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -69,6 +69,9 @@
 #  api:
      # Configure the listening path for the API. Default to /management
 #    entrypoint: /management
+#    automation:
+#      enabled: false  # Enable the Automation API for declarative GitOps-style resource management
+#      entrypoint: /management/automation  # Listening path for the Automation API
 #  cors:
 #      Allows to configure the header Access-Control-Allow-Origin (default value: *)
 #      '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.

--- a/gravitee-am-management-api/pom.xml
+++ b/gravitee-am-management-api/pom.xml
@@ -36,6 +36,7 @@
         <module>gravitee-am-management-api-service</module>
         <module>gravitee-am-management-api-services</module>
         <module>gravitee-am-management-api-rest</module>
+        <module>gravitee-am-management-api-automation</module>
         <module>gravitee-am-management-api-standalone</module>
     </modules>
 </project>

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Certificate.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Certificate.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -39,9 +40,19 @@ import java.util.stream.StreamSupport;
  */
 // todo: remove @Schema once this class is not directly used in any API responses
 @Data
-public class Certificate {
+public class Certificate implements Managed {
 
     private String id;
+
+    /**
+     * Stable, human-chosen identifier used to address this certificate in declarative APIs
+     * (e.g. the Automation API). Set when the Automation API creates the resource; null for
+     * certificates created via the management API. Distinct from the mutable {@link #name}.
+     * Read-only over the management API.
+     */
+    @JsonProperty("key")
+    @Schema(name = "key", accessMode = Schema.AccessMode.READ_ONLY)
+    private String automationKey;
 
     private String name;
 
@@ -64,6 +75,11 @@ public class Certificate {
 
     private boolean system;
 
+    /**
+     * Indicates the source of truth for this certificate.
+     */
+    private ManagedBy managedBy;
+
     @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
     @ToString.Exclude
@@ -83,6 +99,7 @@ public class Certificate {
 
     public Certificate(Certificate other) {
         this.id = other.id;
+        this.automationKey = other.automationKey;
         this.name = other.name;
         this.type = other.type;
         this.configuration = other.configuration;
@@ -92,6 +109,7 @@ public class Certificate {
         this.updatedAt = other.updatedAt;
         this.expiresAt = other.expiresAt;
         this.system = other.system;
+        this.managedBy = other.managedBy;
     }
 
     /**

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/CertificateSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/CertificateSettings.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,7 +37,18 @@ public class CertificateSettings {
      */
     private String fallbackCertificate;
 
+    /**
+     * Automation API key shadowing {@link #fallbackCertificate}. Owned by the Automation API so it can
+     * losslessly echo the human-readable certificate key even when the referenced certificate does not
+     * (yet) exist. Ignored by the management API and the gateway, which read only {@link #fallbackCertificate};
+     * hidden from the management OpenAPI (the Automation API surfaces it under
+     * {@code AutomationCertificateSettings.fallbackCertificate}).
+     */
+    @Schema(hidden = true)
+    private String fallbackCertificateKey;
+
     public CertificateSettings(CertificateSettings other) {
         this.fallbackCertificate = other.fallbackCertificate;
+        this.fallbackCertificateKey = other.fallbackCertificateKey;
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Domain.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Domain.java
@@ -22,6 +22,7 @@ import io.gravitee.am.model.login.WebAuthnSettings;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.scim.SCIMSettings;
 import io.gravitee.am.model.uma.UMASettings;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -37,7 +38,7 @@ import java.util.Set;
  */
 @Builder
 @AllArgsConstructor
-public class Domain implements Resource {
+public class Domain implements Resource, Managed {
 
     /**
      * Domain identifier.
@@ -48,6 +49,16 @@ public class Domain implements Resource {
      * Domain human readable identifier.
      */
     private String hrid;
+
+    /**
+     * Stable, human-chosen identifier used to address this domain in declarative APIs
+     * (e.g. the Automation API). Set when the Automation API creates the resource; null for
+     * domains created via the management API. Distinct from {@link #hrid}, which is derived
+     * from the name. Read-only over the management API.
+     */
+    @JsonProperty("key")
+    @Schema(name = "key", accessMode = Schema.AccessMode.READ_ONLY)
+    private String automationKey;
 
     /**
      * Domain name.
@@ -202,6 +213,11 @@ public class Domain implements Resource {
      */
     private CertificateSettings certificateSettings;
 
+    /**
+     * Indicates the source of truth for this domain.
+     */
+    private ManagedBy managedBy;
+
     public Domain() {
     }
 
@@ -216,6 +232,7 @@ public class Domain implements Resource {
     public Domain(Domain other) {
         this.id = other.id;
         this.hrid = other.hrid;
+        this.automationKey = other.automationKey;
         this.name = other.name;
         this.version = other.version;
         this.description = other.description;
@@ -245,6 +262,7 @@ public class Domain implements Resource {
         this.secretExpirationSettings = other.secretExpirationSettings != null ? new SecretExpirationSettings(other.secretExpirationSettings) : null;
         this.tokenExchangeSettings = other.tokenExchangeSettings;
         this.certificateSettings = other.certificateSettings != null ? new CertificateSettings(other.certificateSettings) : null;
+        this.managedBy = other.managedBy;
     }
 
     @Override
@@ -262,6 +280,14 @@ public class Domain implements Resource {
 
     public void setHrid(String hrid) {
         this.hrid = hrid;
+    }
+
+    public String getAutomationKey() {
+        return automationKey;
+    }
+
+    public void setAutomationKey(String automationKey) {
+        this.automationKey = automationKey;
     }
 
     public String getName() {
@@ -570,6 +596,14 @@ public class Domain implements Resource {
         return this.getOidc() != null &&
                 this.getOidc().getClientRegistrationSettings() != null &&
                 this.getOidc().getClientRegistrationSettings().isAllowRedirectUriParamsExpressionLanguage();
+    }
+
+    public ManagedBy getManagedBy() {
+        return managedBy;
+    }
+
+    public void setManagedBy(ManagedBy managedBy) {
+        this.managedBy = managedBy;
     }
 
     @Override

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/IdentityProvider.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/IdentityProvider.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,9 +33,19 @@ import java.util.Objects;
 @Getter
 @Setter
 @NoArgsConstructor
-public class IdentityProvider {
+public class IdentityProvider implements Managed {
 
     private String id;
+
+    /**
+     * Stable, human-chosen identifier used to address this identity provider in
+     * declarative APIs (e.g. the Automation API). Set when the Automation API creates the
+     * resource; null for IdPs created via the management API. Read-only over the management
+     * API.
+     */
+    @JsonProperty("key")
+    @Schema(name = "key", accessMode = Schema.AccessMode.READ_ONLY)
+    private String automationKey;
 
     private String name;
 
@@ -70,8 +81,14 @@ public class IdentityProvider {
      */
     private String dataPlaneId;
 
+    /**
+     * Indicates the source of truth for this identity provider.
+     */
+    private ManagedBy managedBy;
+
     public IdentityProvider(IdentityProvider other) {
         this.id = other.id;
+        this.automationKey = other.automationKey;
         this.name = other.name;
         this.type = other.type;
         this.system = other.system;
@@ -87,6 +104,7 @@ public class IdentityProvider {
         this.updatedAt = other.updatedAt;
         this.passwordPolicy = other.passwordPolicy;
         this.dataPlaneId = other.dataPlaneId;
+        this.managedBy = other.managedBy;
     }
 
     @Override

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Managed.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Managed.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model;
+
+/**
+ * Implemented by resources whose source of truth can be an external manager
+ * (see {@link ManagedBy}).
+ *
+ * @author GraviteeSource Team
+ */
+public interface Managed {
+
+    ManagedBy getManagedBy();
+
+    default boolean isManagedBy(ManagedBy managedBy) {
+        return getManagedBy() == managedBy;
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/ManagedBy.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/ManagedBy.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Indicates the source of truth for a managed resource.
+ * When set to anything other than NONE, the resource should be treated
+ * as read-only through the standard Management API.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Schema(enumAsRef = true)
+public enum ManagedBy {
+    NONE,
+    TERRAFORM,
+    GKO,
+    AUTOMATION_API
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Reporter.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Reporter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,9 +30,19 @@ import java.util.Date;
 @Data
 @Builder(toBuilder = true)
 @AllArgsConstructor
-public class Reporter {
+public class Reporter implements Managed {
 
     private String id;
+
+    /**
+     * Stable, human-chosen identifier used to address this reporter in declarative APIs (e.g. the
+     * Automation API). Set when the Automation API creates the resource; null for reporters created
+     * via the management API. Read-only over the management API.
+     */
+    @JsonProperty("key")
+    @Schema(name = "key", accessMode = Schema.AccessMode.READ_ONLY)
+    private String automationKey;
+
     private Reference reference;
     private boolean enabled;
     private String type;
@@ -49,11 +60,17 @@ public class Reporter {
      */
     private boolean inherited;
 
+    /**
+     * Indicates the source of truth for this reporter.
+     */
+    private ManagedBy managedBy;
+
     public Reporter() {
     }
 
     public Reporter(Reporter other) {
         this.id = other.id;
+        this.automationKey = other.automationKey;
         this.reference = other.reference;
         this.enabled = other.enabled;
         this.type = other.type;
@@ -64,6 +81,7 @@ public class Reporter {
         this.createdAt = other.createdAt;
         this.updatedAt = other.updatedAt;
         this.inherited = other.inherited;
+        this.managedBy = other.managedBy;
     }
 
     /**

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/SAMLSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/SAMLSettings.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * See <a href="https://www.oasis-open.org/committees/download.php/56786/sstc-saml-metadata-errata-2.0-wd-05-diff.pdf">2.4.3 Element <IDPSSODescriptor></a>
  *
@@ -35,6 +37,14 @@ public class SAMLSettings {
      * X.509 Public Key Certificate — the IdP's base-64 encoded public key certificate, which is used by the SP to verify SAML authorization responses
      */
     private String certificate;
+    /**
+     * Automation API key shadowing {@link #certificate}. Owned by the Automation API so it can losslessly
+     * echo the human-readable certificate key even when the referenced certificate does not (yet) exist.
+     * Ignored by the management API and the gateway, which read only {@link #certificate}; hidden from the
+     * management OpenAPI (the Automation API surfaces it under {@code AutomationSamlSettings.certificate}).
+     */
+    @Schema(hidden = true)
+    private String certificateKey;
 
     public SAMLSettings() {}
 
@@ -42,6 +52,7 @@ public class SAMLSettings {
         this.enabled = other.enabled;
         this.entityId = other.entityId;
         this.certificate = other.certificate;
+        this.certificateKey = other.certificateKey;
     }
 
     public boolean isEnabled() {
@@ -66,5 +77,13 @@ public class SAMLSettings {
 
     public void setCertificate(String certificate) {
         this.certificate = certificate;
+    }
+
+    public String getCertificateKey() {
+        return certificateKey;
+    }
+
+    public void setCertificateKey(String certificateKey) {
+        this.certificateKey = certificateKey;
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/account/AccountSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/account/AccountSettings.java
@@ -18,6 +18,7 @@ package io.gravitee.am.model.account;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.Client;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 import java.util.Optional;
@@ -82,6 +83,16 @@ public class AccountSettings {
      * Default identity provider used for user registration
      */
     private String defaultIdentityProviderForRegistration;
+
+    /**
+     * Automation API key shadowing {@link #defaultIdentityProviderForRegistration}. Owned by the
+     * Automation API so it can losslessly echo the human-readable identity-provider key even when the
+     * referenced provider does not (yet) exist. Ignored by the management API and the gateway, which
+     * read only {@link #defaultIdentityProviderForRegistration}; hidden from the management OpenAPI (the
+     * Automation API surfaces it under {@code AutomationAccountSettings.defaultIdentityProviderForRegistration}).
+     */
+    @Schema(hidden = true)
+    private String defaultIdentityProviderForRegistrationKey;
 
     /**
      * Auto login user after reset password process
@@ -189,6 +200,7 @@ public class AccountSettings {
         this.useBotDetection = other.useBotDetection;
         this.botDetectionPlugin = other.botDetectionPlugin;
         this.defaultIdentityProviderForRegistration = other.defaultIdentityProviderForRegistration;
+        this.defaultIdentityProviderForRegistrationKey = other.defaultIdentityProviderForRegistrationKey;
         this.mfaChallengeAttemptsDetectionEnabled = other.mfaChallengeAttemptsDetectionEnabled;
         this.mfaChallengeMaxAttempts = other.mfaChallengeMaxAttempts;
         this.mfaChallengeAttemptsResetTime = other.mfaChallengeAttemptsResetTime;
@@ -282,6 +294,14 @@ public class AccountSettings {
 
     public void setDefaultIdentityProviderForRegistration(String defaultIdentityProviderForRegistration) {
         this.defaultIdentityProviderForRegistration = defaultIdentityProviderForRegistration;
+    }
+
+    public String getDefaultIdentityProviderForRegistrationKey() {
+        return defaultIdentityProviderForRegistrationKey;
+    }
+
+    public void setDefaultIdentityProviderForRegistrationKey(String defaultIdentityProviderForRegistrationKey) {
+        this.defaultIdentityProviderForRegistrationKey = defaultIdentityProviderForRegistrationKey;
     }
 
     public boolean isAutoLoginAfterResetPassword() {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcCertificateRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcCertificateRepository.java
@@ -48,6 +48,7 @@ import static reactor.adapter.rxjava.RxJava3Adapter.monoToSingle;
 public class JdbcCertificateRepository extends AbstractJdbcRepository implements CertificateRepository, InitializingBean {
 
     public static final String COL_ID = "id";
+    public static final String COL_AUTOMATION_KEY = "automation_key";
     public static final String COL_TYPE = "type";
     public static final String COL_CONFIGURATION = "configuration";
     public static final String COL_DOMAIN = "domain";
@@ -57,9 +58,11 @@ public class JdbcCertificateRepository extends AbstractJdbcRepository implements
     public static final String COL_UPDATED_AT = "updated_at";
     public static final String COL_EXPIRES_AT = "expires_at";
     public static final String COL_SYSTEM = "system";
+    public static final String COL_MANAGED_BY = "managed_by";
 
     private static final List<String> columns = List.of(
             COL_ID,
+            COL_AUTOMATION_KEY,
             COL_TYPE,
             COL_CONFIGURATION,
             COL_DOMAIN,
@@ -68,7 +71,8 @@ public class JdbcCertificateRepository extends AbstractJdbcRepository implements
             COL_CREATED_AT,
             COL_UPDATED_AT,
             COL_EXPIRES_AT,
-            COL_SYSTEM
+            COL_SYSTEM,
+            COL_MANAGED_BY
     );
 
     private String insertStatement;
@@ -132,6 +136,7 @@ public class JdbcCertificateRepository extends AbstractJdbcRepository implements
         DatabaseClient.GenericExecuteSpec insertSpec = getTemplate().getDatabaseClient().sql(insertStatement);
 
         insertSpec = addQuotedField(insertSpec,COL_ID, item.getId(), String.class);
+        insertSpec = addQuotedField(insertSpec,COL_AUTOMATION_KEY, item.getAutomationKey(), String.class);
         insertSpec = addQuotedField(insertSpec,COL_TYPE, item.getType(), String.class);
         insertSpec = addQuotedField(insertSpec,COL_CONFIGURATION, item.getConfiguration(), String.class);
         insertSpec = addQuotedField(insertSpec,COL_DOMAIN, item.getDomain(), String.class);
@@ -141,6 +146,7 @@ public class JdbcCertificateRepository extends AbstractJdbcRepository implements
         insertSpec = addQuotedField(insertSpec,COL_UPDATED_AT, dateConverter.convertTo(item.getUpdatedAt(), null), LocalDateTime.class);
         insertSpec = addQuotedField(insertSpec,COL_EXPIRES_AT, dateConverter.convertTo(item.getExpiresAt(), null), LocalDateTime.class);
         insertSpec = addQuotedField(insertSpec,COL_SYSTEM, item.isSystem(), boolean.class);
+        insertSpec = addQuotedField(insertSpec,COL_MANAGED_BY, item.getManagedBy() != null ? item.getManagedBy().name() : null, String.class);
         Mono<Long> action = insertSpec.fetch().rowsUpdated();
 
         return monoToSingle(action).flatMap(i -> this.findById(item.getId()).toSingle())
@@ -154,6 +160,7 @@ public class JdbcCertificateRepository extends AbstractJdbcRepository implements
         DatabaseClient.GenericExecuteSpec update = getTemplate().getDatabaseClient().sql(updateStatement);
 
         update = addQuotedField(update,COL_ID, item.getId(), String.class);
+        update = addQuotedField(update,COL_AUTOMATION_KEY, item.getAutomationKey(), String.class);
         update = addQuotedField(update,COL_TYPE, item.getType(), String.class);
         update = addQuotedField(update,COL_CONFIGURATION, item.getConfiguration(), String.class);
         update = addQuotedField(update,COL_DOMAIN, item.getDomain(), String.class);
@@ -163,6 +170,7 @@ public class JdbcCertificateRepository extends AbstractJdbcRepository implements
         update = addQuotedField(update,COL_UPDATED_AT, dateConverter.convertTo(item.getUpdatedAt(), null), LocalDateTime.class);
         update = addQuotedField(update,COL_EXPIRES_AT, dateConverter.convertTo(item.getExpiresAt(), null), LocalDateTime.class);
         update = addQuotedField(update,COL_SYSTEM, item.isSystem(), boolean.class);
+        update = addQuotedField(update,COL_MANAGED_BY, item.getManagedBy() != null ? item.getManagedBy().name() : null, String.class);
 
         Mono<Long> updateAction = update.fetch().rowsUpdated();
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcIdentityProviderRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcIdentityProviderRepository.java
@@ -50,6 +50,7 @@ import static reactor.adapter.rxjava.RxJava3Adapter.monoToSingle;
 public class JdbcIdentityProviderRepository extends AbstractJdbcRepository implements IdentityProviderRepository, InitializingBean {
 
     public static final String COL_ID = "id";
+    public static final String COL_AUTOMATION_KEY = "automation_key";
     public static final String COL_TYPE = "type";
     public static final String COL_NAME = "name";
     public static final String COL_SYSTEM = "system";
@@ -65,9 +66,11 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
     public static final String COL_GROUP_MAPPER = "group_mapper";
     public static final String COL_PASSWORD_POLICY = "password_policy";
     public static final String COL_DATA_PLANE_ID = "data_plane_id";
+    public static final String COL_MANAGED_BY = "managed_by";
 
     private static final List<String> columns = List.of(
             COL_ID,
+            COL_AUTOMATION_KEY,
             COL_TYPE,
             COL_NAME,
             COL_SYSTEM,
@@ -82,7 +85,8 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
             COL_ROLE_MAPPER,
             COL_GROUP_MAPPER,
             COL_PASSWORD_POLICY,
-            COL_DATA_PLANE_ID
+            COL_DATA_PLANE_ID,
+            COL_MANAGED_BY
     );
 
     private String insertStatement;
@@ -168,6 +172,7 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
         DatabaseClient.GenericExecuteSpec insertSpec = getTemplate().getDatabaseClient().sql(insertStatement);
 
         insertSpec = addQuotedField(insertSpec, COL_ID, item.getId(), String.class);
+        insertSpec = addQuotedField(insertSpec, COL_AUTOMATION_KEY, item.getAutomationKey(), String.class);
         insertSpec = addQuotedField(insertSpec, COL_TYPE, item.getType(), String.class);
         insertSpec = addQuotedField(insertSpec, COL_NAME, item.getName(), String.class);
         insertSpec = addQuotedField(insertSpec, COL_DATA_PLANE_ID, item.getDataPlaneId(), String.class);
@@ -184,6 +189,7 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
         insertSpec = databaseDialectHelper.addJsonField(insertSpec, COL_GROUP_MAPPER, item.getGroupMapper());
         insertSpec = databaseDialectHelper.addJsonField(insertSpec, COL_PASSWORD_POLICY, item.getPasswordPolicy());
         insertSpec = addQuotedField(insertSpec, COL_PASSWORD_POLICY, item.getPasswordPolicy(), String.class);
+        insertSpec = addQuotedField(insertSpec, COL_MANAGED_BY, item.getManagedBy() != null ? item.getManagedBy().name() : null, String.class);
 
         Mono<Long> action = insertSpec.fetch().rowsUpdated();
 
@@ -198,6 +204,7 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
         DatabaseClient.GenericExecuteSpec update = getTemplate().getDatabaseClient().sql(updateStatement);
 
         update = addQuotedField(update, COL_ID, item.getId(), String.class);
+        update = addQuotedField(update, COL_AUTOMATION_KEY, item.getAutomationKey(), String.class);
         update = addQuotedField(update, COL_TYPE, item.getType(), String.class);
         update = addQuotedField(update, COL_NAME, item.getName(), String.class);
         update = addQuotedField(update, COL_DATA_PLANE_ID, item.getDataPlaneId(), String.class);
@@ -213,6 +220,7 @@ public class JdbcIdentityProviderRepository extends AbstractJdbcRepository imple
         update = databaseDialectHelper.addJsonField(update, COL_ROLE_MAPPER, item.getRoleMapper());
         update = databaseDialectHelper.addJsonField(update, COL_GROUP_MAPPER, item.getGroupMapper());
         update = addQuotedField(update, COL_PASSWORD_POLICY, item.getPasswordPolicy(), String.class);
+        update = addQuotedField(update, COL_MANAGED_BY, item.getManagedBy() != null ? item.getManagedBy().name() : null, String.class);
 
         Mono<Long> action = update.fetch().rowsUpdated();
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcReporterRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.jdbc.management.api;
 
 import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.Reporter;
 import io.gravitee.am.repository.jdbc.management.AbstractJdbcRepository;
@@ -55,6 +56,7 @@ public class JdbcReporterRepository extends AbstractJdbcRepository implements Re
     protected Reporter toEntity(JdbcReporter entity) {
         return Reporter.builder()
                 .id(entity.getId())
+                .automationKey(entity.getAutomationKey())
                 .reference(new Reference(entity.getReferenceType(), entity.getReferenceId()))
                 .name(entity.getName())
                 .configuration(entity.getConfiguration())
@@ -65,12 +67,14 @@ public class JdbcReporterRepository extends AbstractJdbcRepository implements Re
                 .updatedAt(toDate(entity.getUpdatedAt()))
                 .type(entity.getType())
                 .inherited(entity.isInherited())
+                .managedBy(entity.getManagedBy() != null ? ManagedBy.valueOf(entity.getManagedBy()) : null)
                 .build();
     }
 
     protected JdbcReporter toJdbcEntity(Reporter entity) {
         return JdbcReporter.builder()
                 .id(entity.getId())
+                .automationKey(entity.getAutomationKey())
                 .referenceType(entity.getReference().type())
                 .referenceId(entity.getReference().id())
                 .name(entity.getName())
@@ -82,12 +86,14 @@ public class JdbcReporterRepository extends AbstractJdbcRepository implements Re
                 .updatedAt(toLocalDateTime(entity.getUpdatedAt()))
                 .type(entity.getType())
                 .inherited(entity.isInherited())
+                .managedBy(entity.getManagedBy() != null ? entity.getManagedBy().name() : null)
                 .build();
 
     }
 
     private static final List<FieldSpec<JdbcReporter, ?>> fields = List.of(
             new FieldSpec<>(COL_ID, JdbcReporter::getId, String.class),
+            new FieldSpec<>("automation_key", JdbcReporter::getAutomationKey, String.class),
             new FieldSpec<>("reference_type", r-> r.getReferenceType().name(), String.class),
             new FieldSpec<>("reference_id", JdbcReporter::getReferenceId, String.class),
             new FieldSpec<>("enabled", JdbcReporter::isEnabled, boolean.class),
@@ -97,6 +103,7 @@ public class JdbcReporterRepository extends AbstractJdbcRepository implements Re
             new FieldSpec<>("configuration", JdbcReporter::getConfiguration, String.class),
             new FieldSpec<>("system", JdbcReporter::isSystem, boolean.class),
             new FieldSpec<>("inherited", JdbcReporter::isInherited, boolean.class),
+            new FieldSpec<>("managed_by", JdbcReporter::getManagedBy, String.class),
             new FieldSpec<>("created_at", JdbcReporter::getCreatedAt, LocalDateTime.class),
             new FieldSpec<>("updated_at", JdbcReporter::getUpdatedAt, LocalDateTime.class)
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcCertificate.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcCertificate.java
@@ -29,6 +29,8 @@ import java.time.LocalDateTime;
 public class JdbcCertificate {
     @Id
     private String id;
+    @Column("automation_key")
+    private String automationKey;
     private String name;
     private String type;
     private String configuration;
@@ -43,12 +45,23 @@ public class JdbcCertificate {
 
     private boolean system;
 
+    @Column("managed_by")
+    private String managedBy;
+
     public String getId() {
         return id;
     }
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getAutomationKey() {
+        return automationKey;
+    }
+
+    public void setAutomationKey(String automationKey) {
+        this.automationKey = automationKey;
     }
 
     public String getName() {
@@ -121,5 +134,13 @@ public class JdbcCertificate {
 
     public void setSystem(boolean system) {
         this.system = system;
+    }
+
+    public String getManagedBy() {
+        return managedBy;
+    }
+
+    public void setManagedBy(String managedBy) {
+        this.managedBy = managedBy;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcDomain.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcDomain.java
@@ -34,6 +34,8 @@ public class JdbcDomain {
     @Id
     private String id;
     private String hrid;
+    @Column("automation_key")
+    private String automationKey;
     private String name;
     private String version;
     private String description;
@@ -69,6 +71,8 @@ public class JdbcDomain {
     private String corsSettings;
     @Column("data_plane_id")
     private String dataPlaneId;
+    @Column("managed_by")
+    private String managedBy;
     @Column("secret_expiration_settings")
     private String secretExpirationSettings;
     @Column("token_exchange_settings")

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcIdentityProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcIdentityProvider.java
@@ -33,6 +33,8 @@ import java.time.LocalDateTime;
 public class JdbcIdentityProvider {
     @Id
     private String id;
+    @Column("automation_key")
+    private String automationKey;
     private String name;
     private String type;
     private boolean system;
@@ -57,4 +59,6 @@ public class JdbcIdentityProvider {
     private String passwordPolicy;
     @Column("data_plane_id")
     private String dataPlaneId;
+    @Column("managed_by")
+    private String managedBy;
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcReporter.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcReporter.java
@@ -39,6 +39,9 @@ public class JdbcReporter  {
     @Id
     private String id;
 
+    @Column("automation_key")
+    private String automationKey;
+
     private ReferenceType referenceType;
     private String referenceId;
     private boolean enabled;
@@ -54,5 +57,7 @@ public class JdbcReporter  {
     @Column("system")
     private boolean system;
     private boolean inherited;
+    @Column("managed_by")
+    private String managedBy;
 
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/4.12.0-add-cimd-metadata-documents.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/4.12.0-add-cimd-metadata-documents.yml
@@ -19,12 +19,26 @@ databaseChangeLog:
             columnNames: id
             tableName: cimd_metadata_documents
 
-        - createIndex:
-            columns:
-              - column:
-                  name: domain_id
-              - column:
-                  name: client_id
-            indexName: idx_cimd_metadata_documents_domain_client
-            tableName: cimd_metadata_documents
-            unique: true
+        # PostgreSQL: use functional unique index (client_id is too long for a direct index)
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            sql: "CREATE UNIQUE INDEX uq_cimd_metadata_documents_domain_client ON cimd_metadata_documents(domain_id, md5(client_id))"
+
+        # SQL Server: add persisted computed column using HASHBYTES('SHA2_256', client_id)
+        - sql:
+            dbms: mssql
+            splitStatements: false
+            sql: "ALTER TABLE cimd_metadata_documents ADD client_id_hash AS LOWER(CONVERT(VARCHAR(64), HASHBYTES('SHA2_256', client_id), 2)) PERSISTED"
+
+        # MySQL/MariaDB: add generated column using SHA2(client_id, 256)
+        - sql:
+            dbms: mysql, mariadb
+            splitStatements: false
+            sql: "ALTER TABLE cimd_metadata_documents ADD COLUMN client_id_hash VARCHAR(64) GENERATED ALWAYS AS (SHA2(client_id, 256)) STORED"
+
+        # Unique constraint for MySQL/MariaDB/MSSQL (PostgreSQL uses functional index above)
+        - sql:
+            dbms: mysql, mariadb, mssql
+            splitStatements: false
+            sql: "ALTER TABLE cimd_metadata_documents ADD CONSTRAINT uq_cimd_metadata_documents_domain_client UNIQUE (domain_id, client_id_hash)"

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/4.12.0-automation-initial-columns.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/4.12.0-automation-initial-columns.yml
@@ -1,0 +1,145 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0-add-managed-by-to-domains
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: domains
+              columnName: managed_by
+      changes:
+        - addColumn:
+            tableName: domains
+            columns:
+              - column:
+                  name: managed_by
+                  type: varchar(64)
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 4.12.0-add-automation-key-to-domains
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: domains
+              columnName: automation_key
+      changes:
+        - addColumn:
+            tableName: domains
+            columns:
+              - column:
+                  name: automation_key
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 4.12.0-add-managed-by-to-identities
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: identities
+              columnName: managed_by
+      changes:
+        - addColumn:
+            tableName: identities
+            columns:
+              - column:
+                  name: managed_by
+                  type: varchar(64)
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 4.12.0-add-automation-key-to-identities
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: identities
+              columnName: automation_key
+      changes:
+        - addColumn:
+            tableName: identities
+            columns:
+              - column:
+                  name: automation_key
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 4.12.0-add-managed-by-to-certificates
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: certificates
+              columnName: managed_by
+      changes:
+        - addColumn:
+            tableName: certificates
+            columns:
+              - column:
+                  name: managed_by
+                  type: varchar(64)
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 4.12.0-add-automation-key-to-certificates
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: certificates
+              columnName: automation_key
+      changes:
+        - addColumn:
+            tableName: certificates
+            columns:
+              - column:
+                  name: automation_key
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 4.12.0-add-managed-by-to-reporters
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: reporters
+              columnName: managed_by
+      changes:
+        - addColumn:
+            tableName: reporters
+            columns:
+              - column:
+                  name: managed_by
+                  type: varchar(64)
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 4.12.0-add-automation-key-to-reporters
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: reporters
+              columnName: automation_key
+      changes:
+        - addColumn:
+            tableName: reporters
+            columns:
+              - column:
+                  name: automation_key
+                  type: varchar(255)
+                  constraints:
+                    nullable: true

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
@@ -215,3 +215,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_12_0/4.12.0-trust-domains-table.yml
   - include:
       - file: liquibase/changelogs/v4_12_0/4.12.0-applications-add-kind.yml
+  - include:
+      - file: liquibase/changelogs/v4_12_0/4.12.0-automation-initial-columns.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoCertificateRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoCertificateRepository.java
@@ -19,6 +19,7 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.model.Certificate;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.repository.management.api.CertificateRepository;
 import io.gravitee.am.repository.mongodb.management.internal.model.CertificateMongo;
 import io.reactivex.rxjava3.core.Completable;
@@ -121,6 +122,7 @@ public class MongoCertificateRepository extends AbstractManagementMongoRepositor
 
         Certificate certificate = new Certificate();
         certificate.setId(certificateMongo.getId());
+        certificate.setAutomationKey(certificateMongo.getAutomationKey());
         certificate.setName(certificateMongo.getName());
         certificate.setType(certificateMongo.getType());
         certificate.setConfiguration(certificateMongo.getConfiguration());
@@ -136,6 +138,7 @@ public class MongoCertificateRepository extends AbstractManagementMongoRepositor
         certificate.setUpdatedAt(certificateMongo.getUpdatedAt());
         certificate.setExpiresAt(certificateMongo.getExpiresAt());
         certificate.setSystem(certificateMongo.isSystem());
+        certificate.setManagedBy(certificateMongo.getManagedBy() != null ? ManagedBy.valueOf(certificateMongo.getManagedBy()) : null);
         return certificate;
     }
 
@@ -146,6 +149,7 @@ public class MongoCertificateRepository extends AbstractManagementMongoRepositor
 
         CertificateMongo certificateMongo = new CertificateMongo();
         certificateMongo.setId(certificate.getId());
+        certificateMongo.setAutomationKey(certificate.getAutomationKey());
         certificateMongo.setName(certificate.getName());
         certificateMongo.setType(certificate.getType());
         certificateMongo.setConfiguration(certificate.getConfiguration());
@@ -155,6 +159,7 @@ public class MongoCertificateRepository extends AbstractManagementMongoRepositor
         certificateMongo.setUpdatedAt(certificate.getUpdatedAt());
         certificateMongo.setExpiresAt(certificate.getExpiresAt());
         certificateMongo.setSystem(certificate.isSystem());
+        certificateMongo.setManagedBy(certificate.getManagedBy() != null ? certificate.getManagedBy().name() : null);
         return certificateMongo;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
@@ -23,6 +23,7 @@ import io.gravitee.am.common.webauthn.AttestationConveyancePreference;
 import io.gravitee.am.common.webauthn.AuthenticatorAttachment;
 import io.gravitee.am.common.webauthn.UserVerification;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.PasswordSettings;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.SAMLSettings;
@@ -209,6 +210,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         domain.setId(domainMongo.getId());
         domain.setVersion(domainMongo.getVersion());
         domain.setHrid(domainMongo.getHrid());
+        domain.setAutomationKey(domainMongo.getAutomationKey());
         domain.setPath(domainMongo.getPath());
         domain.setVhostMode(domainMongo.isVhostMode());
         domain.setVhosts(domainMongo.getVhosts());
@@ -234,6 +236,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         domain.setMaster(domainMongo.isMaster());
         domain.setCorsSettings(domainMongo.getCorsSettings());
         domain.setDataPlaneId(domainMongo.getDataPlaneId());
+        domain.setManagedBy(domainMongo.getManagedBy() != null ? ManagedBy.valueOf(domainMongo.getManagedBy()) : null);
         domain.setSecretExpirationSettings(convert(domainMongo.getSecretSettings()));
         domain.setTokenExchangeSettings(convert(domainMongo.getTokenExchangeSettings()));
         domain.setCertificateSettings(domainMongo.getCertificateSettings());
@@ -250,6 +253,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         domainMongo.setId(domain.getId());
         domainMongo.setVersion(domain.getVersion());
         domainMongo.setHrid(domain.getHrid());
+        domainMongo.setAutomationKey(domain.getAutomationKey());
         domainMongo.setPath(domain.getPath());
         domainMongo.setVhostMode(domain.isVhostMode());
         domainMongo.setVhosts(domain.getVhosts());
@@ -275,6 +279,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         domainMongo.setMaster(domain.isMaster());
         domainMongo.setCorsSettings(domain.getCorsSettings());
         domainMongo.setDataPlaneId(domain.getDataPlaneId());
+        domainMongo.setManagedBy(domain.getManagedBy() != null ? domain.getManagedBy().name() : null);
         domainMongo.setSecretSettings(convert(domain.getSecretExpirationSettings()));
         domainMongo.setTokenExchangeSettings(convert(domain.getTokenExchangeSettings()));
         domainMongo.setCertificateSettings(domain.getCertificateSettings());

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoIdentityProviderRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoIdentityProviderRepository.java
@@ -19,6 +19,7 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.repository.management.api.IdentityProviderRepository;
@@ -150,6 +151,7 @@ public class MongoIdentityProviderRepository extends AbstractManagementMongoRepo
 
         var identityProvider = new IdentityProvider();
         identityProvider.setId(identityProviderMongo.getId());
+        identityProvider.setAutomationKey(identityProviderMongo.getAutomationKey());
         identityProvider.setName(identityProviderMongo.getName());
         identityProvider.setDataPlaneId(identityProviderMongo.getDataPlaneId());
         identityProvider.setType(identityProviderMongo.getType());
@@ -189,6 +191,7 @@ public class MongoIdentityProviderRepository extends AbstractManagementMongoRepo
         identityProvider.setCreatedAt(identityProviderMongo.getCreatedAt());
         identityProvider.setUpdatedAt(identityProviderMongo.getUpdatedAt());
         identityProvider.setPasswordPolicy(identityProviderMongo.getPasswordPolicy());
+        identityProvider.setManagedBy(identityProviderMongo.getManagedBy() != null ? ManagedBy.valueOf(identityProviderMongo.getManagedBy()) : null);
         return identityProvider;
     }
 
@@ -196,6 +199,7 @@ public class MongoIdentityProviderRepository extends AbstractManagementMongoRepo
         return ofNullable(identityProvider).map(Objects::nonNull).map(idp -> {
             var identityProviderMongo = new IdentityProviderMongo();
             identityProviderMongo.setId(identityProvider.getId());
+            identityProviderMongo.setAutomationKey(identityProvider.getAutomationKey());
             identityProviderMongo.setName(identityProvider.getName());
             identityProviderMongo.setType(identityProvider.getType());
             identityProviderMongo.setDataPlaneId(identityProvider.getDataPlaneId());
@@ -217,6 +221,7 @@ public class MongoIdentityProviderRepository extends AbstractManagementMongoRepo
                             .map(BsonString::new)
                             .collect(toCollection(BsonArray::new)));
             identityProviderMongo.setPasswordPolicy(identityProvider.getPasswordPolicy());
+            identityProviderMongo.setManagedBy(identityProvider.getManagedBy() != null ? identityProvider.getManagedBy().name() : null);
             return identityProviderMongo;
         });
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoReporterRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoReporterRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.am.repository.mongodb.management;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
@@ -128,6 +129,7 @@ public class MongoReporterRepository extends AbstractManagementMongoRepository i
 
         ReporterMongo reporterMongo = new ReporterMongo();
         reporterMongo.setId(reporter.getId());
+        reporterMongo.setAutomationKey(reporter.getAutomationKey());
         reporterMongo.setEnabled(reporter.isEnabled());
         reporterMongo.setReferenceType(reporter.getReference().type());
         reporterMongo.setReferenceId(reporter.getReference().id());
@@ -139,6 +141,7 @@ public class MongoReporterRepository extends AbstractManagementMongoRepository i
         reporterMongo.setCreatedAt(reporter.getCreatedAt());
         reporterMongo.setUpdatedAt(reporter.getUpdatedAt());
         reporterMongo.setInherited(reporter.isInherited());
+        reporterMongo.setManagedBy(reporter.getManagedBy() != null ? reporter.getManagedBy().name() : null);
         return reporterMongo;
     }
 
@@ -149,6 +152,7 @@ public class MongoReporterRepository extends AbstractManagementMongoRepository i
 
         Reporter reporter = new Reporter();
         reporter.setId(reporterMongo.getId());
+        reporter.setAutomationKey(reporterMongo.getAutomationKey());
         reporter.setEnabled(reporterMongo.isEnabled());
         if (reporterMongo.getReferenceType() != null) {
             reporter.setReference(new Reference(reporterMongo.getReferenceType(), reporterMongo.getReferenceId()));
@@ -165,6 +169,7 @@ public class MongoReporterRepository extends AbstractManagementMongoRepository i
         reporter.setCreatedAt(reporterMongo.getCreatedAt());
         reporter.setUpdatedAt(reporterMongo.getUpdatedAt());
         reporter.setInherited(reporterMongo.isInherited());
+        reporter.setManagedBy(reporterMongo.getManagedBy() != null ? ManagedBy.valueOf(reporterMongo.getManagedBy()) : null);
         return reporter;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/AccountSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/AccountSettingsMongo.java
@@ -39,6 +39,7 @@ public class AccountSettingsMongo {
     private String redirectUriAfterRegistration;
     private boolean dynamicUserRegistration;
     private String defaultIdentityProviderForRegistration;
+    private String defaultIdentityProviderForRegistrationKey;
     private boolean autoLoginAfterResetPassword;
     private String redirectUriAfterResetPassword;
     private boolean deletePasswordlessDevicesAfterResetPassword;
@@ -142,6 +143,14 @@ public class AccountSettingsMongo {
 
     public void setDefaultIdentityProviderForRegistration(String defaultIdentityProviderForRegistration) {
         this.defaultIdentityProviderForRegistration = defaultIdentityProviderForRegistration;
+    }
+
+    public String getDefaultIdentityProviderForRegistrationKey() {
+        return defaultIdentityProviderForRegistrationKey;
+    }
+
+    public void setDefaultIdentityProviderForRegistrationKey(String defaultIdentityProviderForRegistrationKey) {
+        this.defaultIdentityProviderForRegistrationKey = defaultIdentityProviderForRegistrationKey;
     }
 
     public boolean isAutoLoginAfterResetPassword() {
@@ -284,6 +293,7 @@ public class AccountSettingsMongo {
         accountSettings.setRedirectUriAfterRegistration(getRedirectUriAfterRegistration());
         accountSettings.setDynamicUserRegistration(isDynamicUserRegistration());
         accountSettings.setDefaultIdentityProviderForRegistration(getDefaultIdentityProviderForRegistration());
+        accountSettings.setDefaultIdentityProviderForRegistrationKey(getDefaultIdentityProviderForRegistrationKey());
         accountSettings.setAutoLoginAfterResetPassword(isAutoLoginAfterResetPassword());
         accountSettings.setRedirectUriAfterResetPassword(getRedirectUriAfterResetPassword());
         accountSettings.setSendRecoverAccountEmail(isSendRecoverAccountEmail());
@@ -321,6 +331,7 @@ public class AccountSettingsMongo {
         accountSettingsMongo.setRedirectUriAfterRegistration(accountSettings.getRedirectUriAfterRegistration());
         accountSettingsMongo.setDynamicUserRegistration(accountSettings.isDynamicUserRegistration());
         accountSettingsMongo.setDefaultIdentityProviderForRegistration(accountSettings.getDefaultIdentityProviderForRegistration());
+        accountSettingsMongo.setDefaultIdentityProviderForRegistrationKey(accountSettings.getDefaultIdentityProviderForRegistrationKey());
         accountSettingsMongo.setAutoLoginAfterResetPassword(accountSettings.isAutoLoginAfterResetPassword());
         accountSettingsMongo.setRedirectUriAfterResetPassword(accountSettings.getRedirectUriAfterResetPassword());
         accountSettingsMongo.setSendRecoverAccountEmail(accountSettings.isSendRecoverAccountEmail());

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/CertificateMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/CertificateMongo.java
@@ -30,6 +30,8 @@ public class CertificateMongo extends Auditable {
     @BsonId
     private String id;
 
+    private String automationKey;
+
     private String name;
 
     private String type;
@@ -44,12 +46,22 @@ public class CertificateMongo extends Auditable {
 
     private boolean system;
 
+    private String managedBy;
+
     public String getId() {
         return id;
     }
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getAutomationKey() {
+        return automationKey;
+    }
+
+    public void setAutomationKey(String automationKey) {
+        this.automationKey = automationKey;
     }
 
     public String getName() {
@@ -106,6 +118,14 @@ public class CertificateMongo extends Auditable {
 
     public void setSystem(boolean system) {
         this.system = system;
+    }
+
+    public String getManagedBy() {
+        return managedBy;
+    }
+
+    public void setManagedBy(String managedBy) {
+        this.managedBy = managedBy;
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/DomainMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/DomainMongo.java
@@ -43,6 +43,8 @@ public class DomainMongo extends Auditable {
 
     private String hrid;
 
+    private String automationKey;
+
     private String name;
 
     private DomainVersion version;
@@ -90,6 +92,8 @@ public class DomainMongo extends Auditable {
     private boolean master;
 
     private String dataPlaneId;
+
+    private String managedBy;
 
     private SecretSettingsMongo secretSettings;
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/IdentityProviderMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/IdentityProviderMongo.java
@@ -34,6 +34,8 @@ public class IdentityProviderMongo extends Auditable {
     @BsonId
     private String id;
 
+    private String automationKey;
+
     private String name;
 
     private String type;
@@ -68,6 +70,8 @@ public class IdentityProviderMongo extends Auditable {
     private String passwordPolicy;
 
     private String dataPlaneId;
+
+    private String managedBy;
 
     @Override
     public boolean equals(Object o) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ReporterMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ReporterMongo.java
@@ -33,6 +33,8 @@ public class ReporterMongo extends Auditable {
     @BsonId
     private String id;
 
+    private String automationKey;
+
     /**
      * @deprecated use referenceType & referenceId instead
      */
@@ -68,5 +70,7 @@ public class ReporterMongo extends Auditable {
     private String configuration;
 
     private boolean inherited;
+
+    private String managedBy;
 
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/SAMLSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/SAMLSettingsMongo.java
@@ -26,6 +26,7 @@ public class SAMLSettingsMongo {
     private boolean enabled;
     private String entityId;
     private String certificate;
+    private String certificateKey;
 
     public boolean isEnabled() {
         return enabled;
@@ -51,11 +52,20 @@ public class SAMLSettingsMongo {
         this.certificate = certificate;
     }
 
+    public String getCertificateKey() {
+        return certificateKey;
+    }
+
+    public void setCertificateKey(String certificateKey) {
+        this.certificateKey = certificateKey;
+    }
+
     public SAMLSettings convert() {
         SAMLSettings samlSettings = new SAMLSettings();
         samlSettings.setEnabled(isEnabled());
         samlSettings.setEntityId(getEntityId());
         samlSettings.setCertificate(getCertificate());
+        samlSettings.setCertificateKey(getCertificateKey());
         return samlSettings;
     }
 
@@ -67,6 +77,7 @@ public class SAMLSettingsMongo {
         samlSettings.setEnabled(other.isEnabled());
         samlSettings.setEntityId(other.getEntityId());
         samlSettings.setCertificate(other.getCertificate());
+        samlSettings.setCertificateKey(other.getCertificateKey());
         return samlSettings;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DomainRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DomainRepositoryTest.java
@@ -19,6 +19,7 @@ import io.gravitee.am.model.CertificateSettings;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.DomainVersion;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.SAMLSettings;
 import io.gravitee.am.model.SelfServiceAccountManagementSettings;
 import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.model.account.AccountSettings;
@@ -118,7 +119,10 @@ public class DomainRepositoryTest extends AbstractManagementTest {
         domain.setTags(new HashSet<>(Arrays.asList("tag1", "tag2")));
         domain.setIdentities(new HashSet<>(Arrays.asList("id1", "id2")));
 
-        domain.setAccountSettings(new AccountSettings());
+        AccountSettings accountSettings = new AccountSettings();
+        accountSettings.setDefaultIdentityProviderForRegistration("default-idp-id");
+        accountSettings.setDefaultIdentityProviderForRegistrationKey("default-idp-key");
+        domain.setAccountSettings(accountSettings);
         domain.setLoginSettings(new LoginSettings());
         domain.getLoginSettings().setResetPasswordOnExpiration(true);
         final OIDCSettings oidc = new OIDCSettings();
@@ -136,7 +140,15 @@ public class DomainRepositoryTest extends AbstractManagementTest {
         domain.setSelfServiceAccountManagementSettings(new SelfServiceAccountManagementSettings());
         CertificateSettings certificateSettings = new CertificateSettings();
         certificateSettings.setFallbackCertificate("fallback-cert-id");
+        certificateSettings.setFallbackCertificateKey("fallback-cert-key");
         domain.setCertificateSettings(certificateSettings);
+
+        SAMLSettings saml = new SAMLSettings();
+        saml.setEnabled(true);
+        saml.setEntityId("https://idp.example.com");
+        saml.setCertificate("saml-cert-id");
+        saml.setCertificateKey("saml-cert-key");
+        domain.setSaml(saml);
 
         return domain;
     }
@@ -223,6 +235,11 @@ public class DomainRepositoryTest extends AbstractManagementTest {
         testObserver.assertValue(d -> d.getSelfServiceAccountManagementSettings() != null);
         testObserver.assertValue(d -> d.getCertificateSettings() != null);
         testObserver.assertValue(d -> "fallback-cert-id".equals(d.getCertificateSettings().getFallbackCertificate()));
+        // Automation API parallel-key references must survive the persistence round-trip in every store
+        // (regression guard: hand-mapped Mongo subtypes silently drop new model fields).
+        testObserver.assertValue(d -> "fallback-cert-key".equals(d.getCertificateSettings().getFallbackCertificateKey()));
+        testObserver.assertValue(d -> "default-idp-key".equals(d.getAccountSettings().getDefaultIdentityProviderForRegistrationKey()));
+        testObserver.assertValue(d -> d.getSaml() != null && "saml-cert-key".equals(d.getSaml().getCertificateKey()));
     }
 
     @Test

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/IdentityProviderRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/IdentityProviderRepositoryTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.management.api;
 
 import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.repository.management.AbstractManagementTest;
 import io.reactivex.rxjava3.observers.TestObserver;
@@ -211,6 +212,32 @@ public class IdentityProviderRepositoryTest extends AbstractManagementTest {
         testObserver.assertComplete();
         testObserver.assertNoValues();
         testObserver.assertNoErrors();
+    }
+
+    @Test
+    public void testManagedByRoundTrips() {
+        IdentityProvider identityProvider = buildIdentityProvider();
+        identityProvider.setManagedBy(ManagedBy.AUTOMATION_API);
+        IdentityProvider created = identityProviderRepository.create(identityProvider).blockingGet();
+
+        TestObserver<IdentityProvider> testObserver = identityProviderRepository.findById(created.getId()).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(idp -> idp.getManagedBy() == ManagedBy.AUTOMATION_API);
+    }
+
+    @Test
+    public void testKeyRoundTrips() {
+        IdentityProvider identityProvider = buildIdentityProvider();
+        identityProvider.setAutomationKey("customer-users");
+        IdentityProvider created = identityProviderRepository.create(identityProvider).blockingGet();
+
+        TestObserver<IdentityProvider> testObserver = identityProviderRepository.findById(created.getId()).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(idp -> "customer-users".equals(idp.getAutomationKey()));
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/CertificateService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/CertificateService.java
@@ -46,6 +46,12 @@ public interface CertificateService {
     Single<Certificate> create(Domain domain);
 
     /**
+     * Create the domain's system certificate from {@code gravitee.yaml} settings on behalf of the
+     * Automation API.
+     */
+    Single<Certificate> createSystem(Domain domain, String id, String automationKey, User principal);
+
+    /**
      * Request the generation of a new system certificate for the given domain
      * @param domain
      * @return the new Certificate

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/ReporterService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/ReporterService.java
@@ -44,6 +44,12 @@ public interface ReporterService {
 
     Single<Reporter> createDefault(Reference reference);
 
+    /**
+     * Create the domain's system reporter from {@code gravitee.yaml} repository settings on behalf of
+     * the Automation API.
+     */
+    Single<Reporter> createSystem(Reference reference, String id, String automationKey, User principal);
+
     NewReporter createInternal(Reference reference);
 
     Single<Reporter> create(Reference reference, NewReporter newReporter, User principal, boolean system);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Certificate;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Event;
@@ -56,6 +57,7 @@ import io.gravitee.am.service.exception.CertificateWithIdpException;
 import io.gravitee.am.service.exception.CertificateWithProtectedResourceException;
 import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
+import io.gravitee.am.service.model.AutomationNewCertificate;
 import io.gravitee.am.service.model.NewCertificate;
 import io.gravitee.am.service.model.UpdateCertificate;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
@@ -276,7 +278,6 @@ public class CertificateServiceImpl implements CertificateService {
 
     private Certificate createCertificate(String domain, NewCertificate newCertificate, boolean isSystem, byte[] content) {
         var certificate = new Certificate();
-        certificate.setId(RandomString.generate());
         certificate.setDomain(domain);
         certificate.setName(newCertificate.getName());
         certificate.setType(newCertificate.getType());
@@ -285,6 +286,14 @@ public class CertificateServiceImpl implements CertificateService {
         certificate.setConfiguration(newCertificate.getConfiguration());
         certificate.setCreatedAt(new Date());
         certificate.setUpdatedAt(certificate.getCreatedAt());
+        if (newCertificate instanceof AutomationNewCertificate auto) {
+            // the Automation API supplies a deterministic id derived from the domain + key
+            certificate.setId(auto.getId() == null ? RandomString.generate() : auto.getId());
+            certificate.setAutomationKey(auto.getAutomationKey());
+            certificate.setManagedBy(ManagedBy.AUTOMATION_API);
+        } else {
+            certificate.setId(RandomString.generate());
+        }
         return certificate;
     }
 
@@ -359,7 +368,9 @@ public class CertificateServiceImpl implements CertificateService {
         var certificateToUpdate = new Certificate(oldCertificate.certificate());
         certificateToUpdate.setName(updateCertificate.getName());
         certificateToUpdate.setUpdatedAt(new Date());
-        if (!certificateToUpdate.isSystem()) { // system certificate can't be updated
+        // System certificate config is normally immutable through the API, but the Automation API owns the
+        // lifecycle of the resources it manages, so it may update their configuration.
+        if (!certificateToUpdate.isSystem() || certificateToUpdate.getManagedBy() == ManagedBy.AUTOMATION_API) {
             oldCertificate.schema.getFileKey().ifPresent(fileKey -> updateEmbeddedKeys(updateCertificate, certificateToUpdate, oldCertificate, fileKey));
             certificateToUpdate.setConfiguration(updateCertificate.getConfiguration());
         }
@@ -467,6 +478,30 @@ public class CertificateServiceImpl implements CertificateService {
 
     @Override
     public Single<Certificate> create(Domain domain) {
+        return buildDefaultCertificate(domain)
+                .flatMap(certificate -> create(domain, certificate, true));
+    }
+
+    @Override
+    public Single<Certificate> createSystem(Domain domain, String id, String automationKey, User principal) {
+        return buildDefaultCertificate(domain)
+                .flatMap(base -> {
+                    AutomationNewCertificate auto = new AutomationNewCertificate();
+                    auto.setId(id);
+                    auto.setAutomationKey(automationKey);
+                    auto.setName(base.getName());
+                    auto.setType(base.getType());
+                    auto.setConfiguration(base.getConfiguration());
+                    return create(domain, auto, principal, true);
+                });
+    }
+
+    /**
+     * Build the default PKCS12 {@link NewCertificate} for the given domain from the
+     * {@code domains.certificates.default.*} settings in {@code gravitee.yaml}. The returned model carries
+     * the name, type and configuration but no id and no automation key — those are assigned by the caller.
+     */
+    private Single<NewCertificate> buildDefaultCertificate(Domain domain) {
         // Define the default certificate
         // Create a default PKCS12 certificate: io.gravitee.am.certificate.pkcs12.PKCS12Configuration
         NewCertificate certificate = new NewCertificate();
@@ -502,9 +537,10 @@ public class CertificateServiceImpl implements CertificateService {
                     certificateNode.put(KEY_PASS, keyPass);
 
                     return objectMapper.writeValueAsString(certificateNode);
-                }).flatMap(configuration -> {
+                })
+                .map(configuration -> {
                     certificate.setConfiguration(configuration);
-                    return create(domain, certificate, true);
+                    return certificate;
                 });
     }
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
@@ -38,6 +38,7 @@ import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Event;
@@ -53,6 +54,7 @@ import io.gravitee.am.service.exception.IdentityProviderNotFoundException;
 import io.gravitee.am.service.exception.IdentityProviderWithApplicationsException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.AssignPasswordPolicy;
+import io.gravitee.am.service.model.AutomationNewIdentityProvider;
 import io.gravitee.am.service.model.NewIdentityProvider;
 import io.gravitee.am.service.model.UpdateIdentityProvider;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
@@ -193,6 +195,10 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
     private static IdentityProvider prepareIdp(NewIdentityProvider newIdentityProvider, ReferenceType domain, String domain1, boolean system) {
         var identityProvider = new IdentityProvider();
         identityProvider.setId(newIdentityProvider.getId() == null ? RandomString.generate() : newIdentityProvider.getId());
+        if (newIdentityProvider instanceof AutomationNewIdentityProvider auto) {
+            identityProvider.setAutomationKey(auto.getAutomationKey());
+            identityProvider.setManagedBy(ManagedBy.AUTOMATION_API);
+        }
         identityProvider.setReferenceType(domain);
         identityProvider.setReferenceId(domain1);
         identityProvider.setName(newIdentityProvider.getName());
@@ -215,7 +221,9 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
                 .flatMap(oldIdentity -> {
                     IdentityProvider identityToUpdate = new IdentityProvider(oldIdentity);
                     identityToUpdate.setName(updateIdentityProvider.getName());
-                    if (!identityToUpdate.isSystem() || isUpgrader) {
+                    // System idp config is normally immutable through the API, but the Automation API owns
+                    // the lifecycle of the resources it manages, so it may update their configuration.
+                    if (!identityToUpdate.isSystem() || isUpgrader || identityToUpdate.isManagedBy(ManagedBy.AUTOMATION_API)) {
                         identityToUpdate.setConfiguration(updateIdentityProvider.getConfiguration());
                     }
                     identityToUpdate.setMappers(updateIdentityProvider.getMappers());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.am.common.event.Action;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
@@ -40,6 +41,7 @@ import io.gravitee.am.service.exception.ReporterConfigurationException;
 import io.gravitee.am.service.exception.ReporterDeleteException;
 import io.gravitee.am.service.exception.ReporterNotFoundException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
+import io.gravitee.am.service.model.AutomationNewReporter;
 import io.gravitee.am.service.model.NewReporter;
 import io.gravitee.am.service.model.UpdateReporter;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
@@ -148,6 +150,23 @@ public class ReporterServiceImpl implements ReporterService {
     }
 
     @Override
+    public Single<Reporter> createSystem(Reference reference, String id, String automationKey, User principal) {
+        LOGGER.debug("Create system (Automation API) reporter for {} with key {}", reference, automationKey);
+        NewReporter base = createInternal(reference);
+        if (base == null) {
+            return Single.error(new ReporterNotFoundException("Reporter type " + this.environment.getProperty(MANAGEMENT_TYPE) + " not found"));
+        }
+        AutomationNewReporter auto = new AutomationNewReporter();
+        auto.setId(id);
+        auto.setAutomationKey(automationKey);
+        auto.setEnabled(base.isEnabled());
+        auto.setName(base.getName());
+        auto.setType(base.getType());
+        auto.setConfiguration(base.getConfiguration());
+        return create(reference, auto, principal, true);
+    }
+
+    @Override
     public NewReporter createInternal(Reference reference) {
         NewReporter newReporter = null;
         if (useMongoReporter()) {
@@ -180,6 +199,11 @@ public class ReporterServiceImpl implements ReporterService {
                 .updatedAt(now)
                 .build();
 
+        if (newReporter instanceof AutomationNewReporter auto) {
+            reporter.setAutomationKey(auto.getAutomationKey());
+            reporter.setManagedBy(ManagedBy.AUTOMATION_API);
+        }
+
 
         return checkReporterConfiguration(reporter)
                 .flatMap(ignore -> reporterRepository.create(reporter))
@@ -210,7 +234,9 @@ public class ReporterServiceImpl implements ReporterService {
                     reporterToUpdate.setEnabled(updateReporter.isEnabled());
 
                     reporterToUpdate.setName(updateReporter.getName());
-                    if (!oldReporter.isSystem() || isUpgrader) {
+                    // System reporter config is normally immutable through the API, but the Automation API
+                    // owns the lifecycle of the resources it manages, so it may update their configuration.
+                    if (!oldReporter.isSystem() || isUpgrader || oldReporter.isManagedBy(ManagedBy.AUTOMATION_API)) {
                         reporterToUpdate.setConfiguration(updateReporter.getConfiguration());
                     }
                     if (updateReporter.isInherited() && (oldReporter.getReference().type() != ReferenceType.ORGANIZATION || oldReporter.isSystem())) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AutomationNewCertificate.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AutomationNewCertificate.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Marker subclass that flags a certificate as created by the Automation API so the
+ * service layer can set {@code managedBy = AUTOMATION_API}, carrying the deterministic
+ * {@code id} and the external {@code key} for the resource.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationNewCertificate extends NewCertificate {
+
+    private String id;
+
+    private String automationKey;
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AutomationNewDomain.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AutomationNewDomain.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Extends NewDomain with fields for declarative domain creation via the Automation API.
+ * When these fields are set, the service uses them instead of auto-generating values.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationNewDomain extends NewDomain {
+
+    private String id;
+
+    private String automationKey;
+
+    private String path;
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AutomationNewIdentityProvider.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AutomationNewIdentityProvider.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Extends NewIdentityProvider with fields for declarative IDP management via the Automation API.
+ *
+ * @author Stuart Clark
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationNewIdentityProvider extends NewIdentityProvider {
+
+    private String automationKey;
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AutomationNewReporter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/AutomationNewReporter.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Marker subclass that flags a reporter as created by the Automation API so the service layer can set
+ * {@code managedBy = AUTOMATION_API}, carrying the external {@code key} for the resource. The deterministic
+ * {@code id} is carried by {@link NewReporter#getId()}.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AutomationNewReporter extends NewReporter {
+
+    private String automationKey;
+}

--- a/gravitee-am-test/api/management/models/Domain.ts
+++ b/gravitee-am-test/api/management/models/Domain.ts
@@ -182,6 +182,12 @@ export interface Domain {
   loginSettings?: LoginSettings;
   /**
    *
+   * @type {string}
+   * @memberof Domain
+   */
+  managedBy?: DomainManagedByEnum;
+  /**
+   *
    * @type {boolean}
    * @memberof Domain
    */
@@ -335,6 +341,17 @@ export interface Domain {
 /**
  * @export
  */
+export const DomainManagedByEnum = {
+  None: 'NONE',
+  Terraform: 'TERRAFORM',
+  Gko: 'GKO',
+  AutomationApi: 'AUTOMATION_API',
+} as const;
+export type DomainManagedByEnum = typeof DomainManagedByEnum[keyof typeof DomainManagedByEnum];
+
+/**
+ * @export
+ */
 export const DomainReferenceTypeEnum = {
   Platform: 'PLATFORM',
   Domain: 'DOMAIN',
@@ -386,6 +403,7 @@ export function DomainFromJSONTyped(json: any, ignoreDiscriminator: boolean): Do
     id: json['id'] == null ? undefined : json['id'],
     identities: json['identities'] == null ? undefined : new Set(json['identities']),
     loginSettings: json['loginSettings'] == null ? undefined : LoginSettingsFromJSON(json['loginSettings']),
+    managedBy: json['managedBy'] == null ? undefined : json['managedBy'],
     master: json['master'] == null ? undefined : json['master'],
     name: json['name'] == null ? undefined : json['name'],
     oidc: json['oidc'] == null ? undefined : OIDCSettingsFromJSON(json['oidc']),
@@ -445,6 +463,7 @@ export function DomainToJSONTyped(value?: Domain | null, ignoreDiscriminator: bo
     id: value['id'],
     identities: value['identities'] == null ? undefined : Array.from(value['identities'] as Set<any>),
     loginSettings: LoginSettingsToJSON(value['loginSettings']),
+    managedBy: value['managedBy'],
     master: value['master'],
     name: value['name'],
     oidc: OIDCSettingsToJSON(value['oidc']),

--- a/gravitee-am-test/api/management/models/IdentityProvider.ts
+++ b/gravitee-am-test/api/management/models/IdentityProvider.ts
@@ -76,6 +76,12 @@ export interface IdentityProvider {
   id?: string;
   /**
    *
+   * @type {string}
+   * @memberof IdentityProvider
+   */
+  managedBy?: IdentityProviderManagedByEnum;
+  /**
+   *
    * @type {{ [key: string]: string; }}
    * @memberof IdentityProvider
    */
@@ -133,6 +139,17 @@ export interface IdentityProvider {
 /**
  * @export
  */
+export const IdentityProviderManagedByEnum = {
+  None: 'NONE',
+  Terraform: 'TERRAFORM',
+  Gko: 'GKO',
+  AutomationApi: 'AUTOMATION_API',
+} as const;
+export type IdentityProviderManagedByEnum = typeof IdentityProviderManagedByEnum[keyof typeof IdentityProviderManagedByEnum];
+
+/**
+ * @export
+ */
 export const IdentityProviderReferenceTypeEnum = {
   Platform: 'PLATFORM',
   Domain: 'DOMAIN',
@@ -166,6 +183,7 @@ export function IdentityProviderFromJSONTyped(json: any, ignoreDiscriminator: bo
     external: json['external'] == null ? undefined : json['external'],
     groupMapper: json['groupMapper'] == null ? undefined : json['groupMapper'],
     id: json['id'] == null ? undefined : json['id'],
+    managedBy: json['managedBy'] == null ? undefined : json['managedBy'],
     mappers: json['mappers'] == null ? undefined : json['mappers'],
     name: json['name'] == null ? undefined : json['name'],
     passwordPolicy: json['passwordPolicy'] == null ? undefined : json['passwordPolicy'],
@@ -195,6 +213,7 @@ export function IdentityProviderToJSONTyped(value?: IdentityProvider | null, ign
     external: value['external'],
     groupMapper: value['groupMapper'],
     id: value['id'],
+    managedBy: value['managedBy'],
     mappers: value['mappers'],
     name: value['name'],
     passwordPolicy: value['passwordPolicy'],

--- a/gravitee-am-test/specs/management/automation/auth-and-openapi.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/auth-and-openapi.jest.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Asserts the existing cross-cutting Automation API functionality:
+ *  - stateless bearer-JWT authentication (401 for missing / invalid tokens)
+ *  - the OpenAPI specification endpoints (served unauthenticated, automation-only)
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import {
+  AutomationAuthFixture,
+  setupAutomationAuthFixture,
+} from './fixtures/automation-domain-fixture';
+import { authHeaders, automationUrl, envPath, jsonHeaders } from './fixtures/automation-client';
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+
+setup();
+
+let fixture: AutomationAuthFixture;
+
+beforeAll(async () => {
+  fixture = await setupAutomationAuthFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('Automation API - Authentication (stateless bearer JWT)', () => {
+  it('should reject a request with no Authorization header (401)', async () => {
+    const response = await performGet(automationUrl(), `${envPath()}/domains`, jsonHeaders());
+    expect(response.status).toBe(401);
+  });
+
+  it('should reject a request with a malformed bearer token (401)', async () => {
+    const response = await performGet(automationUrl(), `${envPath()}/domains`, jsonHeaders({ Authorization: 'Bearer not-a-real-jwt' }));
+    expect(response.status).toBe(401);
+  });
+
+  it('should accept a request with a valid admin bearer JWT (200)', async () => {
+    const response = await performGet(automationUrl(), `${envPath()}/domains`, authHeaders(fixture.accessToken));
+    expect(response.status).toBe(200);
+  });
+});
+
+describe('Automation API - OpenAPI specification', () => {
+  it('should serve /openapi.json without authentication', async () => {
+    const response = await performGet(automationUrl(), '/openapi.json', jsonHeaders());
+    expect(response.status).toBe(200);
+
+    const spec = response.body;
+    expect(spec.openapi).toEqual(expect.stringMatching(/^3\./));
+    expect(spec.info.title).toContain('Automation API');
+
+    // automation-only tags
+    const tagNames = (spec.tags || []).map((t: any) => t.name);
+    expect(tagNames).toEqual(expect.arrayContaining(['Domains', 'Identity Providers']));
+
+    // automation-only paths, no inherited Management API paths
+    const paths = Object.keys(spec.paths || {});
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.every((p) => p.startsWith('/organizations/{orgId}'))).toBe(true);
+    // identity providers are a resource under a domain
+    expect(paths.some((p) => p.endsWith('/identity-providers'))).toBe(true);
+
+    // automation-specific security schemes only (no inherited gravitee-auth)
+    const schemes = Object.keys(spec.components?.securitySchemes || {});
+    expect(schemes).toEqual(expect.arrayContaining(['BearerAuth', 'BasicAuth']));
+    expect(schemes).not.toContain('gravitee-auth');
+  });
+
+  it('should serve /openapi.yaml without authentication', async () => {
+    const response = await performGet(automationUrl(), '/openapi.yaml', {});
+    expect(response.status).toBe(200);
+    const body = response.text || JSON.stringify(response.body);
+    expect(body).toContain('openapi');
+    expect(body).toContain('Automation API');
+  });
+});

--- a/gravitee-am-test/specs/management/automation/domain-account-settings-references.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-account-settings-references.jest.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pins the out-of-scope contract for the domain payload: bot detections and device
+ * notifiers are not managed by the Automation API and never surfaced, and
+ * {@code oidc.cimdSettings} is not surfaced. The in-scope cross-reference
+ * ({@code accountSettings.defaultIdentityProviderForRegistration}) is covered by
+ * domain-identity-providers.jest.spec.ts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import {
+  AutomationDomainFixture,
+  setupAutomationDomainFixture,
+} from './fixtures/automation-domain-fixture';
+
+setup(120000);
+
+let fixture: AutomationDomainFixture;
+
+beforeAll(async () => {
+  fixture = await setupAutomationDomainFixture({ keyPrefix: 'autoacct' });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('Automation API - out-of-scope resources are not surfaced', () => {
+  it('should not surface bot detections or device notifiers on the domain', async () => {
+    const get = await fixture.client.getDomain(fixture.domainKey);
+    expect(get.status).toBe(200);
+    expect(get.body.botDetections).toBeUndefined();
+    expect(get.body.deviceNotifiers).toBeUndefined();
+    expect(get.body.accountSettings?.botDetectionPlugin).toBeUndefined();
+    expect(get.body.accountSettings?.useBotDetection).toBeUndefined();
+  });
+
+  it('should not surface oidc.cimdSettings on GET responses', async () => {
+    const get = await fixture.client.getDomain(fixture.domainKey);
+    expect(get.status).toBe(200);
+    expect(get.body.oidc?.cimdSettings).toBeUndefined();
+  });
+});

--- a/gravitee-am-test/specs/management/automation/domain-certificates-saml.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-certificates-saml.jest.spec.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Certificates are managed individually under a domain via the
+ * /domains/{domainKey}/certificates endpoints — key-keyed, each PUT manages one certificate.
+ * Domain SAML settings reference one of them by `key`, resolved with eventual consistency.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { uniqueName } from '@utils-commands/misc';
+import { setup } from '../../test-fixture';
+import { AutomationDomainFixture, setupAutomationDomainFixture } from './fixtures/automation-domain-fixture';
+import { buildAutomationCertificateDef, buildAutomationDomainDef, buildSystemAutomationDef } from './fixtures/automation-definitions';
+
+setup(120000);
+
+let fixture: AutomationDomainFixture;
+
+beforeAll(async () => {
+  fixture = await setupAutomationDomainFixture({ keyPrefix: 'autocert' });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('Automation API - Certificates (resource under a domain)', () => {
+  const certKey = uniqueName('autosign', true).toLowerCase();
+
+  it('should expose no automation-managed certificates on a freshly-created domain', async () => {
+    const response = await fixture.client.listCertificates(fixture.domainKey);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+  });
+
+  it('should create a certificate via PUT', async () => {
+    const response = await fixture.client.putCertificate(
+      fixture.domainKey,
+      buildAutomationCertificateDef({ key: certKey }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(certKey);
+    // internal id / operational flags are intentionally not surfaced
+    expect(response.body.id).toBeUndefined();
+    expect(response.body.managedBy).toBeUndefined();
+    // a non-system certificate
+    expect(response.body.system ?? false).toBe(false);
+  });
+
+  it('should round-trip the certificate on GET', async () => {
+    const response = await fixture.client.getCertificate(fixture.domainKey, certKey);
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(certKey);
+  });
+
+  it('should update the certificate via a second PUT (idempotent)', async () => {
+    const response = await fixture.client.putCertificate(
+      fixture.domainKey,
+      buildAutomationCertificateDef({ key: certKey, name: 'Renamed cert' }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.name).toEqual('Renamed cert');
+  });
+
+  it('should reject an invalid key pattern (400)', async () => {
+    const response = await fixture.client.putCertificate(
+      fixture.domainKey,
+      buildAutomationCertificateDef({ key: 'Invalid Key!' }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 404 for an unknown certificate key', async () => {
+    const response = await fixture.client.getCertificate(fixture.domainKey, 'does-not-exist-xyz');
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 404 for certificates of an unknown domain', async () => {
+    const response = await fixture.client.listCertificates('no-such-domain-xyz');
+    expect(response.status).toBe(404);
+  });
+
+  it('should delete the certificate', async () => {
+    // also frees its keystore alias, which is unique per domain among non-default certificates
+    const del = await fixture.client.deleteCertificate(fixture.domainKey, certKey);
+    expect(del.status).toBe(204);
+
+    const get = await fixture.client.getCertificate(fixture.domainKey, certKey);
+    expect(get.status).toBe(404);
+  });
+});
+
+describe('Automation API - System certificate', () => {
+  const systemKey = uniqueName('autosyscert', true).toLowerCase();
+  const secondSystemKey = uniqueName('autosyscert2', true).toLowerCase();
+
+  it('should create a system certificate from a minimal {key, system:true} payload', async () => {
+    const response = await fixture.client.putCertificate(
+      fixture.domainKey,
+      buildSystemAutomationDef(systemKey),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(systemKey);
+    expect(response.body.system).toBe(true);
+  });
+
+  it('should be idempotent on re-PUT of a system certificate (200, no update)', async () => {
+    const response = await fixture.client.putCertificate(
+      fixture.domainKey,
+      buildSystemAutomationDef(systemKey),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.system).toBe(true);
+    expect(response.body.key).toEqual(systemKey);
+  });
+
+  it('should reject a second system certificate (400)', async () => {
+    const response = await fixture.client.putCertificate(
+      fixture.domainKey,
+      buildSystemAutomationDef(secondSystemKey),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject flipping system on an existing certificate (400)', async () => {
+    // the system cert was created with system:true; PUT it again as non-system -> rejected (immutable)
+    const response = await fixture.client.putCertificate(
+      fixture.domainKey,
+      buildAutomationCertificateDef({ key: systemKey, system: false }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should delete the system certificate without a system guard', async () => {
+    const del = await fixture.client.deleteCertificate(fixture.domainKey, systemKey);
+    expect(del.status).toBe(204);
+
+    const get = await fixture.client.getCertificate(fixture.domainKey, systemKey);
+    expect(get.status).toBe(404);
+  });
+});
+
+describe('Automation API - Domain SAML certificate reference (by key)', () => {
+  const samlCertKey = uniqueName('autosaml', true).toLowerCase();
+
+  const domainDefinition = (certificateKey: string | null) =>
+    buildAutomationDomainDef({
+      key: fixture.domainKey,
+      saml: {
+        enabled: true,
+        entityId: `https://idp.example.com/${fixture.domainKey}`,
+        certificate: certificateKey,
+      },
+    });
+
+  it('should accept a SAML reference to a not-yet-created certificate (eventual consistency)', async () => {
+    const response = await fixture.client.putDomain(domainDefinition(samlCertKey));
+    expect(response.status).toBe(200);
+    // the key round-trips even though the certificate does not exist yet
+    expect(response.body.saml.certificate).toEqual(samlCertKey);
+  });
+
+  it('should keep the SAML reference once the certificate is created', async () => {
+    // self-contained (no dependency on the previous test): establish the reference, create the
+    // certificate, then confirm a fresh GET round-trips the key — i.e. it is re-read from the
+    // datastore, not just echoed from the in-memory PUT response.
+    const ref = await fixture.client.putDomain(domainDefinition(samlCertKey));
+    expect(ref.status).toBe(200);
+
+    const created = await fixture.client.putCertificate(
+      fixture.domainKey,
+      buildAutomationCertificateDef({ key: samlCertKey }),
+    );
+    expect(created.status).toBe(200);
+
+    const get = await fixture.client.getDomain(fixture.domainKey);
+    expect(get.body.saml.certificate).toEqual(samlCertKey);
+  });
+
+  it('should strictly reconcile settings: omitting SAML on PUT resets it', async () => {
+    const put = await fixture.client.putDomain(buildAutomationDomainDef({ key: fixture.domainKey }));
+    expect(put.status).toBe(200);
+    expect(put.body.saml ?? null).toBeNull();
+  });
+});

--- a/gravitee-am-test/specs/management/automation/domain-identity-providers.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-identity-providers.jest.spec.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Identity providers are managed individually under a domain via the
+ * /domains/{domainKey}/identity-providers endpoints — key-keyed, each PUT manages one IdP.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { uniqueName } from '@utils-commands/misc';
+import { setup } from '../../test-fixture';
+import {
+  AutomationDomainFixture,
+  setupAutomationDomainFixture,
+} from './fixtures/automation-domain-fixture';
+import { buildAutomationDomainDef, buildInlineIdpDef, buildSystemAutomationDef } from './fixtures/automation-definitions';
+
+setup(120000);
+
+let fixture: AutomationDomainFixture;
+
+beforeAll(async () => {
+  fixture = await setupAutomationDomainFixture({ keyPrefix: 'autodomidp' });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('Automation API - Identity providers (resource under a domain)', () => {
+  const idpKey = uniqueName('autoinline', true).toLowerCase();
+
+  it('should expose no automation-managed identity providers on a freshly-created domain', async () => {
+    const response = await fixture.client.listIdentityProviders(fixture.domainKey);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+  });
+
+  it('should create an inline identity provider via PUT', async () => {
+    const response = await fixture.client.putIdentityProvider(
+      fixture.domainKey,
+      buildInlineIdpDef({ key: idpKey, users: [{ username: 'testuser', password: 'Password1!' }] }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(idpKey);
+    expect(response.body.name).toEqual(`Automation IDP ${idpKey}`);
+    expect(response.body.type).toEqual('inline-am-idp');
+    // internal id / operational flags are intentionally not surfaced
+    expect(response.body.id).toBeUndefined();
+    expect(response.body.managedBy).toBeUndefined();
+    expect(response.body.system).toBe(false);
+  });
+
+  it('should round-trip the identity provider on GET', async () => {
+    const response = await fixture.client.getIdentityProvider(fixture.domainKey, idpKey);
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(idpKey);
+    expect(response.body.name).toEqual(`Automation IDP ${idpKey}`);
+  });
+
+  it('should list the identity provider under the domain', async () => {
+    const response = await fixture.client.listIdentityProviders(fixture.domainKey);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([expect.objectContaining({ key: idpKey })]);
+  });
+
+  it('should update the identity provider via a second PUT (idempotent)', async () => {
+    const response = await fixture.client.putIdentityProvider(
+      fixture.domainKey,
+      buildInlineIdpDef({
+        key: idpKey,
+        name: `Automation IDP ${idpKey} Updated`,
+        users: [{ username: 'testuser2', password: 'Password2!' }],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.name).toEqual(`Automation IDP ${idpKey} Updated`);
+  });
+
+  it('should reject an invalid key pattern (400)', async () => {
+    const response = await fixture.client.putIdentityProvider(
+      fixture.domainKey,
+      buildInlineIdpDef({ key: 'Invalid Key!', users: [{ username: 'u', password: 'P@ssword1' }] }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 404 for an unknown identity provider key', async () => {
+    const response = await fixture.client.getIdentityProvider(fixture.domainKey, 'does-not-exist-xyz');
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 404 for identity providers of an unknown domain', async () => {
+    const response = await fixture.client.listIdentityProviders('no-such-domain-xyz');
+    expect(response.status).toBe(404);
+  });
+
+  it('should delete the identity provider', async () => {
+    const del = await fixture.client.deleteIdentityProvider(fixture.domainKey, idpKey);
+    expect(del.status).toBe(204);
+
+    const get = await fixture.client.getIdentityProvider(fixture.domainKey, idpKey);
+    expect(get.status).toBe(404);
+  });
+});
+
+describe('Automation API - Domain - defaultIdentityProviderForRegistration reference', () => {
+  const idpKey = uniqueName('autodefidp', true).toLowerCase();
+
+  it('should accept a null reference on the initial domain PUT', async () => {
+    const response = await fixture.client.putDomain(
+      buildAutomationDomainDef({ key: fixture.domainKey, accountSettings: { inherited: false } }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.accountSettings?.defaultIdentityProviderForRegistration ?? null).toBeNull();
+  });
+
+  it('should accept a reference to a not-yet-created identity provider (eventual consistency)', async () => {
+    const response = await fixture.client.putDomain(
+      buildAutomationDomainDef({
+        key: fixture.domainKey,
+        accountSettings: { defaultIdentityProviderForRegistration: 'not-created-yet' },
+      }),
+    );
+    // the reference is accepted and the key round-trips even though the IdP does not exist yet
+    expect(response.status).toBe(200);
+    expect(response.body.accountSettings.defaultIdentityProviderForRegistration).toEqual('not-created-yet');
+  });
+
+  it('should resolve a reference to a pre-created identity provider', async () => {
+    const created = await fixture.client.putIdentityProvider(
+      fixture.domainKey,
+      buildInlineIdpDef({ key: idpKey, users: [{ username: 'reg', password: 'P@ssword1' }] }),
+    );
+    expect(created.status).toBe(200);
+
+    const response = await fixture.client.putDomain(
+      buildAutomationDomainDef({
+        key: fixture.domainKey,
+        accountSettings: { defaultIdentityProviderForRegistration: idpKey },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.accountSettings.defaultIdentityProviderForRegistration).toEqual(idpKey);
+  });
+});
+
+describe('Automation API - System identity provider', () => {
+  const systemIdpKey = uniqueName('autosysidp', true).toLowerCase();
+  const secondSystemKey = uniqueName('autosysidp2', true).toLowerCase();
+
+  it('should create a system identity provider from a minimal {key, system:true} payload', async () => {
+    const response = await fixture.client.putIdentityProvider(
+      fixture.domainKey,
+      buildSystemAutomationDef(systemIdpKey),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(systemIdpKey);
+    expect(response.body.system).toBe(true);
+  });
+
+  it('should be idempotent on re-PUT of a system identity provider (200, no update)', async () => {
+    const response = await fixture.client.putIdentityProvider(
+      fixture.domainKey,
+      buildSystemAutomationDef(systemIdpKey),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.system).toBe(true);
+    expect(response.body.key).toEqual(systemIdpKey);
+  });
+
+  it('should reject a second system identity provider (400)', async () => {
+    const response = await fixture.client.putIdentityProvider(
+      fixture.domainKey,
+      buildSystemAutomationDef(secondSystemKey),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject flipping system on an existing identity provider (400)', async () => {
+    // systemIdpKey was created with system:true; PUT it again as non-system -> rejected (immutable)
+    const response = await fixture.client.putIdentityProvider(
+      fixture.domainKey,
+      buildInlineIdpDef({ key: systemIdpKey, system: false, users: [{ username: 'def', password: 'P@ssword1' }] }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should delete the system identity provider without a system guard', async () => {
+    const del = await fixture.client.deleteIdentityProvider(fixture.domainKey, systemIdpKey);
+    expect(del.status).toBe(204);
+  });
+});

--- a/gravitee-am-test/specs/management/automation/domain-reporters.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-reporters.jest.spec.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Reporters are managed individually under a domain via the
+ * /domains/{domainKey}/reporters endpoints — key-keyed, each PUT manages one reporter.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { uniqueName } from '@utils-commands/misc';
+import { setup } from '../../test-fixture';
+import { AutomationDomainFixture, setupAutomationDomainFixture } from './fixtures/automation-domain-fixture';
+import { buildAutomationReporterDef, buildSystemAutomationDef } from './fixtures/automation-definitions';
+
+setup(120000);
+
+let fixture: AutomationDomainFixture;
+
+beforeAll(async () => {
+  fixture = await setupAutomationDomainFixture({ keyPrefix: 'autorep' });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('Automation API - Reporters (resource under a domain)', () => {
+  const reporterKey = uniqueName('autoaudit', true).toLowerCase();
+
+  it('should expose no automation-managed reporters on a freshly-created domain', async () => {
+    const response = await fixture.client.listReporters(fixture.domainKey);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+  });
+
+  it('should create a reporter via PUT', async () => {
+    const response = await fixture.client.putReporter(
+      fixture.domainKey,
+      buildAutomationReporterDef({ key: reporterKey }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(reporterKey);
+    expect(response.body.type).toEqual('reporter-am-kafka');
+    // internal id / operational flags are intentionally not surfaced
+    expect(response.body.id).toBeUndefined();
+    expect(response.body.managedBy).toBeUndefined();
+    expect(response.body.system ?? false).toBe(false);
+  });
+
+  it('should round-trip the reporter on GET', async () => {
+    const response = await fixture.client.getReporter(fixture.domainKey, reporterKey);
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(reporterKey);
+  });
+
+  it('should list the reporter under the domain', async () => {
+    const response = await fixture.client.listReporters(fixture.domainKey);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([expect.objectContaining({ key: reporterKey })]);
+  });
+
+  it('should update the reporter via a second PUT (idempotent)', async () => {
+    const response = await fixture.client.putReporter(
+      fixture.domainKey,
+      buildAutomationReporterDef({ key: reporterKey, name: 'Renamed reporter' }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.name).toEqual('Renamed reporter');
+  });
+
+  it('should reject an invalid key pattern (400)', async () => {
+    const response = await fixture.client.putReporter(
+      fixture.domainKey,
+      buildAutomationReporterDef({ key: 'Invalid Key!' }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 404 for an unknown reporter key', async () => {
+    const response = await fixture.client.getReporter(fixture.domainKey, 'does-not-exist-xyz');
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 404 for reporters of an unknown domain', async () => {
+    const response = await fixture.client.listReporters('no-such-domain-xyz');
+    expect(response.status).toBe(404);
+  });
+
+  it('should delete the reporter', async () => {
+    const del = await fixture.client.deleteReporter(fixture.domainKey, reporterKey);
+    expect(del.status).toBe(204);
+
+    const get = await fixture.client.getReporter(fixture.domainKey, reporterKey);
+    expect(get.status).toBe(404);
+  });
+});
+
+describe('Automation API - System reporter', () => {
+  const systemKey = uniqueName('autosysrep', true).toLowerCase();
+  const secondSystemKey = uniqueName('autosysrep2', true).toLowerCase();
+
+  it('should create a system reporter from a minimal {key, system:true} payload', async () => {
+    const response = await fixture.client.putReporter(
+      fixture.domainKey,
+      buildSystemAutomationDef(systemKey),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(systemKey);
+    expect(response.body.system).toBe(true);
+  });
+
+  it('should be idempotent on re-PUT of a system reporter (200, no update)', async () => {
+    const response = await fixture.client.putReporter(
+      fixture.domainKey,
+      buildSystemAutomationDef(systemKey),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.system).toBe(true);
+    expect(response.body.key).toEqual(systemKey);
+  });
+
+  it('should reject a second system reporter (400)', async () => {
+    const response = await fixture.client.putReporter(
+      fixture.domainKey,
+      buildSystemAutomationDef(secondSystemKey),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject flipping system on an existing reporter (400)', async () => {
+    // the system reporter was created with system:true; PUT it again as non-system -> rejected (immutable)
+    const response = await fixture.client.putReporter(
+      fixture.domainKey,
+      buildAutomationReporterDef({ key: systemKey, system: false }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('should delete the system reporter without a system guard', async () => {
+    const del = await fixture.client.deleteReporter(fixture.domainKey, systemKey);
+    expect(del.status).toBe(204);
+  });
+});

--- a/gravitee-am-test/specs/management/automation/domains.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domains.jest.spec.ts
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { uniqueName } from '@utils-commands/misc';
+import { setup } from '../../test-fixture';
+import {
+  AutomationAuthFixture,
+  setupAutomationAuthFixture,
+} from './fixtures/automation-domain-fixture';
+import { buildAutomationDomainDef } from './fixtures/automation-definitions';
+
+setup();
+
+let fixture: AutomationAuthFixture;
+const createdDomainKeys: string[] = [];
+
+beforeAll(async () => {
+  fixture = await setupAutomationAuthFixture();
+});
+
+afterAll(async () => {
+  for (const key of createdDomainKeys) {
+    await fixture.client.deleteDomain(key);
+  }
+});
+
+describe('Automation API - Domain - List', () => {
+  it('should list domains for the default environment', async () => {
+    const response = await fixture.client.listDomains();
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body)).toBe(true);
+  });
+});
+
+describe('Automation API - Domain - PUT on collection (Idempotent Create/Update)', () => {
+  const domainKey = uniqueName('autodom', true).toLowerCase();
+
+  it('should create a new domain via PUT to collection with key in body', async () => {
+    const response = await fixture.client.putDomain(
+      buildAutomationDomainDef({
+        key: domainKey,
+        name: `Automation Domain ${domainKey}`,
+        enabled: true,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    // Internal id is intentionally not exposed — the Automation API is key-only.
+    expect(response.body.id).toBeUndefined();
+    expect(response.body.key).toEqual(domainKey);
+    expect(response.body.name).toEqual(`Automation Domain ${domainKey}`);
+    expect(response.body.description).toEqual('Created via Automation API');
+    createdDomainKeys.push(domainKey);
+  });
+
+  it('should be idempotent on a subsequent PUT (createdAt unchanged)', async () => {
+    const first = await fixture.client.getDomain(domainKey);
+    expect(first.status).toBe(200);
+
+    const response = await fixture.client.putDomain(
+      buildAutomationDomainDef({ key: domainKey, enabled: true }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(domainKey);
+    // createdAt is stable across an update; a duplicate create would reset it
+    expect(response.body.createdAt).toEqual(first.body.createdAt);
+  });
+
+  it('should retrieve the created domain by key via path', async () => {
+    const response = await fixture.client.getDomain(domainKey);
+
+    expect(response.status).toBe(200);
+    expect(response.body.name).toEqual(`Automation Domain ${domainKey}`);
+  });
+
+  it('should update the domain via second PUT to collection (idempotent)', async () => {
+    const response = await fixture.client.putDomain(
+      buildAutomationDomainDef({
+        key: domainKey,
+        description: 'Updated via Automation API',
+        enabled: true,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.description).toEqual('Updated via Automation API');
+    expect(createdDomainKeys).toContain(response.body.key);
+  });
+
+  it('should appear in the domain list', async () => {
+    const response = await fixture.client.listDomains();
+
+    expect(response.status).toBe(200);
+    const found = response.body.find((d: any) => d.key === domainKey);
+    expect(found).toEqual(expect.objectContaining({ key: domainKey }));
+  });
+});
+
+describe('Automation API - Domain - DELETE via path', () => {
+  const deleteKey = uniqueName('autodel', true).toLowerCase();
+
+  it('should create then delete a domain', async () => {
+    const createResponse = await fixture.client.putDomain(
+      buildAutomationDomainDef({
+        key: deleteKey,
+        name: `Delete Me ${deleteKey}`,
+        description: 'To be deleted',
+      }),
+    );
+    expect(createResponse.status).toBe(200);
+    expect(createResponse.body.key).toEqual(deleteKey);
+
+    const deleteResponse = await fixture.client.deleteDomain(deleteKey);
+    expect(deleteResponse.status).toBe(204);
+
+    const getResponse = await fixture.client.getDomain(deleteKey);
+    expect(getResponse.status).toBe(404);
+  });
+});
+
+describe('Automation API - Domain - Error Handling', () => {
+  it('should return 404 for a non-existent domain key', async () => {
+    const response = await fixture.client.getDomain('does-not-exist-xyz');
+
+    expect(response.status).toBe(404);
+  });
+
+  it('should reject PUT with missing required key (400)', async () => {
+    const response = await fixture.client.putDomain({ name: 'Missing key field' });
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('Automation API - Domain - Round-trip preserves all writable fields', () => {
+  const roundTripKey = uniqueName('autorr', true).toLowerCase();
+
+  // Settings blocks chosen to cover the major paths through AutomationDomainMapper:
+  //  - shared sub-models reused by reference (login/cors/account/scim/password)
+  //  - the OIDC wrapper (we project name-keyed CIBA references through it)
+  //  - tags/vhosts (lists)
+  const fullDef = () =>
+    buildAutomationDomainDef({
+      key: roundTripKey,
+      name: `Round-trip ${roundTripKey}`,
+      description: 'covers every settings block we surface',
+      enabled: false, // diverges from the build* default; must survive the round-trip
+      tags: ['alpha', 'beta'],
+      vhosts: [{ host: 'auth.example.com', path: `/${roundTripKey}`, overrideEntrypoint: true }],
+      oidc: {
+        redirectUriStrictMatching: true,
+        postLogoutRedirectUris: ['https://app.example.com/post-logout'],
+        requestUris: ['https://app.example.com/request'],
+        clientRegistrationSettings: {
+          allowLocalhostRedirectUri: true,
+          allowHttpSchemeRedirectUri: true,
+          isDynamicClientRegistrationEnabled: true,
+        },
+        securityProfileSettings: {
+          enablePlainFapi: true,
+        },
+      },
+      loginSettings: {
+        inherited: false,
+        registerEnabled: true,
+        forgotPasswordEnabled: true,
+        rememberMeEnabled: true,
+        hideForm: false,
+      },
+      accountSettings: {
+        inherited: false,
+        loginAttemptsDetectionEnabled: true,
+        maxLoginAttempts: 5,
+        loginAttemptsResetTime: 600,
+        rememberMe: true,
+        rememberMeDuration: 86400,
+      },
+      passwordSettings: {
+        inherited: false,
+        minLength: 12,
+        maxLength: 64,
+        includeNumbers: true,
+        includeSpecialCharacters: true,
+        lettersInMixedCase: true,
+      },
+      corsSettings: {
+        enabled: true,
+        allowedOrigins: ['https://app.example.com'],
+        allowedMethods: ['GET', 'POST'],
+        allowedHeaders: ['Authorization', 'Content-Type'],
+        allowCredentials: true,
+        maxAge: 3600,
+      },
+      scim: { enabled: true },
+      selfServiceAccountManagementSettings: { enabled: true },
+    });
+
+  it('should create the domain with every settings block populated', async () => {
+    const response = await fixture.client.putDomain(fullDef());
+    expect(response.status).toBe(200);
+    createdDomainKeys.push(roundTripKey);
+  });
+
+  it('should return every settings block unchanged on GET', async () => {
+    const response = await fixture.client.getDomain(roundTripKey);
+    expect(response.status).toBe(200);
+
+    const body = response.body;
+    expect(body.key).toEqual(roundTripKey);
+    expect(body.enabled).toBe(false);
+    expect(body.tags).toEqual(expect.arrayContaining(['alpha', 'beta']));
+    expect(body.vhosts).toEqual([
+      expect.objectContaining({
+        host: 'auth.example.com',
+        path: `/${roundTripKey}`,
+        overrideEntrypoint: true,
+      }),
+    ]);
+
+    expect(body.oidc.redirectUriStrictMatching).toBe(true);
+    expect(body.oidc.postLogoutRedirectUris).toEqual(['https://app.example.com/post-logout']);
+    expect(body.oidc.requestUris).toEqual(['https://app.example.com/request']);
+    expect(body.oidc.clientRegistrationSettings).toEqual(
+      expect.objectContaining({
+        allowLocalhostRedirectUri: true,
+        allowHttpSchemeRedirectUri: true,
+        isDynamicClientRegistrationEnabled: true,
+      }),
+    );
+    expect(body.oidc.securityProfileSettings).toEqual(expect.objectContaining({ enablePlainFapi: true }));
+
+    expect(body.loginSettings).toEqual(expect.objectContaining({
+      registerEnabled: true,
+      forgotPasswordEnabled: true,
+      rememberMeEnabled: true,
+      hideForm: false,
+    }));
+
+    expect(body.accountSettings).toEqual(expect.objectContaining({
+      loginAttemptsDetectionEnabled: true,
+      maxLoginAttempts: 5,
+      loginAttemptsResetTime: 600,
+      rememberMe: true,
+      rememberMeDuration: 86400,
+    }));
+
+    expect(body.passwordSettings).toEqual(expect.objectContaining({
+      minLength: 12,
+      maxLength: 64,
+      includeNumbers: true,
+      includeSpecialCharacters: true,
+      lettersInMixedCase: true,
+    }));
+
+    expect(body.corsSettings).toEqual(expect.objectContaining({
+      enabled: true,
+      allowCredentials: true,
+      maxAge: 3600,
+    }));
+    expect(body.corsSettings.allowedOrigins).toEqual(['https://app.example.com']);
+    expect(body.corsSettings.allowedMethods).toEqual(expect.arrayContaining(['GET', 'POST']));
+    expect(body.corsSettings.allowedHeaders).toEqual(expect.arrayContaining(['Authorization', 'Content-Type']));
+
+    expect(body.scim).toEqual(expect.objectContaining({ enabled: true }));
+    expect(body.selfServiceAccountManagementSettings).toEqual(expect.objectContaining({ enabled: true }));
+  });
+
+  it('should preserve untouched fields when one block is changed on update', async () => {
+    const before = await fixture.client.getDomain(roundTripKey);
+
+    // Modify only the description; every other declared block stays the same
+    const mutated = { ...fullDef(), description: 'updated round-trip description' };
+    const put = await fixture.client.putDomain(mutated);
+    expect(put.status).toBe(200);
+
+    const after = await fixture.client.getDomain(roundTripKey);
+    expect(after.body.description).toEqual('updated round-trip description');
+    // every other block must still match what came back before the update
+    expect(after.body.tags).toEqual(before.body.tags);
+    expect(after.body.vhosts).toEqual(before.body.vhosts);
+    expect(after.body.oidc).toEqual(before.body.oidc);
+    expect(after.body.loginSettings).toEqual(before.body.loginSettings);
+    expect(after.body.accountSettings).toEqual(before.body.accountSettings);
+    expect(after.body.passwordSettings).toEqual(before.body.passwordSettings);
+    expect(after.body.corsSettings).toEqual(before.body.corsSettings);
+    expect(after.body.scim).toEqual(before.body.scim);
+    expect(after.body.selfServiceAccountManagementSettings).toEqual(before.body.selfServiceAccountManagementSettings);
+    expect(after.body.createdAt).toEqual(before.body.createdAt);
+  });
+
+  it('should strictly reset a settings block omitted from the PUT payload', async () => {
+    // Omit loginSettings entirely; declarative semantics must wipe it (null)
+    const without = { ...fullDef() };
+    delete (without as any).loginSettings;
+
+    const put = await fixture.client.putDomain(without);
+    expect(put.status).toBe(200);
+    expect(put.body.loginSettings ?? null).toBeNull();
+
+    const get = await fixture.client.getDomain(roundTripKey);
+    expect(get.body.loginSettings ?? null).toBeNull();
+  });
+
+  it('should not surface any internal-id field on PUT, GET or list', async () => {
+    const put = await fixture.client.putDomain(fullDef());
+    const get = await fixture.client.getDomain(roundTripKey);
+    const list = await fixture.client.listDomains();
+    const fromList = list.body.find((d: any) => d.key === roundTripKey);
+
+    for (const body of [put.body, get.body, fromList]) {
+      expect(body.id).toBeUndefined();
+      expect(body.referenceId).toBeUndefined();
+      expect(body.referenceType).toBeUndefined();
+      expect(body.managedBy).toBeUndefined();
+    }
+  });
+});

--- a/gravitee-am-test/specs/management/automation/fixtures/automation-client.ts
+++ b/gravitee-am-test/specs/management/automation/fixtures/automation-client.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { performDelete, performGet, performPut } from '@gateway-commands/oauth-oidc-commands';
+
+export const automationUrl = (): string => `${process.env.AM_MANAGEMENT_URL}/management/automation`;
+
+export const envPath = (): string =>
+  `/organizations/${process.env.AM_DEF_ORG_ID}/environments/${process.env.AM_DEF_ENV_ID}`;
+
+export const jsonHeaders = (extra: Record<string, string> = {}): Record<string, string> => ({
+  'Content-Type': 'application/json',
+  ...extra,
+});
+
+export const authHeaders = (accessToken: string, extra: Record<string, string> = {}): Record<string, string> =>
+  jsonHeaders({ Authorization: `Bearer ${accessToken}`, ...extra });
+
+/**
+ * Thin wrapper around the raw `performX` calls so specs don't repeat
+ * URL/header construction for every request. Returns the raw supertest
+ * response (non-2xx does not throw) so tests assert status explicitly.
+ */
+export class AutomationClient {
+  constructor(private readonly accessToken: string) {}
+
+  private headers() {
+    return authHeaders(this.accessToken);
+  }
+
+  // ---- Domains ----------------------------------------------------------
+
+  listDomains() {
+    return performGet(automationUrl(), `${envPath()}/domains`, this.headers());
+  }
+
+  putDomain(definition: object) {
+    return performPut(automationUrl(), `${envPath()}/domains`, definition, this.headers());
+  }
+
+  getDomain(key: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${key}`, this.headers());
+  }
+
+  deleteDomain(key: string) {
+    return performDelete(automationUrl(), `${envPath()}/domains/${key}`, this.headers());
+  }
+
+  // ---- Identity providers (under a domain) ------------------------------
+
+  listIdentityProviders(domainKey: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/identity-providers`, this.headers());
+  }
+
+  putIdentityProvider(domainKey: string, definition: object) {
+    return performPut(automationUrl(), `${envPath()}/domains/${domainKey}/identity-providers`, definition, this.headers());
+  }
+
+  getIdentityProvider(domainKey: string, idpKey: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/identity-providers/${idpKey}`, this.headers());
+  }
+
+  deleteIdentityProvider(domainKey: string, idpKey: string) {
+    return performDelete(automationUrl(), `${envPath()}/domains/${domainKey}/identity-providers/${idpKey}`, this.headers());
+  }
+
+  // ---- Certificates (under a domain) ------------------------------------
+
+  listCertificates(domainKey: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/certificates`, this.headers());
+  }
+
+  putCertificate(domainKey: string, definition: object) {
+    return performPut(automationUrl(), `${envPath()}/domains/${domainKey}/certificates`, definition, this.headers());
+  }
+
+  getCertificate(domainKey: string, certKey: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/certificates/${certKey}`, this.headers());
+  }
+
+  deleteCertificate(domainKey: string, certKey: string) {
+    return performDelete(automationUrl(), `${envPath()}/domains/${domainKey}/certificates/${certKey}`, this.headers());
+  }
+
+  // ---- Reporters (under a domain) ---------------------------------------
+
+  listReporters(domainKey: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/reporters`, this.headers());
+  }
+
+  putReporter(domainKey: string, definition: object) {
+    return performPut(automationUrl(), `${envPath()}/domains/${domainKey}/reporters`, definition, this.headers());
+  }
+
+  getReporter(domainKey: string, reporterKey: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/reporters/${reporterKey}`, this.headers());
+  }
+
+  deleteReporter(domainKey: string, reporterKey: string) {
+    return performDelete(automationUrl(), `${envPath()}/domains/${domainKey}/reporters/${reporterKey}`, this.headers());
+  }
+
+  // ---- Generic escape hatches (auth + path) -----------------------------
+
+  rawGet(path: string, headerOverride?: Record<string, string>) {
+    return performGet(automationUrl(), path, headerOverride ?? this.headers());
+  }
+}

--- a/gravitee-am-test/specs/management/automation/fixtures/automation-definitions.ts
+++ b/gravitee-am-test/specs/management/automation/fixtures/automation-definitions.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildCertificate } from '@api-fixtures/certificates';
+import { buildKafkaReporterConfigJson } from '../../reporters/fixtures/kafka-reporter-config-helper';
+
+export interface AutomationDomainDef {
+  key: string;
+  name?: string;
+  description?: string;
+  path?: string;
+  enabled?: boolean;
+  dataPlaneId?: string;
+  certificates?: object[];
+  accountSettings?: Record<string, unknown>;
+  saml?: object | null;
+  [extra: string]: unknown;
+}
+
+const defaultDataPlaneId = (): string => process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
+
+/**
+ * Build an Automation API domain definition with sensible defaults for path,
+ * name and dataPlaneId. Overrides win — pass `path` or `name` to set them
+ * explicitly, or include extra top-level keys (e.g. `saml`, `certificates`).
+ */
+export const buildAutomationDomainDef = (overrides: AutomationDomainDef): AutomationDomainDef => ({
+  name: `Automation Domain ${overrides.key}`,
+  description: 'Created via Automation API',
+  path: `/${overrides.key}`,
+  dataPlaneId: defaultDataPlaneId(),
+  ...overrides,
+});
+
+export interface InlineUser {
+  username: string;
+  password: string;
+  firstname?: string;
+  lastname?: string;
+}
+
+export interface AutomationIdpDef {
+  key: string;
+  name: string;
+  type: string;
+  configuration: string;
+}
+
+/**
+ * Build an inline-am-idp definition. `users` is serialized into the
+ * `configuration` string field expected by the Automation API.
+ */
+export const buildInlineIdpDef = (overrides: {
+  key: string;
+  name?: string;
+  system?: boolean;
+  users: InlineUser[];
+}): AutomationIdpDef => ({
+  key: overrides.key,
+  name: overrides.name ?? `Automation IDP ${overrides.key}`,
+  type: 'inline-am-idp',
+  ...(overrides.system !== undefined ? { system: overrides.system } : {}),
+  configuration: JSON.stringify({
+    users: overrides.users.map((u) => ({
+      firstname: u.firstname ?? 'Test',
+      lastname: u.lastname ?? 'User',
+      username: u.username,
+      password: u.password,
+    })),
+  }),
+});
+
+/**
+ * Build an Automation API certificate definition keyed by `key`, reusing a known-good
+ * java-keystore certificate configuration. Pass `system: true` to mark it the domain's
+ * system certificate — in which case only `key` is meaningful and the certificate material
+ * is built from `domains.certificates.default.*` settings in {@code gravitee.yaml}.
+ */
+export const buildAutomationCertificateDef = (overrides: {
+  key: string;
+  name?: string;
+  system?: boolean;
+}): object => ({
+  ...buildCertificate(0),
+  key: overrides.key,
+  name: overrides.name ?? `Automation cert ${overrides.key}`,
+  ...(overrides.system !== undefined ? { system: overrides.system } : {}),
+});
+
+/**
+ * Build an Automation API reporter definition keyed by `key`, using a schema-valid Kafka
+ * reporter configuration. Pass `system: true` to mark it the domain's system reporter — in
+ * which case only `key` is meaningful and the reporter is built from
+ * `domains.reporters.default.*` and repository settings in {@code gravitee.yaml}.
+ */
+export const buildAutomationReporterDef = (overrides: {
+  key: string;
+  name?: string;
+  system?: boolean;
+  configuration?: string;
+}): object => ({
+  key: overrides.key,
+  name: overrides.name ?? `Automation reporter ${overrides.key}`,
+  type: 'reporter-am-kafka',
+  configuration: overrides.configuration ?? buildKafkaReporterConfigJson(),
+  ...(overrides.system !== undefined ? { system: overrides.system } : {}),
+});
+
+/**
+ * Build a minimal system payload — only `key` and `system:true`. {@code name}, {@code type}
+ * and {@code configuration} are not required when {@code system} is true; the resource is
+ * built from `gravitee.yaml` settings on the server side. Use this for the system path; use
+ * {@link buildAutomationCertificateDef}/{@link buildAutomationReporterDef} for the non-system path.
+ */
+export const buildSystemAutomationDef = (key: string): object => ({
+  key,
+  system: true,
+});

--- a/gravitee-am-test/specs/management/automation/fixtures/automation-domain-fixture.ts
+++ b/gravitee-am-test/specs/management/automation/fixtures/automation-domain-fixture.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { JWT_FORMAT } from '@specs-utils/jwt-format';
+import { Fixture } from '../../../test-fixture';
+import { AutomationClient } from './automation-client';
+import { AutomationDomainDef, buildAutomationDomainDef } from './automation-definitions';
+
+export interface AutomationAuthFixture extends Fixture {
+  accessToken: string;
+  client: AutomationClient;
+}
+
+/**
+ * Token-only fixture for tests that don't need a domain (auth/openapi).
+ */
+export const setupAutomationAuthFixture = async (): Promise<AutomationAuthFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  expect(accessToken).toMatch(JWT_FORMAT);
+
+  return {
+    accessToken,
+    client: new AutomationClient(accessToken),
+    cleanUp: async () => {},
+  };
+};
+
+export interface AutomationDomainFixture extends AutomationAuthFixture {
+  domainKey: string;
+}
+
+export interface AutomationDomainFixtureOptions {
+  /** Prefix for the unique key; defaults to 'autodom'. */
+  keyPrefix?: string;
+  /** Extra fields merged into the domain definition. */
+  overrides?: Partial<AutomationDomainDef>;
+}
+
+/**
+ * Creates an automation-managed domain via PUT on the Automation API itself
+ * and tears it down via DELETE on the Automation API (key-only).
+ */
+export const setupAutomationDomainFixture = async (
+  options: AutomationDomainFixtureOptions = {},
+): Promise<AutomationDomainFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  expect(accessToken).toMatch(JWT_FORMAT);
+  const client = new AutomationClient(accessToken);
+
+  const domainKey = uniqueName(options.keyPrefix ?? 'autodom', true).toLowerCase();
+  let created = false;
+
+  try {
+    const definition = buildAutomationDomainDef({ key: domainKey, ...(options.overrides ?? {}) });
+    const response = await client.putDomain(definition);
+    expect(response.status).toBe(200);
+    expect(response.body.key).toEqual(domainKey);
+    created = true;
+
+    return {
+      accessToken,
+      client,
+      domainKey,
+      cleanUp: async () => {
+        if (created) {
+          await client.deleteDomain(domainKey);
+        }
+      },
+    };
+  } catch (error) {
+    if (created) {
+      try {
+        await client.deleteDomain(domainKey);
+      } catch (cleanupError) {
+        console.error('Failed to clean up domain after fixture setup error:', cleanupError);
+      }
+    }
+    throw error;
+  }
+};

--- a/gravitee-am-test/specs/management/automation/walkthrough.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/walkthrough.jest.spec.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * End-to-end walkthrough test for the Automation API.
+ *
+ * Simulates a realistic provisioning workflow against the default environment:
+ *   1. Create a "customer-auth" domain, then its identity providers (separate resource)
+ *   2. Update the domain description
+ *   3. Verify idempotency (re-PUT everything)
+ *   4. Tear down
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { JWT_FORMAT } from '@specs-utils/jwt-format';
+import { setup } from '../../test-fixture';
+import { AutomationClient } from './fixtures/automation-client';
+import { buildAutomationDomainDef, buildInlineIdpDef } from './fixtures/automation-definitions';
+
+setup(120000);
+
+const DOMAIN_KEY = uniqueName('customer-auth', true).toLowerCase();
+const TEST_USERS_IDP_KEY = uniqueName('test-users', true).toLowerCase();
+const CORPORATE_IDP_KEY = uniqueName('corporate-idp', true).toLowerCase();
+
+let accessToken: string;
+let client: AutomationClient;
+const cleanupDomainKeys: string[] = [];
+
+beforeAll(async () => {
+  accessToken = await requestAdminAccessToken();
+  expect(accessToken).toMatch(JWT_FORMAT);
+  client = new AutomationClient(accessToken);
+});
+
+afterAll(async () => {
+  for (const key of cleanupDomainKeys) {
+    await client.deleteDomain(key);
+  }
+});
+
+const domainDefinition = (description: string) =>
+  buildAutomationDomainDef({
+    key: DOMAIN_KEY,
+    name: 'Customer Authentication',
+    description,
+    path: `/default/${DOMAIN_KEY}`,
+    enabled: true,
+  });
+
+describe('Walkthrough - Step 1: Create Domain and its Identity Providers', () => {
+  it('should create the customer-auth domain', async () => {
+    const res = await client.putDomain(domainDefinition('Customer auth domain'));
+    expect(res.status).toBe(200);
+    expect(res.body.key).toEqual(DOMAIN_KEY);
+    cleanupDomainKeys.push(res.body.key);
+  });
+
+  it('should create the test-users and corporate identity providers under the domain', async () => {
+    const testUsers = await client.putIdentityProvider(
+      DOMAIN_KEY,
+      buildInlineIdpDef({
+        key: TEST_USERS_IDP_KEY,
+        name: 'Test Users',
+        users: [
+          { username: 'alice', password: 'P@ssword1' },
+          { username: 'bob', password: 'P@ssword1' },
+        ],
+      }),
+    );
+    expect(testUsers.status).toBe(200);
+
+    const corporate = await client.putIdentityProvider(
+      DOMAIN_KEY,
+      buildInlineIdpDef({
+        key: CORPORATE_IDP_KEY,
+        name: 'Corporate Directory',
+        users: [{ username: 'admin', password: 'Admin123!' }],
+      }),
+    );
+    expect(corporate.status).toBe(200);
+  });
+
+  it('should list both identity providers under the domain', async () => {
+    const res = await client.listIdentityProviders(DOMAIN_KEY);
+    expect(res.status).toBe(200);
+    const idpNames = res.body.map((idp: any) => idp.name);
+    expect(idpNames).toContain('Test Users');
+    expect(idpNames).toContain('Corporate Directory');
+  });
+
+  it('should retrieve the customer-auth domain by key', async () => {
+    const res = await client.getDomain(DOMAIN_KEY);
+    expect(res.status).toBe(200);
+    expect(res.body.key).toEqual(DOMAIN_KEY);
+    expect(res.body.description).toEqual('Customer auth domain');
+  });
+});
+
+describe('Walkthrough - Step 2: Update the Domain', () => {
+  it('should update the domain description via PUT', async () => {
+    const res = await client.putDomain(domainDefinition('Updated: now includes social login'));
+    expect(res.status).toBe(200);
+    expect(res.body.description).toEqual('Updated: now includes social login');
+    expect(res.body.key).toEqual(DOMAIN_KEY);
+  });
+});
+
+describe('Walkthrough - Step 3: Verify Idempotency', () => {
+  it('should re-PUT the domain and get the same key with stable createdAt', async () => {
+    const first = await client.putDomain(domainDefinition('Idempotency check'));
+    const second = await client.putDomain(domainDefinition('Idempotency check'));
+
+    expect(first.body.key).toEqual(second.body.key);
+    expect(first.body.createdAt).toEqual(second.body.createdAt);
+  });
+
+  it('should re-PUT an identity provider and preserve its createdAt', async () => {
+    const first = await client.getIdentityProvider(DOMAIN_KEY, TEST_USERS_IDP_KEY);
+    const second = await client.putIdentityProvider(
+      DOMAIN_KEY,
+      buildInlineIdpDef({
+        key: TEST_USERS_IDP_KEY,
+        name: 'Test Users',
+        users: [{ username: 'alice', password: 'P@ssword1' }],
+      }),
+    );
+
+    expect(second.status).toBe(200);
+    expect(second.body.createdAt).toEqual(first.body.createdAt);
+  });
+});
+
+describe('Walkthrough - Step 4: Tear Down', () => {
+  it('should delete the customer-auth domain', async () => {
+    const res = await client.deleteDomain(DOMAIN_KEY);
+    expect(res.status).toBe(204);
+    cleanupDomainKeys.splice(cleanupDomainKeys.indexOf(DOMAIN_KEY), 1);
+  });
+
+  it('should verify the domain is gone (404)', async () => {
+    const res = await client.getDomain(DOMAIN_KEY);
+    expect(res.status).toBe(404);
+  });
+});

--- a/scripts/regen-automation-oas.sh
+++ b/scripts/regen-automation-oas.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Regenerate docs/automation/openapi.yaml using build-time classpath scanning.
+#
+# Uses swagger-maven-plugin-jakarta (generate-oas Maven profile on the
+# gravitee-am-management-api-automation-rest module) to scan the Automation API
+# JAX-RS annotations without starting the management server. The
+# AutomationApiDefinition ReaderListener is auto-discovered and filters the spec
+# to automation-only paths, schemas, and tags, producing output identical to the
+# runtime. The license header and info.version are patched post-generation.
+#
+# Usage:
+#   bash scripts/regen-automation-oas.sh [options]
+#
+#   --output-dir <dir>   Directory to write openapi.yaml into.
+#                        Default: docs/automation/ (overwrites the committed spec).
+#
+#   --also-make          Pass -am to Maven so upstream modules are built first.
+#                        Use this if the module is not already compiled locally.
+#
+#   --maven-settings <file>
+#                        Pass -s <file> to every Maven invocation (CI Artifactory).
+#
+#   --version-only       Skip generation: read project.version from Maven, strip
+#                        a trailing -SNAPSHOT for public info.version, and patch
+#                        only the info.version line in <output-dir>/openapi.yaml.
+#                        Cannot be combined with --also-make.
+#
+# The script patches two things the full-regeneration path cannot leave to the plugin:
+#
+#   info.version  The plugin invokes AutomationApiDefinition.afterScan() which
+#                 reads Version.RUNTIME_VERSION (gravitee-common version, not
+#                 the project version). Patched from pom.xml post-generation.
+#                 Trimmed trailing -SNAPSHOT for the committed spec line.
+#
+#   License header  Extracted from the committed docs/automation/openapi.yaml and
+#                   prepended to the generated file. The committed header is
+#                   the canonical rendered form; it is validated by the
+#                   license-maven-plugin on every mvn validate, so it is
+#                   always correct. This avoids duplicating the template text.
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+MODULE="gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest"
+DEFAULT_OUTPUT_DIR="$REPO_ROOT/docs/automation"
+COMMITTED_SPEC="$REPO_ROOT/docs/automation/openapi.yaml"
+
+OUTPUT_DIR=""
+ALSO_MAKE=""
+MAVEN_SETTINGS_FILE=""
+VERSION_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir) OUTPUT_DIR="${2:?--output-dir requires a path}"; shift 2 ;;
+    --also-make)  ALSO_MAKE="-am"; shift ;;
+    --maven-settings) MAVEN_SETTINGS_FILE="${2:?--maven-settings requires a path}"; shift 2 ;;
+    --version-only) VERSION_ONLY=true; shift ;;
+    *) echo "Error: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -z "$OUTPUT_DIR" ]] && OUTPUT_DIR="$DEFAULT_OUTPUT_DIR"
+OUTPUT_FILE="${OUTPUT_DIR}/openapi.yaml"
+
+MAVEN_ARGS=(-B -ntp)
+if [[ -n "$MAVEN_SETTINGS_FILE" ]]; then
+  MAVEN_ARGS+=(-s "$MAVEN_SETTINGS_FILE")
+fi
+
+patch_info_version() {
+  local target_file="$1"
+  local oas_version="$2"
+  local tmp
+  tmp="$(mktemp)"
+  awk -v ver="$oas_version" '
+    /^info:/                         { in_info=1 }
+    in_info && /^[^ ]/ && !/^info:/ { in_info=0 }
+    in_info && /^  version: /        { print "  version: " ver; next }
+                                     { print }
+  ' "$target_file" > "$tmp"
+  mv "$tmp" "$target_file"
+}
+
+resolve_project_version() {
+  mvn "${MAVEN_ARGS[@]}" -pl "$MODULE" help:evaluate \
+    -Dexpression=project.version -q -DforceStdout | tail -1
+}
+
+if [[ "$VERSION_ONLY" == true ]]; then
+  echo "=== Patching Automation OpenAPI info.version only ==="
+else
+  echo "=== Regenerating Automation OpenAPI spec ==="
+fi
+echo "Output: $OUTPUT_FILE"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 1: Validate
+# ---------------------------------------------------------------------------
+
+if [[ -n "$MAVEN_SETTINGS_FILE" && ! -f "$MAVEN_SETTINGS_FILE" ]]; then
+  echo "Error: maven settings file not found: ${MAVEN_SETTINGS_FILE}" >&2
+  exit 1
+fi
+
+if [[ "$VERSION_ONLY" == true && -n "$ALSO_MAKE" ]]; then
+  echo "Error: --version-only cannot be combined with --also-make" >&2
+  exit 2
+fi
+
+if [[ "$VERSION_ONLY" == true && ! -f "$OUTPUT_FILE" ]]; then
+  echo "Error: spec not found: ${OUTPUT_FILE}" >&2
+  exit 1
+fi
+
+[[ "$VERSION_ONLY" == false ]] && mkdir -p "$OUTPUT_DIR"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Step 2 [full regen]: Capture license header from the committed spec
+# ---------------------------------------------------------------------------
+
+if [[ "$VERSION_ONLY" == false ]]; then
+  HEADER_LINE_COUNT=0
+  if [[ -f "$COMMITTED_SPEC" ]]; then
+    HEADER_LINE_COUNT=$(awk '/^openapi:/{print NR-1; found=1; exit} END {if (!found) print 0}' "$COMMITTED_SPEC")
+    HEADER_CONTENT=$(head -n "$HEADER_LINE_COUNT" "$COMMITTED_SPEC")
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Extract project version
+# ---------------------------------------------------------------------------
+
+PROJECT_VERSION="$(resolve_project_version)"
+
+if [[ -z "$PROJECT_VERSION" ]] || [[ "$PROJECT_VERSION" == *"[ERROR]"* ]]; then
+  echo "Error: could not extract project.version from Maven (see Maven output)." >&2
+  exit 1
+fi
+
+OAS_INFO_VERSION="${PROJECT_VERSION%-SNAPSHOT}"
+echo "Project version: ${PROJECT_VERSION}"
+echo "Public info.version: ${OAS_INFO_VERSION}"
+
+# ---------------------------------------------------------------------------
+# Step 4 [full regen]: Run the swagger-maven-plugin (generate-oas profile)
+# ---------------------------------------------------------------------------
+
+if [[ "$VERSION_ONLY" == false ]]; then
+  echo "Running swagger-maven-plugin-jakarta..."
+  mvn "${MAVEN_ARGS[@]}" \
+      -pl "$MODULE" \
+      process-classes \
+      -Pgenerate-oas \
+      -Doas.outputPath="$OUTPUT_DIR" \
+      -DskipTests \
+      $ALSO_MAKE
+
+  if [[ ! -f "$OUTPUT_FILE" ]]; then
+    echo "Error: expected ${OUTPUT_FILE} to be written by the plugin but it was not found." >&2
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: Patch info.version
+#
+# Replaces the runtime-library version written by the plugin with the Maven
+# project version, trimmed of a trailing -SNAPSHOT.
+# ---------------------------------------------------------------------------
+
+echo "Patching info.version → ${OAS_INFO_VERSION}"
+patch_info_version "$OUTPUT_FILE" "$OAS_INFO_VERSION"
+
+# ---------------------------------------------------------------------------
+# Step 6 [full regen]: Prepend license header
+# ---------------------------------------------------------------------------
+
+if [[ "$VERSION_ONLY" == false ]]; then
+  TMPFILE="$(mktemp)"
+  {
+    [[ "$HEADER_LINE_COUNT" -gt 0 ]] && printf '%s\n\n' "$HEADER_CONTENT"
+    cat "$OUTPUT_FILE"
+  } > "$TMPFILE"
+  mv "$TMPFILE" "$OUTPUT_FILE"
+
+  if [[ "$HEADER_LINE_COUNT" -eq 0 ]]; then
+    echo "Warning: could not extract license header from committed spec — header not prepended." >&2
+    echo "         Run 'mvn license:format -pl ${MODULE}' to add it." >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: Report
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "✅  ${OUTPUT_FILE} written."
+echo ""
+
+if [[ "$VERSION_ONLY" == false && "$OUTPUT_FILE" == "$COMMITTED_SPEC" ]]; then
+  if git diff --quiet HEAD -- "$COMMITTED_SPEC" 2>/dev/null; then
+    echo "No changes vs HEAD — spec was already up to date."
+  else
+    echo "Changes vs HEAD:"
+    git --no-pager diff --stat HEAD -- "$COMMITTED_SPEC"
+  fi
+fi


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6780](https://gravitee.atlassian.net/browse/AM-6780)

## :pencil2: A description of the changes proposed in the pull request
Introduce Automation API.

- New API for idempotent GET/PUT/DELETE operations for Domains, Identity Providers, Certificates and Reporters
- Schemas leverage human-readable `key`s to map to unique internal UUIDs
- Sub-resources expose `default` flag that is immutable to mould into "system" defaults for domains
  - Implicit creation of default identity provider, reporter and certificate for new domains is bypassed
- Updates are handled with a declarative reconciliation approach, meaning changes are made with "desired state" payloads (e.g. omitted entities are removed)
- Dangling references are not strictly validated at creation/modification of domains (and at gateway runtime), allowing for "eventual consistency" between declared entities
- Uses JWT Bearer token authentication
- OpenAPI specification `docs/automation/openapi.yaml` is defined with:
  - Script to regenerate it
  - Staleness and breaking-changes detection hooked into the PR workflow ([example run](https://app.circleci.com/pipelines/github/gravitee-io/gravitee-access-management/30150/workflows/d9a1e8d4-1725-4836-9bd8-f1b4103b075c/jobs/410788))
  - Automatic version update on release
- Models and database schema have been prepared with `managedBy` fields for isolating entities for future read-only usage (not implemented here)

Based on PoC https://github.com/gravitee-io/gravitee-access-management/pull/7575.

### Notable omissions and limitations
- Domain-level CIMD settings are omitted (dependency on `Application`)
- Identity provider `passwordPolicy` is omitted (dependency on `PasswordPolicy`)
- `SCIMSettings.idpSelectionRule` is used verbatim (stores EL that evaluates to IDP ID - there is no lookup from hrid)

## :memo: Test scenarios 
See `gravitee-am-management-api/gravitee-am-management-api-automation/WALKTHROUGH.md` and generated OpenAPI specification `docs/automation/openapi.yaml`.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-6780]: https://gravitee.atlassian.net/browse/AM-6780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ