### PR TITLE
fix: AM-7076 Add logic to ValidationExceptionMapper

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
@@ -60,7 +60,7 @@ import java.util.Set;
 @Setter
 public class AutomationDomain {
 
-    @NotNull(message = "field key is required")
+    @NotNull
     @Size(min = 1, max = 255)
     @JsonProperty("key")
     @Schema(name = "key")

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
@@ -60,7 +60,7 @@ import java.util.Set;
 @Setter
 public class AutomationDomain {
 
-    @NotNull
+    @NotNull(message = "field key is required")
     @Size(min = 1, max = 255)
     @JsonProperty("key")
     @Schema(name = "key")

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/provider/ValidationExceptionMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/provider/ValidationExceptionMapper.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.am.management.handlers.management.api.provider;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.am.management.handlers.management.api.model.ErrorEntity;
 import io.gravitee.common.http.HttpStatusCode;
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.ValidationException;
 import jakarta.ws.rs.core.MediaType;
@@ -25,6 +27,7 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.hibernate.validator.internal.engine.path.PathImpl;
 
+import java.lang.reflect.Field;
 import java.util.stream.Collectors;
 
 /**
@@ -43,7 +46,7 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
                                     .getConstraintViolations()
                                     .stream()
                                     .map(constraint -> {
-                                        Object value = constraint.getInvalidValue() == null ? ((PathImpl) constraint.getPropertyPath()).getLeafNode().asString() : constraint.getInvalidValue();
+                                        Object value = constraint.getInvalidValue() == null ? resolveFieldName(constraint) : constraint.getInvalidValue();
                                         return value + ": " + constraint.getMessage();
                                     })
                                     .collect(Collectors.joining(","))
@@ -52,6 +55,31 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
         } else {
             return buildResponse(e.getMessage());
         }
+    }
+
+    private String resolveFieldName(ConstraintViolation<?> constraint) {
+        String leafName = ((PathImpl) constraint.getPropertyPath()).getLeafNode().asString();
+        try {
+            Object leafBean = constraint.getLeafBean();
+            if (leafBean == null) return leafName;
+            Field field = findField(leafBean.getClass(), leafName);
+            if (field == null) return leafName;
+            JsonProperty jp = field.getAnnotation(JsonProperty.class);
+            if (jp != null && !jp.value().isEmpty()) return jp.value();
+        } catch (Exception ignored) {
+        }
+        return leafName;
+    }
+
+    private static Field findField(Class<?> clazz, String name) {
+        while (clazz != null) {
+            try {
+                return clazz.getDeclaredField(name);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        return null;
     }
 
     private Response buildResponse(String message) {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/provider/ValidationExceptionMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/provider/ValidationExceptionMapper.java
@@ -15,10 +15,8 @@
  */
 package io.gravitee.am.management.handlers.management.api.provider;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.am.management.handlers.management.api.model.ErrorEntity;
 import io.gravitee.common.http.HttpStatusCode;
-import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.ValidationException;
 import jakarta.ws.rs.core.MediaType;
@@ -27,7 +25,6 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.hibernate.validator.internal.engine.path.PathImpl;
 
-import java.lang.reflect.Field;
 import java.util.stream.Collectors;
 
 /**
@@ -46,7 +43,7 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
                                     .getConstraintViolations()
                                     .stream()
                                     .map(constraint -> {
-                                        Object value = constraint.getInvalidValue() == null ? resolveFieldName(constraint) : constraint.getInvalidValue();
+                                        Object value = constraint.getInvalidValue() == null ? ((PathImpl) constraint.getPropertyPath()).getLeafNode().asString() : constraint.getInvalidValue();
                                         return value + ": " + constraint.getMessage();
                                     })
                                     .collect(Collectors.joining(","))
@@ -55,29 +52,6 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
         } else {
             return buildResponse(e.getMessage());
         }
-    }
-
-    private String resolveFieldName(ConstraintViolation<?> constraint) {
-        String leafName = ((PathImpl) constraint.getPropertyPath()).getLeafNode().asString();
-        try {
-            Field field = findField(constraint.getRootBeanClass(), leafName);
-            if (field == null) return leafName;
-            JsonProperty jp = field.getAnnotation(JsonProperty.class);
-            if (jp != null && !jp.value().isEmpty()) return jp.value();
-        } catch (Exception ignored) {
-        }
-        return leafName;
-    }
-
-    private static Field findField(Class<?> clazz, String name) {
-        while (clazz != null) {
-            try {
-                return clazz.getDeclaredField(name);
-            } catch (NoSuchFieldException e) {
-                clazz = clazz.getSuperclass();
-            }
-        }
-        return null;
     }
 
     private Response buildResponse(String message) {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/provider/ValidationExceptionMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/provider/ValidationExceptionMapper.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.am.management.handlers.management.api.provider;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.am.management.handlers.management.api.model.ErrorEntity;
 import io.gravitee.common.http.HttpStatusCode;
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.ValidationException;
 import jakarta.ws.rs.core.MediaType;
@@ -25,6 +27,7 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.hibernate.validator.internal.engine.path.PathImpl;
 
+import java.lang.reflect.Field;
 import java.util.stream.Collectors;
 
 /**
@@ -43,7 +46,7 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
                                     .getConstraintViolations()
                                     .stream()
                                     .map(constraint -> {
-                                        Object value = constraint.getInvalidValue() == null ? ((PathImpl) constraint.getPropertyPath()).getLeafNode().asString() : constraint.getInvalidValue();
+                                        Object value = constraint.getInvalidValue() == null ? resolveFieldName(constraint) : constraint.getInvalidValue();
                                         return value + ": " + constraint.getMessage();
                                     })
                                     .collect(Collectors.joining(","))
@@ -52,6 +55,29 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
         } else {
             return buildResponse(e.getMessage());
         }
+    }
+
+    private String resolveFieldName(ConstraintViolation<?> constraint) {
+        String leafName = ((PathImpl) constraint.getPropertyPath()).getLeafNode().asString();
+        try {
+            Field field = findField(constraint.getRootBeanClass(), leafName);
+            if (field == null) return leafName;
+            JsonProperty jp = field.getAnnotation(JsonProperty.class);
+            if (jp != null && !jp.value().isEmpty()) return jp.value();
+        } catch (Exception ignored) {
+        }
+        return leafName;
+    }
+
+    private static Field findField(Class<?> clazz, String name) {
+        while (clazz != null) {
+            try {
+                return clazz.getDeclaredField(name);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        return null;
     }
 
     private Response buildResponse(String message) {


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7076

## :pencil2: A description of the changes proposed in the pull request

**ValidationExceptionMapper.java** - added reflection logic to resolve the @JsonProperty name so validation errors display the API field name instead of the internal Java field name.

**AutomationDomain.java** - reverted custom message as it's no longer needed.
  
  **Before:**
 ```json
{ 
    "message": "[automationKey: must not be null]", 
     "http_status": 400 
}
```

  **After:**
```json
{ 
    "message": "[key: must not be null]", 
    "http_status": 400 
}
```

## :memo: Test scenarios 
See JIRA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
NA