### PR TITLE
GMA-321 agent as template

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -1517,10 +1517,6 @@ public class ApplicationServiceImpl implements ApplicationService {
             return Single.error(new InvalidClientMetadataException(
                     "Unknown kind '" + kind + "' for AGENT application. Allowed values: [" + allowed + "]"));
         }
-        if (application.isTemplate()) {
-            return Single.error(new InvalidClientMetadataException("Agent applications cannot be marked as a template"));
-        }
-
         // USER_EMBEDDED and HOSTED_DELEGATED rely on authorization_code; redirect_uri is required.
         // AUTONOMOUS uses client_credentials only — no redirect needed.
         if (agentType != AgentType.AUTONOMOUS) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ApplicationServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ApplicationServiceTest.java
@@ -2120,21 +2120,6 @@ public class ApplicationServiceTest {
     }
 
     @Test
-    public void shouldNot_update_agentApp_markedAsTemplate() {
-        Application toPatch = agentBaseline();
-        // baseline is HOSTED_DELEGATED-friendly (authorization_code), make it valid for that profile
-        toPatch.setKind(AgentType.HOSTED_DELEGATED.name());
-        toPatch.setTemplate(true);
-
-        TestObserver testObserver = applicationService.update(toPatch).test();
-        testObserver.awaitDone(10, TimeUnit.SECONDS);
-
-        testObserver.assertError(error -> error instanceof InvalidClientMetadataException
-                && ((Throwable) error).getMessage().toLowerCase().contains("template"));
-        verify(applicationRepository, never()).update(any(Application.class));
-    }
-
-    @Test
     public void shouldNot_update_agentApp_withForbiddenGrant_implicit() {
         Application toPatch = agentBaseline();
         toPatch.setKind(AgentType.USER_EMBEDDED.name());

--- a/gravitee-am-test/specs/management/agent-applications/agent-applications.jest.spec.ts
+++ b/gravitee-am-test/specs/management/agent-applications/agent-applications.jest.spec.ts
@@ -16,6 +16,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { Application } from '@management-models/Application';
+import { patchApplication } from '@management-commands/application-management-commands';
 import { uniqueName } from '@utils-commands/misc';
 import { setup } from '../../test-fixture';
 import { AgentApplicationsFixture, setupAgentApplicationsFixture } from './fixtures/agent-applications-fixture';
@@ -115,5 +116,25 @@ describe('GET /applications?type=AGENT', () => {
   it('rejects requests without a bearer token with 401', async () => {
     const response = await fixture.listAgentsRaw(fixture.domain.id!, '', { size: 1 });
     expect(response.status).toEqual(401);
+  });
+});
+
+describe('PATCH /applications/:id template flag', () => {
+  it('allows an agent application to be marked as a template', async () => {
+    const agent = await fixture.createAgentApp(
+      fixture.domain.id!,
+      uniqueName(`${RUN}-template-toggle`, true),
+      'AUTONOMOUS',
+    );
+    expect(agent.template).toBeFalsy();
+
+    const patched = await patchApplication(
+      fixture.domain.id!,
+      fixture.accessToken,
+      { template: true } as any,
+      agent.id!,
+    );
+
+    expect(patched.template).toEqual(true);
   });
 });


### PR DESCRIPTION
## :id: Reference related issue

[GMA-321](https://gravitee.atlassian.net/browse/GMA-321)

## :pencil2: A description of the changes proposed in the pull request

Drops the backend restriction that prevented `AGENT` applications from being marked as a DCR/CIMD registration template. The "Use as DCR / CIMD registration template" toggle in the application settings UI already POSTs `template: true` for any app — the only thing blocking it for agent apps was a check inside `ApplicationServiceImpl.validateAgentSettings` that rejected the patch with `InvalidClientMetadataException("Agent applications cannot be marked as a template")`.

Removing that check (3 lines) is sufficient — no UI changes, no CIMD-selection changes, and no change to how the template is consumed at DCR time.

## :memo: Test scenarios

- New Jest integration test in `agent-applications.jest.spec.ts`: creates an `AUTONOMOUS` agent app, PATCHes `template: true`, asserts the response has `template === true`.
- Existing tests in the same spec (the `GET /applications?type=AGENT` block, 6 tests) act as regression coverage — all still pass.

## :computer: Add screenshots for UI

N/A — backend only. The UI toggle was already wired up.

## :books: Any other comments that will help with documentation

The `template` flag here is the existing per-application DCR/CIMD seed flag (see `oidc.cimdSettings.templateId`). This change does not alter which app the domain selects as its CIMD template, nor the seeding logic — admins are now simply free to pick an agent app for that slot if they want.

## :man: :woman: @mentions

[GMA-321]: https://gravitee.atlassian.net/browse/GMA-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ