### PR TITLE
fix: AM-7079 repair system IDP reference

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
@@ -25,11 +25,13 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.model.AutomationNewIdentityProvider;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -166,6 +168,8 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
                         }
                         if (definition.isSystem()) {
                             return defaultIdentityProviderService.create(domain, key, principal)
+                                    .flatMap(created -> reconcileDomainReference(domain, key, created.getId())
+                                            .andThen(Single.just(created)))
                                     .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
                         }
                         Single<AutomationIdentityProvider> rejection = rejectIfMissingIdentityProviderFields(definition, key);
@@ -191,6 +195,23 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
                     "Field 'type' is required for a non-system identity provider '" + key + "'"));
         }
         return null;
+    }
+
+    /**
+     * Repair a {@code accountSettings.defaultIdentityProviderForRegistration} id after a system
+     * identity provider has been created. A system provider adopts the conventional
+     * {@code default-idp-<domainId>} id rather than the deterministic key-based id the domain mapper
+     * computes for a not-yet-existing reference.
+     */
+    private Completable reconcileDomainReference(Domain domain, String idpKey, String realIdpId) {
+        AccountSettings account = domain.getAccountSettings();
+        if (account == null
+                || !idpKey.equals(account.getDefaultIdentityProviderForRegistrationKey())
+                || realIdpId.equals(account.getDefaultIdentityProviderForRegistration())) {
+            return Completable.complete();
+        }
+        account.setDefaultIdentityProviderForRegistration(realIdpId);
+        return domainService.update(domain.getId(), domain, false).ignoreElement();
     }
 
     @Path("/{idpKey}")

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
@@ -21,11 +21,13 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.account.AccountSettings;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 
@@ -157,6 +159,56 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         assertTrue(readEntity(response, AutomationIdentityProvider.class).isSystem());
         // The payload path must never run for a system create.
         verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(true));
+    }
+
+    @Test
+    void put_creates_system_repairs_invalid_domain_reference() {
+        // The domain was applied before its system IDP existed, so its registration reference holds the
+        // deterministic key-based id; creating the system IDP must rewrite it to the real default-idp id.
+        String systemIdpId = AutomationIds.systemIdentityProviderId(domainId);
+        String staleId = AutomationIds.identityProviderId(domainId, "sys-idp");
+        Domain domain = domain();
+        AccountSettings account = new AccountSettings();
+        account.setDefaultIdentityProviderForRegistrationKey("sys-idp");
+        account.setDefaultIdentityProviderForRegistration(staleId);
+        domain.setAccountSettings(account);
+
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+        when(defaultIdentityProviderService.create(any(Domain.class), eq("sys-idp"), any()))
+                .thenReturn(Single.just(idp(systemIdpId, "sys-idp", ManagedBy.AUTOMATION_API, true)));
+        when(domainService.update(eq(domainId), any(Domain.class), eq(false)))
+                .thenAnswer(invocation -> Single.just(invocation.getArgument(1)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
+
+        assertEquals(200, response.getStatus());
+        ArgumentCaptor<Domain> captor = ArgumentCaptor.forClass(Domain.class);
+        verify(domainService).update(eq(domainId), captor.capture(), eq(false));
+        assertEquals(systemIdpId,
+                captor.getValue().getAccountSettings().getDefaultIdentityProviderForRegistration());
+    }
+
+    @Test
+    void put_creates_system_leaves_unrelated_domain_reference_untouched() {
+        String systemIdpId = AutomationIds.systemIdentityProviderId(domainId);
+        Domain domain = domain();
+        AccountSettings account = new AccountSettings();
+        account.setDefaultIdentityProviderForRegistrationKey("other-idp");
+        account.setDefaultIdentityProviderForRegistration(AutomationIds.identityProviderId(domainId, "other-idp"));
+        domain.setAccountSettings(account);
+
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+        when(defaultIdentityProviderService.create(any(Domain.class), eq("sys-idp"), any()))
+                .thenReturn(Single.just(idp(systemIdpId, "sys-idp", ManagedBy.AUTOMATION_API, true)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
+
+        assertEquals(200, response.getStatus());
+        verify(domainService, never()).update(anyString(), any(Domain.class), anyBoolean());
     }
 
     @Test


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7079](https://gravitee.atlassian.net/browse/AM-7079)

## :pencil2: A description of the changes proposed in the pull request
Context:
- When a domain is PUT using the automation API it can reference an IDP by its automation key in the `account.defaultIdentityProviderForRegistration` field, but, to support eventual consistency, the IDP does not have to exist (yet).
- When an IDP is PUT with the `system` flag (meaning it is created as the default database-source IDP for a domain) it changes the behaviour of the internal id generation of the IDP from deterministic to randomised with a prefix of `default-idp-`.

This change repairs the reference for the scenario where the domain is new (initial PUT) and the referenced IDP does not yet exist, but is then added with `system` flag.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7079]: https://gravitee.atlassian.net/browse/AM-7079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ