### PR TITLE
chore: Playwright auth callback flakiness

### DIFF
--- a/gravitee-am-test/playwright/GUIDELINES.md
+++ b/gravitee-am-test/playwright/GUIDELINES.md
@@ -521,15 +521,18 @@ await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
 await page.waitForURL(/.*login.*/i);
 ```
 
-### Consent handling
+### OAuth callback and consent handling
 
-Not all OAuth flows trigger a consent page. Use the shared `handleConsentIfPresent` helper:
+Not all OAuth flows trigger a consent page. To finish an OAuth leg and assert an authorisation code in the redirect URI, use `reachOAuthAuthorizationCallback` — it polls `page.url()` for `callback` + `code=` and clicks through consent when needed. **Do not** pair `handleConsentIfPresent` with `waitForURL(/callback?code=/)`: the test redirect URI (`https://gravitee.io/callback`) is an external marketing site that may never reach the `load` event in CI while the URL already contains a valid `code`.
 
 ```typescript
-import { handleConsentIfPresent } from '../../../utils/webauthn-helpers';
+import { reachOAuthAuthorizationCallback } from '../../../utils/oauth-callback-helpers';
+// or from the area fixture barrel (e.g. webauthn.fixture, mfa-enrollment-matrix.fixture)
 
-await handleConsentIfPresent(page);  // uses BRIEF_TIMEOUT (5s) by default
+await reachOAuthAuthorizationCallback(page);
 ```
+
+Use `handleConsentIfPresent` only when you need to click consent mid-flow without waiting for the callback (rare). Composite helpers (`loginAndRegisterWebAuthn`, `fullMfaLogin`, etc.) call `reachOAuthAuthorizationCallback` internally.
 
 ### Navigation helpers for non-deterministic routing
 
@@ -549,7 +552,7 @@ The conditional in the helper handles infrastructure non-determinism, not a feat
 
 ### Second authorisation in the same browser context
 
-If a test runs **two** OAuth round-trips on the same `page` / context, the gateway may still hold an **end-user session** after the first callback. A second `goto(authorizeUrl)` can then skip `/login` and sometimes **skip step-up MFA**, going straight to the client **callback with `code`**. Helpers that treat “callback + code” as a successful wait target return immediately while your test still expects `/mfa/challenge` or `/login` — leading to timeouts.
+If a test runs **two** OAuth round-trips on the same `page` / context, the gateway may still hold an **end-user session** after the first callback. A second `goto(authorizeUrl)` can then skip `/login` and sometimes **skip step-up MFA**, going straight to the client **callback with `code`**. Calling `reachOAuthAuthorizationCallback` when you still expect `/mfa/challenge` or `/login` will return immediately on the short-circuited callback — leading to timeouts on the next assertion.
 
 When the scenario requires a **fresh login** or **MFA challenge** on the second leg, call `await page.context().clearCookies()` before that authorisation (or use a new context). The Xray parity example under [§6](#6-xray-test-parity) uses the same pattern for a second login path.
 
@@ -604,9 +607,10 @@ Use the shared helpers for common multi-step flows:
 
 | Helper | Flow |
 |---|---|
-| `loginAndRegisterWebAuthn(page, gatewayUrl, clientId, username, password)` | Login → WebAuthn register → consent → callback |
-| `passwordlessLogin(page, auth, gatewayUrl, clientId, username)` | Authorize → login → passwordless link → WebAuthn login → consent → callback |
-| `fullLoginWithMfaAndWebAuthn(page, gatewayUrl, clientId, username, password, mfaCode, rememberDevice)` | Login → WebAuthn register → MFA enroll → MFA challenge → consent → callback |
+| `loginAndRegisterWebAuthn(page, gatewayUrl, clientId, username, password)` | Login → WebAuthn register → callback (`reachOAuthAuthorizationCallback`) |
+| `passwordlessLogin(page, auth, gatewayUrl, clientId, username)` | Authorize → login → passwordless link → WebAuthn login → callback |
+| `fullLoginWithMfaAndWebAuthn(page, gatewayUrl, clientId, username, password, mfaCode, rememberDevice)` | Login → WebAuthn register → MFA enroll → MFA challenge → callback |
+| `reachOAuthAuthorizationCallback(page)` | Poll URL for `callback?code=`; handle consent between hops (use instead of `waitForURL(/callback?code=/)`) |
 | `navigateToWebAuthnLogin(page, gatewayUrl, clientId)` | Navigate to WebAuthn login (handles non-deterministic routing) |
 | `clearSessionOnly(page)` | Clear session cookie only (preserve device recognition) |
 
@@ -699,6 +703,7 @@ From `playwright.config.ts`:
 | 400 errors, fields silently missing | Native fetch instead of cross-fetch | Ensure `base.fixture.ts` sets `globalThis.fetch = crossFetch` |
 | "Element detached from DOM" | `*ngIf` + `.clear()` removes element | Use triple-click + `pressSequentially()` |
 | `waitForURL(/mfa\/challenge/)` timeout on second OAuth | Prior leg left an AM session; second `/authorize` hits callback without step-up | `await page.context().clearCookies()` before the second authorisation (see [Gateway Page Tests §16](#16-gateway-page-tests)) |
+| `waitForURL(/callback?code=/)` timeout; page shows gravitee.io 404 | Redirect URI is external; `waitForURL` waits for `load` on marketing site | Use `reachOAuthAuthorizationCallback` (polls URL for `code=`) |
 | `Cannot find module '.../api/commands/...'` when loading spec | Wrong relative depth: `../../api` from `playwright/tests/<area>/` resolves under `playwright/`, not `gravitee-am-test/api` | **Prefer aliases** (`@management-commands/...`, `@utils-commands/...`, `@management-models/...`) — same as Jest; resolved at runtime via `playwright/utils/register-paths.ts`. If using relatives: from `playwright/tests/<one-level>/` use `../../../api/...`; from `playwright/fixtures/` use `../../api/...` |
 | Themed `img.logo` still shows `gravitee-logo.svg` | Theme updated only after the gateway loaded the domain context | Set logo and colour fields **before** `startDomain`, or wait for theme propagation and reload the login page |
 

--- a/gravitee-am-test/playwright/fixtures/global.setup.ts
+++ b/gravitee-am-test/playwright/fixtures/global.setup.ts
@@ -29,9 +29,7 @@ export async function cleanupTestDomains(label: string): Promise<void> {
   try {
     const token = await requestAdminAccessToken();
     const page = await listDomains(token, { size: 200 });
-    const staleDomains = (page.data || []).filter((d) =>
-      TEST_DOMAIN_PREFIXES.some((prefix) => d.name?.startsWith(prefix)),
-    );
+    const staleDomains = (page.data || []).filter((d) => TEST_DOMAIN_PREFIXES.some((prefix) => d.name?.startsWith(prefix)));
 
     if (staleDomains.length === 0) return;
 

--- a/gravitee-am-test/playwright/fixtures/login-flows-external-oidc.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/login-flows-external-oidc.fixture.ts
@@ -60,9 +60,7 @@ export const test = base.extend<{ externalOidcBundle: ExternalOidcBundle; hideLo
     const adminToken = await requestAdminAccessToken();
     const gatewayBase = getGatewayBaseUrl();
 
-    const clientDomain = await quietly(() =>
-      createDomain(adminToken, uniqueTestName('pw-oidc-client'), 'Phase 7 AM-2207 client domain'),
-    );
+    const clientDomain = await quietly(() => createDomain(adminToken, uniqueTestName('pw-oidc-client'), 'Phase 7 AM-2207 client domain'));
 
     let providerDomain = await quietly(() =>
       createDomain(adminToken, uniqueTestName('pw-oidc-provider'), 'Phase 7 AM-2207 provider domain'),

--- a/gravitee-am-test/playwright/fixtures/login-flows-password-mfa-remember.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/login-flows-password-mfa-remember.fixture.ts
@@ -59,9 +59,7 @@ export const test = base.extend<PasswordMfaRememberFixtures>({
 
   rememberDomain: async ({ adminToken }, use) => {
     const name = uniqueTestName('pw-mfa-remember-pw');
-    const domain = await quietly(() =>
-      createDomain(adminToken, name, 'Phase 7 AM-2218 — password MFA + remember device'),
-    );
+    const domain = await quietly(() => createDomain(adminToken, name, 'Phase 7 AM-2218 — password MFA + remember device'));
     await use(domain);
     await quietly(() => safeDeleteDomain(domain.id, adminToken));
   },
@@ -107,31 +105,36 @@ export const test = base.extend<PasswordMfaRememberFixtures>({
     );
 
     await quietly(() =>
-      patchApplication(rememberDomain.id, adminToken, {
-        settings: {
-          mfa: {
-            factor: {
-              defaultFactorId: rememberFactorId,
-              applicationFactors: [{ id: rememberFactorId, selectionRule: '' }],
+      patchApplication(
+        rememberDomain.id,
+        adminToken,
+        {
+          settings: {
+            mfa: {
+              factor: {
+                defaultFactorId: rememberFactorId,
+                applicationFactors: [{ id: rememberFactorId, selectionRule: '' }],
+              },
+              enroll: {
+                active: true,
+                forceEnrollment: true,
+                type: 'REQUIRED',
+              },
+              challenge: {
+                active: true,
+                type: 'REQUIRED',
+              },
+              rememberDevice: {
+                active: true,
+                deviceIdentifierId: rememberDeviceId,
+                expirationTimeSeconds: 600,
+              },
             },
-            enroll: {
-              active: true,
-              forceEnrollment: true,
-              type: 'REQUIRED',
-            },
-            challenge: {
-              active: true,
-              type: 'REQUIRED',
-            },
-            rememberDevice: {
-              active: true,
-              deviceIdentifierId: rememberDeviceId,
-              expirationTimeSeconds: 600,
-            },
+            advanced: { skipConsent: true },
           },
-          advanced: { skipConsent: true },
         },
-      }, app.id),
+        app.id,
+      ),
     );
 
     await use(app);
@@ -159,12 +162,10 @@ export const test = base.extend<PasswordMfaRememberFixtures>({
     await quietly(() => startDomain(rememberDomain.id, adminToken));
     await quietly(() => waitForDomainSync(rememberDomain.id, { timeoutMillis: 90_000, intervalMillis: 500 }));
     await waitForOidcReady(rememberDomain.hrid, { timeoutMs: 45_000, intervalMs: 500 });
-    await waitForOAuthAuthorizeRedirectsToLogin(
-      rememberDomain.hrid,
-      rememberApp.settings.oauth.clientId,
-      REDIRECT_URI,
-      { timeoutMs: 90_000, intervalMs: 500 },
-    );
+    await waitForOAuthAuthorizeRedirectsToLogin(rememberDomain.hrid, rememberApp.settings.oauth.clientId, REDIRECT_URI, {
+      timeoutMs: 90_000,
+      intervalMs: 500,
+    });
     await use(`${getGatewayBaseUrl()}/${rememberDomain.hrid}`);
   },
 });
@@ -176,4 +177,5 @@ export {
   enrollMockFactor,
   completeMfaChallenge,
   handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
 } from '../utils/mfa-helpers';

--- a/gravitee-am-test/playwright/fixtures/login-flows-recovery.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/login-flows-recovery.fixture.ts
@@ -56,9 +56,7 @@ export const test = base.extend<RecoveryFlowFixtures>({
 
   recoveryDomain: async ({ adminToken }, use) => {
     const name = uniqueTestName('pw-recovery-mfa');
-    const domain = await quietly(() =>
-      createDomain(adminToken, name, 'Phase 7 AM-2216 — MFA recovery codes'),
-    );
+    const domain = await quietly(() => createDomain(adminToken, name, 'Phase 7 AM-2216 — MFA recovery codes'));
     await use(domain);
     await quietly(() => safeDeleteDomain(domain.id, adminToken));
   },
@@ -105,29 +103,34 @@ export const test = base.extend<RecoveryFlowFixtures>({
     );
 
     await quietly(() =>
-      patchApplication(recoveryDomain.id, adminToken, {
-        settings: {
-          mfa: {
-            factor: {
-              defaultFactorId: mockFactorId,
-              applicationFactors: [
-                { id: mockFactorId, selectionRule: '' },
-                { id: recoveryFactorId, selectionRule: '' },
-              ],
+      patchApplication(
+        recoveryDomain.id,
+        adminToken,
+        {
+          settings: {
+            mfa: {
+              factor: {
+                defaultFactorId: mockFactorId,
+                applicationFactors: [
+                  { id: mockFactorId, selectionRule: '' },
+                  { id: recoveryFactorId, selectionRule: '' },
+                ],
+              },
+              enroll: {
+                active: true,
+                forceEnrollment: true,
+                type: 'REQUIRED',
+              },
+              challenge: {
+                active: true,
+                type: 'REQUIRED',
+              },
             },
-            enroll: {
-              active: true,
-              forceEnrollment: true,
-              type: 'REQUIRED',
-            },
-            challenge: {
-              active: true,
-              type: 'REQUIRED',
-            },
+            advanced: { skipConsent: true },
           },
-          advanced: { skipConsent: true },
         },
-      }, app.id),
+        app.id,
+      ),
     );
 
     await use(app);
@@ -155,12 +158,10 @@ export const test = base.extend<RecoveryFlowFixtures>({
     await quietly(() => startDomain(recoveryDomain.id, adminToken));
     await quietly(() => waitForDomainSync(recoveryDomain.id, { timeoutMillis: 90_000, intervalMillis: 500 }));
     await waitForOidcReady(recoveryDomain.hrid, { timeoutMs: 45_000, intervalMs: 500 });
-    await waitForOAuthAuthorizeRedirectsToLogin(
-      recoveryDomain.hrid,
-      recoveryApp.settings.oauth.clientId,
-      REDIRECT_URI,
-      { timeoutMs: 90_000, intervalMs: 500 },
-    );
+    await waitForOAuthAuthorizeRedirectsToLogin(recoveryDomain.hrid, recoveryApp.settings.oauth.clientId, REDIRECT_URI, {
+      timeoutMs: 90_000,
+      intervalMs: 500,
+    });
     await use(`${getGatewayBaseUrl()}/${recoveryDomain.hrid}`);
   },
 });
@@ -172,6 +173,7 @@ export {
   enrollMockFactor,
   completeMfaChallenge,
   handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   readFirstRecoveryCodeFromPage,
   submitRecoveryCodesContinue,
   openMfaChallengeAlternatives,

--- a/gravitee-am-test/playwright/fixtures/login-flows-role-mapper.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/login-flows-role-mapper.fixture.ts
@@ -64,9 +64,7 @@ export const test = base.extend<RoleMapperFlowFixtures>({
 
   mapperDomain: async ({ adminToken }, use) => {
     const name = uniqueTestName('pw-role-mapper');
-    const domain = await quietly(() =>
-      createDomain(adminToken, name, 'Phase 7 AM-2219 — IdP role mapper'),
-    );
+    const domain = await quietly(() => createDomain(adminToken, name, 'Phase 7 AM-2219 — IdP role mapper'));
     await use(domain);
     await quietly(() => safeDeleteDomain(domain.id, adminToken));
   },
@@ -113,14 +111,19 @@ export const test = base.extend<RoleMapperFlowFixtures>({
 
     // Role mapper before domain start (gateway not polling yet). Sync is applied when the domain starts below.
     await quietly(() =>
-      updateIdp(mapperDomain.id, adminToken, {
-        name: idp.name,
-        type: idp.type,
-        configuration: idp.configuration,
-        mappers: {},
-        roleMapper: { [mappedRoleName]: [`firstname=${MAPPED_FIRSTNAME}`] },
-        groupMapper: {},
-      }, idp.id),
+      updateIdp(
+        mapperDomain.id,
+        adminToken,
+        {
+          name: idp.name,
+          type: idp.type,
+          configuration: idp.configuration,
+          mappers: {},
+          roleMapper: { [mappedRoleName]: [`firstname=${MAPPED_FIRSTNAME}`] },
+          groupMapper: {},
+        },
+        idp.id,
+      ),
     );
 
     await use(idp);

--- a/gravitee-am-test/playwright/fixtures/mfa-default-factor-selection.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/mfa-default-factor-selection.fixture.ts
@@ -59,9 +59,7 @@ export const test = base.extend<MfaDefaultFactorFixtures>({
 
   defDomain: async ({ adminToken }, use) => {
     const name = uniqueTestName('pw-mfa-def-factor');
-    const domain = await quietly(() =>
-      createDomain(adminToken, name, 'Phase 9 AM-2820 — default factor when rules miss'),
-    );
+    const domain = await quietly(() => createDomain(adminToken, name, 'Phase 9 AM-2820 — default factor when rules miss'));
     await use(domain);
     await quietly(() => safeDeleteDomain(domain.id, adminToken));
   },
@@ -108,32 +106,37 @@ export const test = base.extend<MfaDefaultFactorFixtures>({
     );
 
     await quietly(() =>
-      patchApplication(defDomain.id, adminToken, {
-        settings: {
-          mfa: {
-            factor: {
-              defaultFactorId,
-              applicationFactors: [
-                {
-                  id: mismatchFactorId,
-                  selectionRule: "{#request.params['username'] matches '^__impossible_username__$'}",
-                },
-                { id: defaultFactorId, selectionRule: '' },
-              ],
+      patchApplication(
+        defDomain.id,
+        adminToken,
+        {
+          settings: {
+            mfa: {
+              factor: {
+                defaultFactorId,
+                applicationFactors: [
+                  {
+                    id: mismatchFactorId,
+                    selectionRule: "{#request.params['username'] matches '^__impossible_username__$'}",
+                  },
+                  { id: defaultFactorId, selectionRule: '' },
+                ],
+              },
+              enroll: {
+                active: true,
+                forceEnrollment: true,
+                type: 'REQUIRED',
+              },
+              challenge: {
+                active: true,
+                type: 'REQUIRED',
+              },
             },
-            enroll: {
-              active: true,
-              forceEnrollment: true,
-              type: 'REQUIRED',
-            },
-            challenge: {
-              active: true,
-              type: 'REQUIRED',
-            },
+            advanced: { skipConsent: true },
           },
-          advanced: { skipConsent: true },
         },
-      }, app.id),
+        app.id,
+      ),
     );
 
     await use(app);
@@ -176,4 +179,5 @@ export {
   enrollMockFactor,
   completeMfaChallenge,
   handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
 } from '../utils/mfa-helpers';

--- a/gravitee-am-test/playwright/fixtures/mfa-enrollment-matrix.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/mfa-enrollment-matrix.fixture.ts
@@ -200,12 +200,10 @@ export const test = base.extend<MfaMatrixFixtures>({
     await quietly(() => startDomain(matrixDomain.id, adminToken));
     await quietly(() => waitForDomainSync(matrixDomain.id, { timeoutMillis: 90_000, intervalMillis: 500 }));
     await waitForOidcReady(matrixDomain.hrid, { timeoutMs: 45_000, intervalMs: 500 });
-    await waitForOAuthAuthorizeRedirectsToLogin(
-      matrixDomain.hrid,
-      matrixApp.settings.oauth.clientId,
-      REDIRECT_URI,
-      { timeoutMs: 90_000, intervalMs: 500 },
-    );
+    await waitForOAuthAuthorizeRedirectsToLogin(matrixDomain.hrid, matrixApp.settings.oauth.clientId, REDIRECT_URI, {
+      timeoutMs: 90_000,
+      intervalMs: 500,
+    });
     await use(`${getGatewayBaseUrl()}/${matrixDomain.hrid}`);
   },
 });
@@ -217,6 +215,7 @@ export {
   enrollMockFactor,
   completeMfaChallenge,
   handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   skipMfaEnrollment,
   secondAuthorizeExpectCallbackWithoutMfa,
   waitAfterAuthorizeThenLoginIfNeeded,

--- a/gravitee-am-test/playwright/fixtures/mfa-login.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/mfa-login.fixture.ts
@@ -184,5 +184,6 @@ export {
   enrollMockFactor,
   completeMfaChallenge,
   handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   fullMfaLogin,
 } from '../utils/mfa-helpers';

--- a/gravitee-am-test/playwright/fixtures/token-exchange.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/token-exchange.fixture.ts
@@ -19,7 +19,13 @@ import crossFetch from 'cross-fetch';
 globalThis.fetch = crossFetch;
 
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
-import { createDomain, startDomain, waitForDomainSync, safeDeleteDomain, waitForOidcReady } from '@management-commands/domain-management-commands';
+import {
+  createDomain,
+  startDomain,
+  waitForDomainSync,
+  safeDeleteDomain,
+  waitForOidcReady,
+} from '@management-commands/domain-management-commands';
 import { waitForNextSync } from '@gateway-commands/monitoring-commands';
 import { getAllIdps } from '@management-commands/idp-management-commands';
 import { buildCreateAndTestUser } from '@management-commands/user-management-commands';
@@ -61,10 +67,7 @@ export const TOKEN_EXCHANGE_DEFAULTS = {
     'urn:ietf:params:oauth:token-type:id_token',
     'urn:ietf:params:oauth:token-type:jwt',
   ],
-  ALLOWED_REQUESTED_TOKEN_TYPES: [
-    'urn:ietf:params:oauth:token-type:access_token',
-    'urn:ietf:params:oauth:token-type:id_token',
-  ],
+  ALLOWED_REQUESTED_TOKEN_TYPES: ['urn:ietf:params:oauth:token-type:access_token', 'urn:ietf:params:oauth:token-type:id_token'],
   ALLOWED_ACTOR_TOKEN_TYPES: [
     'urn:ietf:params:oauth:token-type:access_token',
     'urn:ietf:params:oauth:token-type:id_token',
@@ -158,15 +161,14 @@ export function createTokenExchangeFixture(config: TokenExchangeConfig = {}) {
     },
 
     tokenExchangeApp: async ({ teAdminToken, tokenExchangeDomain }, use) => {
-      const {
-        grantTypes = TOKEN_EXCHANGE_DEFAULTS.GRANT_TYPES,
-        scopes = TOKEN_EXCHANGE_DEFAULTS.SCOPES,
-      } = config;
+      const { grantTypes = TOKEN_EXCHANGE_DEFAULTS.GRANT_TYPES, scopes = TOKEN_EXCHANGE_DEFAULTS.SCOPES } = config;
 
       const idpSet = await getAllIdps(tokenExchangeDomain.id, teAdminToken);
       const defaultIdp = idpSet.values().next().value;
       if (!defaultIdp) {
-        throw new Error(`No identity providers found for domain "${tokenExchangeDomain.id}". Cannot create token exchange app without an IdP.`);
+        throw new Error(
+          `No identity providers found for domain "${tokenExchangeDomain.id}". Cannot create token exchange app without an IdP.`,
+        );
       }
 
       const app = await quietly(() =>

--- a/gravitee-am-test/playwright/fixtures/webauthn-mfa.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/webauthn-mfa.fixture.ts
@@ -141,30 +141,35 @@ export const test = base.extend<MfaWebAuthnFixtures>({
 
     // Enable MFA with mock factor + remember device
     await quietly(() =>
-      patchApplication(mfaDomain.id, mfaAdminToken, {
-        settings: {
-          mfa: {
-            factor: {
-              defaultFactorId: mfaFactorId,
-              applicationFactors: [{ id: mfaFactorId, selectionRule: '' }],
-            },
-            enroll: {
-              active: true,
-              forceEnrollment: true,
-              type: 'REQUIRED',
-            },
-            challenge: {
-              active: true,
-              type: 'REQUIRED',
-            },
-            rememberDevice: {
-              active: true,
-              deviceIdentifierId: mfaDeviceId,
-              expirationTimeSeconds: 180, // 3 minutes
+      patchApplication(
+        mfaDomain.id,
+        mfaAdminToken,
+        {
+          settings: {
+            mfa: {
+              factor: {
+                defaultFactorId: mfaFactorId,
+                applicationFactors: [{ id: mfaFactorId, selectionRule: '' }],
+              },
+              enroll: {
+                active: true,
+                forceEnrollment: true,
+                type: 'REQUIRED',
+              },
+              challenge: {
+                active: true,
+                type: 'REQUIRED',
+              },
+              rememberDevice: {
+                active: true,
+                deviceIdentifierId: mfaDeviceId,
+                expirationTimeSeconds: 180, // 3 minutes
+              },
             },
           },
         },
-      }, app.id),
+        app.id,
+      ),
     );
 
     await use(app);
@@ -205,6 +210,7 @@ export {
   getCredentials,
   removeVirtualAuthenticator,
   handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   buildAuthorizeUrl,
   loginAndRegisterWebAuthn,
   passwordlessLogin,

--- a/gravitee-am-test/playwright/fixtures/webauthn.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/webauthn.fixture.ts
@@ -49,6 +49,7 @@ export {
   getCredentials,
   removeVirtualAuthenticator,
   handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   buildAuthorizeUrl,
   navigateToWebAuthnLogin,
   loginAndRegisterWebAuthn,

--- a/gravitee-am-test/playwright/tests/auth/login/login-flows-mfa-remember.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/login/login-flows-mfa-remember.spec.ts
@@ -20,7 +20,7 @@ import {
   submitLogin,
   enrollMockFactor,
   completeMfaChallenge,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   MOCK_MFA_CODE,
 } from '../../../fixtures/login-flows-password-mfa-remember.fixture';
 import { clearSessionOnly } from '../../../utils/webauthn-helpers';
@@ -32,10 +32,12 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test.describe('Gateway MFA + Remember Device — password login (AM-2218)', () => {
   test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
-  test('AM-2218: after remembering device, second sign-in skips MFA challenge', async (
-    { page, gatewayUrl, rememberApp, rememberUser },
-    testInfo,
-  ) => {
+  test('AM-2218: after remembering device, second sign-in skips MFA challenge', async ({
+    page,
+    gatewayUrl,
+    rememberApp,
+    rememberUser,
+  }, testInfo) => {
     linkJira(testInfo, 'AM-2218');
 
     const clientId = rememberApp.settings.oauth.clientId;
@@ -50,8 +52,7 @@ test.describe('Gateway MFA + Remember Device — password login (AM-2218)', () =
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE, { rememberDevice: true });
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
 
     await clearSessionOnly(page);
@@ -60,8 +61,7 @@ test.describe('Gateway MFA + Remember Device — password login (AM-2218)', () =
     await page.waitForURL(/.*login.*/i);
     await submitLogin(page, rememberUser.username, API_USER_PASSWORD);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(page.url()).not.toMatch(/mfa\/challenge/i);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });

--- a/gravitee-am-test/playwright/tests/auth/login/login-flows-recovery.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/login/login-flows-recovery.spec.ts
@@ -20,7 +20,7 @@ import {
   submitLogin,
   enrollMockFactor,
   completeMfaChallenge,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   readFirstRecoveryCodeFromPage,
   submitRecoveryCodesContinue,
   openMfaChallengeAlternatives,
@@ -34,16 +34,13 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test.describe('MFA recovery codes (AM-2216)', () => {
   test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
-  test('AM-2216: enrol mock MFA, capture recovery codes, then sign in with recovery code', async (
-    {
-      page,
-      gatewayUrl,
-      recoveryApp,
-      recoveryUser,
-      recoveryFactorId,
-    },
-    testInfo,
-  ) => {
+  test('AM-2216: enrol mock MFA, capture recovery codes, then sign in with recovery code', async ({
+    page,
+    gatewayUrl,
+    recoveryApp,
+    recoveryUser,
+    recoveryFactorId,
+  }, testInfo) => {
     linkJira(testInfo, 'AM-2216');
 
     const clientId = recoveryApp.settings.oauth.clientId;
@@ -62,8 +59,7 @@ test.describe('MFA recovery codes (AM-2216)', () => {
     const recoveryCode = await readFirstRecoveryCodeFromPage(page);
     await submitRecoveryCodesContinue(page);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
 
     await page.context().clearCookies();
@@ -80,8 +76,7 @@ test.describe('MFA recovery codes (AM-2216)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, recoveryCode);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
 });

--- a/gravitee-am-test/playwright/tests/auth/login/login-flows-role-mapper.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/login/login-flows-role-mapper.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { test, expect, buildAuthorizeUrl, submitLogin, handleConsentIfPresent } from '../../../fixtures/login-flows-role-mapper.fixture';
+import { test, expect, buildAuthorizeUrl, submitLogin } from '../../../fixtures/login-flows-role-mapper.fixture';
 import { listUsers } from '@management-commands/user-management-commands';
 import { reachOAuthAuthorizationCallback } from '../../../utils/mfa-helpers';
 import { AUTH_CODE_FORMAT, MULTI_PHASE_TEST_TIMEOUT } from '../../../utils/test-constants';
@@ -24,10 +24,15 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test.describe('IdP role mapper (AM-2219)', () => {
   test.setTimeout(MULTI_PHASE_TEST_TIMEOUT * 2);
 
-  test('AM-2219: user matching mapper rule receives mapped domain role', async (
-    { page, gatewayUrl, mapperApp, mapperDomain, adminToken, gatewayUser, mappedRoleName },
-    testInfo,
-  ) => {
+  test('AM-2219: user matching mapper rule receives mapped domain role', async ({
+    page,
+    gatewayUrl,
+    mapperApp,
+    mapperDomain,
+    adminToken,
+    gatewayUser,
+    mappedRoleName,
+  }, testInfo) => {
     linkJira(testInfo, 'AM-2219');
 
     const clientId = mapperApp.settings.oauth.clientId;
@@ -36,7 +41,6 @@ test.describe('IdP role mapper (AM-2219)', () => {
     await page.waitForURL(/.*login.*/i);
     await submitLogin(page, gatewayUser.username, gatewayUser.password);
 
-    await handleConsentIfPresent(page);
     await reachOAuthAuthorizationCallback(page, { iterations: 32, consentTimeoutMs: 10_000 });
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
 

--- a/gravitee-am-test/playwright/tests/auth/login/login-flows.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/login/login-flows.spec.ts
@@ -17,7 +17,7 @@ import { expect } from '@playwright/test';
 import { test as consoleTest } from '../../../fixtures/base.fixture';
 import { test as gatewayTest } from '../../../fixtures/login-flows-gateway.fixture';
 import { linkJira } from '../../../utils/jira';
-import { buildAuthorizeUrl, submitLogin, handleConsentIfPresent } from '../../../utils/mfa-helpers';
+import { buildAuthorizeUrl, submitLogin, reachOAuthAuthorizationCallback } from '../../../utils/mfa-helpers';
 import { ADMIN_PASSWORD, AUTH_CODE_FORMAT } from '../../../utils/test-constants';
 
 consoleTest.describe('Console admin login (AM-2230)', () => {
@@ -78,8 +78,7 @@ gatewayTest.describe('Gateway identifier-first login (AM-2170)', () => {
     await page.locator('#password').fill(password);
     await page.locator('#submitBtn').click();
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/callback\?code=/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
 });
@@ -96,8 +95,7 @@ gatewayTest.describe('Gateway IdP selection rules (AM-2819)', () => {
     await page.goto(buildAuthorizeUrl(loginFlowsBundle.gatewayUrl, clientId));
     await page.waitForURL(/login/i);
     await submitLogin(page, username, password);
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/callback\?code=/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
 
@@ -110,9 +108,7 @@ gatewayTest.describe('Gateway IdP selection rules (AM-2819)', () => {
     await page.goto(buildAuthorizeUrl(loginFlowsBundle.gatewayUrl, clientId));
     await page.waitForURL(/login/i);
     await submitLogin(page, username, password);
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/callback\?code=/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
 });
-

--- a/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-auth-filter.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-auth-filter.spec.ts
@@ -16,7 +16,7 @@
 import {
   test,
   expect,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   loginAndRegisterWebAuthn,
   passwordlessLogin,
   removeVirtualAuthenticator,
@@ -47,12 +47,7 @@ test.describe('WebAuthn - Authentication Filter (AM-4550, AM-4551, AM-4552)', ()
     }
   });
 
-  test('AM-4550: non-registered user can login successfully with password', async ({
-    page,
-    waApp,
-    waUser,
-    gatewayUrl,
-  }, testInfo) => {
+  test('AM-4550: non-registered user can login successfully with password', async ({ page, waApp, waUser, gatewayUrl }, testInfo) => {
     linkJira(testInfo, 'AM-4550');
     const clientId = waApp.settings.oauth.clientId;
 
@@ -69,19 +64,13 @@ test.describe('WebAuthn - Authentication Filter (AM-4550, AM-4551, AM-4552)', ()
     const skipLink = page.locator('a[href*="skipAction"], a:has-text("skip"), a:has(span.icons:text("arrow_forward"))');
     await skipLink.click();
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
 
     const url = new URL(page.url());
     expect(url.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
 
-  test('AM-4551: non-registered user fails login with wrong password', async ({
-    page,
-    waApp,
-    waUser,
-    gatewayUrl,
-  }, testInfo) => {
+  test('AM-4551: non-registered user fails login with wrong password', async ({ page, waApp, waUser, gatewayUrl }, testInfo) => {
     linkJira(testInfo, 'AM-4551');
     const clientId = waApp.settings.oauth.clientId;
 
@@ -101,12 +90,7 @@ test.describe('WebAuthn - Authentication Filter (AM-4550, AM-4551, AM-4552)', ()
     expect(page.url()).not.toContain('callback?code=');
   });
 
-  test('AM-4552: registered user succeeds with passwordless login', async ({
-    page,
-    waApp,
-    waUser,
-    gatewayUrl,
-  }, testInfo) => {
+  test('AM-4552: registered user succeeds with passwordless login', async ({ page, waApp, waUser, gatewayUrl }, testInfo) => {
     linkJira(testInfo, 'AM-4552');
     test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
     const clientId = waApp.settings.oauth.clientId;

--- a/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-device-recognition.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-device-recognition.spec.ts
@@ -13,20 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { Page } from '@playwright/test';
 import {
   test,
   expect,
   loginAndRegisterWebAuthn,
   simulateWebAuthnGesture,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   removeVirtualAuthenticator,
   clearSessionOnly,
   VirtualAuthenticator,
 } from '../../../fixtures/webauthn.fixture';
-import { API_USER_PASSWORD, AUTH_CODE_FORMAT, MULTI_PHASE_TEST_TIMEOUT } from '../../../utils/test-constants';
+import { API_USER_PASSWORD, AUTH_CODE_FORMAT } from '../../../utils/test-constants';
 import { linkJira } from '../../../utils/jira';
 import { patchDomain, waitForOidcReady } from '@management-commands/domain-management-commands';
 import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+
+/**
+ * Poll authorize until device recognition routes to /webauthn/login (gateway config propagation).
+ */
+async function waitUntilWebAuthnLoginAfterDeviceRecognition(page: Page, authorizeUrl: string): Promise<void> {
+  const deadline = Date.now() + 30000;
+  while (true) {
+    try {
+      await page.goto(authorizeUrl);
+      await page.waitForURL(/.*login.*/i, { timeout: 15000 });
+      if (page.url().includes('webauthn/login')) {
+        return;
+      }
+    } catch {
+      // Transient navigation/timeout — retry within the deadline
+    }
+    if (Date.now() > deadline) {
+      throw new Error('Device recognition did not redirect to webauthn/login within 30s');
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
 
 /**
  * AM-5292: WebAuthn & Passwordless Device Recognition
@@ -84,24 +107,12 @@ test.describe('WebAuthn - Device Recognition (AM-5292)', () => {
       `&redirect_uri=${encodeURIComponent('https://gravitee.io/callback')}` +
       `&scope=openid`;
 
-    // Device recognition redirect depends on the patchDomain config being fully
-    // propagated to the gateway. Poll navigation until we land on webauthn/login
-    // rather than the normal login page.
-    const deadline = Date.now() + 30000;
-    while (true) {
-      await page.goto(authorizeUrl);
-      await page.waitForURL(/.*login.*/i, { timeout: 15000 });
-      if (page.url().includes('webauthn/login')) break;
-      if (Date.now() > deadline) {
-        throw new Error('Device recognition did not redirect to webauthn/login within 30s');
-      }
-      await new Promise((r) => setTimeout(r, 1000));
-    }
+    await waitUntilWebAuthnLoginAfterDeviceRecognition(page, authorizeUrl);
 
     // Verify we're on the WebAuthn login page with the username field
     await expect(page.locator('#username')).toBeVisible();
     // The password field should NOT be present
-    await expect(page.locator('#password')).not.toBeVisible();
+    await expect(page.locator('#password')).toBeHidden();
 
     // Complete the passwordless login
     await page.locator('#username').fill(waUser.username);
@@ -110,11 +121,10 @@ test.describe('WebAuthn - Device Recognition (AM-5292)', () => {
       await page.locator('button.primary, button#login-button').click();
     });
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i, { timeout: 15000 });
+    await reachOAuthAuthorizationCallback(page);
 
     const url = new URL(page.url());
-    expect(url.searchParams.get('code')).toBeTruthy();
+    expect(url.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
 
   test('disabling device recognition shows normal login page for returning user (AM-5292)', async ({

--- a/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-enforce-password-device-recognition.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-enforce-password-device-recognition.spec.ts
@@ -18,7 +18,7 @@ import {
   expect,
   loginAndRegisterWebAuthn,
   simulateWebAuthnGesture,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   removeVirtualAuthenticator,
   clearSessionOnly,
   buildAuthorizeUrl,
@@ -88,8 +88,7 @@ test.describe('WebAuthn - Enforce Password + Device Recognition', () => {
       });
 
       // Within max age — passwordless should succeed
-      await handleConsentIfPresent(page);
-      await page.waitForURL(/.*callback\?code=.*/i);
+      await reachOAuthAuthorizationCallback(page);
 
       const url = new URL(page.url());
       expect(url.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);

--- a/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-enforce-password.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-enforce-password.spec.ts
@@ -57,12 +57,7 @@ test.describe('WebAuthn - Enforce Password Usage', () => {
       },
     });
 
-    test('AM-2376: passwordless login succeeds within enforce password max age', async ({
-      page,
-      waApp,
-      waUser,
-      gatewayUrl,
-    }, testInfo) => {
+    test('AM-2376: passwordless login succeeds within enforce password max age', async ({ page, waApp, waUser, gatewayUrl }, testInfo) => {
       linkJira(testInfo, 'AM-2376');
       const clientId = waApp.settings.oauth.clientId;
 

--- a/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-login.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-login.spec.ts
@@ -20,7 +20,7 @@ import {
   simulateWebAuthnGesture,
   getCredentials,
   removeVirtualAuthenticator,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   buildAuthorizeUrl,
   PASSWORDLESS_LINK_SELECTOR,
   VirtualAuthenticator,
@@ -40,12 +40,7 @@ test.describe('WebAuthn Passwordless Login', () => {
     }
   });
 
-  test('AM-2194: user can register then login with WebAuthn credential', async ({
-    page,
-    waApp,
-    waUser,
-    gatewayUrl,
-  }, testInfo) => {
+  test('AM-2194: user can register then login with WebAuthn credential', async ({ page, waApp, waUser, gatewayUrl }, testInfo) => {
     linkJira(testInfo, 'AM-2194');
     test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
     const clientId = waApp.settings.oauth.clientId;
@@ -75,8 +70,7 @@ test.describe('WebAuthn Passwordless Login', () => {
     expect(credentials).toHaveLength(1);
 
     // Handle consent page if present, then wait for callback
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
 
     // Clear cookies to simulate a new session
     await page.context().clearCookies();
@@ -101,17 +95,12 @@ test.describe('WebAuthn Passwordless Login', () => {
     });
 
     // Handle consent if present, then verify callback with authorization code
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const url = new URL(page.url());
     expect(url.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
 
-  test('AM-2194: passwordless login fails for unregistered user', async ({
-    page,
-    waApp,
-    gatewayUrl,
-  }, testInfo) => {
+  test('AM-2194: passwordless login fails for unregistered user', async ({ page, waApp, gatewayUrl }, testInfo) => {
     linkJira(testInfo, 'AM-2194');
     const clientId = waApp.settings.oauth.clientId;
 
@@ -136,11 +125,7 @@ test.describe('WebAuthn Passwordless Login', () => {
     await expect(errorVisible.first()).toBeVisible();
   });
 
-  test('AM-2194: back to sign in link returns to login page', async ({
-    page,
-    waApp,
-    gatewayUrl,
-  }, testInfo) => {
+  test('AM-2194: back to sign in link returns to login page', async ({ page, waApp, gatewayUrl }, testInfo) => {
     linkJira(testInfo, 'AM-2194');
     const clientId = waApp.settings.oauth.clientId;
 

--- a/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-mfa-remember-device.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-mfa-remember-device.spec.ts
@@ -17,7 +17,7 @@ import { test, expect, MOCK_MFA_CODE } from '../../../fixtures/webauthn-mfa.fixt
 import {
   fullLoginWithMfaAndWebAuthn,
   simulateWebAuthnGesture,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   removeVirtualAuthenticator,
   clearSessionOnly,
   navigateToWebAuthnLogin,
@@ -44,12 +44,7 @@ test.describe('WebAuthn - MFA + Remember Device (AM-5333, AM-5334)', () => {
     }
   });
 
-  test('AM-5334: passwordless login skips MFA when device is remembered', async ({
-    page,
-    mfaApp,
-    mfaUser,
-    gatewayUrl,
-  }, testInfo) => {
+  test('AM-5334: passwordless login skips MFA when device is remembered', async ({ page, mfaApp, mfaUser, gatewayUrl }, testInfo) => {
     linkJira(testInfo, 'AM-5334');
     test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
     const clientId = mfaApp.settings.oauth.clientId;
@@ -70,8 +65,7 @@ test.describe('WebAuthn - MFA + Remember Device (AM-5333, AM-5334)', () => {
     });
 
     // Should go straight to consent/callback — no MFA challenge
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
 
     const url = new URL(page.url());
     expect(url.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
@@ -116,8 +110,7 @@ test.describe('WebAuthn - MFA + Remember Device (AM-5333, AM-5334)', () => {
     await page.locator('#verify').click();
 
     // Now should proceed to consent/callback
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
 
     const url = new URL(page.url());
     expect(url.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);

--- a/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-register.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-register.spec.ts
@@ -20,7 +20,7 @@ import {
   simulateWebAuthnGesture,
   getCredentials,
   removeVirtualAuthenticator,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   buildAuthorizeUrl,
   VirtualAuthenticator,
 } from '../../../fixtures/webauthn.fixture';
@@ -40,12 +40,7 @@ test.describe('WebAuthn Registration', () => {
     }
   });
 
-  test('AM-2194: user can register a WebAuthn credential after password login', async ({
-    page,
-    waApp,
-    waUser,
-    gatewayUrl,
-  }, testInfo) => {
+  test('AM-2194: user can register a WebAuthn credential after password login', async ({ page, waApp, waUser, gatewayUrl }, testInfo) => {
     linkJira(testInfo, 'AM-2194');
     const clientId = waApp.settings.oauth.clientId;
 
@@ -78,8 +73,7 @@ test.describe('WebAuthn Registration', () => {
     expect(after).toHaveLength(1);
 
     // 7. May redirect to consent, then to callback with authorization code
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
   });
 
   test('AM-2194: user can skip WebAuthn registration when not enrolling a FIDO2 factor', async ({
@@ -107,7 +101,6 @@ test.describe('WebAuthn Registration', () => {
     await skipLink.click();
 
     // 4. May redirect to consent, then to callback with authorization code
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
   });
 });

--- a/gravitee-am-test/playwright/tests/mfa/mfa-default-factor-selection.spec.ts
+++ b/gravitee-am-test/playwright/tests/mfa/mfa-default-factor-selection.spec.ts
@@ -20,7 +20,7 @@ import {
   submitLogin,
   enrollMockFactor,
   completeMfaChallenge,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   DEFAULT_SELECTION_MOCK_CODE,
 } from '../../fixtures/mfa-default-factor-selection.fixture';
 import { linkJira } from '../../utils/jira';
@@ -31,10 +31,12 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test.describe('MFA default factor when selection rules miss (AM-2820)', () => {
   test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
-  test('AM-2820: enrollment lists only the default factor; challenge uses default mock code', async (
-    { page, gatewayUrl, defApp, defUser },
-    testInfo,
-  ) => {
+  test('AM-2820: enrollment lists only the default factor; challenge uses default mock code', async ({
+    page,
+    gatewayUrl,
+    defApp,
+    defUser,
+  }, testInfo) => {
     linkJira(testInfo, 'AM-2820');
 
     const clientId = defApp.settings.oauth.clientId;
@@ -54,8 +56,7 @@ test.describe('MFA default factor when selection rules miss (AM-2820)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, DEFAULT_SELECTION_MOCK_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
 });

--- a/gravitee-am-test/playwright/tests/mfa/mfa-enrollment-matrix.spec.ts
+++ b/gravitee-am-test/playwright/tests/mfa/mfa-enrollment-matrix.spec.ts
@@ -20,7 +20,7 @@ import {
   submitLogin,
   enrollMockFactor,
   completeMfaChallenge,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   skipMfaEnrollment,
   secondAuthorizeExpectCallbackWithoutMfa,
   waitAfterAuthorizeThenLoginIfNeeded,
@@ -69,8 +69,7 @@ test.describe('Enrollment Required (AM-2822)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
@@ -98,8 +97,7 @@ test.describe('Enrollment Optional — skip (AM-2821)', () => {
 
     await skipMfaEnrollment(page);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
@@ -150,17 +148,10 @@ test.describe('Enrollment optional — minimal skip window re-prompt (AM-2190)',
     await skipMfaEnrollment(page);
     const skipHandledAtMs = Date.now();
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
 
-    await waitUntilMfaEnrollmentSkipWindowExpired(
-      matrixDomain.id,
-      adminToken,
-      matrixUser.id,
-      enrollSkipTimeSeconds,
-      skipHandledAtMs,
-    );
+    await waitUntilMfaEnrollmentSkipWindowExpired(matrixDomain.id, adminToken, matrixUser.id, enrollSkipTimeSeconds, skipHandledAtMs);
 
     await clearSessionOnly(page);
 
@@ -216,12 +207,7 @@ test.describe('Enrollment Optional with extended enrollment skip window (AM-2827
   });
   test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
-  test('user skips optional enrollment with 24h skip window configured', async ({
-    page,
-    gatewayUrl,
-    matrixApp,
-    matrixUser,
-  }, testInfo) => {
+  test('user skips optional enrollment with 24h skip window configured', async ({ page, gatewayUrl, matrixApp, matrixUser }, testInfo) => {
     linkJira(testInfo, 'AM-2827');
     await expectEnrollSkipThenCallback(page, gatewayUrl, matrixApp.settings.oauth.clientId, matrixUser.username, API_USER_PASSWORD);
   });
@@ -262,7 +248,12 @@ test.describe('Enrollment Conditional = false (AM-2824)', () => {
   });
   test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
-  test('enrollment page is shown when conditional rule evaluates to false', async ({ page, gatewayUrl, matrixApp, matrixUser }, testInfo) => {
+  test('enrollment page is shown when conditional rule evaluates to false', async ({
+    page,
+    gatewayUrl,
+    matrixApp,
+    matrixUser,
+  }, testInfo) => {
     linkJira(testInfo, 'AM-2824');
 
     await page.goto(buildAuthorizeUrl(gatewayUrl, matrixApp.settings.oauth.clientId));
@@ -280,8 +271,7 @@ test.describe('Enrollment Conditional = false (AM-2824)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
@@ -310,7 +300,13 @@ test.describe('Enrollment Conditional false + skip disabled + REQUIRED challenge
     matrixUser,
   }, testInfo) => {
     linkJira(testInfo, 'AM-2826');
-    await expectEnrollThenChallengeThenCallback(page, gatewayUrl, matrixApp.settings.oauth.clientId, matrixUser.username, API_USER_PASSWORD);
+    await expectEnrollThenChallengeThenCallback(
+      page,
+      gatewayUrl,
+      matrixApp.settings.oauth.clientId,
+      matrixUser.username,
+      API_USER_PASSWORD,
+    );
   });
 });
 
@@ -352,8 +348,7 @@ test.describe('Enrollment Conditional false + CONDITIONAL challenge (AM-2840)', 
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
@@ -384,7 +379,13 @@ test.describe('Enrollment Conditional false + skip policy + RISK_BASED challenge
     matrixUser,
   }, testInfo) => {
     linkJira(testInfo, 'AM-2841');
-    await expectEnrollThenChallengeThenCallback(page, gatewayUrl, matrixApp.settings.oauth.clientId, matrixUser.username, API_USER_PASSWORD);
+    await expectEnrollThenChallengeThenCallback(
+      page,
+      gatewayUrl,
+      matrixApp.settings.oauth.clientId,
+      matrixUser.username,
+      API_USER_PASSWORD,
+    );
   });
 });
 
@@ -412,7 +413,13 @@ test.describe('Enrollment Conditional false + skip policy + REQUIRED challenge (
     matrixUser,
   }, testInfo) => {
     linkJira(testInfo, 'AM-2842');
-    await expectEnrollThenChallengeThenCallback(page, gatewayUrl, matrixApp.settings.oauth.clientId, matrixUser.username, API_USER_PASSWORD);
+    await expectEnrollThenChallengeThenCallback(
+      page,
+      gatewayUrl,
+      matrixApp.settings.oauth.clientId,
+      matrixUser.username,
+      API_USER_PASSWORD,
+    );
   });
 });
 
@@ -441,7 +448,13 @@ test.describe('Enrollment Conditional false + skip policy + CONDITIONAL challeng
     matrixUser,
   }, testInfo) => {
     linkJira(testInfo, 'AM-2843');
-    await expectEnrollThenChallengeThenCallback(page, gatewayUrl, matrixApp.settings.oauth.clientId, matrixUser.username, API_USER_PASSWORD);
+    await expectEnrollThenChallengeThenCallback(
+      page,
+      gatewayUrl,
+      matrixApp.settings.oauth.clientId,
+      matrixUser.username,
+      API_USER_PASSWORD,
+    );
   });
 });
 
@@ -461,7 +474,13 @@ test.describe('Required Enrollment + Required Challenge (AM-2836)', () => {
 
   test('user enrolls then completes MFA challenge', async ({ page, gatewayUrl, matrixApp, matrixUser }, testInfo) => {
     linkJira(testInfo, 'AM-2836');
-    await expectEnrollThenChallengeThenCallback(page, gatewayUrl, matrixApp.settings.oauth.clientId, matrixUser.username, API_USER_PASSWORD);
+    await expectEnrollThenChallengeThenCallback(
+      page,
+      gatewayUrl,
+      matrixApp.settings.oauth.clientId,
+      matrixUser.username,
+      API_USER_PASSWORD,
+    );
   });
 });
 
@@ -505,8 +524,7 @@ test.describe('Optional Enrollment + Required Challenge (AM-2833)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
@@ -542,8 +560,7 @@ test.describe('Optional Enrollment + RISK_BASED challenge skips MFA when rule is
     await page.waitForURL(/.*mfa\/enroll.*/i);
     await skipMfaEnrollment(page);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(page.url()).not.toMatch(/mfa\/challenge/i);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
@@ -580,8 +597,7 @@ test.describe('Optional Enrollment + CONDITIONAL challenge skips MFA when rule i
     await page.waitForURL(/.*mfa\/enroll.*/i);
     await skipMfaEnrollment(page);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(page.url()).not.toMatch(/mfa\/challenge/i);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
@@ -616,8 +632,7 @@ test.describe('Conditional enrollment true + RISK_BASED challenge safe (AM-2838)
     await page.waitForURL(/.*login.*/i);
     await submitLogin(page, matrixUser.username, API_USER_PASSWORD);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(page.url()).not.toMatch(/mfa\/enroll/i);
     expect(page.url()).not.toMatch(/mfa\/challenge/i);
     const callbackUrl = new URL(page.url());
@@ -652,8 +667,7 @@ test.describe('Conditional enrollment true + REQUIRED challenge active (AM-2839)
     await page.waitForURL(/.*login.*/i);
     await submitLogin(page, matrixUser.username, API_USER_PASSWORD);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     expect(page.url()).not.toMatch(/mfa\/enroll/i);
     expect(page.url()).not.toMatch(/mfa\/challenge/i);
     const callbackUrl = new URL(page.url());
@@ -693,8 +707,7 @@ test.describe('Required Enrollment + RISK_BASED challenge (AM-2835)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const firstCode = new URL(page.url()).searchParams.get('code');
     expect(firstCode).toMatch(AUTH_CODE_FORMAT);
 
@@ -740,8 +753,7 @@ test.describe('Required Enrollment + CONDITIONAL challenge (AM-2837)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const firstCode = new URL(page.url()).searchParams.get('code');
     expect(firstCode).toMatch(AUTH_CODE_FORMAT);
 
@@ -787,14 +799,20 @@ test.describe('Standalone challenge RISK_BASED rule safe (AM-2828)', () => {
     await enrollMockFactor(page);
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
 
-    await applyStandaloneChallengeMfaPatch(matrixDomain.id, adminToken, matrixApp.id, factorId, {
-      active: true,
-      type: 'RISK_BASED',
-      challengeRule: '{{ true }}',
-    }, matrixDomain.hrid);
+    await applyStandaloneChallengeMfaPatch(
+      matrixDomain.id,
+      adminToken,
+      matrixApp.id,
+      factorId,
+      {
+        active: true,
+        type: 'RISK_BASED',
+        challengeRule: '{{ true }}',
+      },
+      matrixDomain.hrid,
+    );
 
     await secondAuthorizeExpectCallbackWithoutMfa(
       page,
@@ -836,14 +854,20 @@ test.describe('Standalone challenge REQUIRED (AM-2829)', () => {
     await enrollMockFactor(page);
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
 
-    await applyStandaloneChallengeMfaPatch(matrixDomain.id, adminToken, matrixApp.id, factorId, {
-      active: true,
-      type: 'REQUIRED',
-      challengeRule: '',
-    }, matrixDomain.hrid);
+    await applyStandaloneChallengeMfaPatch(
+      matrixDomain.id,
+      adminToken,
+      matrixApp.id,
+      factorId,
+      {
+        active: true,
+        type: 'REQUIRED',
+        challengeRule: '',
+      },
+      matrixDomain.hrid,
+    );
 
     // Drop AM session so the second authorisation cannot short-circuit to callback without step-up MFA.
     await page.context().clearCookies();
@@ -852,8 +876,7 @@ test.describe('Standalone challenge REQUIRED (AM-2829)', () => {
     await waitAfterAuthorizeThenLoginIfNeeded(page, matrixUser.username, API_USER_PASSWORD, { allowMfa: true });
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
@@ -887,14 +910,20 @@ test.describe('Standalone challenge CONDITIONAL rule true skips challenge (AM-28
     await enrollMockFactor(page);
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
 
-    await applyStandaloneChallengeMfaPatch(matrixDomain.id, adminToken, matrixApp.id, factorId, {
-      active: true,
-      type: 'CONDITIONAL',
-      challengeRule: '{{ true }}',
-    }, matrixDomain.hrid);
+    await applyStandaloneChallengeMfaPatch(
+      matrixDomain.id,
+      adminToken,
+      matrixApp.id,
+      factorId,
+      {
+        active: true,
+        type: 'CONDITIONAL',
+        challengeRule: '{{ true }}',
+      },
+      matrixDomain.hrid,
+    );
 
     await secondAuthorizeExpectCallbackWithoutMfa(
       page,
@@ -936,14 +965,20 @@ test.describe('Standalone challenge CONDITIONAL rule false requires challenge (A
     await enrollMockFactor(page);
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
 
-    await applyStandaloneChallengeMfaPatch(matrixDomain.id, adminToken, matrixApp.id, factorId, {
-      active: true,
-      type: 'CONDITIONAL',
-      challengeRule: '{{ false }}',
-    }, matrixDomain.hrid);
+    await applyStandaloneChallengeMfaPatch(
+      matrixDomain.id,
+      adminToken,
+      matrixApp.id,
+      factorId,
+      {
+        active: true,
+        type: 'CONDITIONAL',
+        challengeRule: '{{ false }}',
+      },
+      matrixDomain.hrid,
+    );
 
     await page.context().clearCookies();
 
@@ -951,8 +986,7 @@ test.describe('Standalone challenge CONDITIONAL rule false requires challenge (A
     await waitAfterAuthorizeThenLoginIfNeeded(page, matrixUser.username, API_USER_PASSWORD, { allowMfa: true });
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });

--- a/gravitee-am-test/playwright/tests/mfa/mfa-login.spec.ts
+++ b/gravitee-am-test/playwright/tests/mfa/mfa-login.spec.ts
@@ -20,7 +20,7 @@ import {
   submitLogin,
   enrollMockFactor,
   completeMfaChallenge,
-  handleConsentIfPresent,
+  reachOAuthAuthorizationCallback,
   fullMfaLogin,
   MOCK_MFA_CODE,
 } from '../../fixtures/mfa-login.fixture';
@@ -64,8 +64,7 @@ test.describe('Single MFA login (AM-2197)', () => {
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
     // Handle consent if present, then verify callback with auth code
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
@@ -101,8 +100,7 @@ test.describe('Multiple MFA login (AM-2191)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });
@@ -137,8 +135,7 @@ test.describe('Force MFA enrollment (AM-2221)', () => {
     await page.waitForURL(/.*mfa\/challenge.*/i);
     await completeMfaChallenge(page, MOCK_MFA_CODE);
 
-    await handleConsentIfPresent(page);
-    await page.waitForURL(/.*callback\?code=.*/i);
+    await reachOAuthAuthorizationCallback(page);
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });

--- a/gravitee-am-test/playwright/utils/forgot-password-ui.ts
+++ b/gravitee-am-test/playwright/utils/forgot-password-ui.ts
@@ -16,7 +16,7 @@
 
 import { expect, Page } from '@playwright/test';
 
-import { buildAuthorizeUrl, handleConsentIfPresent, submitLogin } from './mfa-helpers';
+import { buildAuthorizeUrl, reachOAuthAuthorizationCallback, submitLogin } from './mfa-helpers';
 
 /** Gateway login → forgot-password link (href or visible text). */
 export async function openLoginThenForgotPasswordPage(page: Page, gatewayUrl: string, clientId: string): Promise<void> {
@@ -63,6 +63,5 @@ export async function loginOnGatewayWithPassword(
   await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
   await page.waitForURL(/.*login.*/i);
   await submitLogin(page, username, password);
-  await handleConsentIfPresent(page);
-  await page.waitForURL(/.*callback\?code=.*/i);
+  await reachOAuthAuthorizationCallback(page);
 }

--- a/gravitee-am-test/playwright/utils/mfa-helpers.ts
+++ b/gravitee-am-test/playwright/utils/mfa-helpers.ts
@@ -15,7 +15,10 @@
  */
 import { Page, expect } from '@playwright/test';
 import { AUTH_CODE_FORMAT, BRIEF_TIMEOUT, MOCK_MFA_CODE, MULTI_PHASE_TEST_TIMEOUT } from './test-constants';
+import { reachOAuthAuthorizationCallback } from './oauth-callback-helpers';
 import { buildAuthorizeUrl } from './webauthn-helpers';
+
+export { handleConsentIfPresent, reachOAuthAuthorizationCallback } from './oauth-callback-helpers';
 import { patchApplication } from '@management-commands/application-management-commands';
 import { waitForDomainSync, waitForOidcReady } from '@management-commands/domain-management-commands';
 import { getUser } from '@management-commands/user-management-commands';
@@ -84,52 +87,6 @@ export async function completeMfaChallenge(
 }
 
 /**
- * Handle the OAuth consent page if present.
- */
-export async function handleConsentIfPresent(page: Page, timeoutMs = BRIEF_TIMEOUT): Promise<void> {
-  try {
-    await page.waitForURL(/.*oauth\/consent.*/i, { timeout: timeoutMs });
-    await page.locator('button:has-text("Accept"), input[value="Accept"], #submitBtn').click();
-  } catch {
-    // No consent page — that's fine
-  }
-}
-
-/**
- * Poll until the browser reaches the OAuth redirect_uri with an authorisation code, handling consent between hops.
- * Prefer this over a single {@code waitForURL} when redirects can be slow or interleaved with consent.
- */
-function assertNoFatalOAuthErrorOnPage(page: Page): void {
-  const href = page.url();
-  if (!/\/login/i.test(href)) {
-    return;
-  }
-  if (href.includes('error=login_failed') || href.includes('error_code=invalid_user')) {
-    throw new Error(`Gateway login error: ${href}`);
-  }
-}
-
-export async function reachOAuthAuthorizationCallback(
-  page: Page,
-  options?: { iterations?: number; consentTimeoutMs?: number },
-): Promise<void> {
-  const iterations = options?.iterations ?? 24;
-  const consentTimeoutMs = options?.consentTimeoutMs ?? 8000;
-  for (let i = 0; i < iterations; i++) {
-    assertNoFatalOAuthErrorOnPage(page);
-    const href = page.url();
-    if (href.includes('callback') && href.includes('code=')) {
-      const redirect = new URL(href);
-      if (redirect.searchParams.get('code')) {
-        return;
-      }
-    }
-    await handleConsentIfPresent(page, consentTimeoutMs);
-  }
-  throw new Error(`OAuth callback with code not reached, last URL: ${page.url()}`);
-}
-
-/**
  * Click the "Skip" button on the MFA enrollment page.
  * Only visible when enrollment is optional (forceEnrollment=false).
  *
@@ -163,8 +120,7 @@ export async function secondAuthorizeExpectCallbackWithoutMfa(
   await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
   await waitAfterAuthorizeThenLoginIfNeeded(page, username, password);
 
-  await handleConsentIfPresent(page);
-  await page.waitForURL(/.*callback\?code=.*/i);
+  await reachOAuthAuthorizationCallback(page);
   expect(page.url()).not.toMatch(/mfa\/enroll/i);
   expect(page.url()).not.toMatch(/mfa\/challenge/i);
   const callbackUrl = new URL(page.url());
@@ -259,9 +215,7 @@ export async function waitUntilMfaEnrollmentSkipWindowExpired(
     await new Promise((r) => setTimeout(r, pollMs));
   }
 
-  throw new Error(
-    `Timed out waiting for MFA enrollment skip window (${skipTimeSeconds}s) to elapse for user ${userId}`,
-  );
+  throw new Error(`Timed out waiting for MFA enrollment skip window (${skipTimeSeconds}s) to elapse for user ${userId}`);
 }
 
 /**
@@ -309,7 +263,11 @@ export async function applyStandaloneChallengeMfaPatch(
 
 /** Login -> enroll -> challenge -> callback. Asserts auth code in callback URL. */
 export async function expectEnrollThenChallengeThenCallback(
-  page: Page, gatewayUrl: string, clientId: string, username: string, password: string,
+  page: Page,
+  gatewayUrl: string,
+  clientId: string,
+  username: string,
+  password: string,
 ): Promise<void> {
   await fullMfaLogin(page, gatewayUrl, clientId, username, password);
   const callbackUrl = new URL(page.url());
@@ -318,28 +276,34 @@ export async function expectEnrollThenChallengeThenCallback(
 
 /** Login -> enroll page shown -> skip -> callback. Asserts auth code in callback URL. */
 export async function expectEnrollSkipThenCallback(
-  page: Page, gatewayUrl: string, clientId: string, username: string, password: string,
+  page: Page,
+  gatewayUrl: string,
+  clientId: string,
+  username: string,
+  password: string,
 ): Promise<void> {
   await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
   await page.waitForURL(/.*login.*/i);
   await submitLogin(page, username, password);
   await page.waitForURL(/.*mfa\/enroll.*/i);
   await skipMfaEnrollment(page);
-  await handleConsentIfPresent(page);
-  await page.waitForURL(/.*callback\?code=.*/i);
+  await reachOAuthAuthorizationCallback(page);
   const callbackUrl = new URL(page.url());
   expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
 }
 
 /** Login -> enrollment bypassed (conditional=true) -> callback. Asserts no enroll page appeared. */
 export async function expectEnrollBypassedThenCallback(
-  page: Page, gatewayUrl: string, clientId: string, username: string, password: string,
+  page: Page,
+  gatewayUrl: string,
+  clientId: string,
+  username: string,
+  password: string,
 ): Promise<void> {
   await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
   await page.waitForURL(/.*login.*/i);
   await submitLogin(page, username, password);
-  await handleConsentIfPresent(page);
-  await page.waitForURL(/.*callback\?code=.*/i);
+  await reachOAuthAuthorizationCallback(page);
   const callbackUrl = new URL(page.url());
   expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   expect(page.url()).not.toMatch(/mfa\/enroll/);
@@ -366,6 +330,5 @@ export async function fullMfaLogin(
   await page.waitForURL(/.*mfa\/challenge.*/i);
   await completeMfaChallenge(page, code);
 
-  await handleConsentIfPresent(page);
-  await page.waitForURL(/.*callback\?code=.*/i);
+  await reachOAuthAuthorizationCallback(page);
 }

--- a/gravitee-am-test/playwright/utils/oauth-callback-helpers.ts
+++ b/gravitee-am-test/playwright/utils/oauth-callback-helpers.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Page } from '@playwright/test';
+import { BRIEF_TIMEOUT } from './test-constants';
+
+const CONSENT_ACCEPT_SELECTOR = 'button:has-text("Accept"), input[value="Accept"], #submitBtn';
+
+/**
+ * Handle the OAuth consent page if present.
+ */
+export async function handleConsentIfPresent(page: Page, timeoutMs = BRIEF_TIMEOUT): Promise<void> {
+  try {
+    await page.waitForURL(/.*oauth\/consent.*/i, { timeout: timeoutMs });
+    await page.locator(CONSENT_ACCEPT_SELECTOR).click();
+  } catch {
+    // No consent page — that's fine
+  }
+}
+
+function assertNoFatalOAuthErrorOnPage(page: Page): void {
+  const href = page.url();
+  if (!/\/login/i.test(href)) {
+    return;
+  }
+  if (href.includes('error=login_failed') || href.includes('error_code=invalid_user')) {
+    throw new Error(`Gateway login error: ${href}`);
+  }
+}
+
+/** True when the browser has landed on the client redirect URI with an authorisation code. */
+function hasOAuthCallbackCode(href: string): boolean {
+  try {
+    const url = new URL(href);
+    return url.pathname.includes('callback') && !!url.searchParams.get('code');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Poll until the browser reaches the OAuth redirect_uri with an authorisation code, handling consent between hops.
+ * Prefer this over {@code waitForURL(/callback?code=/)} — the external redirect URI (gravitee.io) may never
+ * reach the {@code load} event in CI while the URL already contains a valid {@code code}.
+ */
+export async function reachOAuthAuthorizationCallback(
+  page: Page,
+  options?: { iterations?: number; consentTimeoutMs?: number; pollIntervalMs?: number },
+): Promise<void> {
+  const pollIntervalMs = options?.pollIntervalMs ?? 250;
+  const pollingWindowMs = options?.consentTimeoutMs ?? 30_000;
+  const iterations = options?.iterations ?? Math.ceil(pollingWindowMs / pollIntervalMs);
+  for (let i = 0; i < iterations; i++) {
+    assertNoFatalOAuthErrorOnPage(page);
+    const href = page.url();
+    if (hasOAuthCallbackCode(href)) {
+      return;
+    }
+    if (href.includes('/oauth/consent')) {
+      try {
+        await page.locator(CONSENT_ACCEPT_SELECTOR).click();
+      } catch {
+        // Transient click failure — retry on next iteration
+      }
+    } else {
+      try {
+        await page.waitForURL(/.*oauth\/consent.*/i, { timeout: pollIntervalMs });
+        await page.locator(CONSENT_ACCEPT_SELECTOR).click();
+      } catch {
+        // Consent not shown yet — wait before the next poll
+        await new Promise((r) => setTimeout(r, pollIntervalMs));
+      }
+    }
+  }
+  throw new Error(`OAuth callback with code not reached, last URL: ${page.url()}`);
+}

--- a/gravitee-am-test/playwright/utils/webauthn-helpers.ts
+++ b/gravitee-am-test/playwright/utils/webauthn-helpers.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import { CDPSession, Page, expect } from '@playwright/test';
+import { reachOAuthAuthorizationCallback } from './oauth-callback-helpers';
 import { BRIEF_TIMEOUT } from './test-constants';
+
+export { handleConsentIfPresent, reachOAuthAuthorizationCallback } from './oauth-callback-helpers';
 
 /* ------------------------------------------------------------------ */
 /*  Constants                                                          */
@@ -23,8 +26,7 @@ import { BRIEF_TIMEOUT } from './test-constants';
 export const REDIRECT_URI = 'https://gravitee.io/callback';
 
 /** Locator string for the passwordless / "Sign in with fingerprint" link on the login page. */
-export const PASSWORDLESS_LINK_SELECTOR =
-  'a:has-text("passwordless"), a:has-text("Sign in with fingerprint"), a[href*="webauthn/login"]';
+export const PASSWORDLESS_LINK_SELECTOR = 'a:has-text("passwordless"), a:has-text("Sign in with fingerprint"), a[href*="webauthn/login"]';
 
 const SESSION_COOKIE = 'GRAVITEE_IO_AM_SESSION';
 
@@ -135,26 +137,6 @@ export async function removeVirtualAuthenticator(auth: VirtualAuthenticator): Pr
   }
 }
 
-/**
- * Handle the OAuth consent page if present.
- * After WebAuthn registration/login the flow may land on /oauth/consent.
- * Clicks "Accept" and waits for redirect to the callback.
- */
-export async function handleConsentIfPresent(page: Page, timeoutMs = BRIEF_TIMEOUT): Promise<void> {
-  const currentUrl = page.url();
-  if (currentUrl.includes('/oauth/consent')) {
-    await page.locator('button:has-text("Accept"), input[value="Accept"], #submitBtn').click();
-    return;
-  }
-  // Maybe we haven't navigated there yet — wait briefly
-  try {
-    await page.waitForURL(/.*oauth\/consent.*/i, { timeout: timeoutMs });
-    await page.locator('button:has-text("Accept"), input[value="Accept"], #submitBtn').click();
-  } catch {
-    // No consent page appeared — that's fine
-  }
-}
-
 /* ------------------------------------------------------------------ */
 /*  URL helpers                                                        */
 /* ------------------------------------------------------------------ */
@@ -179,11 +161,7 @@ export function buildAuthorizeUrl(gatewayUrl: string, clientId: string): string 
  * Device recognition may route directly to /webauthn/login, or to the standard
  * login page where the passwordless link must be clicked.
  */
-export async function navigateToWebAuthnLogin(
-  page: Page,
-  gatewayUrl: string,
-  clientId: string,
-): Promise<void> {
+export async function navigateToWebAuthnLogin(page: Page, gatewayUrl: string, clientId: string): Promise<void> {
   await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
   await page.waitForURL(/.*(?:login|webauthn\/login).*/i);
   if (!page.url().includes('webauthn/login')) {
@@ -226,8 +204,7 @@ export async function loginAndRegisterWebAuthn(
     await page.locator('button.primary, button#register-button').click();
   });
 
-  await handleConsentIfPresent(page);
-  await page.waitForURL(/.*callback\?code=.*/i);
+  await reachOAuthAuthorizationCallback(page);
 
   return auth;
 }
@@ -256,8 +233,7 @@ export async function passwordlessLogin(
     await page.locator('button.primary, button#login-button').click();
   });
 
-  await handleConsentIfPresent(page);
-  await page.waitForURL(/.*callback\?code=.*/i);
+  await reachOAuthAuthorizationCallback(page);
 }
 
 /**
@@ -331,8 +307,7 @@ export async function fullLoginWithMfaAndWebAuthn(
 
   await page.locator('#verify').click();
 
-  await handleConsentIfPresent(page);
-  await page.waitForURL(/.*callback\?code=.*/i);
+  await reachOAuthAuthorizationCallback(page);
 
   return auth;
 }


### PR DESCRIPTION
## :id: Reference related issue. 
n/a

## :pencil2: A description of the changes proposed in the pull request
Replace `page.waitForURL(/callback?code=/)` with a `reachOAuthAuthorizationCallback` helper that polls the URL for `callback` + `code=` and handles consent without depending on external `gravitee.io` page load. Harden related assertions in line with guidelines.

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am