### PR TITLE
fix: AM-7127 harden cert/reporter resource validation

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/CertificatesResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/CertificatesResource.java
@@ -158,6 +158,16 @@ public class CertificatesResource extends AbstractAutomationResource {
                                 // re-PUT is an idempotent no-op
                                 return Single.just(AutomationCertificateMapper.toAutomationCertificate(existing));
                             }
+                            // 'type' is an immutable identity attribute; reject a change early
+                            if (!isBlank(definition.getType()) && !definition.getType().equals(existing.getType())) {
+                                return Single.error(new InvalidParameterException(
+                                        "The 'type' is immutable for an existing certificate '" + key
+                                                + "'; delete and recreate it to change it"));
+                            }
+                            Single<AutomationCertificate> updateRejection = rejectIfMissingCertificateFields(definition, key);
+                            if (updateRejection != null) {
+                                return updateRejection;
+                            }
                             return certificateService.update(domain, existing.getId(),
                                             AutomationCertificateMapper.toUpdateCertificate(definition), principal)
                                     .map(AutomationCertificateMapper::toAutomationCertificate);

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/ReportersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/ReportersResource.java
@@ -25,12 +25,10 @@ import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.Reporter;
 import io.gravitee.am.model.permissions.Permission;
-import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.ReporterService;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.model.AutomationNewReporter;
-import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -75,9 +73,6 @@ public class ReportersResource extends AbstractAutomationResource {
 
     @Autowired
     private ReporterPluginService reporterPluginService;
-
-    @Autowired
-    private PluginConfigurationValidationService validationService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -169,6 +164,16 @@ public class ReportersResource extends AbstractAutomationResource {
                                 // re-PUT is an idempotent no-op
                                 return Single.just(AutomationReporterMapper.toAutomationReporter(existing));
                             }
+                            // 'type' is an immutable identity attribute; reject a change early
+                            if (!isBlank(definition.getType()) && !definition.getType().equals(existing.getType())) {
+                                return Single.error(new InvalidParameterException(
+                                        "The 'type' is immutable for an existing reporter '" + key
+                                                + "'; delete and recreate it to change it"));
+                            }
+                            Single<AutomationReporter> updateRejection = rejectIfMissingReporterFields(definition, key);
+                            if (updateRejection != null) {
+                                return updateRejection;
+                            }
                             return reporterPluginService.checkPluginDeployment(definition.getType())
                                     .andThen(reporterService.update(reference, existing.getId(),
                                             AutomationReporterMapper.toUpdateReporter(definition), principal, false))
@@ -199,8 +204,6 @@ public class ReportersResource extends AbstractAutomationResource {
                         AutomationNewReporter newReporter = AutomationReporterMapper.toNewReporter(definition);
                         newReporter.setId(reporterId);
                         return reporterPluginService.checkPluginDeployment(definition.getType())
-                                .andThen(Completable.fromAction(() ->
-                                        validationService.validate(definition.getType(), definition.getConfiguration())))
                                 .andThen(Single.defer(() -> reporterService.create(reference, newReporter, principal, false)))
                                 .map(AutomationReporterMapper::toAutomationReporter);
                     });

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/CertificatesResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/CertificatesResourceTest.java
@@ -20,6 +20,7 @@ import io.gravitee.am.management.handlers.automation.model.AutomationCertificate
 import io.gravitee.am.model.Certificate;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -182,6 +183,90 @@ class CertificatesResourceTest extends AutomationJerseySpringTest {
         Response response = put(certificatesTarget(DOMAIN_KEY), definition("my-cert", false));
 
         assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void put_create_propagates_invalid_configuration_as_400() {
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId))).thenReturn(Flowable.empty());
+        when(certificateService.create(any(Domain.class), any(), any(), eq(false)))
+                .thenReturn(Single.error(InvalidPluginConfigurationException.fromValidationError("not valid")));
+
+        AutomationCertificate def = definition("my-cert", false);
+        def.setConfiguration("not-json");
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(certificateService).create(any(Domain.class), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_update_rejects_missing_required_fields() {
+        String certId = AutomationIds.certificateId(domainId, "my-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert(certId, "my-cert", false, ManagedBy.AUTOMATION_API)));
+
+        AutomationCertificate def = new AutomationCertificate();
+        def.setAutomationKey("my-cert");
+        // name and type intentionally omitted
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(certificateService, never()).update(any(Domain.class), eq(certId), any(), any());
+    }
+
+    @Test
+    void put_update_rejects_configuration_not_matching_schema() {
+        String certId = AutomationIds.certificateId(domainId, "my-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert(certId, "my-cert", false, ManagedBy.AUTOMATION_API)));
+        when(certificateService.update(any(Domain.class), eq(certId), any(), any()))
+                .thenReturn(Single.error(InvalidPluginConfigurationException.fromValidationError("not valid")));
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), definition("my-cert", false));
+
+        assertEquals(400, response.getStatus());
+        verify(certificateService).update(any(Domain.class), eq(certId), any(), any());
+    }
+
+    @Test
+    void put_update_rejects_blank_configuration() {
+        String certId = AutomationIds.certificateId(domainId, "my-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert(certId, "my-cert", false, ManagedBy.AUTOMATION_API)));
+
+        AutomationCertificate def = definition("my-cert", false);
+        def.setConfiguration("");
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("Field 'configuration' is required for a non-system certificate"));
+        verify(certificateService, never()).update(any(Domain.class), eq(certId), any(), any());
+    }
+
+    @Test
+    void put_update_rejects_type_change_without_config_checks() {
+        String certId = AutomationIds.certificateId(domainId, "my-cert");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(certificateService.findByDomain(eq(domainId)))
+                .thenReturn(Flowable.just(cert(certId, "my-cert", false, ManagedBy.AUTOMATION_API)));
+
+        AutomationCertificate def = definition("my-cert", false); // existing type is javakeystore-am-certificate
+        def.setType("pkcs12-am-certificate");
+
+        Response response = put(certificatesTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("The 'type' is immutable for an existing certificate"));
+        verify(certificateService, never()).update(any(Domain.class), eq(certId), any(), any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReportersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/ReportersResourceTest.java
@@ -39,7 +39,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -212,12 +211,12 @@ class ReportersResourceTest extends AutomationJerseySpringTest {
     }
 
     @Test
-    void put_rejects_configuration_not_matching_schema() {
-        // A configuration that fails schema validation (e.g. malformed / non-conforming) is rejected.
+    void put_create_propagates_invalid_configuration_as_400() {
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
         when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
-        doThrow(InvalidPluginConfigurationException.fromValidationError("not valid"))
-                .when(validationService).validate(eq("reporter-am-file"), anyString());
+        when(reporterPluginService.checkPluginDeployment(eq("reporter-am-file"))).thenReturn(Completable.complete());
+        when(reporterService.create(eq(reference), any(), any(), eq(false)))
+                .thenReturn(Single.error(InvalidPluginConfigurationException.fromValidationError("not valid")));
 
         AutomationReporter def = definition("audit-log", false);
         def.setConfiguration("not-json");
@@ -225,11 +224,12 @@ class ReportersResourceTest extends AutomationJerseySpringTest {
         Response response = put(reportersTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
-        verify(reporterService, never()).create(eq(reference), any(), any(), eq(false));
+        verify(reporterPluginService).checkPluginDeployment(eq("reporter-am-file"));
+        verify(reporterService).create(eq(reference), any(), any(), eq(false));
     }
 
     @Test
-    void put_validates_type_and_configuration_before_create() {
+    void put_checks_plugin_deployment_before_create() {
         String reporterId = AutomationIds.reporterId(domainId, "audit-log");
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
         when(reporterService.findByReference(eq(reference))).thenReturn(Flowable.empty());
@@ -240,7 +240,6 @@ class ReportersResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(200, response.getStatus());
         verify(reporterPluginService).checkPluginDeployment(eq("reporter-am-file"));
-        verify(validationService).validate(eq("reporter-am-file"), eq("{}"));
     }
 
     @Test
@@ -255,6 +254,77 @@ class ReportersResourceTest extends AutomationJerseySpringTest {
         Response response = put(reportersTarget(DOMAIN_KEY), definition("audit-log", false));
 
         assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void put_update_rejects_missing_required_fields() {
+        String reporterId = AutomationIds.reporterId(domainId, "audit-log");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+
+        AutomationReporter def = new AutomationReporter();
+        def.setAutomationKey("audit-log");
+        // name and type intentionally omitted
+
+        Response response = put(reportersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        verify(reporterService, never()).update(eq(reference), eq(reporterId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_update_rejects_configuration_not_matching_schema() {
+        String reporterId = AutomationIds.reporterId(domainId, "audit-log");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+        when(reporterPluginService.checkPluginDeployment(eq("reporter-am-file"))).thenReturn(Completable.complete());
+        when(reporterService.update(eq(reference), eq(reporterId), any(), any(), eq(false)))
+                .thenReturn(Single.error(InvalidPluginConfigurationException.fromValidationError("not valid")));
+
+        Response response = put(reportersTarget(DOMAIN_KEY), definition("audit-log", false));
+
+        assertEquals(400, response.getStatus());
+        verify(reporterPluginService).checkPluginDeployment(eq("reporter-am-file"));
+        verify(reporterService).update(eq(reference), eq(reporterId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_update_rejects_blank_configuration() {
+        String reporterId = AutomationIds.reporterId(domainId, "audit-log");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+
+        AutomationReporter def = definition("audit-log", false);
+        def.setConfiguration("");
+
+        Response response = put(reportersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("Field 'configuration' is required for a non-system reporter"));
+        verify(reporterService, never()).update(eq(reference), eq(reporterId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_update_rejects_type_change() {
+        String reporterId = AutomationIds.reporterId(domainId, "audit-log");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(reporterService.findByReference(eq(reference)))
+                .thenReturn(Flowable.just(reporter(reporterId, "audit-log", false, ManagedBy.AUTOMATION_API)));
+
+        AutomationReporter def = definition("audit-log", false); // existing type is reporter-am-file
+        def.setType("reporter-am-kafka");
+
+        Response response = put(reportersTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("The 'type' is immutable for an existing reporter"));
+        verify(reporterPluginService, never()).checkPluginDeployment(anyString());
+        verify(reporterService, never()).update(eq(reference), eq(reporterId), any(), any(), eq(false));
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/CertificateServiceImpl.java
@@ -56,6 +56,7 @@ import io.gravitee.am.service.exception.CertificateWithApplicationsException;
 import io.gravitee.am.service.exception.CertificateWithIdpException;
 import io.gravitee.am.service.exception.CertificateWithProtectedResourceException;
 import io.gravitee.am.service.exception.InvalidParameterException;
+import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.AutomationNewCertificate;
 import io.gravitee.am.service.model.NewCertificate;
@@ -239,6 +240,9 @@ public class CertificateServiceImpl implements CertificateService {
                     } catch (CertificateException ex) {
                         log.error("An error occurs while trying to create certificate configuration", ex);
                         return Single.error(ex);
+                    } catch (AbstractManagementException ex) {
+                        // a malformed configuration is a client error; preserve its 4xx status
+                        return Single.error(ex);
                     } catch (Exception ex) {
                         log.error("An error occurs while trying to create certificate configuration", ex);
                         return Single.error(new TechnicalManagementException("An error occurs while trying to create a certificate", ex));
@@ -271,12 +275,46 @@ public class CertificateServiceImpl implements CertificateService {
 
     @SneakyThrows
     private Certificate createCertificateWithEmbeddedKeys(String domain, NewCertificate newCertificate, boolean isSystem, String fileKey) {
-        JsonNode configuration = objectMapper.readTree(newCertificate.getConfiguration());
-        var file = objectMapper.readTree(configuration.get(fileKey).asText());
+        ObjectNode configuration = (ObjectNode) objectMapper.readTree(newCertificate.getConfiguration());
+        EmbeddedFile file = parseEmbeddedFile(requireFileValue(configuration, fileKey), fileKey);
         // update configuration to set the file name
-        ((ObjectNode) configuration).put(fileKey, file.get(NAME).asText());
+        configuration.put(fileKey, file.name());
         newCertificate.setConfiguration(objectMapper.writeValueAsString(configuration));
-        return createCertificate(domain, newCertificate, isSystem, Base64.getDecoder().decode(file.get(CONTENT).asText()));
+        return createCertificate(domain, newCertificate, isSystem, file.content());
+    }
+
+    /**
+     * Read the value carried under {@code fileKey} in a certificate configuration.
+     */
+    private String requireFileValue(JsonNode configuration, String fileKey) {
+        JsonNode node = configuration.get(fileKey);
+        if (node == null || node.isNull() || !node.isTextual() || node.asText().isBlank()) {
+            throw InvalidPluginConfigurationException.fromValidationError("Field '" + fileKey + "' is required");
+        }
+        return node.asText();
+    }
+
+    /**
+     * Parse the embedded keystore file ({@code content} + {@code name}) carried as the value of a file field.
+     */
+    private EmbeddedFile parseEmbeddedFile(String fileValue, String fileKey) {
+        final JsonNode file;
+        try {
+            file = objectMapper.readTree(fileValue);
+        } catch (JsonProcessingException e) {
+            throw InvalidPluginConfigurationException.fromValidationError("Field '" + fileKey + "' must contain a valid certificate file");
+        }
+        JsonNode contentNode = file == null ? null : file.get(CONTENT);
+        JsonNode nameNode = file == null ? null : file.get(NAME);
+        if (contentNode == null || !contentNode.isTextual() || nameNode == null || !nameNode.isTextual()) {
+            throw InvalidPluginConfigurationException.fromValidationError(
+                    "Field '" + fileKey + "' must contain a certificate file with 'content' and 'name'");
+        }
+        try {
+            return new EmbeddedFile(Base64.getDecoder().decode(contentNode.asText()), nameNode.asText());
+        } catch (IllegalArgumentException e) {
+            throw InvalidPluginConfigurationException.fromValidationError("Field '" + fileKey + "' contains invalid Base64 file content");
+        }
     }
 
     private Certificate createCertificate(String domain, NewCertificate newCertificate, boolean isSystem) {
@@ -333,6 +371,10 @@ public class CertificateServiceImpl implements CertificateService {
                     }
                 })
                 .flatMap(oldCertificate -> {
+                    Certificate existing = oldCertificate.certificate();
+                    if (!existing.isSystem()) {
+                        ensureParseableConfiguration(updateCertificate.getConfiguration());
+                    }
                     var certificate = getCertificateToUpdate(updateCertificate, oldCertificate);
 
                     Optional<String> newAlias = extractAlias(certificate.getConfiguration());
@@ -378,13 +420,28 @@ public class CertificateServiceImpl implements CertificateService {
                 });
     }
 
+    /**
+     * Ensure a user-supplied configuration is present and well-formed JSON before it is parsed for key
+     * embedding.
+     */
+    private void ensureParseableConfiguration(String configuration) {
+        if (configuration == null || configuration.isBlank()) {
+            throw InvalidPluginConfigurationException.fromValidationError("configuration is required");
+        }
+        try {
+            objectMapper.readTree(configuration);
+        } catch (JsonProcessingException e) {
+            throw InvalidPluginConfigurationException.fromValidationError("configuration is not valid JSON");
+        }
+    }
+
     private Certificate getCertificateToUpdate(UpdateCertificate updateCertificate, CertificateWithSchema oldCertificate) throws JsonProcessingException, CertificateException {
         var certificateToUpdate = new Certificate(oldCertificate.certificate());
         certificateToUpdate.setName(updateCertificate.getName());
         certificateToUpdate.setUpdatedAt(new Date());
-        // System certificate config is normally immutable through the API, but the Automation API owns the
-        // lifecycle of the resources it manages, so it may update their configuration.
-        if (!certificateToUpdate.isSystem() || certificateToUpdate.getManagedBy() == ManagedBy.AUTOMATION_API) {
+        // A system certificate's configuration is immutable through the service layer (it is owned by
+        // gravitee.yaml); only a non-system certificate's configuration is updated.
+        if (!certificateToUpdate.isSystem()) {
             oldCertificate.schema.getFileKey().ifPresent(fileKey -> updateEmbeddedKeys(updateCertificate, certificateToUpdate, oldCertificate, fileKey));
             certificateToUpdate.setConfiguration(updateCertificate.getConfiguration());
         }
@@ -397,15 +454,16 @@ public class CertificateServiceImpl implements CertificateService {
                                     Certificate certificateToUpdate,
                                     CertificateWithSchema oldCertificate,
                                     String fileKey) {
-        JsonNode updateCertJson = objectMapper.readTree(updateCertificate.getConfiguration());
-        var oldFileInformation = objectMapper.readTree(oldCertificate.certificate().getConfiguration()).get(fileKey).asText();
-        var fileInformation = updateCertJson.get(fileKey).asText();
+        ObjectNode updateCertJson = (ObjectNode) objectMapper.readTree(updateCertificate.getConfiguration());
+        var fileInformation = requireFileValue(updateCertJson, fileKey);
+        JsonNode oldFileNode = objectMapper.readTree(oldCertificate.certificate().getConfiguration()).get(fileKey);
+        var oldFileInformation = oldFileNode == null ? null : oldFileNode.asText();
         // file has changed, let's update it
         if (!oldFileInformation.equals(fileInformation)) {
-            var file = objectMapper.readTree(fileInformation);
-            certificateToUpdate.setMetadata(Maps.newHashMap(Map.of(FILE, Base64.getDecoder().decode(file.get(CONTENT).asText()))));
+            EmbeddedFile file = parseEmbeddedFile(fileInformation, fileKey);
+            certificateToUpdate.setMetadata(Maps.newHashMap(Map.of(FILE, file.content())));
             // update configuration to set the file path
-            ((ObjectNode) updateCertJson).put(fileKey, file.get(NAME).asText());
+            updateCertJson.put(fileKey, file.name());
         }
         updateCertificate.setConfiguration(objectMapper.writeValueAsString(updateCertJson));
     }
@@ -720,5 +778,8 @@ public class CertificateServiceImpl implements CertificateService {
         validationResult.getAdditionalInformation("expDate", Date.class)
             .ifPresent(certificate::setExpiresAt);
         return certificate;
+    }
+
+    private record EmbeddedFile(byte[] content, String name) {
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/CertificateServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/CertificateServiceTest.java
@@ -334,6 +334,38 @@ public class CertificateServiceTest {
     }
 
     @Test
+    public void shouldNotCreate_missingFileContent_returnsInvalidPluginConfigurationException() {
+        var type = DEFAULT_CERTIFICATE_PLUGIN;
+        when(certificatePluginService.getSchema(type)).thenReturn(Maybe.just(certificateSchemaDefinition));
+        var newCertificate = new NewCertificate();
+        newCertificate.setName("cert");
+        newCertificate.setType(type);
+        newCertificate.setConfiguration("{\"storepass\":\"ca-secret\",\"alias\":\"test-cert\",\"keypass\":\"ca-secret\"}");
+
+        TestObserver<Certificate> testObserver = certificateService.create(DOMAIN, newCertificate, Mockito.mock(User.class)).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertError(InvalidPluginConfigurationException.class);
+
+        verify(certificateRepository, never()).create(any());
+    }
+
+    @Test
+    public void shouldNotCreate_malformedFileContent_returnsInvalidPluginConfigurationException() {
+        var type = DEFAULT_CERTIFICATE_PLUGIN;
+        when(certificatePluginService.getSchema(type)).thenReturn(Maybe.just(certificateSchemaDefinition));
+        var newCertificate = new NewCertificate();
+        newCertificate.setName("cert");
+        newCertificate.setType(type);
+        newCertificate.setConfiguration("{\"content\":\"not-a-file-object\",\"storepass\":\"ca-secret\",\"alias\":\"test-cert\",\"keypass\":\"ca-secret\"}");
+
+        TestObserver<Certificate> testObserver = certificateService.create(DOMAIN, newCertificate, Mockito.mock(User.class)).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertError(InvalidPluginConfigurationException.class);
+
+        verify(certificateRepository, never()).create(any());
+    }
+
+    @Test
     public void shouldCreateAwsCertificate() {
         var type = "aws-am-certificate";
         when(certificatePluginService.getSchema(type)).thenReturn(Maybe.just(certificateAwsSchemaDefinition));
@@ -381,6 +413,44 @@ public class CertificateServiceTest {
         verify(certificateRepository, times(1)).update(any());
         verify(eventService, times(1)).create(any(), any());
         verify(validationService).validate(any(), any());
+    }
+
+    @Test
+    public void shouldNotUpdate_malformedConfiguration_rejectedBeforeKeyEmbedding() {
+        var id = "123";
+        var type = DEFAULT_CERTIFICATE_PLUGIN; // has a file key, so a malformed config fails during key embedding
+        when(certificatePluginService.getSchema(type)).thenReturn(Maybe.just(certificateSchemaDefinition));
+        var updateCertificate = new UpdateCertificate();
+        updateCertificate.setConfiguration("not-json");
+        var certificate = new Certificate(); // non-system
+        certificate.setType(type);
+        when(certificateRepository.findById(any())).thenReturn(Maybe.just(certificate));
+
+        certificateService.update(DOMAIN, id, updateCertificate, Mockito.mock(User.class))
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(InvalidPluginConfigurationException.class);
+
+        verify(certificateRepository, never()).update(any());
+    }
+
+    @Test
+    public void shouldNotUpdate_missingFileContent_returnsInvalidPluginConfigurationException() {
+        var id = "123";
+        var type = DEFAULT_CERTIFICATE_PLUGIN;
+        when(certificatePluginService.getSchema(type)).thenReturn(Maybe.just(certificateSchemaDefinition));
+        var updateCertificate = new UpdateCertificate();
+        updateCertificate.setConfiguration("{\"storepass\":\"ca-secret\",\"alias\":\"test-cert\",\"keypass\":\"ca-secret\"}");
+        var certificate = new Certificate(); // non-system
+        certificate.setType(type);
+        when(certificateRepository.findById(any())).thenReturn(Maybe.just(certificate));
+
+        certificateService.update(DOMAIN, id, updateCertificate, Mockito.mock(User.class))
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(InvalidPluginConfigurationException.class);
+
+        verify(certificateRepository, never()).update(any());
     }
 
     @Test


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7127](https://gravitee.atlassian.net/browse/AM-7127)

## :pencil2: A description of the changes proposed in the pull request

Improve consistency of certificate and reporter validation for APIs.
- Return consistent missing field error for `configuration` field for new/updated resources - e.g.
```json
{
    "message": "Field 'configuration' is required for a non-system reporter 'test-reporter'",
    "http_status": 400
}
```
- Format AAPI message for `type` immutability to match that of IdP resource - e.g.
```json
{
    "message": "The 'type' is immutable for an existing reporter 'non-default-reporter'; delete and recreate it to change it",
    "http_status": 400
}
```
- Harden certificate validation to avoid 500 internal server errors - e.g. with invalid `configuration`
```json
{
    "message": "Field 'content' must contain a certificate file with 'content' and 'name'",
    "http_status": 400
}
```
- Simplify redundant conditions/validation
  - Remove AAPI-managed system cert updates in service layer (that was unreachable)
  - Remove validation in AAPI reporter create scenario (duplicated in service layer)
- Improve unit test coverage

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7127]: https://gravitee.atlassian.net/browse/AM-7127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ