### PR TITLE
fix: AM-7036 deep clone domains

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -904,6 +904,7 @@ public class DomainServiceImpl implements DomainService {
                 || isCimdRevokeOnDocumentChangeEnabled(domainAfterPatch)) {
             return Completable.complete();
         }
+        LOGGER.info("Cleaning up CIMD client state for domain {}", domainAfterPatch.getId());
         return cimdClientStateService.deleteByDomain(domainAfterPatch)
                 .doOnError(e -> LOGGER.warn("Failed to clean up CIMD client state for domain {}: {}", domainAfterPatch.getId(), e.getMessage()))
                 .onErrorComplete();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -104,6 +104,8 @@ import io.gravitee.am.service.impl.PasswordHistoryService;
 import io.gravitee.am.service.model.NewDomain;
 import io.gravitee.am.service.model.NewSystemScope;
 import io.gravitee.am.service.model.PatchDomain;
+import io.gravitee.am.service.model.openid.PatchCIMDSettings;
+import io.gravitee.am.service.model.openid.PatchOIDCSettings;
 import io.gravitee.am.service.validators.accountsettings.AccountSettingsValidator;
 import io.gravitee.am.service.validators.domain.DomainValidator;
 import io.gravitee.am.service.validators.tokenexchange.TokenExchangeSettingsValidator;
@@ -1946,8 +1948,8 @@ public class DomainServiceTest {
     @Test
     public void shouldPatch_deletesCimdClientState_whenRevokeOnDocumentChangeBecomesDisabled() {
         Domain oldDomain = buildCimdPatchDomain(true);
-        Domain newDomain = buildCimdPatchDomain(false);
-        PatchDomain patchDomain = stubCimdPatch(oldDomain, newDomain);
+        PatchDomain patchDomain = realPatchTurningRevokeOnDocumentChange(false);
+        stubCimdPatch(oldDomain);
 
         domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, DOMAIN_ID), DOMAIN_ID, patchDomain, null)
                 .test()
@@ -1961,8 +1963,8 @@ public class DomainServiceTest {
     @Test
     public void shouldPatch_doesNotDeleteCimdClientState_whenRevokeOnDocumentChangeRemainsEnabled() {
         Domain oldDomain = buildCimdPatchDomain(true);
-        Domain newDomain = buildCimdPatchDomain(true);
-        PatchDomain patchDomain = stubCimdPatch(oldDomain, newDomain);
+        PatchDomain patchDomain = realPatchTurningRevokeOnDocumentChange(true);
+        stubCimdPatch(oldDomain);
 
         domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, DOMAIN_ID), DOMAIN_ID, patchDomain, null)
                 .test()
@@ -1976,8 +1978,8 @@ public class DomainServiceTest {
     @Test
     public void shouldPatch_doesNotDeleteCimdClientState_whenRevokeOnDocumentChangeRemainsDisabled() {
         Domain oldDomain = buildCimdPatchDomain(false);
-        Domain newDomain = buildCimdPatchDomain(false);
-        PatchDomain patchDomain = stubCimdPatch(oldDomain, newDomain);
+        PatchDomain patchDomain = realPatchTurningRevokeOnDocumentChange(false);
+        stubCimdPatch(oldDomain);
 
         domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, DOMAIN_ID), DOMAIN_ID, patchDomain, null)
                 .test()
@@ -1991,8 +1993,8 @@ public class DomainServiceTest {
     @Test
     public void shouldPatch_doesNotDeleteCimdClientState_whenRevokeOnDocumentChangeBecomesEnabled() {
         Domain oldDomain = buildCimdPatchDomain(false);
-        Domain newDomain = buildCimdPatchDomain(true);
-        PatchDomain patchDomain = stubCimdPatch(oldDomain, newDomain);
+        PatchDomain patchDomain = realPatchTurningRevokeOnDocumentChange(true);
+        stubCimdPatch(oldDomain);
 
         domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, DOMAIN_ID), DOMAIN_ID, patchDomain, null)
                 .test()
@@ -2022,19 +2024,27 @@ public class DomainServiceTest {
         return d;
     }
 
-    private PatchDomain stubCimdPatch(Domain oldDomain, Domain newDomain) {
-        PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
-        when(patchDomain.patch(any())).thenReturn(newDomain);
+    private static PatchDomain realPatchTurningRevokeOnDocumentChange(boolean newValue) {
+        PatchCIMDSettings patchCimd = new PatchCIMDSettings();
+        patchCimd.setRevokeOnDocumentChange(Optional.of(newValue));
+        PatchOIDCSettings patchOidc = new PatchOIDCSettings();
+        patchOidc.setCimdSettings(Optional.of(patchCimd));
+        PatchDomain patchDomain = new PatchDomain();
+        patchDomain.setOidc(Optional.of(patchOidc));
+        return patchDomain;
+    }
+
+    private void stubCimdPatch(Domain oldDomain) {
         when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(oldDomain));
         when(domainRepository.findByHrid(any(), anyString(), anyString())).thenReturn(Maybe.just(oldDomain));
         when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
         when(domainReadService.listAll()).thenReturn(Flowable.empty());
-        when(domainRepository.update(any(Domain.class))).thenReturn(Single.just(newDomain));
+        when(domainRepository.update(any(Domain.class)))
+                .thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
         when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
         doReturn(Completable.complete()).when(domainValidator).validate(any(), any());
         doReturn(Completable.complete()).when(virtualHostValidator).validateDomainVhosts(any(), any());
         doReturn(true).when(accountSettingsValidator).validate(any());
         doReturn(Completable.complete()).when(tokenExchangeSettingsValidator).validate(any());
-        return patchDomain;
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Domain.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Domain.java
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -226,22 +227,22 @@ public class Domain implements Resource {
         this.identities = other.identities;
         this.master = other.master;
         this.vhostMode = other.vhostMode;
-        this.vhosts = other.vhosts;
+        this.vhosts = other.vhosts != null ? new ArrayList<>(other.vhosts) : null;
         this.tags = other.tags;
         this.createdAt = other.createdAt;
         this.updatedAt = other.updatedAt;
-        this.oidc = other.oidc;
+        this.oidc = other.oidc != null ? new OIDCSettings(other.oidc) : null;
         this.uma = other.uma;
-        this.loginSettings = other.loginSettings;
+        this.loginSettings = other.loginSettings != null ? new LoginSettings(other.loginSettings) : null;
         this.webAuthnSettings = other.webAuthnSettings;
         this.scim = other.scim;
-        this.accountSettings = other.accountSettings;
-        this.passwordSettings = other.passwordSettings;
+        this.accountSettings = other.accountSettings != null ? new AccountSettings(other.accountSettings) : null;
+        this.passwordSettings = other.passwordSettings != null ? new PasswordSettings(other.passwordSettings) : null;
         this.selfServiceAccountManagementSettings = other.selfServiceAccountManagementSettings;
-        this.saml = other.saml;
+        this.saml = other.saml != null ? new SAMLSettings(other.saml) : null;
         this.corsSettings = other.corsSettings;
         this.dataPlaneId = other.dataPlaneId;
-        this.secretExpirationSettings = other.secretExpirationSettings;
+        this.secretExpirationSettings = other.secretExpirationSettings != null ? new SecretExpirationSettings(other.secretExpirationSettings) : null;
         this.tokenExchangeSettings = other.tokenExchangeSettings;
         this.certificateSettings = other.certificateSettings != null ? new CertificateSettings(other.certificateSettings) : null;
     }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIBASettingNotifier.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIBASettingNotifier.java
@@ -22,6 +22,13 @@ package io.gravitee.am.model.oidc;
 public class CIBASettingNotifier {
     private String id;
 
+    public CIBASettingNotifier() {
+    }
+
+    public CIBASettingNotifier(CIBASettingNotifier other) {
+        this.id = other.id;
+    }
+
     public String getId() {
         return id;
     }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIBASettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIBASettings.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.am.model.oidc;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -43,6 +45,19 @@ public class CIBASettings {
      * Authentication Device Notifiers to use when the EndUser has to be notified
      */
     private List<CIBASettingNotifier> deviceNotifiers;
+
+    public CIBASettings() {
+    }
+
+    public CIBASettings(CIBASettings other) {
+        this.enabled = other.enabled;
+        this.authReqExpiry = other.authReqExpiry;
+        this.tokenReqInterval = other.tokenReqInterval;
+        this.bindingMessageLength = other.bindingMessageLength;
+        this.deviceNotifiers = other.deviceNotifiers != null
+                ? other.deviceNotifiers.stream().map(CIBASettingNotifier::new).collect(Collectors.toCollection(ArrayList::new))
+                : null;
+    }
 
     public boolean isEnabled() {
         return enabled;

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIMDSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CIMDSettings.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model.oidc;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -88,6 +89,22 @@ public class CIMDSettings {
      * of its metadata document reveals that any of the monitored properties have changed.
      */
     private boolean revokeOnDocumentChange;
+
+    public CIMDSettings() {
+    }
+
+    public CIMDSettings(CIMDSettings other) {
+        this.enabled = other.enabled;
+        this.allowUnsecuredHttpUri = other.allowUnsecuredHttpUri;
+        this.allowPrivateIpAddress = other.allowPrivateIpAddress;
+        this.fetchTimeoutMs = other.fetchTimeoutMs;
+        this.maxResponseSizeKb = other.maxResponseSizeKb;
+        this.allowedDomains = other.allowedDomains != null ? new ArrayList<>(other.allowedDomains) : null;
+        this.cacheTtlSeconds = other.cacheTtlSeconds;
+        this.cacheMaxEntries = other.cacheMaxEntries;
+        this.templateId = other.templateId;
+        this.revokeOnDocumentChange = other.revokeOnDocumentChange;
+    }
 
     public boolean isEnabled() {
         return enabled;

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/ClientRegistrationSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/ClientRegistrationSettings.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model.oidc;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -72,6 +73,22 @@ public class ClientRegistrationSettings {
      * Enable client to be used as template for dynamic client registration
      */
     private boolean isClientTemplateEnabled;
+
+    public ClientRegistrationSettings() {
+    }
+
+    public ClientRegistrationSettings(ClientRegistrationSettings other) {
+        this.allowLocalhostRedirectUri = other.allowLocalhostRedirectUri;
+        this.allowHttpSchemeRedirectUri = other.allowHttpSchemeRedirectUri;
+        this.allowWildCardRedirectUri = other.allowWildCardRedirectUri;
+        this.isDynamicClientRegistrationEnabled = other.isDynamicClientRegistrationEnabled;
+        this.isOpenDynamicClientRegistrationEnabled = other.isOpenDynamicClientRegistrationEnabled;
+        this.allowRedirectUriParamsExpressionLanguage = other.allowRedirectUriParamsExpressionLanguage;
+        this.defaultScopes = other.defaultScopes != null ? new ArrayList<>(other.defaultScopes) : null;
+        this.isAllowedScopesEnabled = other.isAllowedScopesEnabled;
+        this.allowedScopes = other.allowedScopes != null ? new ArrayList<>(other.allowedScopes) : null;
+        this.isClientTemplateEnabled = other.isClientTemplateEnabled;
+    }
 
     public boolean isAllowLocalhostRedirectUri() {
         return allowLocalhostRedirectUri;

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/OIDCSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/OIDCSettings.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model.oidc;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -47,6 +48,22 @@ public class OIDCSettings {
     private CIBASettings cibaSettings;
 
     private CIMDSettings cimdSettings;
+
+    public OIDCSettings() {
+    }
+
+    public OIDCSettings(OIDCSettings other) {
+        this.clientRegistrationSettings = other.clientRegistrationSettings != null
+                ? new ClientRegistrationSettings(other.clientRegistrationSettings) : null;
+        this.securityProfileSettings = other.securityProfileSettings != null
+                ? new SecurityProfileSettings(other.securityProfileSettings) : null;
+        this.redirectUriStrictMatching = other.redirectUriStrictMatching;
+        this.postLogoutRedirectUris = other.postLogoutRedirectUris != null
+                ? new ArrayList<>(other.postLogoutRedirectUris) : null;
+        this.requestUris = other.requestUris != null ? new ArrayList<>(other.requestUris) : null;
+        this.cibaSettings = other.cibaSettings != null ? new CIBASettings(other.cibaSettings) : null;
+        this.cimdSettings = other.cimdSettings != null ? new CIMDSettings(other.cimdSettings) : null;
+    }
 
     public ClientRegistrationSettings getClientRegistrationSettings() {
         return clientRegistrationSettings!=null?clientRegistrationSettings: ClientRegistrationSettings.defaultSettings();

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/SecurityProfileSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/SecurityProfileSettings.java
@@ -31,6 +31,14 @@ public class SecurityProfileSettings {
      */
     private boolean enableFapiBrazil;
 
+    public SecurityProfileSettings() {
+    }
+
+    public SecurityProfileSettings(SecurityProfileSettings other) {
+        this.enablePlainFapi = other.enablePlainFapi;
+        this.enableFapiBrazil = other.enableFapiBrazil;
+    }
+
     public boolean isEnablePlainFapi() {
         return enablePlainFapi;
     }

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/DomainTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/DomainTest.java
@@ -15,11 +15,20 @@
  */
 package io.gravitee.am.model;
 
+import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.CIMDSettings;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Alexandre FARIA (contact at alexandrefaria.net)
@@ -143,5 +152,91 @@ public class DomainTest {
 
         boolean isEnabled = domain.isRedirectUriExpressionLanguageEnabled();
         assertFalse("By default EL param evaluation should be disabled",isEnabled);
+    }
+
+    @Test
+    public void copyConstructor_deepCopiesNestedSettings() {
+        Domain original = new Domain("d1");
+        original.setOidc(OIDCSettings.defaultSettings());
+        original.getOidc().setCimdSettings(new CIMDSettings());
+        original.getOidc().getCimdSettings().setRevokeOnDocumentChange(true);
+        original.setLoginSettings(new LoginSettings());
+        original.setAccountSettings(new AccountSettings());
+        original.setPasswordSettings(new PasswordSettings());
+        original.setSaml(new SAMLSettings());
+        original.setSecretExpirationSettings(new SecretExpirationSettings());
+        original.setCertificateSettings(new CertificateSettings());
+
+        Domain copy = new Domain(original);
+
+        assertNotSame("oidc must be deep-copied", original.getOidc(), copy.getOidc());
+        assertNotSame("oidc.cimdSettings must be deep-copied",
+                original.getOidc().getCimdSettings(), copy.getOidc().getCimdSettings());
+        assertNotSame("oidc.clientRegistrationSettings must be deep-copied",
+                original.getOidc().getClientRegistrationSettings(), copy.getOidc().getClientRegistrationSettings());
+        assertNotSame("oidc.securityProfileSettings must be deep-copied",
+                original.getOidc().getSecurityProfileSettings(), copy.getOidc().getSecurityProfileSettings());
+        assertNotSame("oidc.cibaSettings must be deep-copied",
+                original.getOidc().getCibaSettings(), copy.getOidc().getCibaSettings());
+        assertNotSame("loginSettings must be deep-copied", original.getLoginSettings(), copy.getLoginSettings());
+        assertNotSame("accountSettings must be deep-copied", original.getAccountSettings(), copy.getAccountSettings());
+        assertNotSame("passwordSettings must be deep-copied", original.getPasswordSettings(), copy.getPasswordSettings());
+        assertNotSame("saml must be deep-copied", original.getSaml(), copy.getSaml());
+        assertNotSame("secretExpirationSettings must be deep-copied",
+                original.getSecretExpirationSettings(), copy.getSecretExpirationSettings());
+        assertNotSame("certificateSettings must be deep-copied",
+                original.getCertificateSettings(), copy.getCertificateSettings());
+
+        copy.getOidc().getCimdSettings().setRevokeOnDocumentChange(false);
+        assertTrue("Mutating the copy's CIMD settings must not affect the original",
+                original.getOidc().getCimdSettings().isRevokeOnDocumentChange());
+        assertFalse(copy.getOidc().getCimdSettings().isRevokeOnDocumentChange());
+    }
+
+    @Test
+    public void copyConstructor_preservesNullNestedSettings() {
+        Domain original = new Domain("d1");
+        // Nested settings deliberately left null.
+
+        Domain copy = new Domain(original);
+
+        assertEquals("d1", copy.getId());
+        Assert.assertNull(copy.getOidc());
+        Assert.assertNull(copy.getLoginSettings());
+        Assert.assertNull(copy.getAccountSettings());
+        Assert.assertNull(copy.getPasswordSettings());
+        Assert.assertNull(copy.getSaml());
+        Assert.assertNull(copy.getSecretExpirationSettings());
+        Assert.assertNull(copy.getCertificateSettings());
+    }
+
+    @Test
+    public void copyConstructor_copiesVhosts() {
+        VirtualHost vhost = new VirtualHost();
+        vhost.setHost("auth.example.com");
+        vhost.setPath("/am");
+        List<VirtualHost> vhosts = new ArrayList<>();
+        vhosts.add(vhost);
+
+        Domain original = new Domain("d1");
+        original.setVhosts(vhosts);
+
+        Domain copy = new Domain(original);
+
+        assertEquals(1, copy.getVhosts().size());
+        assertEquals("auth.example.com", copy.getVhosts().get(0).getHost());
+        assertNotSame(original.getVhosts(), copy.getVhosts());
+
+        original.getVhosts().add(new VirtualHost());
+        assertEquals(1, copy.getVhosts().size());
+    }
+
+    @Test
+    public void copyConstructor_preservesNullVhosts() {
+        Domain original = new Domain("d1");
+
+        Domain copy = new Domain(original);
+
+        Assert.assertNull(copy.getVhosts());
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIBASettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIBASettings.java
@@ -92,7 +92,7 @@ public class PatchCIBASettings {
     }
 
     public CIBASettings patch(CIBASettings toPatch) {
-        CIBASettings result=toPatch!=null ? toPatch : CIBASettings.defaultSettings();
+        CIBASettings result = toPatch == null ? CIBASettings.defaultSettings() : new CIBASettings(toPatch);
 
         SetterUtils.safeSet(result::setEnabled, this.getEnabled(), boolean.class);
         SetterUtils.safeSet(result::setAuthReqExpiry, this.getAuthReqExpiry(), int.class);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIMDSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchCIMDSettings.java
@@ -131,7 +131,7 @@ public class PatchCIMDSettings {
     }
 
     public CIMDSettings patch(CIMDSettings toPatch) {
-        CIMDSettings result = toPatch != null ? toPatch : CIMDSettings.defaultSettings();
+        CIMDSettings result = toPatch == null ? CIMDSettings.defaultSettings() : new CIMDSettings(toPatch);
 
         SetterUtils.safeSet(result::setEnabled, this.getEnabled(), boolean.class);
         SetterUtils.safeSet(result::setAllowUnsecuredHttpUri, this.getAllowUnsecuredHttpUri(), boolean.class);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchClientRegistrationSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchClientRegistrationSettings.java
@@ -162,7 +162,7 @@ public class PatchClientRegistrationSettings {
     }
 
     public ClientRegistrationSettings patch(ClientRegistrationSettings toPatch) {
-        ClientRegistrationSettings result=toPatch!=null?toPatch: ClientRegistrationSettings.defaultSettings();
+        ClientRegistrationSettings result = toPatch == null ? ClientRegistrationSettings.defaultSettings() : new ClientRegistrationSettings(toPatch);
 
         SetterUtils.safeSet(result::setAllowWildCardRedirectUri, this.getAllowWildCardRedirectUri(), boolean.class);
         SetterUtils.safeSet(result::setAllowHttpSchemeRedirectUri, this.getAllowHttpSchemeRedirectUri(), boolean.class);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchOIDCSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchOIDCSettings.java
@@ -111,11 +111,7 @@ public class PatchOIDCSettings {
     }
 
     public OIDCSettings patch(OIDCSettings toPatch) {
-
-        //If source may be null, in such case init with default values
-        if (toPatch == null ) {
-            toPatch = OIDCSettings.defaultSettings();
-        }
+        toPatch = toPatch == null ? OIDCSettings.defaultSettings() : new OIDCSettings(toPatch);
         SetterUtils.safeSet(toPatch::setRedirectUriStrictMatching, this.getRedirectUriStrictMatching(), boolean.class);
         SetterUtils.safeSet(toPatch::setPostLogoutRedirectUris, this.getPostLogoutRedirectUris());
         SetterUtils.safeSet(toPatch::setRequestUris, this.getRequestUris());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchSecurityProfileSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchSecurityProfileSettings.java
@@ -54,7 +54,7 @@ public class PatchSecurityProfileSettings {
     }
 
     public SecurityProfileSettings patch(SecurityProfileSettings toPatch) {
-        SecurityProfileSettings result=toPatch!=null? toPatch: SecurityProfileSettings.defaultSettings();
+        SecurityProfileSettings result = toPatch == null ? SecurityProfileSettings.defaultSettings() : new SecurityProfileSettings(toPatch);
 
         SetterUtils.safeSet(result::setEnablePlainFapi, this.getEnablePlainFapi(), boolean.class);
         SetterUtils.safeSet(result::setEnableFapiBrazil, this.getEnableFapiBrazil(), boolean.class);


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7036](https://gravitee.atlassian.net/browse/AM-7036)

## :pencil2: A description of the changes proposed in the pull request
Update `Domain` model and its nested models copy constructors to recreate objects rather than persisting references. This affects patching in the Management REST API and resolves an issue with change detection of the CIMD `revokeOnDocumentChange` setting, which drives cleaning up of persisted `cimd_client_state` records.

Note that the shallow cloning antipattern is extant in 15 other `io.gravitee.am.model` models, not scoped into this fix.

## :memo: Test scenarios
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7036]: https://gravitee.atlassian.net/browse/AM-7036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ