### PR TITLE
GMA-329 spiffe instance support v3

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -501,11 +501,14 @@ jobs:
           name: Spin up stack with Mongo << parameters.mongo_version >>
           command: MONGO_VERSION=<< parameters.mongo_version >> npm --prefix docker/local-stack run stack:ci:setup:mongo
       - run:
+          name: Bring up SPIRE overlay
+          command: npm --prefix docker/local-stack run stack:dev:spire
+      - run:
           name: Run Management Jest tests (parallel)
           command: JEST_JUNIT_OUTPUT_NAME=junit-management.xml npm --prefix gravitee-am-test run ci:management:parallel
       - run:
           name: Run Gateway Jest tests (sequential)
-          command: JEST_JUNIT_OUTPUT_NAME=junit-gateway.xml npm --prefix gravitee-am-test run ci:gateway
+          command: JEST_JUNIT_OUTPUT_NAME=junit-gateway.xml RUN_SPIRE_TESTS=true npm --prefix gravitee-am-test run ci:gateway
       - store_test_results:
           path: gravitee-am-test/jest-reports/junit
       - store_artifacts:

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -16992,7 +16992,6 @@ components:
           enum:
           - EXACT
           - PREFIX
-          default: EXACT
         trustDomain:
           type: string
     SpiffeDomainSettings:

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -16982,17 +16982,17 @@ components:
           type: string
         subjectMatchMode:
           type: string
-          enum:
-            - EXACT
-            - PREFIX
-          default: EXACT
-          description: |
+          description: |-
             How the configured `subject` is matched against the SVID `sub` claim.
             `EXACT` (default) requires equality.
-            `PREFIX` is only allowed for HOSTED_DELEGATED or AUTONOMOUS agent
-            applications; the SVID `sub` is accepted when it equals the
-            configured subject or starts with `<subject>/`. The full SVID
-            SPIFFE ID then becomes the per-instance `act.sub` in minted tokens.
+            `PREFIX` is only allowed for HOSTED_DELEGATED or AUTONOMOUS agent applications;
+            the configured `subject` must end with `/` and the SVID `sub` is accepted when
+            it starts with that subject. The full SVID SPIFFE ID then becomes the
+            per-instance `act.sub` in minted tokens.
+          enum:
+          - EXACT
+          - PREFIX
+          default: EXACT
         trustDomain:
           type: string
     SpiffeDomainSettings:

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -16980,6 +16980,19 @@ components:
       properties:
         subject:
           type: string
+        subjectMatchMode:
+          type: string
+          enum:
+            - EXACT
+            - PREFIX
+          default: EXACT
+          description: |
+            How the configured `subject` is matched against the SVID `sub` claim.
+            `EXACT` (default) requires equality.
+            `PREFIX` is only allowed for HOSTED_DELEGATED or AUTONOMOUS agent
+            applications; the SVID `sub` is accepted when it equals the
+            configured subject or starts with `<subject>/`. The full SVID
+            SPIFFE ID then becomes the per-instance `act.sub` in minted tokens.
         trustDomain:
           type: string
     SpiffeDomainSettings:

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidator.java
@@ -30,6 +30,7 @@ import io.gravitee.am.gateway.handler.oidc.service.spiffe.SpiffeJwtSvidValidator
 import io.gravitee.am.gateway.handler.oidc.service.spiffe.TrustBundleService;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.application.AgentType;
 import io.gravitee.am.model.application.SpiffeApplicationSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
@@ -133,13 +134,24 @@ public class SpiffeClientAssertionValidator implements ClientAssertionValidator 
                                 String fail = new SpiffeJwtSvidValidator(settings)
                                         .validate(signedJWT, td, spiffe, tokenEndpoint);
                                 if (fail != null) {
-                                    log.debug("SPIFFE assertion rejected for client {}: {}", client.getClientId(), fail);
-                                    return Maybe.error(NOT_VALID);
+                                    log.info("SPIFFE assertion rejected for client {}: {}", client.getClientId(), fail);
+                                    return Maybe.error(new InvalidClientException("assertion is not valid: " + fail));
                                 }
                                 return verifySpiffeSignature(signedJWT, td)
-                                        .map(ok -> client);
+                                        .map(ok -> buildAgentClientIfApplicable(client, sub));
                             });
                 });
+    }
+
+    private static Client buildAgentClientIfApplicable(Client client, String spiffeId) {
+        if (client.isAgentApplication()
+                && (client.getAgentType() == AgentType.HOSTED_DELEGATED
+                    || client.getAgentType() == AgentType.AUTONOMOUS)) {
+            Client instance = new Client(client);
+            instance.setAgentInstanceId(spiffeId);
+            return instance;
+        }
+        return client;
     }
 
     private Maybe<Boolean> verifySpiffeSignature(SignedJWT signedJWT, TrustDomain td) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidator.java
@@ -100,7 +100,18 @@ public final class SpiffeJwtSvidValidator {
             return "client missing spiffe settings";
         }
         String expected = spiffeApplicationSettings.getSubject();
-        if (expected == null || expected.isBlank() || !expected.equals(sub)) {
+        if (expected == null || expected.isBlank()) {
+            return "sub does not match client subject";
+        }
+        SpiffeApplicationSettings.SubjectMatchMode mode = spiffeApplicationSettings.getSubjectMatchMode();
+        if (mode == null) {
+            mode = SpiffeApplicationSettings.SubjectMatchMode.EXACT;
+        }
+        boolean match = switch (mode) {
+            case EXACT -> expected.equals(sub);
+            case PREFIX -> sub.equals(expected) || sub.startsWith(expected + "/");
+        };
+        if (!match) {
             return "sub does not match client subject";
         }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidator.java
@@ -109,7 +109,7 @@ public final class SpiffeJwtSvidValidator {
         }
         boolean match = switch (mode) {
             case EXACT -> expected.equals(sub);
-            case PREFIX -> sub.equals(expected) || sub.startsWith(expected + "/");
+            case PREFIX -> sub.startsWith(expected);
         };
         if (!match) {
             return "sub does not match client subject";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidator.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -103,10 +104,8 @@ public final class SpiffeJwtSvidValidator {
         if (expected == null || expected.isBlank()) {
             return "sub does not match client subject";
         }
-        SpiffeApplicationSettings.SubjectMatchMode mode = spiffeApplicationSettings.getSubjectMatchMode();
-        if (mode == null) {
-            mode = SpiffeApplicationSettings.SubjectMatchMode.EXACT;
-        }
+        SpiffeApplicationSettings.SubjectMatchMode mode = Optional.ofNullable(spiffeApplicationSettings.getSubjectMatchMode())
+                .orElse(SpiffeApplicationSettings.SubjectMatchMode.EXACT);
         boolean match = switch (mode) {
             case EXACT -> expected.equals(sub);
             case PREFIX -> sub.startsWith(expected);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidatorTest.java
@@ -30,6 +30,8 @@ import io.gravitee.am.gateway.handler.oidc.service.jws.JWSService;
 import io.gravitee.am.gateway.handler.oidc.service.spiffe.TrustBundleService;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.application.AgentType;
+import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.application.SpiffeApplicationSettings;
 import io.gravitee.am.model.jose.RSAKey;
 import io.gravitee.am.model.oidc.Client;
@@ -344,6 +346,114 @@ class SpiffeClientAssertionValidatorTest {
         validator.validate(svid().serialize(), BASE_PATH, null).test()
                 .assertNoErrors()
                 .assertValue(c -> SUBJECT.equals(c.getClientId()));
+    }
+
+    @Test
+    void synthesises_perInstanceAgentClient_forHostedDelegated_withPrefixSubject() throws Exception {
+        stubDiscovery();
+        stubDomainOidc();
+        stubDomainId();
+
+        String parent = "spiffe://example.org/hotel-agent";
+        String instanceSpiffeId = parent + "/instance-a";
+        String blueprintClientId = "blueprint-1";
+
+        Client blueprint = new Client();
+        blueprint.setClientId(blueprintClientId);
+        blueprint.setTokenEndpointAuthMethod(ClientAuthenticationMethod.SPIFFE_JWT);
+        blueprint.setAppType(ApplicationType.AGENT);
+        blueprint.setAgentType(AgentType.HOSTED_DELEGATED);
+        SpiffeApplicationSettings appSettings = new SpiffeApplicationSettings();
+        appSettings.setTrustDomain(TRUST_DOMAIN_NAME);
+        appSettings.setSubject(parent);
+        appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
+        blueprint.setWorkloadIdentitySettings(appSettings);
+
+        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        RSAKey jwk = new RSAKey();
+        jwk.setKid(KID);
+        when(clientLookupService.findByClientId(blueprintClientId)).thenReturn(Maybe.just(blueprint));
+        when(trustDomainRepository.findByName(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
+                .thenReturn(Maybe.just(td));
+        when(trustBundleService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
+        when(jwsService.isValidSignature(any(), any())).thenReturn(true);
+
+        String assertion = instanceSvid(instanceSpiffeId).serialize();
+
+        validator.validate(assertion, BASE_PATH, blueprintClientId).test()
+                .assertNoErrors()
+                .assertValue(c -> blueprintClientId.equals(c.getClientId())
+                        && instanceSpiffeId.equals(c.getAgentInstanceId()));
+    }
+
+    @Test
+    void synthesises_perInstanceAgentClient_forAutonomous_withPrefixSubject() throws Exception {
+        stubDiscovery();
+        stubDomainOidc();
+        stubDomainId();
+
+        String parent = "spiffe://example.org/hotel-agent";
+        String instanceSpiffeId = parent + "/instance-b";
+        String blueprintClientId = "blueprint-2";
+
+        Client blueprint = new Client();
+        blueprint.setClientId(blueprintClientId);
+        blueprint.setTokenEndpointAuthMethod(ClientAuthenticationMethod.SPIFFE_JWT);
+        blueprint.setAppType(ApplicationType.AGENT);
+        blueprint.setAgentType(AgentType.AUTONOMOUS);
+        SpiffeApplicationSettings appSettings = new SpiffeApplicationSettings();
+        appSettings.setTrustDomain(TRUST_DOMAIN_NAME);
+        appSettings.setSubject(parent);
+        appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
+        blueprint.setWorkloadIdentitySettings(appSettings);
+
+        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        RSAKey jwk = new RSAKey();
+        jwk.setKid(KID);
+        when(clientLookupService.findByClientId(blueprintClientId)).thenReturn(Maybe.just(blueprint));
+        when(trustDomainRepository.findByName(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
+                .thenReturn(Maybe.just(td));
+        when(trustBundleService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
+        when(jwsService.isValidSignature(any(), any())).thenReturn(true);
+
+        validator.validate(instanceSvid(instanceSpiffeId).serialize(), BASE_PATH, blueprintClientId).test()
+                .assertNoErrors()
+                .assertValue(c -> instanceSpiffeId.equals(c.getAgentInstanceId()));
+    }
+
+    @Test
+    void doesNotSynthesise_forNonAgentClient_evenWithMatchingSvid() throws Exception {
+        stubDiscovery();
+        stubDomainOidc();
+        stubDomainId();
+        Client client = clientWithSpiffeSettings(); // SERVICE-style, no appType=AGENT
+        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        RSAKey jwk = new RSAKey();
+        jwk.setKid(KID);
+        when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
+        when(trustDomainRepository.findByName(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
+                .thenReturn(Maybe.just(td));
+        when(trustBundleService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
+        when(jwsService.isValidSignature(any(), any())).thenReturn(true);
+
+        validator.validate(svid().serialize(), BASE_PATH, null).test()
+                .assertNoErrors()
+                .assertValue(c -> c.getAgentInstanceId() == null && SUBJECT.equals(c.getClientId()));
+    }
+
+    private SignedJWT instanceSvid(String spiffeId) throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .subject(spiffeId)
+                .audience(TOKEN_ENDPOINT)
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(60)))
+                .build();
+        SignedJWT jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(KID).build(),
+                claims);
+        jwt.sign(new RSASSASigner(privateKey));
+        return jwt;
     }
 
     // --- helpers -----------------------------------------------------------

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidatorTest.java
@@ -354,8 +354,8 @@ class SpiffeClientAssertionValidatorTest {
         stubDomainOidc();
         stubDomainId();
 
-        String parent = "spiffe://example.org/hotel-agent";
-        String instanceSpiffeId = parent + "/instance-a";
+        String parent = "spiffe://example.org/hotel-agent/";
+        String instanceSpiffeId = parent + "instance-a";
         String blueprintClientId = "blueprint-1";
 
         Client blueprint = new Client();
@@ -392,8 +392,8 @@ class SpiffeClientAssertionValidatorTest {
         stubDomainOidc();
         stubDomainId();
 
-        String parent = "spiffe://example.org/hotel-agent";
-        String instanceSpiffeId = parent + "/instance-b";
+        String parent = "spiffe://example.org/hotel-agent/";
+        String instanceSpiffeId = parent + "instance-b";
         String blueprintClientId = "blueprint-2";
 
         Client blueprint = new Client();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidatorTest.java
@@ -168,27 +168,17 @@ class SpiffeJwtSvidValidatorTest {
 
     @Test
     void validate_acceptsPrefixMatch_whenSubIsBelowConfiguredSubject() throws Exception {
-        String parent = "spiffe://example.org/hotel-agent";
+        String parent = "spiffe://example.org/hotel-agent/";
         appSettings.setSubject(parent);
         appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
-        SignedJWT jwt = signedJwt(defaultClaims().subject(parent + "/instance-a").build(), JWSAlgorithm.RS256);
-
-        assertThat(validator.validate(jwt, trustDomain, appSettings, TOKEN_ENDPOINT)).isNull();
-    }
-
-    @Test
-    void validate_acceptsPrefixMatch_whenSubEqualsConfiguredSubject() throws Exception {
-        String parent = "spiffe://example.org/hotel-agent";
-        appSettings.setSubject(parent);
-        appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
-        SignedJWT jwt = signedJwt(defaultClaims().subject(parent).build(), JWSAlgorithm.RS256);
+        SignedJWT jwt = signedJwt(defaultClaims().subject(parent + "instance-a").build(), JWSAlgorithm.RS256);
 
         assertThat(validator.validate(jwt, trustDomain, appSettings, TOKEN_ENDPOINT)).isNull();
     }
 
     @Test
     void validate_rejectsPrefixMatch_whenSubOutsidePrefix() throws Exception {
-        appSettings.setSubject("spiffe://example.org/hotel-agent");
+        appSettings.setSubject("spiffe://example.org/hotel-agent/");
         appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
         SignedJWT jwt = signedJwt(
                 defaultClaims().subject("spiffe://example.org/other-agent/instance-a").build(),
@@ -200,8 +190,8 @@ class SpiffeJwtSvidValidatorTest {
 
     @Test
     void validate_rejectsPrefixMatch_whenSubIsSiblingNotChild() throws Exception {
-        // Guards against substring-style prefix bugs: "/hotel-agent-2" must not match prefix "/hotel-agent".
-        appSettings.setSubject("spiffe://example.org/hotel-agent");
+        // Guards against substring-style prefix bugs: "/hotel-agent-2" must not match prefix "/hotel-agent/".
+        appSettings.setSubject("spiffe://example.org/hotel-agent/");
         appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
         SignedJWT jwt = signedJwt(
                 defaultClaims().subject("spiffe://example.org/hotel-agent-2").build(),

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidatorTest.java
@@ -167,6 +167,51 @@ class SpiffeJwtSvidValidatorTest {
     }
 
     @Test
+    void validate_acceptsPrefixMatch_whenSubIsBelowConfiguredSubject() throws Exception {
+        String parent = "spiffe://example.org/hotel-agent";
+        appSettings.setSubject(parent);
+        appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
+        SignedJWT jwt = signedJwt(defaultClaims().subject(parent + "/instance-a").build(), JWSAlgorithm.RS256);
+
+        assertThat(validator.validate(jwt, trustDomain, appSettings, TOKEN_ENDPOINT)).isNull();
+    }
+
+    @Test
+    void validate_acceptsPrefixMatch_whenSubEqualsConfiguredSubject() throws Exception {
+        String parent = "spiffe://example.org/hotel-agent";
+        appSettings.setSubject(parent);
+        appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
+        SignedJWT jwt = signedJwt(defaultClaims().subject(parent).build(), JWSAlgorithm.RS256);
+
+        assertThat(validator.validate(jwt, trustDomain, appSettings, TOKEN_ENDPOINT)).isNull();
+    }
+
+    @Test
+    void validate_rejectsPrefixMatch_whenSubOutsidePrefix() throws Exception {
+        appSettings.setSubject("spiffe://example.org/hotel-agent");
+        appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
+        SignedJWT jwt = signedJwt(
+                defaultClaims().subject("spiffe://example.org/other-agent/instance-a").build(),
+                JWSAlgorithm.RS256);
+
+        assertThat(validator.validate(jwt, trustDomain, appSettings, TOKEN_ENDPOINT))
+                .isEqualTo("sub does not match client subject");
+    }
+
+    @Test
+    void validate_rejectsPrefixMatch_whenSubIsSiblingNotChild() throws Exception {
+        // Guards against substring-style prefix bugs: "/hotel-agent-2" must not match prefix "/hotel-agent".
+        appSettings.setSubject("spiffe://example.org/hotel-agent");
+        appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
+        SignedJWT jwt = signedJwt(
+                defaultClaims().subject("spiffe://example.org/hotel-agent-2").build(),
+                JWSAlgorithm.RS256);
+
+        assertThat(validator.validate(jwt, trustDomain, appSettings, TOKEN_ENDPOINT))
+                .isEqualTo("sub does not match client subject");
+    }
+
+    @Test
     void validate_rejects_whenAudienceMissingTokenEndpoint() throws Exception {
         SignedJWT jwt = signedJwt(
                 defaultClaims().audience("https://other.example.com/token").build(),

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/SpiffeApplicationSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/SpiffeApplicationSettings.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model.application;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -35,6 +36,15 @@ public class SpiffeApplicationSettings {
     private String subject;
 
     /** How {@link #subject} is matched against the SVID {@code sub}. Defaults to {@link SubjectMatchMode#EXACT}. */
+    @Schema(
+            defaultValue = "EXACT",
+            description = """
+                    How the configured `subject` is matched against the SVID `sub` claim.
+                    `EXACT` (default) requires equality.
+                    `PREFIX` is only allowed for HOSTED_DELEGATED or AUTONOMOUS agent applications;
+                    the configured `subject` must end with `/` and the SVID `sub` is accepted when
+                    it starts with that subject. The full SVID SPIFFE ID then becomes the
+                    per-instance `act.sub` in minted tokens.""")
     private SubjectMatchMode subjectMatchMode = SubjectMatchMode.EXACT;
 
     public SpiffeApplicationSettings(SpiffeApplicationSettings other) {

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/SpiffeApplicationSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/SpiffeApplicationSettings.java
@@ -37,7 +37,6 @@ public class SpiffeApplicationSettings {
 
     /** How {@link #subject} is matched against the SVID {@code sub}. Defaults to {@link SubjectMatchMode#EXACT}. */
     @Schema(
-            defaultValue = "EXACT",
             description = """
                     How the configured `subject` is matched against the SVID `sub` claim.
                     `EXACT` (default) requires equality.

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/SpiffeApplicationSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/SpiffeApplicationSettings.java
@@ -31,11 +31,20 @@ public class SpiffeApplicationSettings {
     /** Name of the {@code TrustDomain} this application authenticates against. */
     private String trustDomain;
 
-    /** Exact SPIFFE ID expected in the SVID's {@code sub} claim. */
+    /** SPIFFE ID expected in the SVID's {@code sub} claim. Interpreted per {@link #subjectMatchMode}. */
     private String subject;
+
+    /** How {@link #subject} is matched against the SVID {@code sub}. Defaults to {@link SubjectMatchMode#EXACT}. */
+    private SubjectMatchMode subjectMatchMode = SubjectMatchMode.EXACT;
 
     public SpiffeApplicationSettings(SpiffeApplicationSettings other) {
         this.trustDomain = other.trustDomain;
         this.subject = other.subject;
+        this.subjectMatchMode = other.subjectMatchMode != null ? other.subjectMatchMode : SubjectMatchMode.EXACT;
+    }
+
+    public enum SubjectMatchMode {
+        EXACT,
+        PREFIX
     }
 }

--- a/gravitee-am-reporter/gravitee-am-reporter-file/src/test/java/io/gravitee/am/reporter/file/audit/JsonFileAuditReporterTest.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-file/src/test/java/io/gravitee/am/reporter/file/audit/JsonFileAuditReporterTest.java
@@ -31,6 +31,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
@@ -47,6 +49,7 @@ public class JsonFileAuditReporterTest extends FileAuditReporterTest {
     @Override
     protected  void checkAuditLogs(List<Audit> reportables, int loop) throws IOException {
         List<String> lines = Files.readAllLines(Paths.get(buildAuditLogsFilename()));
+        assertEquals("expected " + loop + " audit lines but got " + lines.size(), loop, lines.size());
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -851,6 +851,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         SpiffeApplicationSettings settings = new SpiffeApplicationSettings();
         settings.setTrustDomain(other.getTrustDomain());
         settings.setSubject(other.getSubject());
+        settings.setSubjectMatchMode(other.getSubjectMatchMode());
         return settings;
     }
 
@@ -862,6 +863,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         SpiffeApplicationSettingsMongo settings = new SpiffeApplicationSettingsMongo();
         settings.setTrustDomain(other.getTrustDomain());
         settings.setSubject(other.getSubject());
+        settings.setSubjectMatchMode(other.getSubjectMatchMode());
         return settings;
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/SpiffeApplicationSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/SpiffeApplicationSettingsMongo.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.repository.mongodb.management.internal.model;
 
+import io.gravitee.am.model.application.SpiffeApplicationSettings.SubjectMatchMode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,4 +25,5 @@ public class SpiffeApplicationSettingsMongo {
 
     private String trustDomain;
     private String subject;
+    private SubjectMatchMode subjectMatchMode;
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -1499,9 +1499,9 @@ public class ApplicationServiceImpl implements ApplicationService {
                 return Single.error(new InvalidClientMetadataException(
                         "spiffe.subjectMatchMode=PREFIX is only allowed for HOSTED_DELEGATED or AUTONOMOUS agent applications"));
             }
-            if (spiffe.getSubject().endsWith("/")) {
+            if (!spiffe.getSubject().endsWith("/")) {
                 return Single.error(new InvalidClientMetadataException(
-                        "spiffe.subject must not end with '/' when subjectMatchMode=PREFIX"));
+                        "spiffe.subject must end with '/' when subjectMatchMode=PREFIX"));
             }
         }
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -1478,7 +1478,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                     "spiffe.subject must start with " + anchor));
         }
 
-        if (spiffe.getSubjectMatchMode().equals(SpiffeApplicationSettings.SubjectMatchMode.PREFIX)) {
+        if (SpiffeApplicationSettings.SubjectMatchMode.PREFIX.equals(spiffe.getSubjectMatchMode())) {
             AgentType agentType = AgentType.orNull(application.getKind());
             boolean prefixEligible = ApplicationType.AGENT.equals(application.getType())
                     && (agentType == AgentType.HOSTED_DELEGATED || agentType == AgentType.AUTONOMOUS);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -30,17 +30,12 @@ import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.Certificate;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.application.*;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.Membership;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.account.AccountSettings;
-import io.gravitee.am.model.application.AgentType;
-import io.gravitee.am.model.application.ApplicationOAuthSettings;
-import io.gravitee.am.model.application.ApplicationSAMLSettings;
-import io.gravitee.am.model.application.ApplicationScopeSettings;
-import io.gravitee.am.model.application.ApplicationSettings;
-import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.common.event.Event;
 import io.gravitee.am.model.common.event.Payload;
@@ -106,14 +101,7 @@ import org.springframework.util.ObjectUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -1467,7 +1455,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         io.gravitee.am.model.application.SpiffeApplicationSettings spiffe =
                 application.getSettings() != null ? application.getSettings().getWorkloadIdentitySettings() : null;
 
-        boolean usesSpiffeAuth = oauth != null && io.gravitee.am.common.oidc.ClientAuthenticationMethod.SPIFFE_JWT
+        boolean usesSpiffeAuth = oauth != null && ClientAuthenticationMethod.SPIFFE_JWT
                 .equalsIgnoreCase(oauth.getTokenEndpointAuthMethod());
 
         if (!usesSpiffeAuth) {
@@ -1484,14 +1472,13 @@ public class ApplicationServiceImpl implements ApplicationService {
         if (spiffe.getSubject() == null || spiffe.getSubject().isBlank()) {
             return Single.error(new InvalidClientMetadataException("spiffe.subject is required for spiffe_jwt"));
         }
-        String anchor = "spiffe://" + spiffe.getTrustDomain().toLowerCase(java.util.Locale.ROOT) + "/";
+        String anchor = "spiffe://" + spiffe.getTrustDomain().toLowerCase(Locale.ROOT) + "/";
         if (!spiffe.getSubject().startsWith(anchor)) {
             return Single.error(new InvalidClientMetadataException(
                     "spiffe.subject must start with " + anchor));
         }
 
-        io.gravitee.am.model.application.SpiffeApplicationSettings.SubjectMatchMode mode = spiffe.getSubjectMatchMode();
-        if (mode == io.gravitee.am.model.application.SpiffeApplicationSettings.SubjectMatchMode.PREFIX) {
+        if (spiffe.getSubjectMatchMode().equals(SpiffeApplicationSettings.SubjectMatchMode.PREFIX)) {
             AgentType agentType = AgentType.orNull(application.getKind());
             boolean prefixEligible = ApplicationType.AGENT.equals(application.getType())
                     && (agentType == AgentType.HOSTED_DELEGATED || agentType == AgentType.AUTONOMOUS);
@@ -1505,7 +1492,7 @@ public class ApplicationServiceImpl implements ApplicationService {
             }
         }
 
-        return trustDomainRepository.findByName(io.gravitee.am.model.ReferenceType.DOMAIN,
+        return trustDomainRepository.findByName(ReferenceType.DOMAIN,
                         application.getDomain(), spiffe.getTrustDomain())
                 .switchIfEmpty(Single.error(new InvalidClientMetadataException(
                         "spiffe.trustDomain '" + spiffe.getTrustDomain() + "' is not registered for this domain")))

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -1462,7 +1462,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                 });
     }
 
-    private Single<Application> validateSpiffeSettings(Application application) {
+    Single<Application> validateSpiffeSettings(Application application) {
         ApplicationOAuthSettings oauth = application.getSettings() != null ? application.getSettings().getOauth() : null;
         io.gravitee.am.model.application.SpiffeApplicationSettings spiffe =
                 application.getSettings() != null ? application.getSettings().getWorkloadIdentitySettings() : null;
@@ -1488,6 +1488,21 @@ public class ApplicationServiceImpl implements ApplicationService {
         if (!spiffe.getSubject().startsWith(anchor)) {
             return Single.error(new InvalidClientMetadataException(
                     "spiffe.subject must start with " + anchor));
+        }
+
+        io.gravitee.am.model.application.SpiffeApplicationSettings.SubjectMatchMode mode = spiffe.getSubjectMatchMode();
+        if (mode == io.gravitee.am.model.application.SpiffeApplicationSettings.SubjectMatchMode.PREFIX) {
+            AgentType agentType = AgentType.orNull(application.getKind());
+            boolean prefixEligible = ApplicationType.AGENT.equals(application.getType())
+                    && (agentType == AgentType.HOSTED_DELEGATED || agentType == AgentType.AUTONOMOUS);
+            if (!prefixEligible) {
+                return Single.error(new InvalidClientMetadataException(
+                        "spiffe.subjectMatchMode=PREFIX is only allowed for HOSTED_DELEGATED or AUTONOMOUS agent applications"));
+            }
+            if (spiffe.getSubject().endsWith("/")) {
+                return Single.error(new InvalidClientMetadataException(
+                        "spiffe.subject must not end with '/' when subjectMatchMode=PREFIX"));
+            }
         }
 
         return trustDomainRepository.findByName(io.gravitee.am.model.ReferenceType.DOMAIN,

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ApplicationServiceImplSpiffeValidationTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ApplicationServiceImplSpiffeValidationTest.java
@@ -67,7 +67,7 @@ class ApplicationServiceImplSpiffeValidationTest {
     @Test
     void prefixMode_passes_forHostedDelegatedAgent() {
         Application app = agentApp(AgentType.HOSTED_DELEGATED,
-                spiffeSettings("spiffe://acme/hotel-agent",
+                spiffeSettings("spiffe://acme/hotel-agent/",
                         SpiffeApplicationSettings.SubjectMatchMode.PREFIX));
 
         service.validateSpiffeSettings(app).test().assertNoErrors().assertValue(app);
@@ -76,7 +76,7 @@ class ApplicationServiceImplSpiffeValidationTest {
     @Test
     void prefixMode_passes_forAutonomousAgent() {
         Application app = agentApp(AgentType.AUTONOMOUS,
-                spiffeSettings("spiffe://acme/hotel-agent",
+                spiffeSettings("spiffe://acme/hotel-agent/",
                         SpiffeApplicationSettings.SubjectMatchMode.PREFIX));
 
         service.validateSpiffeSettings(app).test().assertNoErrors().assertValue(app);
@@ -111,14 +111,14 @@ class ApplicationServiceImplSpiffeValidationTest {
     }
 
     @Test
-    void prefixMode_rejected_whenSubjectHasTrailingSlash() {
+    void prefixMode_rejected_whenSubjectMissingTrailingSlash() {
         Application app = agentApp(AgentType.HOSTED_DELEGATED,
-                spiffeSettings("spiffe://acme/hotel-agent/",
+                spiffeSettings("spiffe://acme/hotel-agent",
                         SpiffeApplicationSettings.SubjectMatchMode.PREFIX));
 
         service.validateSpiffeSettings(app).test()
                 .assertError(err -> err instanceof InvalidClientMetadataException
-                        && err.getMessage().contains("must not end with '/'"));
+                        && err.getMessage().contains("must end with '/'"));
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ApplicationServiceImplSpiffeValidationTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ApplicationServiceImplSpiffeValidationTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.impl;
+
+import io.gravitee.am.common.oidc.ClientAuthenticationMethod;
+import io.gravitee.am.model.Application;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.application.AgentType;
+import io.gravitee.am.model.application.ApplicationOAuthSettings;
+import io.gravitee.am.model.application.ApplicationSettings;
+import io.gravitee.am.model.application.ApplicationType;
+import io.gravitee.am.model.application.SpiffeApplicationSettings;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.service.exception.InvalidClientMetadataException;
+import io.reactivex.rxjava3.core.Maybe;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationServiceImplSpiffeValidationTest {
+
+    private static final String DOMAIN_ID = "domain-1";
+    private static final String TRUST_DOMAIN = "acme";
+
+    @Mock
+    private TrustDomainRepository trustDomainRepository;
+
+    private ApplicationServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ApplicationServiceImpl();
+        ReflectionTestUtils.setField(service, "trustDomainRepository", trustDomainRepository);
+        lenient().when(trustDomainRepository.findByName(eq(ReferenceType.DOMAIN), eq(DOMAIN_ID), eq(TRUST_DOMAIN)))
+                .thenReturn(Maybe.just(TrustDomain.builder().name(TRUST_DOMAIN).build()));
+    }
+
+    @Test
+    void exactMode_default_passes() {
+        Application app = agentApp(AgentType.HOSTED_DELEGATED,
+                spiffeSettings("spiffe://acme/hotel-agent", null));
+
+        service.validateSpiffeSettings(app).test().assertNoErrors().assertValue(app);
+    }
+
+    @Test
+    void prefixMode_passes_forHostedDelegatedAgent() {
+        Application app = agentApp(AgentType.HOSTED_DELEGATED,
+                spiffeSettings("spiffe://acme/hotel-agent",
+                        SpiffeApplicationSettings.SubjectMatchMode.PREFIX));
+
+        service.validateSpiffeSettings(app).test().assertNoErrors().assertValue(app);
+    }
+
+    @Test
+    void prefixMode_passes_forAutonomousAgent() {
+        Application app = agentApp(AgentType.AUTONOMOUS,
+                spiffeSettings("spiffe://acme/hotel-agent",
+                        SpiffeApplicationSettings.SubjectMatchMode.PREFIX));
+
+        service.validateSpiffeSettings(app).test().assertNoErrors().assertValue(app);
+    }
+
+    @Test
+    void prefixMode_rejected_forNonAgentApp() {
+        Application app = new Application();
+        app.setDomain(DOMAIN_ID);
+        app.setType(ApplicationType.SERVICE);
+        app.setSettings(new ApplicationSettings());
+        ApplicationOAuthSettings oauth = new ApplicationOAuthSettings();
+        oauth.setTokenEndpointAuthMethod(ClientAuthenticationMethod.SPIFFE_JWT);
+        app.getSettings().setOauth(oauth);
+        app.getSettings().setWorkloadIdentitySettings(spiffeSettings("spiffe://acme/hotel-agent",
+                SpiffeApplicationSettings.SubjectMatchMode.PREFIX));
+
+        service.validateSpiffeSettings(app).test()
+                .assertError(err -> err instanceof InvalidClientMetadataException
+                        && err.getMessage().contains("PREFIX is only allowed"));
+    }
+
+    @Test
+    void prefixMode_rejected_forUserEmbeddedAgent() {
+        Application app = agentApp(AgentType.USER_EMBEDDED,
+                spiffeSettings("spiffe://acme/hotel-agent",
+                        SpiffeApplicationSettings.SubjectMatchMode.PREFIX));
+
+        service.validateSpiffeSettings(app).test()
+                .assertError(err -> err instanceof InvalidClientMetadataException
+                        && err.getMessage().contains("PREFIX is only allowed"));
+    }
+
+    @Test
+    void prefixMode_rejected_whenSubjectHasTrailingSlash() {
+        Application app = agentApp(AgentType.HOSTED_DELEGATED,
+                spiffeSettings("spiffe://acme/hotel-agent/",
+                        SpiffeApplicationSettings.SubjectMatchMode.PREFIX));
+
+        service.validateSpiffeSettings(app).test()
+                .assertError(err -> err instanceof InvalidClientMetadataException
+                        && err.getMessage().contains("must not end with '/'"));
+    }
+
+    @Test
+    void exactMode_stillEnforcedFor_subjectAnchor() {
+        Application app = agentApp(AgentType.HOSTED_DELEGATED,
+                spiffeSettings("spiffe://other/hotel-agent", null));
+
+        service.validateSpiffeSettings(app).test()
+                .assertError(err -> err instanceof InvalidClientMetadataException
+                        && err.getMessage().contains("must start with"));
+    }
+
+    private static Application agentApp(AgentType agentType, SpiffeApplicationSettings spiffe) {
+        Application app = new Application();
+        app.setDomain(DOMAIN_ID);
+        app.setType(ApplicationType.AGENT);
+        app.setKind(agentType.name());
+        app.setSettings(new ApplicationSettings());
+        ApplicationOAuthSettings oauth = new ApplicationOAuthSettings();
+        oauth.setTokenEndpointAuthMethod(ClientAuthenticationMethod.SPIFFE_JWT);
+        app.getSettings().setOauth(oauth);
+        app.getSettings().setWorkloadIdentitySettings(spiffe);
+        return app;
+    }
+
+    private static SpiffeApplicationSettings spiffeSettings(String subject,
+                                                            SpiffeApplicationSettings.SubjectMatchMode mode) {
+        SpiffeApplicationSettings s = new SpiffeApplicationSettings();
+        s.setTrustDomain(TRUST_DOMAIN);
+        s.setSubject(subject);
+        if (mode != null) {
+            s.setSubjectMatchMode(mode);
+        }
+        return s;
+    }
+}

--- a/gravitee-am-test/api/management/models/SpiffeApplicationSettings.ts
+++ b/gravitee-am-test/api/management/models/SpiffeApplicationSettings.ts
@@ -39,12 +39,32 @@ export interface SpiffeApplicationSettings {
    */
   subject?: string;
   /**
+   * How `subject` is matched against the SVID `sub` claim. `EXACT` (default)
+   * requires equality. `PREFIX` is only allowed for HOSTED_DELEGATED or
+   * AUTONOMOUS agent applications; the SVID is accepted when its `sub` equals
+   * the configured subject or starts with `<subject>/`, and the full SVID
+   * SPIFFE ID becomes the per-instance `act.sub` in minted tokens.
+   * @type {string}
+   * @memberof SpiffeApplicationSettings
+   */
+  subjectMatchMode?: SpiffeApplicationSettingsSubjectMatchModeEnum;
+  /**
    *
    * @type {string}
    * @memberof SpiffeApplicationSettings
    */
   trustDomain?: string;
 }
+
+/**
+ * @export
+ */
+export const SpiffeApplicationSettingsSubjectMatchModeEnum = {
+  Exact: 'EXACT',
+  Prefix: 'PREFIX',
+} as const;
+export type SpiffeApplicationSettingsSubjectMatchModeEnum =
+  (typeof SpiffeApplicationSettingsSubjectMatchModeEnum)[keyof typeof SpiffeApplicationSettingsSubjectMatchModeEnum];
 
 /**
  * Check if a given object implements the SpiffeApplicationSettings interface.
@@ -63,6 +83,7 @@ export function SpiffeApplicationSettingsFromJSONTyped(json: any, ignoreDiscrimi
   }
   return {
     subject: json['subject'] == null ? undefined : json['subject'],
+    subjectMatchMode: json['subjectMatchMode'] == null ? undefined : json['subjectMatchMode'],
     trustDomain: json['trustDomain'] == null ? undefined : json['trustDomain'],
   };
 }
@@ -78,6 +99,7 @@ export function SpiffeApplicationSettingsToJSONTyped(value?: SpiffeApplicationSe
 
   return {
     subject: value['subject'],
+    subjectMatchMode: value['subjectMatchMode'],
     trustDomain: value['trustDomain'],
   };
 }

--- a/gravitee-am-test/certs/README.md
+++ b/gravitee-am-test/certs/README.md
@@ -1,1 +1,16 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 Client certificates generated with [ca.key](../../docker/local-stack/dev/client-ssl-proxy/server/ca.key) from local-stack

--- a/gravitee-am-test/specs/gateway/blueprint-agents/fixtures/spiffe-prefix-fixture.ts
+++ b/gravitee-am-test/specs/gateway/blueprint-agents/fixtures/spiffe-prefix-fixture.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { Domain } from '@management-models/Domain';
+import {
+  createDomain,
+  DomainOidcConfig,
+  safeDeleteDomain,
+  startDomain,
+  waitForDomainStart,
+} from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+const ORG_ID = process.env.AM_DEF_ORG_ID;
+const ENV_ID = process.env.AM_DEF_ENV_ID;
+
+const SPIRE_TRUST_DOMAIN = 'am.local';
+const SPIRE_JWKS_URL = 'http://spire-oidc:8443/keys';
+
+function managementUrl(path: string): string {
+  return `${process.env.AM_MANAGEMENT_URL}/management/organizations/${ORG_ID}/environments/${ENV_ID}${path}`;
+}
+
+export interface SpiffePrefixFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  clientId: string;
+  blueprintAppId: string;
+  /** Configured `spiffe.subject` for the blueprint app — SVIDs under this are accepted. */
+  prefixSubject: string;
+  /** Fetch a JWT-SVID from the local SPIRE agent for the given SPIFFE ID + audience. */
+  fetchSvid: (spiffeId: string, audience: string) => string;
+  cleanUp: () => Promise<void>;
+}
+
+/**
+ * Sets up domain + trust-domain + HOSTED_DELEGATED agent app wired for SPIFFE
+ * with `subjectMatchMode=PREFIX`. Assumes the SPIRE compose overlay is up
+ * (`docker compose ... -f dev/docker-compose.spire.yml up -d`).
+ */
+export const setupSpiffePrefixFixture = async (): Promise<SpiffePrefixFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  let domain: Domain | null = null;
+
+  try {
+    domain = await createDomain(accessToken, uniqueName('spiffe-prefix', true), 'GMA-329 SPIFFE prefix matching');
+
+    // 1. Enable SPIFFE auth on the domain. SPIRE OIDC discovery is served over plain HTTP
+    //    on the docker network, so we relax both gates.
+    const patchDomainResp = await fetch(managementUrl(`/domains/${domain.id}`), {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        oidc: {
+          workloadIdentitySettings: {
+            enabled: true,
+            allowPrivateIpAddress: true,
+            allowUnsecuredHttpUri: true,
+          },
+        },
+      }),
+    });
+    if (!patchDomainResp.ok) {
+      throw new Error(`Failed to enable SPIFFE on domain: ${patchDomainResp.status} ${await patchDomainResp.text()}`);
+    }
+
+    // 2. Register the SPIRE trust domain via JWKS_URL bundle source.
+    const trustDomainResp = await fetch(managementUrl(`/domains/${domain.id}/trust-domains`), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: SPIRE_TRUST_DOMAIN,
+        bundleSource: 'JWKS_URL',
+        jwksUrl: SPIRE_JWKS_URL,
+      }),
+    });
+    if (!trustDomainResp.ok) {
+      throw new Error(`Failed to register trust domain: ${trustDomainResp.status} ${await trustDomainResp.text()}`);
+    }
+
+    // 3. Create the blueprint agent application.
+    const createAppResp = await fetch(managementUrl(`/domains/${domain.id}/applications`), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: uniqueName('agent-hosted-delegated', true),
+        type: 'AGENT',
+        kind: 'HOSTED_DELEGATED',
+        redirectUris: ['https://am.local/callback'],
+      }),
+    });
+    if (!createAppResp.ok) {
+      throw new Error(`Failed to create blueprint app: ${createAppResp.status} ${await createAppResp.text()}`);
+    }
+    const blueprintApp = await createAppResp.json();
+    const clientId = blueprintApp.settings.oauth.clientId;
+
+    // 4. Switch the app to spiffe_jwt with a PREFIX subject under the bootstrap SPIRE
+    //    entry `spiffe://am.local/agent/test/sample`.
+    const prefixSubject = 'spiffe://am.local/agent/test';
+    const patchAppResp = await fetch(managementUrl(`/domains/${domain.id}/applications/${blueprintApp.id}`), {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        settings: {
+          oauth: { tokenEndpointAuthMethod: 'spiffe_jwt' },
+          workloadIdentitySettings: {
+            trustDomain: SPIRE_TRUST_DOMAIN,
+            subject: prefixSubject,
+            subjectMatchMode: 'PREFIX',
+          },
+        },
+      }),
+    });
+    if (!patchAppResp.ok) {
+      throw new Error(`Failed to configure SPIFFE app settings: ${patchAppResp.status} ${await patchAppResp.text()}`);
+    }
+
+    const startedDomain = await startDomain(domain.id, accessToken);
+    const started = await waitForDomainStart(startedDomain);
+
+    return {
+      accessToken,
+      domain,
+      oidc: started.oidcConfig,
+      clientId,
+      blueprintAppId: blueprintApp.id,
+      prefixSubject,
+      fetchSvid: (spiffeId, audience) => fetchSvidFromSpireAgent(spiffeId, audience),
+      cleanUp: async () => {
+        if (domain?.id && accessToken) {
+          await safeDeleteDomain(domain.id, accessToken);
+        }
+      },
+    };
+  } catch (error) {
+    if (domain?.id && accessToken) {
+      try {
+        await safeDeleteDomain(domain.id, accessToken);
+      } catch (e) {
+        console.error('Cleanup failed:', e);
+      }
+    }
+    throw error;
+  }
+};
+
+/**
+ * Shells out to the SPIRE agent inside the local-stack to mint a JWT-SVID.
+ * Mirrors the convenience script at docker/local-stack/dev/spire/scripts/issue-svid.sh.
+ */
+function fetchSvidFromSpireAgent(spiffeId: string, audience: string): string {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..', '..');
+  const composeBase = path.join(repoRoot, 'docker/local-stack/dev/docker-compose.yml');
+  const composeSpire = path.join(repoRoot, 'docker/local-stack/dev/docker-compose.spire.yml');
+
+  const result = spawnSync(
+    'docker',
+    [
+      'compose',
+      '-f',
+      composeBase,
+      '-f',
+      composeSpire,
+      'exec',
+      '-T',
+      'spire-agent',
+      '/usr/local/bin/spire-agent',
+      'api',
+      'fetch',
+      'jwt',
+      '-socketPath',
+      '/run/spire-agent/public/api.sock',
+      '-audience',
+      audience,
+      '-spiffeID',
+      spiffeId,
+    ],
+    { encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    throw new Error(`spire-agent fetch jwt failed (exit ${result.status}) for ${spiffeId}: ${result.stderr || result.stdout}`);
+  }
+
+  // Output format (relevant lines):
+  //   token(spiffe://am.local/agent/test/sample):
+  //       eyJhbGciOi...
+  const lines = result.stdout.split('\n').map((l) => l.trim());
+  const headerIdx = lines.findIndex((l) => l.startsWith('token('));
+  if (headerIdx < 0 || headerIdx + 1 >= lines.length || !lines[headerIdx + 1]) {
+    throw new Error(`Unable to parse SVID from spire-agent output:\n${result.stdout}`);
+  }
+  return lines[headerIdx + 1];
+}

--- a/gravitee-am-test/specs/gateway/blueprint-agents/fixtures/spiffe-prefix-fixture.ts
+++ b/gravitee-am-test/specs/gateway/blueprint-agents/fixtures/spiffe-prefix-fixture.ts
@@ -114,7 +114,7 @@ export const setupSpiffePrefixFixture = async (): Promise<SpiffePrefixFixture> =
 
     // 4. Switch the app to spiffe_jwt with a PREFIX subject under the bootstrap SPIRE
     //    entry `spiffe://am.local/agent/test/sample`.
-    const prefixSubject = 'spiffe://am.local/agent/test';
+    const prefixSubject = 'spiffe://am.local/agent/test/';
     const patchAppResp = await fetch(managementUrl(`/domains/${domain.id}/applications/${blueprintApp.id}`), {
       method: 'PATCH',
       headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },

--- a/gravitee-am-test/specs/gateway/blueprint-agents/spiffe-prefix-assertion.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/blueprint-agents/spiffe-prefix-assertion.jest.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { decodeJwt } from '@utils-commands/jwt';
+import { setup } from '../../test-fixture';
+import { SpiffePrefixFixture, setupSpiffePrefixFixture } from './fixtures/spiffe-prefix-fixture';
+
+setup(120000);
+
+const JWT_SPIFFE_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-spiffe';
+const JWT_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+/**
+ * GMA-329 — SPIFFE per-instance agent identity.
+ *
+ * Requires the local-stack to be running with the SPIRE overlay AND
+ * RUN_SPIRE_TESTS=true in the environment (skipped otherwise so CI stays green):
+ *   docker compose -f docker/local-stack/dev/docker-compose.yml \
+ *                  -f docker/local-stack/dev/docker-compose-dev.yml \
+ *                  -f docker/local-stack/dev/docker-compose.mongo.yml \
+ *                  -f docker/local-stack/dev/docker-compose.spire.yml up -d
+ *   RUN_SPIRE_TESTS=true npm --prefix gravitee-am-test run test -- \
+ *     specs/gateway/blueprint-agents/spiffe-prefix-assertion.jest.spec.ts
+ *
+ * SPIRE bootstrap provisions:
+ *   - spiffe://am.local/agent/test/sample (under the configured PREFIX)
+ *   - spiffe://am.local/agent/billing      (outside the PREFIX — negative case)
+ */
+const describeIfSpire = process.env.RUN_SPIRE_TESTS === 'true' ? describe : describe.skip;
+
+describeIfSpire('Blueprint Agent — SPIFFE PREFIX subject matching', () => {
+  let fixture: SpiffePrefixFixture;
+
+  beforeAll(async () => {
+    fixture = await setupSpiffePrefixFixture();
+  });
+
+  afterAll(async () => {
+    await fixture?.cleanUp();
+  });
+
+  function postClientAssertion(assertion: string) {
+    // Pin the client_id to our blueprint so client lookup resolves to it; otherwise
+    // the validator falls back to looking the client up by the SVID's `sub`, which
+    // would mask the PREFIX-mismatch path in the negative case below.
+    const body =
+      `grant_type=client_credentials` +
+      `&client_id=${encodeURIComponent(fixture.clientId)}` +
+      `&client_assertion_type=${encodeURIComponent(JWT_SPIFFE_ASSERTION_TYPE)}` +
+      `&client_assertion=${encodeURIComponent(assertion)}`;
+    return performPost(fixture.oidc.token_endpoint, '', body, {
+      'Content-type': 'application/x-www-form-urlencoded',
+    });
+  }
+
+  it('mints a per-instance token when the SVID is under the configured subject prefix', async () => {
+    const instanceId = 'spiffe://am.local/agent/test/sample';
+    const svid = fixture.fetchSvid(instanceId, fixture.oidc.token_endpoint);
+
+    const response = await postClientAssertion(svid).expect(200);
+
+    expect(response.body.access_token).toMatch(JWT_FORMAT);
+    expect(response.body.token_type).toEqual('bearer');
+
+    const decoded = decodeJwt(response.body.access_token);
+    expect(decoded.sub).toEqual(instanceId);
+    expect(decoded.act).toBeDefined();
+    expect((decoded.act as any).sub).toEqual(fixture.clientId);
+  });
+
+  it('rejects SVIDs whose sub falls outside the configured subject prefix', async () => {
+    // Provisioned but unrelated to fixture.prefixSubject (spiffe://am.local/agent/test).
+    const outOfPrefix = 'spiffe://am.local/agent/billing';
+    const svid = fixture.fetchSvid(outOfPrefix, fixture.oidc.token_endpoint);
+
+    await postClientAssertion(svid).expect(401);
+  });
+});

--- a/gravitee-am-test/specs/gateway/blueprint-agents/spiffe-prefix-assertion.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/blueprint-agents/spiffe-prefix-assertion.jest.spec.ts
@@ -83,7 +83,7 @@ describeIfSpire('Blueprint Agent — SPIFFE PREFIX subject matching', () => {
   });
 
   it('rejects SVIDs whose sub falls outside the configured subject prefix', async () => {
-    // Provisioned but unrelated to fixture.prefixSubject (spiffe://am.local/agent/test).
+    // Provisioned but unrelated to fixture.prefixSubject (spiffe://am.local/agent/test/).
     const outOfPrefix = 'spiffe://am.local/agent/billing';
     const svid = fixture.fetchSvid(outOfPrefix, fixture.oidc.token_endpoint);
 

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/component/oauth2-settings.component.html
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/component/oauth2-settings.component.html
@@ -34,6 +34,7 @@
             [customGrantTypes]="customGrantTypes"
             [secretSettings]="resource.secretSettings"
             [applicationType]="resource.type"
+            [applicationKind]="resource.kind"
             [spiffeSettings]="spiffeSettings"
             [readonly]="readonly"
             (settingsChange)="updateSettings($event)"

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/component/oauth2-settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/component/oauth2-settings.component.ts
@@ -180,6 +180,9 @@ export class OAuth2SettingsComponent implements OnInit {
     }
 
     this.oauth2Service.update(this.domainId, this.resourceId, this.resource, oauthSettings, this.spiffeSettings).subscribe(() => {
+      if (oauthSettings.tokenEndpointAuthMethod !== 'spiffe_jwt') {
+        this.spiffeSettings = {};
+      }
       this.snackbarService.open('OAuth2 settings updated');
       this.router.navigate(['.'], { relativeTo: this.route, queryParams: { reload: true } });
       this.formChanged = false;

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
@@ -291,8 +291,8 @@
               <mat-option value="PREFIX">Prefix — one Blueprint backs many instances under the configured subject</mat-option>
             </mat-select>
             <mat-hint>
-              <code>PREFIX</code> accepts SVIDs whose <code>sub</code> starts with <code>&lt;subject&gt;/…</code>; the full SPIFFE ID
-              becomes the per-instance <code>act.sub</code> in minted tokens. Do not include a trailing <code>/</code> in Subject when using
+              <code>PREFIX</code> accepts SVIDs whose <code>sub</code> starts with <code>&lt;subject&gt;</code>; the full SPIFFE ID
+              becomes the per-instance <code>act.sub</code> in minted tokens. Subject must end with a trailing <code>/</code> when using
               <code>PREFIX</code>.
             </mat-hint>
           </mat-form-field>

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
@@ -278,6 +278,24 @@
             />
             <mat-hint>Must start with <code>spiffe://&lt;trust-domain&gt;/</code>.</mat-hint>
           </mat-form-field>
+
+          <mat-form-field *ngIf="isAgentPrefixCapable()" appearance="outline" floatLabel="always">
+            <mat-label>Subject match mode</mat-label>
+            <mat-select
+              name="spiffeSubjectMatchMode"
+              [(ngModel)]="spiffeSettings.subjectMatchMode"
+              (ngModelChange)="spiffeChanged()"
+              [disabled]="readonly"
+            >
+              <mat-option value="EXACT">Exact — SVID sub must equal the configured subject</mat-option>
+              <mat-option value="PREFIX">Prefix — one Blueprint backs many instances under the configured subject</mat-option>
+            </mat-select>
+            <mat-hint>
+              <code>PREFIX</code> accepts SVIDs whose <code>sub</code> starts with <code>&lt;subject&gt;/…</code>; the full SPIFFE ID
+              becomes the per-instance <code>act.sub</code> in minted tokens. Do not include a trailing <code>/</code> in Subject when using
+              <code>PREFIX</code>.
+            </mat-hint>
+          </mat-form-field>
         </div>
       </div>
 

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
@@ -291,8 +291,8 @@
               <mat-option value="PREFIX">Prefix — one Blueprint backs many instances under the configured subject</mat-option>
             </mat-select>
             <mat-hint>
-              <code>PREFIX</code> accepts SVIDs whose <code>sub</code> starts with <code>&lt;subject&gt;</code>; the full SPIFFE ID
-              becomes the per-instance <code>act.sub</code> in minted tokens. Subject must end with a trailing <code>/</code> when using
+              <code>PREFIX</code> accepts SVIDs whose <code>sub</code> starts with <code>&lt;subject&gt;</code>; the full SPIFFE ID becomes
+              the per-instance <code>act.sub</code> in minted tokens. Subject must end with a trailing <code>/</code> when using
               <code>PREFIX</code>.
             </mat-hint>
           </mat-form-field>

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.spec.ts
@@ -224,4 +224,65 @@ describe('GrantFlowsComponent', () => {
       expect(component.oauthSettings.tokenExchangeOAuthSettings.scopeHandling).toBe('downscoping');
     });
   });
+
+  describe('isAgentPrefixCapable', () => {
+    it('returns true for AGENT application with HOSTED_DELEGATED kind', () => {
+      component.applicationType = 'AGENT';
+      component.applicationKind = 'HOSTED_DELEGATED';
+      expect(component.isAgentPrefixCapable()).toBe(true);
+    });
+
+    it('returns true for AGENT application with AUTONOMOUS kind', () => {
+      component.applicationType = 'AGENT';
+      component.applicationKind = 'AUTONOMOUS';
+      expect(component.isAgentPrefixCapable()).toBe(true);
+    });
+
+    it('returns false for AGENT application with USER_EMBEDDED kind', () => {
+      component.applicationType = 'AGENT';
+      component.applicationKind = 'USER_EMBEDDED';
+      expect(component.isAgentPrefixCapable()).toBe(false);
+    });
+
+    it('returns false for AGENT application without a kind', () => {
+      component.applicationType = 'AGENT';
+      component.applicationKind = null;
+      expect(component.isAgentPrefixCapable()).toBe(false);
+    });
+
+    it('returns false for non-AGENT applications even with an agent kind', () => {
+      component.applicationType = 'SERVICE';
+      component.applicationKind = 'HOSTED_DELEGATED';
+      expect(component.isAgentPrefixCapable()).toBe(false);
+    });
+
+    it('matches applicationType case-insensitively', () => {
+      component.applicationType = 'agent';
+      component.applicationKind = 'HOSTED_DELEGATED';
+      expect(component.isAgentPrefixCapable()).toBe(true);
+    });
+  });
+
+  describe('spiffeChanged', () => {
+    it('emits a copy of the current spiffeSettings (including subjectMatchMode)', () => {
+      const emitted: unknown[] = [];
+      component.spiffeSettingsChange.subscribe((s: unknown) => emitted.push(s));
+      component.spiffeSettings = {
+        trustDomain: 'acme',
+        subject: 'spiffe://acme/hotel-agent',
+        subjectMatchMode: 'PREFIX',
+      };
+
+      component.spiffeChanged();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({
+        trustDomain: 'acme',
+        subject: 'spiffe://acme/hotel-agent',
+        subjectMatchMode: 'PREFIX',
+      });
+      // emitted object should be a shallow copy, not the same reference
+      expect(emitted[0]).not.toBe(component.spiffeSettings);
+    });
+  });
 });

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.ts
@@ -40,6 +40,7 @@ export class GrantFlowsComponent implements OnInit {
   // Or better, pass specifically what is needed.
   @Input() secretSettings: any[] = [];
   @Input() applicationType: string = 'service'; // Default to service if not provided? Or make optional
+  @Input() applicationKind: string | null = null; // For AGENT applications: HOSTED_DELEGATED | AUTONOMOUS | USER_EMBEDDED
 
   @Input() customGrantTypes: any[] = [];
   @Input() readonly = false;
@@ -123,6 +124,13 @@ export class GrantFlowsComponent implements OnInit {
   spiffeChanged() {
     this.spiffeSettingsChange.emit({ ...this.spiffeSettings });
     this.formChanged.emit(true);
+  }
+
+  isAgentPrefixCapable(): boolean {
+    return (
+      (this.applicationType || '').toUpperCase() === 'AGENT' &&
+      (this.applicationKind === 'HOSTED_DELEGATED' || this.applicationKind === 'AUTONOMOUS')
+    );
   }
 
   // Helper getters


### PR DESCRIPTION
## :id: Reference related issue
[GMA-329](https://gravitee.atlassian.net/browse/GMA-329)

## :pencil2: A description of the changes proposed in the pull request

Adds SPIFFE instance support for agent applications and the related UI/listing work. Main areas:

**SPIFFE subject matching (backend)**
- Add a `PREFIX` subject match mode for SPIFFE application settings, alongside exact match.
- `SpiffeClientAssertionValidator` / `SpiffeJwtSvidValidator` honour the configured match mode; PREFIX requires a trailing slash on the configured subject so prefixes only match at path boundaries.
- Null-safe handling of `subjectMatchMode` in application validation (defaults to exact match when unset).

**Agent applications**
- Allow agent applications to be marked as templates.
- Support a multi-valued `type` filter on the `/applications` listing so the API can return or exclude agents (`ApplicationCriteria` / `ApplicationFilter` plumbed through Mongo + JDBC repositories and `ApplicationServiceImpl`).

**UI**
- New top-level **Agents** nav section with its own list, resolver and creation flow.
- Applications list now routes through the multi-type filter to exclude agents.
- Expose the SPIFFE subject match mode in the OAuth2 grant-flows settings, including PREFIX trailing-slash hint.
- Reset SPIFFE form state when saving with a non-SPIFFE auth method; surface errors on agent list/resolver/creation subscriptions; send `kind` instead of `subType` on agent creation.

**Contracts**
- Regen `docs/mapi/openapi.yaml` and the management SDK for the new SPIFFE settings and multi-type filter.

## :memo: Test scenarios

- Unit tests for `SpiffeClientAssertionValidator`, `SpiffeJwtSvidValidator`, application type classification, and SPIFFE validation in `ApplicationServiceImpl`.
- Jest coverage: SPIFFE PREFIX subject assertion, agent applications as templates, applications-exclude-agents listing, multi-type filter + pagination.
- SPIRE jest tests enabled in the Mongo gateway CI run.

## :computer: Add screenshots for UI

<img width="1718" height="956" alt="image" src="https://github.com/user-attachments/assets/ba37744d-6345-4052-bb09-eb4cd80c74c7" />


## :man: :woman: Reviewers



[GMA-329]: https://gravitee.atlassian.net/browse/GMA-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ