### PR TITLE
fix(token-exchange): support parameterized scopes in downscoping and delegation

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImpl.java
@@ -21,12 +21,14 @@ import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.oauth2.TokenType;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidScopeException;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequest;
+import io.gravitee.am.gateway.handler.oauth2.service.scope.ScopeManager;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ActorTokenInfo;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenExchangeUserResolver;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenValidator;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenExchangeResult;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenExchangeService;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
+import io.gravitee.am.gateway.handler.oauth2.service.utils.ParameterizedScopeUtils;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceManager;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.ParamUtils;
 import io.gravitee.am.model.Domain;
@@ -41,6 +43,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,13 +61,16 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
     private final List<TokenValidator> validators;
     private final ProtectedResourceManager protectedResourceManager;
     private final TokenExchangeUserResolver userResolver;
+    private final ScopeManager scopeManager;
 
     public TokenExchangeServiceImpl(List<TokenValidator> validators,
                                     ProtectedResourceManager protectedResourceManager,
-                                    TokenExchangeUserResolver userResolver) {
+                                    TokenExchangeUserResolver userResolver,
+                                    ScopeManager scopeManager) {
         this.validators = validators;
         this.protectedResourceManager = protectedResourceManager;
         this.userResolver = userResolver;
+        this.scopeManager = scopeManager;
     }
 
     @Override
@@ -311,6 +317,8 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
 
     /**
      * DOWNSCOPING: allowed = base ∩ (client ∪ resource); subject/actor token scopes cap what can be granted.
+     * Parameterized scopes match by base: a base scope <s> in the pool that is declared parameterized
+     * admits any <s>:<suffix> coming from the cap (subject/actor token).
      */
     private Set<String> computeDownscopingAllowedScopes(Set<String> requestedResourceUris,
             Set<String> baseAllowedScopes,
@@ -319,9 +327,46 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
             return Collections.emptySet();
         }
         Set<String> scopePool = buildScopePool(requestedResourceUris, clientScopes);
-        Set<String> allowedScopes = new HashSet<>(baseAllowedScopes);
-        allowedScopes.retainAll(scopePool);
-        return allowedScopes;
+        List<String> parameterizedPool = parameterizedScopesIn(scopePool);
+        return baseAllowedScopes.stream()
+                .filter(scope -> scopePool.contains(scope)
+                        || ParameterizedScopeUtils.isParameterizedScope(parameterizedPool, scope))
+                .collect(Collectors.toSet());
+    }
+
+    private List<String> parameterizedScopesIn(Collection<String> scopes) {
+        if (scopeManager == null) {
+            return Collections.emptyList();
+        }
+        return scopes.stream().filter(scopeManager::isParameterizedScope).toList();
+    }
+
+    /**
+     * Parameterized-aware intersection of two scope sets (used for subject ∩ actor in delegation).
+     * Exact-string matches are kept; when one side declares the bare parameterized base {@code <s>}
+     * and the other holds {@code <s>:<suffix>}, the suffixed form is kept (more specific wins).
+     * Lateral moves ({@code <s>:<a>} vs {@code <s>:<b>}) collapse to empty.
+     */
+    private Set<String> parameterizedAwareIntersection(Set<String> left, Set<String> right) {
+        if (left.isEmpty() || right.isEmpty()) {
+            return Collections.emptySet();
+        }
+        List<String> leftParameterized = parameterizedScopesIn(left);
+        List<String> rightParameterized = parameterizedScopesIn(right);
+        Set<String> result = new HashSet<>();
+        for (String scope : left) {
+            if (right.contains(scope)
+                    || ParameterizedScopeUtils.isParameterizedScope(rightParameterized, scope)) {
+                result.add(scope);
+            }
+        }
+        for (String scope : right) {
+            if (!result.contains(scope)
+                    && ParameterizedScopeUtils.isParameterizedScope(leftParameterized, scope)) {
+                result.add(scope);
+            }
+        }
+        return result;
     }
 
     /**
@@ -382,7 +427,11 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
         if (noRequestedScopes) {
             return Single.just(allowedScopes);
         }
-        if (allowedScopes.containsAll(requestedScopes)) {
+        List<String> parameterizedAllowed = parameterizedScopesIn(allowedScopes);
+        boolean allValid = requestedScopes.stream().allMatch(scope ->
+                allowedScopes.contains(scope)
+                        || ParameterizedScopeUtils.isParameterizedScope(parameterizedAllowed, scope));
+        if (allValid) {
             return Single.just(requestedScopes);
         }
         return Single.error(new InvalidScopeException("Requested scope is not allowed"));
@@ -421,8 +470,9 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
                                                               Client client,
                                                               Domain domain) {
         Set<String> requestedScopes = Optional.ofNullable(ParamUtils.splitScopes(parsedRequest.scope())).orElse(Collections.emptySet());
-        Set<String> baseAllowed = new HashSet<>(Optional.ofNullable(subjectToken.getScopes()).orElse(Collections.emptySet()));
-        baseAllowed.retainAll(Optional.ofNullable(actorToken.getScopes()).orElse(Collections.emptySet()));
+        Set<String> baseAllowed = parameterizedAwareIntersection(
+                Optional.ofNullable(subjectToken.getScopes()).orElse(Collections.emptySet()),
+                Optional.ofNullable(actorToken.getScopes()).orElse(Collections.emptySet()));
         return computeGrantedScopes(requestedScopes, baseAllowed, tokenRequest, client, domain)
                 .flatMap(grantedScopes -> userResolver.resolve(subjectToken)
                         .switchIfEmpty(Single.error(() -> new IllegalStateException("could not resolve subject token")))

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImpl.java
@@ -329,8 +329,7 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
         Set<String> scopePool = buildScopePool(requestedResourceUris, clientScopes);
         List<String> parameterizedPool = parameterizedScopesIn(scopePool);
         return baseAllowedScopes.stream()
-                .filter(scope -> scopePool.contains(scope)
-                        || ParameterizedScopeUtils.isParameterizedScope(parameterizedPool, scope))
+                .filter(scope -> coversScope(scopePool, parameterizedPool, scope))
                 .collect(Collectors.toSet());
     }
 
@@ -339,6 +338,15 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
             return Collections.emptyList();
         }
         return scopes.stream().filter(scopeManager::isParameterizedScope).toList();
+    }
+
+    /**
+     * True iff {@code scope} is an exact member of {@code pool}, or it is a suffixed form
+     * {@code <base>:<suffix>} whose base is declared parameterized in {@code parameterizedPool}.
+     */
+    private static boolean coversScope(Set<String> pool, List<String> parameterizedPool, String scope) {
+        return pool.contains(scope)
+                || ParameterizedScopeUtils.isParameterizedScope(parameterizedPool, scope);
     }
 
     /**
@@ -355,14 +363,12 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
         List<String> rightParameterized = parameterizedScopesIn(right);
         Set<String> result = new HashSet<>();
         for (String scope : left) {
-            if (right.contains(scope)
-                    || ParameterizedScopeUtils.isParameterizedScope(rightParameterized, scope)) {
+            if (coversScope(right, rightParameterized, scope)) {
                 result.add(scope);
             }
         }
         for (String scope : right) {
-            if (!result.contains(scope)
-                    && ParameterizedScopeUtils.isParameterizedScope(leftParameterized, scope)) {
+            if (coversScope(left, leftParameterized, scope)) {
                 result.add(scope);
             }
         }
@@ -428,9 +434,8 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
             return Single.just(allowedScopes);
         }
         List<String> parameterizedAllowed = parameterizedScopesIn(allowedScopes);
-        boolean allValid = requestedScopes.stream().allMatch(scope ->
-                allowedScopes.contains(scope)
-                        || ParameterizedScopeUtils.isParameterizedScope(parameterizedAllowed, scope));
+        boolean allValid = requestedScopes.stream()
+                .allMatch(scope -> coversScope(allowedScopes, parameterizedAllowed, scope));
         if (allValid) {
             return Single.just(requestedScopes);
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/spring/OAuth2Configuration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/spring/OAuth2Configuration.java
@@ -93,8 +93,9 @@ public class OAuth2Configuration implements ProtocolConfiguration {
     @Bean
     public TokenExchangeService tokenExchangeService(List<TokenValidator> validators,
                                                      ProtectedResourceManager protectedResourceManager,
-                                                     TokenExchangeUserResolver tokenExchangeUserResolver) {
-        return new TokenExchangeServiceImpl(validators, protectedResourceManager, tokenExchangeUserResolver);
+                                                     TokenExchangeUserResolver tokenExchangeUserResolver,
+                                                     ScopeManager scopeManager) {
+        return new TokenExchangeServiceImpl(validators, protectedResourceManager, tokenExchangeUserResolver, scopeManager);
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
@@ -24,6 +24,7 @@ import io.gravitee.am.gateway.handler.oauth2.exception.InvalidScopeException;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceManager;
 import io.gravitee.am.gateway.handler.common.user.UserGatewayService;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequest;
+import io.gravitee.am.gateway.handler.oauth2.service.scope.ScopeManager;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenExchangeResult;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenExchangeUserResolver;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenValidator;
@@ -81,19 +82,23 @@ public class TokenExchangeServiceImplTest {
     @Mock
     private UserGatewayService userGatewayService;
 
+    @Mock
+    private ScopeManager scopeManager;
+
     private TokenExchangeServiceImpl service;
 
     @BeforeEach
     public void setUp() {
         service = createService(List.of(new FixedSubjectTokenValidator()));
         lenient().when(subjectManager.findUserBySub(any())).thenReturn(Maybe.empty());
+        lenient().when(scopeManager.isParameterizedScope(anyString())).thenReturn(false);
     }
 
     private TokenExchangeServiceImpl createService(List<TokenValidator> validators) {
         TokenUserResolver subjectResolver = new TokenUserResolver(subjectManager, userGatewayService);
         TrustedIssuerUserResolver trustedResolver = new TrustedIssuerUserResolver(userGatewayService);
         TokenExchangeUserResolver userResolver = new TokenExchangeUserResolverFacade(subjectResolver, trustedResolver);
-        return new TokenExchangeServiceImpl(validators, protectedResourceManager, userResolver);
+        return new TokenExchangeServiceImpl(validators, protectedResourceManager, userResolver, scopeManager);
     }
 
     @Test
@@ -2127,6 +2132,265 @@ public class TokenExchangeServiceImplTest {
 
             // Downscoping: {A,B} ∩ {A,B,C} = {A,B}
             assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("A", "B");
+        }
+    }
+
+    @Nested
+    class ParameterizedScopeHandling {
+
+        /** Bare parameterized scope in subject → exact match request → granted (both modes). */
+        @Test
+        public void shouldGrantExactMatchOnParameterizedScopeDownscoping() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = scopeValidator(Set.of("mcp"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp"));
+
+            Domain domain = domainWithTokenExchange();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            service.exchange(tokenRequest, client, domain).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("mcp");
+        }
+
+        /** Bare parameterized scope in subject → suffixed request → granted (narrowing, downscoping). */
+        @Test
+        public void shouldGrantSuffixedRequestWhenSubjectHoldsBareParameterizedScopeDownscoping() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = scopeValidator(Set.of("mcp"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp:tenant-a"));
+
+            Domain domain = domainWithTokenExchange();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            service.exchange(tokenRequest, client, domain).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("mcp:tenant-a");
+        }
+
+        /** Same scenario in PERMISSIVE mode (subject scopes ignored). */
+        @Test
+        public void shouldGrantSuffixedRequestWhenSubjectHoldsBareParameterizedScopePermissive() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = scopeValidator(Set.of("mcp"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp:tenant-a"));
+
+            Domain domain = domainWithTokenExchange();
+            Client client = new Client();
+            client.setClientId("client-id");
+            TokenExchangeOAuthSettings teSettings = new TokenExchangeOAuthSettings();
+            teSettings.setInherited(false);
+            teSettings.setScopeHandling(TokenExchangeScopeHandling.PERMISSIVE);
+            client.setTokenExchangeOAuthSettings(teSettings);
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            service.exchange(tokenRequest, client, domain).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("mcp:tenant-a");
+        }
+
+        /** Suffixed scope already in subject token → identical request → granted (exact match). */
+        @Test
+        public void shouldGrantExactSuffixedRequestWhenSubjectAlreadyHoldsItDownscoping() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = scopeValidator(Set.of("mcp:tenant-a"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp:tenant-a"));
+
+            Domain domain = domainWithTokenExchange();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            service.exchange(tokenRequest, client, domain).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("mcp:tenant-a");
+        }
+
+        /** Upscope rejection: subject holds suffixed scope, request bare scope → reject (strips the binding). */
+        @Test
+        public void shouldRejectUpscopeFromSuffixedSubjectToBareScopeDownscoping() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = scopeValidator(Set.of("mcp:tenant-a"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp"));
+
+            Domain domain = domainWithTokenExchange();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            assertThatThrownBy(() -> service.exchange(tokenRequest, client, domain).blockingGet())
+                    .isInstanceOf(InvalidScopeException.class);
+        }
+
+        /** Lateral move rejection: subject holds <scope>:<a>, request <scope>:<b> → reject (downscoping). */
+        @Test
+        public void shouldRejectLateralMoveBetweenSuffixesDownscoping() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = scopeValidator(Set.of("mcp:tenant-a"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp:tenant-b"));
+
+            Domain domain = domainWithTokenExchange();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            assertThatThrownBy(() -> service.exchange(tokenRequest, client, domain).blockingGet())
+                    .isInstanceOf(InvalidScopeException.class);
+        }
+
+        /** Suffix on a non-parameterized scope is rejected even in PERMISSIVE mode. */
+        @Test
+        public void shouldRejectSuffixedRequestWhenScopeIsNotParameterizedPermissive() throws Exception {
+            // scopeManager returns false for all (default) → "openid" is not parameterized
+            TokenValidator validator = scopeValidator(Set.of("openid"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "openid:tenant-a"));
+
+            Domain domain = domainWithTokenExchange();
+            Client client = new Client();
+            client.setClientId("client-id");
+            TokenExchangeOAuthSettings teSettings = new TokenExchangeOAuthSettings();
+            teSettings.setInherited(false);
+            teSettings.setScopeHandling(TokenExchangeScopeHandling.PERMISSIVE);
+            client.setTokenExchangeOAuthSettings(teSettings);
+            client.setScopeSettings(defaultClientScopeSettings("openid"));
+
+            assertThatThrownBy(() -> service.exchange(tokenRequest, client, domain).blockingGet())
+                    .isInstanceOf(InvalidScopeException.class);
+        }
+
+        /** Suffix on a non-parameterized scope is rejected in DOWNSCOPING mode too. */
+        @Test
+        public void shouldRejectSuffixedRequestWhenScopeIsNotParameterizedDownscoping() throws Exception {
+            TokenValidator validator = scopeValidator(Set.of("openid"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "openid:tenant-a"));
+
+            Domain domain = domainWithTokenExchange();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("openid"));
+
+            assertThatThrownBy(() -> service.exchange(tokenRequest, client, domain).blockingGet())
+                    .isInstanceOf(InvalidScopeException.class);
+        }
+
+        // ---- Delegation: subject ∩ actor uses parameterized-aware intersection (more specific wins). ----
+
+        /** Delegation: subject bare parameterized, actor suffixed → intersection narrows to actor's suffix. */
+        @Test
+        public void shouldNarrowDelegationIntersectionToActorSuffixWhenSubjectHoldsBareParameterized() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = delegationScopeValidator(Set.of("mcp"), Set.of("mcp:tenant-a"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildDelegationParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp:tenant-a"));
+
+            Domain domain = domainWithDelegation();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            service.exchange(tokenRequest, client, domain).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("mcp:tenant-a");
+        }
+
+        /** Delegation: subject suffixed, actor bare parameterized → intersection narrows to subject's suffix. */
+        @Test
+        public void shouldNarrowDelegationIntersectionToSubjectSuffixWhenActorHoldsBareParameterized() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = delegationScopeValidator(Set.of("mcp:tenant-a"), Set.of("mcp"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildDelegationParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp:tenant-a"));
+
+            Domain domain = domainWithDelegation();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            service.exchange(tokenRequest, client, domain).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("mcp:tenant-a");
+        }
+
+        /** Delegation: both sides hold the same suffixed scope → exact match preserved. */
+        @Test
+        public void shouldGrantExactSuffixedScopeWhenBothSubjectAndActorHoldItDelegation() throws Exception {
+            when(scopeManager.isParameterizedScope("mcp")).thenReturn(true);
+            TokenValidator validator = delegationScopeValidator(Set.of("mcp:tenant-a"), Set.of("mcp:tenant-a"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildDelegationParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp:tenant-a"));
+
+            Domain domain = domainWithDelegation();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            service.exchange(tokenRequest, client, domain).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("mcp:tenant-a");
+        }
+
+        /** Delegation: subject and actor hold different suffixes of the same base → lateral move rejected. */
+        @Test
+        public void shouldRejectLateralMoveBetweenSubjectAndActorSuffixesDelegation() throws Exception {
+            TokenValidator validator = delegationScopeValidator(Set.of("mcp:tenant-a"), Set.of("mcp:tenant-b"));
+            service = createService(List.of(validator));
+
+            TokenRequest tokenRequest = new TokenRequest();
+            tokenRequest.setClientId("client-id");
+            tokenRequest.setParameters(buildDelegationParametersWithScope(TokenType.ACCESS_TOKEN, TokenType.ACCESS_TOKEN, "mcp:tenant-a"));
+
+            Domain domain = domainWithDelegation();
+            Client client = new Client();
+            client.setClientId("client-id");
+            client.setScopeSettings(defaultClientScopeSettings("mcp"));
+
+            assertThatThrownBy(() -> service.exchange(tokenRequest, client, domain).blockingGet())
+                    .isInstanceOf(InvalidScopeException.class);
         }
     }
 


### PR DESCRIPTION
## :id: Reference related issue. 

[AM-7026](https://gravitee.atlassian.net/browse/AM-7026)

## :pencil2: A description of the changes proposed in the pull request

Make OAuth2 Token Exchange (RFC 8693) aware of **parameterized scopes** (e.g. `read:<resource_id>`) when computing granted scopes. Previously the service compared scopes by exact string equality, so any `` `<base>:<suffix>` `` was rejected even when the parameterized `` `<base>` `` was authorized on the client / protected resource.

Three call sites in `TokenExchangeServiceImpl` are updated:

- **Downscoping** (`computeDownscopingAllowedScopes`) — a parameterized base scope `` `<s>` `` in the client/resource pool now admits any `` `<s>:<suffix>` `` coming from the subject/actor token cap.
- **Delegation cap** (new `parameterizedAwareIntersection` used for the `subject ∩ actor` intersection) — keeps the more-specific suffixed form when only one side declares the bare base (`` `<s>` `` ∩ `` `<s>:x` `` → `` `<s>:x` ``). Lateral moves (`` `<s>:a` `` ∩ `` `<s>:b` ``) still collapse to empty.
- **Requested-vs-allowed validation** (`computeGrantedScopes`) — accepts a requested suffixed scope whose base is in the allowed set.

`ScopeManager` is injected via `OAuth2Configuration` so the service can ask whether a scope is declared parameterized in the domain.

## :memo: Test scenarios

Unit tests in `TokenExchangeServiceImplTest` (added in this PR) cover:

- Downscoping: parameterized base in the client/resource pool accepts a suffixed cap scope from the subject/actor token.
- Downscoping: non-parameterized scope still requires exact match.
- Delegation: `subject={<s>}` ∩ `actor={<s>:x}` → `{<s>:x}` (and the symmetric case).
- Delegation: lateral move `subject={<s>:a}` ∩ `actor={<s>:b}` → `∅`.
- Delegation: identical suffixes are preserved.
- Requested-scope validation: requesting `` `<s>:<suffix>` `` succeeds when `` `<s>` `` is allowed and parameterized; fails when `` `<s>` `` is not parameterized.
- Empty / null scope sets on either side are handled.

Manual:

1. Configure a domain with a parameterized scope `read` (declared parameterized in scope management).
2. Issue a subject token with `read:resource-abc`.
3. Call `POST /oauth/token` with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` on a client whose scopes include `read`.
4. Verify the issued token preserves `read:resource-abc`.
5. Repeat with a non-parameterized scope and confirm exact-match behavior is unchanged.
6. Trigger a lateral move (subject `read:a`, actor `read:b`) and confirm `invalid_scope`.

## :computer: Add screenshots for UI

N/A — backend-only change in `gravitee-am-gateway-handler-oidc`. No UI surface affected.

## :books: Any other comments that will help with documentation

- Behavior aligns parameterized-scope semantics across grant types: token-exchange now matches what the standard authorization-code / client-credentials flows already do via `ScopeManager.isParameterizedScope`.
- The "more-specific wins" rule for the delegation intersection is worth calling out in the Token Exchange docs: `` `<base>` `` ∩ `` `<base>:<suffix>` `` resolves to `` `<base>:<suffix>` ``, not `` `<base>` ``.
- Lateral moves between two different suffixes of the same base are intentionally rejected (no fall-back to the bare base) — surface this in the troubleshooting section.
- No config flag is introduced; the change is on by default for any scope declared parameterized in scope management.

## :man: :woman: @mentions of the person or team responsible for reviewing proposed changes

[AM-7026]: https://gravitee.atlassian.net/browse/AM-7026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ