### PR TITLE
fix: AM-7081 restrict creation of system reporter types

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReportersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReportersResourceTest.java
@@ -21,6 +21,7 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.Reporter;
+import io.gravitee.am.service.exception.ReporterConfigurationException;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -171,6 +172,22 @@ class ReportersResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(400, response.getStatus());
         verify(reporterService, never()).create(eq(reference), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_rejects_non_system_database_reporter_type() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
+        when(reporterService.create(eq(reference), any(), any(), eq(false)))
+                .thenReturn(Single.error(new ReporterConfigurationException(
+                        "Reporter type 'mongodb' cannot be created manually")));
+
+        AutomationReporter def = definition("audit-mongo", false);
+        def.setType("mongodb");
+
+        Response response = put(reportersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
@@ -66,6 +66,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -86,6 +87,7 @@ public class ReporterServiceImpl implements ReporterService {
     private static final String REPORTER_CONFIG_FILENAME = "filename";
     public static final String MANAGEMENT_TYPE = Scope.MANAGEMENT.getRepositoryPropertyKey() + ".type";
     public static final String MONGODB = "mongodb";
+    private static final Set<String> SYSTEM_ONLY_TYPES = Set.of(MONGODB, REPORTER_AM_JDBC);
     // Regex as defined into the Reporter plugin schema in order to apply the same validation rule
     // when a REST call is performed and not only check on the UI
     private final Pattern filenamePattern = Pattern.compile("^([A-Za-z0-9][A-Za-z0-9\\-_.]*)$");
@@ -184,6 +186,11 @@ public class ReporterServiceImpl implements ReporterService {
         var now = new Date();
         if (reference.type() != ReferenceType.ORGANIZATION && newReporter.isInherited()) {
             return Single.error(new ReporterConfigurationException("Only organization reporters can be inherited"));
+        }
+        if (!system && newReporter.getType() != null
+                && SYSTEM_ONLY_TYPES.stream().anyMatch(newReporter.getType()::equalsIgnoreCase)) {
+            return Single.error(new ReporterConfigurationException(
+                    "Reporter type '" + newReporter.getType() + "' cannot be created manually"));
         }
         Reporter reporter = Reporter.builder()
                 .id(Objects.requireNonNullElseGet(newReporter.getId(), RandomString::generate))

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ReporterServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ReporterServiceTest.java
@@ -109,6 +109,51 @@ class ReporterServiceTest {
     }
 
     @Test
+    void shouldReject_manualMongoReporter() {
+        final var reporter = new NewReporter();
+        reporter.setEnabled(true);
+        reporter.setName("Test");
+        reporter.setType("mongodb");
+        reporter.setConfiguration("{}");
+
+        reporterService.create(Reference.domain("domain"), reporter, null, false)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(ReporterConfigurationException.class);
+    }
+
+    @Test
+    void shouldReject_manualJdbcReporter() {
+        final var reporter = new NewReporter();
+        reporter.setEnabled(true);
+        reporter.setName("Test");
+        reporter.setType("reporter-am-jdbc");
+        reporter.setConfiguration("{}");
+
+        reporterService.create(Reference.domain("domain"), reporter, null, false)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(ReporterConfigurationException.class);
+    }
+
+    @Test
+    void shouldAccept_systemMongoReporter() {
+        final var reporter = new NewReporter();
+        reporter.setEnabled(true);
+        reporter.setName("Test");
+        reporter.setType("mongodb");
+        reporter.setConfiguration("{}");
+
+        when(eventService.create(any())).thenReturn(Single.just(new Event()));
+
+        // system reporters (system=true) are the legitimate path for database reporter types
+        reporterService.create(Reference.domain("domain"), reporter, null, true)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertNoErrors();
+    }
+
+    @Test
     void should_validate_config_with_schema() throws Exception{
         final var reporter = new NewReporter();
         reporter.setEnabled(true);


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7081](https://gravitee.atlassian.net/browse/AM-7081)

## :pencil2: A description of the changes proposed in the pull request
Prevent manual creation of `mongodb` and `reporter-am-jdbc` reporter types. These are reserved for system-managed defaults. Enforce in Management and Automation APIs.

## :memo: Test scenarios
Prerequisite: acquire access token
```
curl -s -X POST "http://localhost:8093/management/auth/token" -u admin:adminadmin | jq '.access_token'
```
- Management API (`POST`):
```
curl --location 'http://localhost:8093/management/organizations/DEFAULT/environments/DEFAULT/domains/<DOMAIN_ID>/reporters' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer  ...' \
--data '{
    "name": "Non-System MongoDB Reporter",
    "type": "mongodb",
    "configuration": "{\n  \"uri\": \"mongodb://localhost:27017/gravitee-am?connectTimeoutMS=5000&socketTimeoutMS=5000\",\n  \"host\": \"localhost\",\n  \"port\": 27017,\n  \"enableCredentials\": false,\n  \"database\": \"gravitee-am\",\n  \"reportableCollection\": \"reporter_audits_fef0999f-f767-3077-8960-1bcf8d2f8261\",\n  \"bulkActions\": 1000,\n  \"flushInterval\": 5\n}\n",
    "enabled": true
}'
```
- Automation API (`PUT`):
```
curl --location --request PUT 'http://localhost:8093/management/automation/organizations/DEFAULT/environments/DEFAULT/domains/<DOMAIN_KEY>/reporters' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ...' \
--data '{
    "name": "Non-System MongoDB Reporter",
    "type": "mongodb",
    "configuration": "{\n  \"uri\": \"mongodb://localhost:27017/gravitee-am?connectTimeoutMS=5000&socketTimeoutMS=5000\",\n  \"host\": \"localhost\",\n  \"port\": 27017,\n  \"enableCredentials\": false,\n  \"database\": \"gravitee-am\",\n  \"reportableCollection\": \"reporter_audits_fef0999f-f767-3077-8960-1bcf8d2f8261\",\n  \"bulkActions\": 1000,\n  \"flushInterval\": 5\n}\n",
    "enabled": true,
    "key": "non-default-reporter",
    "system": false
}'
```

Both return 400:
```json
{
    "message": "Reporter type 'mongodb' cannot be created manually",
    "http_status": 400
}
```

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7081]: https://gravitee.atlassian.net/browse/AM-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ