### PR TITLE
fix: AM-7080 consistently validate updated resources

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
@@ -56,6 +56,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -139,65 +140,85 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
             Acl requiredAcl = match.isPresent() ? Acl.UPDATE : Acl.CREATE;
             return checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_IDENTITY_PROVIDER, requiredAcl)
                     .andThen(resolveDomain(environmentId, domainKey))
-                    .flatMap(domain -> {
-                        if (match.isPresent()) {
-                            IdentityProvider existing = match.get();
-                            // 'system' is an immutable identity attribute (it co-determines the internal id and
-                            // the system flag); reject a change.
-                            if (definition.isSystem() != existing.isSystem()) {
-                                return Single.error(new InvalidParameterException(
-                                        "The 'system' flag is immutable for an existing identity provider '" + key
-                                                + "'; delete and recreate it to change it"));
-                            }
-                            if (existing.isSystem()) {
-                                // re-PUT is an idempotent no-op
-                                return Single.just(AutomationIdentityProviderMapper.toAutomationIdentityProvider(existing));
-                            }
-                            return identityProviderManager.checkPluginDeployment(definition.getType())
-                                    .andThen(identityProviderService.update(ReferenceType.DOMAIN, domain.getId(), existing.getId(),
-                                            AutomationIdentityProviderMapper.toUpdateIdentityProvider(definition), principal, false))
-                                    .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
-                        }
-
-                        final String idpId = definition.isSystem()
-                                ? AutomationIds.systemIdentityProviderId(domain.getId())
-                                : AutomationIds.identityProviderId(domain.getId(), key);
-                        Optional<IdentityProvider> occupant = allExisting.stream()
-                                .filter(idp -> idpId.equals(idp.getId()))
-                                .findFirst();
-                        if (occupant.isPresent()) {
-                            return Single.error(new InvalidParameterException(
-                                    "Identity provider key '" + key + "' conflicts with an existing identity provider"
-                                            + (definition.isSystem() ? " (the domain already has a system identity provider)" : "")));
-                        }
-                        if (definition.isSystem() && allExisting.stream()
-                                .anyMatch(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && idp.isSystem())) {
-                            return Single.error(new InvalidParameterException(
-                                    "The domain already has a system identity provider"));
-                        }
-                        if (definition.isSystem()) {
-                            return defaultIdentityProviderService.create(domain, key, principal)
-                                    .flatMap(created -> reconcileDomainReference(domain, key, created.getId())
-                                            .andThen(Single.just(created)))
-                                    .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
-                        }
-                        Single<AutomationIdentityProvider> rejection = rejectIfMissingIdentityProviderFields(definition, key);
-                        if (rejection != null) {
-                            return rejection;
-                        }
-                        AutomationNewIdentityProvider newIdp = AutomationIdentityProviderMapper.toNewIdentityProvider(definition);
-                        newIdp.setId(idpId);
-                        return identityProviderManager.checkPluginDeployment(definition.getType())
-                                .andThen(Completable.fromAction(() -> {
-                                    if (!isBlank(definition.getConfiguration())) {
-                                        validationService.validate(definition.getType(), definition.getConfiguration());
-                                    }
-                                }))
-                                .andThen(Single.defer(() -> identityProviderService.create(domain, newIdp, principal, false)))
-                                .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
-                    });
+                    .flatMap(domain -> match.isPresent()
+                            ? updateExisting(domain, match.get(), definition, key, principal)
+                            : createNew(domain, allExisting, definition, key, principal));
         })
                 .subscribe(response::resume, response::resume);
+    }
+
+    private Single<AutomationIdentityProvider> updateExisting(Domain domain, IdentityProvider existing,
+            AutomationIdentityProvider definition, String key, User principal) {
+        // 'system' is an immutable identity attribute (it co-determines the internal id and the system flag);
+        // reject a change.
+        if (definition.isSystem() != existing.isSystem()) {
+            return Single.error(new InvalidParameterException(
+                    "The 'system' flag is immutable for an existing identity provider '" + key
+                            + "'; delete and recreate it to change it"));
+        }
+        if (existing.isSystem()) {
+            // re-PUT is an idempotent no-op
+            return Single.just(AutomationIdentityProviderMapper.toAutomationIdentityProvider(existing));
+        }
+        // 'type' is an immutable identity attribute; reject a change early
+        if (!isBlank(definition.getType()) && !definition.getType().equals(existing.getType())) {
+            return Single.error(new InvalidParameterException(
+                    "The 'type' is immutable for an existing identity provider '" + key
+                            + "'; delete and recreate it to change it"));
+        }
+        Single<AutomationIdentityProvider> rejection = rejectIfMissingIdentityProviderFields(definition, key);
+        if (rejection != null) {
+            return rejection;
+        }
+        return identityProviderManager.checkPluginDeployment(definition.getType())
+                .andThen(Completable.fromAction(() -> {
+                    if (!isBlank(definition.getConfiguration())) {
+                        validationService.validate(definition.getType(), definition.getConfiguration());
+                    }
+                }))
+                .andThen(Single.defer(() -> identityProviderService.update(ReferenceType.DOMAIN, domain.getId(), existing.getId(),
+                        AutomationIdentityProviderMapper.toUpdateIdentityProvider(definition), principal, false)))
+                .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
+    }
+
+    private Single<AutomationIdentityProvider> createNew(Domain domain, List<IdentityProvider> allExisting,
+            AutomationIdentityProvider definition, String key, User principal) {
+        final String idpId = definition.isSystem()
+                ? AutomationIds.systemIdentityProviderId(domain.getId())
+                : AutomationIds.identityProviderId(domain.getId(), key);
+        Optional<IdentityProvider> occupant = allExisting.stream()
+                .filter(idp -> idpId.equals(idp.getId()))
+                .findFirst();
+        if (occupant.isPresent()) {
+            return Single.error(new InvalidParameterException(
+                    "Identity provider key '" + key + "' conflicts with an existing identity provider"
+                            + (definition.isSystem() ? " (the domain already has a system identity provider)" : "")));
+        }
+        if (definition.isSystem() && allExisting.stream()
+                .anyMatch(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && idp.isSystem())) {
+            return Single.error(new InvalidParameterException(
+                    "The domain already has a system identity provider"));
+        }
+        if (definition.isSystem()) {
+            return defaultIdentityProviderService.create(domain, key, principal)
+                    .flatMap(created -> reconcileDomainReference(domain, key, created.getId())
+                            .andThen(Single.just(created)))
+                    .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
+        }
+        Single<AutomationIdentityProvider> rejection = rejectIfMissingIdentityProviderFields(definition, key);
+        if (rejection != null) {
+            return rejection;
+        }
+        AutomationNewIdentityProvider newIdp = AutomationIdentityProviderMapper.toNewIdentityProvider(definition);
+        newIdp.setId(idpId);
+        return identityProviderManager.checkPluginDeployment(definition.getType())
+                .andThen(Completable.fromAction(() -> {
+                    if (!isBlank(definition.getConfiguration())) {
+                        validationService.validate(definition.getType(), definition.getConfiguration());
+                    }
+                }))
+                .andThen(Single.defer(() -> identityProviderService.create(domain, newIdp, principal, false)))
+                .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
     }
 
     private static Single<AutomationIdentityProvider> rejectIfMissingIdentityProviderFields(AutomationIdentityProvider definition, String key) {

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
@@ -183,6 +183,75 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
     }
 
     @Test
+    void put_update_rejects_missing_required_fields() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+
+        AutomationIdentityProvider def = new AutomationIdentityProvider();
+        def.setAutomationKey("dev-users");
+        // name and type intentionally omitted
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(identityProviderService, never())
+                .update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_update_rejects_configuration_not_matching_schema() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+        doThrow(InvalidPluginConfigurationException.fromValidationError("not valid"))
+                .when(validationService).validate(eq("inline-am-idp"), anyString());
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+
+        assertEquals(400, response.getStatus());
+        verify(identityProviderService, never())
+                .update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_update_rejects_type_change_without_plugin_or_config_checks() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+
+        AutomationIdentityProvider def = definition("dev-users"); // existing type is inline-am-idp
+        def.setType("ldap-am-idp");
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(identityProviderManager, never()).checkPluginDeployment(anyString());
+        verify(validationService, never()).validate(anyString(), anyString());
+        verify(identityProviderService, never())
+                .update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_update_validates_type_and_configuration() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+        when(identityProviderService.update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false)))
+                .thenReturn(Single.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+
+        assertEquals(200, response.getStatus());
+        verify(identityProviderManager).checkPluginDeployment(eq("inline-am-idp"));
+        verify(validationService).validate(eq("inline-am-idp"), eq("{}"));
+    }
+
+    @Test
     void put_creates_system_from_config() {
         String systemIdpId = AutomationIds.systemIdentityProviderId(domainId);
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
@@ -305,9 +305,16 @@ public class CertificateServiceImpl implements CertificateService {
         log.debug("Update a certificate {} for domain {}", id, domain.getId());
         return certificateRepository.findById(id)
                 .switchIfEmpty(Single.error(() -> new CertificateNotFoundException(id)))
-                .flatMap((Function<Certificate, SingleSource<CertificateWithSchema>>) certificate -> certificatePluginService.getSchema(certificate.getType())
-                        .switchIfEmpty(Single.error(() -> new CertificatePluginSchemaNotFoundException(certificate.getType())))
-                        .map(schema -> new CertificateWithSchema(certificate, objectMapper.readValue(schema, CertificateSchema.class))))
+                .flatMap((Function<Certificate, SingleSource<CertificateWithSchema>>) certificate -> {
+                    // 'type' is immutable for an existing certificate
+                    if (updateCertificate.getType() != null && !updateCertificate.getType().isBlank()
+                            && !updateCertificate.getType().equals(certificate.getType())) {
+                        return Single.error(new InvalidParameterException("Certificate type cannot be changed"));
+                    }
+                    return certificatePluginService.getSchema(certificate.getType())
+                            .switchIfEmpty(Single.error(() -> new CertificatePluginSchemaNotFoundException(certificate.getType())))
+                            .map(schema -> new CertificateWithSchema(certificate, objectMapper.readValue(schema, CertificateSchema.class)));
+                })
                 .flatMap(oldCertificate -> {
                     boolean oldWithMTls = usageContains(oldCertificate.certificate().getConfiguration(), "mtls");
                     boolean newWithMTls = usageContains(updateCertificate.getConfiguration(), "mtls");

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
@@ -52,6 +52,7 @@ import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.exception.AbstractManagementException;
 import io.gravitee.am.service.exception.IdentityProviderNotFoundException;
 import io.gravitee.am.service.exception.IdentityProviderWithApplicationsException;
+import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.AssignPasswordPolicy;
 import io.gravitee.am.service.model.AutomationNewIdentityProvider;
@@ -219,6 +220,11 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
         return identityProviderRepository.findById(referenceType, referenceId, id)
                 .switchIfEmpty(Single.error(new IdentityProviderNotFoundException(id)))
                 .flatMap(oldIdentity -> {
+                    // 'type' is immutable for an existing identity provider
+                    if (updateIdentityProvider.getType() != null && !updateIdentityProvider.getType().isBlank()
+                            && !updateIdentityProvider.getType().equals(oldIdentity.getType())) {
+                        return Single.error(new InvalidParameterException("Identity provider type cannot be changed"));
+                    }
                     IdentityProvider identityToUpdate = new IdentityProvider(oldIdentity);
                     identityToUpdate.setName(updateIdentityProvider.getName());
                     // System idp config is normally immutable through the API, but the Automation API owns

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
@@ -37,6 +37,7 @@ import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.ReporterService;
 import io.gravitee.am.service.exception.AbstractManagementException;
+import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.exception.ReporterConfigurationException;
 import io.gravitee.am.service.exception.ReporterDeleteException;
 import io.gravitee.am.service.exception.ReporterNotFoundException;
@@ -237,6 +238,11 @@ public class ReporterServiceImpl implements ReporterService {
         return reporterRepository.findById(reporterId)
                 .switchIfEmpty(Single.error(new ReporterNotFoundException(reporterId)))
                 .flatMap(oldReporter -> {
+                    // 'type' is immutable for an existing reporter
+                    if (updateReporter.getType() != null && !updateReporter.getType().isBlank()
+                            && !updateReporter.getType().equals(oldReporter.getType())) {
+                        return Single.error(new InvalidParameterException("Reporter type cannot be changed"));
+                    }
                     Reporter reporterToUpdate = new Reporter(oldReporter);
                     reporterToUpdate.setEnabled(updateReporter.isEnabled());
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/CertificateServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/CertificateServiceImplTest.java
@@ -42,6 +42,7 @@ import io.gravitee.am.service.exception.CertificateIsFallbackException;
 import io.gravitee.am.service.exception.CertificateWithApplicationsException;
 import io.gravitee.am.service.exception.CertificateWithIdpException;
 import io.gravitee.am.service.exception.CertificateWithProtectedResourceException;
+import io.gravitee.am.service.exception.InvalidParameterException;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -351,6 +352,28 @@ class CertificateServiceImplTest {
         assertEquals(fileName, realMapper.readTree(storedConfig).get("content").asText());
         assertFalse(storedConfig.contains(base64),
                 "stored configuration must not contain the raw base64 keystore content");
+    }
+
+    @Test
+    void update_rejects_type_change() {
+        String certId = "cert-id";
+        Certificate existing = new Certificate();
+        existing.setId(certId);
+        existing.setDomain("domainId");
+        existing.setType("javakeystore-am-certificate");
+        Mockito.when(certificateRepository.findById(certId)).thenReturn(Maybe.just(existing));
+
+        Domain domain = new Domain();
+        domain.setId("domainId");
+        UpdateCertificate update = new UpdateCertificate();
+        update.setName("My cert");
+        update.setType("pkcs12-am-certificate");
+        update.setConfiguration("{}");
+
+        TestObserver<Certificate> observer = service.update(domain, certId, update, new DefaultUser()).test();
+        observer.awaitDone(5, java.util.concurrent.TimeUnit.SECONDS);
+        observer.assertError(InvalidParameterException.class);
+        Mockito.verify(certificateRepository, Mockito.never()).update(Mockito.any());
     }
 
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/IdentityProviderServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/IdentityProviderServiceImplTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.identityprovider.api.DefaultUser;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Event;
+import io.gravitee.am.repository.management.api.IdentityProviderRepository;
+import io.gravitee.am.service.ApplicationService;
+import io.gravitee.am.service.AuditService;
+import io.gravitee.am.service.EventService;
+import io.gravitee.am.service.PluginConfigurationValidationService;
+import io.gravitee.am.service.exception.InvalidParameterException;
+import io.gravitee.am.service.model.UpdateIdentityProvider;
+import io.gravitee.am.service.validators.idp.DatasourceValidator;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class IdentityProviderServiceImplTest {
+
+    @Mock
+    private IdentityProviderRepository identityProviderRepository;
+
+    @Mock
+    private ApplicationService applicationService;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private PluginConfigurationValidationService validationService;
+
+    @Mock
+    private DatasourceValidator datasourceValidator;
+
+    @InjectMocks
+    private IdentityProviderServiceImpl service;
+
+    private static final String IDP_ID = "idp-id";
+    private static final String DOMAIN_ID = "domainId";
+
+    private IdentityProvider existing(String type) {
+        IdentityProvider idp = new IdentityProvider();
+        idp.setId(IDP_ID);
+        idp.setType(type);
+        idp.setConfiguration("{}");
+        idp.setReferenceType(ReferenceType.DOMAIN);
+        idp.setReferenceId(DOMAIN_ID);
+        return idp;
+    }
+
+    @Test
+    void update_rejects_type_change() {
+        when(identityProviderRepository.findById(eq(ReferenceType.DOMAIN), eq(DOMAIN_ID), eq(IDP_ID)))
+                .thenReturn(Maybe.just(existing("inline-am-idp")));
+
+        UpdateIdentityProvider update = new UpdateIdentityProvider();
+        update.setName("name");
+        update.setType("ldap-am-idp");
+        update.setConfiguration("{}");
+
+        TestObserver<IdentityProvider> observer =
+                service.update(ReferenceType.DOMAIN, DOMAIN_ID, IDP_ID, update, new DefaultUser(), false).test();
+        observer.awaitDone(5, TimeUnit.SECONDS);
+        observer.assertError(InvalidParameterException.class);
+        verify(identityProviderRepository, never()).update(any());
+    }
+
+    @Test
+    void update_allows_matching_type() {
+        when(identityProviderRepository.findById(eq(ReferenceType.DOMAIN), eq(DOMAIN_ID), eq(IDP_ID)))
+                .thenReturn(Maybe.just(existing("inline-am-idp")));
+        when(datasourceValidator.validate(any())).thenReturn(Completable.complete());
+        when(identityProviderRepository.update(any())).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+        when(eventService.create(any())).thenReturn(Single.just(new Event()));
+
+        UpdateIdentityProvider update = new UpdateIdentityProvider();
+        update.setName("name");
+        update.setType("inline-am-idp");
+        update.setConfiguration("{}");
+
+        TestObserver<IdentityProvider> observer =
+                service.update(ReferenceType.DOMAIN, DOMAIN_ID, IDP_ID, update, new DefaultUser(), false).test();
+        observer.awaitDone(5, TimeUnit.SECONDS);
+        observer.assertComplete();
+        verify(identityProviderRepository).update(any());
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ReporterServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ReporterServiceImplTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.impl;
+
+import io.gravitee.am.common.env.RepositoriesEnvironment;
+import io.gravitee.am.identityprovider.api.DefaultUser;
+import io.gravitee.am.model.Reference;
+import io.gravitee.am.model.Reporter;
+import io.gravitee.am.model.common.event.Event;
+import io.gravitee.am.repository.management.api.ReporterRepository;
+import io.gravitee.am.service.AuditService;
+import io.gravitee.am.service.EventService;
+import io.gravitee.am.service.PluginConfigurationValidationService;
+import io.gravitee.am.service.exception.InvalidParameterException;
+import io.gravitee.am.service.model.UpdateReporter;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class ReporterServiceImplTest {
+
+    @Mock
+    private RepositoriesEnvironment environment;
+
+    @Mock
+    private ReporterRepository reporterRepository;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private PluginConfigurationValidationService validationService;
+
+    @InjectMocks
+    private ReporterServiceImpl service;
+
+    private static final String REPORTER_ID = "reporter-id";
+    private final Reference reference = Reference.domain("domainId");
+
+    private Reporter existing(String type) {
+        return Reporter.builder()
+                .id(REPORTER_ID)
+                .type(type)
+                .configuration("{}")
+                .enabled(true)
+                .reference(reference)
+                .build();
+    }
+
+    @Test
+    void update_rejects_type_change() {
+        when(reporterRepository.findById(REPORTER_ID)).thenReturn(Maybe.just(existing("reporter-am-kafka")));
+
+        UpdateReporter update = new UpdateReporter();
+        update.setName("name");
+        update.setType("reporter-am-file");
+        update.setConfiguration("{}");
+
+        TestObserver<Reporter> observer = service.update(reference, REPORTER_ID, update, new DefaultUser(), false).test();
+        observer.awaitDone(5, TimeUnit.SECONDS);
+        observer.assertError(InvalidParameterException.class);
+        verify(reporterRepository, never()).update(any());
+    }
+
+    @Test
+    void update_allows_matching_type() {
+        when(reporterRepository.findById(REPORTER_ID)).thenReturn(Maybe.just(existing("reporter-am-kafka")));
+        when(reporterRepository.update(any())).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+        when(eventService.create(any())).thenReturn(Single.just(new Event()));
+
+        UpdateReporter update = new UpdateReporter();
+        update.setName("name");
+        update.setType("reporter-am-kafka");
+        update.setConfiguration("{}");
+
+        TestObserver<Reporter> observer = service.update(reference, REPORTER_ID, update, new DefaultUser(), false).test();
+        observer.awaitDone(5, TimeUnit.SECONDS);
+        observer.assertComplete();
+        verify(reporterRepository).update(any());
+    }
+}

--- a/gravitee-am-test/specs/management/automation/domain-certificates-saml.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-certificates-saml.jest.spec.ts
@@ -19,7 +19,7 @@
  * /domains/{domainKey}/certificates endpoints — key-keyed, each PUT manages one certificate.
  * Domain SAML settings reference one of them by `key`, resolved with eventual consistency.
  */
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { uniqueName } from '@utils-commands/misc';
 import { setup } from '../../test-fixture';
 import { AutomationDomainFixture, setupAutomationDomainFixture } from './fixtures/automation-domain-fixture';
@@ -39,23 +39,41 @@ afterAll(async () => {
   }
 });
 
-describe('Automation API - Certificates (resource under a domain)', () => {
-  const certKey = uniqueName('autosign', true).toLowerCase();
+const createdCertKeys: string[] = [];
 
-  it('should expose no automation-managed certificates on a freshly-created domain', async () => {
+afterEach(async () => {
+  while (createdCertKeys.length) {
+    await fixture.client.deleteCertificate(fixture.domainKey, createdCertKeys.pop());
+  }
+});
+
+/** Create a certificate via PUT and track its key for cleanup. */
+async function createCertificate(overrides: { key?: string; name?: string } = {}) {
+  const key = overrides.key ?? uniqueName('autosign', true).toLowerCase();
+  createdCertKeys.push(key);
+  const response = await fixture.client.putCertificate(fixture.domainKey, buildAutomationCertificateDef({ ...overrides, key }));
+  return { key, response };
+}
+
+/** Create a system certificate via PUT and track its key for cleanup. */
+async function createSystemCertificate(key = uniqueName('autosyscert', true).toLowerCase()) {
+  createdCertKeys.push(key);
+  const response = await fixture.client.putCertificate(fixture.domainKey, buildSystemAutomationDef(key));
+  return { key, response };
+}
+
+describe('Automation API - Certificates (resource under a domain)', () => {
+  it('should list no certificates when none exist', async () => {
     const response = await fixture.client.listCertificates(fixture.domainKey);
     expect(response.status).toBe(200);
     expect(response.body).toEqual([]);
   });
 
   it('should create a certificate via PUT', async () => {
-    const response = await fixture.client.putCertificate(
-      fixture.domainKey,
-      buildAutomationCertificateDef({ key: certKey }),
-    );
+    const { key, response } = await createCertificate();
 
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(certKey);
+    expect(response.body.key).toEqual(key);
     // internal id / operational flags are intentionally not surfaced
     expect(response.body.id).toBeUndefined();
     expect(response.body.managedBy).toBeUndefined();
@@ -64,18 +82,32 @@ describe('Automation API - Certificates (resource under a domain)', () => {
   });
 
   it('should round-trip the certificate on GET', async () => {
-    const response = await fixture.client.getCertificate(fixture.domainKey, certKey);
+    const { key } = await createCertificate();
+
+    const response = await fixture.client.getCertificate(fixture.domainKey, key);
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(certKey);
+    expect(response.body.key).toEqual(key);
   });
 
   it('should update the certificate via a second PUT (idempotent)', async () => {
+    const { key } = await createCertificate();
+
     const response = await fixture.client.putCertificate(
       fixture.domainKey,
-      buildAutomationCertificateDef({ key: certKey, name: 'Renamed cert' }),
+      buildAutomationCertificateDef({ key, name: 'Renamed cert' }),
     );
     expect(response.status).toBe(200);
     expect(response.body.name).toEqual('Renamed cert');
+  });
+
+  it('should reject changing the type of an existing certificate (400)', async () => {
+    const { key } = await createCertificate();
+
+    const response = await fixture.client.putCertificate(fixture.domainKey, {
+      ...buildAutomationCertificateDef({ key }),
+      type: 'pkcs12-am-certificate',
+    });
+    expect(response.status).toBe(400);
   });
 
   it('should reject an invalid key pattern (400)', async () => {
@@ -97,68 +129,66 @@ describe('Automation API - Certificates (resource under a domain)', () => {
   });
 
   it('should delete the certificate', async () => {
-    // also frees its keystore alias, which is unique per domain among non-default certificates
-    const del = await fixture.client.deleteCertificate(fixture.domainKey, certKey);
+    const { key } = await createCertificate();
+
+    const del = await fixture.client.deleteCertificate(fixture.domainKey, key);
     expect(del.status).toBe(204);
 
-    const get = await fixture.client.getCertificate(fixture.domainKey, certKey);
+    const get = await fixture.client.getCertificate(fixture.domainKey, key);
     expect(get.status).toBe(404);
   });
 });
 
 describe('Automation API - System certificate', () => {
-  const systemKey = uniqueName('autosyscert', true).toLowerCase();
-  const secondSystemKey = uniqueName('autosyscert2', true).toLowerCase();
-
   it('should create a system certificate from a minimal {key, system:true} payload', async () => {
-    const response = await fixture.client.putCertificate(
-      fixture.domainKey,
-      buildSystemAutomationDef(systemKey),
-    );
+    const { key, response } = await createSystemCertificate();
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(systemKey);
+    expect(response.body.key).toEqual(key);
     expect(response.body.system).toBe(true);
   });
 
   it('should be idempotent on re-PUT of a system certificate (200, no update)', async () => {
-    const response = await fixture.client.putCertificate(
-      fixture.domainKey,
-      buildSystemAutomationDef(systemKey),
-    );
+    const { key } = await createSystemCertificate();
+
+    const response = await fixture.client.putCertificate(fixture.domainKey, buildSystemAutomationDef(key));
     expect(response.status).toBe(200);
     expect(response.body.system).toBe(true);
-    expect(response.body.key).toEqual(systemKey);
+    expect(response.body.key).toEqual(key);
   });
 
   it('should reject a second system certificate (400)', async () => {
+    await createSystemCertificate();
+
     const response = await fixture.client.putCertificate(
       fixture.domainKey,
-      buildSystemAutomationDef(secondSystemKey),
+      buildSystemAutomationDef(uniqueName('autosyscert2', true).toLowerCase()),
     );
     expect(response.status).toBe(400);
   });
 
   it('should reject flipping system on an existing certificate (400)', async () => {
-    // the system cert was created with system:true; PUT it again as non-system -> rejected (immutable)
+    const { key } = await createSystemCertificate();
+
+    // the cert was created with system:true; PUT it again as non-system -> rejected (immutable)
     const response = await fixture.client.putCertificate(
       fixture.domainKey,
-      buildAutomationCertificateDef({ key: systemKey, system: false }),
+      buildAutomationCertificateDef({ key, system: false }),
     );
     expect(response.status).toBe(400);
   });
 
   it('should delete the system certificate without a system guard', async () => {
-    const del = await fixture.client.deleteCertificate(fixture.domainKey, systemKey);
+    const { key } = await createSystemCertificate();
+
+    const del = await fixture.client.deleteCertificate(fixture.domainKey, key);
     expect(del.status).toBe(204);
 
-    const get = await fixture.client.getCertificate(fixture.domainKey, systemKey);
+    const get = await fixture.client.getCertificate(fixture.domainKey, key);
     expect(get.status).toBe(404);
   });
 });
 
 describe('Automation API - Domain SAML certificate reference (by key)', () => {
-  const samlCertKey = uniqueName('autosaml', true).toLowerCase();
-
   const domainDefinition = (certificateKey: string | null) =>
     buildAutomationDomainDef({
       key: fixture.domainKey,
@@ -170,6 +200,7 @@ describe('Automation API - Domain SAML certificate reference (by key)', () => {
     });
 
   it('should accept a SAML reference to a not-yet-created certificate (eventual consistency)', async () => {
+    const samlCertKey = uniqueName('autosaml', true).toLowerCase();
     const response = await fixture.client.putDomain(domainDefinition(samlCertKey));
     expect(response.status).toBe(200);
     // the key round-trips even though the certificate does not exist yet
@@ -177,16 +208,13 @@ describe('Automation API - Domain SAML certificate reference (by key)', () => {
   });
 
   it('should keep the SAML reference once the certificate is created', async () => {
-    // self-contained (no dependency on the previous test): establish the reference, create the
-    // certificate, then confirm a fresh GET round-trips the key — i.e. it is re-read from the
-    // datastore, not just echoed from the in-memory PUT response.
+    // establish the reference, create the certificate, then confirm a fresh GET
+    // round-trips the key — i.e. it is re-read from the datastore, not just echoed from the PUT response.
+    const samlCertKey = uniqueName('autosaml', true).toLowerCase();
     const ref = await fixture.client.putDomain(domainDefinition(samlCertKey));
     expect(ref.status).toBe(200);
 
-    const created = await fixture.client.putCertificate(
-      fixture.domainKey,
-      buildAutomationCertificateDef({ key: samlCertKey }),
-    );
+    const { response: created } = await createCertificate({ key: samlCertKey });
     expect(created.status).toBe(200);
 
     const get = await fixture.client.getDomain(fixture.domainKey);

--- a/gravitee-am-test/specs/management/automation/domain-identity-providers.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-identity-providers.jest.spec.ts
@@ -18,7 +18,7 @@
  * Identity providers are managed individually under a domain via the
  * /domains/{domainKey}/identity-providers endpoints — key-keyed, each PUT manages one IdP.
  */
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { uniqueName } from '@utils-commands/misc';
 import { setup } from '../../test-fixture';
 import {
@@ -41,24 +41,48 @@ afterAll(async () => {
   }
 });
 
-describe('Automation API - Identity providers (resource under a domain)', () => {
-  const idpKey = uniqueName('autoinline', true).toLowerCase();
+const createdIdpKeys: string[] = [];
 
-  it('should expose no automation-managed identity providers on a freshly-created domain', async () => {
+afterEach(async () => {
+  while (createdIdpKeys.length) {
+    await fixture.client.deleteIdentityProvider(fixture.domainKey, createdIdpKeys.pop());
+  }
+});
+
+type InlineUser = { username: string; password: string };
+const defaultUsers: InlineUser[] = [{ username: 'testuser', password: 'Password1!' }];
+
+/** Create an inline IdP via PUT and track its key for cleanup. */
+async function createIdp(overrides: { key?: string; name?: string; users?: InlineUser[] } = {}) {
+  const key = overrides.key ?? uniqueName('autoinline', true).toLowerCase();
+  createdIdpKeys.push(key);
+  const response = await fixture.client.putIdentityProvider(
+    fixture.domainKey,
+    buildInlineIdpDef({ key, name: overrides.name, users: overrides.users ?? defaultUsers }),
+  );
+  return { key, response };
+}
+
+/** Create a system IdP via PUT and track its key for cleanup. */
+async function createSystemIdp(key = uniqueName('autosysidp', true).toLowerCase()) {
+  createdIdpKeys.push(key);
+  const response = await fixture.client.putIdentityProvider(fixture.domainKey, buildSystemAutomationDef(key));
+  return { key, response };
+}
+
+describe('Automation API - Identity providers (resource under a domain)', () => {
+  it('should list no identity providers when none exist', async () => {
     const response = await fixture.client.listIdentityProviders(fixture.domainKey);
     expect(response.status).toBe(200);
     expect(response.body).toEqual([]);
   });
 
   it('should create an inline identity provider via PUT', async () => {
-    const response = await fixture.client.putIdentityProvider(
-      fixture.domainKey,
-      buildInlineIdpDef({ key: idpKey, users: [{ username: 'testuser', password: 'Password1!' }] }),
-    );
+    const { key, response } = await createIdp();
 
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(idpKey);
-    expect(response.body.name).toEqual(`Automation IDP ${idpKey}`);
+    expect(response.body.key).toEqual(key);
+    expect(response.body.name).toEqual(`Automation IDP ${key}`);
     expect(response.body.type).toEqual('inline-am-idp');
     // internal id / operational flags are intentionally not surfaced
     expect(response.body.id).toBeUndefined();
@@ -67,30 +91,57 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   });
 
   it('should round-trip the identity provider on GET', async () => {
-    const response = await fixture.client.getIdentityProvider(fixture.domainKey, idpKey);
+    const { key } = await createIdp();
+
+    const response = await fixture.client.getIdentityProvider(fixture.domainKey, key);
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(idpKey);
-    expect(response.body.name).toEqual(`Automation IDP ${idpKey}`);
+    expect(response.body.key).toEqual(key);
+    expect(response.body.name).toEqual(`Automation IDP ${key}`);
   });
 
   it('should list the identity provider under the domain', async () => {
+    const { key } = await createIdp();
+
     const response = await fixture.client.listIdentityProviders(fixture.domainKey);
     expect(response.status).toBe(200);
-    expect(response.body).toEqual([expect.objectContaining({ key: idpKey })]);
+    expect(response.body).toEqual([expect.objectContaining({ key })]);
   });
 
   it('should update the identity provider via a second PUT (idempotent)', async () => {
+    const { key } = await createIdp();
+
     const response = await fixture.client.putIdentityProvider(
       fixture.domainKey,
       buildInlineIdpDef({
-        key: idpKey,
-        name: `Automation IDP ${idpKey} Updated`,
+        key,
+        name: `Automation IDP ${key} Updated`,
         users: [{ username: 'testuser2', password: 'Password2!' }],
       }),
     );
 
     expect(response.status).toBe(200);
-    expect(response.body.name).toEqual(`Automation IDP ${idpKey} Updated`);
+    expect(response.body.name).toEqual(`Automation IDP ${key} Updated`);
+  });
+
+  it('should reject changing the type of an existing identity provider (400)', async () => {
+    const { key } = await createIdp();
+
+    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+      ...buildInlineIdpDef({ key, users: defaultUsers }),
+      type: 'ldap-am-idp',
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject an update missing the required name (400)', async () => {
+    const { key } = await createIdp();
+
+    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+      key,
+      type: 'inline-am-idp',
+      configuration: JSON.stringify({ users: defaultUsers }),
+    });
+    expect(response.status).toBe(400);
   });
 
   it('should reject an invalid key pattern (400)', async () => {
@@ -112,17 +163,17 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   });
 
   it('should delete the identity provider', async () => {
-    const del = await fixture.client.deleteIdentityProvider(fixture.domainKey, idpKey);
+    const { key } = await createIdp();
+
+    const del = await fixture.client.deleteIdentityProvider(fixture.domainKey, key);
     expect(del.status).toBe(204);
 
-    const get = await fixture.client.getIdentityProvider(fixture.domainKey, idpKey);
+    const get = await fixture.client.getIdentityProvider(fixture.domainKey, key);
     expect(get.status).toBe(404);
   });
 });
 
 describe('Automation API - Domain - defaultIdentityProviderForRegistration reference', () => {
-  const idpKey = uniqueName('autodefidp', true).toLowerCase();
-
   it('should accept a null reference on the initial domain PUT', async () => {
     const response = await fixture.client.putDomain(
       buildAutomationDomainDef({ key: fixture.domainKey, accountSettings: { inherited: false } }),
@@ -144,29 +195,23 @@ describe('Automation API - Domain - defaultIdentityProviderForRegistration refer
   });
 
   it('should resolve a reference to a pre-created identity provider', async () => {
-    const created = await fixture.client.putIdentityProvider(
-      fixture.domainKey,
-      buildInlineIdpDef({ key: idpKey, users: [{ username: 'reg', password: 'P@ssword1' }] }),
-    );
-    expect(created.status).toBe(200);
+    const { key } = await createIdp({ users: [{ username: 'reg', password: 'P@ssword1' }] });
 
     const response = await fixture.client.putDomain(
       buildAutomationDomainDef({
         key: fixture.domainKey,
-        accountSettings: { defaultIdentityProviderForRegistration: idpKey },
+        accountSettings: { defaultIdentityProviderForRegistration: key },
       }),
     );
     expect(response.status).toBe(200);
-    expect(response.body.accountSettings.defaultIdentityProviderForRegistration).toEqual(idpKey);
+    expect(response.body.accountSettings.defaultIdentityProviderForRegistration).toEqual(key);
   });
 });
 
 describe('Automation API - Identity providers - payload validation', () => {
-  const users = [{ username: 'val', password: 'P@ssword1' }];
-
   it('should reject an unknown identity provider type (400)', async () => {
     const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
-      ...buildInlineIdpDef({ key: uniqueName('autobadtype', true).toLowerCase(), users }),
+      ...buildInlineIdpDef({ key: uniqueName('autobadtype', true).toLowerCase(), users: defaultUsers }),
       type: 'unknown-am-idp',
     });
     expect(response.status).toBe(400);
@@ -174,14 +219,16 @@ describe('Automation API - Identity providers - payload validation', () => {
 
   it('should reject a configuration that is not valid JSON (400)', async () => {
     const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
-      ...buildInlineIdpDef({ key: uniqueName('autobadcfg', true).toLowerCase(), users }),
+      ...buildInlineIdpDef({ key: uniqueName('autobadcfg', true).toLowerCase(), users: defaultUsers }),
       configuration: 'not-json',
     });
     expect(response.status).toBe(400);
   });
 
   it('should tolerate an unknown extra property in the configuration (200)', async () => {
-    const base = buildInlineIdpDef({ key: uniqueName('autoextracfg', true).toLowerCase(), users });
+    const key = uniqueName('autoextracfg', true).toLowerCase();
+    createdIdpKeys.push(key);
+    const base = buildInlineIdpDef({ key, users: defaultUsers });
     const configuration = JSON.stringify({ ...JSON.parse(base.configuration), extraUnknownField: 'tolerated' });
     const response = await fixture.client.putIdentityProvider(fixture.domainKey, { ...base, configuration });
     expect(response.status).toBe(200);
@@ -189,48 +236,47 @@ describe('Automation API - Identity providers - payload validation', () => {
 });
 
 describe('Automation API - System identity provider', () => {
-  const systemIdpKey = uniqueName('autosysidp', true).toLowerCase();
-  const secondSystemKey = uniqueName('autosysidp2', true).toLowerCase();
-
   it('should create a system identity provider from a minimal {key, system:true} payload', async () => {
-    const response = await fixture.client.putIdentityProvider(
-      fixture.domainKey,
-      buildSystemAutomationDef(systemIdpKey),
-    );
+    const { key, response } = await createSystemIdp();
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(systemIdpKey);
+    expect(response.body.key).toEqual(key);
     expect(response.body.system).toBe(true);
   });
 
   it('should be idempotent on re-PUT of a system identity provider (200, no update)', async () => {
-    const response = await fixture.client.putIdentityProvider(
-      fixture.domainKey,
-      buildSystemAutomationDef(systemIdpKey),
-    );
+    const { key } = await createSystemIdp();
+
+    const response = await fixture.client.putIdentityProvider(fixture.domainKey, buildSystemAutomationDef(key));
     expect(response.status).toBe(200);
     expect(response.body.system).toBe(true);
-    expect(response.body.key).toEqual(systemIdpKey);
+    expect(response.body.key).toEqual(key);
   });
 
   it('should reject a second system identity provider (400)', async () => {
+    await createSystemIdp();
+
     const response = await fixture.client.putIdentityProvider(
       fixture.domainKey,
-      buildSystemAutomationDef(secondSystemKey),
+      buildSystemAutomationDef(uniqueName('autosysidp2', true).toLowerCase()),
     );
     expect(response.status).toBe(400);
   });
 
   it('should reject flipping system on an existing identity provider (400)', async () => {
-    // systemIdpKey was created with system:true; PUT it again as non-system -> rejected (immutable)
+    const { key } = await createSystemIdp();
+
+    // the IdP was created with system:true; PUT it again as non-system -> rejected (immutable)
     const response = await fixture.client.putIdentityProvider(
       fixture.domainKey,
-      buildInlineIdpDef({ key: systemIdpKey, system: false, users: [{ username: 'def', password: 'P@ssword1' }] }),
+      buildInlineIdpDef({ key, system: false, users: [{ username: 'def', password: 'P@ssword1' }] }),
     );
     expect(response.status).toBe(400);
   });
 
   it('should delete the system identity provider without a system guard', async () => {
-    const del = await fixture.client.deleteIdentityProvider(fixture.domainKey, systemIdpKey);
+    const { key } = await createSystemIdp();
+
+    const del = await fixture.client.deleteIdentityProvider(fixture.domainKey, key);
     expect(del.status).toBe(204);
   });
 });

--- a/gravitee-am-test/specs/management/automation/domain-reporters.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-reporters.jest.spec.ts
@@ -18,7 +18,7 @@
  * Reporters are managed individually under a domain via the
  * /domains/{domainKey}/reporters endpoints — key-keyed, each PUT manages one reporter.
  */
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { uniqueName } from '@utils-commands/misc';
 import { setup } from '../../test-fixture';
 import { AutomationDomainFixture, setupAutomationDomainFixture } from './fixtures/automation-domain-fixture';
@@ -38,23 +38,42 @@ afterAll(async () => {
   }
 });
 
-describe('Automation API - Reporters (resource under a domain)', () => {
-  const reporterKey = uniqueName('autoaudit', true).toLowerCase();
+const createdReporterKeys: string[] = [];
 
-  it('should expose no automation-managed reporters on a freshly-created domain', async () => {
+afterEach(async () => {
+  while (createdReporterKeys.length) {
+    // tolerant: a test may have already deleted its reporter (404), which is fine
+    await fixture.client.deleteReporter(fixture.domainKey, createdReporterKeys.pop());
+  }
+});
+
+/** Create a reporter via PUT and track its key for cleanup. */
+async function createReporter(overrides: { key?: string; name?: string } = {}) {
+  const key = overrides.key ?? uniqueName('autoaudit', true).toLowerCase();
+  createdReporterKeys.push(key);
+  const response = await fixture.client.putReporter(fixture.domainKey, buildAutomationReporterDef({ ...overrides, key }));
+  return { key, response };
+}
+
+/** Create a system reporter via PUT and track its key for cleanup. */
+async function createSystemReporter(key = uniqueName('autosysrep', true).toLowerCase()) {
+  createdReporterKeys.push(key);
+  const response = await fixture.client.putReporter(fixture.domainKey, buildSystemAutomationDef(key));
+  return { key, response };
+}
+
+describe('Automation API - Reporters (resource under a domain)', () => {
+  it('should list no reporters when none exist', async () => {
     const response = await fixture.client.listReporters(fixture.domainKey);
     expect(response.status).toBe(200);
     expect(response.body).toEqual([]);
   });
 
   it('should create a reporter via PUT', async () => {
-    const response = await fixture.client.putReporter(
-      fixture.domainKey,
-      buildAutomationReporterDef({ key: reporterKey }),
-    );
+    const { key, response } = await createReporter();
 
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(reporterKey);
+    expect(response.body.key).toEqual(key);
     expect(response.body.type).toEqual('reporter-am-kafka');
     // internal id / operational flags are intentionally not surfaced
     expect(response.body.id).toBeUndefined();
@@ -63,24 +82,40 @@ describe('Automation API - Reporters (resource under a domain)', () => {
   });
 
   it('should round-trip the reporter on GET', async () => {
-    const response = await fixture.client.getReporter(fixture.domainKey, reporterKey);
+    const { key } = await createReporter();
+
+    const response = await fixture.client.getReporter(fixture.domainKey, key);
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(reporterKey);
+    expect(response.body.key).toEqual(key);
   });
 
   it('should list the reporter under the domain', async () => {
+    const { key } = await createReporter();
+
     const response = await fixture.client.listReporters(fixture.domainKey);
     expect(response.status).toBe(200);
-    expect(response.body).toEqual([expect.objectContaining({ key: reporterKey })]);
+    expect(response.body).toEqual([expect.objectContaining({ key })]);
   });
 
   it('should update the reporter via a second PUT (idempotent)', async () => {
+    const { key } = await createReporter();
+
     const response = await fixture.client.putReporter(
       fixture.domainKey,
-      buildAutomationReporterDef({ key: reporterKey, name: 'Renamed reporter' }),
+      buildAutomationReporterDef({ key, name: 'Renamed reporter' }),
     );
     expect(response.status).toBe(200);
     expect(response.body.name).toEqual('Renamed reporter');
+  });
+
+  it('should reject changing the type of an existing reporter (400)', async () => {
+    const { key } = await createReporter();
+
+    const response = await fixture.client.putReporter(fixture.domainKey, {
+      ...buildAutomationReporterDef({ key }),
+      type: 'reporter-am-file',
+    });
+    expect(response.status).toBe(400);
   });
 
   it('should reject an invalid key pattern (400)', async () => {
@@ -102,10 +137,12 @@ describe('Automation API - Reporters (resource under a domain)', () => {
   });
 
   it('should delete the reporter', async () => {
-    const del = await fixture.client.deleteReporter(fixture.domainKey, reporterKey);
+    const { key } = await createReporter();
+
+    const del = await fixture.client.deleteReporter(fixture.domainKey, key);
     expect(del.status).toBe(204);
 
-    const get = await fixture.client.getReporter(fixture.domainKey, reporterKey);
+    const get = await fixture.client.getReporter(fixture.domainKey, key);
     expect(get.status).toBe(404);
   });
 });
@@ -128,9 +165,9 @@ describe('Automation API - Reporters - payload validation', () => {
   });
 
   it('should tolerate an unknown extra property in the configuration (200)', async () => {
-    const base = buildAutomationReporterDef({ key: uniqueName('autoextracfg', true).toLowerCase() }) as {
-      configuration: string;
-    };
+    const key = uniqueName('autoextracfg', true).toLowerCase();
+    createdReporterKeys.push(key);
+    const base = buildAutomationReporterDef({ key }) as { configuration: string };
     const configuration = JSON.stringify({ ...JSON.parse(base.configuration), extraUnknownField: 'tolerated' });
     const response = await fixture.client.putReporter(fixture.domainKey, { ...base, configuration });
     expect(response.status).toBe(200);
@@ -138,48 +175,47 @@ describe('Automation API - Reporters - payload validation', () => {
 });
 
 describe('Automation API - System reporter', () => {
-  const systemKey = uniqueName('autosysrep', true).toLowerCase();
-  const secondSystemKey = uniqueName('autosysrep2', true).toLowerCase();
-
   it('should create a system reporter from a minimal {key, system:true} payload', async () => {
-    const response = await fixture.client.putReporter(
-      fixture.domainKey,
-      buildSystemAutomationDef(systemKey),
-    );
+    const { key, response } = await createSystemReporter();
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(systemKey);
+    expect(response.body.key).toEqual(key);
     expect(response.body.system).toBe(true);
   });
 
   it('should be idempotent on re-PUT of a system reporter (200, no update)', async () => {
-    const response = await fixture.client.putReporter(
-      fixture.domainKey,
-      buildSystemAutomationDef(systemKey),
-    );
+    const { key } = await createSystemReporter();
+
+    const response = await fixture.client.putReporter(fixture.domainKey, buildSystemAutomationDef(key));
     expect(response.status).toBe(200);
     expect(response.body.system).toBe(true);
-    expect(response.body.key).toEqual(systemKey);
+    expect(response.body.key).toEqual(key);
   });
 
   it('should reject a second system reporter (400)', async () => {
+    await createSystemReporter();
+
     const response = await fixture.client.putReporter(
       fixture.domainKey,
-      buildSystemAutomationDef(secondSystemKey),
+      buildSystemAutomationDef(uniqueName('autosysrep2', true).toLowerCase()),
     );
     expect(response.status).toBe(400);
   });
 
   it('should reject flipping system on an existing reporter (400)', async () => {
-    // the system reporter was created with system:true; PUT it again as non-system -> rejected (immutable)
+    const { key } = await createSystemReporter();
+
+    // the reporter was created with system:true; PUT it again as non-system -> rejected (immutable)
     const response = await fixture.client.putReporter(
       fixture.domainKey,
-      buildAutomationReporterDef({ key: systemKey, system: false }),
+      buildAutomationReporterDef({ key, system: false }),
     );
     expect(response.status).toBe(400);
   });
 
   it('should delete the system reporter without a system guard', async () => {
-    const del = await fixture.client.deleteReporter(fixture.domainKey, systemKey);
+    const { key } = await createSystemReporter();
+
+    const del = await fixture.client.deleteReporter(fixture.domainKey, key);
     expect(del.status).toBe(204);
   });
 });

--- a/gravitee-am-test/specs/management/automation/domains.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domains.jest.spec.ts
@@ -13,29 +13,105 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+
+import { afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { uniqueName } from '@utils-commands/misc';
 import { setup } from '../../test-fixture';
 import {
   AutomationAuthFixture,
   setupAutomationAuthFixture,
 } from './fixtures/automation-domain-fixture';
-import { buildAutomationDomainDef } from './fixtures/automation-definitions';
+import { AutomationDomainDef, buildAutomationDomainDef } from './fixtures/automation-definitions';
 
-setup();
+setup(120000);
+
+const ISO_8601_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 let fixture: AutomationAuthFixture;
-const createdDomainKeys: string[] = [];
 
 beforeAll(async () => {
   fixture = await setupAutomationAuthFixture();
 });
 
-afterAll(async () => {
-  for (const key of createdDomainKeys) {
-    await fixture.client.deleteDomain(key);
+const createdDomainKeys: string[] = [];
+
+afterEach(async () => {
+  while (createdDomainKeys.length) {
+    await fixture.client.deleteDomain(createdDomainKeys.pop());
   }
 });
+
+/** PUT a domain on the collection and track its key for cleanup. */
+async function createDomain(overrides: Partial<AutomationDomainDef> & { key?: string } = {}) {
+  const key = overrides.key ?? uniqueName('autodom', true).toLowerCase();
+  createdDomainKeys.push(key);
+  const response = await fixture.client.putDomain(buildAutomationDomainDef({ ...overrides, key }));
+  return { key, response };
+}
+
+// A definition exercising every settings block we surface, parameterised by key.
+const fullDef = (key: string) =>
+  buildAutomationDomainDef({
+    key,
+    name: `Round-trip ${key}`,
+    description: 'covers every settings block we surface',
+    enabled: false, // diverges from the build* default; must survive the round-trip
+    tags: ['alpha', 'beta'],
+    vhosts: [{ host: 'auth.example.com', path: `/${key}`, overrideEntrypoint: true }],
+    oidc: {
+      redirectUriStrictMatching: true,
+      postLogoutRedirectUris: ['https://app.example.com/post-logout'],
+      requestUris: ['https://app.example.com/request'],
+      clientRegistrationSettings: {
+        allowLocalhostRedirectUri: true,
+        allowHttpSchemeRedirectUri: true,
+        isDynamicClientRegistrationEnabled: true,
+      },
+      securityProfileSettings: {
+        enablePlainFapi: true,
+      },
+    },
+    loginSettings: {
+      inherited: false,
+      registerEnabled: true,
+      forgotPasswordEnabled: true,
+      rememberMeEnabled: true,
+      hideForm: false,
+    },
+    accountSettings: {
+      inherited: false,
+      loginAttemptsDetectionEnabled: true,
+      maxLoginAttempts: 5,
+      loginAttemptsResetTime: 600,
+      rememberMe: true,
+      rememberMeDuration: 86400,
+    },
+    passwordSettings: {
+      inherited: false,
+      minLength: 12,
+      maxLength: 64,
+      includeNumbers: true,
+      includeSpecialCharacters: true,
+      lettersInMixedCase: true,
+    },
+    corsSettings: {
+      enabled: true,
+      allowedOrigins: ['https://app.example.com'],
+      allowedMethods: ['GET', 'POST'],
+      allowedHeaders: ['Authorization', 'Content-Type'],
+      allowCredentials: true,
+      maxAge: 3600,
+    },
+    scim: { enabled: true },
+    selfServiceAccountManagementSettings: { enabled: true },
+  });
+
+/** Create a domain from {@link fullDef} and track its key for cleanup. */
+async function createFullDomain(key = uniqueName('autorr', true).toLowerCase()) {
+  createdDomainKeys.push(key);
+  const response = await fixture.client.putDomain(fullDef(key));
+  return { key, response };
+}
 
 describe('Automation API - Domain - List', () => {
   it('should list domains for the default environment', async () => {
@@ -47,84 +123,69 @@ describe('Automation API - Domain - List', () => {
 });
 
 describe('Automation API - Domain - PUT on collection (Idempotent Create/Update)', () => {
-  const domainKey = uniqueName('autodom', true).toLowerCase();
-
   it('should create a new domain via PUT to collection with key in body', async () => {
-    const response = await fixture.client.putDomain(
-      buildAutomationDomainDef({
-        key: domainKey,
-        name: `Automation Domain ${domainKey}`,
-        enabled: true,
-      }),
-    );
+    const { key, response } = await createDomain({ enabled: true });
 
     expect(response.status).toBe(200);
     // Internal id is intentionally not exposed — the Automation API is key-only.
     expect(response.body.id).toBeUndefined();
-    expect(response.body.key).toEqual(domainKey);
-    expect(response.body.name).toEqual(`Automation Domain ${domainKey}`);
+    expect(response.body.key).toEqual(key);
+    expect(response.body.name).toEqual(`Automation Domain ${key}`);
     expect(response.body.description).toEqual('Created via Automation API');
-    createdDomainKeys.push(domainKey);
   });
 
   it('should be idempotent on a subsequent PUT (createdAt unchanged)', async () => {
-    const first = await fixture.client.getDomain(domainKey);
-    expect(first.status).toBe(200);
+    const { key, response: created } = await createDomain({ enabled: true });
+    expect(created.status).toBe(200);
 
-    const response = await fixture.client.putDomain(
-      buildAutomationDomainDef({ key: domainKey, enabled: true }),
-    );
+    const response = await fixture.client.putDomain(buildAutomationDomainDef({ key, enabled: true }));
 
     expect(response.status).toBe(200);
-    expect(response.body.key).toEqual(domainKey);
+    expect(response.body.key).toEqual(key);
     // createdAt is stable across an update; a duplicate create would reset it
-    expect(response.body.createdAt).toEqual(first.body.createdAt);
-    const ISO_8601_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+    expect(response.body.createdAt).toEqual(created.body.createdAt);
     expect(typeof response.body.createdAt).toBe('string');
     expect(response.body.createdAt).toMatch(ISO_8601_UTC);
     expect(response.body.updatedAt).toMatch(ISO_8601_UTC);
   });
 
   it('should retrieve the created domain by key via path', async () => {
-    const response = await fixture.client.getDomain(domainKey);
+    const { key } = await createDomain({ enabled: true });
+
+    const response = await fixture.client.getDomain(key);
 
     expect(response.status).toBe(200);
-    expect(response.body.name).toEqual(`Automation Domain ${domainKey}`);
+    expect(response.body.name).toEqual(`Automation Domain ${key}`);
   });
 
   it('should update the domain via second PUT to collection (idempotent)', async () => {
+    const { key } = await createDomain({ enabled: true });
+
     const response = await fixture.client.putDomain(
-      buildAutomationDomainDef({
-        key: domainKey,
-        description: 'Updated via Automation API',
-        enabled: true,
-      }),
+      buildAutomationDomainDef({ key, description: 'Updated via Automation API', enabled: true }),
     );
 
     expect(response.status).toBe(200);
     expect(response.body.description).toEqual('Updated via Automation API');
-    expect(createdDomainKeys).toContain(response.body.key);
+    expect(response.body.key).toEqual(key);
   });
 
   it('should appear in the domain list', async () => {
+    const { key } = await createDomain({ enabled: true });
+
     const response = await fixture.client.listDomains();
 
     expect(response.status).toBe(200);
-    const found = response.body.find((d: any) => d.key === domainKey);
-    expect(found).toEqual(expect.objectContaining({ key: domainKey }));
+    const found = response.body.find((d: any) => d.key === key);
+    expect(found).toEqual(expect.objectContaining({ key }));
   });
 });
 
 describe('Automation API - Domain - DELETE via path', () => {
-  const deleteKey = uniqueName('autodel', true).toLowerCase();
-
   it('should create then delete a domain', async () => {
+    const deleteKey = uniqueName('autodel', true).toLowerCase();
     const createResponse = await fixture.client.putDomain(
-      buildAutomationDomainDef({
-        key: deleteKey,
-        name: `Delete Me ${deleteKey}`,
-        description: 'To be deleted',
-      }),
+      buildAutomationDomainDef({ key: deleteKey, name: `Delete Me ${deleteKey}`, description: 'To be deleted' }),
     );
     expect(createResponse.status).toBe(200);
     expect(createResponse.body.key).toEqual(deleteKey);
@@ -152,86 +213,25 @@ describe('Automation API - Domain - Error Handling', () => {
 });
 
 describe('Automation API - Domain - Round-trip preserves all writable fields', () => {
-  const roundTripKey = uniqueName('autorr', true).toLowerCase();
-
-  // Settings blocks chosen to cover the major paths through AutomationDomainMapper:
-  //  - shared sub-models reused by reference (login/cors/account/scim/password)
-  //  - the OIDC wrapper (we project name-keyed CIBA references through it)
-  //  - tags/vhosts (lists)
-  const fullDef = () =>
-    buildAutomationDomainDef({
-      key: roundTripKey,
-      name: `Round-trip ${roundTripKey}`,
-      description: 'covers every settings block we surface',
-      enabled: false, // diverges from the build* default; must survive the round-trip
-      tags: ['alpha', 'beta'],
-      vhosts: [{ host: 'auth.example.com', path: `/${roundTripKey}`, overrideEntrypoint: true }],
-      oidc: {
-        redirectUriStrictMatching: true,
-        postLogoutRedirectUris: ['https://app.example.com/post-logout'],
-        requestUris: ['https://app.example.com/request'],
-        clientRegistrationSettings: {
-          allowLocalhostRedirectUri: true,
-          allowHttpSchemeRedirectUri: true,
-          isDynamicClientRegistrationEnabled: true,
-        },
-        securityProfileSettings: {
-          enablePlainFapi: true,
-        },
-      },
-      loginSettings: {
-        inherited: false,
-        registerEnabled: true,
-        forgotPasswordEnabled: true,
-        rememberMeEnabled: true,
-        hideForm: false,
-      },
-      accountSettings: {
-        inherited: false,
-        loginAttemptsDetectionEnabled: true,
-        maxLoginAttempts: 5,
-        loginAttemptsResetTime: 600,
-        rememberMe: true,
-        rememberMeDuration: 86400,
-      },
-      passwordSettings: {
-        inherited: false,
-        minLength: 12,
-        maxLength: 64,
-        includeNumbers: true,
-        includeSpecialCharacters: true,
-        lettersInMixedCase: true,
-      },
-      corsSettings: {
-        enabled: true,
-        allowedOrigins: ['https://app.example.com'],
-        allowedMethods: ['GET', 'POST'],
-        allowedHeaders: ['Authorization', 'Content-Type'],
-        allowCredentials: true,
-        maxAge: 3600,
-      },
-      scim: { enabled: true },
-      selfServiceAccountManagementSettings: { enabled: true },
-    });
-
   it('should create the domain with every settings block populated', async () => {
-    const response = await fixture.client.putDomain(fullDef());
+    const { response } = await createFullDomain();
     expect(response.status).toBe(200);
-    createdDomainKeys.push(roundTripKey);
   });
 
   it('should return every settings block unchanged on GET', async () => {
-    const response = await fixture.client.getDomain(roundTripKey);
+    const { key } = await createFullDomain();
+
+    const response = await fixture.client.getDomain(key);
     expect(response.status).toBe(200);
 
     const body = response.body;
-    expect(body.key).toEqual(roundTripKey);
+    expect(body.key).toEqual(key);
     expect(body.enabled).toBe(false);
     expect(body.tags).toEqual(expect.arrayContaining(['alpha', 'beta']));
     expect(body.vhosts).toEqual([
       expect.objectContaining({
         host: 'auth.example.com',
-        path: `/${roundTripKey}`,
+        path: `/${key}`,
         overrideEntrypoint: true,
       }),
     ]);
@@ -285,14 +285,15 @@ describe('Automation API - Domain - Round-trip preserves all writable fields', (
   });
 
   it('should preserve untouched fields when one block is changed on update', async () => {
-    const before = await fixture.client.getDomain(roundTripKey);
+    const { key } = await createFullDomain();
+    const before = await fixture.client.getDomain(key);
 
     // Modify only the description; every other declared block stays the same
-    const mutated = { ...fullDef(), description: 'updated round-trip description' };
+    const mutated = { ...fullDef(key), description: 'updated round-trip description' };
     const put = await fixture.client.putDomain(mutated);
     expect(put.status).toBe(200);
 
-    const after = await fixture.client.getDomain(roundTripKey);
+    const after = await fixture.client.getDomain(key);
     expect(after.body.description).toEqual('updated round-trip description');
     // every other block must still match what came back before the update
     expect(after.body.tags).toEqual(before.body.tags);
@@ -308,23 +309,25 @@ describe('Automation API - Domain - Round-trip preserves all writable fields', (
   });
 
   it('should strictly reset a settings block omitted from the PUT payload', async () => {
+    const { key } = await createFullDomain();
+
     // Omit loginSettings entirely; declarative semantics must wipe it (null)
-    const without = { ...fullDef() };
+    const without = { ...fullDef(key) };
     delete (without as any).loginSettings;
 
     const put = await fixture.client.putDomain(without);
     expect(put.status).toBe(200);
     expect(put.body.loginSettings ?? null).toBeNull();
 
-    const get = await fixture.client.getDomain(roundTripKey);
+    const get = await fixture.client.getDomain(key);
     expect(get.body.loginSettings ?? null).toBeNull();
   });
 
   it('should not surface any internal-id field on PUT, GET or list', async () => {
-    const put = await fixture.client.putDomain(fullDef());
-    const get = await fixture.client.getDomain(roundTripKey);
+    const { key, response: put } = await createFullDomain();
+    const get = await fixture.client.getDomain(key);
     const list = await fixture.client.listDomains();
-    const fromList = list.body.find((d: any) => d.key === roundTripKey);
+    const fromList = list.body.find((d: any) => d.key === key);
 
     for (const body of [put.body, get.body, fromList]) {
       expect(body.id).toBeUndefined();


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7080](https://gravitee.atlassian.net/browse/AM-7080)

## :pencil2: A description of the changes proposed in the pull request
Consistently validate resources updated using the Automation API and Management API:
- Automation API `PUT /management/automation/organizations/{{orgId}}/environments/{{envId}}/domains/{{domainKey}}/identity-providers` validates required fields and `configuration`.
  - Example:
```json
400 Bad Request
{
    "message": "Field 'name' is required for a non-system identity provider 'non-default-idp'",
    "http_status": 400
}
```
- Automation **and** Management APIs disallow changes to `type` field of reporters, identity providers and certificates.
   - Note that, previously, changes to `type` were ignored.
  - Example:
```json
400 Bad Request
{
    "message": "Reporter type cannot be changed",
    "http_status": 400
}
```

Additionally, improve Jest test implementation by reducing statefulness and ordering brittleness.

## :memo: Test scenarios 
Using either Management or Automation API, create reporter/IDP/certificate resource (`POST` or `PUT` depending on which API), then attempt to `PUT` with modified `type` or `configuration` values.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7080]: https://gravitee.atlassian.net/browse/AM-7080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ