### PR TITLE
AM-7132 - fix: exclude agents from application listings by default

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationsResource.java
@@ -55,7 +55,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.net.URI;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -106,7 +105,9 @@ public class ApplicationsResource extends AbstractDomainResource {
             @QueryParam("type") List<ApplicationType> typeParams,
             @Suspended final AsyncResponse response) {
         User authenticatedUser = getAuthenticatedUser();
-        Set<ApplicationType> types = (typeParams == null || typeParams.isEmpty()) ? null : new HashSet<>(typeParams);
+        // When no type is requested, default to every application type except AGENT so agents
+        // are not returned by the generic applications listing (they are listed explicitly via type=AGENT).
+        Set<ApplicationType> types = ApplicationType.defaultingToNonAgent(typeParams);
         ApplicationFilter filter = new ApplicationFilter(status, ownerEmail, types);
 
         // owner.email filter requires ORGANIZATION_USER[READ] — checked here, resolved in service

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationsResourceSearcher.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationsResourceSearcher.java
@@ -122,7 +122,7 @@ public class ApplicationsResourceSearcher extends AbstractDomainResource {
                 page,
                 query,
                 status == null ? null : STATUS_ENABLED.equalsIgnoreCase(status),
-                types
+                effectiveTypes(types)
         );
         processCursorRequest(organizationId, environmentId, domainId, cursorRequest, ownerEmail, limit, expands, uriInfo)
                 .subscribe(response::resume, response::resume);
@@ -159,7 +159,7 @@ public class ApplicationsResourceSearcher extends AbstractDomainResource {
             @Context UriInfo uriInfo) {
         Set<ApplicationExpand> expands = ApplicationExpand.convertToApplicationExpands(expandsParam);
         Boolean enabled = status == null ? null : STATUS_ENABLED.equalsIgnoreCase(status);
-        ApplicationCursorRequest cursorRequest = ApplicationCursorRequest.initialCursor(sort, direction, page, query, enabled, types);
+        ApplicationCursorRequest cursorRequest = ApplicationCursorRequest.initialCursor(sort, direction, page, query, enabled, effectiveTypes(types));
         processCursorRequest(organizationId, environmentId, domainId, cursorRequest, ownerEmail, limit, expands, uriInfo)
                 .subscribe(response::resume, response::resume);
     }
@@ -195,6 +195,16 @@ public class ApplicationsResourceSearcher extends AbstractDomainResource {
                 .onErrorResumeNext(ex -> ex instanceof IllegalArgumentException
                         ? Single.error(new BadRequestException(ex.getMessage()))
                         : Single.error(ex));
+    }
+
+    /**
+     * When no type is requested, default to every application type except AGENT so agents are
+     * excluded from the standard listing; an explicit type list is forwarded unchanged.
+     */
+    private static List<ApplicationType> effectiveTypes(List<ApplicationType> requested) {
+        return (requested == null || requested.isEmpty())
+                ? List.copyOf(ApplicationType.defaultingToNonAgent(null))
+                : requested;
     }
 
     private String nextCursorPath(ApplicationCursorRequest nextCursor,

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceSearcherTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceSearcherTest.java
@@ -210,6 +210,36 @@ public class ApplicationsResourceSearcherTest extends JerseySpringTest {
     }
 
     @Test
+    public void shouldSearch_noType_defaultsToNonAgentTypes() {
+        doReturn(Maybe.just(mockDomain())).when(domainService).findById(DOMAIN_ID);
+        doReturn(Single.just(page(List.of(), null, 0L)))
+                .when(applicationSearcher).searchByDomainCursor(eq(ORGANIZATION_ID), eq(DOMAIN_ID), any(ApplicationCursorRequest.class), any(), anyInt());
+
+        target("domains").path(DOMAIN_ID).path("applications").path("search").request().get();
+
+        final ArgumentCaptor<ApplicationCursorRequest> captor = ArgumentCaptor.forClass(ApplicationCursorRequest.class);
+        verify(applicationSearcher, atLeastOnce()).searchByDomainCursor(eq(ORGANIZATION_ID), eq(DOMAIN_ID), captor.capture(), any(), anyInt());
+        final List<ApplicationType> types = captor.getValue().getTypes();
+        assertNotNull("no-type search should default to an explicit type set", types);
+        assertFalse("agents must be excluded by default", types.contains(ApplicationType.AGENT));
+        assertTrue("non-agent types should be present", types.contains(ApplicationType.WEB));
+    }
+
+    @Test
+    public void shouldSearch_agentType_forwardedVerbatim() {
+        doReturn(Maybe.just(mockDomain())).when(domainService).findById(DOMAIN_ID);
+        doReturn(Single.just(page(List.of(), null, 0L)))
+                .when(applicationSearcher).searchByDomainCursor(eq(ORGANIZATION_ID), eq(DOMAIN_ID), any(ApplicationCursorRequest.class), any(), anyInt());
+
+        target("domains").path(DOMAIN_ID).path("applications").path("search")
+                .queryParam("type", "AGENT").request().get();
+
+        final ArgumentCaptor<ApplicationCursorRequest> captor = ArgumentCaptor.forClass(ApplicationCursorRequest.class);
+        verify(applicationSearcher, atLeastOnce()).searchByDomainCursor(eq(ORGANIZATION_ID), eq(DOMAIN_ID), captor.capture(), any(), anyInt());
+        assertEquals(List.of(ApplicationType.AGENT), captor.getValue().getTypes());
+    }
+
+    @Test
     public void shouldSearch_queryAndOwnerEmailForwarded() {
         doReturn(Maybe.just(mockDomain())).when(domainService).findById(DOMAIN_ID);
         doReturn(Single.just(page(List.of(), null, 0L)))

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceTest.java
@@ -111,7 +111,7 @@ public class ApplicationsResourceTest extends JerseySpringTest {
     @Test
     public void shouldGetApplications_technicalManagementException() {
         final String domainId = "domain-1";
-        doReturn(Single.error(new TechnicalManagementException("error occurs"))).when(applicationService).findByDomain(domainId);
+        doReturn(Single.error(new TechnicalManagementException("error occurs"))).when(applicationService).findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
 
         final Response response = target("domains").path(domainId).path("applications").request().get();
         assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR_500, response.getStatus());

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/ApplicationsResourceTest.java
@@ -94,13 +94,18 @@ public class ApplicationsResourceTest extends JerseySpringTest {
         doReturn(Flowable.just("client-1-id"))
                 .when(permissionService).getReferenceIdsWithPermission(Mockito.any(), eq(APPLICATION), eq(Permission.APPLICATION), eq(Set.of(Acl.READ)));
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
-        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(domainId, (ApplicationType) null, 0, 50);
+        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
 
         final Response response = target("domains").path(domainId).path("applications").request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         final Map responseEntity = readEntity(response, Map.class);
         assertEquals(2, ((List) responseEntity.get("data")).size());
+
+        // No type filter requested: defaults to every type except AGENT
+        final ArgumentCaptor<ApplicationFilter> filterCaptor = ArgumentCaptor.forClass(ApplicationFilter.class);
+        verify(applicationService, atLeastOnce()).findByDomain(eq(domainId), eq("DEFAULT"), filterCaptor.capture(), eq(0), eq(50));
+        assertEquals(Set.of(ApplicationType.WEB, ApplicationType.NATIVE, ApplicationType.BROWSER, ApplicationType.SERVICE, ApplicationType.RESOURCE_SERVER), filterCaptor.getValue().types());
     }
 
     @Test
@@ -268,7 +273,7 @@ public class ApplicationsResourceTest extends JerseySpringTest {
         doReturn(Flowable.just("client-1-id"))
                 .when(permissionService).getReferenceIdsWithPermission(Mockito.any(), eq(APPLICATION), eq(Permission.APPLICATION), eq(Set.of(Acl.READ)));
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
-        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(domainId, (ApplicationType) null, 0, 50);
+        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
 
         final Response response = target("domains").path(domainId).path("applications")
                 .queryParam("expand", "clientId")
@@ -300,7 +305,7 @@ public class ApplicationsResourceTest extends JerseySpringTest {
         final Page<Application> applicationPage = new Page(List.of(mockClient), 0, 1);
 
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
-        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(domainId, (ApplicationType) null, 0, 50);
+        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
 
         final Response response = target("domains").path(domainId).path("applications").request().get();
 
@@ -325,7 +330,7 @@ public class ApplicationsResourceTest extends JerseySpringTest {
         final Page<Application> applicationPage = new Page(List.of(mockClient), 0, 1);
 
         doReturn(Maybe.just(mockDomain)).when(domainService).findById(domainId);
-        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(domainId, (ApplicationType) null, 0, 50);
+        doReturn(Single.just(applicationPage)).when(applicationService).findByDomain(eq(domainId), eq("DEFAULT"), any(ApplicationFilter.class), eq(0), eq(50));
 
         final Response response = target("domains").path(domainId).path("applications")
                 .queryParam("expand", "unknownValue")

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationType.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationType.java
@@ -15,6 +15,11 @@
  */
 package io.gravitee.am.model.application;
 
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -32,5 +37,17 @@ public enum ApplicationType {
         } catch (IllegalArgumentException e) {
             return null;
         }
+    }
+
+    /**
+     * Resolves the effective set of application types to filter on for the generic
+     * applications listing: when no type is explicitly requested, every type except
+     * {@link #AGENT} is returned so agents are excluded from the standard listing.
+     * Agents remain reachable by requesting {@code AGENT} explicitly.
+     */
+    public static Set<ApplicationType> defaultingToNonAgent(Collection<ApplicationType> requested) {
+        return (requested == null || requested.isEmpty())
+                ? EnumSet.complementOf(EnumSet.of(AGENT))
+                : new HashSet<>(requested);
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationCursorRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationCursorRepository.java
@@ -35,6 +35,7 @@ import java.util.List;
 import static io.gravitee.am.repository.jdbc.management.api.JdbcApplicationRepository.COL_DOMAIN;
 import static io.gravitee.am.repository.jdbc.management.api.JdbcApplicationRepository.COL_ID;
 import static io.gravitee.am.repository.jdbc.management.api.JdbcApplicationRepository.COL_NAME;
+import static io.gravitee.am.repository.jdbc.management.api.JdbcApplicationRepository.COL_TYPE;
 import static io.gravitee.am.repository.jdbc.management.api.JdbcApplicationRepository.COL_UPDATED_AT;
 
 @Component
@@ -68,6 +69,11 @@ public class JdbcApplicationCursorRepository
             where.append(" AND ").append(applicationColumn(COL_ID)).append(" IN (:applicationIds)");
         }
 
+        boolean hasTypes = cursor.getTypes() != null && !cursor.getTypes().isEmpty();
+        if (hasTypes) {
+            where.append(" AND ").append(applicationColumn(COL_TYPE)).append(" IN (:types)");
+        }
+
         String queryValue = null;
         if (StringUtils.hasText(cursor.getQuery())) {
             boolean wildcardMatch = cursor.getQuery().contains("*");
@@ -85,6 +91,7 @@ public class JdbcApplicationCursorRepository
         String countSql = "SELECT COUNT(DISTINCT " + applicationColumn(COL_ID) + ") FROM applications a WHERE " + filter;
         String selectSql = "SELECT * FROM applications a WHERE " + filter;
         String finalQueryValue = queryValue;
+        List<String> typeNames = hasTypes ? cursor.getTypes().stream().map(Enum::name).toList() : null;
 
         return new CursorQuerySpec(
                 selectSql,
@@ -93,6 +100,9 @@ public class JdbcApplicationCursorRepository
                     spec = spec.bind(COL_DOMAIN, domain);
                     if (applicationIds != null) {
                         spec = spec.bind("applicationIds", applicationIds);
+                    }
+                    if (typeNames != null) {
+                        spec = spec.bind("types", typeNames);
                     }
                     if (finalQueryValue != null) {
                         spec = spec.bind("value", finalQueryValue);

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationCursorRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationCursorRepository.java
@@ -40,6 +40,7 @@ import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.or;
 import static io.gravitee.am.repository.mongodb.management.MongoApplicationRepository.FIELD_CLIENT_ID;
+import static io.gravitee.am.repository.mongodb.management.MongoApplicationRepository.FIELD_TYPE;
 
 @Component
 public class MongoApplicationCursorRepository extends AbstractMongoCursorRepository<ApplicationMongo, Application, ApplicationCursorRequest> implements ApplicationCursorRepository {
@@ -125,11 +126,12 @@ public class MongoApplicationCursorRepository extends AbstractMongoCursorReposit
     }
 
     private Bson cursorFilter(Bson baseFilter, ApplicationCursorRequest cursor) {
-        Bson filter;
+        Bson filter = baseFilter;
+        if (cursor.getTypes() != null && !cursor.getTypes().isEmpty()) {
+            filter = and(filter, in(FIELD_TYPE, cursor.getTypes().stream().map(Enum::name).toList()));
+        }
         if (StringUtils.isNotBlank(cursor.getQuery())) {
-            filter = withQuery(baseFilter, cursor.getQuery());
-        } else {
-            filter = baseFilter;
+            filter = withQuery(filter, cursor.getQuery());
         }
         return filter;
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -127,7 +127,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
     private static final String FIELD_FACTORS = "factors";
     private static final String FIELD_CERTIFICATE = "certificate";
     private static final String FIELD_GRANT_TYPES = "settings.oauth.grantTypes";
-    private static final String FIELD_TYPE = "type";
+    static final String FIELD_TYPE = "type";
     private MongoCollection<ApplicationMongo> applicationsCollection;
 
     @PostConstruct

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationCursorRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationCursorRepositoryTest.java
@@ -19,6 +19,7 @@ import io.gravitee.am.model.Application;
 import io.gravitee.am.model.application.ApplicationCursorRequest;
 import io.gravitee.am.model.application.ApplicationOAuthSettings;
 import io.gravitee.am.model.application.ApplicationSettings;
+import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.cursor.CursorPage;
 import io.gravitee.am.repository.management.AbstractManagementTest;
 import io.reactivex.rxjava3.observers.TestObserver;
@@ -144,6 +145,26 @@ public class ApplicationCursorRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
+    public void findByDomainCursor_typeFilter_restrictsToRequestedTypes() {
+        String domain = "cursor-type-domain-" + UUID.randomUUID();
+        createApp(domain, "app-web", null, ApplicationType.WEB);
+        createApp(domain, "app-agent", null, ApplicationType.AGENT);
+
+        // default non-agent set excludes the agent
+        ApplicationCursorRequest nonAgent = ApplicationCursorRequest.initialCursor("name", "ASC", 0, null, null,
+                List.of(ApplicationType.WEB, ApplicationType.NATIVE, ApplicationType.BROWSER, ApplicationType.SERVICE, ApplicationType.RESOURCE_SERVER));
+        CursorPage<Application, ApplicationCursorRequest> nonAgentPage = applicationCursorRepository.findByDomainCursor(domain, nonAgent, 10).blockingGet();
+        assertEquals(List.of("app-web"), nonAgentPage.getData().stream().map(Application::getName).toList());
+        assertEquals(Long.valueOf(1), nonAgentPage.getTotalCount());
+
+        // explicit AGENT type returns only the agent
+        ApplicationCursorRequest agentOnly = ApplicationCursorRequest.initialCursor("name", "ASC", 0, null, null, List.of(ApplicationType.AGENT));
+        CursorPage<Application, ApplicationCursorRequest> agentPage = applicationCursorRepository.findByDomainCursor(domain, agentOnly, 10).blockingGet();
+        assertEquals(List.of("app-agent"), agentPage.getData().stream().map(Application::getName).toList());
+        assertEquals(Long.valueOf(1), agentPage.getTotalCount());
+    }
+
+    @Test
     public void findByDomainCursor_invalidSortField_returnsError() {
         String domain = "cursor-invalid-sort-domain-" + UUID.randomUUID();
         createApp(domain, "app-a");
@@ -160,9 +181,14 @@ public class ApplicationCursorRepositoryTest extends AbstractManagementTest {
     }
 
     private Application createApp(String domain, String name, String clientId) {
+        return createApp(domain, name, clientId, null);
+    }
+
+    private Application createApp(String domain, String name, String clientId, ApplicationType type) {
         Application app = new Application();
         app.setDomain(domain);
         app.setName(name);
+        app.setType(type);
         if (clientId != null) {
             ApplicationSettings settings = new ApplicationSettings();
             ApplicationOAuthSettings oauth = new ApplicationOAuthSettings();

--- a/gravitee-am-test/specs/management/applications/applications-exclude-agents.jest.spec.ts
+++ b/gravitee-am-test/specs/management/applications/applications-exclude-agents.jest.spec.ts
@@ -80,12 +80,13 @@ describe('GET /applications with multi-valued type filter', () => {
       expect(page.totalCount).toEqual(nonAgentIds.length);
     });
 
-    it('returns every application when no type filter is supplied', async () => {
+    it('excludes agents by default when no type filter is supplied', async () => {
       const page = await listApplications(fixture.primaryDomain.id!, fixture.accessToken, { size: 50 });
       const returnedIds = page.data.map((app) => app.id!);
 
-      expect(returnedIds.sort()).toEqual([...nonAgentIds, ...agentIds].sort());
-      expect(page.totalCount).toEqual(nonAgentIds.length + agentIds.length);
+      expect(returnedIds.sort()).toEqual([...nonAgentIds].sort());
+      expect(returnedIds.some((id) => agentIds.includes(id))).toBe(false);
+      expect(page.totalCount).toEqual(nonAgentIds.length);
     });
 
     it('returns only agents when called with the agent type set', async () => {


### PR DESCRIPTION
The app listings were returning agents mixed in with normal applications. Agents are just `Application` rows with `type = AGENT`, so any listing that doesn't filter by type picks them up too.

Turns out fixing the `/applications` endpoint alone wasn't enough. The console list actually uses the cursor endpoint `/applications/search`, and that one was silently ignoring the `type` filter entirely. The cursor request carried `types` and the resource forwarded them, but neither the Mongo nor JDBC cursor repo ever applied them to the query. So that gap had to be closed first.

What this does, across all three listing paths (`/applications`, `/applications?q=`, and `/applications/search`):

- adds `ApplicationType.defaultingToNonAgent(...)` so when no `type` is given we default to every type except AGENT (via `EnumSet.complementOf`, so any future type is included automatically). Agents are still reachable with an explicit `type=AGENT`.
- wires `types` into the cursor query in `MongoApplicationCursorRepository` and `JdbcApplicationCursorRepository`.

Left the same `status`/`enabled` cursor gap alone, out of scope here.

Test plan:
- `ApplicationsResourceTest`, `ApplicationsResourceFilterTest`, `ApplicationsResourceSearcherTest` updated, plus new cases for the no-type default and `type=AGENT` passthrough.
- `ApplicationCursorRepositoryTest` has a new type-filter test passing against both Mongo and JDBC (8/8 each), so the exclusion is verified at the DB level.
