### PR TITLE
feat(GMA-322): set act.sub to agent instance id for user-bound agent …

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -46,6 +46,7 @@ import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryServ
 import io.gravitee.am.gateway.handler.oidc.service.idtoken.IDTokenService;
 import io.gravitee.am.model.TokenClaim;
 import io.gravitee.am.model.User;
+import io.gravitee.am.model.application.AgentType;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.safe.ClientProperties;
 import io.gravitee.am.model.safe.UserProperties;
@@ -477,11 +478,14 @@ public class TokenServiceImpl implements TokenService {
             jwt.put(Claims.ACT, request.getActClaim());
         }
 
-        // Agent application - inject "act" claim (actor = agent or blueprint client_id) and
-        // tag the actor with sub_profile so downstream consumers can reason about the chain.
+        // Agent application - inject "act" claim (actor = agent instance or blueprint client_id)
+        // and tag the actor with sub_profile so downstream consumers can reason about the chain.
+        // For user-bound kinds (USER_EMBEDDED, HOSTED_DELEGATED) the agent's instance id is the
+        // truer actor identity than the blueprint client_id, matching the top-level sub idiom
+        // used for client-only flows in createJWT.
         if (client.isAgentApplication() && jwt.get(Claims.ACT) == null) {
             Map<String, Object> act = new HashMap<>();
-            act.put(Claims.SUB, client.getClientId());
+            act.put(Claims.SUB, resolveAgentActSubject(client));
             if (client.getAgentType() != null) {
                 act.put(Claims.SUB_PROFILE, client.getAgentType().name().toLowerCase());
             }
@@ -508,6 +512,18 @@ public class TokenServiceImpl implements TokenService {
         setResources(request, jwt);
 
         return jwt;
+    }
+
+    // For user-bound agent kinds the issued token's top-level sub is the end-user, so the agent
+    // instance id (when known) is the truer actor identity to expose in act.sub. AUTONOMOUS keeps
+    // the blueprint client_id since its top-level sub already exposes the instance id.
+    private static String resolveAgentActSubject(Client client) {
+        AgentType agentType = client.getAgentType();
+        boolean userBound = agentType == AgentType.USER_EMBEDDED || agentType == AgentType.HOSTED_DELEGATED;
+        if (userBound && client.getAgentInstanceId() != null) {
+            return client.getAgentInstanceId();
+        }
+        return client.getClientId();
     }
 
     private void setResources(OAuth2Request request, JWT jwt) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -520,10 +520,12 @@ public class TokenServiceImpl implements TokenService {
     private static String resolveAgentActSubject(Client client) {
         AgentType agentType = client.getAgentType();
         boolean userBound = agentType == AgentType.USER_EMBEDDED || agentType == AgentType.HOSTED_DELEGATED;
-        if (userBound && client.getAgentInstanceId() != null) {
-            return client.getAgentInstanceId();
-        }
-        return client.getClientId();
+        return userBound ? resolveAgentSubject(client) : client.getClientId();
+    }
+
+    // The agent's subject identity: its instance id when known, otherwise the blueprint client_id.
+    private static String resolveAgentSubject(Client client) {
+        return client.getAgentInstanceId() != null ? client.getAgentInstanceId() : client.getClientId();
     }
 
     private void setResources(OAuth2Request request, JWT jwt) {
@@ -561,8 +563,7 @@ public class TokenServiceImpl implements TokenService {
         jwt.setIss(openIDDiscoveryService.getIssuer(oAuth2Request.getOrigin()));
         if (oAuth2Request.isClientOnly()) {
             // For blueprint-agent jwt-bearer assertions in client_credentials flow, use the agent instance ID as sub
-            String sub = client.getAgentInstanceId() != null ? client.getAgentInstanceId() : client.getClientId();
-            jwt.setSub(sub);
+            jwt.setSub(resolveAgentSubject(client));
         } else {
             subjectManager.updateJWT(jwt, user);
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenServiceTest.java
@@ -269,6 +269,98 @@ public class TokenServiceTest {
     }
 
     @Test
+    public void shouldCreate_userEmbeddedAgentWithInstanceIdSetsActSubToInstanceId() {
+        OAuth2Request oAuth2Request = new OAuth2Request();
+        oAuth2Request.setSubject("userid");
+
+        Client client = new Client();
+        client.setClientId("my-agent-client-id");
+        client.setAppType(io.gravitee.am.model.application.ApplicationType.AGENT);
+        client.setAgentType(AgentType.USER_EMBEDDED);
+        client.setAgentInstanceId("agent-instance-001");
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenAnswer(ans -> Single.just(ans.getArgument(0)));
+        when(executionContextFactory.create(any())).thenReturn(executionContext);
+        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+
+        TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        ArgumentCaptor<JWT> jwtArgumentCaptor = ArgumentCaptor.forClass(JWT.class);
+        verify(jwtService).encodeJwt(jwtArgumentCaptor.capture(), eq(client));
+        Map<?, ?> actClaim = (Map<?, ?>) jwtArgumentCaptor.getValue().get(Claims.ACT);
+        assertNotNull(actClaim);
+        assertEquals("agent-instance-001", actClaim.get(Claims.SUB));
+        assertEquals("user_embedded", actClaim.get(Claims.SUB_PROFILE));
+
+        expectTokenCreatedAuditLog();
+    }
+
+    @Test
+    public void shouldCreate_hostedDelegatedAgentWithInstanceIdSetsActSubToInstanceId() {
+        OAuth2Request oAuth2Request = new OAuth2Request();
+        oAuth2Request.setSubject("userid");
+
+        Client client = new Client();
+        client.setClientId("my-agent-client-id");
+        client.setAppType(io.gravitee.am.model.application.ApplicationType.AGENT);
+        client.setAgentType(AgentType.HOSTED_DELEGATED);
+        client.setAgentInstanceId("agent-instance-002");
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenAnswer(ans -> Single.just(ans.getArgument(0)));
+        when(executionContextFactory.create(any())).thenReturn(executionContext);
+        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+
+        TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        ArgumentCaptor<JWT> jwtArgumentCaptor = ArgumentCaptor.forClass(JWT.class);
+        verify(jwtService).encodeJwt(jwtArgumentCaptor.capture(), eq(client));
+        Map<?, ?> actClaim = (Map<?, ?>) jwtArgumentCaptor.getValue().get(Claims.ACT);
+        assertNotNull(actClaim);
+        assertEquals("agent-instance-002", actClaim.get(Claims.SUB));
+        assertEquals("hosted_delegated", actClaim.get(Claims.SUB_PROFILE));
+
+        expectTokenCreatedAuditLog();
+    }
+
+    @Test
+    public void shouldCreate_hostedDelegatedAgentWithoutInstanceIdFallsBackToClientId() {
+        OAuth2Request oAuth2Request = new OAuth2Request();
+        oAuth2Request.setSubject("userid");
+
+        Client client = new Client();
+        client.setClientId("my-agent-client-id");
+        client.setAppType(io.gravitee.am.model.application.ApplicationType.AGENT);
+        client.setAgentType(AgentType.HOSTED_DELEGATED);
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenAnswer(ans -> Single.just(ans.getArgument(0)));
+        when(executionContextFactory.create(any())).thenReturn(executionContext);
+        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+
+        TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        ArgumentCaptor<JWT> jwtArgumentCaptor = ArgumentCaptor.forClass(JWT.class);
+        verify(jwtService).encodeJwt(jwtArgumentCaptor.capture(), eq(client));
+        Map<?, ?> actClaim = (Map<?, ?>) jwtArgumentCaptor.getValue().get(Claims.ACT);
+        assertNotNull(actClaim);
+        assertEquals("my-agent-client-id", actClaim.get(Claims.SUB));
+        assertEquals("hosted_delegated", actClaim.get(Claims.SUB_PROFILE));
+
+        expectTokenCreatedAuditLog();
+    }
+
+    @Test
     public void shouldCreateWithoutAdditionalParameters() {
         tokenService.setStrictResponse(true);
         OAuth2Request oAuth2Request = new OAuth2Request();

--- a/gravitee-am-test/specs/gateway/blueprint-agents/flows/hosted-delegated-workload-jwt.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/blueprint-agents/flows/hosted-delegated-workload-jwt.jest.spec.ts
@@ -107,7 +107,7 @@ describe('HOSTED_DELEGATED agent — workload-jwt assertion + grants', () => {
 
     const decoded = decodeJwt(response.body.access_token);
     expect(decoded.sub).toEqual(agentInstanceId);
-    expect((decoded.act as any)?.sub).toEqual(agent.settings.oauth.clientId);
+    expect((decoded.act as any)?.sub).toEqual(agentInstanceId);
   });
 
   it('should reject workload-jwt with invalid signature', async () => {
@@ -186,7 +186,7 @@ describe('HOSTED_DELEGATED agent — workload-jwt assertion + grants', () => {
 
       const decoded = decodeJwt(response.body.access_token);
       expect(decoded.sub).toEqual(instanceId);
-      expect((decoded.act as any)?.sub).toEqual(agent.settings.oauth.clientId);
+      expect((decoded.act as any)?.sub).toEqual(instanceId);
     }
   });
 


### PR DESCRIPTION
## :id: Reference related issue.

[GMA-322](https://gravitee.atlassian.net/browse/GMA-322)

## :pencil2: A description of the changes proposed in the pull request

For user-bound agent kinds (`USER_EMBEDDED`, `HOSTED_DELEGATED`) the issued token's top-level `sub` is the end user, not the agent. That meant the `act.sub` actor claim was falling back to the blueprint `client_id`, which isn't really the actor doing the work.

This sets `act.sub` to the agent's instance id when we know it, so the actor in the delegation chain points at the actual agent instance rather than the blueprint. The logic lives in a small `resolveAgentActSubject` helper in `TokenServiceImpl`:

- `USER_EMBEDDED` / `HOSTED_DELEGATED` with an instance id → `act.sub` = agent instance id
- same kinds with no instance id → fall back to `client_id`
- `AUTONOMOUS` → unchanged (its top-level `sub` already carries the instance id)

`act.sub_profile` still gets the lower-cased agent type as before.

## :memo: Test scenarios

Unit tests in `TokenServiceTest`:
- USER_EMBEDDED with instance id sets `act.sub` to the instance id
- HOSTED_DELEGATED with instance id sets `act.sub` to the instance id
- HOSTED_DELEGATED without an instance id falls back to `client_id`

Updated the `hosted-delegated-workload-jwt` gateway integration spec to expect `act.sub` to equal the agent instance id.

## :computer: Add screenshots for UI

n/a

## :books: Any other comments that will help with documentation

`act.sub` now means "the agent instance acting", not "the blueprint client". Worth noting for anyone consuming the delegation chain downstream.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes



[GMA-322]: https://gravitee.atlassian.net/browse/GMA-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ