### PR TITLE
fix: AM-7115 consistent resource validation

### DIFF
--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -695,7 +695,7 @@ paths:
       tags:
       - Certificates
       - Domains
-  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identity-providers:
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identities:
     get:
       description: Returns all identity providers managed by the Automation API under
         the domain. Identity providers created outside the Automation API are not
@@ -916,7 +916,7 @@ paths:
       tags:
       - Identity Providers
       - Domains
-  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identity-providers/{idpKey}:
+  /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identities/{identityKey}:
     delete:
       description: Deletes an Automation-managed identity provider by its key. Deleting
         an identity provider that does not exist also returns 204.
@@ -944,10 +944,10 @@ paths:
         required: true
         schema:
           type: string
-      - description: Key of the identity provider within the domain.
+      - description: Key of the identity within the domain.
         example: corporate-ldap
         in: path
-        name: idpKey
+        name: identityKey
         required: true
         schema:
           type: string
@@ -1007,10 +1007,10 @@ paths:
         required: true
         schema:
           type: string
-      - description: Key of the identity provider within the domain.
+      - description: Key of the identity within the domain.
         example: corporate-ldap
         in: path
-        name: idpKey
+        name: identityKey
         required: true
         schema:
           type: string

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/WALKTHROUGH.md
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/WALKTHROUGH.md
@@ -178,13 +178,13 @@ curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth" \
 ## 2. Identity Providers — a resource under the domain
 
 Identity providers are managed as their own resource under a domain, at
-`/domains/{domainKey}/identity-providers`. Each IdP is identified by its `key`. This
+`/domains/{domainKey}/identities`. Each IdP is identified by its `key`. This
 keeps payloads small: manage one IdP at a time without re-sending the whole domain.
 
 ### Inline IDP (test users)
 
 ```bash
-curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers" \
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identities" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -198,7 +198,7 @@ curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth
 ### LDAP IDP with mappers
 
 ```bash
-curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/internal-admin/identity-providers" \
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/internal-admin/identities" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -219,7 +219,7 @@ curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/internal-admi
 When `system` is `true`, only `key` is required; the IDP is built from `domains.identities.default.*` in `gravitee.yml`:
 
 ```bash
-curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers" \
+curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identities" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -230,13 +230,13 @@ curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth
 
 List / read / delete identity providers under a domain:
 ```bash
-curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers" \
+curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identities" \
   -H "Authorization: Bearer $TOKEN" | jq '.[].key'
 
-curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers/dev-test-users" \
+curl -s "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identities/dev-test-users" \
   -H "Authorization: Bearer $TOKEN" | jq '{key, name, type}'
 
-curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers/dev-test-users" \
+curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identities/dev-test-users" \
   -H "Authorization: Bearer $TOKEN" -w "\nHTTP %{http_code}\n"
 ```
 
@@ -396,7 +396,7 @@ certificates and reporters.
 
 ```bash
 # remove a single identity provider
-curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identity-providers/dev-test-users" \
+curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/customer-auth/identities/dev-test-users" \
   -H "Authorization: Bearer $TOKEN" -w "\nHTTP %{http_code}\n"
 
 # remove a whole domain
@@ -422,7 +422,7 @@ curl -s http://localhost:8093/management/automation/openapi.yaml | head -20
 | Resource | PUT (create/update) | GET one | GET list | DELETE |
 |----------|---------------------|---------|----------|--------|
 | Domain | `PUT .../domains` | `GET .../domains/{key}` | `GET .../domains` | `DELETE .../domains/{key}` |
-| Identity Provider | `PUT .../domains/{key}/identity-providers` | `GET .../domains/{key}/identity-providers/{key}` | `GET .../domains/{key}/identity-providers` | `DELETE .../domains/{key}/identity-providers/{key}` |
+| Identity Provider | `PUT .../domains/{key}/identities` | `GET .../domains/{key}/identities/{identityKey}` | `GET .../domains/{key}/identities` | `DELETE .../domains/{key}/identities/{identityKey}` |
 | Certificate | `PUT .../domains/{key}/certificates` | `GET .../domains/{key}/certificates/{key}` | `GET .../domains/{key}/certificates` | `DELETE .../domains/{key}/certificates/{key}` |
 | Reporter | `PUT .../domains/{key}/reporters` | `GET .../domains/{key}/reporters/{key}` | `GET .../domains/{key}/reporters` | `DELETE .../domains/{key}/reporters/{key}` |
 

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationAccountSettings.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationAccountSettings.java
@@ -26,7 +26,7 @@ import java.util.List;
  * Automation API mirror of {@link io.gravitee.am.model.account.AccountSettings}, wrapped
  * because {@link #defaultIdentityProviderForRegistration} is a cross-resource reference
  * expressed in the key-only contract: the {@code key} of an identity provider that exists
- * under this domain (created via the identity-providers endpoints, resolved against the IdP
+ * under this domain (created via the identities endpoints, resolved against the IdP
  * rows at apply time). A reference to an IdP that does not exist is rejected with {@code 400}.
  *
  * @author GraviteeSource Team

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainResource.java
@@ -103,7 +103,7 @@ public class DomainResource extends AbstractAutomationResource {
                 .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
     }
 
-    @Path("/identity-providers")
+    @Path("/identities")
     public IdentityProvidersResource getIdentityProvidersResource() {
         return resourceContext.getResource(IdentityProvidersResource.class);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProviderResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProviderResource.java
@@ -70,13 +70,13 @@ public class IdentityProviderResource extends AbstractAutomationResource {
             @PathParam("orgId") String organizationId,
             @PathParam("envId") String environmentId,
             @PathParam("domainKey") String domainKey,
-            @PathParam("idpKey") String idpKey,
+            @PathParam("identityKey") String identityKey,
             @Suspended final AsyncResponse response) {
 
         final var principal = getAuthenticatedUser();
         checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_IDENTITY_PROVIDER, Acl.READ)
                 .andThen(resolveDomain(environmentId, domainKey))
-                .flatMap(domain -> resolveIdentityProvider(domain, idpKey)
+                .flatMap(domain -> resolveIdentityProvider(domain, identityKey)
                         .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider))
                 .subscribe(response::resume, response::resume);
     }
@@ -90,14 +90,14 @@ public class IdentityProviderResource extends AbstractAutomationResource {
             @PathParam("orgId") String organizationId,
             @PathParam("envId") String environmentId,
             @PathParam("domainKey") String domainKey,
-            @PathParam("idpKey") String idpKey,
+            @PathParam("identityKey") String identityKey,
             @Suspended final AsyncResponse response) {
 
         final var principal = getAuthenticatedUser();
         checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN_IDENTITY_PROVIDER, Acl.DELETE)
                 .andThen(resolveDomainMaybe(environmentId, domainKey))
                 .flatMapCompletable(domain -> identityProviderService.findAll(ReferenceType.DOMAIN, domain.getId())
-                        .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && idpKey.equals(idp.getAutomationKey()))
+                        .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && identityKey.equals(idp.getAutomationKey()))
                         .firstElement()
                         .flatMapCompletable(idp -> identityProviderService.delete(ReferenceType.DOMAIN, domain.getId(), idp.getId(), principal)))
                 .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
@@ -121,11 +121,11 @@ public class IdentityProviderResource extends AbstractAutomationResource {
      * system provider — which adopts the conventional {@code default-idp-<domainId>} id rather than the
      * deterministic key-based id — resolves like any other.
      */
-    private Single<IdentityProvider> resolveIdentityProvider(Domain domain, String idpKey) {
+    private Single<IdentityProvider> resolveIdentityProvider(Domain domain, String identityKey) {
         return identityProviderService.findAll(ReferenceType.DOMAIN, domain.getId())
-                .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && idpKey.equals(idp.getAutomationKey()))
+                .filter(idp -> idp.isManagedBy(ManagedBy.AUTOMATION_API) && identityKey.equals(idp.getAutomationKey()))
                 .firstElement()
-                .switchIfEmpty(Maybe.error(() -> new IdentityProviderNotFoundException(idpKey)))
+                .switchIfEmpty(Maybe.error(() -> new IdentityProviderNotFoundException(identityKey)))
                 .toSingle();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
@@ -199,11 +199,8 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
             return rejection;
         }
         return identityProviderManager.checkPluginDeployment(definition.getType())
-                .andThen(Completable.fromAction(() -> {
-                    if (!isBlank(definition.getConfiguration())) {
-                        validationService.validate(definition.getType(), definition.getConfiguration());
-                    }
-                }))
+                .andThen(Completable.fromAction(() ->
+                        validationService.validate(definition.getType(), definition.getConfiguration())))
                 .andThen(Single.defer(() -> identityProviderService.update(ReferenceType.DOMAIN, domain.getId(), existing.getId(),
                         AutomationIdentityProviderMapper.toUpdateIdentityProvider(definition), principal, false)))
                 .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
@@ -240,11 +237,8 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
         AutomationNewIdentityProvider newIdp = AutomationIdentityProviderMapper.toNewIdentityProvider(definition);
         newIdp.setId(idpId);
         return identityProviderManager.checkPluginDeployment(definition.getType())
-                .andThen(Completable.fromAction(() -> {
-                    if (!isBlank(definition.getConfiguration())) {
-                        validationService.validate(definition.getType(), definition.getConfiguration());
-                    }
-                }))
+                .andThen(Completable.fromAction(() ->
+                        validationService.validate(definition.getType(), definition.getConfiguration())))
                 .andThen(Single.defer(() -> identityProviderService.create(domain, newIdp, principal, false)))
                 .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
     }
@@ -257,6 +251,10 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
         if (isBlank(definition.getType())) {
             return Single.error(new InvalidParameterException(
                     "Field 'type' is required for a non-system identity provider '" + key + "'"));
+        }
+        if (isBlank(definition.getConfiguration())) {
+            return Single.error(new InvalidParameterException(
+                    "Field 'configuration' is required for a non-system identity provider '" + key + "'"));
         }
         return null;
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
@@ -276,7 +276,7 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
         return domainService.update(domain.getId(), domain, false).ignoreElement();
     }
 
-    @Path("/{idpKey}")
+    @Path("/{identityKey}")
     public IdentityProviderResource getIdentityProviderResource() {
         return resourceContext.getResource(IdentityProviderResource.class);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
@@ -95,7 +95,7 @@ public class AutomationApiDefinition implements ReaderListener {
             "domainKey", new String[]{"Key of the domain: its stable, immutable Automation identifier within the " +
                     "environment.", "example-domain"},
             "certKey", new String[]{"Key of the certificate within the domain.", "signing-cert"},
-            "idpKey", new String[]{"Key of the identity provider within the domain.", "corporate-ldap"},
+            "identityKey", new String[]{"Key of the identity within the domain.", "corporate-ldap"},
             "reporterKey", new String[]{"Key of the reporter within the domain.", "audit-kafka"});
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
@@ -201,9 +201,9 @@ public abstract class AutomationJerseySpringTest {
         return orgTarget().path("environments").path(ENV_ID).path("domains");
     }
 
-    /** {@code /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identity-providers}. */
-    protected final WebTarget identityProvidersTarget(String domainKey) {
-        return domainsTarget().path(domainKey).path("identity-providers");
+    /** {@code /organizations/{orgId}/environments/{envId}/domains/{domainKey}/identities}. */
+    protected final WebTarget identitiesTarget(String domainKey) {
+        return domainsTarget().path(domainKey).path("identities");
     }
 
     /** {@code /organizations/{orgId}/environments/{envId}/domains/{domainKey}/certificates}. */

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProviderResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProviderResourceTest.java
@@ -67,7 +67,7 @@ class IdentityProviderResourceTest extends AutomationJerseySpringTest {
     }
 
     private Response getRequest() {
-        return identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().get();
+        return identitiesTarget(DOMAIN_KEY).path(IDP_KEY).request().get();
     }
 
     @Test
@@ -120,7 +120,7 @@ class IdentityProviderResourceTest extends AutomationJerseySpringTest {
         when(identityProviderService.delete(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any()))
                 .thenReturn(Completable.complete());
 
-        Response response = identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
+        Response response = identitiesTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
 
         assertEquals(204, response.getStatus());
     }
@@ -130,7 +130,7 @@ class IdentityProviderResourceTest extends AutomationJerseySpringTest {
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
         when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
 
-        Response response = identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
+        Response response = identitiesTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
 
         assertEquals(204, response.getStatus());
         verify(identityProviderService, never()).delete(any(), anyString(), anyString(), any());
@@ -140,7 +140,7 @@ class IdentityProviderResourceTest extends AutomationJerseySpringTest {
     void delete_returns_204_when_domain_absent() {
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
 
-        Response response = identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
+        Response response = identitiesTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
 
         assertEquals(204, response.getStatus());
         verify(identityProviderService, never()).delete(any(), anyString(), anyString(), any());
@@ -158,7 +158,7 @@ class IdentityProviderResourceTest extends AutomationJerseySpringTest {
     void delete_returns_403_when_not_permitted() {
         denyPermission();
 
-        Response response = identityProvidersTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
+        Response response = identitiesTarget(DOMAIN_KEY).path(IDP_KEY).request().delete();
 
         assertEquals(403, response.getStatus());
         verify(identityProviderService, never()).delete(any(), anyString(), anyString(), any());

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
@@ -168,6 +168,24 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
     }
 
     @Test
+    void put_create_rejects_blank_configuration() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+
+        AutomationIdentityProvider def = definition("dev-users");
+        def.setConfiguration("");
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("Field 'configuration' is required for a non-system identity provider"));
+        verify(validationService, never()).validate(any(), any());
+        verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(false));
+    }
+
+    @Test
     void put_updates_when_present() {
         String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
@@ -212,6 +230,28 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
 
         assertEquals(400, response.getStatus());
+        verify(identityProviderService, never())
+                .update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_update_rejects_blank_configuration() {
+        // A blank configuration is a missing-required-field error and must read consistently with the
+        // other required fields (name/type) and with the reporter/certificate resources.
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+
+        AutomationIdentityProvider def = definition("dev-users");
+        def.setConfiguration("");
+
+        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("Field 'configuration' is required for a non-system identity provider"));
+        verify(validationService, never()).validate(any(), any());
         verify(identityProviderService, never())
                 .update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false));
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
@@ -109,7 +109,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
                         idp("id-legacy", "legacy", null),
                         idp("id-a", "alpha", ManagedBy.AUTOMATION_API)));
 
-        Response response = identityProvidersTarget(DOMAIN_KEY).request().get();
+        Response response = identitiesTarget(DOMAIN_KEY).request().get();
 
         assertEquals(200, response.getStatus());
         List<AutomationIdentityProvider> body = readListEntity(response, AutomationIdentityProvider.class);
@@ -127,7 +127,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(identityProviderService.create(any(Domain.class), any(), any(), eq(false)))
                 .thenReturn(Single.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("dev-users"));
 
         assertEquals(200, response.getStatus());
         assertEquals("dev-users", readEntity(response, AutomationIdentityProvider.class).getAutomationKey());
@@ -144,7 +144,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         AutomationIdentityProvider def = definition("dev-users");
         def.setType("unknown-am-idp");
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
         verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(false));
@@ -161,7 +161,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         AutomationIdentityProvider def = definition("dev-users");
         def.setConfiguration("{\"bad\":true}");
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
         verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(false));
@@ -176,7 +176,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         AutomationIdentityProvider def = definition("dev-users");
         def.setConfiguration("");
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
         assertTrue(response.readEntity(String.class)
@@ -194,7 +194,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(identityProviderService.update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false)))
                 .thenReturn(Single.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("dev-users"));
 
         assertEquals(200, response.getStatus());
         assertEquals("dev-users", readEntity(response, AutomationIdentityProvider.class).getAutomationKey());
@@ -211,7 +211,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         def.setAutomationKey("dev-users");
         // name and type intentionally omitted
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
         verify(identityProviderService, never())
@@ -227,7 +227,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         doThrow(InvalidPluginConfigurationException.fromValidationError("not valid"))
                 .when(validationService).validate(eq("inline-am-idp"), anyString());
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("dev-users"));
 
         assertEquals(400, response.getStatus());
         verify(identityProviderService, never())
@@ -246,7 +246,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         AutomationIdentityProvider def = definition("dev-users");
         def.setConfiguration("");
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
         assertTrue(response.readEntity(String.class)
@@ -266,7 +266,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         AutomationIdentityProvider def = definition("dev-users"); // existing type is inline-am-idp
         def.setType("ldap-am-idp");
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
         verify(identityProviderManager, never()).checkPluginDeployment(anyString());
@@ -284,7 +284,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(identityProviderService.update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false)))
                 .thenReturn(Single.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("dev-users"));
 
         assertEquals(200, response.getStatus());
         verify(identityProviderManager).checkPluginDeployment(eq("inline-am-idp"));
@@ -300,7 +300,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(defaultIdentityProviderService.create(any(Domain.class), eq("sys-idp"), any()))
                 .thenReturn(Single.just(idp(systemIdpId, "sys-idp", ManagedBy.AUTOMATION_API, true)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
 
         assertEquals(200, response.getStatus());
         assertTrue(readEntity(response, AutomationIdentityProvider.class).isSystem());
@@ -328,7 +328,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(domainService.update(eq(domainId), any(Domain.class), eq(false)))
                 .thenAnswer(invocation -> Single.just(invocation.getArgument(1)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
 
         assertEquals(200, response.getStatus());
         ArgumentCaptor<Domain> captor = ArgumentCaptor.forClass(Domain.class);
@@ -352,7 +352,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(defaultIdentityProviderService.create(any(Domain.class), eq("sys-idp"), any()))
                 .thenReturn(Single.just(idp(systemIdpId, "sys-idp", ManagedBy.AUTOMATION_API, true)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
 
         assertEquals(200, response.getStatus());
         verify(domainService, never()).update(anyString(), any(Domain.class), anyBoolean());
@@ -366,7 +366,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
                 .thenReturn(Flowable.just(idp(systemIdpId, "sys-idp", ManagedBy.AUTOMATION_API, true)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), systemDefinition("sys-idp"));
 
         assertEquals(200, response.getStatus());
         verify(identityProviderService, never())
@@ -382,7 +382,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
                 .thenReturn(Flowable.just(idp(existingSystemId, "primary", ManagedBy.AUTOMATION_API, true)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), systemDefinition("second-system"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), systemDefinition("second-system"));
 
         assertEquals(400, response.getStatus());
     }
@@ -397,7 +397,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         def.setAutomationKey("incomplete");
         // name, type intentionally left null
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
         verify(identityProviderService, never()).create(any(Domain.class), any(), any(), eq(false));
@@ -413,7 +413,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         AutomationIdentityProvider def = definition("dev-users");
         def.setSystem(true);
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), def);
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
     }
@@ -425,7 +425,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
                 .thenReturn(Flowable.just(idp(idpId, "dev-users", null)));
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("dev-users"));
 
         assertEquals(400, response.getStatus());
     }
@@ -434,7 +434,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
     void put_returns_404_when_domain_absent() {
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("dev-users"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("dev-users"));
 
         assertEquals(404, response.getStatus());
     }
@@ -444,7 +444,7 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
         when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
 
-        Response response = put(identityProvidersTarget(DOMAIN_KEY), definition("Dev Users!"));
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("Dev Users!"));
 
         assertEquals(400, response.getStatus());
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/IdentityProviderResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/IdentityProviderResourceTest.java
@@ -19,12 +19,16 @@ import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.service.model.UpdateIdentityProvider;
 import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.rxjava3.core.Maybe;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 
 /**
@@ -82,6 +86,24 @@ public class IdentityProviderResourceTest extends JerseySpringTest {
 
         final Response response = target("domains").path(domainId).path("identities").path(identityProviderId).request().get();
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotUpdate_nullConfiguration() {
+        final String domainId = "domain-id";
+        final String identityProviderId = "identityProvider-id";
+
+        UpdateIdentityProvider updateIdentityProvider = new UpdateIdentityProvider();
+        updateIdentityProvider.setName("idp-name");
+        updateIdentityProvider.setType("idp-type");
+        // configuration intentionally omitted (null)
+
+        final Response response = target("domains").path(domainId).path("identities").path(identityProviderId)
+                .request().put(Entity.json(updateIdentityProvider));
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        final String body = response.readEntity(String.class);
+        assertTrue("expected the message to mention the configuration field: " + body, body.contains("configuration"));
+        assertFalse("message interpolation must not leak: " + body, body.contains("HV000149"));
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/IdentityProvidersResourceTest.java
@@ -18,6 +18,8 @@ package io.gravitee.am.management.handlers.management.api.resources;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 
@@ -106,6 +108,29 @@ public class IdentityProvidersResourceTest extends JerseySpringTest {
                 .path("identities")
                 .request().post(Entity.json(newIdentityProvider));
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotCreate_nullConfiguration() {
+        final String domainId = "domain-1";
+        final Domain mockDomain = new Domain();
+        mockDomain.setId(domainId);
+
+        NewIdentityProvider newIdentityProvider = new NewIdentityProvider();
+        newIdentityProvider.setName("idp-name");
+        newIdentityProvider.setType("idp-type");
+        // configuration intentionally omitted (null)
+
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
+
+        final Response response = target("domains")
+                .path(domainId)
+                .path("identities")
+                .request().post(Entity.json(newIdentityProvider));
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        final String body = response.readEntity(String.class);
+        assertTrue("expected the message to mention the configuration field: " + body, body.contains("configuration"));
+        assertFalse("message interpolation must not leak: " + body, body.contains("HV000149"));
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AbstractSensitiveProxy.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AbstractSensitiveProxy.java
@@ -16,6 +16,7 @@
 
 package io.gravitee.am.management.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -23,6 +24,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Strings;
 import io.gravitee.am.model.PluginConfigurableEntity;
 import io.gravitee.am.service.AuditService;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
 import io.gravitee.am.service.model.PluginConfigurableUpdate;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -56,6 +58,22 @@ public abstract class AbstractSensitiveProxy {
 
     private static final String USERINFO_PATTERN_EXTRACTOR = "^(?:[^/]+://)?(?<userInfo>[^/@]+)@.*";
     private static final Pattern USER_INFO_PATTERN = Pattern.compile(USERINFO_PATTERN_EXTRACTOR);
+
+    /**
+     * Parse a user-supplied plugin configuration, surfacing a missing or malformed configuration as a
+     * {@link InvalidPluginConfigurationException}.
+     */
+    protected static JsonNode parseConfiguration(ObjectMapper objectMapper, String configuration) {
+        if (configuration == null || configuration.isBlank()) {
+            throw InvalidPluginConfigurationException.fromValidationError("configuration is required");
+        }
+        try {
+            return objectMapper.readTree(configuration);
+        } catch (JsonProcessingException e) {
+            throw InvalidPluginConfigurationException.fromValidationError("configuration is not valid JSON");
+        }
+    }
+
     protected void filterSensitiveData(
             JsonNode schemaNode,
             JsonNode configurationNode,

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/CertificateServiceProxyImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/CertificateServiceProxyImpl.java
@@ -217,7 +217,7 @@ public class CertificateServiceProxyImpl extends AbstractSensitiveProxy implemen
         return certificatePluginService.getSchema(oldCertificate.getType())
                 .switchIfEmpty(Single.error(() -> new CertificatePluginSchemaNotFoundException(oldCertificate.getType())))
                 .map(schema -> {
-                    var updateConfig = objectMapper.readTree(updateCertificate.getConfiguration());
+                    var updateConfig = parseConfiguration(objectMapper, updateCertificate.getConfiguration());
                     var oldConfig = objectMapper.readTree(oldCertificate.getConfiguration());
                     var schemaConfig = objectMapper.readTree(schema);
                     super.updateSensitiveData(updateConfig, oldConfig, schemaConfig, updateCertificate::setConfiguration);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderServiceProxyImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderServiceProxyImpl.java
@@ -211,7 +211,7 @@ public class IdentityProviderServiceProxyImpl extends AbstractSensitiveProxy imp
         return identityProviderPluginService.getSchema(oldIdentityProvider.getType())
                 .switchIfEmpty(Single.error(new IdentityProviderPluginSchemaNotFoundException(oldIdentityProvider.getType())))
                 .map(schema -> {
-                    var updateConfig = objectMapper.readTree(updateIdentityProvider.getConfiguration());
+                    var updateConfig = parseConfiguration(objectMapper, updateIdentityProvider.getConfiguration());
                     validateConfiguration(updateConfig);
                     var oldConfig = objectMapper.readTree(oldIdentityProvider.getConfiguration());
                     var schemaConfig = objectMapper.readTree(schema);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ReporterServiceProxyImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ReporterServiceProxyImpl.java
@@ -168,7 +168,7 @@ public class ReporterServiceProxyImpl extends AbstractSensitiveProxy implements 
         return reporterPluginService.getSchema(oldReporter.getType())
                 .switchIfEmpty(Single.error(new ReporterPluginSchemaNotFoundException(oldReporter.getType())))
                 .map(schema -> {
-                    var updateConfig = objectMapper.readTree(updateReporter.getConfiguration());
+                    var updateConfig = parseConfiguration(objectMapper, updateReporter.getConfiguration());
                     var oldConfig = objectMapper.readTree(oldReporter.getConfiguration());
                     var schemaConfig = objectMapper.readTree(schema);
                     super.updateSensitiveData(updateConfig, oldConfig, schemaConfig, updateReporter::setConfiguration);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/SensitiveProxyTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/SensitiveProxyTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.management.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +26,29 @@ import org.junit.jupiter.api.Test;
  */
 public class SensitiveProxyTest {
     private static final String COMPLEX_PASSWORD = "KU!$~25;&vZUP,745lpeO";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private AbstractSensitiveProxy proxy = new AbstractSensitiveProxy(){};
+
+    @Test
+    public void parseConfiguration_should_return_node_for_valid_json() {
+        Assertions.assertEquals(1, AbstractSensitiveProxy.parseConfiguration(OBJECT_MAPPER, "{\"a\":1}").get("a").asInt());
+    }
+
+    @Test
+    public void parseConfiguration_should_reject_null_or_blank() {
+        for (String config : new String[]{null, "", "   "}) {
+            var ex = Assertions.assertThrows(InvalidPluginConfigurationException.class,
+                    () -> AbstractSensitiveProxy.parseConfiguration(OBJECT_MAPPER, config));
+            Assertions.assertEquals("configuration is required", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void parseConfiguration_should_reject_malformed_json() {
+        var ex = Assertions.assertThrows(InvalidPluginConfigurationException.class,
+                () -> AbstractSensitiveProxy.parseConfiguration(OBJECT_MAPPER, "not-json"));
+        Assertions.assertEquals("configuration is not valid JSON", ex.getMessage());
+    }
 
     @Test
     public void should_extract_userInfo_from_http_url() {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
@@ -219,7 +219,7 @@ public class CertificateServiceImpl implements CertificateService {
     @Override
     public Single<Certificate> create(Domain domain, NewCertificate newCertificate, User principal, boolean isSystem) {
         log.debug("Create a new certificate {} for domain {}", newCertificate, domain.getId());
-        return certificatePluginService
+        return validateConfiguration(newCertificate, isSystem).andThen(Single.defer(() -> certificatePluginService
                 .getSchema(newCertificate.getType())
                 .switchIfEmpty(Single.error(() -> new CertificatePluginSchemaNotFoundException(newCertificate.getType())))
                 .map(schema -> objectMapper.readValue(schema, CertificateSchema.class))
@@ -259,7 +259,14 @@ public class CertificateServiceImpl implements CertificateService {
                         return Single.error(ex);
                     }
                     return Single.error(new TechnicalManagementException("An error occurs while trying to create a certificate", ex));
-                });
+                })));
+    }
+
+    private Completable validateConfiguration(NewCertificate newCertificate, boolean isSystem) {
+        if (isSystem) {
+            return Completable.complete();
+        }
+        return Completable.fromAction(() -> validationService.validate(newCertificate.getType(), newCertificate.getConfiguration()));
     }
 
     @SneakyThrows

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/IdentityProviderServiceImpl.java
@@ -166,7 +166,8 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
     @Override
     public Single<IdentityProvider> create(ReferenceType referenceType, String referenceId, NewIdentityProvider newIdentityProvider, User principal, boolean system) {
         LOGGER.debug("Create a new identity provider {} for {} {}", newIdentityProvider, referenceType, referenceId);
-        return innerCreate(prepareIdp(newIdentityProvider, referenceType, referenceId, system));
+        var identityProvider = prepareIdp(newIdentityProvider, referenceType, referenceId, system);
+        return validateConfiguration(identityProvider, system).andThen(Single.defer(() -> innerCreate(identityProvider)));
     }
 
     @Override
@@ -176,7 +177,14 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
         var identityProvider = prepareIdp(newIdentityProvider, ReferenceType.DOMAIN, domain.getId(), system);
         identityProvider.setDataPlaneId(domain.getDataPlaneId());
 
-        return innerCreate(identityProvider);
+        return validateConfiguration(identityProvider, system).andThen(Single.defer(() -> innerCreate(identityProvider)));
+    }
+
+    private Completable validateConfiguration(IdentityProvider identityProvider, boolean system) {
+        if (system) {
+            return Completable.complete();
+        }
+        return Completable.fromAction(() -> validationService.validate(identityProvider.getType(), identityProvider.getConfiguration()));
     }
 
     private Single<IdentityProvider> innerCreate(IdentityProvider identityProvider) {
@@ -188,6 +196,9 @@ public class IdentityProviderServiceImpl implements IdentityProviderService {
                     return eventService.create(event).flatMap(__ -> Single.just(identityProvider1));
                 })
                 .onErrorResumeNext(ex -> {
+                    if (ex instanceof AbstractManagementException) {
+                        return Single.error(ex);
+                    }
                     LOGGER.error("An error occurs while trying to create an identity provider", ex);
                     return Single.error(new TechnicalManagementException("An error occurs while trying to create an identity provider", ex));
                 });

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PluginConfigurationValidationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PluginConfigurationValidationServiceImpl.java
@@ -17,6 +17,7 @@
 package io.gravitee.am.service.impl;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidatorsRegistry;
 import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
@@ -30,10 +31,21 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class PluginConfigurationValidationServiceImpl implements PluginConfigurationValidationService {
+
     private final PluginConfigurationValidatorsRegistry pluginValidatorsRegistry;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void validate(String pluginType, String configuration) {
+        if (configuration == null || configuration.isBlank()) {
+            throw InvalidPluginConfigurationException.fromValidationError("configuration is required");
+        }
+        try {
+            objectMapper.readTree(configuration);
+        } catch (Exception e) {
+            throw InvalidPluginConfigurationException.fromValidationError("configuration is not valid JSON");
+        }
+
         pluginValidatorsRegistry.get(pluginType)
                 .ifPresent(pluginValidator -> {
                     final var result = pluginValidator.validate(configuration);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ReporterServiceImpl.java
@@ -213,23 +213,30 @@ public class ReporterServiceImpl implements ReporterService {
         }
 
 
-        return checkReporterConfiguration(reporter)
-                .flatMap(ignore -> reporterRepository.create(reporter))
-                .flatMap(createdReporter -> {
-                    // create event for sync process
-                    Event event = new Event(Type.REPORTER, new Payload(createdReporter.getId(), createdReporter.getReference(), Action.CREATE));
-                    return eventService.create(event).flatMap(e -> Single.just(createdReporter));
-                })
-                .onErrorResumeNext(ex -> {
-                    LOGGER.error("An error occurs while trying to create a reporter", ex);
-                    String message = "An error occurs while trying to create a reporter. ";
-                    if (ex instanceof ReporterConfigurationException) {
-                        message += ex.getMessage();
-                    }
-                    return Single.error(new TechnicalManagementException(message, ex));
-                });
+        return validateConfiguration(newReporter, system)
+                .andThen(Single.defer(() -> checkReporterConfiguration(reporter)
+                        .flatMap(ignore -> reporterRepository.create(reporter))
+                        .flatMap(createdReporter -> {
+                            // create event for sync process
+                            Event event = new Event(Type.REPORTER, new Payload(createdReporter.getId(), createdReporter.getReference(), Action.CREATE));
+                            return eventService.create(event).flatMap(e -> Single.just(createdReporter));
+                        })
+                        .onErrorResumeNext(ex -> {
+                            LOGGER.error("An error occurs while trying to create a reporter", ex);
+                            String message = "An error occurs while trying to create a reporter. ";
+                            if (ex instanceof ReporterConfigurationException) {
+                                message += ex.getMessage();
+                            }
+                            return Single.error(new TechnicalManagementException(message, ex));
+                        })));
     }
 
+    private Completable validateConfiguration(NewReporter newReporter, boolean system) {
+        if (system) {
+            return Completable.complete();
+        }
+        return Completable.fromAction(() -> validationService.validate(newReporter.getType(), newReporter.getConfiguration()));
+    }
 
     @Override
     public Single<Reporter> update(Reference reference, String reporterId, UpdateReporter updateReporter, User principal, boolean isUpgrader) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewCertificate.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewCertificate.java
@@ -22,7 +22,7 @@ import jakarta.validation.constraints.NotNull;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class NewCertificate implements PluginConfigurationPayload {
+public class NewCertificate {
 
     @NotBlank
     private String type;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewIdentityProvider.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewIdentityProvider.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 @Getter
 @Setter
-public class NewIdentityProvider implements PluginConfigurationPayload {
+public class NewIdentityProvider {
 
     private String id;
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewReporter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewReporter.java
@@ -23,7 +23,7 @@ import lombok.Data;
  * @author GraviteeSource Team
  */
 @Data
-public class NewReporter implements PluginConfigurationPayload {
+public class NewReporter {
 
     private String id;
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/plugincfg/PluginJsonFormValidator.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/plugincfg/PluginJsonFormValidator.java
@@ -41,9 +41,24 @@ public class PluginJsonFormValidator implements ConstraintValidator<PluginJsonFo
             return true;
         } else {
             ctx.disableDefaultConstraintViolation();
-            ctx.buildConstraintViolationWithTemplate(result.getMsg()).addConstraintViolation();
+            ctx.buildConstraintViolationWithTemplate(escapeTemplate(result.getMsg())).addConstraintViolation();
             return false;
         }
+    }
+
+    /**
+     * Validator messages may contain characters that Hibernate's message interpolation treats as
+     * EL/parameter markers ('{', '}', '$'); escaping them prevents the message from being interpreted
+     * as a template, which otherwise fails with "HV000149: An exception occurred during message interpolation".
+     */
+    private static String escapeTemplate(String message) {
+        if (message == null) {
+            return "";
+        }
+        return message.replace("\\", "\\\\")
+                .replace("{", "\\{")
+                .replace("}", "\\}")
+                .replace("$", "\\$");
     }
 
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/CertificateServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/CertificateServiceTest.java
@@ -34,6 +34,7 @@ import io.gravitee.am.service.exception.CertificateNotFoundException;
 import io.gravitee.am.service.exception.CertificateWithApplicationsException;
 import io.gravitee.am.service.exception.CertificateWithProtectedResourceException;
 import io.gravitee.am.service.exception.InvalidParameterException;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.CertificateServiceImpl;
 import io.gravitee.am.service.model.NewCertificate;
@@ -81,6 +82,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 /**
@@ -312,6 +314,23 @@ public class CertificateServiceTest {
     public void shouldCreate_defaultCertificate_Ec() throws Exception {
         TestObserver<Certificate> testObserver = defaultCertificate(256, "SHA256withECDSA", true);
         testObserver.assertComplete();
+    }
+
+    @Test
+    public void shouldNotCreate_configValidation_fails() {
+        var newCertificate = new NewCertificate();
+        newCertificate.setName("cert");
+        newCertificate.setType("aws-am-certificate");
+        newCertificate.setConfiguration("");
+        doThrow(InvalidPluginConfigurationException.fromValidationError("configuration is required"))
+                .when(validationService).validate(any(), any());
+
+        TestObserver<Certificate> testObserver = certificateService.create(DOMAIN, newCertificate, Mockito.mock(User.class)).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertError(InvalidPluginConfigurationException.class);
+
+        verify(certificateRepository, never()).create(any());
+        verify(validationService).validate(any(), any());
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/IdentityProviderServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/IdentityProviderServiceTest.java
@@ -227,6 +227,40 @@ public class IdentityProviderServiceTest {
     }
 
     @Test
+    public void shouldNotCreate_configValidation_fails() {
+        NewIdentityProvider newIdentityProvider = mock(NewIdentityProvider.class);
+        doThrow(InvalidPluginConfigurationException.fromValidationError("configuration is required"))
+                .when(validationService).validate(any(), any());
+
+        TestObserver testObserver = identityProviderService.create(new Domain(DOMAIN), newIdentityProvider, null).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertError(InvalidPluginConfigurationException.class);
+
+        verify(identityProviderRepository, never()).create(any(IdentityProvider.class));
+        verify(eventService, never()).create(any());
+        verify(validationService).validate(any(), any());
+    }
+
+    @Test
+    public void shouldCreate_system_skipsConfigValidation() {
+        NewIdentityProvider newIdentityProvider = mock(NewIdentityProvider.class);
+        IdentityProvider idp = new IdentityProvider();
+        idp.setReferenceType(ReferenceType.DOMAIN);
+        idp.setReferenceId("domain#1");
+        when(identityProviderRepository.create(any(IdentityProvider.class))).thenReturn(Single.just(idp));
+        when(eventService.create(any())).thenReturn(Single.just(new Event()));
+        when(datasourceValidator.validate(any())).thenReturn(Completable.complete());
+
+        TestObserver testObserver = identityProviderService.create(new Domain(DOMAIN), newIdentityProvider, null, true).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(validationService, never()).validate(any(), any());
+    }
+
+    @Test
     public void shouldNotUpdate_configValidation_fails() {
         UpdateIdentityProvider updateIdentityProvider = mock(UpdateIdentityProvider.class);
         IdentityProvider idp = new IdentityProvider();

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ReporterServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ReporterServiceTest.java
@@ -22,6 +22,7 @@ import io.gravitee.am.model.Reporter;
 import io.gravitee.am.model.common.event.Event;
 import io.gravitee.am.repository.junit.management.MemoryReporterRepository;
 import io.gravitee.am.repository.management.api.ReporterRepository;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
 import io.gravitee.am.service.exception.ReporterConfigurationException;
 import io.gravitee.am.service.exception.ReporterDeleteException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -134,6 +136,24 @@ class ReporterServiceTest {
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
                 .assertError(ReporterConfigurationException.class);
+    }
+
+    @Test
+    void shouldNotCreate_configValidation_fails() {
+        final var reporter = new NewReporter();
+        reporter.setEnabled(true);
+        reporter.setName("Test");
+        reporter.setType("reporter-am-file");
+        reporter.setConfiguration("");
+        doThrow(InvalidPluginConfigurationException.fromValidationError("configuration is required"))
+                .when(validationService).validate(any(), any());
+
+        reporterService.create(Reference.domain("domain"), reporter, null, false)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(InvalidPluginConfigurationException.class);
+
+        verify(validationService).validate(any(), any());
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/PluginConfigurationValidationServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/PluginConfigurationValidationServiceImplTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidator;
+import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidatorsRegistry;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
+import io.gravitee.json.validation.JsonSchemaValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class PluginConfigurationValidationServiceImplTest {
+
+    private static final String TYPE = "some-am-idp";
+
+    private PluginConfigurationValidatorsRegistry registry;
+    private PluginConfigurationValidationServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        registry = new PluginConfigurationValidatorsRegistry();
+        service = new PluginConfigurationValidationServiceImpl(registry, new ObjectMapper());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "\t", "\n"})
+    void should_reject_null_or_blank_configuration(String configuration) {
+        var ex = assertThrows(InvalidPluginConfigurationException.class, () -> service.validate(TYPE, configuration));
+        assertEquals("configuration is required", ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{", "not-json", "}{", "{\"a\":}"})
+    void should_reject_malformed_json_configuration(String configuration) {
+        var ex = assertThrows(InvalidPluginConfigurationException.class, () -> service.validate(TYPE, configuration));
+        assertEquals("configuration is not valid JSON", ex.getMessage());
+    }
+
+    @Test
+    void should_pass_when_well_formed_json_and_no_validator_registered() {
+        assertDoesNotThrow(() -> service.validate("unregistered-type", "{\"a\":1}"));
+    }
+
+    @Test
+    void should_pass_when_well_formed_json_matches_schema() {
+        var jsonSchemaValidator = mock(JsonSchemaValidator.class);
+        when(jsonSchemaValidator.validate(anyString(), anyString())).thenReturn("");
+        registry.put(new PluginConfigurationValidator(TYPE, "schema", jsonSchemaValidator));
+
+        assertDoesNotThrow(() -> service.validate(TYPE, "{\"a\":1}"));
+    }
+
+    @Test
+    void should_reject_when_well_formed_json_fails_schema() {
+        var jsonSchemaValidator = mock(JsonSchemaValidator.class);
+        when(jsonSchemaValidator.validate(anyString(), anyString())).thenThrow(new RuntimeException("missing required field"));
+        registry.put(new PluginConfigurationValidator(TYPE, "schema", jsonSchemaValidator));
+
+        var ex = assertThrows(InvalidPluginConfigurationException.class, () -> service.validate(TYPE, "{\"a\":1}"));
+        assertEquals("missing required field", ex.getMessage());
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/plugincfg/PluginJsonFormValidatorTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/plugincfg/PluginJsonFormValidatorTest.java
@@ -19,6 +19,7 @@ import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidator;
 import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidatorsRegistry;
 import io.gravitee.am.service.CertificateServiceTest;
 import io.gravitee.am.service.model.PluginConfigurationPayload;
+import io.gravitee.json.validation.JsonSchemaValidator;
 import io.gravitee.json.validation.JsonSchemaValidatorImpl;
 import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.internal.util.io.IOUtil;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -120,6 +122,34 @@ class PluginJsonFormValidatorTest {
         // then
         Assertions.assertFalse(result);
         Mockito.verify(violation, times(1)).addConstraintViolation();
+    }
+
+    @Test
+    public void should_escape_braces_in_violation_message_to_avoid_HV000149() {
+        // given a validator whose failure message contains brace characters (as the JSON parser produces,
+        // e.g. "A JSONObject text must begin with '{' at 0"). Passed verbatim, Hibernate would treat the
+        // brace as a message parameter and fail interpolation with HV000149.
+        var jsonSchemaValidator = mock(JsonSchemaValidator.class);
+        when(jsonSchemaValidator.validate(anyString(), anyString()))
+                .thenThrow(new RuntimeException("A JSONObject text must begin with '{' at 0 [character 1 line 1]"));
+        registry.put(new PluginConfigurationValidator("id", "schema", jsonSchemaValidator));
+
+        var payload = new TestPayload("id", "");
+
+        var ctx = mock(ConstraintValidatorContext.class);
+        var violation = mock(ConstraintViolationBuilder.class);
+        var template = ArgumentCaptor.forClass(String.class);
+        when(ctx.buildConstraintViolationWithTemplate(template.capture())).thenReturn(violation);
+
+        // when
+        boolean result = jsonFormValidator.isValid(payload, ctx);
+
+        // then
+        Assertions.assertFalse(result);
+        String captured = template.getValue();
+        Assertions.assertTrue(captured.contains("\\{"), "brace should be escaped: " + captured);
+        Assertions.assertFalse(captured.replace("\\{", "").contains("{"), "unescaped '{' present: " + captured);
+        Assertions.assertFalse(captured.replace("\\}", "").contains("}"), "unescaped '}' present: " + captured);
     }
 
     @SneakyThrows

--- a/gravitee-am-test/specs/management/automation/auth-and-openapi.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/auth-and-openapi.jest.spec.ts
@@ -77,7 +77,7 @@ describe('Automation API - OpenAPI specification', () => {
     expect(paths.length).toBeGreaterThan(0);
     expect(paths.every((p) => p.startsWith('/organizations/{orgId}'))).toBe(true);
     // identity providers are a resource under a domain
-    expect(paths.some((p) => p.endsWith('/identity-providers'))).toBe(true);
+    expect(paths.some((p) => p.endsWith('/identities'))).toBe(true);
 
     // automation-specific security schemes only (no inherited gravitee-auth)
     const schemes = Object.keys(spec.components?.securitySchemes || {});

--- a/gravitee-am-test/specs/management/automation/domain-account-settings-references.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-account-settings-references.jest.spec.ts
@@ -19,7 +19,7 @@
  * notifiers are not managed by the Automation API and never surfaced, and
  * {@code oidc.cimdSettings} is not surfaced. The in-scope cross-reference
  * ({@code accountSettings.defaultIdentityProviderForRegistration}) is covered by
- * domain-identity-providers.jest.spec.ts.
+ * domain-identities.jest.spec.ts.
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { setup } from '../../test-fixture';

--- a/gravitee-am-test/specs/management/automation/domain-identities.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-identities.jest.spec.ts
@@ -16,7 +16,7 @@
 
 /**
  * Identity providers are managed individually under a domain via the
- * /domains/{domainKey}/identity-providers endpoints — key-keyed, each PUT manages one IdP.
+ * /domains/{domainKey}/identities endpoints — key-keyed, each PUT manages one IdP.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { uniqueName } from '@utils-commands/misc';
@@ -45,7 +45,7 @@ const createdIdpKeys: string[] = [];
 
 afterEach(async () => {
   while (createdIdpKeys.length) {
-    await fixture.client.deleteIdentityProvider(fixture.domainKey, createdIdpKeys.pop());
+    await fixture.client.deleteIdentity(fixture.domainKey, createdIdpKeys.pop());
   }
 });
 
@@ -56,7 +56,7 @@ const defaultUsers: InlineUser[] = [{ username: 'testuser', password: 'Password1
 async function createIdp(overrides: { key?: string; name?: string; users?: InlineUser[] } = {}) {
   const key = overrides.key ?? uniqueName('autoinline', true).toLowerCase();
   createdIdpKeys.push(key);
-  const response = await fixture.client.putIdentityProvider(
+  const response = await fixture.client.putIdentity(
     fixture.domainKey,
     buildInlineIdpDef({ key, name: overrides.name, users: overrides.users ?? defaultUsers }),
   );
@@ -66,13 +66,13 @@ async function createIdp(overrides: { key?: string; name?: string; users?: Inlin
 /** Create a system IdP via PUT and track its key for cleanup. */
 async function createSystemIdp(key = uniqueName('autosysidp', true).toLowerCase()) {
   createdIdpKeys.push(key);
-  const response = await fixture.client.putIdentityProvider(fixture.domainKey, buildSystemAutomationDef(key));
+  const response = await fixture.client.putIdentity(fixture.domainKey, buildSystemAutomationDef(key));
   return { key, response };
 }
 
 describe('Automation API - Identity providers (resource under a domain)', () => {
   it('should list no identity providers when none exist', async () => {
-    const response = await fixture.client.listIdentityProviders(fixture.domainKey);
+    const response = await fixture.client.listIdentities(fixture.domainKey);
     expect(response.status).toBe(200);
     expect(response.body).toEqual([]);
   });
@@ -93,7 +93,7 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   it('should round-trip the identity provider on GET', async () => {
     const { key } = await createIdp();
 
-    const response = await fixture.client.getIdentityProvider(fixture.domainKey, key);
+    const response = await fixture.client.getIdentity(fixture.domainKey, key);
     expect(response.status).toBe(200);
     expect(response.body.key).toEqual(key);
     expect(response.body.name).toEqual(`Automation IDP ${key}`);
@@ -102,7 +102,7 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   it('should list the identity provider under the domain', async () => {
     const { key } = await createIdp();
 
-    const response = await fixture.client.listIdentityProviders(fixture.domainKey);
+    const response = await fixture.client.listIdentities(fixture.domainKey);
     expect(response.status).toBe(200);
     expect(response.body).toEqual([expect.objectContaining({ key })]);
   });
@@ -110,7 +110,7 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   it('should update the identity provider via a second PUT (idempotent)', async () => {
     const { key } = await createIdp();
 
-    const response = await fixture.client.putIdentityProvider(
+    const response = await fixture.client.putIdentity(
       fixture.domainKey,
       buildInlineIdpDef({
         key,
@@ -126,7 +126,7 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   it('should reject changing the type of an existing identity provider (400)', async () => {
     const { key } = await createIdp();
 
-    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+    const response = await fixture.client.putIdentity(fixture.domainKey, {
       ...buildInlineIdpDef({ key, users: defaultUsers }),
       type: 'ldap-am-idp',
     });
@@ -136,7 +136,7 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   it('should reject an update missing the required name (400)', async () => {
     const { key } = await createIdp();
 
-    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+    const response = await fixture.client.putIdentity(fixture.domainKey, {
       key,
       type: 'inline-am-idp',
       configuration: JSON.stringify({ users: defaultUsers }),
@@ -145,7 +145,7 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   });
 
   it('should reject an invalid key pattern (400)', async () => {
-    const response = await fixture.client.putIdentityProvider(
+    const response = await fixture.client.putIdentity(
       fixture.domainKey,
       buildInlineIdpDef({ key: 'Invalid Key!', users: [{ username: 'u', password: 'P@ssword1' }] }),
     );
@@ -153,22 +153,22 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
   });
 
   it('should return 404 for an unknown identity provider key', async () => {
-    const response = await fixture.client.getIdentityProvider(fixture.domainKey, 'does-not-exist-xyz');
+    const response = await fixture.client.getIdentity(fixture.domainKey, 'does-not-exist-xyz');
     expect(response.status).toBe(404);
   });
 
   it('should return 404 for identity providers of an unknown domain', async () => {
-    const response = await fixture.client.listIdentityProviders('no-such-domain-xyz');
+    const response = await fixture.client.listIdentities('no-such-domain-xyz');
     expect(response.status).toBe(404);
   });
 
   it('should delete the identity provider', async () => {
     const { key } = await createIdp();
 
-    const del = await fixture.client.deleteIdentityProvider(fixture.domainKey, key);
+    const del = await fixture.client.deleteIdentity(fixture.domainKey, key);
     expect(del.status).toBe(204);
 
-    const get = await fixture.client.getIdentityProvider(fixture.domainKey, key);
+    const get = await fixture.client.getIdentity(fixture.domainKey, key);
     expect(get.status).toBe(404);
   });
 });
@@ -210,7 +210,7 @@ describe('Automation API - Domain - defaultIdentityProviderForRegistration refer
 
 describe('Automation API - Identity providers - payload validation', () => {
   it('should reject an unknown identity provider type (400)', async () => {
-    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+    const response = await fixture.client.putIdentity(fixture.domainKey, {
       ...buildInlineIdpDef({ key: uniqueName('autobadtype', true).toLowerCase(), users: defaultUsers }),
       type: 'unknown-am-idp',
     });
@@ -218,7 +218,7 @@ describe('Automation API - Identity providers - payload validation', () => {
   });
 
   it('should reject a configuration that is not valid JSON (400)', async () => {
-    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+    const response = await fixture.client.putIdentity(fixture.domainKey, {
       ...buildInlineIdpDef({ key: uniqueName('autobadcfg', true).toLowerCase(), users: defaultUsers }),
       configuration: 'not-json',
     });
@@ -230,12 +230,12 @@ describe('Automation API - Identity providers - payload validation', () => {
       key: uniqueName('autonocfg', true).toLowerCase(),
       users: defaultUsers,
     });
-    const response = await fixture.client.putIdentityProvider(fixture.domainKey, withoutConfiguration);
+    const response = await fixture.client.putIdentity(fixture.domainKey, withoutConfiguration);
     expect(response.status).toBe(400);
   });
 
   it('should reject an empty configuration (400)', async () => {
-    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+    const response = await fixture.client.putIdentity(fixture.domainKey, {
       ...buildInlineIdpDef({ key: uniqueName('autoemptycfg', true).toLowerCase(), users: defaultUsers }),
       configuration: '',
     });
@@ -247,7 +247,7 @@ describe('Automation API - Identity providers - payload validation', () => {
     createdIdpKeys.push(key);
     const base = buildInlineIdpDef({ key, users: defaultUsers });
     const configuration = JSON.stringify({ ...JSON.parse(base.configuration), extraUnknownField: 'tolerated' });
-    const response = await fixture.client.putIdentityProvider(fixture.domainKey, { ...base, configuration });
+    const response = await fixture.client.putIdentity(fixture.domainKey, { ...base, configuration });
     expect(response.status).toBe(200);
   });
 });
@@ -263,7 +263,7 @@ describe('Automation API - System identity provider', () => {
   it('should be idempotent on re-PUT of a system identity provider (200, no update)', async () => {
     const { key } = await createSystemIdp();
 
-    const response = await fixture.client.putIdentityProvider(fixture.domainKey, buildSystemAutomationDef(key));
+    const response = await fixture.client.putIdentity(fixture.domainKey, buildSystemAutomationDef(key));
     expect(response.status).toBe(200);
     expect(response.body.system).toBe(true);
     expect(response.body.key).toEqual(key);
@@ -272,7 +272,7 @@ describe('Automation API - System identity provider', () => {
   it('should reject a second system identity provider (400)', async () => {
     await createSystemIdp();
 
-    const response = await fixture.client.putIdentityProvider(
+    const response = await fixture.client.putIdentity(
       fixture.domainKey,
       buildSystemAutomationDef(uniqueName('autosysidp2', true).toLowerCase()),
     );
@@ -283,7 +283,7 @@ describe('Automation API - System identity provider', () => {
     const { key } = await createSystemIdp();
 
     // the IdP was created with system:true; PUT it again as non-system -> rejected (immutable)
-    const response = await fixture.client.putIdentityProvider(
+    const response = await fixture.client.putIdentity(
       fixture.domainKey,
       buildInlineIdpDef({ key, system: false, users: [{ username: 'def', password: 'P@ssword1' }] }),
     );
@@ -293,7 +293,7 @@ describe('Automation API - System identity provider', () => {
   it('should delete the system identity provider without a system guard', async () => {
     const { key } = await createSystemIdp();
 
-    const del = await fixture.client.deleteIdentityProvider(fixture.domainKey, key);
+    const del = await fixture.client.deleteIdentity(fixture.domainKey, key);
     expect(del.status).toBe(204);
   });
 });

--- a/gravitee-am-test/specs/management/automation/domain-identity-providers.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-identity-providers.jest.spec.ts
@@ -225,6 +225,23 @@ describe('Automation API - Identity providers - payload validation', () => {
     expect(response.status).toBe(400);
   });
 
+  it('should reject an omitted configuration (400)', async () => {
+    const { configuration, ...withoutConfiguration } = buildInlineIdpDef({
+      key: uniqueName('autonocfg', true).toLowerCase(),
+      users: defaultUsers,
+    });
+    const response = await fixture.client.putIdentityProvider(fixture.domainKey, withoutConfiguration);
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject an empty configuration (400)', async () => {
+    const response = await fixture.client.putIdentityProvider(fixture.domainKey, {
+      ...buildInlineIdpDef({ key: uniqueName('autoemptycfg', true).toLowerCase(), users: defaultUsers }),
+      configuration: '',
+    });
+    expect(response.status).toBe(400);
+  });
+
   it('should tolerate an unknown extra property in the configuration (200)', async () => {
     const key = uniqueName('autoextracfg', true).toLowerCase();
     createdIdpKeys.push(key);

--- a/gravitee-am-test/specs/management/automation/fixtures/automation-client.ts
+++ b/gravitee-am-test/specs/management/automation/fixtures/automation-client.ts
@@ -58,22 +58,22 @@ export class AutomationClient {
     return performDelete(automationUrl(), `${envPath()}/domains/${key}`, this.headers());
   }
 
-  // ---- Identity providers (under a domain) ------------------------------
+  // ---- Identities (under a domain) --------------------------------------
 
-  listIdentityProviders(domainKey: string) {
-    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/identity-providers`, this.headers());
+  listIdentities(domainKey: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/identities`, this.headers());
   }
 
-  putIdentityProvider(domainKey: string, definition: object) {
-    return performPut(automationUrl(), `${envPath()}/domains/${domainKey}/identity-providers`, definition, this.headers());
+  putIdentity(domainKey: string, definition: object) {
+    return performPut(automationUrl(), `${envPath()}/domains/${domainKey}/identities`, definition, this.headers());
   }
 
-  getIdentityProvider(domainKey: string, idpKey: string) {
-    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/identity-providers/${idpKey}`, this.headers());
+  getIdentity(domainKey: string, identityKey: string) {
+    return performGet(automationUrl(), `${envPath()}/domains/${domainKey}/identities/${identityKey}`, this.headers());
   }
 
-  deleteIdentityProvider(domainKey: string, idpKey: string) {
-    return performDelete(automationUrl(), `${envPath()}/domains/${domainKey}/identity-providers/${idpKey}`, this.headers());
+  deleteIdentity(domainKey: string, identityKey: string) {
+    return performDelete(automationUrl(), `${envPath()}/domains/${domainKey}/identities/${identityKey}`, this.headers());
   }
 
   // ---- Certificates (under a domain) ------------------------------------

--- a/gravitee-am-test/specs/management/automation/walkthrough.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/walkthrough.jest.spec.ts
@@ -71,7 +71,7 @@ describe('Walkthrough - Step 1: Create Domain and its Identity Providers', () =>
   });
 
   it('should create the test-users and corporate identity providers under the domain', async () => {
-    const testUsers = await client.putIdentityProvider(
+    const testUsers = await client.putIdentity(
       DOMAIN_KEY,
       buildInlineIdpDef({
         key: TEST_USERS_IDP_KEY,
@@ -84,7 +84,7 @@ describe('Walkthrough - Step 1: Create Domain and its Identity Providers', () =>
     );
     expect(testUsers.status).toBe(200);
 
-    const corporate = await client.putIdentityProvider(
+    const corporate = await client.putIdentity(
       DOMAIN_KEY,
       buildInlineIdpDef({
         key: CORPORATE_IDP_KEY,
@@ -96,7 +96,7 @@ describe('Walkthrough - Step 1: Create Domain and its Identity Providers', () =>
   });
 
   it('should list both identity providers under the domain', async () => {
-    const res = await client.listIdentityProviders(DOMAIN_KEY);
+    const res = await client.listIdentities(DOMAIN_KEY);
     expect(res.status).toBe(200);
     const idpNames = res.body.map((idp: any) => idp.name);
     expect(idpNames).toContain('Test Users');
@@ -130,8 +130,8 @@ describe('Walkthrough - Step 3: Verify Idempotency', () => {
   });
 
   it('should re-PUT an identity provider and preserve its createdAt', async () => {
-    const first = await client.getIdentityProvider(DOMAIN_KEY, TEST_USERS_IDP_KEY);
-    const second = await client.putIdentityProvider(
+    const first = await client.getIdentity(DOMAIN_KEY, TEST_USERS_IDP_KEY);
+    const second = await client.putIdentity(
       DOMAIN_KEY,
       buildInlineIdpDef({
         key: TEST_USERS_IDP_KEY,

--- a/gravitee-am-test/specs/management/identity-provider/identity-provider.jest.spec.ts
+++ b/gravitee-am-test/specs/management/identity-provider/identity-provider.jest.spec.ts
@@ -118,3 +118,68 @@ describe('after creating identity providers', () => {
     expect(idpSet.length).toEqual(10);
   });
 });
+
+describe('identity provider configuration validation', () => {
+  let validIdpId: string;
+
+  beforeAll(async () => {
+    const { newIdp } = buildIdp(100);
+    const created = await createIdp(fixture.domain.id, fixture.accessToken, newIdp);
+    validIdpId = created.id;
+  });
+
+  afterAll(async () => {
+    if (validIdpId) {
+      await deleteIdp(fixture.domain.id, fixture.accessToken, validIdpId);
+    }
+  });
+
+  it('rejects create with an omitted configuration (400)', async () => {
+    const { configuration, ...withoutConfiguration } = buildIdp(101).newIdp;
+    await expect(createIdp(fixture.domain.id, fixture.accessToken, withoutConfiguration)).rejects.toMatchObject({
+      response: { status: 400 },
+    });
+  });
+
+  it('rejects create with an empty configuration (400)', async () => {
+    const { newIdp } = buildIdp(102);
+    await expect(
+      createIdp(fixture.domain.id, fixture.accessToken, { ...newIdp, configuration: '' }),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+  });
+
+  it('rejects create with a malformed JSON configuration (400)', async () => {
+    const { newIdp } = buildIdp(103);
+    await expect(
+      createIdp(fixture.domain.id, fixture.accessToken, { ...newIdp, configuration: 'not-json' }),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+  });
+
+  it('rejects update with an omitted configuration (400)', async () => {
+    await expect(
+      updateIdp(fixture.domain.id, fixture.accessToken, { name: 'inmemory', type: 'inline-am-idp' }, validIdpId),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+  });
+
+  it('rejects update with an empty configuration (400)', async () => {
+    await expect(
+      updateIdp(
+        fixture.domain.id,
+        fixture.accessToken,
+        { name: 'inmemory', type: 'inline-am-idp', configuration: '' },
+        validIdpId,
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+  });
+
+  it('rejects update with a malformed JSON configuration (400)', async () => {
+    await expect(
+      updateIdp(
+        fixture.domain.id,
+        fixture.accessToken,
+        { name: 'inmemory', type: 'inline-am-idp', configuration: 'not-json' },
+        validIdpId,
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7115](https://gravitee.atlassian.net/browse/AM-7115)

## :pencil2: A description of the changes proposed in the pull request
Provide predictable and consistent validation for `configuration` property values in API endpoints. Affects
- Management API `POST`/`PUT` `identities`/`reporters`/`certificates` operations
- Automation API `PUT` `identities`/`reporters`/`certificates` operations

Additionally, rename Automation API resource `identity-providers` -> `identities` for consistency with existing Management REST endpoints.

## :memo: Test scenarios 
See Jira for examples ([AM-7115](https://gravitee.atlassian.net/browse/AM-7115), [AM-7114](https://gravitee.atlassian.net/browse/AM-7114)), or attempt any create or update operation with `identities`/`reporters`/`certificates` with invalid (omitted, null, empty or malformed JSON) using the APIs.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7115]: https://gravitee.atlassian.net/browse/AM-7115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AM-7114]: https://gravitee.atlassian.net/browse/AM-7114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ