### PR TITLE
fix(ui): use lowercase SPIFFE subjectMatchMode option values to match…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -46,7 +46,6 @@ import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryServ
 import io.gravitee.am.gateway.handler.oidc.service.idtoken.IDTokenService;
 import io.gravitee.am.model.TokenClaim;
 import io.gravitee.am.model.User;
-import io.gravitee.am.model.application.AgentType;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.safe.ClientProperties;
 import io.gravitee.am.model.safe.UserProperties;
@@ -485,7 +484,7 @@ public class TokenServiceImpl implements TokenService {
         // used for client-only flows in createJWT.
         if (client.isAgentApplication() && jwt.get(Claims.ACT) == null) {
             Map<String, Object> act = new HashMap<>();
-            act.put(Claims.SUB, resolveAgentActSubject(client));
+            act.put(Claims.SUB, resolveAgentActSubject(request, client));
             if (client.getAgentType() != null) {
                 act.put(Claims.SUB_PROFILE, client.getAgentType().name().toLowerCase());
             }
@@ -514,13 +513,12 @@ public class TokenServiceImpl implements TokenService {
         return jwt;
     }
 
-    // For user-bound agent kinds the issued token's top-level sub is the end-user, so the agent
-    // instance id (when known) is the truer actor identity to expose in act.sub. AUTONOMOUS keeps
-    // the blueprint client_id since its top-level sub already exposes the instance id.
-    private static String resolveAgentActSubject(Client client) {
-        AgentType agentType = client.getAgentType();
-        boolean userBound = agentType == AgentType.USER_EMBEDDED || agentType == AgentType.HOSTED_DELEGATED;
-        return userBound ? resolveAgentSubject(client) : client.getClientId();
+    // act.sub is the counterpart to the token's top-level sub. In user-bound flows the top-level sub
+    // is the end-user, so the agent instance id (when known) is the truer actor identity to expose.
+    // In client-only flows (client_credentials, incl. SPIFFE per-instance blueprints) the top-level
+    // sub is already the agent instance id, so act.sub must point to the blueprint client_id.
+    private static String resolveAgentActSubject(OAuth2Request request, Client client) {
+        return request.isClientOnly() ? client.getClientId() : resolveAgentSubject(client);
     }
 
     // The agent's subject identity: its instance id when known, otherwise the blueprint client_id.

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenServiceTest.java
@@ -269,6 +269,41 @@ public class TokenServiceTest {
     }
 
     @Test
+    public void shouldCreate_hostedDelegatedAgentClientCredentialsSetsActSubToBlueprint() {
+        OAuth2Request oAuth2Request = new OAuth2Request();
+        // No subject set — client_credentials (SPIFFE per-instance blueprint) flow.
+
+        Client client = new Client();
+        client.setClientId("blueprint-client-id");
+        client.setAppType(io.gravitee.am.model.application.ApplicationType.AGENT);
+        client.setAgentType(AgentType.HOSTED_DELEGATED);
+        client.setAgentInstanceId("spiffe://am.local/agent/test/sample");
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenAnswer(ans -> Single.just(ans.getArgument(0)));
+        when(executionContextFactory.create(any())).thenReturn(executionContext);
+        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+
+        TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        ArgumentCaptor<JWT> jwtArgumentCaptor = ArgumentCaptor.forClass(JWT.class);
+        verify(jwtService).encodeJwt(jwtArgumentCaptor.capture(), eq(client));
+        JWT capturedJwt = jwtArgumentCaptor.getValue();
+
+        // sub is the agent instance id; act.sub must point to the blueprint, not duplicate sub.
+        assertEquals("spiffe://am.local/agent/test/sample", capturedJwt.getSub());
+        Map<?, ?> actClaim = (Map<?, ?>) capturedJwt.get(Claims.ACT);
+        assertNotNull(actClaim);
+        assertEquals("blueprint-client-id", actClaim.get(Claims.SUB));
+        assertEquals("hosted_delegated", actClaim.get(Claims.SUB_PROFILE));
+
+        expectTokenCreatedAuditLog();
+    }
+
+    @Test
     public void shouldCreate_userEmbeddedAgentWithInstanceIdSetsActSubToInstanceId() {
         OAuth2Request oAuth2Request = new OAuth2Request();
         oAuth2Request.setSubject("userid");

--- a/gravitee-am-test/specs/gateway/blueprint-agents/flows/hosted-delegated-workload-jwt.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/blueprint-agents/flows/hosted-delegated-workload-jwt.jest.spec.ts
@@ -107,7 +107,8 @@ describe('HOSTED_DELEGATED agent — workload-jwt assertion + grants', () => {
 
     const decoded = decodeJwt(response.body.access_token);
     expect(decoded.sub).toEqual(agentInstanceId);
-    expect((decoded.act as any)?.sub).toEqual(agentInstanceId);
+    // client_credentials flow: top-level sub is the instance id, so act.sub points to the blueprint client_id.
+    expect((decoded.act as any)?.sub).toEqual(agent.settings.oauth.clientId);
   });
 
   it('should reject workload-jwt with invalid signature', async () => {
@@ -186,7 +187,7 @@ describe('HOSTED_DELEGATED agent — workload-jwt assertion + grants', () => {
 
       const decoded = decodeJwt(response.body.access_token);
       expect(decoded.sub).toEqual(instanceId);
-      expect((decoded.act as any)?.sub).toEqual(instanceId);
+      expect((decoded.act as any)?.sub).toEqual(agent.settings.oauth.clientId);
     }
   });
 

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
@@ -287,8 +287,8 @@
               (ngModelChange)="spiffeChanged()"
               [disabled]="readonly"
             >
-              <mat-option value="EXACT">Exact — SVID sub must equal the configured subject</mat-option>
-              <mat-option value="PREFIX">Prefix — one Blueprint backs many instances under the configured subject</mat-option>
+              <mat-option value="exact">Exact — SVID sub must equal the configured subject</mat-option>
+              <mat-option value="prefix">Prefix — one Blueprint backs many instances under the configured subject</mat-option>
             </mat-select>
             <mat-hint>
               <code>PREFIX</code> accepts SVIDs whose <code>sub</code> starts with <code>&lt;subject&gt;</code>; the full SPIFFE ID becomes

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.spec.ts
@@ -270,7 +270,7 @@ describe('GrantFlowsComponent', () => {
       component.spiffeSettings = {
         trustDomain: 'acme',
         subject: 'spiffe://acme/hotel-agent',
-        subjectMatchMode: 'PREFIX',
+        subjectMatchMode: 'prefix',
       };
 
       component.spiffeChanged();
@@ -279,7 +279,7 @@ describe('GrantFlowsComponent', () => {
       expect(emitted[0]).toEqual({
         trustDomain: 'acme',
         subject: 'spiffe://acme/hotel-agent',
-        subjectMatchMode: 'PREFIX',
+        subjectMatchMode: 'prefix',
       });
       // emitted object should be a shallow copy, not the same reference
       expect(emitted[0]).not.toBe(component.spiffeSettings);


### PR DESCRIPTION
## :id: Reference related issue. 
fixes: GMA-368

## :pencil2: A description of the changes proposed in the pull request
This pull request updates the SPIFFE Workload Identity configuration to use lowercase values for the `subjectMatchMode` property, ensuring consistency between the UI and the underlying data model. The changes affect both the UI and the related unit tests.

**SPIFFE subjectMatchMode value normalization:**

* Updated the values for the `mat-option` elements in `grant-flows.component.html` from uppercase (`EXACT`, `PREFIX`) to lowercase (`exact`, `prefix`) to match the expected data model.
* Updated the `subjectMatchMode` property in the `GrantFlowsComponent` unit tests from uppercase to lowercase to align with the UI changes and maintain test accuracy. 

## :memo: Test scenarios 

 * Create Autonomous Agent Application
 * Navigate to OAuth Settings
 * Set Client Authentication type to `spiffe_jwt`
 * Set the Trust Domain/SPIFFE ID/ Subject Match Mode
 * Save
 * Refresh Page, settings should still be applied and visible


## :computer: Add screenshots for UI
<img width="825" height="413" alt="image" src="https://github.com/user-attachments/assets/81a18aa9-7911-4393-a31d-85a2966b0751" />


## :books: Any other comments that will help with documentation
N/A
