### PR TITLE
fix: AM-7144 surface all writable domain fields in AAPI

### DIFF
--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -1645,6 +1645,62 @@ components:
             \ a certificate created via the domain's certificate endpoints."
           example: default
       title: Certificate settings
+    AutomationClientRegistrationSettings:
+      type: object
+      description: OpenID Connect Dynamic Client Registration configuration for the
+        domain.
+      properties:
+        allowHttpSchemeRedirectUri:
+          type: boolean
+          default: false
+          description: Whether the unsecured http scheme is permitted in redirect
+            URIs.
+        allowLocalhostRedirectUri:
+          type: boolean
+          default: false
+          description: Whether localhost is permitted as a redirect URI host.
+        allowRedirectUriParamsExpressionLanguage:
+          type: boolean
+          default: false
+          description: Whether expression language is permitted in redirect URI parameters.
+        allowWildCardRedirectUri:
+          type: boolean
+          default: false
+          description: Whether wildcards are permitted in redirect URIs.
+        allowedScopes:
+          type: array
+          description: Scopes permitted on client registration requests when the allowed
+            list is enabled.
+          items:
+            type: string
+            description: Scopes permitted on client registration requests when the
+              allowed list is enabled.
+        allowedScopesEnabled:
+          type: boolean
+          default: false
+          description: Whether registered client scopes are restricted to an allowed
+            list.
+        clientTemplateEnabled:
+          type: boolean
+          default: false
+          description: Whether a client may be used as a template for dynamic client
+            registration.
+        defaultScopes:
+          type: array
+          description: Default scopes added to every client registration request.
+          items:
+            type: string
+            description: Default scopes added to every client registration request.
+        dynamicClientRegistrationEnabled:
+          type: boolean
+          default: false
+          description: Whether Dynamic Client Registration is enabled for the domain.
+        openDynamicClientRegistrationEnabled:
+          type: boolean
+          default: false
+          description: Whether open (unauthenticated) Dynamic Client Registration
+            is enabled for the domain.
+      title: Client registration settings
     AutomationDomain:
       type: object
       description: "A security domain managed by the Automation API. The key field\
@@ -1654,6 +1710,9 @@ components:
       properties:
         accountSettings:
           $ref: "#/components/schemas/AutomationAccountSettings"
+        alertEnabled:
+          type: boolean
+          description: Whether alerting is enabled for the domain.
         certificateSettings:
           $ref: "#/components/schemas/AutomationCertificateSettings"
         corsSettings:
@@ -1691,6 +1750,11 @@ components:
           title: Key
         loginSettings:
           $ref: "#/components/schemas/LoginSettings"
+        master:
+          type: boolean
+          default: false
+          description: Whether this is the master domain of its environment. A master
+            domain may perform cross-domain token introspection.
         name:
           type: string
           description: Human-readable name of the domain.
@@ -1736,6 +1800,11 @@ components:
           format: date-time
           description: "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
           readOnly: true
+        vhostMode:
+          type: boolean
+          default: false
+          description: "Whether the domain is exposed through its virtual hosts rather\
+            \ than the default context path. When true, vhosts must be supplied."
         vhosts:
           type: array
           description: "Virtual hosts the domain is exposed on, overriding the default\
@@ -1863,7 +1932,7 @@ components:
         cibaSettings:
           $ref: "#/components/schemas/AutomationCIBASettings"
         clientRegistrationSettings:
-          $ref: "#/components/schemas/ClientRegistrationSettings"
+          $ref: "#/components/schemas/AutomationClientRegistrationSettings"
         postLogoutRedirectUris:
           type: array
           description: URLs the user may be redirected to after sign-out (post_logout_redirect_uri).
@@ -1885,6 +1954,8 @@ components:
               objects by reference.
         securityProfileSettings:
           $ref: "#/components/schemas/SecurityProfileSettings"
+        workloadIdentitySettings:
+          $ref: "#/components/schemas/SpiffeDomainSettings"
       title: OpenID Connect settings
     AutomationReporter:
       type: object
@@ -1966,51 +2037,6 @@ components:
             ID).
           example: https://auth.example.com/saml2/idp/entity
       title: SAML 2.0 settings
-    ClientRegistrationSettings:
-      type: object
-      description: OpenID Connect Dynamic Client Registration configuration for the
-        domain.
-      properties:
-        allowHttpSchemeRedirectUri:
-          type: boolean
-          default: false
-          description: Whether the unsecured http scheme is permitted in redirect
-            URIs.
-        allowLocalhostRedirectUri:
-          type: boolean
-          default: false
-          description: Whether localhost is permitted as a redirect URI host.
-        allowRedirectUriParamsExpressionLanguage:
-          type: boolean
-          default: false
-          description: Whether expression language is permitted in redirect URI parameters.
-        allowWildCardRedirectUri:
-          type: boolean
-          default: false
-          description: Whether wildcards are permitted in redirect URIs.
-        allowedScopes:
-          type: array
-          description: Scopes permitted on client registration requests when the allowed
-            list is enabled.
-          items:
-            type: string
-            description: Scopes permitted on client registration requests when the
-              allowed list is enabled.
-        allowedScopesEnabled:
-          type: boolean
-        clientTemplateEnabled:
-          type: boolean
-        defaultScopes:
-          type: array
-          description: Default scopes added to every client registration request.
-          items:
-            type: string
-            description: Default scopes added to every client registration request.
-        dynamicClientRegistrationEnabled:
-          type: boolean
-        openDynamicClientRegistrationEnabled:
-          type: boolean
-      title: Client registration settings
     CorsSettings:
       type: object
       description: Cross-Origin Resource Sharing configuration controlling which web
@@ -2109,8 +2135,6 @@ components:
         certificateBasedAuthUrl:
           type: string
           description: URL used for certificate-based authentication.
-        enforcePasswordPolicyEnabled:
-          type: boolean
         forgotPasswordEnabled:
           type: boolean
           default: false
@@ -2304,6 +2328,63 @@ components:
         resetPassword:
           $ref: "#/components/schemas/ResetPasswordSettings"
       title: Self-service account management settings
+    SpiffeDomainSettings:
+      type: object
+      description: Workload identity (SPIFFE) settings for the domain.
+      properties:
+        allowPrivateIpAddress:
+          type: boolean
+          default: false
+          description: Whether trust bundles can be fetched from private IP addresses.
+        allowUnsecuredHttpUri:
+          type: boolean
+          default: false
+          description: Whether trust bundles can be fetched over unsecured HTTP URIs.
+        cacheMaxEntries:
+          type: integer
+          format: int32
+          default: 50
+          description: Maximum number of trust bundle entries retained in the cache.
+        cacheTtlSeconds:
+          type: integer
+          format: int32
+          default: 300
+          description: "Time-to-live, in seconds, for cached trust bundle entries."
+        clockSkewSeconds:
+          type: integer
+          format: int32
+          default: 30
+          description: "Allowed clock skew, in seconds, when validating JWT temporal\
+            \ claims."
+        defaultAllowedAlgorithms:
+          type: array
+          description: Default allowlist of signature algorithms accepted for SPIFFE
+            JWT validation.
+          items:
+            type: string
+            description: Default allowlist of signature algorithms accepted for SPIFFE
+              JWT validation.
+        enabled:
+          type: boolean
+          default: false
+          description: Whether SPIFFE workload identity support is enabled for the
+            domain.
+        fetchTimeoutMs:
+          type: integer
+          format: int32
+          default: 5000
+          description: "Timeout, in milliseconds, for fetching trust bundles."
+        maxJwtLifetimeSeconds:
+          type: integer
+          format: int32
+          default: 300
+          description: "Maximum accepted JWT lifetime, in seconds, computed as exp\
+            \ minus iat."
+        maxResponseSizeKb:
+          type: integer
+          format: int32
+          default: 32
+          description: "Maximum trust bundle response size, in kilobytes."
     TokenExchangeOAuthSettings:
       type: object
       description: "OAuth-specific token-exchange behavior, such as how scopes are\
@@ -2316,12 +2397,12 @@ components:
             rather than defined here.
         scopeHandling:
           type: string
-          default: DOWNSCOPING
+          default: downscoping
           description: How scopes are handled when issuing the exchanged token. DOWNSCOPING
             restricts the issued token to a subset of the original scopes.
           enum:
-          - DOWNSCOPING
-          - PERMISSIVE
+          - downscoping
+          - permissive
       title: Token exchange OAuth settings
     TokenExchangeSettings:
       type: object
@@ -2414,8 +2495,8 @@ components:
           description: How the issuer's signing key is resolved. JWKS_URL fetches
             keys from a JWKS endpoint; PEM uses an inline X.509 certificate.
           enum:
-          - JWKS_URL
-          - PEM
+          - jwks_url
+          - pem
         scopeMappings:
           type: object
           additionalProperties:
@@ -2489,26 +2570,26 @@ components:
       properties:
         attestationConveyancePreference:
           type: string
-          default: NONE
+          default: none
           description: "Relying-party preference for attestation conveyance during\
             \ credential creation. NONE requests no attestation, INDIRECT allows anonymized\
             \ attestation, and DIRECT requests the authenticator's attestation statement."
           enum:
-          - NONE
-          - INDIRECT
-          - DIRECT
+          - none
+          - indirect
+          - direct
         authenticatorAttachment:
           type: string
           description: Preferred authenticator attachment. PLATFORM selects authenticators
             bound to the device (such as a fingerprint reader); CROSS_PLATFORM selects
             roaming authenticators (such as a security key).
           enum:
-          - CROSS_PLATFORM
-          - PLATFORM
+          - cross_platform
+          - platform
         certificates:
           type: object
           additionalProperties:
-            type: object
+            type: string
             description: "Trusted device-attestation X.509 certificates, keyed by\
               \ name."
           description: "Trusted device-attestation X.509 certificates, keyed by name."
@@ -2549,14 +2630,14 @@ components:
             (discoverable) credential.
         userVerification:
           type: string
-          default: PREFERRED
+          default: preferred
           description: "Relying-party requirement regarding user verification during\
             \ a ceremony. REQUIRED enforces verification, PREFERRED requests it when\
             \ available, and DISCOURAGED avoids it."
           enum:
-          - REQUIRED
-          - PREFERRED
-          - DISCOURAGED
+          - required
+          - preferred
+          - discouraged
       title: WebAuthn settings
   securitySchemes:
     BearerAuth:

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -14566,8 +14566,6 @@ components:
         certificateBasedAuthUrl:
           type: string
           description: URL used for certificate-based authentication.
-        enforcePasswordPolicyEnabled:
-          type: boolean
         forgotPasswordEnabled:
           type: boolean
           default: false
@@ -17476,32 +17474,57 @@ components:
       properties:
         allowPrivateIpAddress:
           type: boolean
+          default: false
+          description: Whether trust bundles can be fetched from private IP addresses.
         allowUnsecuredHttpUri:
           type: boolean
+          default: false
+          description: Whether trust bundles can be fetched over unsecured HTTP URIs.
         cacheMaxEntries:
           type: integer
           format: int32
+          default: 50
+          description: Maximum number of trust bundle entries retained in the cache.
         cacheTtlSeconds:
           type: integer
           format: int32
+          default: 300
+          description: "Time-to-live, in seconds, for cached trust bundle entries."
         clockSkewSeconds:
           type: integer
           format: int32
+          default: 30
+          description: "Allowed clock skew, in seconds, when validating JWT temporal\
+            \ claims."
         defaultAllowedAlgorithms:
           type: array
+          description: Default allowlist of signature algorithms accepted for SPIFFE
+            JWT validation.
           items:
             type: string
+            description: Default allowlist of signature algorithms accepted for SPIFFE
+              JWT validation.
         enabled:
           type: boolean
+          default: false
+          description: Whether SPIFFE workload identity support is enabled for the
+            domain.
         fetchTimeoutMs:
           type: integer
           format: int32
+          default: 5000
+          description: "Timeout, in milliseconds, for fetching trust bundles."
         maxJwtLifetimeSeconds:
           type: integer
           format: int32
+          default: 300
+          description: "Maximum accepted JWT lifetime, in seconds, computed as exp\
+            \ minus iat."
         maxResponseSizeKb:
           type: integer
           format: int32
+          default: 32
+          description: "Maximum trust bundle response size, in kilobytes."
     StatusEntity:
       type: object
       properties:

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapper.java
@@ -18,6 +18,7 @@ package io.gravitee.am.management.handlers.automation.mapper;
 import io.gravitee.am.management.handlers.automation.model.AutomationAccountSettings;
 import io.gravitee.am.management.handlers.automation.model.AutomationCIBASettings;
 import io.gravitee.am.management.handlers.automation.model.AutomationCertificateSettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationClientRegistrationSettings;
 import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
 import io.gravitee.am.management.handlers.automation.model.AutomationOidcSettings;
 import io.gravitee.am.management.handlers.automation.model.AutomationSamlSettings;
@@ -30,6 +31,7 @@ import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.SAMLSettings;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.oidc.CIBASettings;
+import io.gravitee.am.model.oidc.ClientRegistrationSettings;
 import io.gravitee.am.model.oidc.OIDCSettings;
 
 import java.util.List;
@@ -65,8 +67,11 @@ public final class AutomationDomainMapper {
         out.setName(domain.getName());
         out.setDescription(domain.getDescription());
         out.setEnabled(domain.isEnabled());
+        out.setMaster(domain.isMaster());
+        out.setAlertEnabled(domain.isAlertEnabled());
         out.setPath(domain.getPath());
         out.setTags(domain.getTags());
+        out.setVhostMode(domain.isVhostMode());
         out.setVhosts(domain.getVhosts());
         out.setDataPlaneId(domain.getDataPlaneId());
         out.setCreatedAt(domain.getCreatedAt());
@@ -107,8 +112,9 @@ public final class AutomationDomainMapper {
             return null;
         }
         AutomationOidcSettings out = new AutomationOidcSettings();
-        out.setClientRegistrationSettings(oidc.getClientRegistrationSettings());
+        out.setClientRegistrationSettings(toAutomationClientRegistration(oidc.getClientRegistrationSettings()));
         out.setSecurityProfileSettings(oidc.getSecurityProfileSettings());
+        out.setWorkloadIdentitySettings(oidc.getWorkloadIdentitySettings());
         out.setRedirectUriStrictMatching(oidc.isRedirectUriStrictMatching());
         out.setPostLogoutRedirectUris(oidc.getPostLogoutRedirectUris());
         out.setRequestUris(oidc.getRequestUris());
@@ -177,8 +183,11 @@ public final class AutomationDomainMapper {
         target.setName(in.getName());
         target.setDescription(in.getDescription());
         target.setEnabled(in.isEnabled());
+        target.setMaster(in.isMaster());
+        target.setAlertEnabled(in.getAlertEnabled() != null ? in.getAlertEnabled() : false);
         target.setPath(in.getPath());
         target.setTags(in.getTags());
+        target.setVhostMode(in.isVhostMode());
         target.setVhosts(in.getVhosts());
 
         // oidc must never be null — reset to the same default the domain is created with
@@ -219,8 +228,9 @@ public final class AutomationDomainMapper {
 
     private static OIDCSettings toModelOidc(AutomationOidcSettings in) {
         OIDCSettings out = new OIDCSettings();
-        out.setClientRegistrationSettings(in.getClientRegistrationSettings());
+        out.setClientRegistrationSettings(toModelClientRegistration(in.getClientRegistrationSettings()));
         out.setSecurityProfileSettings(in.getSecurityProfileSettings());
+        out.setWorkloadIdentitySettings(in.getWorkloadIdentitySettings());
         out.setRedirectUriStrictMatching(in.isRedirectUriStrictMatching());
         out.setPostLogoutRedirectUris(in.getPostLogoutRedirectUris());
         out.setRequestUris(in.getRequestUris());
@@ -272,6 +282,44 @@ public final class AutomationDomainMapper {
         out.setMfaChallengeMaxAttempts(in.getMfaChallengeMaxAttempts());
         out.setMfaChallengeAttemptsResetTime(in.getMfaChallengeAttemptsResetTime());
         out.setMfaChallengeSendVerifyAlertEmail(in.isMfaChallengeSendVerifyAlertEmail());
+        return out;
+    }
+
+    // --- client registration settings (wrapped to drop the shared model's "is"-prefixed wire names) ---
+
+    private static AutomationClientRegistrationSettings toAutomationClientRegistration(ClientRegistrationSettings in) {
+        if (in == null) {
+            return null;
+        }
+        AutomationClientRegistrationSettings out = new AutomationClientRegistrationSettings();
+        out.setAllowLocalhostRedirectUri(in.isAllowLocalhostRedirectUri());
+        out.setAllowHttpSchemeRedirectUri(in.isAllowHttpSchemeRedirectUri());
+        out.setAllowWildCardRedirectUri(in.isAllowWildCardRedirectUri());
+        out.setAllowRedirectUriParamsExpressionLanguage(in.isAllowRedirectUriParamsExpressionLanguage());
+        out.setDynamicClientRegistrationEnabled(in.isDynamicClientRegistrationEnabled());
+        out.setOpenDynamicClientRegistrationEnabled(in.isOpenDynamicClientRegistrationEnabled());
+        out.setDefaultScopes(in.getDefaultScopes());
+        out.setAllowedScopesEnabled(in.isAllowedScopesEnabled());
+        out.setAllowedScopes(in.getAllowedScopes());
+        out.setClientTemplateEnabled(in.isClientTemplateEnabled());
+        return out;
+    }
+
+    private static ClientRegistrationSettings toModelClientRegistration(AutomationClientRegistrationSettings in) {
+        if (in == null) {
+            return null;
+        }
+        ClientRegistrationSettings out = new ClientRegistrationSettings();
+        out.setAllowLocalhostRedirectUri(in.isAllowLocalhostRedirectUri());
+        out.setAllowHttpSchemeRedirectUri(in.isAllowHttpSchemeRedirectUri());
+        out.setAllowWildCardRedirectUri(in.isAllowWildCardRedirectUri());
+        out.setAllowRedirectUriParamsExpressionLanguage(in.isAllowRedirectUriParamsExpressionLanguage());
+        out.setDynamicClientRegistrationEnabled(in.isDynamicClientRegistrationEnabled());
+        out.setOpenDynamicClientRegistrationEnabled(in.isOpenDynamicClientRegistrationEnabled());
+        out.setDefaultScopes(in.getDefaultScopes());
+        out.setAllowedScopesEnabled(in.isAllowedScopesEnabled());
+        out.setAllowedScopes(in.getAllowedScopes());
+        out.setClientTemplateEnabled(in.isClientTemplateEnabled());
         return out;
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationClientRegistrationSettings.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationClientRegistrationSettings.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Automation API mirror of {@link io.gravitee.am.model.oidc.ClientRegistrationSettings}.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+@Schema(name = "AutomationClientRegistrationSettings", title = "Client registration settings",
+        description = "OpenID Connect Dynamic Client Registration configuration for the domain.")
+public class AutomationClientRegistrationSettings {
+
+    @Schema(description = "Whether localhost is permitted as a redirect URI host.", defaultValue = "false")
+    private boolean allowLocalhostRedirectUri;
+
+    @Schema(description = "Whether the unsecured http scheme is permitted in redirect URIs.",
+            defaultValue = "false")
+    private boolean allowHttpSchemeRedirectUri;
+
+    @Schema(description = "Whether wildcards are permitted in redirect URIs.", defaultValue = "false")
+    private boolean allowWildCardRedirectUri;
+
+    @Schema(description = "Whether expression language is permitted in redirect URI parameters.",
+            defaultValue = "false")
+    private boolean allowRedirectUriParamsExpressionLanguage;
+
+    @Schema(description = "Whether Dynamic Client Registration is enabled for the domain.", defaultValue = "false")
+    private boolean dynamicClientRegistrationEnabled;
+
+    @Schema(description = "Whether open (unauthenticated) Dynamic Client Registration is enabled for the domain.",
+            defaultValue = "false")
+    private boolean openDynamicClientRegistrationEnabled;
+
+    @Schema(description = "Default scopes added to every client registration request.")
+    private List<String> defaultScopes;
+
+    @Schema(description = "Whether registered client scopes are restricted to an allowed list.",
+            defaultValue = "false")
+    private boolean allowedScopesEnabled;
+
+    @Schema(description = "Scopes permitted on client registration requests when the allowed list is enabled.")
+    private List<String> allowedScopes;
+
+    @Schema(description = "Whether a client may be used as a template for dynamic client registration.",
+            defaultValue = "false")
+    private boolean clientTemplateEnabled;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
@@ -87,6 +87,13 @@ public class AutomationDomain {
             defaultValue = "true")
     private boolean enabled = true;
 
+    @Schema(description = "Whether this is the master domain of its environment. A master domain may perform " +
+            "cross-domain token introspection.", defaultValue = "false")
+    private boolean master;
+
+    @Schema(description = "Whether alerting is enabled for the domain.")
+    private Boolean alertEnabled;
+
     @NotNull
     @Size(min = 1, max = 255)
     @Schema(description = "Context path the domain is served under, relative to the gateway. Must start with a slash.",
@@ -96,6 +103,10 @@ public class AutomationDomain {
     @Schema(description = "Sharding tags that control which gateways deploy this domain.",
             example = "[\"eu\",\"production\"]")
     private Set<String> tags;
+
+    @Schema(description = "Whether the domain is exposed through its virtual hosts rather than the default " +
+            "context path. When true, vhosts must be supplied.", defaultValue = "false")
+    private boolean vhostMode;
 
     @Schema(description = "Virtual hosts the domain is exposed on, overriding the default context path.")
     private List<VirtualHost> vhosts;

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationOidcSettings.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationOidcSettings.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.am.management.handlers.automation.model;
 
-import io.gravitee.am.model.oidc.ClientRegistrationSettings;
 import io.gravitee.am.model.oidc.SecurityProfileSettings;
+import io.gravitee.am.model.oidc.SpiffeDomainSettings;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.Getter;
@@ -44,10 +44,14 @@ import java.util.List;
 public class AutomationOidcSettings {
 
     @Schema(description = "Dynamic Client Registration (DCR) settings for the domain.")
-    private ClientRegistrationSettings clientRegistrationSettings;
+    @Valid
+    private AutomationClientRegistrationSettings clientRegistrationSettings;
 
     @Schema(description = "Financial-grade API (FAPI) security profile settings for the domain.")
     private SecurityProfileSettings securityProfileSettings;
+
+    @Schema(description = "Workload identity (SPIFFE) settings for the domain.")
+    private SpiffeDomainSettings workloadIdentitySettings;
 
     @Schema(description = "Whether redirect_uri and post_logout_redirect_uri values are matched strictly " +
             "during OpenID Connect flows.", defaultValue = "false")

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainsResource.java
@@ -130,9 +130,9 @@ public class DomainsResource extends AbstractAutomationResource {
 
         // An 'id:' body addresses a preexisting domain directly (update-only)
         if (domainRef instanceof AutomationRef.IdRef(String id)) {
-            checkAnyPermission(principal, organizationId, environmentId, id, Permission.DOMAIN, Acl.UPDATE)
-                    .andThen(resolver.resolveDomain(environmentId, domainRef))
-                    .flatMap(domain -> applyAndRespond(domain, definition, principal))
+            resolver.resolveDomain(environmentId, domainRef)
+                    .flatMap(domain -> checkAnyPermission(principal, organizationId, environmentId, domain.getId(), Permission.DOMAIN, Acl.UPDATE)
+                            .andThen(applyAndRespond(domain, definition, principal)))
                     .subscribe(response::resume, response::resume);
             return;
         }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResource.java
@@ -249,8 +249,11 @@ public class IdentityProvidersResource extends AbstractAutomationResource {
         AutomationNewIdentityProvider newIdp = AutomationIdentityProviderMapper.toNewIdentityProvider(definition);
         newIdp.setId(idpId);
         return identityProviderManager.checkPluginDeployment(definition.getType())
-                .andThen(Completable.fromAction(() ->
-                        validationService.validate(definition.getType(), definition.getConfiguration())))
+                .andThen(Completable.fromAction(() -> {
+                    validationService.validate(definition.getType(), definition.getConfiguration());
+                    // 'external' is intrinsic to the plugin type; derive it from the plugin descriptor
+                    newIdp.setExternal(identityProviderManager.isExternalProvider(definition.getType()));
+                }))
                 .andThen(Single.defer(() -> identityProviderService.create(domain, newIdp, principal, false)))
                 .map(AutomationIdentityProviderMapper::toAutomationIdentityProvider);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -180,6 +181,8 @@ public class AutomationApiDefinition implements ReaderListener {
                     filteredSchemas.put(name, allSchemas.get(name));
                 }
             }
+            fixWebAuthnCertificatesValueType(filteredSchemas);
+            filteredSchemas.values().forEach(AutomationApiDefinition::lowercaseEnumsInSchema);
             // sort properties within each schema for deterministic output
             filteredSchemas.values().forEach(AutomationApiDefinition::sortSchemaProperties);
             openAPI.getComponents().setSchemas(filteredSchemas);
@@ -429,6 +432,50 @@ public class AutomationApiDefinition implements ReaderListener {
     private static void sortSchemaProperties(Schema schema) {
         if (schema.getProperties() != null) {
             schema.setProperties(new LinkedHashMap<>(new TreeMap<>(schema.getProperties())));
+        }
+    }
+
+    /**
+     * Retypes {@code WebAuthnSettings.certificates} map values to {@code string} as a spec-only correction.
+     */
+    @SuppressWarnings("rawtypes")
+    private static void fixWebAuthnCertificatesValueType(Map<String, Schema> schemas) {
+        Schema webAuthn = schemas.get("WebAuthnSettings");
+        if (webAuthn == null || webAuthn.getProperties() == null) {
+            return;
+        }
+        Object certificates = webAuthn.getProperties().get("certificates");
+        if (certificates instanceof Schema certificatesSchema
+                && certificatesSchema.getAdditionalProperties() instanceof Schema valueSchema) {
+            valueSchema.setType("string");
+        }
+    }
+
+    /**
+     * Lowercases the {@code enum} values (and an enum-typed {@code default}) of a schema and, recursively, of
+     * its properties, array items and map values to match the runtime wire format.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void lowercaseEnumsInSchema(Schema schema) {
+        if (schema == null) {
+            return;
+        }
+        List<Object> values = schema.getEnum();
+        if (values != null && !values.isEmpty()) {
+            values.replaceAll(value -> value instanceof String s ? s.toLowerCase(Locale.ROOT) : value);
+            if (schema.getDefault() instanceof String defaultValue) {
+                schema.setDefault(defaultValue.toLowerCase(Locale.ROOT));
+            }
+        }
+        if (schema.getProperties() != null) {
+            ((Map<String, Schema>) schema.getProperties()).values()
+                    .forEach(AutomationApiDefinition::lowercaseEnumsInSchema);
+        }
+        if (schema.getItems() != null) {
+            lowercaseEnumsInSchema(schema.getItems());
+        }
+        if (schema.getAdditionalProperties() instanceof Schema additionalProperties) {
+            lowercaseEnumsInSchema(additionalProperties);
         }
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
@@ -86,7 +86,7 @@ public abstract class AutomationJerseySpringTest {
 
     protected ObjectMapper objectMapper = new ObjectMapperResolver()
             .getContext(ObjectMapper.class)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
     @Autowired
     protected PermissionService permissionService;

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapperTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapperTest.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.automation.mapper;
 
 import io.gravitee.am.management.handlers.automation.model.AutomationAccountSettings;
 import io.gravitee.am.management.handlers.automation.model.AutomationCertificateSettings;
+import io.gravitee.am.management.handlers.automation.model.AutomationClientRegistrationSettings;
 import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
 import io.gravitee.am.management.handlers.automation.model.AutomationOidcSettings;
 import io.gravitee.am.management.handlers.automation.model.AutomationSamlSettings;
@@ -29,7 +30,6 @@ import io.gravitee.am.model.PasswordSettings;
 import io.gravitee.am.model.SecretExpirationSettings;
 import io.gravitee.am.model.SelfServiceAccountManagementSettings;
 import io.gravitee.am.model.TokenExchangeSettings;
-import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.login.WebAuthnSettings;
 import io.gravitee.am.model.oidc.CIMDSettings;
@@ -73,10 +73,7 @@ class AutomationDomainMapperTest {
             "version",        // internal domain schema version, not declarative state
             "referenceType",  // internal; always ENVIRONMENT
             "referenceId",    // internal; the environment id is taken from the URL path
-            "alertEnabled",   // alerting is not exposed via the Automation API
             "identities",     // legacy field, DefaultOrganizationUpgrader use only
-            "master",         // cross-domain token introspection toggle, not exposed
-            "vhostMode",      // not independently exposed (driven by the vhosts list)
             "managedBy"       // set server-side to AUTOMATION_API; not a writable input
     );
 
@@ -226,11 +223,9 @@ class AutomationDomainMapperTest {
 
     @Test
     void oidcReusableSubBlocksAreReusedByReference() {
-        ClientRegistrationSettings clientReg = new ClientRegistrationSettings();
         SecurityProfileSettings security = new SecurityProfileSettings();
 
         AutomationOidcSettings oidc = new AutomationOidcSettings();
-        oidc.setClientRegistrationSettings(clientReg);
         oidc.setSecurityProfileSettings(security);
 
         AutomationDomain in = new AutomationDomain();
@@ -241,8 +236,42 @@ class AutomationDomainMapperTest {
         Domain target = newDomain();
         AutomationDomainMapper.applyTo(in, target, List.of());
 
-        assertSame(clientReg, target.getOidc().getClientRegistrationSettings());
         assertSame(security, target.getOidc().getSecurityProfileSettings());
+    }
+
+    @Test
+    void clientRegistrationSettingsAreMappedWithCleanWireNames() {
+        AutomationClientRegistrationSettings clientReg = new AutomationClientRegistrationSettings();
+        clientReg.setDynamicClientRegistrationEnabled(true);
+        clientReg.setOpenDynamicClientRegistrationEnabled(true);
+        clientReg.setClientTemplateEnabled(true);
+        clientReg.setAllowedScopesEnabled(true);
+
+        AutomationOidcSettings oidc = new AutomationOidcSettings();
+        oidc.setClientRegistrationSettings(clientReg);
+
+        AutomationDomain in = new AutomationDomain();
+        in.setName("My Domain");
+        in.setPath("/app");
+        in.setOidc(oidc);
+
+        Domain target = newDomain();
+        AutomationDomainMapper.applyTo(in, target, List.of());
+
+        // wrapped, not reused by reference: values map onto the shared model's is-prefixed fields
+        ClientRegistrationSettings mapped = target.getOidc().getClientRegistrationSettings();
+        assertTrue(mapped.isDynamicClientRegistrationEnabled());
+        assertTrue(mapped.isOpenDynamicClientRegistrationEnabled());
+        assertTrue(mapped.isClientTemplateEnabled());
+        assertTrue(mapped.isAllowedScopesEnabled());
+
+        // and back out with the same clean names
+        AutomationClientRegistrationSettings out =
+                AutomationDomainMapper.toAutomationDomain(target).getOidc().getClientRegistrationSettings();
+        assertTrue(out.isDynamicClientRegistrationEnabled());
+        assertTrue(out.isOpenDynamicClientRegistrationEnabled());
+        assertTrue(out.isClientTemplateEnabled());
+        assertTrue(out.isAllowedScopesEnabled());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
@@ -112,6 +112,30 @@ class DomainsResourceTest extends AutomationJerseySpringTest {
     }
 
     @Test
+    void put_with_id_ref_returns_404_when_domain_does_not_exist() {
+        String missingId = "missing-id";
+        AutomationDomain idRefDefinition = definition("id:" + missingId);
+        when(domainService.findById(eq(missingId))).thenReturn(Maybe.empty());
+
+        Response response = put(domainsTarget(), idRefDefinition);
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void put_with_id_ref_returns_403_when_update_permission_is_denied() {
+        String domainId = "domain-id";
+        AutomationDomain idRefDefinition = definition("id:" + domainId);
+        Domain existing = domain(domainId, "customer-auth");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(existing));
+        denyPermission();
+
+        Response response = put(domainsTarget(), idRefDefinition);
+
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
     void put_is_rejected_when_required_fields_missing() {
         AutomationDomain invalid = new AutomationDomain();
         invalid.setAutomationKey("customer-auth"); // name, path, dataPlaneId missing

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/IdentityProvidersResourceTest.java
@@ -24,6 +24,7 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.service.exception.InvalidPluginConfigurationException;
 import io.gravitee.am.service.exception.PluginNotDeployedException;
+import io.gravitee.am.service.model.NewIdentityProvider;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -35,6 +36,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -309,10 +311,50 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("The 'type' is immutable for an existing identity provider 'dev-users'"));
         verify(identityProviderManager, never()).checkPluginDeployment(anyString());
         verify(validationService, never()).validate(anyString(), anyString());
         verify(identityProviderService, never())
                 .update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_create_derives_external_flag_from_plugin_descriptor() {
+        // 'external' is internal and intrinsic to the plugin type: the AAPI ignores the client and stamps
+        // it from the plugin descriptor at creation. A plugin reported as external must persist external.
+        String idpId = AutomationIds.identityProviderId(domainId, "social-login");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+        when(identityProviderManager.isExternalProvider(eq("inline-am-idp"))).thenReturn(true);
+        when(identityProviderService.create(any(Domain.class), any(), any(), eq(false)))
+                .thenReturn(Single.just(idp(idpId, "social-login", ManagedBy.AUTOMATION_API)));
+
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("social-login"));
+
+        assertEquals(200, response.getStatus());
+        ArgumentCaptor<NewIdentityProvider> captor = ArgumentCaptor.forClass(NewIdentityProvider.class);
+        verify(identityProviderService).create(any(Domain.class), captor.capture(), any(), eq(false));
+        assertTrue(captor.getValue().isExternal());
+    }
+
+    @Test
+    void put_create_marks_non_external_plugin_as_internal() {
+        String idpId = AutomationIds.identityProviderId(domainId, "dev-users");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.empty());
+        when(identityProviderManager.isExternalProvider(eq("inline-am-idp"))).thenReturn(false);
+        when(identityProviderService.create(any(Domain.class), any(), any(), eq(false)))
+                .thenReturn(Single.just(idp(idpId, "dev-users", ManagedBy.AUTOMATION_API)));
+
+        Response response = put(identitiesTarget(DOMAIN_KEY), definition("dev-users"));
+
+        assertEquals(200, response.getStatus());
+        ArgumentCaptor<NewIdentityProvider> captor = ArgumentCaptor.forClass(NewIdentityProvider.class);
+        verify(identityProviderService).create(any(Domain.class), captor.capture(), any(), eq(false));
+        assertFalse(captor.getValue().isExternal());
     }
 
     @Test
@@ -456,6 +498,29 @@ class IdentityProvidersResourceTest extends AutomationJerseySpringTest {
         Response response = put(identitiesTarget(DOMAIN_KEY), def);
 
         assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("The 'system' flag is immutable for an existing identity provider 'dev-users'"));
+        verify(identityProviderService, never())
+                .update(eq(ReferenceType.DOMAIN), eq(domainId), eq(idpId), any(), any(), eq(false));
+    }
+
+    @Test
+    void put_rejects_clearing_system_on_existing() {
+        String systemIdpId = AutomationIds.systemIdentityProviderId(domainId);
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(domain()));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), eq(domainId)))
+                .thenReturn(Flowable.just(idp(systemIdpId, "sys-idp", ManagedBy.AUTOMATION_API, true)));
+
+        AutomationIdentityProvider def = definition("sys-idp");
+        def.setSystem(false);
+
+        Response response = put(identitiesTarget(DOMAIN_KEY), def);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.readEntity(String.class)
+                .contains("The 'system' flag is immutable for an existing identity provider 'sys-idp'"));
+        verify(identityProviderService, never())
+                .update(eq(ReferenceType.DOMAIN), anyString(), anyString(), any(), any(), anyBoolean());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/IdentityProviderManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/IdentityProviderManager.java
@@ -38,4 +38,12 @@ public interface IdentityProviderManager extends Service<IdentityProviderManager
     Completable loadIdentityProviders();
 
     Completable checkPluginDeployment(String type);
+
+    /**
+     * Whether the identity provider plugin of the given type is external (delegates authentication to a
+     * third party) rather than AM-managed. The value is intrinsic to the plugin descriptor and is the
+     * source of truth for the {@code external} flag set when an identity provider is created. Returns
+     * {@code false} for an unknown type.
+     */
+    boolean isExternalProvider(String type);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/IdentityProviderManagerImpl.java
@@ -239,4 +239,13 @@ public class IdentityProviderManagerImpl extends AbstractService<IdentityProvide
         }
         return Completable.complete();
     }
+
+    @Override
+    public boolean isExternalProvider(String type) {
+        return identityProviderPluginManager.findAll().stream()
+                .filter(plugin -> plugin.id().equals(type))
+                .map(plugin -> plugin.external())
+                .findFirst()
+                .orElse(false);
+    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/IdentityProviderManagerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/IdentityProviderManagerTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.management.service.impl;
 
+import io.gravitee.am.identityprovider.api.AuthenticationProvider;
+import io.gravitee.am.identityprovider.api.IdentityProvider;
 import io.gravitee.am.identityprovider.api.UserProvider;
 import io.gravitee.am.management.service.InMemoryIdentityProviderListener;
 import io.gravitee.am.model.Organization;
@@ -34,9 +36,13 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.argThat;
@@ -146,5 +152,33 @@ public class IdentityProviderManagerTest {
         observer.assertValueCount(1);
 
         verify(idpPluginManager, never()).findById(any());
+    }
+
+    @Test
+    public void isExternalProvider_readsFlagFromPluginDescriptor() {
+        // build the stub descriptors before the findAll() stubbing — constructing them itself records
+        // mock interactions, which Mockito would otherwise flag as nested/unfinished stubbing
+        Collection<IdentityProvider<?, AuthenticationProvider>> plugins =
+                List.of(idpPlugin("inline-am-idp", false), idpPlugin("oidc-am-idp", true));
+        when(idpPluginManager.findAll()).thenReturn(plugins);
+
+        assertTrue(cut.isExternalProvider("oidc-am-idp"));
+        assertFalse(cut.isExternalProvider("inline-am-idp"));
+    }
+
+    @Test
+    public void isExternalProvider_defaultsToFalseForUnknownType() {
+        Collection<IdentityProvider<?, AuthenticationProvider>> plugins = List.of(idpPlugin("inline-am-idp", false));
+        when(idpPluginManager.findAll()).thenReturn(plugins);
+
+        assertFalse(cut.isExternalProvider("unknown-am-idp"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static IdentityProvider<?, AuthenticationProvider> idpPlugin(String id, boolean external) {
+        var plugin = mock(IdentityProvider.class);
+        when(plugin.id()).thenReturn(id);
+        when(plugin.external()).thenReturn(external);
+        return plugin;
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/login/LoginSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/login/LoginSettings.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.model.login;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.Client;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -91,6 +92,7 @@ public class LoginSettings {
         this.resetPasswordOnExpiration = other.resetPasswordOnExpiration;
     }
 
+    @Schema(hidden = true)
     public boolean isEnforcePasswordPolicyEnabled() {
         return passwordlessEnforcePasswordEnabled
                 && passwordlessEnforcePasswordMaxAge != null;

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/SpiffeDomainSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/SpiffeDomainSettings.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.model.oidc;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -38,22 +40,36 @@ public class SpiffeDomainSettings {
     /**
      * Whether the {@code spiffe_jwt} authentication method is permitted in this domain.
      */
+    @Schema(description = "Whether SPIFFE workload identity support is enabled for the domain.",
+            defaultValue = "false")
     private boolean enabled;
 
     // --- SSRF Protection ---
 
+    @Schema(description = "Whether trust bundles can be fetched over unsecured HTTP URIs.",
+            defaultValue = "false")
     private boolean allowUnsecuredHttpUri;
 
+    @Schema(description = "Whether trust bundles can be fetched from private IP addresses.",
+            defaultValue = "false")
     private boolean allowPrivateIpAddress;
 
+    @Schema(description = "Timeout, in milliseconds, for fetching trust bundles.",
+            defaultValue = "5000")
     private int fetchTimeoutMs = DEFAULT_FETCH_TIMEOUT_MS;
 
+    @Schema(description = "Maximum trust bundle response size, in kilobytes.",
+            defaultValue = "32")
     private int maxResponseSizeKb = DEFAULT_MAX_RESPONSE_SIZE_KB;
 
     // --- Bundle Caching ---
 
+    @Schema(description = "Time-to-live, in seconds, for cached trust bundle entries.",
+            defaultValue = "300")
     private int cacheTtlSeconds = DEFAULT_CACHE_TTL_SECONDS;
 
+    @Schema(description = "Maximum number of trust bundle entries retained in the cache.",
+            defaultValue = "50")
     private int cacheMaxEntries = DEFAULT_CACHE_MAX_ENTRIES;
 
     // --- JWT Validation Policy ---
@@ -61,13 +77,18 @@ public class SpiffeDomainSettings {
     /**
      * Maximum permitted {@code exp - iat} on an incoming SVID (SPIFFE guidance: ≤ 5 min).
      */
+    @Schema(description = "Maximum accepted JWT lifetime, in seconds, computed as exp minus iat.",
+            defaultValue = "300")
     private int maxJwtLifetimeSeconds = DEFAULT_MAX_JWT_LIFETIME_SECONDS;
 
+    @Schema(description = "Allowed clock skew, in seconds, when validating JWT temporal claims.",
+            defaultValue = "30")
     private int clockSkewSeconds = DEFAULT_CLOCK_SKEW_SECONDS;
 
     /**
      * Default algorithm allowlist; {@code none} and HMAC are always rejected.
      */
+    @Schema(description = "Default allowlist of signature algorithms accepted for SPIFFE JWT validation.")
     private List<String> defaultAllowedAlgorithms = DEFAULT_ALLOWED_ALGORITHMS;
 
     public SpiffeDomainSettings() {

--- a/gravitee-am-test/specs/management/automation/domain-identities.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-identities.jest.spec.ts
@@ -87,6 +87,7 @@ describe('Automation API - Identity providers (resource under a domain)', () => 
     // internal id / operational flags are intentionally not surfaced
     expect(response.body.id).toBeUndefined();
     expect(response.body.managedBy).toBeUndefined();
+    expect(response.body.external).toBeUndefined();
     expect(response.body.system).toBe(false);
   });
 

--- a/gravitee-am-test/specs/management/automation/domains.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domains.jest.spec.ts
@@ -56,7 +56,10 @@ const fullDef = (key: string) =>
     name: `Round-trip ${key}`,
     description: 'covers every settings block we surface',
     enabled: false, // diverges from the build* default; must survive the round-trip
+    master: true,
+    alertEnabled: true,
     tags: ['alpha', 'beta'],
+    vhostMode: true,
     vhosts: [{ host: 'auth.example.com', path: `/${key}`, overrideEntrypoint: true }],
     oidc: {
       redirectUriStrictMatching: true,
@@ -65,10 +68,17 @@ const fullDef = (key: string) =>
       clientRegistrationSettings: {
         allowLocalhostRedirectUri: true,
         allowHttpSchemeRedirectUri: true,
-        isDynamicClientRegistrationEnabled: true,
+        dynamicClientRegistrationEnabled: true,
+        openDynamicClientRegistrationEnabled: true,
+        clientTemplateEnabled: true,
+        allowedScopesEnabled: true,
       },
       securityProfileSettings: {
         enablePlainFapi: true,
+      },
+      workloadIdentitySettings: {
+        enabled: true,
+        allowUnsecuredHttpUri: true,
       },
     },
     loginSettings: {
@@ -227,7 +237,10 @@ describe('Automation API - Domain - Round-trip preserves all writable fields', (
     const body = response.body;
     expect(body.key).toEqual(key);
     expect(body.enabled).toBe(false);
+    expect(body.master).toBe(true);
+    expect(body.alertEnabled).toBe(true);
     expect(body.tags).toEqual(expect.arrayContaining(['alpha', 'beta']));
+    expect(body.vhostMode).toBe(true);
     expect(body.vhosts).toEqual([
       expect.objectContaining({
         host: 'auth.example.com',
@@ -243,10 +256,16 @@ describe('Automation API - Domain - Round-trip preserves all writable fields', (
       expect.objectContaining({
         allowLocalhostRedirectUri: true,
         allowHttpSchemeRedirectUri: true,
-        isDynamicClientRegistrationEnabled: true,
+        dynamicClientRegistrationEnabled: true,
+        openDynamicClientRegistrationEnabled: true,
+        clientTemplateEnabled: true,
+        allowedScopesEnabled: true,
       }),
     );
     expect(body.oidc.securityProfileSettings).toEqual(expect.objectContaining({ enablePlainFapi: true }));
+    expect(body.oidc.workloadIdentitySettings).toEqual(
+      expect.objectContaining({ enabled: true, allowUnsecuredHttpUri: true }),
+    );
 
     expect(body.loginSettings).toEqual(expect.objectContaining({
       registerEnabled: true,


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7144](https://gravitee.atlassian.net/browse/AM-7144)

## :pencil2: A description of the changes proposed in the pull request
Define all configurable domain fields for use in the Automation API.

Additionally:
- Amend enum casing to match data on the wire (avoids downstream unmarshalling problems with Terraform)
- Omit calculated `loginSettings.enforcePasswordPolicyEnabled` field from both APIs (it is already not included in JSON)
- Wrap and map boolean fields in `oidc.ClientRegistrationSettings` (e.g. `allowedScopesEnabled` -> `isAllowedScopesEnabled`) to avoid mismatches
- Retype `webAuthnSettings.certificates` to map of `String` for strict correctness (avoids downstream unmarshalling problems with Terraform)
- Resolve identity providers' `external` flag automatically from the plugin provider types at creation time, avoiding the need for surfacing the internal field (AAPI only)
- Remove unused `ManagedBy` enum values (affects MAPI OAS only)
- Document properties of `SpiffeDomainSettings.java`
- Also fix [AM-7156](https://gravitee.atlassian.net/browse/AM-7156) - for domain `PUT` with `id:<UUID>` reference format, check domain existence before permissions in order to return consistent 404 response

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7144]: https://gravitee.atlassian.net/browse/AM-7144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AM-7156]: https://gravitee.atlassian.net/browse/AM-7156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ