### PR TITLE
chore: introduce oss-bundle and ee-bundle Maven profiles

### DIFF
--- a/.circleci/scripts/ee-schema-compat-check.sh
+++ b/.circleci/scripts/ee-schema-compat-check.sh
@@ -240,7 +240,7 @@ for entry in "${TO_CHECK[@]}"; do
     fi
   else
     echo "  ❌  New ZIP not found in any distribution target directory."
-    echo "      Run 'mvn install -P full-bundle' first to build the distributions."
+    echo "      Run 'mvn install -P ee-bundle,addons-bundle' first to build the distributions."
     echo ""
     MISSING_ZIPS=$((MISSING_ZIPS + 1))
     continue
@@ -285,7 +285,7 @@ done
 
 echo "=== Summary ==="
 if [[ $MISSING_ZIPS -gt 0 ]]; then
-  echo "❌  $MISSING_ZIPS plugin ZIP(s) were not found. Run 'mvn install -P full-bundle' first."
+  echo "❌  $MISSING_ZIPS plugin ZIP(s) were not found. Run 'mvn install -P ee-bundle,addons-bundle' first."
   exit 1
 elif [[ $DOWNLOAD_FAILURES -gt 0 ]]; then
   echo "❌  $DOWNLOAD_FAILURES old plugin ZIP(s) could not be downloaded from Maven."

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -438,8 +438,8 @@ jobs:
       - run:
           name: Maven Package & deploy on artifactory
           command: |
-            mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot,full-bundle clean deploy -pl \!gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip,\!gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip
-            mvn -s /tmp/.gravitee.settings.xml -P full-bundle package -DskipTests -pl gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip,gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip
+            mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot,ee-bundle,addons-bundle clean deploy -pl \!gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip,\!gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip
+            mvn -s /tmp/.gravitee.settings.xml -P ee-bundle,addons-bundle package -DskipTests -pl gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip,gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip
             cp ./gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/target/*.zip ~/
             cp ./gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/target/*.zip ~/
             cp ./gravitee-am-ui/target/*.zip ~/
@@ -1106,7 +1106,7 @@ jobs:
           command: |
             mvn -B -V -ntp -s /tmp/.gravitee.settings.xml install \
               -pl gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution,gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution \
-              -P full-bundle -am -DskipTests -Dlicense.skip=true
+              -P ee-bundle,addons-bundle -am -DskipTests -Dlicense.skip=true
       - run:
           name: Check EE plugin schema backward compatibility
           command: bash .circleci/scripts/ee-schema-compat-check.sh
@@ -1170,7 +1170,7 @@ jobs:
       - run:
           name: "Maven Package Install (no tests)"
           command: |
-            mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot,full-bundle clean install -DskipTests
+            mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot,ee-bundle,addons-bundle clean install -DskipTests
       - save-maven-job-cache:
           jobName: pull_requests
       - run:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -40,7 +40,7 @@ git checkout -b issue/#<issue-id>-my-fix-branch master
 * Build your changes locally to **ensure all the tests pass**:
 
 ```shell
-mvn clean install
+mvn clean install -P oss-bundle
 ```
 
 * Push your branch to GitHub:

--- a/docs/agent-standards/skills/check-schemas/SKILL.md
+++ b/docs/agent-standards/skills/check-schemas/SKILL.md
@@ -180,7 +180,7 @@ unzip -p /tmp/plugins/<artifactId>-<version>.zip 'schemas/schema-form.json' > /t
 - The automated `schema-compat-check.sh` covers schemas tracked in this git repository.
 - The automated `ee-schema-compat-check.sh` covers schemas in EE plugins that are distributed as closed-source ZIPs.
 
-> **Prerequisite:** run `mvn install -P full-bundle` first. The EE script locates new plugin
+> **Prerequisite:** run `mvn install -P ee-bundle,addons-bundle` first. The EE script locates new plugin
 > ZIPs from the local build output; it will error with a clear message if they are absent.
 
 ```bash

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
@@ -155,14 +155,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.graviteesource.am.certificate</groupId>
-            <artifactId>gravitee-am-certificate-aws</artifactId>
-            <version>${gravitee-am-certificate-aws.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.gravitee.am.repository</groupId>
             <artifactId>gravitee-am-repository-mongodb</artifactId>
             <version>${project.version}</version>
@@ -471,13 +463,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.graviteesource.secretprovider</groupId>
-            <artifactId>gravitee-secret-provider-aws</artifactId>
-            <version>${gravitee-secretprovider-aws.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>io.gravitee.am.dataplane</groupId>
             <artifactId>gravitee-am-dataplane-mongodb</artifactId>
             <version>${project.version}</version>
@@ -505,25 +490,10 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>com.graviteesource.am.authorizationengine.openfga</groupId>
-            <artifactId>gravitee-am-authorizationengine-openfga</artifactId>
-            <version>${gravitee-am-authorizationengine-openfga.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.am.gateway.handler</groupId>
-            <artifactId>gravitee-am-gateway-handler-authzen</artifactId>
-            <version>${gravitee-am-gateway-handler-authzen.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build>
         <finalName>distribution</finalName>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -633,13 +603,6 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                 </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.certificate</groupId>
-                                    <artifactId>gravitee-am-certificate-aws</artifactId>
-                                    <version>${gravitee-am-certificate-aws.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-
                                 <!-- Repositories -->
                                 <artifactItem>
                                     <groupId>io.gravitee.am.repository</groupId>
@@ -921,111 +884,6 @@
                                     <type>zip</type>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>com.graviteesource.secretprovider</groupId>
-                                    <artifactId>gravitee-secret-provider-aws</artifactId>
-                                    <version>${gravitee-secretprovider-aws.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-
-                                <!-- AM EE plugins -->
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-saml2-generic</artifactId>
-                                    <version>${gravitee-am-idp-saml2.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-ldap</artifactId>
-                                    <version>${gravitee-am-idp-ldap.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-azure-ad</artifactId>
-                                    <version>${gravitee-am-idp-azure-ad.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-franceconnect</artifactId>
-                                    <version>${gravitee-am-idp-franceconnect.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-salesforce</artifactId>
-                                    <version>${gravitee-am-idp-salesforce.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-call</artifactId>
-                                    <version>${gravitee-am-factor-call.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-sms</artifactId>
-                                    <version>${gravitee-am-factor-sms.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-fido2</artifactId>
-                                    <version>${gravitee-am-factor-fido2.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-http</artifactId>
-                                    <version>${gravitee-am-factor-http.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-recovery-code</artifactId>
-                                    <version>${gravitee-am-factor-recovery-code.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-otp-sender</artifactId>
-                                    <version>${gravitee-am-factor-otp-sender.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.resource</groupId>
-                                    <artifactId>gravitee-am-resource-twilio</artifactId>
-                                    <version>${gravitee-am-resource-twilio.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.policy</groupId>
-                                    <artifactId>gravitee-am-policy-account-linking</artifactId>
-                                    <version>${gravitee-am-policy-account-linking.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.policy</groupId>
-                                    <artifactId>gravitee-am-policy-mfa-challenge</artifactId>
-                                    <version>${gravitee-am-policy-mfa-challenge.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.authorizationengine.openfga</groupId>
-                                    <artifactId>gravitee-am-authorizationengine-openfga</artifactId>
-                                    <version>${gravitee-am-authorizationengine-openfga.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.gateway.handler</groupId>
-                                    <artifactId>gravitee-am-gateway-handler-authzen</artifactId>
-                                    <version>${gravitee-am-gateway-handler-authzen.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-
-                                <artifactItem>
                                     <groupId>io.gravitee.am.authenticator</groupId>
                                     <artifactId>gravitee-am-authenticator-magiclink</artifactId>
                                     <version>${gravitee-am-authenticator-magiclink.version}</version>
@@ -1061,7 +919,7 @@
 
     <profiles>
         <profile>
-            <id>full-bundle</id>
+            <id>addons-bundle</id>
             <dependencies>
                 <!-- Identity Providers -->
                 <dependency>
@@ -1258,6 +1116,179 @@
                                             <groupId>io.gravitee.am.authenticator</groupId>
                                             <artifactId>gravitee-am-authenticator-cba</artifactId>
                                             <version>${gravitee-am-authenticator-cba.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>oss-bundle</id>
+            <!-- Activating this profile deactivates 'ee-bundle' (activeByDefault).
+                 Result: only io.gravitee.* artifacts are included. -->
+        </profile>
+
+        <profile>
+            <id>ee-bundle</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.graviteesource.am.certificate</groupId>
+                    <artifactId>gravitee-am-certificate-aws</artifactId>
+                    <version>${gravitee-am-certificate-aws.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.secretprovider</groupId>
+                    <artifactId>gravitee-secret-provider-aws</artifactId>
+                    <version>${gravitee-secretprovider-aws.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.am.authorizationengine.openfga</groupId>
+                    <artifactId>gravitee-am-authorizationengine-openfga</artifactId>
+                    <version>${gravitee-am-authorizationengine-openfga.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.am.gateway.handler</groupId>
+                    <artifactId>gravitee-am-gateway-handler-authzen</artifactId>
+                    <version>${gravitee-am-gateway-handler-authzen.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-ee-plugins</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/staging</outputDirectory>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.certificate</groupId>
+                                            <artifactId>gravitee-am-certificate-aws</artifactId>
+                                            <version>${gravitee-am-certificate-aws.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.secretprovider</groupId>
+                                            <artifactId>gravitee-secret-provider-aws</artifactId>
+                                            <version>${gravitee-secretprovider-aws.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <!-- AM EE plugins -->
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-saml2-generic</artifactId>
+                                            <version>${gravitee-am-idp-saml2.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-ldap</artifactId>
+                                            <version>${gravitee-am-idp-ldap.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-azure-ad</artifactId>
+                                            <version>${gravitee-am-idp-azure-ad.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-franceconnect</artifactId>
+                                            <version>${gravitee-am-idp-franceconnect.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-salesforce</artifactId>
+                                            <version>${gravitee-am-idp-salesforce.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-call</artifactId>
+                                            <version>${gravitee-am-factor-call.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-sms</artifactId>
+                                            <version>${gravitee-am-factor-sms.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-fido2</artifactId>
+                                            <version>${gravitee-am-factor-fido2.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-http</artifactId>
+                                            <version>${gravitee-am-factor-http.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-recovery-code</artifactId>
+                                            <version>${gravitee-am-factor-recovery-code.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-otp-sender</artifactId>
+                                            <version>${gravitee-am-factor-otp-sender.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.resource</groupId>
+                                            <artifactId>gravitee-am-resource-twilio</artifactId>
+                                            <version>${gravitee-am-resource-twilio.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.policy</groupId>
+                                            <artifactId>gravitee-am-policy-account-linking</artifactId>
+                                            <version>${gravitee-am-policy-account-linking.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.policy</groupId>
+                                            <artifactId>gravitee-am-policy-mfa-challenge</artifactId>
+                                            <version>${gravitee-am-policy-mfa-challenge.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.authorizationengine.openfga</groupId>
+                                            <artifactId>gravitee-am-authorizationengine-openfga</artifactId>
+                                            <version>${gravitee-am-authorizationengine-openfga.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.gateway.handler</groupId>
+                                            <artifactId>gravitee-am-gateway-handler-authzen</artifactId>
+                                            <version>${gravitee-am-gateway-handler-authzen.version}</version>
                                             <type>zip</type>
                                         </artifactItem>
                                     </artifactItems>

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/pom.xml
@@ -149,14 +149,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.graviteesource.am.certificate</groupId>
-            <artifactId>gravitee-am-certificate-aws</artifactId>
-            <version>${gravitee-am-certificate-aws.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.gravitee.am.repository</groupId>
             <artifactId>gravitee-am-repository-mongodb</artifactId>
             <version>${project.version}</version>
@@ -442,13 +434,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.graviteesource.secretprovider</groupId>
-            <artifactId>gravitee-secret-provider-aws</artifactId>
-            <version>${gravitee-secretprovider-aws.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>io.gravitee.am.dataplane</groupId>
             <artifactId>gravitee-am-dataplane-mongodb</artifactId>
             <version>${project.version}</version>
@@ -462,14 +447,6 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>com.graviteesource.am.authorizationengine.openfga</groupId>
-            <artifactId>gravitee-am-authorizationengine-openfga</artifactId>
-            <version>${gravitee-am-authorizationengine-openfga.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -582,13 +559,6 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                 </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.certificate</groupId>
-                                    <artifactId>gravitee-am-certificate-aws</artifactId>
-                                    <version>${gravitee-am-certificate-aws.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-
                                 <!-- Repositories -->
                                 <artifactItem>
                                     <groupId>io.gravitee.am.repository</groupId>
@@ -837,104 +807,6 @@
                                     <version>${gravitee-secretprovider-kubernetes.version}</version>
                                     <type>zip</type>
                                 </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.secretprovider</groupId>
-                                    <artifactId>gravitee-secret-provider-aws</artifactId>
-                                    <version>${gravitee-secretprovider-aws.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-
-                                <!-- AM EE plugins -->
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-saml2-generic</artifactId>
-                                    <version>${gravitee-am-idp-saml2.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-ldap</artifactId>
-                                    <version>${gravitee-am-idp-ldap.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-azure-ad</artifactId>
-                                    <version>${gravitee-am-idp-azure-ad.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-franceconnect</artifactId>
-                                    <version>${gravitee-am-idp-franceconnect.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.identityprovider</groupId>
-                                    <artifactId>gravitee-am-identityprovider-salesforce</artifactId>
-                                    <version>${gravitee-am-idp-salesforce.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-call</artifactId>
-                                    <version>${gravitee-am-factor-call.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-sms</artifactId>
-                                    <version>${gravitee-am-factor-sms.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-fido2</artifactId>
-                                    <version>${gravitee-am-factor-fido2.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-http</artifactId>
-                                    <version>${gravitee-am-factor-http.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-recovery-code</artifactId>
-                                    <version>${gravitee-am-factor-recovery-code.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.factor</groupId>
-                                    <artifactId>gravitee-am-factor-otp-sender</artifactId>
-                                    <version>${gravitee-am-factor-otp-sender.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.resource</groupId>
-                                    <artifactId>gravitee-am-resource-twilio</artifactId>
-                                    <version>${gravitee-am-resource-twilio.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.policy</groupId>
-                                    <artifactId>gravitee-am-policy-account-linking</artifactId>
-                                    <version>${gravitee-am-policy-account-linking.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.policy</groupId>
-                                    <artifactId>gravitee-am-policy-mfa-challenge</artifactId>
-                                    <version>${gravitee-am-policy-mfa-challenge.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.graviteesource.am.authorizationengine.openfga</groupId>
-                                    <artifactId>gravitee-am-authorizationengine-openfga</artifactId>
-                                    <version>${gravitee-am-authorizationengine-openfga.version}</version>
-                                    <type>zip</type>
-                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -970,7 +842,7 @@
 
     <profiles>
         <profile>
-            <id>full-bundle</id>
+            <id>addons-bundle</id>
             <dependencies>
                 <!-- Identity Providers -->
                 <dependency>
@@ -1153,6 +1025,166 @@
                                             <groupId>com.graviteesource.service</groupId>
                                             <artifactId>gravitee-service-geoip</artifactId>
                                             <version>${gravitee-service-geoip.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>oss-bundle</id>
+            <!-- Activating this profile deactivates 'ee-bundle' (activeByDefault).
+                 Result: only io.gravitee.* artifacts are included. -->
+        </profile>
+
+        <profile>
+            <id>ee-bundle</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.graviteesource.am.certificate</groupId>
+                    <artifactId>gravitee-am-certificate-aws</artifactId>
+                    <version>${gravitee-am-certificate-aws.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.secretprovider</groupId>
+                    <artifactId>gravitee-secret-provider-aws</artifactId>
+                    <version>${gravitee-secretprovider-aws.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.am.authorizationengine.openfga</groupId>
+                    <artifactId>gravitee-am-authorizationengine-openfga</artifactId>
+                    <version>${gravitee-am-authorizationengine-openfga.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-ee-plugins</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/staging</outputDirectory>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.certificate</groupId>
+                                            <artifactId>gravitee-am-certificate-aws</artifactId>
+                                            <version>${gravitee-am-certificate-aws.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.secretprovider</groupId>
+                                            <artifactId>gravitee-secret-provider-aws</artifactId>
+                                            <version>${gravitee-secretprovider-aws.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <!-- AM EE plugins -->
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-saml2-generic</artifactId>
+                                            <version>${gravitee-am-idp-saml2.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-ldap</artifactId>
+                                            <version>${gravitee-am-idp-ldap.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-azure-ad</artifactId>
+                                            <version>${gravitee-am-idp-azure-ad.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-franceconnect</artifactId>
+                                            <version>${gravitee-am-idp-franceconnect.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.identityprovider</groupId>
+                                            <artifactId>gravitee-am-identityprovider-salesforce</artifactId>
+                                            <version>${gravitee-am-idp-salesforce.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-call</artifactId>
+                                            <version>${gravitee-am-factor-call.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-sms</artifactId>
+                                            <version>${gravitee-am-factor-sms.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-fido2</artifactId>
+                                            <version>${gravitee-am-factor-fido2.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-http</artifactId>
+                                            <version>${gravitee-am-factor-http.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-recovery-code</artifactId>
+                                            <version>${gravitee-am-factor-recovery-code.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.factor</groupId>
+                                            <artifactId>gravitee-am-factor-otp-sender</artifactId>
+                                            <version>${gravitee-am-factor-otp-sender.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.resource</groupId>
+                                            <artifactId>gravitee-am-resource-twilio</artifactId>
+                                            <version>${gravitee-am-resource-twilio.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.policy</groupId>
+                                            <artifactId>gravitee-am-policy-account-linking</artifactId>
+                                            <version>${gravitee-am-policy-account-linking.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.policy</groupId>
+                                            <artifactId>gravitee-am-policy-mfa-challenge</artifactId>
+                                            <version>${gravitee-am-policy-mfa-challenge.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.graviteesource.am.authorizationengine.openfga</groupId>
+                                            <artifactId>gravitee-am-authorizationengine-openfga</artifactId>
+                                            <version>${gravitee-am-authorizationengine-openfga.version}</version>
                                             <type>zip</type>
                                         </artifactItem>
                                     </artifactItems>

--- a/gravitee-am-test/GUIDELINES.md
+++ b/gravitee-am-test/GUIDELINES.md
@@ -1100,7 +1100,7 @@ The integration tests run against a local Docker stack. After code changes (or o
 
 ```bash
 # 1. Build distribution ZIPs (includes mock plugins from Artifactory)
-mvn install -DskipTests -P full-bundle
+mvn install -DskipTests -P ee-bundle,addons-bundle
 
 # 2. Copy ZIPs into Docker build context
 npm --prefix docker/local-stack run stack:init:copy-am
@@ -1112,7 +1112,7 @@ npm --prefix docker/local-stack run stack:init:build
 npm --prefix docker/local-stack run stack:down && npm --prefix docker/local-stack run stack:dev:setup:mongo
 ```
 
-> **Important:** The `-P full-bundle` profile is required to include mock test plugins (`gravitee-am-factor-mock`, `gravitee-am-resource-mfa-mock`). Without it, tests that use MFA mocks will fail with `Plugin type mock-am-factor not deployed`.
+> **Important:** The `-P ee-bundle,addons-bundle` profile is required to include mock test plugins (`gravitee-am-factor-mock`, `gravitee-am-resource-mfa-mock`). Without it, tests that use MFA mocks will fail with `Plugin type mock-am-factor not deployed`.
 
 ### Running Tests
 

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <gravitee-am-authenticator-cba.version>2.0.0-alpha.1</gravitee-am-authenticator-cba.version>
         <gravitee-am-authenticator-magiclink.version>2.0.0-alpha.2</gravitee-am-authenticator-magiclink.version>
 
-        <!-- Plugins included to full-bundle -->
+        <!-- Plugins included to addons-bundle -->
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
         <gravitee-am-gateway-handler-saml2-idp.version>5.0.0-alpha.4</gravitee-am-gateway-handler-saml2-idp.version>
         <gravitee-am-resource-sfr.version>2.0.0-alpha.1</gravitee-am-resource-sfr.version>


### PR DESCRIPTION
Split com.graviteesource.* EE artifacts out of the default build into a new ee-bundle profile (activeByDefault=true) in both gateway and management-api distribution poms. An oss-bundle profile is provided to build without any EE plugins by deactivating ee-bundle.

Update CI mvn invocations that use full-bundle to also activate ee-bundle, preserving the existing behaviour.
