### PR TITLE
fix: AM-7134 automation base path [master]

### DIFF
--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -36,7 +36,7 @@ info:
   title: Gravitee.io AM - Automation API
   version: 4.13.0
 servers:
-- url: http://localhost:8093/management/automation
+- url: http://localhost:8093/automation
 security:
 - BearerAuth: []
 tags:

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/WALKTHROUGH.md
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/WALKTHROUGH.md
@@ -32,7 +32,7 @@ TOKEN=$(curl -s http://localhost:8093/management/auth/token \
 ## Base URL
 
 ```
-http://localhost:8093/management/automation
+http://localhost:8093/automation
 ```
 
 ## API Pattern
@@ -132,7 +132,7 @@ The `key` in the body is the unique identifier within the environment.
 ```bash
 ORG="DEFAULT"
 ENV="DEFAULT"
-BASE="http://localhost:8093/management/automation"
+BASE="http://localhost:8093/automation"
 
 # Customer-facing auth domain
 curl -s -X PUT "$BASE/organizations/$ORG/environments/$ENV/domains" \
@@ -411,8 +411,8 @@ curl -s -X DELETE "$BASE/organizations/$ORG/environments/$ENV/domains/internal-a
 Auto-generated from annotations, available without authentication:
 
 ```bash
-curl -s http://localhost:8093/management/automation/openapi.json | jq .info
-curl -s http://localhost:8093/management/automation/openapi.yaml | head -20
+curl -s http://localhost:8093/automation/openapi.json | jq .info
+curl -s http://localhost:8093/automation/openapi.yaml | head -20
 ```
 
 ---
@@ -427,7 +427,7 @@ curl -s http://localhost:8093/management/automation/openapi.yaml | head -20
 | Reporter | `PUT .../domains/{key}/reporters` | `GET .../domains/{key}/reporters/{key}` | `GET .../domains/{key}/reporters` | `DELETE .../domains/{key}/reporters/{key}` |
 
 All paths are prefixed with
-`http://{host}/management/automation/organizations/{orgId}/environments/{envId}`.
+`http://{host}/automation/organizations/{orgId}/environments/{envId}`.
 
 Domains, identity providers, certificates and reporters are all addressed by their `key`.
 Only resources whose `managedBy = AUTOMATION_API` are visible to this API — UI-created

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
@@ -69,7 +69,7 @@ public class AutomationApiDefinition implements ReaderListener {
      * configuration (see {@code http.api.automation.entrypoint}). The generated OAS is static, so the
      * declared server url always reflects this default even when the runtime path is overridden.
      */
-    public static final String DEFAULT_AUTOMATION_ENTRYPOINT = "/management/automation";
+    public static final String DEFAULT_AUTOMATION_ENTRYPOINT = "/automation";
 
     private static final Set<String> AUTOMATION_TAGS = Set.of("Domains", "Identity Providers", "Certificates", "Reporters");
 
@@ -192,7 +192,7 @@ public class AutomationApiDefinition implements ReaderListener {
                 .collect(ArrayList::new, ArrayList::add, ArrayList::addAll));
 
         // The Automation API is mounted at the configurable http.api.automation.entrypoint
-        // (defaults to /management/automation), mirroring how the management API declares its
+        // (defaults to /automation), mirroring how the management API declares its
         // /management server in GraviteeApiDefinition. The spec is static, so it always reflects the default.
         openAPI.servers(List.of(new Server().url("http://localhost:8093" + DEFAULT_AUTOMATION_ENTRYPOINT)));
         openAPI.info(new Info()

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -71,7 +71,7 @@
 #    entrypoint: /management
 #    automation:
 #      enabled: false  # Enable the Automation API for declarative GitOps-style resource management
-#      entrypoint: /management/automation  # Listening path for the Automation API
+#      entrypoint: /automation  # Listening path for the Automation API
 #  cors:
 #      Allows to configure the header Access-Control-Allow-Origin (default value: *)
 #      '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.

--- a/gravitee-am-test/specs/management/automation/fixtures/automation-client.ts
+++ b/gravitee-am-test/specs/management/automation/fixtures/automation-client.ts
@@ -15,7 +15,7 @@
  */
 import { performDelete, performGet, performPut } from '@gateway-commands/oauth-oidc-commands';
 
-export const automationUrl = (): string => `${process.env.AM_MANAGEMENT_URL}/management/automation`;
+export const automationUrl = (): string => `${process.env.AM_MANAGEMENT_URL}/automation`;
 
 export const envPath = (): string =>
   `/organizations/${process.env.AM_DEF_ORG_ID}/environments/${process.env.AM_DEF_ENV_ID}`;

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -446,7 +446,7 @@ api:
 #      entrypoint: /management
 #      automation:
 #        enabled: false
-#        entrypoint: /management/automation
+#        entrypoint: /automation
     services:
       metrics:
         enabled: false


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7134](https://gravitee.atlassian.net/browse/AM-7134)

## :pencil2: A description of the changes proposed in the pull request
Change Automation API base path `/management/automation` -> `/automation`.

See also https://github.com/gravitee-io/gravitee-access-management/pull/8019.

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7134]: https://gravitee.atlassian.net/browse/AM-7134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ