### PR TITLE
fix: try all providers sharing the same kid before rejecting token va…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/impl/JWTServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/impl/JWTServiceImpl.java
@@ -42,9 +42,11 @@ import java.security.Key;
 import java.security.KeyPair;
 import java.text.ParseException;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -148,16 +150,20 @@ public class JWTServiceImpl implements JWTService {
         if (clientCertificateId == null) {
             return Single.error(new IllegalArgumentException("clientCertificateId is required"));
         }
-        return Maybe.fromOptional(parseSignedToken(jwt)
-                        .flatMap(this::findProviderByKid))
-                .switchIfEmpty(resolveClientCertificateProvider(clientCertificateId))
+        List<CertificateProvider> kidProviders = parseSignedToken(jwt)
+                .map(this::findProvidersByKid)
+                .orElse(List.of());
+        if (!kidProviders.isEmpty()) {
+            return verifyWithAnyProvider(jwt, kidProviders, tokenType);
+        }
+        return resolveClientCertificateProvider(clientCertificateId)
                 .flatMap(certificateProvider -> decodeAndVerify(jwt, certificateProvider, tokenType));
     }
 
-    private Optional<CertificateProvider> findProviderByKid(SignedJWT signedJWT) {
+    private List<CertificateProvider> findProvidersByKid(SignedJWT signedJWT) {
         String kid = signedJWT.getHeader().getKeyID();
         if (kid == null) {
-            return Optional.empty();
+            return List.of();
         }
 
         String issuerDomain = extractDomain(signedJWT);
@@ -168,7 +174,14 @@ public class JWTServiceImpl implements JWTService {
                 .filter(Objects::nonNull)
                 .filter(provider -> kid.equals(provider.getKeyId()))
                 .filter(provider -> issuerDomain == null || issuerDomain.equals(provider.getDomain()))
-                .findFirst();
+                .collect(Collectors.toList());
+    }
+
+    private Single<JWT> verifyWithAnyProvider(String jwt, List<CertificateProvider> providers, TokenType tokenType) {
+        return providers.stream()
+                .map(provider -> decodeAndVerify(jwt, provider, tokenType))
+                .reduce((chain, next) -> chain.onErrorResumeNext(err -> next))
+                .get();
     }
 
     private Single<CertificateProvider> resolveClientCertificateProvider(Maybe<String> clientCertificateId) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/jwt/JWTServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/jwt/JWTServiceTest.java
@@ -349,6 +349,45 @@ public class JWTServiceTest {
         assertEquals("matched-A", test.values().get(0).get("marker"));
     }
 
+    @Test
+    public void decodeAndVerify_supplier_duplicateKid_firstFails_secondSucceeds() throws Exception {
+        var wrongKeyProvider = providerWithKeyAndFailingParser("default", "domainD");
+        var correctKeyProvider = providerWithKey("default", "domainD", "correct-decoded");
+
+        when(certificateManager.providers("domainD")).thenReturn(List.of(wrongKeyProvider, correctKeyProvider));
+        when(domain.getId()).thenReturn("domainD");
+
+        String signed = signedJwt("default", "domainD");
+        TestObserver<JWT> test = jwtService.decodeAndVerify(signed, Maybe.just("fallback-id"), JWTService.TokenType.ACCESS_TOKEN).test();
+        test.await(10, TimeUnit.SECONDS);
+        test.assertComplete();
+        assertEquals("correct-decoded", test.values().get(0).get("marker"));
+    }
+
+    @Test
+    public void decodeAndVerify_supplier_duplicateKid_allFail_rejectsToken() throws Exception {
+        var failing1 = providerWithKeyAndFailingParser("default", "domainD");
+        var failing2 = providerWithKeyAndFailingParser("default", "domainD");
+
+        when(certificateManager.providers("domainD")).thenReturn(List.of(failing1, failing2));
+        when(domain.getId()).thenReturn("domainD");
+
+        String signed = signedJwt("default", "domainD");
+        TestObserver<JWT> test = jwtService.decodeAndVerify(signed, Maybe.just("fallback-id"), JWTService.TokenType.ACCESS_TOKEN).test();
+        test.await(10, TimeUnit.SECONDS);
+        test.assertError(io.gravitee.am.common.exception.oauth2.InvalidTokenException.class);
+    }
+
+    private io.gravitee.am.gateway.certificate.CertificateProvider providerWithKeyAndFailingParser(String keyId, String domain) {
+        var theProvider = mock(io.gravitee.am.gateway.certificate.CertificateProvider.class);
+        var actualProvider = mock(CertificateProvider.class);
+        when(theProvider.getKeyId()).thenReturn(keyId);
+        when(theProvider.getDomain()).thenReturn(domain);
+        when(theProvider.getProvider()).thenReturn(actualProvider);
+        when(theProvider.getJwtParser()).thenReturn(token -> { throw new io.gravitee.am.common.exception.oauth2.InvalidTokenException("wrong key"); });
+        return theProvider;
+    }
+
     private io.gravitee.am.gateway.certificate.CertificateProvider providerWithKey(String keyId, String domain, String marker) {
         var theProvider = mock(io.gravitee.am.gateway.certificate.CertificateProvider.class);
         var actualProvider = mock(CertificateProvider.class);


### PR DESCRIPTION
…lidation

When two certificates share the same kid (e.g. both named "Default"), the gateway now attempts verification against each matching provider in sequence and accepts the first success, propagating the error only if all providers fail.

Fixes AM-7099