### PR TITLE
feat: AM-6851 Automation API settings in helm chart

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Access Management 4.x](https://github.com/gravitee-io/gravitee-access-management/tree/master/helm/) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.12.0
+
+- Make Automation API configurable using `api.http.api.automation.enabled` and `api.http.api.automation.entrypoint` values
+
 ### 4.7.0
 
 - We introduced the concept of data planes, thanks to which you can deploy domains in a specific data center. It's configurable with a new section – dataPlanes. More info [link](https://documentation.gravitee.io/am) 

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -62,10 +62,16 @@ data:
         {{- end }}
       {{- end }}
 
-    {{- if and .Values.api.http .Values.api.http.api }}
+    {{- if and .Values.api.http .Values.api.http.api (or .Values.api.http.api.entrypoint .Values.api.http.api.automation) }}
     http:
       api:
+        {{- if .Values.api.http.api.entrypoint }}
         entrypoint: {{ .Values.api.http.api.entrypoint }}
+        {{- end }}
+        {{- with .Values.api.http.api.automation }}
+        automation:
+{{ toYaml . | indent 10 }}
+        {{- end }}
     {{- end }}
 
     {{- if .Values.httpClient }}

--- a/helm/tests/api-configmap_test.yaml
+++ b/helm/tests/api-configmap_test.yaml
@@ -27,6 +27,90 @@ tests:
           path: data["gravitee.yml"]
           pattern: "[ ]{4}entrypoint: /custom/path/mng"
 
+  - it: should not have automation when unset
+    set:
+      api:
+        http:
+          api:
+            entrypoint: /custom/path/mng
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{4}automation:"
+
+  - it: should enable automation without management entrypoint override
+    set:
+      api:
+        http:
+          api:
+            automation:
+              enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{4}automation:"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{6}enabled: true"
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{4}entrypoint:"
+
+  - it: should have custom automation entrypoint
+    set:
+      api:
+        http:
+          api:
+            automation:
+              enabled: true
+              entrypoint: /custom/automation
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{6}enabled: true"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{6}entrypoint: /custom/automation"
+
+  - it: should have custom API entrypoint and automation settings
+    set:
+      api:
+        http:
+          api:
+            entrypoint: /custom/path/mng
+            automation:
+              enabled: true
+              entrypoint: /custom/path/mng/automation
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{4}entrypoint: /custom/path/mng"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{4}automation:"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{6}enabled: true"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{6}entrypoint: /custom/path/mng/automation"
+
   - it: should have notifier with default settings
     asserts:
       - hasDocuments:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -444,6 +444,9 @@ api:
     #responseHeaderSize: 8192
 #    api:
 #      entrypoint: /management
+#      automation:
+#        enabled: false
+#        entrypoint: /management/automation
     services:
       metrics:
         enabled: false


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6851](https://gravitee.atlassian.net/browse/AM-6851)

## :pencil2: A description of the changes proposed in the pull request
Expose `http.api.automation.enabled` and `http.api.automation.entrypoint` via Helm values, aligned with the existing management entrypoint support.

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-6851]: https://gravitee.atlassian.net/browse/AM-6851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ