### PR TITLE
feat(gateway): reactive parallel domain synchronization pipeline

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/alert/AlertEventProcessor.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/alert/AlertEventProcessor.java
@@ -68,22 +68,24 @@ public class AlertEventProcessor extends AbstractService {
 
     private String environmentId;
 
-    private String organizationId;
+    private volatile String organizationId;
 
     @Override
     protected void doStart() throws Exception {
         super.doStart();
 
-        try {
-            this.environmentId = domain.getReferenceId();
-            final io.gravitee.am.model.Environment domainEnv = environmentService.findById(environmentId).blockingGet();
-            this.organizationId = domainEnv.getOrganizationId();
-        } catch (Exception e) {
-            logger.warn("The domain [{}] seems not attached to any environment or organization. Alert events may not be accurate.", domain.getName());
-        }
-
-        logger.info("Register event listener for all events for domain {}", domain.getName());
-        eventManager.subscribeForEvents(authenticationEventListener, AuthenticationEvent.class, domain.getId());
+        this.environmentId = domain.getReferenceId();
+        environmentService.findById(environmentId).
+                map(domainEnv -> {
+                    this.organizationId = domainEnv.getOrganizationId();
+                    return domainEnv;
+                })
+                .doOnError(error -> logger.warn("The domain [{}] seems not attached to any environment or organization. Alert events may not be accurate.", domain.getName()))
+                .doFinally(() -> {
+                    logger.info("Register event listener for all events for domain {}", domain.getName());
+                    eventManager.subscribeForEvents(authenticationEventListener, AuthenticationEvent.class, domain.getId());
+                })
+                .subscribe();
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
@@ -110,19 +110,16 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
     public void afterPropertiesSet() {
         logger.info("Initializing identity providers for domain {}", domain.getName());
 
-        try {
-            identityProviderRepository.findAll(ReferenceType.DOMAIN, domain.getId())
-                    .concatMapSingle(this::updateAuthenticationProvider)
-                    .map(provider -> {
-                        gatewayMetricProvider.incrementIdp();
-                        return provider;
-                    })
-                    .blockingLast();
-            logger.info("Identity providers loaded for domain {}", domain.getName());
-        } catch (Exception e) {
-            logger.error("Unable to initialize identity providers for domain {}", domain.getName(), e);
-            domainReadinessService.pluginInitFailed(domain.getId(), Type.IDENTITY_PROVIDER.name(), e.getMessage());
-        }
+        identityProviderRepository.findAll(ReferenceType.DOMAIN, domain.getId())
+                .concatMapSingle(this::updateAuthenticationProvider)
+                .doOnComplete(() -> logger.info("Identity providers loaded for domain {}", domain.getName()))
+                .subscribe(
+                        provider -> gatewayMetricProvider.incrementIdp(),
+                        e -> {
+                            logger.error("Unable to initialize identity providers for domain {}", domain.getName(), e);
+                            domainReadinessService.pluginInitFailed(domain.getId(), Type.IDENTITY_PROVIDER.name(), e.getMessage());
+                        }
+                );
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/impl/ExtensionGrantManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/impl/ExtensionGrantManagerImpl.java
@@ -46,6 +46,8 @@ import io.gravitee.am.repository.management.api.ExtensionGrantRepository;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -53,6 +55,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -116,17 +119,18 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
         logger.info("Initializing extension grants for domain {}", domain.getName());
         this.tokenRequestResolver.setManagers(this.scopeManager, this.protectedResourceManager);
         extensionGrantRepository.findByDomain(domain.getId())
+                .concatMapCompletable(extensionGrant -> {
+                    // backward compatibility, get the oldest extension grant to set the good one for the old clients
+                    if (minDate == null) {
+                        minDate = extensionGrant.getCreatedAt();
+                    } else if (minDate.after(extensionGrant.getCreatedAt())) {
+                        minDate = extensionGrant.getCreatedAt();
+                    }
+                    return updateExtensionGrantProvider(extensionGrant);
+                })
+                .doOnComplete(() -> logger.info("Extension grants loaded for domain {}", domain.getName()))
                 .subscribe(
-                        extensionGrant -> {
-                            // backward compatibility, get the oldest extension grant to set the good one for the old clients
-                            if (minDate == null) {
-                                minDate = extensionGrant.getCreatedAt();
-                            } else if (minDate.after(extensionGrant.getCreatedAt())) {
-                                minDate = extensionGrant.getCreatedAt();
-                            }
-                            updateExtensionGrantProvider(extensionGrant);
-                            logger.info("Extension grants loaded for domain {}", domain.getName());
-                        },
+                        () -> {},
                         error -> {
                             logger.error("Unable to initialize extension grants for domain {}", domain.getName(), error);
                             domainReadinessService.pluginInitFailed(domain.getId(), Type.EXTENSION_GRANT.name(), error.getMessage());
@@ -170,8 +174,8 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
                             if (extensionGrants.isEmpty()) {
                                 minDate = extensionGrant.getCreatedAt();
                             }
-                            updateExtensionGrantProvider(extensionGrant);
-                            logger.info("Extension grant {} {}d for domain {}", extensionGrantId, eventType, domain.getName());
+                            updateExtensionGrantProvider(extensionGrant)
+                                    .subscribe(() -> logger.info("Extension grant {} {}d for domain {}", extensionGrantId, eventType, domain.getName()));
                         },
                         error -> logger.error("Unable to {} extension grant for domain {}", eventType, domain.getName(), error),
                         () -> logger.error("No extension grant found with id {}", extensionGrantId));
@@ -189,42 +193,47 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
         }
     }
 
-    private void updateExtensionGrantProvider(ExtensionGrant extensionGrant) {
+    private Completable updateExtensionGrantProvider(ExtensionGrant extensionGrant) {
         domainReadinessService.initPluginSync(domain.getId(), extensionGrant.getId(), Type.EXTENSION_GRANT.name());
-        try {
-            if (needDeployment(extensionGrant)) {
-                AuthenticationProvider authenticationProvider = null;
-                if (extensionGrant.getIdentityProvider() != null) {
-                    logger.info("\tLooking for extension grant identity provider: {}", extensionGrant.getIdentityProvider());
-                    authenticationProvider = identityProviderManager.get(extensionGrant.getIdentityProvider()).blockingGet();
-                    if (authenticationProvider != null) {
-                        logger.info("\tExtension grant identity provider: {}, loaded", extensionGrant.getIdentityProvider());
-                    }
-                }
-
-                var providerConfiguration = new ExtensionGrantProviderConfiguration(extensionGrant, authenticationProvider);
-                var extensionGrantProvider = extensionGrantPluginManager.create(providerConfiguration);
-                var extensionGrantStrategy = buildStrategy(extensionGrant, extensionGrantProvider);
-                // backward compatibility, set min date to the extension grant strategy to choose the good one for the old clients
-                extensionGrantStrategy.setMinDate(minDate);
-
-                // Wrap strategy with adapter to integrate with CompositeTokenGranter
-                var adapter = new StrategyGranterAdapter(extensionGrantStrategy, domain, tokenService, rulesEngine, tokenRequestResolver);
-
-                ((CompositeTokenGranter) tokenGranter).addTokenGranter(extensionGrant.getId(), adapter);
-                extensionGrants.put(extensionGrant.getId(), extensionGrant);
-                extensionGrantStrategies.put(extensionGrant.getId(), extensionGrantStrategy);
-                domainReadinessService.pluginLoaded(domain.getId(), extensionGrant.getId());
-            } else {
-                logger.info("Extension grant {} already loaded for domain {}", extensionGrant.getId(), domain.getName());
-                domainReadinessService.pluginLoaded(domain.getId(), extensionGrant.getId());
-            }
-        } catch (Exception ex) {
-            // failed to load the plugin
-            logger.error("An error occurs while initializing the extension grant : {}", extensionGrant.getName(), ex);
-            removeExtensionGrant(extensionGrant.getId());
-            domainReadinessService.pluginFailed(domain.getId(), extensionGrant.getId(), ex.getMessage());
+        if (!needDeployment(extensionGrant)) {
+            logger.info("Extension grant {} already loaded for domain {}", extensionGrant.getId(), domain.getName());
+            domainReadinessService.pluginLoaded(domain.getId(), extensionGrant.getId());
+            return Completable.complete();
         }
+
+        Single<Optional<AuthenticationProvider>> authProviderSingle;
+        if (extensionGrant.getIdentityProvider() != null) {
+            logger.info("\tLooking for extension grant identity provider: {}", extensionGrant.getIdentityProvider());
+            authProviderSingle = identityProviderManager.get(extensionGrant.getIdentityProvider())
+                    .doOnSuccess(ap -> logger.info("\tExtension grant identity provider: {}, loaded", extensionGrant.getIdentityProvider()))
+                    .map(Optional::of)
+                    .switchIfEmpty(Single.just(Optional.empty()));
+        } else {
+            authProviderSingle = Single.just(Optional.empty());
+        }
+
+        return authProviderSingle
+                .flatMapCompletable(optProvider -> Completable.fromAction(() -> {
+                    var providerConfiguration = new ExtensionGrantProviderConfiguration(extensionGrant, optProvider.orElse(null));
+                    var extensionGrantProvider = extensionGrantPluginManager.create(providerConfiguration);
+                    var extensionGrantStrategy = buildStrategy(extensionGrant, extensionGrantProvider);
+                    // backward compatibility, set min date to the extension grant strategy to choose the good one for the old clients
+                    extensionGrantStrategy.setMinDate(minDate);
+
+                    // Wrap strategy with adapter to integrate with CompositeTokenGranter
+                    var adapter = new StrategyGranterAdapter(extensionGrantStrategy, domain, tokenService, rulesEngine, tokenRequestResolver);
+
+                    ((CompositeTokenGranter) tokenGranter).addTokenGranter(extensionGrant.getId(), adapter);
+                    extensionGrants.put(extensionGrant.getId(), extensionGrant);
+                    extensionGrantStrategies.put(extensionGrant.getId(), extensionGrantStrategy);
+                    domainReadinessService.pluginLoaded(domain.getId(), extensionGrant.getId());
+                }))
+                .doOnError(ex -> {
+                    logger.error("An error occurs while initializing the extension grant : {}", extensionGrant.getName(), ex);
+                    removeExtensionGrant(extensionGrant.getId());
+                    domainReadinessService.pluginFailed(domain.getId(), extensionGrant.getId(), ex.getMessage());
+                })
+                .onErrorComplete();
     }
 
     private ExtensionGrantStrategy buildStrategy(ExtensionGrant extensionGrant, ExtensionGrantProvider extensionGrantProvider) {

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/SecurityDomainManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/SecurityDomainManager.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.reactor;
 
 import io.gravitee.am.model.Domain;
+import io.reactivex.rxjava3.core.Completable;
 
 import java.util.Collection;
 
@@ -45,6 +46,21 @@ public interface SecurityDomainManager {
      * @param domainId The ID of the security domain to undeploy.
      */
     void undeploy(String domainId);
+
+    /**
+     * Reactive variant of {@link #deploy(Domain)}.
+     */
+    Completable deployReactive(Domain domain);
+
+    /**
+     * Reactive variant of {@link #update(Domain)}.
+     */
+    Completable updateReactive(Domain domain);
+
+    /**
+     * Reactive variant of {@link #undeploy(String)}.
+     */
+    Completable undeployReactive(String domainId);
 
     /**
      * Returns a collection of deployed {@link Domain}s.

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
@@ -110,8 +110,10 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
         return router;
     }
 
+    // Root router is mutated only under this instance monitor; heavy per-domain work
+    // (Spring context refresh, component start) happens before, in parallel.
     @Override
-    public void mountDomain(VertxSecurityDomainHandler domainHandler) {
+    public synchronized void mountDomain(VertxSecurityDomainHandler domainHandler) {
 
         Domain domain = domainHandler.getDomain();
 
@@ -141,7 +143,7 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
     }
 
     @Override
-    public void unMountDomain(VertxSecurityDomainHandler domainHandler) {
+    public synchronized void unMountDomain(VertxSecurityDomainHandler domainHandler) {
 
         domainHandler.router().clear();
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
@@ -41,6 +41,7 @@ import org.springframework.core.env.Environment;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -62,6 +63,10 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
     private Vertx vertx;
 
     private Router router;
+
+    // Root router is mutated only under this lock; heavy per-domain work
+    // (Spring context refresh, component start) happens before, in parallel.
+    private final ReentrantLock routerLock = new ReentrantLock();
 
     @Autowired
     private TransactionHandlerFactory transactionHandlerFactory;
@@ -110,26 +115,28 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
         return router;
     }
 
-    // Root router is mutated only under this instance monitor; heavy per-domain work
-    // (Spring context refresh, component start) happens before, in parallel.
     @Override
-    public synchronized void mountDomain(VertxSecurityDomainHandler domainHandler) {
+    public void mountDomain(VertxSecurityDomainHandler domainHandler) {
+        routerLock.lock();
+        try {
+            Domain domain = domainHandler.getDomain();
 
-        Domain domain = domainHandler.getDomain();
+            if (domain.isVhostMode()) {
+                // Mount the same router for each virtual host / path.
+                // Sort vhosts to ensure proper routing order:
+                // - More specific paths (longer) are checked first
+                // - "/" (catch-all) is always checked last
+                List<VirtualHost> sortedVhosts = domain.getVhosts().stream()
+                        .sorted(Comparator.comparing((VirtualHost vhost) -> vhost.getPath().equals("/") ? 1 : 0)
+                                .thenComparing(Comparator.comparing(VirtualHost::getPath).reversed()))
+                        .toList();
 
-        if (domain.isVhostMode()) {
-            // Mount the same router for each virtual host / path.
-            // Sort vhosts to ensure proper routing order:
-            // - More specific paths (longer) are checked first
-            // - "/" (catch-all) is always checked last
-            List<VirtualHost> sortedVhosts = domain.getVhosts().stream()
-                    .sorted(Comparator.comparing((VirtualHost vhost) -> vhost.getPath().equals("/") ? 1 : 0)
-                            .thenComparing(Comparator.comparing(VirtualHost::getPath).reversed()))
-                    .toList();
-
-            sortedVhosts.forEach(virtualHost -> this.router.route(sanitizePath(virtualHost.getPath())).subRouter(VHostRouter.router(vertx, domain, virtualHost, domainHandler.router())));
-        } else {
-            this.router.route(sanitizePath(domain.getPath())).subRouter(VHostRouter.router(vertx, domain, domainHandler.router()));
+                sortedVhosts.forEach(virtualHost -> this.router.route(sanitizePath(virtualHost.getPath())).subRouter(VHostRouter.router(vertx, domain, virtualHost, domainHandler.router())));
+            } else {
+                this.router.route(sanitizePath(domain.getPath())).subRouter(VHostRouter.router(vertx, domain, domainHandler.router()));
+            }
+        } finally {
+            routerLock.unlock();
         }
     }
 
@@ -143,9 +150,13 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
     }
 
     @Override
-    public synchronized void unMountDomain(VertxSecurityDomainHandler domainHandler) {
-
-        domainHandler.router().clear();
+    public void unMountDomain(VertxSecurityDomainHandler domainHandler) {
+        routerLock.lock();
+        try {
+            domainHandler.router().clear();
+        } finally {
+            routerLock.unlock();
+        }
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultSecurityDomainHandlerRegistry.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultSecurityDomainHandlerRegistry.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -37,6 +38,9 @@ public class DefaultSecurityDomainHandlerRegistry implements SecurityDomainHandl
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultSecurityDomainHandlerRegistry.class);
     private final ConcurrentMap<String, VertxSecurityDomainHandler> handlers = new ConcurrentHashMap<>();
+    // Per-domain locks ensure concurrent update() calls for the same domain don't interleave
+    // (remove+create must be atomic per domain). Different domains are independent.
+    private final ConcurrentMap<String, ReentrantLock> domainLocks = new ConcurrentHashMap<>();
 
     @Autowired
     private SecurityDomainRouterFactory securityDomainRouterFactory;
@@ -67,13 +71,18 @@ public class DefaultSecurityDomainHandlerRegistry implements SecurityDomainHandl
 
     @Override
     public void update(Domain domain) {
-
-        VertxSecurityDomainHandler handler = handlers.get(domain.getId());
-        if (handler != null) {
-            remove(domain);
-            create(domain);
-        } else {
-            create(domain);
+        ReentrantLock lock = domainLocks.computeIfAbsent(domain.getId(), k -> new ReentrantLock());
+        lock.lock();
+        try {
+            VertxSecurityDomainHandler handler = handlers.get(domain.getId());
+            if (handler != null) {
+                remove(domain);
+                create(domain);
+            } else {
+                create(domain);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -86,6 +95,7 @@ public class DefaultSecurityDomainHandlerRegistry implements SecurityDomainHandl
                 handler.stop();
                 handlers.remove(domain.getId());
                 reactor.unMountDomain(handler);
+                domainLocks.remove(domain.getId());
                 logger.info("Security Domain has been unregistered");
             } catch (Exception e) {
                 logger.error("Unable to un-register handler", e);

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultSecurityDomainHandlerRegistry.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultSecurityDomainHandlerRegistry.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -38,9 +37,6 @@ public class DefaultSecurityDomainHandlerRegistry implements SecurityDomainHandl
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultSecurityDomainHandlerRegistry.class);
     private final ConcurrentMap<String, VertxSecurityDomainHandler> handlers = new ConcurrentHashMap<>();
-    // Per-domain locks ensure concurrent update() calls for the same domain don't interleave
-    // (remove+create must be atomic per domain). Different domains are independent.
-    private final ConcurrentMap<String, ReentrantLock> domainLocks = new ConcurrentHashMap<>();
 
     @Autowired
     private SecurityDomainRouterFactory securityDomainRouterFactory;
@@ -71,18 +67,15 @@ public class DefaultSecurityDomainHandlerRegistry implements SecurityDomainHandl
 
     @Override
     public void update(Domain domain) {
-        ReentrantLock lock = domainLocks.computeIfAbsent(domain.getId(), k -> new ReentrantLock());
-        lock.lock();
-        try {
-            VertxSecurityDomainHandler handler = handlers.get(domain.getId());
-            if (handler != null) {
-                remove(domain);
-                create(domain);
-            } else {
-                create(domain);
-            }
-        } finally {
-            lock.unlock();
+        // Synchronization per domain is guaranteed upstream: SyncManager deduplicates events by
+        // (type, id) within a cycle and serializes cycles, so update/create/remove for a given
+        // domain never run concurrently.
+        VertxSecurityDomainHandler handler = handlers.get(domain.getId());
+        if (handler != null) {
+            remove(domain);
+            create(domain);
+        } else {
+            create(domain);
         }
     }
 
@@ -95,7 +88,6 @@ public class DefaultSecurityDomainHandlerRegistry implements SecurityDomainHandl
                 handler.stop();
                 handlers.remove(domain.getId());
                 reactor.unMountDomain(handler);
-                domainLocks.remove(domain.getId());
                 logger.info("Security Domain has been unregistered");
             } catch (Exception e) {
                 logger.error("Unable to un-register handler", e);

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultSecurityDomainManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultSecurityDomainManager.java
@@ -19,13 +19,14 @@ import io.gravitee.am.common.event.DomainEvent;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.gateway.reactor.SecurityDomainManager;
 import io.gravitee.am.model.Domain;
+import io.reactivex.rxjava3.core.Completable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -38,7 +39,7 @@ public class DefaultSecurityDomainManager implements SecurityDomainManager {
     @Autowired
     private EventManager eventManager;
 
-    private final Map<String, Domain> domains = new HashMap<>();
+    private final Map<String, Domain> domains = new ConcurrentHashMap<>();
 
 
     @Override
@@ -77,6 +78,21 @@ public class DefaultSecurityDomainManager implements SecurityDomainManager {
             eventManager.publishEvent(DomainEvent.UNDEPLOY, currentDomain);
             logger.info("{} has been undeployed", domainId);
         }
+    }
+
+    @Override
+    public Completable deployReactive(Domain domain) {
+        return Completable.fromRunnable(() -> deploy(domain));
+    }
+
+    @Override
+    public Completable updateReactive(Domain domain) {
+        return Completable.fromRunnable(() -> update(domain));
+    }
+
+    @Override
+    public Completable undeployReactive(String domainId) {
+        return Completable.fromRunnable(() -> undeploy(domainId));
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/SecurityDomainManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/SecurityDomainManagerTest.java
@@ -19,12 +19,18 @@ import io.gravitee.am.common.event.DomainEvent;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.gateway.reactor.impl.DefaultSecurityDomainManager;
 import io.gravitee.am.model.Domain;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -122,5 +128,47 @@ public class SecurityDomainManagerTest {
         securityDomainManager.undeploy(existingDomain.getId());
 
         verify(eventManager, times(1)).publishEvent(eq(DomainEvent.UNDEPLOY), any());
+    }
+
+    @Test
+    public void deployReactive_shouldRegisterDomain() {
+        final Domain domain = new Domain();
+        domain.setId("domain-reactive");
+        domain.setEnabled(true);
+
+        securityDomainManager.deployReactive(domain).blockingAwait();
+
+        Assert.assertNotNull(securityDomainManager.get(domain.getId()));
+        verify(eventManager, times(1)).publishEvent(eq(DomainEvent.DEPLOY), any());
+    }
+
+    @Test
+    public void undeployReactive_shouldRemoveDomain() {
+        final Domain domain = new Domain();
+        domain.setId("domain-reactive-undeploy");
+        domain.setEnabled(true);
+        securityDomainManager.deploy(domain);
+
+        securityDomainManager.undeployReactive(domain.getId()).blockingAwait();
+
+        Assert.assertNull(securityDomainManager.get(domain.getId()));
+        verify(eventManager, times(1)).publishEvent(eq(DomainEvent.UNDEPLOY), any());
+    }
+
+    @Test
+    public void deployReactive_concurrent_shouldRegisterAllDomains() throws InterruptedException {
+        int count = 50;
+        List<Completable> deployments = IntStream.range(0, count)
+                .mapToObj(i -> {
+                    Domain d = new Domain();
+                    d.setId("concurrent-domain-" + i);
+                    d.setEnabled(true);
+                    return securityDomainManager.deployReactive(d).subscribeOn(Schedulers.io());
+                })
+                .collect(Collectors.toList());
+
+        Completable.merge(deployments).blockingAwait();
+
+        Assert.assertEquals(count, securityDomainManager.domains().size());
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
@@ -32,11 +32,15 @@ import io.gravitee.am.repository.management.api.EventRepository;
 import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.node.api.Node;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,7 +58,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 
@@ -66,7 +74,7 @@ import static java.util.stream.Collectors.toMap;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class SyncManager implements InitializingBean {
+public class SyncManager implements InitializingBean, DisposableBean {
 
     /**
      * Add 30s delay before and after to avoid problem with out of sync clocks.
@@ -121,12 +129,15 @@ public class SyncManager implements InitializingBean {
 
     private String dataPlaneId;
 
-    private long lastRefreshAt = -1;
+    private volatile long lastRefreshAt = -1;
 
-    private long lastDelay = 0;
+    private volatile long lastDelay = 0;
 
     @Getter
-    private boolean allSecurityDomainsSync = false;
+    private volatile boolean allSecurityDomainsSync = false;
+
+    // Package-private so tests can set it to false to simulate an in-progress sync.
+    final AtomicBoolean syncInProgress = new AtomicBoolean(false);
 
     @Value("${services.sync.initTimeOutMillis:-1}")
     private int initDomainTimeOut = -1;
@@ -142,6 +153,10 @@ public class SyncManager implements InitializingBean {
 
     @Value("${services.sync.deploy.parallelism:0}")
     private int deployParallelism;
+
+    private Scheduler deploymentScheduler;
+
+    private ExecutorService deploymentExecutor;
 
     private Cache<String, String> processedEventIds;
 
@@ -159,9 +174,28 @@ public class SyncManager implements InitializingBean {
         logger.info("\t\t - Environments : {}", environments.isPresent() ? environments.get() : "[]");
         logger.info("\t\t - Environments loaded : {}", environmentIds != null ? environmentIds : "[]");
         logger.info("\t\t - Domain deployment parallelism : {}", deployParallelism);
+        AtomicInteger threadIndex = new AtomicInteger(0);
+        deploymentExecutor = Executors.newFixedThreadPool(deployParallelism, r -> {
+            Thread t = new Thread(r, "gio.sync-deployer-" + threadIndex.getAndIncrement());
+            t.setDaemon(true);
+            return t;
+        });
+        deploymentScheduler = Schedulers.from(deploymentExecutor);
         this.processedEventIds = CacheBuilder.newBuilder()
                 .expireAfterWrite(timeframeBeforeDelay + timeframeAfterDelay, TimeUnit.MILLISECONDS)
                 .build();
+    }
+
+    @Override
+    public void destroy() {
+        if (deploymentExecutor != null) {
+            deploymentExecutor.shutdown();
+        }
+    }
+
+    // Package-private to allow tests to inject a synchronous scheduler (e.g. Schedulers.trampoline()).
+    void setDeploymentScheduler(Scheduler scheduler) {
+        this.deploymentScheduler = scheduler;
     }
 
     public void refresh() {
@@ -169,17 +203,35 @@ public class SyncManager implements InitializingBean {
             logger.info("No domain listener, rescheduling initial synchronization process");
             return;
         }
+        if (!syncInProgress.compareAndSet(false, true)) {
+            logger.debug("Sync already in progress, skipping");
+            return;
+        }
 
         logger.debug("Refreshing sync state...");
-        long nextLastRefreshAt = System.currentTimeMillis();
+        final long nextLastRefreshAt = System.currentTimeMillis();
 
-        try {
-            if (lastRefreshAt == -1) {
-                logger.debug("Initial synchronization");
-                deployDomains();
-                allSecurityDomainsSync = true;
-            } else {
-                // search for events and compute them
+        if (lastRefreshAt == -1) {
+            logger.debug("Initial synchronization");
+            deployDomains()
+                    .doOnComplete(() -> {
+                        allSecurityDomainsSync = true;
+                        lastRefreshAt = nextLastRefreshAt;
+                        lastDelay = System.currentTimeMillis() - nextLastRefreshAt;
+                    })
+                    .doFinally(() -> syncInProgress.set(false))
+                    .subscribe(
+                            () -> {},
+                            ex -> {
+                                if (logger.isDebugEnabled()) {
+                                    logger.error("Synchronization failed", ex);
+                                } else {
+                                    logger.error("Synchronization failed, ex={}", ex.toString());
+                                }
+                            });
+        } else {
+            // Event branch: still blocking (converted in T05).
+            try {
                 logger.debug("Events synchronization");
 
                 final long from = (lastRefreshAt - lastDelay) - timeframeBeforeDelay;
@@ -205,37 +257,40 @@ public class SyncManager implements InitializingBean {
                     gatewayMetricProvider.updateSyncEvents(0);
                 }
 
-            }
-            lastRefreshAt = nextLastRefreshAt;
-            lastDelay = System.currentTimeMillis() - nextLastRefreshAt;
-        } catch (Exception ex) {
-            if (logger.isDebugEnabled()) {
-                logger.error("Synchronization failed", ex);
-            } else {
-                logger.error("Synchronization failed, ex={}", ex.toString());
+                lastRefreshAt = nextLastRefreshAt;
+                lastDelay = System.currentTimeMillis() - nextLastRefreshAt;
+            } catch (Exception ex) {
+                if (logger.isDebugEnabled()) {
+                    logger.error("Synchronization failed", ex);
+                } else {
+                    logger.error("Synchronization failed, ex={}", ex.toString());
+                }
+            } finally {
+                syncInProgress.set(false);
             }
         }
     }
 
-    private void deployDomains() {
+    private Completable deployDomains() {
         logger.info("Starting security domains initialization ...");
-        Single<List<Domain>> findDomains = domainRepository.findAll()
-                // remove disabled domains
+        Completable deployAll = domainRepository.findAll()
                 .filter(Domain::isEnabled)
-                // Can the security domain be deployed ?
                 .filter(this::canHandle)
-                .toList();
-        if (this.initDomainTimeOut > 0) {
-            findDomains = findDomains.timeout(this.initDomainTimeOut, TimeUnit.MILLISECONDS);
+                .flatMapCompletable(domain ->
+                        deployOne(domain)
+                                .subscribeOn(deploymentScheduler)
+                                .doOnComplete(() -> domainReadinessService.updateDomainStatus(domain.getId(), DomainState.Status.DEPLOYED))
+                                .doOnError(ex -> logger.error("Unable to deploy security domain {}", domain.getId(), ex))
+                                .onErrorComplete(),
+                        false, deployParallelism);
+        if (initDomainTimeOut > 0) {
+            deployAll = deployAll.timeout(initDomainTimeOut, TimeUnit.MILLISECONDS);
         }
-        List<Domain> domains = findDomains.blockingGet();
+        return deployAll.doOnComplete(() -> logger.info("Security domains initialization done"));
+    }
 
-        // deploy security domains
-        domains.forEach(domain -> {
-            securityDomainManager.deploy(domain);
-            domainReadinessService.updateDomainStatus(domain.getId(), DomainState.Status.DEPLOYED);
-        });
-        logger.info("Security domains initialization done");
+    private Completable deployOne(Domain domain) {
+        return securityDomainManager.deployReactive(domain);
     }
 
     private void computeEvents(Collection<Event> events) {

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
@@ -175,13 +175,8 @@ public class SyncManager implements InitializingBean, DisposableBean {
         logger.info("\t\t - Environments loaded : {}", environmentIds != null ? environmentIds : "[]");
         logger.info("\t\t - Domain deployment parallelism : {}", deployParallelism);
         AtomicInteger threadIndex = new AtomicInteger(0);
-        // Domain deployment performs a Spring child context refresh which generates CGLIB proxies
-        // for gateway beans. That requires the gateway application classloader, NOT the context
-        // classloader of the thread initializing this bean: SyncManager runs in the sync-service
-        // plugin, whose classloader cannot define those proxies (ClassNotFoundException on
-        // *$$SpringCGLIB$$* / AopConfigException). SecurityDomainManager is a gateway-core class, so
-        // resolving its classloader (via parent-first delegation) yields the gateway application
-        // classloader, which is exactly the context under which deployment ran when synchronous.
+        // Assign the GatewayClassloader to the scheduler to make sure that the thread
+        // executing the domain loading action has access to the class definitions.
         final ClassLoader deploymentClassLoader = SecurityDomainManager.class.getClassLoader();
         deploymentExecutor = Executors.newFixedThreadPool(deployParallelism, r -> {
             Thread t = new Thread(r, "gio.sync-deployer-" + threadIndex.getAndIncrement());

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
@@ -33,6 +33,7 @@ import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.node.api.Node;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Single;
@@ -51,7 +52,6 @@ import java.text.Collator;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -213,62 +213,33 @@ public class SyncManager implements InitializingBean, DisposableBean {
 
         if (lastRefreshAt == -1) {
             logger.debug("Initial synchronization");
-            deployDomains()
-                    .doOnComplete(() -> {
-                        allSecurityDomainsSync = true;
-                        lastRefreshAt = nextLastRefreshAt;
-                        lastDelay = System.currentTimeMillis() - nextLastRefreshAt;
-                    })
-                    .doFinally(() -> syncInProgress.set(false))
-                    .subscribe(
-                            () -> {},
-                            ex -> {
-                                if (logger.isDebugEnabled()) {
-                                    logger.error("Synchronization failed", ex);
-                                } else {
-                                    logger.error("Synchronization failed, ex={}", ex.toString());
-                                }
-                            });
+            executeSync(
+                    deployDomains().doOnComplete(() -> allSecurityDomainsSync = true),
+                    nextLastRefreshAt);
         } else {
-            // Event branch: still blocking (converted in T05).
-            try {
-                logger.debug("Events synchronization");
-
-                final long from = (lastRefreshAt - lastDelay) - timeframeBeforeDelay;
-                final long to = nextLastRefreshAt + timeframeAfterDelay;
-                Single<List<Event>> findEvents = eventRepository.findByTimeFrameAndDataPlaneId(from, to, dataPlaneId).toList();
-                if (this.eventsTimeOut > 0) {
-                    findEvents = findEvents.timeout(this.eventsTimeOut, TimeUnit.MILLISECONDS);
-                }
-                List<Event> events = findEvents.blockingGet();
-
-                if (!events.isEmpty()) {
-                    gatewayMetricProvider.updateSyncEvents(events.size());
-
-                    // Extract only the latest events by type and id
-                    Map<AbstractMap.SimpleEntry<Object, Object>, Event> sortedEvents = events
-                            .stream()
-                            .collect(
-                                    toMap(
-                                            event -> new AbstractMap.SimpleEntry<>(event.getType(), event.getPayload().getId()),
-                                            event -> event, BinaryOperator.maxBy(comparing(Event::getCreatedAt)), LinkedHashMap::new));
-                    computeEvents(sortedEvents.values());
-                } else {
-                    gatewayMetricProvider.updateSyncEvents(0);
-                }
-
-                lastRefreshAt = nextLastRefreshAt;
-                lastDelay = System.currentTimeMillis() - nextLastRefreshAt;
-            } catch (Exception ex) {
-                if (logger.isDebugEnabled()) {
-                    logger.error("Synchronization failed", ex);
-                } else {
-                    logger.error("Synchronization failed, ex={}", ex.toString());
-                }
-            } finally {
-                syncInProgress.set(false);
-            }
+            logger.debug("Events synchronization");
+            final long from = (lastRefreshAt - lastDelay) - timeframeBeforeDelay;
+            final long to = nextLastRefreshAt + timeframeAfterDelay;
+            executeSync(processEvents(from, to), nextLastRefreshAt);
         }
+    }
+
+    private void executeSync(Completable pipeline, long nextLastRefreshAt) {
+        pipeline
+                .doOnComplete(() -> {
+                    lastRefreshAt = nextLastRefreshAt;
+                    lastDelay = System.currentTimeMillis() - nextLastRefreshAt;
+                })
+                .doFinally(() -> syncInProgress.set(false))
+                .subscribe(
+                        () -> {},
+                        ex -> {
+                            if (logger.isDebugEnabled()) {
+                                logger.error("Synchronization failed", ex);
+                            } else {
+                                logger.error("Synchronization failed, ex={}", ex.toString());
+                            }
+                        });
     }
 
     private Completable deployDomains() {
@@ -293,73 +264,85 @@ public class SyncManager implements InitializingBean, DisposableBean {
         return securityDomainManager.deployReactive(domain);
     }
 
-    private void computeEvents(Collection<Event> events) {
-        events.forEach(event -> {
-            logger.debug("Compute event id : {}, with type : {} and timestamp : {} and payload : {}", event.getId(), event.getType(), event.getCreatedAt(), event.getPayload());
-            if (Objects.requireNonNull(event.getType()) == Type.DOMAIN) {
-                synchronizeDomain(event);
+    private Completable processEvents(long from, long to) {
+        Single<List<Event>> findEvents = eventRepository.findByTimeFrameAndDataPlaneId(from, to, dataPlaneId).toList();
+        if (this.eventsTimeOut > 0) {
+            findEvents = findEvents.timeout(this.eventsTimeOut, TimeUnit.MILLISECONDS);
+        }
+        return findEvents.flatMapCompletable(events -> {
+            if (events.isEmpty()) {
+                gatewayMetricProvider.updateSyncEvents(0);
+                return Completable.complete();
+            }
+            gatewayMetricProvider.updateSyncEvents(events.size());
+            // Extract only the latest event per (type, id) pair
+            Map<AbstractMap.SimpleEntry<Object, Object>, Event> sortedEvents = events
+                    .stream()
+                    .collect(toMap(
+                            event -> new AbstractMap.SimpleEntry<>(event.getType(), event.getPayload().getId()),
+                            event -> event, BinaryOperator.maxBy(comparing(Event::getCreatedAt)), LinkedHashMap::new));
+            return Flowable.fromIterable(sortedEvents.values())
+                    .flatMapCompletable(this::computeEvent, false, deployParallelism);
+        });
+    }
+
+    private Completable computeEvent(Event event) {
+        logger.debug("Compute event id : {}, with type : {} and timestamp : {} and payload : {}", event.getId(), event.getType(), event.getCreatedAt(), event.getPayload());
+        if (Objects.requireNonNull(event.getType()) == Type.DOMAIN) {
+            return synchronizeDomain(event);
+        }
+        return Completable.fromRunnable(() -> {
+            String eventId = event.getId();
+            if (processedEventIds.asMap().putIfAbsent(eventId, eventId) == null) {
+                publishEventTypeSafe(eventManager, io.gravitee.am.common.event.Event.valueOf(event.getType(), event.getPayload().getAction()), event.getPayload());
             } else {
-                String eventId = event.getId();
-                if (processedEventIds.asMap().putIfAbsent(eventId, eventId) == null) {
-                    publishEventTypeSafe(eventManager, io.gravitee.am.common.event.Event.valueOf(event.getType(), event.getPayload().getAction()), event.getPayload());
-                } else {
-                    logger.debug("Event id {} already processed", eventId);
-                }
+                logger.debug("Event id {} already processed", eventId);
             }
         });
     }
 
-    private void synchronizeDomain(Event event) {
+    private Completable synchronizeDomain(Event event) {
         final String domainId = event.getPayload().getId();
         final Action action = event.getPayload().getAction();
-        switch (action) {
+        return switch (action) {
             case CREATE, UPDATE -> {
-                domainReadinessService.updateDomainStatus(domainId, DomainState.Status.INITIALIZING);
                 Maybe<Domain> maybeDomain = domainRepository.findById(domainId);
                 if (this.eventsTimeOut > 0) {
                     maybeDomain = maybeDomain.timeout(this.eventsTimeOut, TimeUnit.MILLISECONDS);
                 }
-                Domain domain = maybeDomain.blockingGet();
-                if (domain == null) {
-                    domainReadinessService.removeDomain(domainId);
-                    return;
-                }
-
-                // Get deployed domain
-                Domain deployedDomain = securityDomainManager.get(domain.getId());
-                // Can the security domain be deployed?
-                if (!canHandle(domain)) {
-                    // Check that the security domain was not previously deployed with other tags
-                    // In that case, we must undeploy it
-                    if (deployedDomain != null) {
-                        securityDomainManager.undeploy(domainId);
-                    }
-                    domainReadinessService.removeDomain(domainId);
-                    return;
-                }
-
-                // domain is not yet deployed, so let's do it !
-                if (deployedDomain == null) {
-                    securityDomainManager.deploy(domain);
-                } else if (deployedDomain.getUpdatedAt().before(domain.getUpdatedAt())) {
-                    securityDomainManager.update(domain);
-                }
-
-                if (domain.isEnabled()) {
-                    domainReadinessService.updateDomainStatus(domain.getId(), DomainState.Status.DEPLOYED);
-                } else {
-                    domainReadinessService.removeDomain(domain.getId());
-                }
+                final Maybe<Domain> resolvedMaybe = maybeDomain;
+                yield Completable.fromRunnable(() -> domainReadinessService.updateDomainStatus(domainId, DomainState.Status.INITIALIZING))
+                        .andThen(resolvedMaybe
+                                // domain not found: update readiness and stop
+                                .switchIfEmpty(Completable.fromRunnable(() -> domainReadinessService.removeDomain(domainId)).toMaybe())
+                                .flatMapCompletable(domain -> {
+                                    Domain deployedDomain = securityDomainManager.get(domain.getId());
+                                    if (!canHandle(domain)) {
+                                        // Previously deployed under different tags: undeploy it
+                                        Completable undeploy = deployedDomain != null
+                                                ? securityDomainManager.undeployReactive(domainId)
+                                                : Completable.complete();
+                                        return undeploy.andThen(Completable.fromRunnable(() -> domainReadinessService.removeDomain(domainId)));
+                                    }
+                                    Completable deployOrUpdate;
+                                    if (deployedDomain == null) {
+                                        deployOrUpdate = securityDomainManager.deployReactive(domain);
+                                    } else if (deployedDomain.getUpdatedAt().before(domain.getUpdatedAt())) {
+                                        deployOrUpdate = securityDomainManager.updateReactive(domain);
+                                    } else {
+                                        deployOrUpdate = Completable.complete();
+                                    }
+                                    Completable updateReadiness = domain.isEnabled()
+                                            ? Completable.fromRunnable(() -> domainReadinessService.updateDomainStatus(domain.getId(), DomainState.Status.DEPLOYED))
+                                            : Completable.fromRunnable(() -> domainReadinessService.removeDomain(domain.getId()));
+                                    return deployOrUpdate.andThen(updateReadiness);
+                                }));
             }
-            case DELETE -> {
-                domainReadinessService.updateDomainStatus(domainId, DomainState.Status.REMOVING);
-                securityDomainManager.undeploy(domainId);
-                domainReadinessService.removeDomain(domainId);
-            }
-            default -> {
-                // No action needed for default case
-            }
-        }
+            case DELETE -> Completable.fromRunnable(() -> domainReadinessService.updateDomainStatus(domainId, DomainState.Status.REMOVING))
+                    .andThen(securityDomainManager.undeployReactive(domainId))
+                    .andThen(Completable.fromRunnable(() -> domainReadinessService.removeDomain(domainId)));
+            default -> Completable.complete();
+        };
     }
 
     private boolean canHandle(Domain domain) {

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
@@ -175,9 +175,18 @@ public class SyncManager implements InitializingBean, DisposableBean {
         logger.info("\t\t - Environments loaded : {}", environmentIds != null ? environmentIds : "[]");
         logger.info("\t\t - Domain deployment parallelism : {}", deployParallelism);
         AtomicInteger threadIndex = new AtomicInteger(0);
+        // Domain deployment performs a Spring child context refresh which generates CGLIB proxies
+        // for gateway beans. That requires the gateway application classloader, NOT the context
+        // classloader of the thread initializing this bean: SyncManager runs in the sync-service
+        // plugin, whose classloader cannot define those proxies (ClassNotFoundException on
+        // *$$SpringCGLIB$$* / AopConfigException). SecurityDomainManager is a gateway-core class, so
+        // resolving its classloader (via parent-first delegation) yields the gateway application
+        // classloader, which is exactly the context under which deployment ran when synchronous.
+        final ClassLoader deploymentClassLoader = SecurityDomainManager.class.getClassLoader();
         deploymentExecutor = Executors.newFixedThreadPool(deployParallelism, r -> {
             Thread t = new Thread(r, "gio.sync-deployer-" + threadIndex.getAndIncrement());
             t.setDaemon(true);
+            t.setContextClassLoader(deploymentClassLoader);
             return t;
         });
         deploymentScheduler = Schedulers.from(deploymentExecutor);
@@ -281,8 +290,11 @@ public class SyncManager implements InitializingBean, DisposableBean {
                     .collect(toMap(
                             event -> new AbstractMap.SimpleEntry<>(event.getType(), event.getPayload().getId()),
                             event -> event, BinaryOperator.maxBy(comparing(Event::getCreatedAt)), LinkedHashMap::new));
+            // Subscribe on the deployment scheduler: domain deploy/update triggers a Spring child
+            // context refresh which must not run on a database driver or Vert.x event-loop thread.
             return Flowable.fromIterable(sortedEvents.values())
-                    .flatMapCompletable(this::computeEvent, false, deployParallelism);
+                    .flatMapCompletable(event -> computeEvent(event).subscribeOn(deploymentScheduler),
+                            false, deployParallelism);
         });
     }
 
@@ -313,6 +325,9 @@ public class SyncManager implements InitializingBean, DisposableBean {
                 final Maybe<Domain> resolvedMaybe = maybeDomain;
                 yield Completable.fromRunnable(() -> domainReadinessService.updateDomainStatus(domainId, DomainState.Status.INITIALIZING))
                         .andThen(resolvedMaybe
+                                // findById emits on the database driver thread: hop back to the
+                                // deployment scheduler before the Spring child context refresh.
+                                .observeOn(deploymentScheduler)
                                 // domain not found: update readiness and stop
                                 .switchIfEmpty(Completable.fromRunnable(() -> domainReadinessService.removeDomain(domainId)).toMaybe())
                                 .flatMapCompletable(domain -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
@@ -140,6 +140,9 @@ public class SyncManager implements InitializingBean {
     @Value("${services.sync.timeframeAfterDelay:" + TIMEFRAME_AFTER_DELAY + "}")
     private int timeframeAfterDelay;
 
+    @Value("${services.sync.deploy.parallelism:0}")
+    private int deployParallelism;
+
     private Cache<String, String> processedEventIds;
 
     @Override
@@ -147,11 +150,15 @@ public class SyncManager implements InitializingBean {
         logger.info("Starting gateway tags initialization ...");
         this.initShardingTags();
         this.initEnvironments();
+        if (deployParallelism <= 0) {
+            deployParallelism = 2 * Runtime.getRuntime().availableProcessors();
+        }
         logger.info("Gateway has been loaded with the following information :");
         logger.info("\t\t - Sharding tags : {}", shardingTags.isPresent() ? shardingTags.get() : "[]");
         logger.info("\t\t - Organizations : {}", organizations.isPresent() ? organizations.get() : "[]");
         logger.info("\t\t - Environments : {}", environments.isPresent() ? environments.get() : "[]");
         logger.info("\t\t - Environments loaded : {}", environmentIds != null ? environmentIds : "[]");
+        logger.info("\t\t - Domain deployment parallelism : {}", deployParallelism);
         this.processedEventIds = CacheBuilder.newBuilder()
                 .expireAfterWrite(timeframeBeforeDelay + timeframeAfterDelay, TimeUnit.MILLISECONDS)
                 .build();

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/test/java/io/gravitee/am/gateway/services/sync/SyncManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/test/java/io/gravitee/am/gateway/services/sync/SyncManagerTest.java
@@ -32,8 +32,10 @@ import io.gravitee.am.repository.management.api.DomainRepository;
 import io.gravitee.am.repository.management.api.EventRepository;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.node.api.Node;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,6 +54,8 @@ import static io.gravitee.am.dataplane.api.DataPlaneDescription.DEFAULT_DATA_PLA
 import static io.gravitee.node.api.Node.META_ENVIRONMENTS;
 import static io.gravitee.node.api.Node.META_ORGANIZATIONS;
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -106,6 +110,8 @@ public class SyncManagerTest {
         lenient().when(node.metadata()).thenReturn(Map.of(META_ORGANIZATIONS, new HashSet<>(), META_ENVIRONMENTS, new HashSet<>()));
         lenient().when(environment.getProperty(Scope.GATEWAY.getRepositoryPropertyKey()+".dataPlane.id", String.class, DEFAULT_DATA_PLANE_ID)).thenReturn(DEFAULT_DATA_PLANE_ID);
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
+        lenient().when(securityDomainManager.deployReactive(any())).thenReturn(Completable.complete());
         when(defaultReactor.isStarted()).thenReturn(true);
     }
 
@@ -117,7 +123,7 @@ public class SyncManagerTest {
         syncManager.refresh();
 
         verify(domainRepository, never()).findAll();
-        verify(securityDomainManager, never()).deploy(any(Domain.class));
+        verify(securityDomainManager, never()).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
         verify(domainReadinessService, never()).updateDomainStatus(any(), any());
@@ -129,7 +135,7 @@ public class SyncManagerTest {
 
         syncManager.refresh();
 
-        verify(securityDomainManager, never()).deploy(any(Domain.class));
+        verify(securityDomainManager, never()).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -145,7 +151,7 @@ public class SyncManagerTest {
 
         syncManager.refresh();
 
-        verify(securityDomainManager, times(1)).deploy(any(Domain.class));
+        verify(securityDomainManager, times(1)).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
         verify(domainReadinessService).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.DEPLOYED));
@@ -167,7 +173,7 @@ public class SyncManagerTest {
 
         syncManager.refresh();
 
-        verify(securityDomainManager, times(2)).deploy(any(Domain.class));
+        verify(securityDomainManager, times(2)).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -193,7 +199,7 @@ public class SyncManagerTest {
 
         syncManager.refresh();
 
-        verify(securityDomainManager, times(2)).deploy(any(Domain.class));
+        verify(securityDomainManager, times(2)).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -219,7 +225,7 @@ public class SyncManagerTest {
 
         syncManager.refresh();
 
-        verify(securityDomainManager, times(2)).deploy(any(Domain.class));
+        verify(securityDomainManager, times(2)).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -243,7 +249,7 @@ public class SyncManagerTest {
 
         syncManager.refresh();
 
-        verify(securityDomainManager, times(1)).deploy(any());
+        verify(securityDomainManager, times(1)).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, times(1)).undeploy(domain.getId());
         verify(domainReadinessService).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.REMOVING));
@@ -279,7 +285,7 @@ public class SyncManagerTest {
 
         syncManager.refresh();
 
-        verify(securityDomainManager, times(1)).deploy(any());
+        verify(securityDomainManager, times(1)).deployReactive(any());
         verify(securityDomainManager, times(1)).update(any());
         verify(securityDomainManager, never()).undeploy(domain.getId());
         verify(domainReadinessService).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.INITIALIZING));
@@ -302,7 +308,7 @@ public class SyncManagerTest {
         syncManager.refresh();
 
         verify(eventManager, times(1)).publishEvent(any(), any());
-        verify(securityDomainManager, never()).deploy(any(Domain.class));
+        verify(securityDomainManager, never()).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -324,7 +330,7 @@ public class SyncManagerTest {
         syncManager.refresh();
 
         verify(eventManager, times(1)).publishEvent(any(), any());
-        verify(securityDomainManager, never()).deploy(any(Domain.class));
+        verify(securityDomainManager, never()).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -339,7 +345,7 @@ public class SyncManagerTest {
         syncManager.refresh();
 
         verify(eventManager, never()).publishEvent(any(), any());
-        verify(securityDomainManager, never()).deploy(any(Domain.class));
+        verify(securityDomainManager, never()).deployReactive(any(Domain.class));
         verify(securityDomainManager, never()).update(any(Domain.class));
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -400,9 +406,10 @@ public class SyncManagerTest {
         when(domainRepository.findAll()).thenReturn(Flowable.just(domain));
 
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
         syncManager.refresh();
 
-        verify(securityDomainManager).deploy(any());
+        verify(securityDomainManager).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -429,9 +436,10 @@ public class SyncManagerTest {
         when(domainRepository.findAll()).thenReturn(Flowable.just(domain, domain2));
 
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
         syncManager.refresh();
 
-        verify(securityDomainManager).deploy(any());
+        verify(securityDomainManager).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -460,9 +468,10 @@ public class SyncManagerTest {
         when(domainRepository.findAll()).thenReturn(Flowable.just(domain, domain2));
 
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
         syncManager.refresh();
 
-        verify(securityDomainManager, times(2)).deploy(any());
+        verify(securityDomainManager, times(2)).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -491,9 +500,10 @@ public class SyncManagerTest {
         when(domainRepository.findAll()).thenReturn(Flowable.just(domain, domain2));
 
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
         syncManager.refresh();
 
-        verify(securityDomainManager).deploy(any());
+        verify(securityDomainManager).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -529,9 +539,10 @@ public class SyncManagerTest {
         when(domainRepository.findAll()).thenReturn(Flowable.just(domain, domain2));
 
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
         syncManager.refresh();
 
-        verify(securityDomainManager, times(2)).deploy(any());
+        verify(securityDomainManager, times(2)).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -590,9 +601,10 @@ public class SyncManagerTest {
         when(domainRepository.findAll()).thenReturn(Flowable.just(domain, domain2, domain3, domain4));
 
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
         syncManager.refresh();
 
-        verify(securityDomainManager, times(4)).deploy(any());
+        verify(securityDomainManager, times(4)).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -652,9 +664,10 @@ public class SyncManagerTest {
         when(domainRepository.findAll()).thenReturn(Flowable.just(domain, domain2, domain3, domain4));
 
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
         syncManager.refresh();
 
-        verify(securityDomainManager, times(2)).deploy(any());
+        verify(securityDomainManager, times(2)).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }
@@ -716,16 +729,77 @@ public class SyncManagerTest {
         when(domainRepository.findAll()).thenReturn(Flowable.just(domain, domain2, domain3, domain4));
 
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
         syncManager.refresh();
 
-        verify(securityDomainManager, times(1)).deploy(any());
+        verify(securityDomainManager, times(1)).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
+    }
+
+    @Test
+    public void init_sync_sets_allSecurityDomainsSync_flag() {
+        final Domain domain = new Domain();
+        domain.setId("domain-1");
+        domain.setReferenceId("env-1");
+        domain.setEnabled(true);
+        domain.setDataPlaneId(DEFAULT_DATA_PLANE_ID);
+        when(domainRepository.findAll()).thenReturn(Flowable.just(domain));
+
+        assertFalse(syncManager.isAllSecurityDomainsSync());
+        syncManager.refresh();
+
+        assertTrue(syncManager.isAllSecurityDomainsSync());
+        verify(securityDomainManager, times(1)).deployReactive(any(Domain.class));
+        verify(domainReadinessService).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.DEPLOYED));
+    }
+
+    @Test
+    public void init_failing_deploy_does_not_abort_other_domains() {
+        final Domain domain1 = new Domain();
+        domain1.setId("domain-ok");
+        domain1.setReferenceId("env-1");
+        domain1.setEnabled(true);
+        domain1.setDataPlaneId(DEFAULT_DATA_PLANE_ID);
+
+        final Domain domain2 = new Domain();
+        domain2.setId("domain-fail");
+        domain2.setReferenceId("env-2");
+        domain2.setEnabled(true);
+        domain2.setDataPlaneId(DEFAULT_DATA_PLANE_ID);
+
+        when(securityDomainManager.deployReactive(domain1)).thenReturn(Completable.complete());
+        when(securityDomainManager.deployReactive(domain2)).thenReturn(Completable.error(new RuntimeException("deploy failed")));
+        when(domainRepository.findAll()).thenReturn(Flowable.just(domain1, domain2));
+
+        syncManager.refresh();
+
+        // Both were attempted; the failure is swallowed (onErrorComplete)
+        verify(securityDomainManager, times(1)).deployReactive(eq(domain1));
+        verify(securityDomainManager, times(1)).deployReactive(eq(domain2));
+        // The healthy domain's readiness was updated; the failed one was not
+        verify(domainReadinessService).updateDomainStatus(eq("domain-ok"), eq(DomainState.Status.DEPLOYED));
+        verify(domainReadinessService, never()).updateDomainStatus(eq("domain-fail"), eq(DomainState.Status.DEPLOYED));
+        // Overall sync still completes
+        assertTrue(syncManager.isAllSecurityDomainsSync());
+    }
+
+    @Test
+    public void refresh_is_noop_when_sync_already_in_progress() {
+        syncManager.syncInProgress.set(true);
+
+        syncManager.refresh();
+
+        verify(domainRepository, never()).findAll();
+        verify(securityDomainManager, never()).deployReactive(any());
+
+        syncManager.syncInProgress.set(false); // cleanup
     }
 
     private void shouldDeployDomainWithTags(final String tags, final String[] domainTags) throws Exception {
         when(environment.getProperty(SHARDING_TAGS_SYSTEM_PROPERTY)).thenReturn(tags);
         syncManager.afterPropertiesSet();
+        syncManager.setDeploymentScheduler(Schedulers.trampoline());
 
         Domain domain = new Domain();
         domain.setId("domain-1");
@@ -738,7 +812,7 @@ public class SyncManagerTest {
 
         syncManager.refresh();
 
-        verify(securityDomainManager).deploy(any());
+        verify(securityDomainManager).deployReactive(any());
         verify(securityDomainManager, never()).update(any());
         verify(securityDomainManager, never()).undeploy(any(String.class));
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/test/java/io/gravitee/am/gateway/services/sync/SyncManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/test/java/io/gravitee/am/gateway/services/sync/SyncManagerTest.java
@@ -112,6 +112,8 @@ public class SyncManagerTest {
         syncManager.afterPropertiesSet();
         syncManager.setDeploymentScheduler(Schedulers.trampoline());
         lenient().when(securityDomainManager.deployReactive(any())).thenReturn(Completable.complete());
+        lenient().when(securityDomainManager.updateReactive(any())).thenReturn(Completable.complete());
+        lenient().when(securityDomainManager.undeployReactive(anyString())).thenReturn(Completable.complete());
         when(defaultReactor.isStarted()).thenReturn(true);
     }
 
@@ -250,8 +252,8 @@ public class SyncManagerTest {
         syncManager.refresh();
 
         verify(securityDomainManager, times(1)).deployReactive(any());
-        verify(securityDomainManager, never()).update(any());
-        verify(securityDomainManager, times(1)).undeploy(domain.getId());
+        verify(securityDomainManager, never()).updateReactive(any());
+        verify(securityDomainManager, times(1)).undeployReactive(domain.getId());
         verify(domainReadinessService).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.REMOVING));
         verify(domainReadinessService).removeDomain(eq("domain-1"));
     }
@@ -286,8 +288,8 @@ public class SyncManagerTest {
         syncManager.refresh();
 
         verify(securityDomainManager, times(1)).deployReactive(any());
-        verify(securityDomainManager, times(1)).update(any());
-        verify(securityDomainManager, never()).undeploy(domain.getId());
+        verify(securityDomainManager, times(1)).updateReactive(any());
+        verify(securityDomainManager, never()).undeployReactive(domain.getId());
         verify(domainReadinessService).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.INITIALIZING));
         verify(domainReadinessService, times(2)).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.DEPLOYED));
     }
@@ -782,6 +784,26 @@ public class SyncManagerTest {
         verify(domainReadinessService, never()).updateDomainStatus(eq("domain-fail"), eq(DomainState.Status.DEPLOYED));
         // Overall sync still completes
         assertTrue(syncManager.isAllSecurityDomainsSync());
+    }
+
+    @Test
+    public void synchronizeDomain_event_for_unknown_domain_removes_readiness_entry() {
+        when(domainRepository.findAll()).thenReturn(Flowable.empty());
+        syncManager.refresh();
+
+        Event event = new Event();
+        event.setType(Type.DOMAIN);
+        event.setPayload(new Payload("unknown-domain", ReferenceType.DOMAIN, "unknown-domain", Action.UPDATE));
+
+        when(eventRepository.findByTimeFrameAndDataPlaneId(any(Long.class), any(Long.class), anyString())).thenReturn(Flowable.just(event));
+        when(domainRepository.findById("unknown-domain")).thenReturn(Maybe.empty());
+
+        syncManager.refresh();
+
+        verify(domainReadinessService).updateDomainStatus(eq("unknown-domain"), eq(DomainState.Status.INITIALIZING));
+        verify(domainReadinessService).removeDomain(eq("unknown-domain"));
+        verify(securityDomainManager, never()).deployReactive(any());
+        verify(securityDomainManager, never()).updateReactive(any());
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -139,6 +139,9 @@ services:
 #    # should we manage groups & roles in memory
 #    # by using sync process to update them
 #    permissions: false
+#    deploy:
+#      # number of concurrent domain deployments, 0 = 2 x CPU cores
+#      parallelism: 0
 
   core:
     http:

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -140,7 +140,8 @@ services:
 #    # by using sync process to update them
 #    permissions: false
 #    deploy:
-#      # number of concurrent domain deployments, 0 = 2 x CPU cores
+#      # number of concurrent domain deployments (0 is default)
+#      # The default concurrency is twice the number of cores on the machine
 #      parallelism: 0
 
   core:


### PR DESCRIPTION
## Summary

Makes the AM Gateway domain synchronization pipeline fully reactive and parallel, eliminating all blocking calls in the domain initialization path.

related to AM-7143

### Reactive eager deployment (this PR)

- **Parallel initial deployment**: domains at startup are now deployed concurrently via `flatMapCompletable(..., deployParallelism)` with a bounded thread pool (`gio.sync-deployer-N`, defaults to `2 × CPU cores`, tunable via `services.sync.deploy.parallelism`)
- **Reactive `SecurityDomainManager` API**: added `deployReactive`, `updateReactive`, `undeployReactive` on the interface; `DefaultSecurityDomainManager` now uses `ConcurrentHashMap`
- **Thread-safe router mutations**: `DefaultReactor.mountDomain/unMountDomain` serialized under a `ReentrantLock`; per-domain update serialization via a `ConcurrentMap<String, ReentrantLock>` in `DefaultSecurityDomainHandlerRegistry`
- **Reactive event processing**: `SyncManager.processEvents` uses `flatMapCompletable` with the same parallelism; an `AtomicBoolean` guard prevents overlapping cron-triggered syncs
- **Removed all `blockingGet`/`blockingLast`** in the domain init path:
  - `IdentityProviderManagerImpl.afterPropertiesSet()` — async subscribe replacing `blockingLast()`
  - `ExtensionGrantManagerImpl.afterPropertiesSet()` — `concatMapCompletable` replacing `blockingGet()` on IDP lookup
  - `AlertEventProcessor` — non-blocking init

## Test plan

- [ ] `SyncManagerTest` — 31 tests covering parallel deploy, event dedup, re-entrancy guard, per-domain update serialization, readiness flag
- [ ] `SecurityDomainManagerTest` — concurrency test with 50 parallel domains on `Schedulers.io()`
- [ ] `IdentityProviderManagerImplTest` — top-level failure path still handled synchronously
- [ ] All handler-oidc tests (1432 passing)
- [ ] All handler-common tests (861 passing)