### PR TITLE
fix: extend domain search to match on name field in addition to hrid

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcDomainRepository.java
@@ -200,10 +200,9 @@ public class JdbcDomainRepository extends AbstractJdbcRepository implements Doma
         String wildcardQuery = query.replaceAll("\\*+", "%");
 
         String search = new StringBuilder("SELECT * FROM domains d WHERE")
-
                 .append(" d.reference_type = :refType AND d.reference_id = :refId")
-                .append(" AND UPPER(d.hrid) " + (wildcardMatch ? "LIKE" : "="))
-                .append(" :value")
+                .append(" AND (UPPER(d.hrid) " + (wildcardMatch ? "LIKE" : "=") + " :value")
+                .append(" OR UPPER(d.name) " + (wildcardMatch ? "LIKE" : "=") + " :value)")
                 .toString();
 
         return fluxToFlowable(getTemplate().getDatabaseClient().sql(search)

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/4.11.0-domain-name-search-index.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/4.11.0-domain-name-search-index.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.0-create-idx_domains_ref_name
+      author: GraviteeSource Team
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                indexName: idx_domains_ref_name
+                tableName: domains
+      changes:
+        - createIndex:
+            columns:
+              - column:
+                  name: reference_id
+              - column:
+                  name: reference_type
+              - column:
+                  name: name
+            indexName: idx_domains_ref_name
+            tableName: domains

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
@@ -209,3 +209,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_11_0/4.11.0-update-domains-certificate-settings.yml
   - include:
       - file: liquibase/changelogs/v4_11_0/4.11.0-action-lease-table.yml
+  - include:
+      - file: liquibase/changelogs/v4_11_0/4.11.0-domain-name-search-index.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
@@ -78,6 +78,7 @@ import java.util.stream.Collectors;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
+import static com.mongodb.client.model.Filters.or;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -89,6 +90,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
 
     private MongoCollection<DomainMongo> domainsCollection;
     private static final String FIELD_HRID = "hrid";
+    private static final String FIELD_NAME = "name";
 
     private final Set<String> UNUSED_INDEXES = Set.of("ri1rt1");
 
@@ -99,6 +101,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
 
         final var indexes = new HashMap<Document, IndexOptions>();
         indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_HRID, 1), new IndexOptions().name("ri1rt1h1"));
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_NAME, 1), new IndexOptions().name("ri1rt1n1"));
 
         super.createIndex(domainsCollection, indexes);
         if (ensureIndexOnStart) {
@@ -148,19 +151,23 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
 
     @Override
     public Flowable<Domain> search(String environmentId, String query) {
-        // currently search on hrid field
-        Bson searchQuery = eq(FIELD_HRID, query);
-        // if query contains wildcard, use the regex query
+        Bson hridQuery;
+        Bson nameQuery;
         if (query.contains("*")) {
             String compactQuery = query.replaceAll("\\*+", ".*");
             String regex = "^" + compactQuery;
             Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-            searchQuery = new BasicDBObject(FIELD_HRID, pattern);
+            hridQuery = new BasicDBObject(FIELD_HRID, pattern);
+            nameQuery = new BasicDBObject(FIELD_NAME, pattern);
+        } else {
+            hridQuery = eq(FIELD_HRID, query);
+            nameQuery = eq(FIELD_NAME, query);
         }
 
         Bson mongoQuery = and(
                 eq(FIELD_REFERENCE_TYPE, ReferenceType.ENVIRONMENT.name()),
-                eq(FIELD_REFERENCE_ID, environmentId), searchQuery);
+                eq(FIELD_REFERENCE_ID, environmentId),
+                or(hridQuery, nameQuery));
 
         return Flowable.fromPublisher(withMaxTime(domainsCollection.find(mongoQuery))).map(MongoDomainRepository::convert)
                 .observeOn(Schedulers.computation());

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DomainRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DomainRepositoryTest.java
@@ -366,6 +366,43 @@ public class DomainRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
+    public void testSearch_on_name() {
+        // create domain with distinct name and hrid
+        Domain domain = initDomain();
+        domain.setHrid("some-other-hrid");
+        domain.setReferenceType(ReferenceType.ENVIRONMENT);
+        domain.setReferenceId("environment#search-name");
+        domainRepository.create(domain).blockingGet();
+
+        // search by name — hrid does not match, name does
+        TestSubscriber<Domain> testSubscriber = domainRepository.search("environment#search-name", domain.getName()).test();
+        testSubscriber.awaitDone(10, TimeUnit.SECONDS);
+
+        testSubscriber.assertComplete();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertValueCount(1);
+    }
+
+    @Test
+    public void testSearch_on_name_wildcard() {
+        // create domain with distinct name and hrid
+        Domain domain = initDomain();
+        domain.setHrid("some-other-hrid");
+        domain.setReferenceType(ReferenceType.ENVIRONMENT);
+        domain.setReferenceId("environment#search-name-wildcard");
+        domainRepository.create(domain).blockingGet();
+
+        // search with wildcard matching the name prefix
+        String wildcardQuery = domain.getName().substring(0, 4) + "*";
+        TestSubscriber<Domain> testSubscriber = domainRepository.search("environment#search-name-wildcard", wildcardQuery).test();
+        testSubscriber.awaitDone(10, TimeUnit.SECONDS);
+
+        testSubscriber.assertComplete();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertValueCount(1);
+    }
+
+    @Test
     public void createDomain_withDataPlaneId() {
         // create domain
         Domain domain = initDomain();


### PR DESCRIPTION
## Summary

- Extended `DomainRepository.search()` to match on both `hrid` **and** `name` fields (OR logic), supporting both exact and wildcard queries
- Added a compound index `(reference_type, reference_id, name)` in MongoDB (`ri1rt1n1`) and a Liquibase migration for JDBC (`idx_domains_ref_name`)
- Added two new repository tests: exact match on `name` and wildcard match on `name`

## Test plan

- [ ] `testSearch_on_name` — creates a domain with a different `hrid` and `name`, searches by `name`, expects 1 result
- [ ] `testSearch_on_name_wildcard` — same setup, searches with a wildcard prefix on `name`, expects 1 result
- [ ] Existing `testSearch_wildcard` still passes (hrid search unaffected)

Closes AM-7098