### PR TITLE
fix: add option to provide clientId as value in the access logs

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/handler/GraviteeLoggerHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/handler/GraviteeLoggerHandler.java
@@ -15,20 +15,25 @@
  */
 package io.gravitee.am.gateway.handler.root.handler;
 
+import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.service.utils.vertx.RequestUtils;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.ext.web.impl.Utils;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.net.SocketAddress;
 import io.vertx.rxjava3.ext.web.RoutingContext;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 
+import java.net.URLDecoder;
+import java.util.Base64;
 import java.util.Optional;
+
+import static io.gravitee.am.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author Eric Leleu (eric.leleu@graviteesource.com)
@@ -40,52 +45,77 @@ public class GraviteeLoggerHandler implements Handler<RoutingContext> {
     final boolean includeUriParameter;
     final boolean includeDuration;
     final boolean useXForwardedFor;
+    final boolean includeClientId;
+
 
     public GraviteeLoggerHandler(Environment environment) {
         includeUriParameter = environment.getProperty("handlers.request.logger.accesslog.includeUriParams", Boolean.class, true);
         includeDuration = environment.getProperty("handlers.request.logger.accesslog.includeDuration", Boolean.class, false);
         useXForwardedFor = environment.getProperty("handlers.request.logger.accesslog.useXForward", Boolean.class, false);
+        includeClientId = environment.getProperty("handlers.request.logger.accesslog.includeClientId", Boolean.class, false);
     }
 
     private void log(RoutingContext context, long timestamp, String remoteClient, HttpVersion version, HttpMethod method, String uri) {
         HttpServerRequest request = context.request();
-        final var contentLength = request.response().bytesWritten();
-        String versionFormatted = "-";
-        switch (version){
-            case HTTP_1_0:
-                versionFormatted = "HTTP/1.0";
-                break;
-            case HTTP_1_1:
-                versionFormatted = "HTTP/1.1";
-                break;
-            case HTTP_2:
-                versionFormatted = "HTTP/2.0";
-                break;
-            default:
-                versionFormatted = version.alpnName();
-        }
-
         final var headers = request.headers();
         final var status = request.response().getStatusCode();
         // as per RFC1945 the header is referer but it is not mandatory some implementations use referrer
-        var referrer = headers.contains("referrer") ? headers.get("referrer") : headers.get("referer");
-        var userAgent = request.headers().get("user-agent");
-        referrer = referrer == null ? "-" : referrer;
-        userAgent = userAgent == null ? "-" : userAgent;
+        final var referrer = headers.contains("referrer") ? headers.get("referrer") : headers.get("referer");
+        final var userAgent = headers.get("user-agent");
 
-        final var message = String.format(includeDuration ? "%s - - [%s] \"%s %s %s\" %d %d \"%s\" \"%s\" %d" : "%s - - [%s] \"%s %s %s\" %d %d \"%s\" \"%s\"",
+        final var entry = new AccessLogEntry(
                 remoteClient,
                 Utils.formatRFC1123DateTime(timestamp),
                 method,
                 uri,
-                versionFormatted,
+                formatVersion(version),
                 status,
-                contentLength,
-                referrer,
-                userAgent,
-                System.currentTimeMillis() - timestamp);
+                request.response().bytesWritten(),
+                referrer == null ? "-" : referrer,
+                userAgent == null ? "-" : userAgent,
+                includeDuration ? System.currentTimeMillis() - timestamp : null,
+                includeClientId ? extractClientId(context).orElse("-") : null);
 
-        doLog(status, message);
+        doLog(status, entry.toLogLine());
+    }
+
+    private static String formatVersion(HttpVersion version) {
+        return switch (version) {
+            case HTTP_1_0 -> "HTTP/1.0";
+            case HTTP_1_1 -> "HTTP/1.1";
+            case HTTP_2 -> "HTTP/2.0";
+            default -> version.alpnName();
+        };
+    }
+
+    record AccessLogEntry(
+            String remoteClient,
+            String timestamp,
+            HttpMethod method,
+            String uri,
+            String httpVersion,
+            int status,
+            long contentLength,
+            String referrer,
+            String userAgent,
+            Long duration,
+            String clientId) {
+
+        String toLogLine() {
+            final var sb = new StringBuilder()
+                    .append(remoteClient).append(" - - [")
+                    .append(timestamp).append("] \"")
+                    .append(method).append(' ').append(uri).append(' ').append(httpVersion).append("\" ")
+                    .append(status).append(' ').append(contentLength)
+                    .append(" \"").append(referrer).append("\" \"").append(userAgent).append('"');
+            if (duration != null) {
+                sb.append(' ').append(duration);
+            }
+            if (clientId != null) {
+                sb.append(" \"").append(clientId).append('"');
+            }
+            return sb.toString();
+        }
     }
 
     protected void doLog(int status, String message) {
@@ -109,5 +139,54 @@ public class GraviteeLoggerHandler implements Handler<RoutingContext> {
         context.addEndHandler(v -> log(context, timestamp, remoteClient, version, method, uri));
 
         context.next();
+    }
+
+    private static Optional<String> extractClientId(RoutingContext context) {
+        final Client client = context.get(CLIENT_CONTEXT_KEY);
+        if (client != null) {
+            return Optional.ofNullable(client.getClientId());
+        }
+
+        final HttpServerRequest request = context.request();
+        if (request.getHeader(HttpHeaders.AUTHORIZATION) != null) {
+            return extractClientIdFromAuthHeader(request).or(() -> extractClientIdFromQueryParam(request));
+        }
+
+        return extractClientIdFromQueryParam(request);
+    }
+
+    private static Optional<String> extractClientIdFromAuthHeader(HttpServerRequest request) {
+        final var authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        final var authHeaderParts = authHeader.split(" ");
+
+        if (authHeaderParts[0].trim().equalsIgnoreCase("Basic") && authHeaderParts.length == 2) {
+            try {
+                final var decoded = new String(Base64.getDecoder().decode(authHeaderParts[1].trim()));
+                final var colonIdx = decoded.indexOf(":");
+                if (colonIdx == -1) {
+                    throw new IllegalArgumentException();
+                }
+                return Optional.ofNullable(urlDecode(decoded.substring(0, colonIdx)));
+            } catch (IllegalArgumentException e) {
+                // Malformed Base64 or invalid characters, ignore.
+                log.debug("Unable to decode Basic auth credentials for logging", e);
+            }
+        } else {
+            log.debug("Authorization header is not of type Basic, ignoring");
+        }
+
+        return Optional.empty();
+    }
+
+    private static String urlDecode(String value) {
+        try {
+            return URLDecoder.decode(value, UTF_8);
+        } catch (IllegalArgumentException e) {
+            return value;
+        }
+    }
+
+    private static Optional<String> extractClientIdFromQueryParam(HttpServerRequest request) {
+        return Optional.ofNullable(request.getParam("client_id"));
     }
 }


### PR DESCRIPTION
fixes AM-7054

# expose clientId and duration

```
handlers:
  request:
    logger:
      accesslog:
        enabled: true
        includeDuration: true
        includeClientId: true
```

Will give :

`18:27:36.624 [vert.x-eventloop-thread-4] [] INFO  i.g.a.g.h.r.h.GraviteeLoggerHandler - 0:0:0:0:0:0:0:1 - - [Fri, 22 May 2026 16:27:36 GMT] "POST /domain/oauth/token HTTP/1.1" 200 756 "-" "curl/8.7.1" 59 "service"
`

The line contains:

* timestamp of the log (logback)
* thread executing the log action 
* log level
* Logger name
* remoteAddr
* timestamp of request (timestamp at which the request start to be process)
* the requets information (method, path, protocol)
* status
* response content-length
* referer
* userAgent
* duration in ms
* clientId


# expose clientId only

```
handlers:
  request:
    logger:
      accesslog:
        enabled: true
        includeDuration: false
        includeClientId: true
```

Will give :

`18:27:36.624 [vert.x-eventloop-thread-4] [] INFO  i.g.a.g.h.r.h.GraviteeLoggerHandler - 0:0:0:0:0:0:0:1 - - [Fri, 22 May 2026 16:27:36 GMT] "POST /domain/oauth/token HTTP/1.1" 200 756 "-" "curl/8.7.1" "service"
`

The line contains:

* timestamp of the log (logback)
* thread executing the log action 
* log level
* Logger name
* remoteAddr
* timestamp of request (timestamp at which the request start to be process)
* the requets information (method, path, protocol)
* status
* response content-length
* referer
* userAgent
* clientId


# expose duration only

```
handlers:
  request:
    logger:
      accesslog:
        enabled: true
        includeDuration: true
        includeClientId: false
```

Will give :

`18:27:36.624 [vert.x-eventloop-thread-4] [] INFO  i.g.a.g.h.r.h.GraviteeLoggerHandler - 0:0:0:0:0:0:0:1 - - [Fri, 22 May 2026 16:27:36 GMT] "POST /domain/oauth/token HTTP/1.1" 200 756 "-" "curl/8.7.1" 59
`

The line contains:

* timestamp of the log (logback)
* thread executing the log action 
* log level
* Logger name
* remoteAddr
* timestamp of request (timestamp at which the request start to be process)
* the requets information (method, path, protocol)
* status
* response content-length
* referer
* userAgent
* duration in ms

