### PR TITLE
feat: reduce impact of audit retention purge (AM-7041)

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AuditReporterManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/AuditReporterManager.java
@@ -21,6 +21,8 @@ import io.gravitee.am.reporter.api.provider.Reporter;
 import io.gravitee.common.service.Service;
 import io.reactivex.rxjava3.core.Maybe;
 
+import java.util.Optional;
+
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
@@ -32,4 +34,12 @@ public interface AuditReporterManager extends Service<AuditReporterManager> {
     }
 
     Maybe<Reporter> getReporter(Reference domain);
+
+    /**
+     * Returns the internal (platform) reporter. This reporter is created in memory at startup and is not persisted in
+     * the reporter repository, so it is not returned by {@link io.gravitee.am.service.ReporterService#findAll()}.
+     *
+     * @return the internal reporter, or an empty {@link Optional} if it has not been initialized yet
+     */
+    Optional<Reporter> getInternalReporter();
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementAuditReporterManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementAuditReporterManager.java
@@ -172,6 +172,11 @@ public class ManagementAuditReporterManager extends AbstractService<AuditReporte
         }
     }
 
+    @Override
+    public Optional<Reporter> getInternalReporter() {
+        return Optional.ofNullable(internalReporter);
+    }
+
     private Maybe<Reporter> doGetReporter(Reference reference) {
         Optional<Reporter> optionalReporter = auditReporters
                 .entrySet()

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/purge/ReporterAuditSweeper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/purge/ReporterAuditSweeper.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 @Component
@@ -33,9 +34,8 @@ import java.time.temporal.ChronoUnit;
 public class ReporterAuditSweeper implements ExpiredDataSweeper {
 
     public static final String LEASE_ACTION_AUDIT_SWEEPER = "auditSweeper";
-    public static final int MAX_CONCURRENCY = 4;
-    public static final boolean NO_DELAY_ERRORS = false;
     public static final int DEFAULT_AUDIT_SWEEPER_LEASE_DURATION_IN_SECONDS = 3600;
+    public static final int DEFAULT_AUDIT_SWEEPER_GLOBAL_TIMEOUT_IN_SECONDS = 3600;
 
     private final AuditReporterManager auditReporterManager;
 
@@ -57,34 +57,47 @@ public class ReporterAuditSweeper implements ExpiredDataSweeper {
     @Value("${services.purge.audits.leaseDuration:"+ DEFAULT_AUDIT_SWEEPER_LEASE_DURATION_IN_SECONDS +"}")
     private int leaseDuration;
 
+    /**
+     * Maximum duration (in seconds) of a single purge execution shared across all reporters. Once this
+     * deadline is reached no further reporter is started and any running purge stops gracefully; the
+     * remaining work resumes on the next scheduled execution.
+     */
+    @Value("${services.purge.audits.globalTimeout:"+ DEFAULT_AUDIT_SWEEPER_GLOBAL_TIMEOUT_IN_SECONDS +"}")
+    private int globalTimeout;
+
 
     @Override
     public Completable purgeExpiredData() {
-        log.info("Starting audit reporter data purge (retention: {} days)", retentionDays);
+        log.info("Starting audit reporter data purge (retention: {} days, global timeout: {}s)", retentionDays, globalTimeout);
+
+        // a single deadline is shared by every reporter so the whole execution cannot exceed the configured duration
+        final Instant deadline = Instant.now().plusSeconds(globalTimeout);
 
         return actionLeaseService.acquireLease(LEASE_ACTION_AUDIT_SWEEPER, Duration.of(leaseDuration, ChronoUnit.SECONDS))
+                // reporters are purged one at a time (concatMapCompletable) to limit the pressure on the backend
                 .flatMapCompletable(lease -> reporterService.findAll()
-                        .flatMapCompletable(reporter -> purgeReporter(reporter)
+                        .concatMapCompletable(reporter -> purgeReporter(reporter, deadline)
                                 .onErrorResumeNext(error -> {
-                                    log.error("Failed to purge audits for reporter {}: {}",
-                                            reporter.getName(), error.getMessage(), error);
+                                    log.error("Failed to purge audits for reporter {}/{}: {}",
+                                            reporter.getName(), reporter.getId(), error.getMessage(), error);
                                     return Completable.complete();
-                                }),
-                                NO_DELAY_ERRORS,
-                                MAX_CONCURRENCY
-                        )
+                                }))
                         // the internal (platform) reporter is created in memory and is not returned by findAll(),
                         // so it must be purged explicitly otherwise its 'reporter_audits_PLATFORM' collection grows unbounded
-                        .andThen(purgeInternalReporter()))
+                        .andThen(purgeInternalReporter(deadline)))
                 .doOnComplete(() -> log.info("Audit reporter data purge completed"))
                 .doOnError(error -> log.error("Audit reporter data purge failed", error));
     }
 
-    private Completable purgeInternalReporter() {
+    private Completable purgeInternalReporter(Instant deadline) {
+        if (Instant.now().isAfter(deadline)) {
+            log.warn("Global purge timeout reached, skipping the internal (platform) reporter until next execution");
+            return Completable.complete();
+        }
         return auditReporterManager.getInternalReporter()
                 .map(internalReporter -> {
                     log.debug("Purging audits for internal (platform) reporter");
-                    return internalReporter.purgeExpiredData()
+                    return internalReporter.purgeExpiredData(deadline)
                             .onErrorResumeNext(error -> {
                                 log.error("Failed to purge audits for internal (platform) reporter: {}", error.getMessage(), error);
                                 return Completable.complete();
@@ -96,15 +109,21 @@ public class ReporterAuditSweeper implements ExpiredDataSweeper {
                 });
     }
 
-    private Completable purgeReporter(io.gravitee.am.model.Reporter reporterConfig) {
+    private Completable purgeReporter(io.gravitee.am.model.Reporter reporterConfig, Instant deadline) {
         if (!reporterConfig.isEnabled()) {
+            return Completable.complete();
+        }
+
+        // do not start purging a new reporter once the global deadline has been reached
+        if (Instant.now().isAfter(deadline)) {
+            log.warn("Global purge timeout reached, skipping reporter {} until next execution", reporterConfig.getName());
             return Completable.complete();
         }
 
         return auditReporterManager.getReporter(reporterConfig.getReference())
                 .flatMapCompletable(reporter -> {
-                    log.debug("Purging audits for reporter: {}", reporterConfig.getName());
-                    return reporter.purgeExpiredData();
+                    log.debug("Purging audits for reporter: {}/{}", reporterConfig.getName(), reporterConfig.getId());
+                    return reporter.purgeExpiredData(deadline);
                 });
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/purge/ReporterAuditSweeper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/purge/ReporterAuditSweeper.java
@@ -63,18 +63,37 @@ public class ReporterAuditSweeper implements ExpiredDataSweeper {
         log.info("Starting audit reporter data purge (retention: {} days)", retentionDays);
 
         return actionLeaseService.acquireLease(LEASE_ACTION_AUDIT_SWEEPER, Duration.of(leaseDuration, ChronoUnit.SECONDS))
-                .flatMapPublisher(lease -> reporterService.findAll())
-                .flatMapCompletable(reporter -> purgeReporter(reporter)
-                        .onErrorResumeNext(error -> {
-                            log.error("Failed to purge audits for reporter {}: {}",
-                                    reporter.getName(), error.getMessage(), error);
-                            return Completable.complete();
-                        }),
-                        NO_DELAY_ERRORS,
-                        MAX_CONCURRENCY
-                )
+                .flatMapCompletable(lease -> reporterService.findAll()
+                        .flatMapCompletable(reporter -> purgeReporter(reporter)
+                                .onErrorResumeNext(error -> {
+                                    log.error("Failed to purge audits for reporter {}: {}",
+                                            reporter.getName(), error.getMessage(), error);
+                                    return Completable.complete();
+                                }),
+                                NO_DELAY_ERRORS,
+                                MAX_CONCURRENCY
+                        )
+                        // the internal (platform) reporter is created in memory and is not returned by findAll(),
+                        // so it must be purged explicitly otherwise its 'reporter_audits_PLATFORM' collection grows unbounded
+                        .andThen(purgeInternalReporter()))
                 .doOnComplete(() -> log.info("Audit reporter data purge completed"))
                 .doOnError(error -> log.error("Audit reporter data purge failed", error));
+    }
+
+    private Completable purgeInternalReporter() {
+        return auditReporterManager.getInternalReporter()
+                .map(internalReporter -> {
+                    log.debug("Purging audits for internal (platform) reporter");
+                    return internalReporter.purgeExpiredData()
+                            .onErrorResumeNext(error -> {
+                                log.error("Failed to purge audits for internal (platform) reporter: {}", error.getMessage(), error);
+                                return Completable.complete();
+                            });
+                })
+                .orElseGet(() -> {
+                    log.debug("No internal (platform) reporter to purge");
+                    return Completable.complete();
+                });
     }
 
     private Completable purgeReporter(io.gravitee.am.model.Reporter reporterConfig) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/purge/ReporterAuditSweeper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/purge/ReporterAuditSweeper.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
 @Slf4j
@@ -42,6 +43,13 @@ public class ReporterAuditSweeper implements ExpiredDataSweeper {
     private final ReporterService reporterService;
 
     private final ActionLeaseService actionLeaseService;
+
+    /**
+     * In-process, non-reentrant guard preventing two purge executions from running concurrently on the
+     * same node. This is independent of the distributed lease (which stays re-entrant for crash recovery)
+     * and protects against overlapping runs whatever the configured cron frequency.
+     */
+    private final AtomicBoolean running = new AtomicBoolean(false);
 
     public ReporterAuditSweeper(@Lazy AuditReporterManager auditReporterManager,
                                 @Lazy ReporterService reporterService,
@@ -68,25 +76,35 @@ public class ReporterAuditSweeper implements ExpiredDataSweeper {
 
     @Override
     public Completable purgeExpiredData() {
-        log.info("Starting audit reporter data purge (retention: {} days, global timeout: {}s)", retentionDays, globalTimeout);
+        // evaluated at subscription time so the guard reflects the state when the purge actually starts
+        return Completable.defer(() -> {
+            if (!running.compareAndSet(false, true)) {
+                log.warn("An audit reporter data purge is already running on this node, skipping this execution");
+                return Completable.complete();
+            }
 
-        // a single deadline is shared by every reporter so the whole execution cannot exceed the configured duration
-        final Instant deadline = Instant.now().plusSeconds(globalTimeout);
+            log.info("Starting audit reporter data purge (retention: {} days, global timeout: {}s)", retentionDays, globalTimeout);
 
-        return actionLeaseService.acquireLease(LEASE_ACTION_AUDIT_SWEEPER, Duration.of(leaseDuration, ChronoUnit.SECONDS))
-                // reporters are purged one at a time (concatMapCompletable) to limit the pressure on the backend
-                .flatMapCompletable(lease -> reporterService.findAll()
-                        .concatMapCompletable(reporter -> purgeReporter(reporter, deadline)
-                                .onErrorResumeNext(error -> {
-                                    log.error("Failed to purge audits for reporter {}/{}: {}",
-                                            reporter.getName(), reporter.getId(), error.getMessage(), error);
-                                    return Completable.complete();
-                                }))
-                        // the internal (platform) reporter is created in memory and is not returned by findAll(),
-                        // so it must be purged explicitly otherwise its 'reporter_audits_PLATFORM' collection grows unbounded
-                        .andThen(purgeInternalReporter(deadline)))
-                .doOnComplete(() -> log.info("Audit reporter data purge completed"))
-                .doOnError(error -> log.error("Audit reporter data purge failed", error));
+            // a single deadline is shared by every reporter so the whole execution cannot exceed the configured duration
+            final Instant deadline = Instant.now().plusSeconds(globalTimeout);
+
+            return actionLeaseService.acquireLease(LEASE_ACTION_AUDIT_SWEEPER, Duration.of(leaseDuration, ChronoUnit.SECONDS))
+                    // reporters are purged one at a time (concatMapCompletable) to limit the pressure on the backend
+                    .flatMapCompletable(lease -> reporterService.findAll()
+                            .concatMapCompletable(reporter -> purgeReporter(reporter, deadline)
+                                    .onErrorResumeNext(error -> {
+                                        log.error("Failed to purge audits for reporter {}/{}: {}",
+                                                reporter.getName(), reporter.getId(), error.getMessage(), error);
+                                        return Completable.complete();
+                                    }))
+                            // the internal (platform) reporter is created in memory and is not returned by findAll(),
+                            // so it must be purged explicitly otherwise its 'reporter_audits_PLATFORM' collection grows unbounded
+                            .andThen(purgeInternalReporter(deadline)))
+                    .doOnComplete(() -> log.info("Audit reporter data purge completed"))
+                    .doOnError(error -> log.error("Audit reporter data purge failed", error))
+                    // release the in-process guard whatever the outcome (complete, error or dispose)
+                    .doFinally(() -> running.set(false));
+        });
     }
 
     private Completable purgeInternalReporter(Instant deadline) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/purge/ReporterAuditSweeperTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/purge/ReporterAuditSweeperTest.java
@@ -32,6 +32,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -218,6 +219,86 @@ public class ReporterAuditSweeperTest {
         verify(reporter1).purgeExpiredData();
         verify(reporter2).purgeExpiredData();
         verify(reporter3).purgeExpiredData();
+    }
+
+    @Test
+    public void should_purge_internal_platform_reporter() {
+        // Given
+        io.gravitee.am.reporter.api.provider.Reporter dbReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+        io.gravitee.am.reporter.api.provider.Reporter internalReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+
+        Reporter config = createReporterConfig("MongoDB Reporter", true);
+
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
+        when(reporterService.findAll()).thenReturn(Flowable.just(config));
+        when(auditReporterManager.getReporter(any(Reference.class))).thenReturn(Maybe.just(dbReporter));
+        when(dbReporter.purgeExpiredData()).thenReturn(Completable.complete());
+        when(auditReporterManager.getInternalReporter()).thenReturn(Optional.of(internalReporter));
+        when(internalReporter.purgeExpiredData()).thenReturn(Completable.complete());
+
+        // When
+        TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
+        testObserver.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(dbReporter).purgeExpiredData();
+        verify(internalReporter).purgeExpiredData();
+    }
+
+    @Test
+    public void should_handle_internal_platform_reporter_error_gracefully() {
+        // Given
+        io.gravitee.am.reporter.api.provider.Reporter internalReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
+        when(reporterService.findAll()).thenReturn(Flowable.empty());
+        when(auditReporterManager.getInternalReporter()).thenReturn(Optional.of(internalReporter));
+        when(internalReporter.purgeExpiredData())
+                .thenReturn(Completable.error(new RuntimeException("Database connection error")));
+
+        // When
+        TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
+        testObserver.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then
+        testObserver.assertComplete(); // Should complete despite error on internal reporter
+        testObserver.assertNoErrors();
+        verify(internalReporter).purgeExpiredData();
+    }
+
+    @Test
+    public void should_complete_when_internal_platform_reporter_not_initialized() {
+        // Given
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
+        when(reporterService.findAll()).thenReturn(Flowable.empty());
+        when(auditReporterManager.getInternalReporter()).thenReturn(Optional.empty());
+
+        // When
+        TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
+        testObserver.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+    }
+
+    @Test
+    public void should_not_purge_internal_platform_reporter_when_lease_not_acquired() {
+        // Given
+        io.gravitee.am.reporter.api.provider.Reporter internalReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.empty());
+
+        // When
+        TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
+        testObserver.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(auditReporterManager, never()).getInternalReporter();
+        verify(internalReporter, never()).purgeExpiredData();
     }
 
     private Reporter createReporterConfig(String name, boolean enabled) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/purge/ReporterAuditSweeperTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/purge/ReporterAuditSweeperTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -302,6 +303,33 @@ public class ReporterAuditSweeperTest {
         testObserver.assertNoErrors();
         verify(auditReporterManager, never()).getInternalReporter();
         verify(internalReporter, never()).purgeExpiredData(any());
+    }
+
+    @Test
+    public void should_skip_concurrent_purge_on_same_node() {
+        // Given a reporter whose purge never completes, so the first execution stays in-flight
+        io.gravitee.am.reporter.api.provider.Reporter blockingReporter = mock(io.gravitee.am.reporter.api.provider.Reporter.class);
+        Reporter config = createReporterConfig("MongoDB Reporter", true);
+
+        when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
+        when(reporterService.findAll()).thenReturn(Flowable.just(config));
+        when(auditReporterManager.getReporter(any(Reference.class))).thenReturn(Maybe.just(blockingReporter));
+        when(blockingReporter.purgeExpiredData(any())).thenReturn(Completable.never());
+
+        // When a first execution starts (and stays running)
+        TestObserver<Void> firstRun = sweeper.purgeExpiredData().test();
+        firstRun.assertNotComplete();
+
+        // And a second execution is triggered on the same node while the first is still running
+        TestObserver<Void> secondRun = sweeper.purgeExpiredData().test();
+        secondRun.awaitDone(5, TimeUnit.SECONDS);
+
+        // Then the second execution is skipped (completes immediately without doing any work)
+        secondRun.assertComplete();
+        secondRun.assertNoErrors();
+        verify(actionLeaseService, times(1)).acquireLease(any(), any());
+        verify(reporterService, times(1)).findAll();
+        verify(blockingReporter, times(1)).purgeExpiredData(any());
     }
 
     private Reporter createReporterConfig(String name, boolean enabled) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/purge/ReporterAuditSweeperTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/purge/ReporterAuditSweeperTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -58,6 +59,8 @@ public class ReporterAuditSweeperTest {
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        // @Value defaults are not applied in unit tests; set a non-zero timeout so reporters are not skipped
+        ReflectionTestUtils.setField(sweeper, "globalTimeout", 3600);
     }
 
     @Test
@@ -74,8 +77,8 @@ public class ReporterAuditSweeperTest {
         when(auditReporterManager.getReporter(any(Reference.class)))
                 .thenReturn(Maybe.just(mockReporter1))
                 .thenReturn(Maybe.just(mockReporter2));
-        when(mockReporter1.purgeExpiredData()).thenReturn(Completable.complete());
-        when(mockReporter2.purgeExpiredData()).thenReturn(Completable.complete());
+        when(mockReporter1.purgeExpiredData(any())).thenReturn(Completable.complete());
+        when(mockReporter2.purgeExpiredData(any())).thenReturn(Completable.complete());
 
         // When
         TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
@@ -84,8 +87,8 @@ public class ReporterAuditSweeperTest {
         // Then
         testObserver.assertComplete();
         testObserver.assertNoErrors();
-        verify(mockReporter1).purgeExpiredData();
-        verify(mockReporter2).purgeExpiredData();
+        verify(mockReporter1).purgeExpiredData(any());
+        verify(mockReporter2).purgeExpiredData(any());
     }
 
     @Test
@@ -104,8 +107,8 @@ public class ReporterAuditSweeperTest {
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         verify(reporterService, never()).findAll();
-        verify(mockReporter1, never()).purgeExpiredData();
-        verify(mockReporter2, never()).purgeExpiredData();
+        verify(mockReporter1, never()).purgeExpiredData(any());
+        verify(mockReporter2, never()).purgeExpiredData(any());
     }
 
     @Test
@@ -135,7 +138,7 @@ public class ReporterAuditSweeperTest {
         when(reporterService.findAll()).thenReturn(Flowable.just(config));
         when(auditReporterManager.getReporter(any(Reference.class)))
                 .thenReturn(Maybe.just(mockReporter));
-        when(mockReporter.purgeExpiredData())
+        when(mockReporter.purgeExpiredData(any()))
                 .thenReturn(Completable.error(new RuntimeException("Database connection error")));
 
         // When
@@ -145,7 +148,7 @@ public class ReporterAuditSweeperTest {
         // Then
         testObserver.assertComplete(); // Should complete despite error
         testObserver.assertNoErrors(); // Error handled gracefully
-        verify(mockReporter).purgeExpiredData();
+        verify(mockReporter).purgeExpiredData(any());
     }
 
     @Test
@@ -205,9 +208,9 @@ public class ReporterAuditSweeperTest {
                 .thenReturn(Maybe.just(reporter2))
                 .thenReturn(Maybe.just(reporter3));
 
-        when(reporter1.purgeExpiredData()).thenReturn(Completable.complete());
-        when(reporter2.purgeExpiredData()).thenReturn(Completable.error(new RuntimeException("Reporter 2 failed")));
-        when(reporter3.purgeExpiredData()).thenReturn(Completable.complete());
+        when(reporter1.purgeExpiredData(any())).thenReturn(Completable.complete());
+        when(reporter2.purgeExpiredData(any())).thenReturn(Completable.error(new RuntimeException("Reporter 2 failed")));
+        when(reporter3.purgeExpiredData(any())).thenReturn(Completable.complete());
 
         // When
         TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
@@ -216,9 +219,9 @@ public class ReporterAuditSweeperTest {
         // Then
         testObserver.assertComplete();
         testObserver.assertNoErrors();
-        verify(reporter1).purgeExpiredData();
-        verify(reporter2).purgeExpiredData();
-        verify(reporter3).purgeExpiredData();
+        verify(reporter1).purgeExpiredData(any());
+        verify(reporter2).purgeExpiredData(any());
+        verify(reporter3).purgeExpiredData(any());
     }
 
     @Test
@@ -232,9 +235,9 @@ public class ReporterAuditSweeperTest {
         when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
         when(reporterService.findAll()).thenReturn(Flowable.just(config));
         when(auditReporterManager.getReporter(any(Reference.class))).thenReturn(Maybe.just(dbReporter));
-        when(dbReporter.purgeExpiredData()).thenReturn(Completable.complete());
+        when(dbReporter.purgeExpiredData(any())).thenReturn(Completable.complete());
         when(auditReporterManager.getInternalReporter()).thenReturn(Optional.of(internalReporter));
-        when(internalReporter.purgeExpiredData()).thenReturn(Completable.complete());
+        when(internalReporter.purgeExpiredData(any())).thenReturn(Completable.complete());
 
         // When
         TestObserver<Void> testObserver = sweeper.purgeExpiredData().test();
@@ -243,8 +246,8 @@ public class ReporterAuditSweeperTest {
         // Then
         testObserver.assertComplete();
         testObserver.assertNoErrors();
-        verify(dbReporter).purgeExpiredData();
-        verify(internalReporter).purgeExpiredData();
+        verify(dbReporter).purgeExpiredData(any());
+        verify(internalReporter).purgeExpiredData(any());
     }
 
     @Test
@@ -255,7 +258,7 @@ public class ReporterAuditSweeperTest {
         when(actionLeaseService.acquireLease(any(), any())).thenReturn(Maybe.just(new ActionLease()));
         when(reporterService.findAll()).thenReturn(Flowable.empty());
         when(auditReporterManager.getInternalReporter()).thenReturn(Optional.of(internalReporter));
-        when(internalReporter.purgeExpiredData())
+        when(internalReporter.purgeExpiredData(any()))
                 .thenReturn(Completable.error(new RuntimeException("Database connection error")));
 
         // When
@@ -265,7 +268,7 @@ public class ReporterAuditSweeperTest {
         // Then
         testObserver.assertComplete(); // Should complete despite error on internal reporter
         testObserver.assertNoErrors();
-        verify(internalReporter).purgeExpiredData();
+        verify(internalReporter).purgeExpiredData(any());
     }
 
     @Test
@@ -298,7 +301,7 @@ public class ReporterAuditSweeperTest {
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         verify(auditReporterManager, never()).getInternalReporter();
-        verify(internalReporter, never()).purgeExpiredData();
+        verify(internalReporter, never()).purgeExpiredData(any());
     }
 
     private Reporter createReporterConfig(String name, boolean enabled) {

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -154,6 +154,10 @@ services:
 #    audits:                                     # audits retention period in days (0 means disabled)
 #      retention:
 #        days: 90
+#      batchSize: 2000                          # number of audits deleted per batch for each reporter (default and hard max: 2000)
+#      batchDelay: 500                           # wait time in ms between two batches to let the backend sync its replication journal (default: 500)
+#      globalTimeout: 3600                       # max duration in seconds of a single purge execution shared across all reporters; once reached no further reporter is started and the purge resumes on the next execution (default: 3600)
+#      leaseDuration: 3600                       # how much time the Management API currently processing the audits deletion owns the exclusive lock
 
   # platform notifier service
   notifier:

--- a/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/provider/Reporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/provider/Reporter.java
@@ -23,6 +23,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 
+import java.time.Instant;
 import java.util.Map;
 
 /**
@@ -30,6 +31,13 @@ import java.util.Map;
  * @author GraviteeSource Team
  */
 public interface Reporter<R extends Reportable, C extends ReportableCriteria> extends io.gravitee.reporter.api.Reporter {
+
+    /**
+     * Maximum number of records purged per batch, whatever the backend (MongoDB or RDBMS). This hard
+     * cap bounds memory usage, lock footprint and the number of bind parameters per delete statement
+     * (e.g. SQL Server limits a statement to 2100 parameters), so any larger configured value is clamped.
+     */
+    int PURGE_MAX_BATCH_SIZE = 2000;
 
     Single<Page<R>> search(ReferenceType referenceType, String referenceId, C criteria, int page, int size);
 
@@ -41,5 +49,18 @@ public interface Reporter<R extends Reportable, C extends ReportableCriteria> ex
 
     default Completable purgeExpiredData(){
         return Completable.complete();
+    }
+
+    /**
+     * Purge expired data while respecting a deadline shared across the whole purge execution.
+     * <p>
+     * Implementations must stop processing once {@code deadline} is reached and resume on the next
+     * execution, so that a single run cannot monopolize the backend indefinitely.
+     *
+     * @param deadline the instant after which the purge must stop until the next execution
+     */
+    default Completable purgeExpiredData(Instant deadline){
+        // by default, fall back to the legacy behaviour so existing reporters remain compatible
+        return purgeExpiredData();
     }
 }

--- a/gravitee-am-reporter/gravitee-am-reporter-jdbc/src/main/java/io/gravitee/am/reporter/jdbc/audit/JdbcAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-jdbc/src/main/java/io/gravitee/am/reporter/jdbc/audit/JdbcAuditReporter.java
@@ -204,7 +204,7 @@ public class JdbcAuditReporter extends AbstractService<Reporter> implements Audi
     @Value("${services.purge.audits.retention.days:0}")
     private int retentionDays;
 
-    @Value("${services.purge.audits.batchDelay:500}")
+    @Value("${services.purge.audits.batchDelay:1000}")
     private long batchDelayMs;
 
     @Value("${services.purge.audits.batchSize:" + PURGE_MAX_BATCH_SIZE + "}")

--- a/gravitee-am-reporter/gravitee-am-reporter-jdbc/src/main/java/io/gravitee/am/reporter/jdbc/audit/JdbcAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-jdbc/src/main/java/io/gravitee/am/reporter/jdbc/audit/JdbcAuditReporter.java
@@ -71,6 +71,7 @@ import reactor.core.publisher.Mono;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -110,7 +111,6 @@ public class JdbcAuditReporter extends AbstractService<Reporter> implements Audi
     public static final String AUDIT_FIELD_ACTOR = "actor";
     public static final String AUDIT_FIELD_TARGET = "target";
     public static final String NOT_BOOTSTRAPPED = "Reporter not yet bootstrapped";
-    public static final int DELETE_BATCH_SIZE = 2000;
 
     private final Pattern pattern = Pattern.compile("___");
 
@@ -204,6 +204,12 @@ public class JdbcAuditReporter extends AbstractService<Reporter> implements Audi
     @Value("${services.purge.audits.retention.days:0}")
     private int retentionDays;
 
+    @Value("${services.purge.audits.batchDelay:500}")
+    private long batchDelayMs;
+
+    @Value("${services.purge.audits.batchSize:" + PURGE_MAX_BATCH_SIZE + "}")
+    private int batchSize = PURGE_MAX_BATCH_SIZE;
+
     private String INSERT_AUDIT_STATEMENT;
     private String INSERT_ENTITY_STATEMENT;
     private String INSERT_OUTCOMES_STATEMENT;
@@ -216,6 +222,11 @@ public class JdbcAuditReporter extends AbstractService<Reporter> implements Audi
 
     @Override
     public Completable purgeExpiredData() {
+        return purgeExpiredData(Instant.MAX);
+    }
+
+    @Override
+    public Completable purgeExpiredData(Instant deadline) {
         if (!purgeEnabled || retentionDays <= 0 || !ready) {
             LOGGER.debug("JDBC audit purge disabled (enabled: {}, retention days: {}, ready: {})",
                     purgeEnabled, retentionDays, ready);
@@ -224,41 +235,61 @@ public class JdbcAuditReporter extends AbstractService<Reporter> implements Audi
 
         LocalDateTime threshold = LocalDateTime.now(ZoneOffset.UTC).minusDays(retentionDays);
 
-        LOGGER.info("Starting JDBC audit purge for records older than {} (retention: {} days)",
-                threshold, retentionDays);
+        LOGGER.info("Starting JDBC audit purge for records older than {} (retention: {} days - tableSuffix: {})",
+                threshold, retentionDays, configuration.getTableSuffix());
 
         final AtomicLong totalDeleted = new AtomicLong(0);
+        final int effectiveBatchSize = cappedBatchSize();
 
-        return deleteInBatches(threshold, totalDeleted)
-                .doOnComplete(() -> LOGGER.info("JDBC audit purge completed. Deleted {} records older than {} days",
-                        totalDeleted.get(), retentionDays))
-                .doOnError(error -> LOGGER.error("Error during JDBC audit purge. Deleted {} records before error",
-                        totalDeleted.get(), error));
+        return deleteInBatches(threshold, deadline, effectiveBatchSize, totalDeleted)
+                .doOnComplete(() -> LOGGER.info("JDBC audit purge completed. Deleted {} records older than {} days (tableSuffix: {})",
+                        totalDeleted.get(), retentionDays, configuration.getTableSuffix()))
+                .doOnError(error -> LOGGER.error("Error during JDBC audit purge. Deleted {} records before error (tableSuffix: {})",
+                        totalDeleted.get(), configuration.getTableSuffix(), error));
     }
 
-    private Completable deleteInBatches(LocalDateTime threshold, AtomicLong totalDeleted) {
+    private int cappedBatchSize() {
+        if (batchSize > PURGE_MAX_BATCH_SIZE) {
+            LOGGER.warn("Configured purge batch size {} exceeds the maximum allowed ({}), using {}",
+                    batchSize, PURGE_MAX_BATCH_SIZE, PURGE_MAX_BATCH_SIZE);
+            return PURGE_MAX_BATCH_SIZE;
+        }
+        return batchSize;
+    }
+
+    private Completable deleteInBatches(LocalDateTime threshold, Instant deadline, int batchSize, AtomicLong totalDeleted) {
         TransactionalOperator trx = TransactionalOperator.create(tm);
 
-        Mono<Long> oneBatch = Mono.defer(() ->
-                findAuditIdsToDelete(threshold, DELETE_BATCH_SIZE)
-                        .flatMap(ids -> {
-                            if (ids.isEmpty()) {
-                                LOGGER.debug("No more audit records to purge");
-                                return Mono.just(0L);
-                            }
+        // Each iteration deletes a limited batch then waits for a configurable period
+        // to let the database sync its replication journal before the next batch. The loop stops when no
+        // record is left or when the global deadline is reached (purge resumes on the next execution).
+        Mono<Long> oneBatch = Mono.defer(() -> {
+            if (Instant.now().isAfter(deadline)) {
+                LOGGER.warn("Global purge timeout reached, stopping JDBC audit purge until next execution. Deleted {} records so far",
+                        totalDeleted.get());
+                return Mono.just(0L);
+            }
 
-                            LOGGER.debug("Deleting batch of {} audit records (CASCADE will delete child records)", ids.size());
+            return findAuditIdsToDelete(threshold, batchSize)
+                    .flatMap(ids -> {
+                        if (ids.isEmpty()) {
+                            LOGGER.debug("No more audit records to purge");
+                            return Mono.just(0L);
+                        }
 
-                            // DELETE parent audits - CASCADE will automatically delete child records
-                            // from auditEntitiesTable, auditOutcomesTable, and auditAccessPointsTable
-                            return trx.transactional(deleteAuditsByIds(ids))
-                                    .doOnSuccess(deleted -> {
-                                        long total = totalDeleted.addAndGet(deleted);
-                                        LOGGER.debug("Deleted {} audit records (requested {}). Total deleted: {}",
-                                                deleted, ids.size(), total);
-                                    });
-                        })
-        );
+                        LOGGER.debug("Deleting batch of {} audit records (CASCADE will delete child records - tableSuffix: {})", ids.size(), configuration.getTableSuffix());
+
+                        // DELETE parent audits - CASCADE will automatically delete child records
+                        // from auditEntitiesTable, auditOutcomesTable, and auditAccessPointsTable
+                        Mono<Long> deleteBatch = trx.transactional(deleteAuditsByIds(ids))
+                                .doOnSuccess(deleted -> {
+                                    long total = totalDeleted.addAndGet(deleted);
+                                    LOGGER.debug("Deleted {} audit records (requested {} - tableSuffix: {}). Total deleted: {}",
+                                            deleted, ids.size(), configuration.getTableSuffix(), total);
+                                });
+                        return batchDelayMs > 0 ? deleteBatch.delayElement(Duration.ofMillis(batchDelayMs)) : deleteBatch;
+                    });
+        });
 
         Mono<Void> execution = oneBatch
                 .repeat()

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
@@ -121,7 +121,6 @@ import static java.util.stream.Collectors.toMap;
 public class MongoAuditReporter extends AbstractService<Reporter> implements AuditReporter, InitializingBean {
 
     private static final Logger logger = LoggerFactory.getLogger(MongoAuditReporter.class);
-    private static final int DELETE_BATCH_SIZE = 10000;
 
     @Autowired
     private ConnectionProvider connectionProvider;
@@ -149,6 +148,14 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
 
     @Value("${services.purge.enabled:false}")
     private boolean purgeEnabled;
+
+    @Value("${services.purge.audits.batchDelay:500}")
+    private long batchDelayMs;
+
+    // introduce purgeBathSize even if batchSize exist to have a single configuration settings
+    // for Mongo and R2DBC about audits retention mechanism
+    @Value("${services.purge.audits.batchSize:" + PURGE_MAX_BATCH_SIZE + "}")
+    private int purgeBatchSize = PURGE_MAX_BATCH_SIZE;
 
     private ClientWrapper<MongoClient> clientWrapper;
 
@@ -274,56 +281,96 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
         }
     }
 
+    @Override
     public Completable purgeExpiredData() {
+        return purgeExpiredData(Instant.MAX);
+    }
+
+    @Override
+    public Completable purgeExpiredData(Instant deadline) {
         if (!purgeEnabled || retentionDays <= 0) {
-            logger.debug("MongoDB audit purge disabled (retention days: {})", retentionDays);
+            logger.debug("MongoDB audit purge disabled (retention days: {} - collection: {})", retentionDays, configuration.getReportableCollection());
             return Completable.complete();
         }
 
         LocalDateTime threshold = LocalDateTime.now(ZoneOffset.UTC).minusDays(retentionDays);
         Date thresholdDate = Date.from(threshold.toInstant(ZoneOffset.UTC));
 
-        logger.info("Starting MongoDB audit purge for records older than {} (retention: {} days)",
-                thresholdDate, retentionDays);
+        logger.info("Starting MongoDB audit purge for records older than {} (retention: {} days - collection: {})",
+                thresholdDate, retentionDays, configuration.getReportableCollection());
         final AtomicLong totalDeleted = new AtomicLong(0);
+        final int effectiveBatchSize = cappedBatchSize();
 
-        return deleteInBatches(thresholdDate, totalDeleted)
+        return deleteInBatches(thresholdDate, deadline, effectiveBatchSize, totalDeleted)
                 .doOnComplete(() ->
-                        logger.info("MongoDB audit purge completed. Deleted {} records older than {} days",
-                                totalDeleted.get(), retentionDays)
+                        logger.info("MongoDB audit purge completed. Deleted {} records older than {} days (collection: {})",
+                                totalDeleted.get(), retentionDays, configuration.getReportableCollection())
                 )
                 .doOnError(error ->
-                        logger.error("Error during MongoDB audit purge. Deleted {} records before error",
-                                totalDeleted.get(), error)
+                        logger.error("Error during MongoDB audit purge. Deleted {} records before error (collection: {})",
+                                totalDeleted.get(), configuration.getReportableCollection(), error)
                 );
     }
 
-    private Completable deleteInBatches(Date threshold, AtomicLong totalDeleted) {
+    private int cappedBatchSize() {
+        // the purge batch is capped independently of the (shared) cursor batchSize used for searches,
+        // to bound the number of ids loaded in memory and deleted per deleteMany whatever the configuration
+        if (purgeBatchSize > PURGE_MAX_BATCH_SIZE) {
+            logger.warn("Configured purge batch size {} exceeds the maximum allowed ({}), using {}",
+                    purgeBatchSize, PURGE_MAX_BATCH_SIZE, PURGE_MAX_BATCH_SIZE);
+            return PURGE_MAX_BATCH_SIZE;
+        }
+        return purgeBatchSize;
+    }
 
-        Flowable<Object> idStream = Flowable.fromPublisher(
-                reportableCollection
-                        .withDocumentClass(Document.class)
-                        .find(lte(FIELD_TIMESTAMP, threshold))
-                        .projection(Projections.include("_id"))
-                        .sort(Sorts.ascending(FIELD_TIMESTAMP, "_id"))
-                        .batchSize(DELETE_BATCH_SIZE)
-        ).map(doc -> doc.get("_id"));
+    private Completable deleteInBatches(Date threshold, Instant deadline, int batchSize, AtomicLong totalDeleted) {
+        // Each iteration fetches a limited (batchSize) set of ids and deletes them, then waits for
+        // a configurable period to let the backend sync its replication journal before the next batch.
+        // The loop stops when no record is left or when the global deadline is reached.
+        Single<Long> oneBatch = Single.defer(() -> {
+            if (Instant.now().isAfter(deadline)) {
+                logger.warn("Global purge timeout reached, stopping MongoDB audit purge until next execution. Deleted {} records so far",
+                        totalDeleted.get());
+                return Single.just(0L);
+            }
 
-        return idStream
-                .buffer(batchSize)
-                .concatMapSingle(ids -> {
-                    if (ids.isEmpty()) {
-                        return Single.just(0L);
-                    }
-                    return Single.fromPublisher(reportableCollection.deleteMany(in("_id", ids)))
-                            .map(DeleteResult::getDeletedCount)
-                            .doOnSuccess(deleted -> {
-                                long total = totalDeleted.addAndGet(deleted);
-                                logger.debug("Deleted {} audits (requested {}). Total deleted: {}",
-                                        deleted, ids.size(), total);
-                            });
-                })
+            return findAuditIdsToDelete(threshold, batchSize)
+                    .flatMap(ids -> {
+                        if (ids.isEmpty()) {
+                            return Single.just(0L);
+                        }
+                        return Single.fromPublisher(reportableCollection.deleteMany(in("_id", ids)))
+                                .map(DeleteResult::getDeletedCount)
+                                .doOnSuccess(deleted -> {
+                                    long total = totalDeleted.addAndGet(deleted);
+                                    logger.debug("Deleted {} audits (requested {} - collection: {}). Total deleted: {}",
+                                            deleted, ids.size(), configuration.getReportableCollection(), total);
+                                })
+                                .compose(this::waitBetweenBatches);
+                    });
+        });
+
+        return oneBatch
+                .repeat()
+                .takeUntil(deleted -> deleted == 0L)
                 .ignoreElements();
+    }
+
+    private Single<List<Object>> findAuditIdsToDelete(Date threshold, int limit) {
+        return Flowable.fromPublisher(
+                        reportableCollection
+                                .withReadPreference(ReadPreference.primary())
+                                .withDocumentClass(Document.class)
+                                .find(lte(FIELD_TIMESTAMP, threshold))
+                                .projection(Projections.include("_id"))
+                                .sort(Sorts.ascending(FIELD_TIMESTAMP, "_id"))
+                                .limit(limit)
+                ).map(doc -> doc.get("_id"))
+                .toList();
+    }
+
+    private Single<Long> waitBetweenBatches(Single<Long> source) {
+        return batchDelayMs > 0 ? source.delay(batchDelayMs, TimeUnit.MILLISECONDS) : source;
     }
 
     private void initIndexes() {

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
@@ -149,7 +149,7 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
     @Value("${services.purge.enabled:false}")
     private boolean purgeEnabled;
 
-    @Value("${services.purge.audits.batchDelay:500}")
+    @Value("${services.purge.audits.batchDelay:1000}")
     private long batchDelayMs;
 
     // introduce purgeBathSize even if batchSize exist to have a single configuration settings

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/vertx/EventBusReporterWrapper.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/vertx/EventBusReporterWrapper.java
@@ -123,6 +123,12 @@ public class EventBusReporterWrapper<R extends Reportable,C extends ReportableCr
     }
 
     @Override
+    public Completable purgeExpiredData(java.time.Instant deadline) {
+        logger.debug("Delegating purge to underlying reporter: {}", reporter.getClass().getSimpleName());
+        return reporter.purgeExpiredData(deadline);
+    }
+
+    @Override
     public void report(io.gravitee.reporter.api.Reportable reportable) {
         // Done by the event bus handler
         // See handle method


### PR DESCRIPTION
## Description

Improves the audit retention purge introduced in 4.11 to reduce its impact on the backend (AM-7041).

Changes:
- **Sequential processing** — reporters are now purged one at a time (`concatMapCompletable`) instead of up to 4 in parallel.
- **Capped, configurable batches** — audits are deleted in batches with a **hard maximum of 2000** rows per batch whatever the backend (bounds memory, lock footprint and bind-parameter count — e.g. SQL Server's 2100-parameter limit). Any larger configured value is clamped with a warning.
- **Wait between batches** — a configurable delay between batches lets the backend sync its replication journal.
- **Shared global timeout** — a single deadline is computed once and shared by every reporter. Once reached, no further reporter is started and any in-flight purge stops gracefully; the remaining work resumes on the next scheduled execution.

### New configuration (under `services.purge.audits`)

| Key | Default | Description |
|-----|---------|-------------|
| `batchSize` | 2000 | audits deleted per batch (also the hard max) |
| `batchDelay` | 1000 | wait in ms between two batches |
| `globalTimeout` | 3600 | max duration in seconds of a purge execution shared across all reporters |

## Notes
- This branch is **stacked on [#8066](https://github.com/gravitee-io/gravitee-access-management/pull/8066)** (AM-7133, branch `am-7133`). Until #8066 is merged into `4.11.x`, this PR's diff also shows the `fix: purge audits of the in-memory platform reporter` commit; GitHub will update it automatically once #8066 lands.
- The Mongo id lookup deliberately reads from the **primary** (not a secondary) to avoid re-reading already-deleted ids during the read→delete loop.

## Tests
- `ReporterAuditSweeperTest` updated and passing (11/11).
- Affected modules compile under JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)