### PR TITLE
fix: AM-7082 match OAS with date fields formats

### DIFF
--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -703,10 +703,13 @@ components:
           type: string
         createdAt:
           type: string
+          description: "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           format: date-time
           readOnly: true
         expiresAt:
           type: string
+          description: "Expiry timestamp (ISO-8601 / RFC 3339, UTC), when known for\
+            \ the certificate type. Read-only."
           format: date-time
           readOnly: true
         key:
@@ -729,6 +732,7 @@ components:
           type: string
         updatedAt:
           type: string
+          description: "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           format: date-time
           readOnly: true
     AutomationCertificateSettings:
@@ -752,6 +756,7 @@ components:
           $ref: "#/components/schemas/CorsSettings"
         createdAt:
           type: string
+          description: "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           format: date-time
           readOnly: true
         dataPlaneId:
@@ -800,6 +805,7 @@ components:
           $ref: "#/components/schemas/UMASettings"
         updatedAt:
           type: string
+          description: "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           format: date-time
           readOnly: true
         vhosts:
@@ -817,6 +823,7 @@ components:
           type: string
         createdAt:
           type: string
+          description: "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           format: date-time
           readOnly: true
         domainWhitelist:
@@ -857,6 +864,7 @@ components:
           type: string
         updatedAt:
           type: string
+          description: "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           format: date-time
           readOnly: true
     AutomationOidcSettings:
@@ -887,6 +895,7 @@ components:
           type: string
         createdAt:
           type: string
+          description: "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           format: date-time
           readOnly: true
         dataType:
@@ -912,6 +921,7 @@ components:
           type: string
         updatedAt:
           type: string
+          description: "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           format: date-time
           readOnly: true
     AutomationSamlSettings:

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -12307,8 +12307,9 @@ components:
         condition:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         domain:
@@ -12329,14 +12330,16 @@ components:
           enum:
           - GROOVY
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     AccessPolicyListItem:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         id:
@@ -12344,14 +12347,16 @@ components:
         name:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     AccountAccessToken:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         issuerId:
           type: string
         issuerUsername:
@@ -12374,8 +12379,9 @@ components:
         tokenId:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         userId:
           type: string
     AccountSettings:
@@ -12468,8 +12474,9 @@ components:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         enabled:
           type: boolean
         id:
@@ -12490,8 +12497,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     AlertServiceStatusEntity:
       type: object
       properties:
@@ -12505,8 +12513,9 @@ components:
           items:
             type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         enabled:
           type: boolean
         id:
@@ -12528,8 +12537,9 @@ components:
           - TOO_MANY_LOGIN_FAILURES
           - RISK_ASSESSMENT
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     AnalyticsTypeParam:
       type: object
       properties:
@@ -12549,8 +12559,9 @@ components:
         certificate:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         domain:
@@ -12605,8 +12616,9 @@ components:
           - RESOURCE_SERVER
           - AGENT
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     ApplicationAdvancedSettings:
       type: object
       properties:
@@ -12667,15 +12679,17 @@ components:
         clientId:
           type: string
         clientIdIssuedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         clientName:
           type: string
         clientSecret:
           type: string
         clientSecretExpiresAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         clientType:
           type: string
         clientUri:
@@ -12970,8 +12984,9 @@ components:
         target:
           $ref: "#/components/schemas/AuditEntity"
         timestamp:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
           writeOnly: true
         transactionId:
           type: string
@@ -13032,8 +13047,9 @@ components:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         name:
@@ -13052,16 +13068,18 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     AuthorizationEngine:
       type: object
       properties:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         name:
@@ -13080,8 +13098,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     BaseJsonNode:
       type: object
     BotDetection:
@@ -13090,8 +13109,9 @@ components:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         detectionType:
           type: string
         id:
@@ -13112,8 +13132,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     BulkCreateOrganizationUser:
       required:
       - action
@@ -13281,11 +13302,13 @@ components:
       type: object
       properties:
         accessedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         certificateExpiresAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         certificateIssuerDN:
           type: string
         certificatePem:
@@ -13297,8 +13320,9 @@ components:
         certificateThumbprint:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         ipAddress:
@@ -13319,8 +13343,9 @@ components:
           - ENVIRONMENT
           - PROTECTED_RESOURCE
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         userAgent:
           type: string
         userId:
@@ -13335,11 +13360,13 @@ components:
           items:
             $ref: "#/components/schemas/Application"
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         expiresAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         identityProviders:
@@ -13525,11 +13552,13 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         expiresAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         name:
@@ -13576,8 +13605,9 @@ components:
         aaguid:
           type: string
         accessedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         attestationStatement:
           type: string
         attestationStatementFormat:
@@ -13586,8 +13616,9 @@ components:
           type: integer
           format: int64
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         credentialId:
           type: string
         deviceName:
@@ -13597,8 +13628,9 @@ components:
         ipAddress:
           type: string
         lastCheckedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         publicKey:
           type: string
         referenceId:
@@ -13613,8 +13645,9 @@ components:
           - ENVIRONMENT
           - PROTECTED_RESOURCE
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         userAgent:
           type: string
         userId:
@@ -13641,8 +13674,9 @@ components:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         name:
@@ -13661,8 +13695,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     Domain:
       type: object
       properties:
@@ -13675,8 +13710,9 @@ components:
         corsSettings:
           $ref: "#/components/schemas/CorsSettings"
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         dataPlaneId:
           type: string
         description:
@@ -13754,8 +13790,9 @@ components:
         uma:
           $ref: "#/components/schemas/UMASettings"
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         version:
           type: string
           enum:
@@ -13820,8 +13857,9 @@ components:
         content:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         defaultTemplate:
           type: boolean
         enabled:
@@ -13851,8 +13889,9 @@ components:
         template:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     EnrollSettings:
       type: object
       properties:
@@ -13883,8 +13922,9 @@ components:
         channel:
           $ref: "#/components/schemas/EnrolledFactorChannel"
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         factorId:
           type: string
         primary:
@@ -13899,8 +13939,9 @@ components:
           - REVOKED
           - "NULL"
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     EnrolledFactorChannel:
       type: object
       properties:
@@ -13921,8 +13962,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         name:
@@ -13930,8 +13972,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     EnrolledFactorSecurity:
       type: object
       properties:
@@ -13955,8 +13998,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         defaultEntrypoint:
           type: boolean
         description:
@@ -13972,16 +14016,18 @@ components:
           items:
             type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         url:
           type: string
     Environment:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         domainRestrictions:
@@ -13999,8 +14045,9 @@ components:
         organizationId:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     ErrorEntity:
       type: object
       properties:
@@ -14017,8 +14064,9 @@ components:
         createUser:
           type: boolean
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         domain:
           type: string
         grantType:
@@ -14032,8 +14080,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         userExists:
           type: boolean
     Factor:
@@ -14042,8 +14091,9 @@ components:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         domain:
           type: string
         factorType:
@@ -14064,8 +14114,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     FactorSettings:
       type: object
       properties:
@@ -14106,8 +14157,9 @@ components:
           - RESOURCE_SERVER
           - AGENT
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     FilteredIdentityProviderInfo:
       type: object
       properties:
@@ -14166,8 +14218,9 @@ components:
         condition:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         enabled:
           type: boolean
         icon:
@@ -14200,8 +14253,9 @@ components:
           - MFA_CHALLENGE
           - MFA_ENROLLMENT
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     Form:
       type: object
       properties:
@@ -14212,8 +14266,9 @@ components:
         content:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         enabled:
           type: boolean
         id:
@@ -14232,8 +14287,9 @@ components:
         template:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     FormField:
       type: object
       properties:
@@ -14247,8 +14303,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         id:
@@ -14275,8 +14332,9 @@ components:
           items:
             type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     GroupPage:
       type: object
       properties:
@@ -14294,8 +14352,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         entries:
           type: object
           additionalProperties:
@@ -14320,16 +14379,18 @@ components:
           - ENVIRONMENT
           - PROTECTED_RESOURCE
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     IdentityProvider:
       type: object
       properties:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         dataPlaneId:
           type: string
         domainWhitelist:
@@ -14381,8 +14442,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     InstallationEntity:
       type: object
       properties:
@@ -14391,13 +14453,15 @@ components:
           additionalProperties:
             type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     JWK:
       type: object
       properties:
@@ -14510,8 +14574,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         domain:
           type: string
         fromRoleMapper:
@@ -14539,8 +14604,9 @@ components:
         roleId:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     MembershipListItem:
       type: object
       properties:
@@ -14567,13 +14633,15 @@ components:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         domain:
           type: string
         expiresAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         metadata:
@@ -14587,8 +14655,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     NewAccountAccessToken:
       required:
       - name
@@ -15040,8 +15109,9 @@ components:
         client:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         credentialsNonExpired:
           type: boolean
         domain:
@@ -15061,11 +15131,13 @@ components:
         lastName:
           type: string
         lastPasswordReset:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         loggedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         loginsCount:
           type: integer
           format: int64
@@ -15082,8 +15154,9 @@ components:
         source:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         username:
           minLength: 1
           type: string
@@ -15315,8 +15388,9 @@ components:
         client:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         credentialsNonExpired:
           type: boolean
         domain:
@@ -15336,11 +15410,13 @@ components:
         lastName:
           type: string
         lastPasswordReset:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         loggedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         loginsCount:
           type: integer
           format: int64
@@ -15355,8 +15431,9 @@ components:
         source:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         username:
           minLength: 1
           type: string
@@ -15456,8 +15533,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         defaultPolicy:
           type: boolean
         excludePasswordsInDictionary:
@@ -15505,8 +15583,9 @@ components:
         regex:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     PasswordPolicyEntity:
       type: object
       properties:
@@ -15733,13 +15812,15 @@ components:
         authorizationSignedResponseAlg:
           type: string
         clientIdIssuedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         clientName:
           type: string
         clientSecretExpiresAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         clientUri:
           type: string
         contacts:
@@ -16666,8 +16747,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         key:
@@ -16677,8 +16759,9 @@ components:
           enum:
           - MCP_TOOL
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
       discriminator:
         propertyName: type
         mapping:
@@ -16728,8 +16811,9 @@ components:
           enum:
           - MCP_SERVER
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     ProtectedResourceSecret:
       type: object
       properties:
@@ -16775,8 +16859,9 @@ components:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         dataType:
           type: string
         enabled:
@@ -16799,8 +16884,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     ResetPasswordSettings:
       type: object
       properties:
@@ -16815,8 +16901,9 @@ components:
         clientId:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         domain:
@@ -16834,8 +16921,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         userId:
           type: string
     ResourceEntity:
@@ -16844,8 +16932,9 @@ components:
         clientId:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         domain:
@@ -16866,8 +16955,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         userDisplayName:
           type: string
         userId:
@@ -16909,8 +16999,9 @@ components:
           - ENVIRONMENT
           - PROTECTED_RESOURCE
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         defaultRole:
           type: boolean
         description:
@@ -16952,8 +17043,9 @@ components:
         system:
           type: boolean
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     RoleEntity:
       type: object
       properties:
@@ -16964,8 +17056,9 @@ components:
           items:
             type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         defaultRole:
           type: boolean
         description:
@@ -16992,8 +17085,9 @@ components:
         system:
           type: boolean
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     RolePage:
       type: object
       properties:
@@ -17043,8 +17137,9 @@ components:
           items:
             type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         discovery:
@@ -17067,8 +17162,9 @@ components:
         system:
           type: boolean
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     ScopeApprovalEntity:
       type: object
       properties:
@@ -17077,13 +17173,15 @@ components:
         clientId:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         domain:
           type: string
         expiresAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         scope:
@@ -17098,8 +17196,9 @@ components:
         transactionId:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         userId:
           $ref: "#/components/schemas/UserId"
     ScopeEntity:
@@ -17154,8 +17253,9 @@ components:
         configuration:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         name:
@@ -17174,8 +17274,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     SessionSettings:
       type: object
       properties:
@@ -17262,8 +17363,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         id:
@@ -17273,14 +17375,16 @@ components:
         organizationId:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     Theme:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         css:
           type: string
         faviconUrl:
@@ -17312,14 +17416,16 @@ components:
         secondaryTextColorHex:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     ThemeEntity:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         css:
           type: string
         faviconUrl:
@@ -17351,8 +17457,9 @@ components:
         secondaryTextColorHex:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     TokenClaim:
       type: object
       properties:
@@ -17419,8 +17526,9 @@ components:
           - JWKS_URL
           - STATIC_JWKS
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         description:
           type: string
         id:
@@ -17446,8 +17554,9 @@ components:
         staticJwks:
           $ref: "#/components/schemas/JWKSet"
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     TrustedIssuer:
       type: object
       properties:
@@ -17910,8 +18019,9 @@ components:
         client:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         credentialsNonExpired:
           type: boolean
         displayName:
@@ -17931,8 +18041,9 @@ components:
         lastName:
           type: string
         loggedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         loginsCount:
           type: integer
           format: int64
@@ -17945,8 +18056,9 @@ components:
         source:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     UpdateUserWithId:
       type: object
       properties:
@@ -17961,8 +18073,9 @@ components:
         client:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         credentialsNonExpired:
           type: boolean
         displayName:
@@ -17984,8 +18097,9 @@ components:
         lastName:
           type: string
         loggedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         loginsCount:
           type: integer
           format: int64
@@ -17998,17 +18112,20 @@ components:
         source:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
     User:
       type: object
       properties:
         accountLockedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         accountLockedUntil:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         accountNonExpired:
           type: boolean
         accountNonLocked:
@@ -18030,8 +18147,9 @@ components:
         client:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         credentialsNonExpired:
           type: boolean
         disabled:
@@ -18101,30 +18219,36 @@ components:
         lastIdentityUsed:
           type: string
         lastLoginWithCredentials:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         lastLogoutAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         lastName:
           type: string
         lastPasswordReset:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         lastUsernameReset:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         locale:
           type: string
         loggedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         loginsCount:
           type: integer
           format: int64
         mfaEnrollmentSkippedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         middleName:
           type: string
         newsletter:
@@ -18188,8 +18312,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         username:
           type: string
         website:
@@ -18211,11 +18336,13 @@ components:
       type: object
       properties:
         accountLockedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         accountLockedUntil:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         accountNonExpired:
           type: boolean
         accountNonLocked:
@@ -18239,8 +18366,9 @@ components:
         client:
           type: string
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         credentialsNonExpired:
           type: boolean
         disabled:
@@ -18310,30 +18438,36 @@ components:
         lastIdentityUsed:
           type: string
         lastLoginWithCredentials:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         lastLogoutAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         lastName:
           type: string
         lastPasswordReset:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         lastUsernameReset:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         locale:
           type: string
         loggedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         loginsCount:
           type: integer
           format: int64
         mfaEnrollmentSkippedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         middleName:
           type: string
         newsletter:
@@ -18399,8 +18533,9 @@ components:
         type:
           type: string
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         username:
           type: string
         website:
@@ -18428,8 +18563,9 @@ components:
           additionalProperties:
             type: object
         linkedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         providerId:
           type: string
         userId:
@@ -18444,8 +18580,9 @@ components:
           additionalProperties:
             type: object
         linkedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         providerId:
           type: string
         providerName:
@@ -18465,8 +18602,9 @@ components:
       type: object
       properties:
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: Epoch timestamp in milliseconds.
+          format: int64
         id:
           type: string
         message:

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationCertificate.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationCertificate.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.automation.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -60,12 +61,15 @@ public class AutomationCertificate {
     @Schema(name = "system", description = "whether this is the domain's system certificate (immutable after creation; when true, only key is required and the certificate is built from domains.certificates.default.* system settings)")
     private boolean system;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
     private Date createdAt;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
     private Date updatedAt;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Expiry timestamp (ISO-8601 / RFC 3339, UTC), when known for the certificate type. Read-only.")
     private Date expiresAt;
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
@@ -25,6 +25,7 @@ import io.gravitee.am.model.login.WebAuthnSettings;
 import io.gravitee.am.model.scim.SCIMSettings;
 import io.gravitee.am.model.uma.UMASettings;
 import io.gravitee.am.model.PasswordSettings;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -93,10 +94,12 @@ public class AutomationDomain {
     @Size(min = 1, max = 255)
     private String dataPlaneId;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
     private Date createdAt;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
     private Date updatedAt;
 
     // --- Shared settings reused by reference (full request/response symmetry) ---

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationIdentityProvider.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationIdentityProvider.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.automation.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -70,9 +71,11 @@ public class AutomationIdentityProvider {
 
     private List<String> domainWhitelist;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
     private Date createdAt;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
     private Date updatedAt;
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationReporter.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationReporter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.automation.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -64,9 +65,11 @@ public class AutomationReporter {
     @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private String dataType;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
     private Date createdAt;
 
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY, type = "java.lang.Long")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
     private Date updatedAt;
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/swagger/GraviteeApiDefinition.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/swagger/GraviteeApiDefinition.java
@@ -60,6 +60,43 @@ public class GraviteeApiDefinition implements ReaderListener {
         }
     }
 
+    /**
+     * Rewrites every {@code string}/{@code date-time} schema to {@code integer}/{@code int64}.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void rewriteEpochMillisTimestamps(Schema schema) {
+        if (schema == null) {
+            return;
+        }
+        if ("string".equals(schema.getType()) && "date-time".equals(schema.getFormat())) {
+            schema.setType("integer");
+            schema.setFormat("int64");
+            if (schema.getDescription() == null) {
+                schema.setDescription("Epoch timestamp in milliseconds.");
+            }
+            return;
+        }
+        if (schema.getProperties() != null) {
+            ((Map<String, Schema>) schema.getProperties()).values()
+                    .forEach(GraviteeApiDefinition::rewriteEpochMillisTimestamps);
+        }
+        if (schema.getItems() != null) {
+            rewriteEpochMillisTimestamps(schema.getItems());
+        }
+        if (schema.getAdditionalProperties() instanceof Schema) {
+            rewriteEpochMillisTimestamps((Schema) schema.getAdditionalProperties());
+        }
+        if (schema.getAllOf() != null) {
+            ((List<Schema>) schema.getAllOf()).forEach(GraviteeApiDefinition::rewriteEpochMillisTimestamps);
+        }
+        if (schema.getAnyOf() != null) {
+            ((List<Schema>) schema.getAnyOf()).forEach(GraviteeApiDefinition::rewriteEpochMillisTimestamps);
+        }
+        if (schema.getOneOf() != null) {
+            ((List<Schema>) schema.getOneOf()).forEach(GraviteeApiDefinition::rewriteEpochMillisTimestamps);
+        }
+    }
+
     @Override
     public void afterScan(OpenApiReader openApiReader, OpenAPI openAPI){
 
@@ -96,6 +133,8 @@ public class GraviteeApiDefinition implements ReaderListener {
         Map<String, Schema> sortedSchemas = new TreeMap<>(openAPI.getComponents().getSchemas());
         // sort properties within each schema for deterministic SDK generation
         sortedSchemas.values().forEach(GraviteeApiDefinition::sortSchemaProperties);
+        // normalize timestamp schemas to match the real wire format (epoch millis)
+        sortedSchemas.values().forEach(GraviteeApiDefinition::rewriteEpochMillisTimestamps);
         Components components = new Components();
         components.schemas(sortedSchemas);
         components.addSecuritySchemes(TOKEN_AUTH_SCHEME, new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("Bearer"));

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/swagger/GraviteeApiDefinitionTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/swagger/GraviteeApiDefinitionTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.resources.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author GraviteeSource Team
+ */
+class GraviteeApiDefinitionTest {
+
+    private static Schema<?> dateTime() {
+        return new Schema<>().type("string").format("date-time");
+    }
+
+    private OpenAPI afterScanOn(Schema<?> rootSchema) {
+        OpenAPI openAPI = new OpenAPI()
+                .paths(new Paths())
+                .components(new Components().addSchemas("Root", rootSchema));
+        new GraviteeApiDefinition().afterScan(null, openAPI);
+        return openAPI;
+    }
+
+    private Schema<?> rootAfterScan(Schema<?> rootSchema) {
+        return afterScanOn(rootSchema).getComponents().getSchemas().get("Root");
+    }
+
+    @Test
+    void should_rewrite_date_time_property_to_epoch_millis_int64() {
+        Map<String, Schema> props = new LinkedHashMap<>();
+        props.put("createdAt", dateTime());
+        Schema<?> result = rootAfterScan(new Schema<>().type("object").properties(props));
+
+        Schema<?> createdAt = (Schema<?>) result.getProperties().get("createdAt");
+        assertThat(createdAt.getType()).isEqualTo("integer");
+        assertThat(createdAt.getFormat()).isEqualTo("int64");
+        assertThat(createdAt.getDescription()).isEqualTo("Epoch timestamp in milliseconds.");
+    }
+
+    @Test
+    void should_not_overwrite_an_existing_description() {
+        Map<String, Schema> props = new LinkedHashMap<>();
+        props.put("createdAt", dateTime().description("Domain creation date"));
+        Schema<?> result = rootAfterScan(new Schema<>().type("object").properties(props));
+
+        Schema<?> createdAt = (Schema<?>) result.getProperties().get("createdAt");
+        assertThat(createdAt.getType()).isEqualTo("integer");
+        assertThat(createdAt.getFormat()).isEqualTo("int64");
+        assertThat(createdAt.getDescription()).isEqualTo("Domain creation date");
+    }
+
+    @Test
+    void should_leave_non_timestamp_strings_untouched() {
+        Map<String, Schema> props = new LinkedHashMap<>();
+        props.put("name", new Schema<>().type("string"));
+        Schema<?> result = rootAfterScan(new Schema<>().type("object").properties(props));
+
+        Schema<?> name = (Schema<?>) result.getProperties().get("name");
+        assertThat(name.getType()).isEqualTo("string");
+        assertThat(name.getFormat()).isNull();
+    }
+
+    @Test
+    void should_recurse_into_array_items_and_map_values() {
+        Map<String, Schema> props = new LinkedHashMap<>();
+        props.put("history", new Schema<>().type("array").items(dateTime()));
+        props.put("byKey", new Schema<>().type("object").additionalProperties(dateTime()));
+        Schema<?> result = rootAfterScan(new Schema<>().type("object").properties(props));
+
+        Schema<?> items = ((Schema<?>) result.getProperties().get("history")).getItems();
+        assertThat(items.getType()).isEqualTo("integer");
+        assertThat(items.getFormat()).isEqualTo("int64");
+
+        Object additional = ((Schema<?>) result.getProperties().get("byKey")).getAdditionalProperties();
+        assertThat(additional).isInstanceOf(Schema.class);
+        assertThat(((Schema<?>) additional).getType()).isEqualTo("integer");
+        assertThat(((Schema<?>) additional).getFormat()).isEqualTo("int64");
+    }
+}

--- a/gravitee-am-test/specs/management/automation/domains.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domains.jest.spec.ts
@@ -79,6 +79,10 @@ describe('Automation API - Domain - PUT on collection (Idempotent Create/Update)
     expect(response.body.key).toEqual(domainKey);
     // createdAt is stable across an update; a duplicate create would reset it
     expect(response.body.createdAt).toEqual(first.body.createdAt);
+    const ISO_8601_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+    expect(typeof response.body.createdAt).toBe('string');
+    expect(response.body.createdAt).toMatch(ISO_8601_UTC);
+    expect(response.body.updatedAt).toMatch(ISO_8601_UTC);
   });
 
   it('should retrieve the created domain by key via path', async () => {

--- a/gravitee-am-test/specs/management/domain-create.jest.spec.ts
+++ b/gravitee-am-test/specs/management/domain-create.jest.spec.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { createDomain, getDomain, safeDeleteDomain } from '@management-commands/domain-management-commands';
+import { getDomainApi } from '@management-commands/service/utils';
 import { uniqueName } from '@utils-commands/misc';
 import { jira } from '@specs-utils/jira';
 import { setup } from '../test-fixture';
@@ -30,7 +31,7 @@ describe('Domain Create', () => {
     accessToken = await requestAdminAccessToken();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     if (domainId && accessToken) {
       await safeDeleteDomain(domainId, accessToken);
     }
@@ -52,5 +53,28 @@ describe('Domain Create', () => {
     expect(fetched.id).toEqual(domain.id);
     expect(fetched.name).toEqual(name);
     expect(fetched.description).toEqual(description);
+  });
+
+  it('should return createdAt and updatedAt as epoch-millisecond numbers', async () => {
+    const name = uniqueName('domain-create-test', true);
+    const description = 'Test domain created by regression test AM-2217';
+
+    const now = Date.now();
+    const domain = await createDomain(accessToken, name, description);
+    domainId = domain.id;
+
+    const raw = await getDomainApi(accessToken).findDomainRaw({
+      organizationId: process.env.AM_DEF_ORG_ID,
+      environmentId: process.env.AM_DEF_ENV_ID,
+      domain: domainId,
+    });
+    expect(raw.raw.status).toBe(200);
+    const { createdAt, updatedAt } = await raw.raw.json();
+    expect(typeof createdAt).toBe('number');
+    expect(typeof updatedAt).toBe('number');
+    expect(createdAt).toBeGreaterThan(now - 60_000);
+    expect(createdAt).toBeLessThan(now + 5_000);
+    expect(updatedAt).toBeGreaterThan(now - 60_000);
+    expect(updatedAt).toBeLessThan(now + 5_000);
   });
 });


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7082](https://gravitee.atlassian.net/browse/AM-7082)

## :pencil2: A description of the changes proposed in the pull request
Correct date/time field schema in OpenApi specifications for both APIs:
- **Management API**
  - correct advertised `type` in OAS `string` -> `integer`
  - continue to serve epoch-millisecond numbers on the wire

**before:**
```yaml
        createdAt:
          type: string
          format: date-time
```
**after:**
```yaml
        createdAt:
          type: integer
          description: Epoch timestamp in milliseconds.
          format: int64
```

- **Automation API**
  - continue advertising `type` in OAS (add descriptions)
  - correct served format of values on the wire to match documented data type (Terraform's expected RFC3339/ISO-8601 format)

**before:**
```yaml
        createdAt:
          type: string
          format: date-time
          readOnly: true
```
**after:**
```yaml
        createdAt:
          type: string
          description: "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
          format: date-time
          readOnly: true
```

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7082]: https://gravitee.atlassian.net/browse/AM-7082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ