### PR TITLE
fix: purge audits of the in-memory platform reporter

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AuditReporterManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AuditReporterManager.java
@@ -21,6 +21,8 @@ import io.gravitee.am.reporter.api.provider.Reporter;
 import io.gravitee.common.service.Service;
 import io.reactivex.rxjava3.core.Maybe;
 
+import java.util.Optional;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -32,4 +34,12 @@ public interface AuditReporterManager extends Service<AuditReporterManager> {
     }
 
     Maybe<Reporter> getReporter(Reference domain);
+
+    /**
+     * Returns the internal (platform) reporter. This reporter is created in memory at startup and is not persisted in
+     * the reporter repository, so it is not returned by {@link io.gravitee.am.service.ReporterService#findAll()}.
+     *
+     * @return the internal reporter, or an empty {@link Optional} if it has not been initialized yet
+     */
+    Optional<Reporter> getInternalReporter();
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementAuditReporterManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementAuditReporterManager.java
@@ -172,6 +172,11 @@ public class ManagementAuditReporterManager extends AbstractService<AuditReporte
         }
     }
 
+    @Override
+    public Optional<Reporter> getInternalReporter() {
+        return Optional.ofNullable(internalReporter);
+    }
+
     private Maybe<Reporter> doGetReporter(Reference reference) {
         Optional<Reporter> optionalReporter = auditReporters
                 .entrySet()

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/purge/ReporterAuditSweeper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/purge/ReporterAuditSweeper.java
@@ -63,18 +63,37 @@ public class ReporterAuditSweeper implements ExpiredDataSweeper {
         log.info("Starting audit reporter data purge (retention: {} days)", retentionDays);
 
         return actionLeaseService.acquireLease(LEASE_ACTION_AUDIT_SWEEPER, Duration.of(leaseDuration, ChronoUnit.SECONDS))
-                .flatMapPublisher(lease -> reporterService.findAll())
-                .flatMapCompletable(reporter -> purgeReporter(reporter)
-                        .onErrorResumeNext(error -> {
-                            log.error("Failed to purge audits for reporter {}: {}",
-                                    reporter.getName(), error.getMessage(), error);
-                            return Completable.complete();
-                        }),
-                        NO_DELAY_ERRORS,
-                        MAX_CONCURRENCY
-                )
+                .flatMapCompletable(lease -> reporterService.findAll()
+                        .flatMapCompletable(reporter -> purgeReporter(reporter)
+                                .onErrorResumeNext(error -> {
+                                    log.error("Failed to purge audits for reporter {}: {}",
+                                            reporter.getName(), error.getMessage(), error);
+                                    return Completable.complete();
+                                }),
+                                NO_DELAY_ERRORS,
+                                MAX_CONCURRENCY
+                        )
+                        // the internal (platform) reporter is created in memory and is not returned by findAll(),
+                        // so it must be purged explicitly otherwise its 'reporter_audits_PLATFORM' collection grows unbounded
+                        .andThen(purgeInternalReporter()))
                 .doOnComplete(() -> log.info("Audit reporter data purge completed"))
                 .doOnError(error -> log.error("Audit reporter data purge failed", error));
+    }
+
+    private Completable purgeInternalReporter() {
+        return auditReporterManager.getInternalReporter()
+                .map(internalReporter -> {
+                    log.debug("Purging audits for internal (platform) reporter");
+                    return internalReporter.purgeExpiredData()
+                            .onErrorResumeNext(error -> {
+                                log.error("Failed to purge audits for internal (platform) reporter: {}", error.getMessage(), error);
+                                return Completable.complete();
+                            });
+                })
+                .orElseGet(() -> {
+                    log.debug("No internal (platform) reporter to purge");
+                    return Completable.complete();
+                });
     }
 
     private Completable purgeReporter(io.gravitee.am.model.Reporter reporterConfig) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/purge/ReporterAuditSweeperTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/purge/ReporterAuditSweeperTest.java
@@ -32,6 +32,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -218,6 +219,86 @@ public class ReporterAuditSweeperTest {
         verify(reporter1).purgeExpiredData();
         verify(reporter2).purgeExpiredData();
         verify(reporter3).purgeExpiredData();
+    }
+
+    @Test
+    public void should_purge_internal_platform_reporter() {
+        // Given
+        io.gravitee.am.reporter.api.provider.Reporter dbReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+        io.gravitee.am.reporter.api.provider.Reporter internalReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+
+        Reporter config = createReporterConfig("MongoDB Reporter", true);
+
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
+        when(reporterService.findAll()).thenReturn(Flowable.just(config));
+        when(auditReporterManager.getReporter(any(Reference.class))).thenReturn(Maybe.just(dbReporter));
+        when(dbReporter.purgeExpiredData()).thenReturn(Completable.complete());
+        when(auditReporterManager.getInternalReporter()).thenReturn(Optional.of(internalReporter));
+        when(internalReporter.purgeExpiredData()).thenReturn(Completable.complete());
+
+        // When
+        TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
+        testObserver.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(dbReporter).purgeExpiredData();
+        verify(internalReporter).purgeExpiredData();
+    }
+
+    @Test
+    public void should_handle_internal_platform_reporter_error_gracefully() {
+        // Given
+        io.gravitee.am.reporter.api.provider.Reporter internalReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
+        when(reporterService.findAll()).thenReturn(Flowable.empty());
+        when(auditReporterManager.getInternalReporter()).thenReturn(Optional.of(internalReporter));
+        when(internalReporter.purgeExpiredData())
+                .thenReturn(Completable.error(new RuntimeException("Database connection error")));
+
+        // When
+        TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
+        testObserver.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then
+        testObserver.assertComplete(); // Should complete despite error on internal reporter
+        testObserver.assertNoErrors();
+        verify(internalReporter).purgeExpiredData();
+    }
+
+    @Test
+    public void should_complete_when_internal_platform_reporter_not_initialized() {
+        // Given
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
+        when(reporterService.findAll()).thenReturn(Flowable.empty());
+        when(auditReporterManager.getInternalReporter()).thenReturn(Optional.empty());
+
+        // When
+        TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
+        testObserver.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+    }
+
+    @Test
+    public void should_not_purge_internal_platform_reporter_when_lease_not_acquired() {
+        // Given
+        io.gravitee.am.reporter.api.provider.Reporter internalReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.empty());
+
+        // When
+        TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
+        testObserver.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(auditReporterManager, never()).getInternalReporter();
+        verify(internalReporter, never()).purgeExpiredData();
     }
 
     private Reporter createReporterConfig(String name, boolean enabled) {


### PR DESCRIPTION
## Description

Fixes [AM-7133](https://gravitee.atlassian.net/browse/AM-7133): audit logs purge does not respect the retention period for the `reporter_audits_PLATFORM` collection.

### Root cause

The internal **platform** reporter is created in memory at startup (`ManagementAuditReporterManager.doStart()` → `ReporterService.createInternal()` with a `PLATFORM/PLATFORM` reference). Because of that reference, its data is written to `reporter_audits_PLATFORM` (Mongo) / table suffix `PLATFORM` (JDBC).

`ReporterAuditSweeper` only iterates `ReporterService.findAll()`, which returns **DB-persisted** reporters (domain/organization). The platform reporter is never persisted, so it is never returned and its collection/table grows unbounded.

### Fix

- Expose the in-memory internal reporter via `AuditReporterManager.getInternalReporter()` (returns `Optional<Reporter>`).
- `ReporterAuditSweeper` now purges the internal reporter explicitly, inside the cluster lease, with the same graceful per-reporter error handling so a failure there does not abort the sweep.

### Tests

Added new test methods to `ReporterAuditSweeperTest` (existing methods untouched):
- `should_purge_internal_platform_reporter`
- `should_handle_internal_platform_reporter_error_gracefully`
- `should_complete_when_internal_platform_reporter_not_initialized`
- `should_not_purge_internal_platform_reporter_when_lease_not_acquired`

All 11 tests pass.

[AM-7133]: https://gravitee.atlassian.net/browse/AM-7133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ