### PR TITLE
fix: AM-7080 validate plugin payloads

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
@@ -20,6 +20,7 @@ import io.gravitee.am.management.handlers.automation.mapper.AutomationIdentityPr
 import io.gravitee.am.management.handlers.automation.model.AutomationIdentityProvider;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.IdentityProviderManager;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
@@ -28,6 +29,7 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.model.AutomationNewIdentityProvider;
@@ -75,6 +77,12 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
 
     @Autowired
     private DefaultIdentityProviderService defaultIdentityProviderService;
+
+    @Autowired
+    private IdentityProviderManager identityProviderManager;
+
+    @Autowired
+    private PluginConfigurationValidationService validationService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -145,8 +153,9 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
                                 // re-PUT is an idempotent no-op
                                 return Single.just(AutomationIdentityProviderMapper.toAutomationIdentityProvider(existing));
                             }
-                            return identityProviderService.update(ReferenceType.DOMAIN, domain.getId(), existing.getId(),
-                                            AutomationIdentityProviderMapper.toUpdateIdentityProvider(definition), principal, false)
+                            return identityProviderManager.checkPluginDeployment(definition.getType())
+                                    .andThen(identityProviderService.update(ReferenceType.DOMAIN, domain.getId(), existing.getId(),
+                                            AutomationIdentityProviderMapper.toUpdateIdentityProvider(definition), principal, false))
                                     .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
                         }
 
@@ -178,7 +187,13 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
                         }
                         AutomationNewIdentityProvider newIdp = AutomationIdentityProviderMapper.toNewIdentityProvider(definition);
                         newIdp.setId(idpId);
-                        return identityProviderService.create(domain, newIdp, principal, false)
+                        return identityProviderManager.checkPluginDeployment(definition.getType())
+                                .andThen(Completable.fromAction(() -> {
+                                    if (!isBlank(definition.getConfiguration())) {
+                                        validationService.validate(definition.getType(), definition.getConfiguration());
+                                    }
+                                }))
+                                .andThen(Single.defer(() -> identityProviderService.create(domain, newIdp, principal, false)))
                                 .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
                     });
         })

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/ReportersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/ReportersResource.java
@@ -18,16 +18,19 @@ package io.gravitee.am.management.handlers.automation.resource;
 import io.gravitee.am.management.handlers.automation.mapper.AutomationReporterMapper;
 import io.gravitee.am.management.handlers.automation.model.AutomationReporter;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.ReporterPluginService;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.Reporter;
 import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.ReporterService;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.model.AutomationNewReporter;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -68,6 +71,12 @@ public class ReportersResource extends AbstractAutomationResource {
 
     @Autowired
     private ReporterService reporterService;
+
+    @Autowired
+    private ReporterPluginService reporterPluginService;
+
+    @Autowired
+    private PluginConfigurationValidationService validationService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -137,8 +146,9 @@ public class ReportersResource extends AbstractAutomationResource {
                                 // re-PUT is an idempotent no-op
                                 return Single.just(AutomationReporterMapper.toAutomationReporter(existing));
                             }
-                            return reporterService.update(reference, existing.getId(),
-                                            AutomationReporterMapper.toUpdateReporter(definition), principal, false)
+                            return reporterPluginService.checkPluginDeployment(definition.getType())
+                                    .andThen(reporterService.update(reference, existing.getId(),
+                                            AutomationReporterMapper.toUpdateReporter(definition), principal, false))
                                     .map(AutomationReporterMapper::toAutomationReporter);
                         }
 
@@ -165,7 +175,10 @@ public class ReportersResource extends AbstractAutomationResource {
                         }
                         AutomationNewReporter newReporter = AutomationReporterMapper.toNewReporter(definition);
                         newReporter.setId(reporterId);
-                        return reporterService.create(reference, newReporter, principal, false)
+                        return reporterPluginService.checkPluginDeployment(definition.getType())
+                                .andThen(Completable.fromAction(() ->
+                                        validationService.validate(definition.getType(), definition.getConfiguration())))
+                                .andThen(Single.defer(() -> reporterService.create(reference, newReporter, principal, false)))
                                 .map(AutomationReporterMapper::toAutomationReporter);
                     });
         })

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
@@ -24,12 +24,16 @@ import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.mapper.ObjectMapperResolver;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.IdentityProviderManager;
 import io.gravitee.am.management.service.PermissionService;
+import io.gravitee.am.management.service.ReporterPluginService;
 import io.gravitee.am.management.service.permissions.PermissionAcls;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.service.CertificateService;
 import io.gravitee.am.service.IdentityProviderService;
+import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.ReporterService;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.client.Entity;
@@ -57,8 +61,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 /**
@@ -99,6 +105,15 @@ public abstract class AutomationJerseySpringTest {
     @Autowired
     protected ReporterService reporterService;
 
+    @Autowired
+    protected ReporterPluginService reporterPluginService;
+
+    @Autowired
+    protected IdentityProviderManager identityProviderManager;
+
+    @Autowired
+    protected PluginConfigurationValidationService validationService;
+
     @BeforeEach
     public void init() {
         // The service mocks are Spring singletons shared across the cached context, so clear any
@@ -106,8 +121,14 @@ public abstract class AutomationJerseySpringTest {
         // (e.g. "delete was never called") scoped to the test at hand.
         clearInvocations(permissionService, domainService, certificateService, identityProviderService,
                 defaultIdentityProviderService, reporterService);
+        // Fully reset the validation mocks (not just their invocations): tests add throwing/erroring stubs
+        // to exercise rejection paths, and those would otherwise leak across the shared singleton context.
+        reset(reporterPluginService, identityProviderManager, validationService);
         when(permissionService.hasPermission(any(User.class), any(PermissionAcls.class)))
                 .thenReturn(Single.just(true));
+        // Plugin type checks pass by default; individual tests override to exercise the rejection paths.
+        when(reporterPluginService.checkPluginDeployment(anyString())).thenReturn(Completable.complete());
+        when(identityProviderManager.checkPluginDeployment(anyString())).thenReturn(Completable.complete());
     }
 
     /**
@@ -150,6 +171,21 @@ public abstract class AutomationJerseySpringTest {
         @Bean
         public ReporterService reporterService() {
             return mock(ReporterService.class);
+        }
+
+        @Bean
+        public ReporterPluginService reporterPluginService() {
+            return mock(ReporterPluginService.class);
+        }
+
+        @Bean
+        public IdentityProviderManager identityProviderManager() {
+            return mock(IdentityProviderManager.class);
+        }
+
+        @Bean
+        public PluginConfigurationValidationService validationService() {
+            return mock(PluginConfigurationValidationService.class);
         }
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
@@ -22,6 +22,9 @@ import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.account.AccountSettings;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
+import io.gravitee.am.service.exception.PluginNotDeployedException;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -37,6 +40,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -127,6 +131,40 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(200, response.getStatus());
         assertEquals("dev-users", readEntity(response, AutomationIdentityProvider.class).getAutomationKey());
+    }
+
+    @Test
+    void put_rejects_unknown_type() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+        when(identityProviderManager.checkPluginDeployment(eq("unknown-am-idp")))
+                .thenReturn(Completable.error(PluginNotDeployedException.forType("unknown-am-idp")));
+
+        AutomationIdentityProvider def = definition("dev-users");
+        def.setType("unknown-am-idp");
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_rejects_configuration_not_matching_schema() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+        doThrow(InvalidPluginConfigurationException.fromValidationError("not valid"))
+                .when(validationService).validate(eq("inline-am-idp"), anyString());
+
+        AutomationIdentityProvider def = definition("dev-users");
+        def.setConfiguration("{\"bad\":true}");
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(false));
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReportersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReportersResourceTest.java
@@ -22,6 +22,9 @@ import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.Reporter;
 import io.gravitee.am.service.exception.ReporterConfigurationException;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
+import io.gravitee.am.service.exception.PluginNotDeployedException;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -36,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -188,6 +192,55 @@ class ReportersResourceTest extends AutomationJerseySpringTest {
         Response response = put(reportersTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_unknown_type() {
+        // An undeployed/unknown plugin type must be rejected before the reporter is persisted.
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
+        when(reporterPluginService.checkPluginDeployment(eq("reporter-am-unknown")))
+                .thenReturn(Completable.error(PluginNotDeployedException.forType("reporter-am-unknown")));
+
+        AutomationReporter def = definition("audit-log", false);
+        def.setType("reporter-am-unknown");
+
+        Response response = put(reportersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(reporterService, never()).create(eq(reference), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_rejects_configuration_not_matching_schema() {
+        // A configuration that fails schema validation (e.g. malformed / non-conforming) is rejected.
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
+        doThrow(InvalidPluginConfigurationException.fromValidationError("not valid"))
+                .when(validationService).validate(eq("reporter-am-file"), anyString());
+
+        AutomationReporter def = definition("audit-log", false);
+        def.setConfiguration("not-json");
+
+        Response response = put(reportersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(reporterService, never()).create(eq(reference), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_validates_type_and_configuration_before_create() {
+        String reporterId = AutomationIds.reporterId(domainId, "audit-log");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
+        when(reporterService.create(eq(reference), any(), any(), eq(false)))
+                .thenReturn(Single.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(reportersTarget(DOMAIN_KEY), definition("audit-log", false));
+
+        assertEquals(200, response.getStatus());
+        verify(reporterPluginService).checkPluginDeployment(eq("reporter-am-file"));
+        verify(validationService).validate(eq("reporter-am-file"), eq("{}"));
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
@@ -393,6 +393,7 @@ public class CertificateServiceImpl implements CertificateService {
             // update configuration to set the file path
             ((ObjectNode) updateCertJson).put(fileKey, file.get(NAME).asText());
         }
+        updateCertificate.setConfiguration(objectMapper.writeValueAsString(updateCertJson));
     }
 
     private Single<Certificate> checkIdentityProviderUsage(Certificate certificate) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/CertificateServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/CertificateServiceImplTest.java
@@ -16,6 +16,8 @@
 package io.gravitee.am.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.am.common.plugin.ValidationResult;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.Certificate;
@@ -24,6 +26,7 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.ProtectedResource;
 import io.gravitee.am.model.common.event.Event;
+import io.gravitee.am.service.model.UpdateCertificate;
 import io.gravitee.am.plugins.certificate.core.CertificatePluginManager;
 import io.gravitee.am.repository.management.api.CertificateRepository;
 import io.gravitee.am.repository.management.api.DomainRepository;
@@ -46,12 +49,18 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
@@ -289,6 +298,59 @@ class CertificateServiceImplTest {
 
         // then
         observer.assertComplete();
+    }
+
+    @Test
+    void update_normalizes_embedded_file_to_filename_in_stored_config() throws Exception {
+        // Use a real ObjectMapper so the embedded-file normalization is exercised faithfully.
+        ReflectionTestUtils.setField(service, "objectMapper", new ObjectMapper());
+        ObjectMapper realMapper = new ObjectMapper();
+
+        String certId = "cert-id";
+        String type = "javakeystore-am-certificate";
+        String fileName = "keystore.p12";
+        String base64 = Base64.getEncoder().encodeToString("dummy-keystore-bytes".getBytes());
+
+        Domain domain = new Domain();
+        domain.setId("domainId");
+
+        // The stored certificate already holds the normalized (filename-form) configuration.
+        Certificate existing = new Certificate();
+        existing.setId(certId);
+        existing.setDomain("domainId");
+        existing.setType(type);
+        existing.setConfiguration("{\"content\":\"" + fileName + "\"}");
+
+        String schema = "{\"properties\":{\"content\":{\"widget\":\"file\"}}}";
+
+        Mockito.when(certificateRepository.findById(certId)).thenReturn(Maybe.just(existing));
+        Mockito.when(certificatePluginService.getSchema(type)).thenReturn(Maybe.just(schema));
+        Mockito.when(certificatePluginManager.validate(any())).thenReturn(ValidationResult.SUCCEEDED);
+        Mockito.when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
+        Mockito.when(certificateRepository.update(any()))
+                .thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+
+        // The update payload carries the full embedded file blob ({name, content:<base64>}).
+        String embeddedFile = "{\"name\":\"" + fileName + "\",\"content\":\"" + base64 + "\"}";
+        ObjectNode cfg = realMapper.createObjectNode();
+        cfg.put("content", embeddedFile);
+        UpdateCertificate update = new UpdateCertificate();
+        update.setName("My cert");
+        update.setConfiguration(realMapper.writeValueAsString(cfg));
+
+        TestObserver<Certificate> observer =
+                service.update(domain, certId, update, new DefaultUser()).test();
+        observer.awaitDone(5, java.util.concurrent.TimeUnit.SECONDS);
+        observer.assertComplete();
+
+        ArgumentCaptor<Certificate> captor = ArgumentCaptor.forClass(Certificate.class);
+        Mockito.verify(certificateRepository).update(captor.capture());
+        String storedConfig = captor.getValue().getConfiguration();
+
+        // The persisted configuration keeps only the file name; the raw base64 content must not leak into it.
+        assertEquals(fileName, realMapper.readTree(storedConfig).get("content").asText());
+        assertFalse(storedConfig.contains(base64),
+                "stored configuration must not contain the raw base64 keystore content");
     }
 
 }

--- a/gravitee-am-test/specs/management/automation/domain-identity-providers.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-identity-providers.jest.spec.ts
@@ -161,6 +161,33 @@ describe('Automation API - Domain - defaultIdentityProviderForRegistration refer
   });
 });
 
+describe('Automation API - Identity providers - payload validation', () => {
+  const users = [{ username: 'val', password: 'P@ssword1' }];
+
+  it('should reject an unknown identity provider type (400)', async () => {
+    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+      ...buildInlineIdpDef({ key: uniqueName('autobadtype', true).toLowerCase(), users }),
+      type: 'unknown-am-idp',
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject a configuration that is not valid JSON (400)', async () => {
+    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+      ...buildInlineIdpDef({ key: uniqueName('autobadcfg', true).toLowerCase(), users }),
+      configuration: 'not-json',
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('should tolerate an unknown extra property in the configuration (200)', async () => {
+    const base = buildInlineIdpDef({ key: uniqueName('autoextracfg', true).toLowerCase(), users });
+    const configuration = JSON.stringify({ ...JSON.parse(base.configuration), extraUnknownField: 'tolerated' });
+    const response = await fixture.client.putIdentityProvider(fixture.domainKey, { ...base, configuration });
+    expect(response.status).toBe(200);
+  });
+});
+
 describe('Automation API - System identity provider', () => {
   const systemIdpKey = uniqueName('autosysidp', true).toLowerCase();
   const secondSystemKey = uniqueName('autosysidp2', true).toLowerCase();

--- a/gravitee-am-test/specs/management/automation/domain-reporters.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-reporters.jest.spec.ts
@@ -110,6 +110,33 @@ describe('Automation API - Reporters (resource under a domain)', () => {
   });
 });
 
+describe('Automation API - Reporters - payload validation', () => {
+  it('should reject an unknown reporter type (400)', async () => {
+    const response = await fixture.client.putReporter(fixture.domainKey, {
+      ...buildAutomationReporterDef({ key: uniqueName('autobadtype', true).toLowerCase() }),
+      type: 'reporter-am-does-not-exist',
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject a configuration that is not valid JSON (400)', async () => {
+    const response = await fixture.client.putReporter(fixture.domainKey, {
+      ...buildAutomationReporterDef({ key: uniqueName('autobadcfg', true).toLowerCase() }),
+      configuration: 'not-json',
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('should tolerate an unknown extra property in the configuration (200)', async () => {
+    const base = buildAutomationReporterDef({ key: uniqueName('autoextracfg', true).toLowerCase() }) as {
+      configuration: string;
+    };
+    const configuration = JSON.stringify({ ...JSON.parse(base.configuration), extraUnknownField: 'tolerated' });
+    const response = await fixture.client.putReporter(fixture.domainKey, { ...base, configuration });
+    expect(response.status).toBe(200);
+  });
+});
+
 describe('Automation API - System reporter', () => {
   const systemKey = uniqueName('autosysrep', true).toLowerCase();
   const secondSystemKey = uniqueName('autosysrep2', true).toLowerCase();


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7080](https://gravitee.atlassian.net/browse/AM-7080)

## :pencil2: A description of the changes proposed in the pull request
Validate payloads for create/update requests in the Automation API:
- reporters
- identity providers

Additionally, normalise certificates on PUT updates so that file names are consistently returned in responses rather than raw base64 `content`. This preserves consistency in both APIs and remains idempotent for the Automation API. 

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7080]: https://gravitee.atlassian.net/browse/AM-7080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ