### PR TITLE
feat: migration tool - seeding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,9 @@ parameters:
   migration_test_filter:
     type: string
     default: ""
+  migration_test_registry:
+    type: string
+    default: ""
   migration_test_with_downgrade:
     type: string
     default: "true"

--- a/.circleci/workflows-migration.yml
+++ b/.circleci/workflows-migration.yml
@@ -21,6 +21,9 @@ parameters:
   migration_test_filter:
     type: string
     default: ""
+  migration_test_registry:
+    type: string
+    default: ""
   migration_test_with_downgrade:
     type: string
     default: "true"
@@ -74,6 +77,9 @@ jobs:
             CMD="${MIGRATION_TEST_BASE}"
             if [ -n "<< pipeline.parameters.migration_test_filter >>" ]; then
               CMD="$CMD --test-filter << pipeline.parameters.migration_test_filter >>"
+            fi
+            if [ -n "<< pipeline.parameters.migration_test_registry >>" ]; then
+              CMD="$CMD --registry << pipeline.parameters.migration_test_registry >>"
             fi
             if [ "<< pipeline.parameters.migration_test_with_downgrade >>" = "true" ]; then
               CMD="$CMD --with-downgrade"

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ CLAUDE.local.md
 
 # Playwright MCP logs
 .playwright-mcp/
+
+# Git worktrees
+.worktrees/

--- a/gravitee-am-test/migration-seeding/bootstrap.test.ts
+++ b/gravitee-am-test/migration-seeding/bootstrap.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { toMinorVersion } from './bootstrap';
+
+describe('migration seed bootstrap', () => {
+  it('normalizes tags to major minor versions', () => {
+    expect(toMinorVersion('4.10.0')).toBe('4.10');
+    expect(toMinorVersion('4.11.0-alpha.3')).toBe('4.11');
+    expect(toMinorVersion('4.12')).toBe('4.12');
+  });
+});

--- a/gravitee-am-test/migration-seeding/bootstrap.ts
+++ b/gravitee-am-test/migration-seeding/bootstrap.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type SeedModule = {
+  seed(label: string): Promise<void>;
+};
+
+export function toMinorVersion(version: string): string {
+  const match = version.match(/^(\d+)\.(\d+)/);
+  if (!match) {
+    throw new Error(`Invalid AM version: ${version}`);
+  }
+  return `${match[1]}.${match[2]}`;
+}
+
+export function applyMissingSeedEnvironmentDefaults(): void {
+  process.env.AM_MANAGEMENT_URL ||= 'http://localhost:8093';
+  process.env.AM_MANAGEMENT_ENDPOINT ||= `${process.env.AM_MANAGEMENT_URL}/management`;
+  process.env.AM_GATEWAY_URL ||= 'http://localhost:8091';
+  process.env.AM_DOMAIN_DATA_PLANE_ID ||= 'dp1';
+  process.env.AM_DEF_ORG_ID ||= 'DEFAULT';
+  process.env.AM_DEF_ENV_ID ||= 'DEFAULT';
+  process.env.AM_ADMIN_USERNAME ||= 'admin';
+  process.env.AM_ADMIN_PASSWORD ||= 'adminadmin';
+}
+
+/**
+ * Seed one version's data set under a channel label.
+ * @param version  Which seed module to run (the data shape), e.g. "4.10". Normalized to major.minor.
+ * @param label    The channel/instance label used to name the seeded entities, e.g. "alpha" (baseline) or "beta" (newline).
+ */
+export async function runSeed(version: string, label: string): Promise<void> {
+  applyMissingSeedEnvironmentDefaults();
+  const minorVersion = toMinorVersion(version);
+  const seedModule = (await import(`./versions/${minorVersion}/seed`)) as SeedModule;
+  await seedModule.seed(label);
+}
+
+function readArg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+if (require.main === module) {
+  const version = readArg('--version');
+  const label = readArg('--label');
+  if (!version) {
+    throw new Error('--version is required');
+  }
+  if (!label) {
+    throw new Error('--label is required');
+  }
+  runSeed(version, label).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/gravitee-am-test/migration-seeding/seed.ts
+++ b/gravitee-am-test/migration-seeding/seed.ts
@@ -1,0 +1,478 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { getApplicationApi, getDomainApi, getExtensionApi, getFactorApi, getIdpApi, getUserApi } from '../api/commands/management/service/utils';
+import { Application } from '../api/management/models/Application';
+import { Domain } from '../api/management/models/Domain';
+import { NewApplicationTypeEnum } from '../api/management/models/NewApplication';
+
+export const JWT_BEARER_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+
+// Static test vectors for the jwt-bearer extension grant (GIVEN_KEY / ssh-rsa resolver). The
+// assertion JWT below is pre-signed by the private key matching EXT_GRANT_PUBLIC_KEY_SSH_RSA, so it
+// validates against the seeded grant without any live signing. Copied from the canonical e2e
+// fixture: specs/gateway/extension-grant/fixture/jwt-bearer-fixture.ts.
+export const EXT_GRANT_PUBLIC_KEY_SSH_RSA =
+  'AAAAB3NzaC1yc2EAAAADAQABAAABAQC7VJTUt9Us8cKjMzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvuNMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZqgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulgp2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlRZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwiVuNd9tyb';
+export const EXT_GRANT_ASSERTION_JWT =
+  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Eci61G6w4zh_u9oOCk_v1M_sKcgk0svOmW4ZsL-rt4ojGUH2QY110bQTYNwbEVlowW7phCg7vluX_MCKVwJkxJT6tMk2Ij3Plad96Jf2G2mMsKbxkC-prvjvQkBFYWrYnKWClPBRCyIcG0dVfBvqZ8Mro3t5bX59IKwQ3WZ7AtGBYz5BSiBlrKkp6J1UmP_bFV3eEzIHEFgzRa3pbr4ol4TK6SnAoF88rLr2NhEz9vpdHglUMlOBQiqcZwqrI-Z4XDyDzvnrpujIToiepq9bCimPgVkP54VoZzy-mMSGbthYpLqsL_4MQXaI1Uf_wKFAUuAtzVn4-ebgsKOpvKNzVA';
+export const EXT_GRANT_ASSERTION_SUB = '1234567890';
+
+export type DataPlaneTarget = { id: string; gatewayUrl: string };
+
+// Seeded data is keyed by an instance label: the channel label (alpha/beta) combined with the
+// data plane id, so each data plane gets its own isolated domain and entities (including the
+// custom IdP user store, which is otherwise shared across domains in the same database).
+export function getInstanceLabel(channelLabel: string, dataPlaneId: string): string {
+  return `${channelLabel}-${dataPlaneId}`;
+}
+
+// The data plane ids to seed. The primary comes from AM_DOMAIN_DATA_PLANE_ID (default "default");
+// a second data plane is seeded only when AM_DOMAIN_DATA_PLANE_ID_DP2 is set (the k8s migration
+// setup), so local/single-data-plane runs keep seeding a single domain.
+export function getDataPlaneIds(): string[] {
+  const primary = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
+  const secondary = process.env.AM_DOMAIN_DATA_PLANE_ID_DP2;
+  return secondary ? [primary, secondary] : [primary];
+}
+
+// Data plane targets for the gateway tests: each id paired with the gateway base URL that serves
+// it. The second target is included only when both its env vars are present.
+export function getDataPlaneTargets(): DataPlaneTarget[] {
+  const targets: DataPlaneTarget[] = [
+    { id: process.env.AM_DOMAIN_DATA_PLANE_ID || 'default', gatewayUrl: process.env.AM_GATEWAY_URL },
+  ];
+  if (process.env.AM_DOMAIN_DATA_PLANE_ID_DP2 && process.env.AM_GATEWAY_URL_DP2) {
+    targets.push({ id: process.env.AM_DOMAIN_DATA_PLANE_ID_DP2, gatewayUrl: process.env.AM_GATEWAY_URL_DP2 });
+  }
+  return targets;
+}
+
+export function getDomainName(label: string): string {
+  return `migration-seeded-domain-${normalizeForName(label)}`;
+}
+
+export function getApplicationName(label: string): string {
+  return `migration-seeded-application-${normalizeForName(label)}`;
+}
+
+export function getApplicationWithCustomIdpName(label: string): string {
+  return `migration-seeded-application-custom-idp-${normalizeForName(label)}`;
+}
+
+export function getConsentApplicationName(label: string): string {
+  return `migration-seeded-application-consent-${normalizeForName(label)}`;
+}
+
+export function getServiceApplicationName(label: string): string {
+  return `migration-seeded-application-service-${normalizeForName(label)}`;
+}
+
+export function getExtensionGrantName(label: string): string {
+  return `migration-seeded-ext-grant-${normalizeForName(label)}`;
+}
+
+export function getFactorId(label: string): string {
+  return `migration-seeded-factor-${normalizeForName(label)}`;
+}
+
+export function getCustomIdpId(label: string): string {
+  return `migration-seeded-custom-idp-${normalizeForName(label)}`;
+}
+
+export function getCustomIdpName(label: string): string {
+  return isJdbcRepository() ? `Migration JDBC IDP ${label}` : `Migration Mongo IDP ${label}`;
+}
+
+export function getDefaultStoreUserName(label: string): string {
+  return `migration-seeded-user-default-${normalizeForName(label)}`;
+}
+
+export function getCustomIdpUserName(label: string): string {
+  return `migration-seeded-user-custom-${normalizeForName(label)}`;
+}
+
+// The seeded "custom" identity provider mirrors the AM repository backend: a JDBC (PostgreSQL)
+// user store when REPOSITORY_TYPE=jdbc, otherwise a MongoDB user store. Same discriminator the
+// e2e helpers use (api/commands/utils/idps-commands.ts).
+function isJdbcRepository(): boolean {
+  return process.env.REPOSITORY_TYPE === 'jdbc';
+}
+
+export async function seedMapiData(channelLabel: string): Promise<void> {
+  const accessToken = await requestAdminAccessToken();
+  const apis = {
+    domainApi: getDomainApi(accessToken),
+    applicationApi: getApplicationApi(accessToken),
+    factorApi: getFactorApi(accessToken),
+    idpApi: getIdpApi(accessToken),
+    userApi: getUserApi(accessToken),
+    extensionGrantApi: getExtensionApi(accessToken),
+  };
+  const organizationId = process.env.AM_DEF_ORG_ID;
+  const environmentId = process.env.AM_DEF_ENV_ID;
+
+  // Duplicate the full data set onto every configured data plane (one domain each).
+  for (const dataPlaneId of getDataPlaneIds()) {
+    await seedDomain(getInstanceLabel(channelLabel, dataPlaneId), dataPlaneId, apis, organizationId, environmentId);
+  }
+}
+
+type SeedApis = {
+  domainApi: any;
+  applicationApi: any;
+  factorApi: any;
+  idpApi: any;
+  userApi: any;
+  extensionGrantApi: any;
+};
+
+async function seedDomain(
+  label: string,
+  dataPlaneId: string,
+  apis: SeedApis,
+  organizationId: string,
+  environmentId: string,
+): Promise<void> {
+  const { domainApi, applicationApi, factorApi, idpApi, userApi, extensionGrantApi } = apis;
+  const domain = await getOrCreateDomain(label, dataPlaneId, domainApi, organizationId, environmentId);
+  const factorId = getFactorId(label);
+  const customIdpId = getCustomIdpId(label);
+  const defaultIdpId = `default-idp-${domain.id}`;
+
+  await domainApi.patchDomain({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    patchDomain: { enabled: true },
+  });
+
+  await getOrCreateTotpFactor(label, factorApi, organizationId, environmentId, domain.id, factorId);
+  await getOrCreateCustomIdp(label, idpApi, organizationId, environmentId, domain.id, customIdpId);
+
+  const application = await getOrCreateApplication(applicationApi, organizationId, environmentId, domain.id, getApplicationName(label));
+  const applicationWithCustomIdp = await getOrCreateApplication(applicationApi, organizationId, environmentId, domain.id, getApplicationWithCustomIdpName(label));
+  const applicationWithConsent = await getOrCreateApplication(applicationApi, organizationId, environmentId, domain.id, getConsentApplicationName(label));
+
+  await configureApplication(applicationApi, organizationId, environmentId, domain.id, factorId, {
+    applicationId: application.id,
+    idpId: defaultIdpId,
+    scopeSettings: [{ scope: 'openid', defaultScope: true }],
+    skipConsent: true,
+  });
+
+  await configureApplication(applicationApi, organizationId, environmentId, domain.id, factorId, {
+    applicationId: applicationWithCustomIdp.id,
+    idpId: customIdpId,
+    scopeSettings: [{ scope: 'openid', defaultScope: true }],
+    skipConsent: true,
+  });
+
+  await configureApplication(applicationApi, organizationId, environmentId, domain.id, factorId, {
+    applicationId: applicationWithConsent.id,
+    idpId: defaultIdpId,
+    mfa: false,
+    scopeSettings: [
+      { scope: 'openid', defaultScope: true },
+      { scope: 'email', defaultScope: false },
+    ],
+  });
+
+  await getOrCreateUser(userApi, organizationId, environmentId, domain.id, defaultIdpId, getDefaultStoreUserName(label));
+  await getOrCreateUser(userApi, organizationId, environmentId, domain.id, customIdpId, getCustomIdpUserName(label));
+
+  // Service application + jwt-bearer extension grant: a third-party JWT (signed by the key matching
+  // EXT_GRANT_PUBLIC_KEY_SSH_RSA) can be exchanged for an AM token via this app.
+  const extensionGrant = await getOrCreateExtensionGrant(label, extensionGrantApi, organizationId, environmentId, domain.id);
+  const serviceApplication = await getOrCreateApplication(
+    applicationApi,
+    organizationId,
+    environmentId,
+    domain.id,
+    getServiceApplicationName(label),
+    NewApplicationTypeEnum.Service,
+  );
+  await configureServiceApplication(applicationApi, organizationId, environmentId, domain.id, serviceApplication.id, extensionGrant.id);
+}
+
+async function getOrCreateDomain(label: string, dataPlaneId: string, domainApi: any, organizationId: string, environmentId: string): Promise<Domain> {
+  const name = getDomainName(label);
+  const existingDomains = await domainApi.listDomains({ organizationId, environmentId, q: name });
+  const existingDomain = existingDomains.data?.find((candidate) => candidate.name === name);
+  if (existingDomain) {
+    return existingDomain;
+  }
+
+  return domainApi.createDomain({
+    organizationId,
+    environmentId,
+    newDomain: {
+      name,
+      description: `Migration seed domain ${label}`,
+      dataPlaneId,
+    },
+  });
+}
+
+async function getOrCreateApplication(
+  applicationApi: any,
+  organizationId: string,
+  environmentId: string,
+  domainId: string,
+  name: string,
+  type: NewApplicationTypeEnum = NewApplicationTypeEnum.Web,
+): Promise<Application> {
+  const existingApplications = await applicationApi.listApplications({ organizationId, environmentId, domain: domainId, q: name });
+  const existingApplication = existingApplications.data?.find((candidate) => candidate.name === name);
+  if (existingApplication) {
+    return existingApplication;
+  }
+
+  return applicationApi.createApplication({
+    organizationId,
+    environmentId,
+    domain: domainId,
+    newApplication: {
+      name,
+      type,
+      clientId: name,
+      clientSecret: name,
+      ...(type === NewApplicationTypeEnum.Service ? {} : { redirectUris: ['https://auth-nightly.gravitee.io/myApp/callback'] }),
+    },
+  });
+}
+
+async function getOrCreateExtensionGrant(
+  label: string,
+  extensionGrantApi: any,
+  organizationId: string,
+  environmentId: string,
+  domainId: string,
+): Promise<{ id: string }> {
+  const name = getExtensionGrantName(label);
+  const existing = await extensionGrantApi.listExtensionGrants({ organizationId, environmentId, domain: domainId });
+  const found = existing?.find((candidate) => candidate.name === name);
+  if (found) {
+    return found;
+  }
+
+  return extensionGrantApi.createExtensionGrant({
+    organizationId,
+    environmentId,
+    domain: domainId,
+    newExtensionGrant: {
+      type: 'jwtbearer-am-extension-grant',
+      grantType: JWT_BEARER_GRANT_TYPE,
+      configuration: JSON.stringify({ publicKeyResolver: 'GIVEN_KEY', publicKey: `ssh-rsa ${EXT_GRANT_PUBLIC_KEY_SSH_RSA}` }),
+      name,
+    },
+  });
+}
+
+async function configureServiceApplication(
+  applicationApi: any,
+  organizationId: string,
+  environmentId: string,
+  domainId: string,
+  applicationId: string,
+  extensionGrantId: string,
+): Promise<void> {
+  await applicationApi.updateApplication({
+    organizationId,
+    environmentId,
+    domain: domainId,
+    application: applicationId,
+    patchApplication: {
+      settings: {
+        oauth: {
+          grantTypes: ['client_credentials', `${JWT_BEARER_GRANT_TYPE}~${extensionGrantId}`],
+        },
+      },
+    },
+  });
+}
+
+async function configureApplication(
+  applicationApi: any,
+  organizationId: string,
+  environmentId: string,
+  domainId: string,
+  factorId: string,
+  options: { applicationId: string; idpId: string; scopeSettings: { scope: string; defaultScope: boolean }[]; skipConsent?: boolean; mfa?: boolean },
+): Promise<void> {
+  await applicationApi.updateApplication({
+    organizationId,
+    environmentId,
+    domain: domainId,
+    application: options.applicationId,
+    patchApplication: {
+      settings: {
+        oauth: {
+          redirectUris: ['https://auth-nightly.gravitee.io/myApp/callback'],
+          grantTypes: ['authorization_code', 'password', 'refresh_token', 'client_credentials'],
+          scopeSettings: options.scopeSettings,
+        },
+        ...(options.skipConsent === undefined ? {} : { advanced: { skipConsent: options.skipConsent } }),
+        ...(options.mfa === false ? {} : { mfa: {
+          factor: {
+            defaultFactorId: factorId,
+            applicationFactors: [{ id: factorId, selectionRule: '' }],
+          },
+          enroll: { active: true, type: 'REQUIRED', forceEnrollment: true },
+          challenge: { active: true, type: 'REQUIRED' },
+        } }),
+      },
+      identityProviders: new Set([{ identity: options.idpId, priority: 0 }]),
+    },
+  });
+}
+
+async function getOrCreateTotpFactor(
+  label: string,
+  factorApi: any,
+  organizationId: string,
+  environmentId: string,
+  domainId: string,
+  factorId: string,
+): Promise<void> {
+  const factors = await factorApi.listFactors({ organizationId, environmentId, domain: domainId });
+  if (factors.some((candidate) => candidate.id === factorId)) {
+    return;
+  }
+
+  await factorApi.createFactor({
+    organizationId,
+    environmentId,
+    domain: domainId,
+    newFactor: {
+      id: factorId,
+      type: 'otp-am-factor',
+      factorType: 'TOTP',
+      configuration: '{"issuer":"Gravitee.io","algorithm":"HmacSHA1","timeStep":"30","returnDigits":"6"}',
+      name: `Migration TOTP factor ${label}`,
+    },
+  });
+}
+
+async function getOrCreateCustomIdp(
+  label: string,
+  idpApi: any,
+  organizationId: string,
+  environmentId: string,
+  domainId: string,
+  customIdpId: string,
+): Promise<void> {
+  const idps = await idpApi.listIdentityProviders({ organizationId, environmentId, domain: domainId });
+  if (idps.some((candidate) => candidate.id === customIdpId)) {
+    return;
+  }
+
+  await idpApi.createIdentityProvider({
+    organizationId,
+    environmentId,
+    domain: domainId,
+    newIdentityProvider: {
+      id: customIdpId,
+      external: false,
+      domainWhitelist: [],
+      name: getCustomIdpName(label),
+      ...buildCustomIdpStore(label),
+    },
+  });
+}
+
+function buildCustomIdpStore(label: string): { type: string; configuration: string } {
+  const usersStore = `migration_seeded_users_${normalizeForName(label).replace(/-/g, '_')}`;
+
+  if (isJdbcRepository()) {
+    return {
+      type: 'jdbc-am-idp',
+      configuration: JSON.stringify({
+        host: process.env.AM_INTERNAL_POSTGRES_HOST || process.env.AM_POSTGRES_HOST,
+        port: Number(process.env.AM_INTERNAL_POSTGRES_PORT || 5432),
+        protocol: 'postgresql',
+        database: process.env.AM_INTERNAL_POSTGRES_DATABASE || 'gravitee-am',
+        usersTable: usersStore,
+        user: process.env.AM_INTERNAL_POSTGRES_USER || 'postgres',
+        password: process.env.AM_INTERNAL_POSTGRES_PASSWORD || 'postgres',
+        autoProvisioning: true,
+        selectUserByUsernameQuery: `SELECT * FROM ${usersStore} WHERE username = %s`,
+        selectUserByMultipleFieldsQuery: `SELECT * FROM ${usersStore} WHERE username = %s or email = %s`,
+        selectUserByEmailQuery: `SELECT * FROM ${usersStore} WHERE email = %s`,
+        identifierAttribute: 'id',
+        usernameAttribute: 'username',
+        emailAttribute: 'email',
+        passwordAttribute: 'password',
+        passwordEncoder: 'None',
+        useDedicatedSalt: false,
+        passwordSaltLength: 32,
+      }),
+    };
+  }
+
+  return {
+    type: 'mongo-am-idp',
+    configuration: JSON.stringify({
+      uri: process.env.AM_INTERNAL_MONGODB_URI || process.env.AM_MONGODB_URI,
+      enableCredentials: false,
+      databaseCredentials: process.env.AM_INTERNAL_MONGODB_DATABASE || 'gravitee-am',
+      database: process.env.AM_INTERNAL_MONGODB_DATABASE || 'gravitee-am',
+      usersCollection: usersStore,
+      findUserByUsernameQuery: '{username: ?}',
+      findUserByEmailQuery: '{email: ?}',
+      usernameField: 'username',
+      passwordField: 'password',
+      passwordEncoder: 'None',
+      useDedicatedSalt: false,
+      passwordSaltLength: 32,
+    }),
+  };
+}
+
+async function getOrCreateUser(
+  userApi: any,
+  organizationId: string,
+  environmentId: string,
+  domainId: string,
+  source: string,
+  username: string,
+): Promise<void> {
+  const users = await userApi.listUsers({ organizationId, environmentId, domain: domainId, q: username });
+  if (users.data?.some((candidate) => candidate.username === username && candidate.source === source)) {
+    return;
+  }
+
+  await userApi.createUser({
+    organizationId,
+    environmentId,
+    domain: domainId,
+    newUser: {
+      username,
+      email: `${username}@example.test`,
+      firstName: 'Migration',
+      lastName: `Seed`,
+      password: 'SomeP@ssw0rd',
+      preRegistration: false,
+      registrationCompleted: true,
+      source,
+    },
+  });
+}
+
+function normalizeForName(label: string): string {
+  return label.replace(/[^0-9A-Za-z]+/g, '-');
+}

--- a/gravitee-am-test/migration-seeding/versions/4.10/seed.ts
+++ b/gravitee-am-test/migration-seeding/versions/4.10/seed.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { seedMapiData } from '../../seed';
+
+export async function seed(label: string): Promise<void> {
+  await seedMapiData(label);
+}

--- a/gravitee-am-test/migration-seeding/versions/4.11/seed.ts
+++ b/gravitee-am-test/migration-seeding/versions/4.11/seed.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { seedMapiData } from '../../seed';
+
+export async function seed(label: string): Promise<void> {
+  await seedMapiData(label);
+}

--- a/gravitee-am-test/migration-seeding/versions/4.12/seed.ts
+++ b/gravitee-am-test/migration-seeding/versions/4.12/seed.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { seedMapiData } from '../../seed';
+
+export async function seed(label: string): Promise<void> {
+  await seedMapiData(label);
+}

--- a/gravitee-am-test/package.json
+++ b/gravitee-am-test/package.json
@@ -11,6 +11,8 @@
     "ci:management:parallel": "jest --maxWorkers=2 --no-cache --config=api/config/ci.config.js specs/management",
     "ci:gateway": "jest --runInBand --no-cache --config=api/config/ci.config.js specs/gateway",
     "ci:gateway:parallel": "jest --maxWorkers=2 --no-cache --config=api/config/ci.config.js specs/gateway",
+    "ci:migration": "jest --runInBand --no-cache --config=api/config/ci.config.js specs/migration",
+    "migration:seed": "cross-env TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register -r tsconfig-paths/register migration-seeding/bootstrap.ts",
     "pw": "playwright test",
     "pw:headed": "playwright test --headed",
     "pw:ui": "playwright test --ui",

--- a/gravitee-am-test/specs/migration/fixture/gateway-fixture.ts
+++ b/gravitee-am-test/specs/migration/fixture/gateway-fixture.ts
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  extractXsrfTokenAndActionResponse,
+  getWellKnownOpenIdConfiguration,
+  performFormPost,
+  performGet,
+  performPost,
+} from '@gateway-commands/oauth-oidc-commands';
+import { getBase64BasicAuth } from '@gateway-commands/utils';
+import { initiateLoginFlow, login } from '@gateway-commands/login-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { expect } from '@jest/globals';
+import { TOTP } from 'otpauth';
+import { extractSharedSecret } from '../../gateway/mfa/fixture/mfa-extract-fixture';
+import { getApplicationApi, getDomainApi, getUserApi } from '../../../api/commands/management/service/utils';
+import { Application } from '../../../api/management/models/Application';
+import { Domain } from '../../../api/management/models/Domain';
+import {
+  getApplicationName,
+  getApplicationWithCustomIdpName,
+  getConsentApplicationName,
+  getCustomIdpUserName,
+  getDefaultStoreUserName,
+  getDomainName,
+  getServiceApplicationName,
+  JWT_BEARER_GRANT_TYPE,
+} from '../../../migration-seeding/seed';
+
+export type GatewayFixtureOptions = {
+  applicationName?: string;
+  userName?: string;
+  password?: string;
+};
+
+const DEFAULT_SEED_PASSWORD = 'SomeP@ssw0rd';
+
+export type GatewayFixture = {
+  application: Application;
+  domain: Domain;
+  loginUser: () => Promise<any>;
+  loginUserWithMfa: () => Promise<any>;
+  loginUserAndConsent: () => Promise<any>;
+  requestToken: (finalAuthorizeResponse: any) => Promise<any>;
+  requestJwtBearerToken: (assertion: string) => Promise<any>;
+  introspectToken: (accessToken: string) => Promise<any>;
+};
+
+export function createCustomIdpGatewayFixture(label: string): Promise<GatewayFixture> {
+  return createGatewayFixture(label, {
+    applicationName: getApplicationWithCustomIdpName(label),
+    userName: getCustomIdpUserName(label),
+  });
+}
+
+export function createConsentGatewayFixture(label: string): Promise<GatewayFixture> {
+  return createGatewayFixture(label, {
+    applicationName: getConsentApplicationName(label),
+  });
+}
+
+export function createExtensionGrantGatewayFixture(label: string): Promise<GatewayFixture> {
+  return createGatewayFixture(label, {
+    applicationName: getServiceApplicationName(label),
+  });
+}
+
+export async function createGatewayFixture(label: string, options: GatewayFixtureOptions = {}): Promise<GatewayFixture> {
+  const domainName = getDomainName(label);
+  const applicationName = options.applicationName ?? getApplicationName(label);
+  const userName = options.userName ?? getDefaultStoreUserName(label);
+  const userPassword = options.password ?? DEFAULT_SEED_PASSWORD;
+  const accessToken = await requestAdminAccessToken();
+  const domainApi = getDomainApi(accessToken);
+  const applicationApi = getApplicationApi(accessToken);
+  const userApi = getUserApi(accessToken);
+  const organizationId = process.env.AM_DEF_ORG_ID;
+  const environmentId = process.env.AM_DEF_ENV_ID;
+  const domains = await domainApi.listDomains({ organizationId, environmentId, q: domainName });
+  const domain = domains.data?.find((candidate) => candidate.name === domainName);
+
+  expect(domain).toBeDefined();
+  const applications = await applicationApi.listApplications({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    q: applicationName,
+  });
+  const matchedApplication = applications.data?.find((candidate) => candidate.name === applicationName);
+
+  expect(matchedApplication).toBeDefined();
+  const application = await applicationApi.findApplication({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    application: matchedApplication.id,
+  });
+  const openIdConfiguration = (await getWellKnownOpenIdConfiguration(domain.hrid)).body;
+
+  async function loginUser(scope?: string) {
+    const authResponse = await startAuthorize(scope);
+
+    return login(authResponse, userName, application.settings.oauth.clientId, userPassword);
+  }
+
+  async function startAuthorize(scope?: string) {
+    if (!scope) {
+      return initiateLoginFlow(application.settings.oauth.clientId, openIdConfiguration, domain);
+    }
+    const clientId = application.settings.oauth.clientId;
+    const redirectUri = application.settings.oauth.redirectUris[0];
+    const params = `?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}&scope=${encodeURIComponent(scope)}`;
+
+    return performGet(openIdConfiguration.authorization_endpoint, params).expect(302);
+  }
+
+  async function loginUserWithMfa() {
+    const afterMfaResponse = await loginAndCompleteMfa();
+
+    expect(afterMfaResponse.headers['location']).toContain('code=');
+    return afterMfaResponse;
+  }
+
+  async function loginUserAndConsent() {
+    await revokeUserConsents();
+    const postLogin = await loginUser('openid email');
+    const consentLocationResponse = await performGet(postLogin.headers['location'], '', {
+      Cookie: postLogin.headers['set-cookie'],
+    }).expect(302);
+
+    expect(consentLocationResponse.headers['location']).toContain('/oauth/consent');
+    const consentResult = await extractXsrfTokenAndActionResponse(consentLocationResponse);
+    const consentResponse = await performFormPost(
+      consentResult.action,
+      '',
+      {
+        'scope.openid': true,
+        'scope.email': true,
+        user_oauth_approval: true,
+        'X-XSRF-TOKEN': consentResult.token,
+      },
+      {
+        Cookie: consentResult.headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
+    ).expect(302);
+    const finalAuthorizeResponse = await performGet(consentResponse.headers['location'], '', {
+      Cookie: consentResponse.headers['set-cookie'],
+    }).expect(302);
+
+    expect(finalAuthorizeResponse.headers['location']).toContain('code=');
+    return finalAuthorizeResponse;
+  }
+
+  async function loginAndCompleteMfa() {
+    await resetUserFactors();
+    const postLogin = await loginUser();
+    const enrollLocationResponse = await performGet(postLogin.headers['location'], '', {
+      Cookie: postLogin.headers['set-cookie'],
+    }).expect(302);
+
+    expect(enrollLocationResponse.headers['location']).toContain('/mfa/enroll');
+    const enrollPage = await performGet(enrollLocationResponse.headers['location'], '', {
+      Cookie: enrollLocationResponse.headers['set-cookie'],
+    }).expect(200);
+    const enrollResult = extractSharedSecret(enrollPage, 'TOTP');
+    const enrollResponse = await performFormPost(
+      enrollResult.action,
+      '',
+      {
+        factorId: getFactorId(),
+        sharedSecret: enrollResult.sharedSecret,
+        user_mfa_enrollment: true,
+        'X-XSRF-TOKEN': enrollResult.token,
+      },
+      {
+        Cookie: enrollPage.headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
+    ).expect(302);
+    const challengeLocationResponse = await performGet(enrollResponse.headers['location'], '', {
+      Cookie: enrollResponse.headers['set-cookie'],
+    }).expect(302);
+
+    return completeMfaChallenge(challengeLocationResponse, enrollResult.sharedSecret);
+  }
+
+  async function completeMfaChallenge(challengeLocationResponse: any, sharedSecret: string) {
+    const challengeResult = await extractXsrfTokenAndActionResponse(challengeLocationResponse);
+    const challengeResponse = await performFormPost(
+      challengeResult.action,
+      '',
+      {
+        factorId: getFactorId(),
+        code: new TOTP({ issuer: 'Gravitee.io', secret: sharedSecret }).generate(),
+        'X-XSRF-TOKEN': challengeResult.token,
+      },
+      {
+        Cookie: challengeResult.headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
+    ).expect(302);
+
+    return performGet(challengeResponse.headers['location'], '', {
+      Cookie: challengeResponse.headers['set-cookie'],
+    }).expect(302);
+  }
+
+  async function requestToken(finalAuthorizeResponse: any) {
+    const authorizationCode = new URL(finalAuthorizeResponse.headers['location']).searchParams.get('code');
+
+    expect(authorizationCode).toBeDefined();
+    return performPost(
+      openIdConfiguration.token_endpoint,
+      `?grant_type=authorization_code&code=${authorizationCode}&redirect_uri=${application.settings.oauth.redirectUris[0]}`,
+      null,
+      {
+        Authorization: `Basic ${getBase64BasicAuth(application.settings.oauth.clientId, application.settings.oauth.clientId)}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    ).expect(200);
+  }
+
+  async function requestJwtBearerToken(assertion: string) {
+    return performPost(openIdConfiguration.token_endpoint, `?grant_type=${JWT_BEARER_GRANT_TYPE}&assertion=${assertion}`, null, {
+      Authorization: `Basic ${getBase64BasicAuth(application.settings.oauth.clientId, application.settings.oauth.clientId)}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    }).expect(200);
+  }
+
+  async function introspectToken(accessToken: string) {
+    const response = await performPost(openIdConfiguration.introspection_endpoint, `?token=${accessToken}`, null, {
+      Authorization: `Basic ${getBase64BasicAuth(application.settings.oauth.clientId, application.settings.oauth.clientId)}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    }).expect(200);
+
+    return response.body;
+  }
+
+  async function findUser() {
+    const users = await userApi.listUsers({ organizationId, environmentId, domain: domain.id, q: userName });
+    const user = users.data?.find((candidate) => candidate.username === userName);
+
+    expect(user).toBeDefined();
+    return user;
+  }
+
+  async function resetUserFactors() {
+    const user = await findUser();
+    const enrolledFactors = await userApi.listUserEnrolledFactors({ organizationId, environmentId, domain: domain.id, user: user.id });
+    await Promise.all(
+      enrolledFactors.map((factor) =>
+        userApi.deleteUserFactor({ organizationId, environmentId, domain: domain.id, user: user.id, factor: factor.id }),
+      ),
+    );
+  }
+
+  async function revokeUserConsents() {
+    const user = await findUser();
+    await userApi.revokeUserConsents({ organizationId, environmentId, domain: domain.id, user: user.id });
+  }
+
+  function getFactorId() {
+    const factorId = application.settings?.mfa?.factor?.defaultFactorId;
+
+    expect(factorId).toBeDefined();
+    return factorId;
+  }
+
+  return {
+    application,
+    domain,
+    loginUser,
+    loginUserWithMfa,
+    loginUserAndConsent,
+    requestToken,
+    requestJwtBearerToken,
+    introspectToken,
+  };
+}

--- a/gravitee-am-test/specs/migration/gateway.jest.spec.ts
+++ b/gravitee-am-test/specs/migration/gateway.jest.spec.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+import { createConsentGatewayFixture, createCustomIdpGatewayFixture, createExtensionGrantGatewayFixture, createGatewayFixture, GatewayFixture } from './fixture/gateway-fixture';
+import { EXT_GRANT_ASSERTION_JWT, EXT_GRANT_ASSERTION_SUB, getDataPlaneTargets, getInstanceLabel } from '../../migration-seeding/seed';
+import { setup } from '../test-fixture';
+
+setup(60000);
+
+const channelLabel = process.env.AM_MIGRATION_TEST_LABEL || 'alpha';
+
+// Run the full gateway suite against every configured data plane (its own domain + gateway URL).
+describe.each(getDataPlaneTargets())('migration Gateway data [data plane $id]', ({ id, gatewayUrl }) => {
+  const label = getInstanceLabel(channelLabel, id);
+  let fixture: GatewayFixture;
+  let consentFixture: GatewayFixture;
+  let customIdpFixture: GatewayFixture;
+  let extGrantFixture: GatewayFixture;
+  let previousGatewayUrl: string | undefined;
+
+  beforeAll(async () => {
+    // Point the gateway commands (well-known, authorize, login) at this data plane's gateway.
+    previousGatewayUrl = process.env.AM_GATEWAY_URL;
+    process.env.AM_GATEWAY_URL = gatewayUrl;
+    fixture = await createGatewayFixture(label);
+    consentFixture = await createConsentGatewayFixture(label);
+    customIdpFixture = await createCustomIdpGatewayFixture(label);
+    extGrantFixture = await createExtensionGrantGatewayFixture(label);
+  });
+
+  afterAll(() => {
+    if (previousGatewayUrl === undefined) {
+      delete process.env.AM_GATEWAY_URL;
+    } else {
+      process.env.AM_GATEWAY_URL = previousGatewayUrl;
+    }
+  });
+
+  it('logs in the user and redirects to an MFA step', async () => {
+    const postLogin = await fixture.loginUser();
+    const authorize = await performGet(postLogin.headers['location'], '', {
+      Cookie: postLogin.headers['set-cookie'],
+    }).expect(302);
+
+    expect(authorize.headers['location']).toContain('/mfa/');
+  });
+
+  it('logs in with MFA, creates a token and introspects it', async () => {
+    const finalAuthorizeResponse = await fixture.loginUserWithMfa();
+    const tokenResponse = await fixture.requestToken(finalAuthorizeResponse);
+    const introspectionResponse = await fixture.introspectToken(tokenResponse.body.access_token);
+
+    expect(tokenResponse.body.access_token).toBeDefined();
+    expect(tokenResponse.body.token_type).toBe('bearer');
+    expect(introspectionResponse.active).toBe(true);
+    expect(introspectionResponse.domain).toBe(fixture.domain.id);
+    expect(introspectionResponse.sub).toBeDefined();
+  });
+
+  it('grants consent for a requested scope and creates a token carrying it', async () => {
+    const finalAuthorizeResponse = await consentFixture.loginUserAndConsent();
+    const tokenResponse = await consentFixture.requestToken(finalAuthorizeResponse);
+    const introspectionResponse = await consentFixture.introspectToken(tokenResponse.body.access_token);
+
+    expect(tokenResponse.body.access_token).toBeDefined();
+    expect(introspectionResponse.active).toBe(true);
+    expect(introspectionResponse.scope).toContain('email');
+  });
+
+  it('logs in a user backed by the custom identity provider and creates a token', async () => {
+    const finalAuthorizeResponse = await customIdpFixture.loginUserWithMfa();
+    const tokenResponse = await customIdpFixture.requestToken(finalAuthorizeResponse);
+    const introspectionResponse = await customIdpFixture.introspectToken(tokenResponse.body.access_token);
+
+    expect(tokenResponse.body.access_token).toBeDefined();
+    expect(tokenResponse.body.token_type).toBe('bearer');
+    expect(introspectionResponse.active).toBe(true);
+    expect(introspectionResponse.domain).toBe(customIdpFixture.domain.id);
+    expect(introspectionResponse.sub).toBeDefined();
+  });
+
+  it('exchanges a JWT assertion for a token via the seeded jwt-bearer extension grant and introspects it', async () => {
+    const tokenResponse = await extGrantFixture.requestJwtBearerToken(EXT_GRANT_ASSERTION_JWT);
+    const introspectionResponse = await extGrantFixture.introspectToken(tokenResponse.body.access_token);
+
+    expect(tokenResponse.body.access_token).toBeDefined();
+    expect(introspectionResponse.active).toBe(true);
+    expect(introspectionResponse.domain).toBe(extGrantFixture.domain.id);
+    expect(introspectionResponse.sub).toBe(EXT_GRANT_ASSERTION_SUB);
+  });
+});

--- a/gravitee-am-test/specs/migration/mapi-data.jest.spec.ts
+++ b/gravitee-am-test/specs/migration/mapi-data.jest.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, beforeAll } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { getApplicationApi, getDomainApi, getFactorApi, getIdpApi, getUserApi } from '../../api/commands/management/service/utils';
+import {
+  getApplicationName,
+  getApplicationWithCustomIdpName,
+  getCustomIdpId,
+  getCustomIdpName,
+  getCustomIdpUserName,
+  getDataPlaneIds,
+  getDefaultStoreUserName,
+  getDomainName,
+  getFactorId,
+  getInstanceLabel,
+} from '../../migration-seeding/seed';
+import { setup } from '../test-fixture';
+
+setup(60000);
+
+const channelLabel = process.env.AM_MIGRATION_TEST_LABEL || 'alpha';
+
+// Verify the seeded MAPI data on every configured data plane's domain.
+describe.each(getDataPlaneIds())('migration MAPI data [data plane %s]', (dataPlaneId) => {
+  let accessToken: string;
+  const label = getInstanceLabel(channelLabel, dataPlaneId);
+  const domainName = getDomainName(label);
+  const applicationName = getApplicationName(label);
+  const applicationWithCustomIdpName = getApplicationWithCustomIdpName(label);
+  const factorId = getFactorId(label);
+  const customIdpId = getCustomIdpId(label);
+  const defaultStoreUserName = getDefaultStoreUserName(label);
+  const customIdpUserName = getCustomIdpUserName(label);
+
+  beforeAll(async () => {
+    accessToken = await requestAdminAccessToken();
+  });
+
+  it('keeps the versioned MAPI data readable through the generated SDK', async () => {
+    const domainApi = getDomainApi(accessToken);
+    const applicationApi = getApplicationApi(accessToken);
+    const factorApi = getFactorApi(accessToken);
+    const idpApi = getIdpApi(accessToken);
+    const organizationId = process.env.AM_DEF_ORG_ID;
+    const environmentId = process.env.AM_DEF_ENV_ID;
+
+    const domains = await domainApi.listDomains({ organizationId, environmentId, q: domainName });
+    const domain = domains.data?.find((candidate) => candidate.name === domainName);
+
+    expect(domain).toBeDefined();
+    expect(domain.id).toBeDefined();
+
+    const applications = await applicationApi.listApplications({
+      organizationId,
+      environmentId,
+      domain: domain.id
+    });
+    const application = applications.data?.find((candidate) => candidate.name === applicationName);
+
+    expect(application).toBeDefined();
+    expect(application.name).toBe(applicationName);
+
+    const applicationCustomIdp = applications.data?.find((candidate) => candidate.name === applicationWithCustomIdpName);
+
+    expect(applicationCustomIdp).toBeDefined();
+    expect(applicationCustomIdp.name).toBe(applicationWithCustomIdpName);
+
+    const factor = await factorApi.getFactor({ organizationId, environmentId, domain: domain.id, factor: factorId });
+    expect(factor.name).toBe(`Migration TOTP factor ${label}`);
+
+    const idp = await idpApi.findIdentityProvider({ organizationId, environmentId, domain: domain.id, identity: customIdpId });
+    expect(idp.name).toBe(getCustomIdpName(label));
+
+    const applicationDetails = await applicationApi.findApplication({
+      organizationId,
+      environmentId,
+      domain: domain.id,
+      application: application.id,
+    });
+    const applicationFactors = applicationDetails.settings?.mfa?.factor?.applicationFactors || [];
+    expect(applicationDetails.settings?.mfa?.factor?.defaultFactorId).toBe(factorId);
+    expect(applicationFactors).toEqual(expect.arrayContaining([expect.objectContaining({ id: factorId })]));
+  });
+});

--- a/scripts/migration-tool/README.md
+++ b/scripts/migration-tool/README.md
@@ -28,25 +28,50 @@ All commands must be run from the **repository root** (e.g. `./scripts/migration
 
 ## Workflow and design
 
+**Terminology:** seeded data is keyed by an **instance label** = *channel label* + *data plane id*, not by version, so the alpha and beta data sets stay distinct even when both sides share the same minor version (e.g. a `4.10.7 → 4.10.8` patch migration). The **`alpha`** channel is seeded with the **`--from-tag`** data; the **`beta`** channel is seeded with the **`--to-tag`** data. The `mapi`/`all` prefix on a verify stage only describes the system state at that point (Management API upgraded vs. full stack); the suffix (`alpha`/`beta`) picks which channel is asserted.
+
+**Multi–data-plane:** each channel is duplicated onto every configured data plane (one domain per data plane). K8s deploys two gateways — **dp1** (port-forward `8091`) and **dp2** (port-forward `8092`) — so the alpha channel produces domains `migration-seeded-domain-alpha-dp1` and `migration-seeded-domain-alpha-dp2` (beta → `…-beta-dp1` / `…-beta-dp2`); all child entities (apps — including a SERVICE app with a jwt-bearer extension grant, factor, custom IdP, users, and the IdP user store) carry the same `-<dataPlaneId>` suffix so the two domains stay fully isolated. The gateway/MAPI verify specs are parameterized (`describe.each`) over the data planes, so the suite runs once per data plane (`AM_GATEWAY_URL` → dp1, `AM_GATEWAY_URL_DP2` → dp2). Locally (single data plane) only one domain is seeded and tested.
+
+Floating tags (`latest`, `4`, `4.11`) are accepted on `--from-tag` and `--to-tag`. Before the
+pipeline runs they are resolved to the concrete `X.Y.Z` version they currently point to (matched
+by Docker image digest on Docker Hub), and the resolved version is printed, e.g.
+`🔖 Resolved --to-tag latest → 4.11.9`. Variant-suffixed tags such as `latest-debian` are not
+supported and fail fast — use a plain tag.
+
+> The channel asserted is derived automatically from the stage suffix (`-alpha` / `-beta`) — no `--test-label` needed.
+
 ### Stages (in order)
 1. **clean** – Remove existing releases, secrets, namespace (K8s) or compose stack (Docker).
 2. **k8s:setup** – (K8s only) Create namespace, deploy DB (MongoDB or PostgreSQL), create auth/license secrets; skip for Docker Compose.
 3. **deploy-from** – Deploy AM at “from” tag (K8s: 1 Management API + 2 Gateways; Docker: 1 API + 1 Gateway). K8s starts port-forwards.
-4. **verify-baseline** – Run management Jest tests (`gravitee-am-test`) against the deployed “from” version.
-5. **upgrade-mapi** – Upgrade Management API (and UI) to “to” tag.
-6. **verify-mapi** – Run management tests again.
-7. **upgrade-gw** – Upgrade Gateways to “to” tag.
-8. **verify-all** – Run gateway Jest tests (K8s: targets dp1 on port 8091).
-9. *Optional, with `--with-downgrade`:* **downgrade-mapi** → **verify-after-downgrade-mapi** → **downgrade-gw** → **verify-after-downgrade**.
+4. **seed-alpha** – Seed deterministic data for the “from” minor version (creates the alpha domain).
+5. **verify-all-alpha** – Verify the alpha domain on the full “from” stack.
+6. **upgrade-mapi** – Upgrade Management API to “to” tag.
+7. **seed-beta** – Seed deterministic data for the “to” minor version (creates the beta domain).
+8. **verify-mapi-alpha** – Verify the alpha domain with MAPI on “to”, Gateways still on “from”.
+9. **verify-mapi-beta** – Verify the beta domain with MAPI on “to”, Gateways still on “from”.
+10. **upgrade-gw** – Upgrade Gateways to “to” tag.
+11. **verify-all-alpha** – Verify the alpha domain on the full “to” stack.
+12. **verify-all-beta** – Verify the beta domain on the full “to” stack.
+
+#### Optional with `--with-downgrade`
+1. **downgrade-gw** – Downgrade Gateways back to “from” tag.
+2. **verify-all-alpha** – Verify the alpha domain (Gateways on “from”, MAPI still on “to”).
+3. **verify-all-beta** – Verify the beta domain (Gateways on “from”, MAPI still on “to”).
+4. **downgrade-mapi** – Downgrade Management API back to “from” tag.
+5. **verify-all-alpha** – Verify the alpha domain on the full “from” stack.
+6. **verify-all-beta** – Verify the beta domain on the full “from” stack.
+
+> For ad-hoc, single-stage debugging there is also a generic **verify** stage which asserts the channel from `--test-label` (default: `alpha`). It is not part of the default pipeline.
 
 ### K8s multi-dataplane
 - One Management API release and two Gateway releases (dp1, dp2) per run.
 - Ports (local port-forward): Management API **8093**, UI **8002** (local browser testing only; Jest uses 8093), Gateway dp1 **8091**, Gateway dp2 **8092**.
-- `AM_GATEWAY_URL` is set to `http://localhost:8091` for verify-all and verify-after-downgrade so gateway tests hit dp1.
+- `AM_GATEWAY_URL` (dp1, `http://localhost:8091`) and `AM_GATEWAY_URL_DP2` (dp2, `http://localhost:8092`) are both set for multi-dataplane verify stages; the gateway specs run against each in turn.
 
 ### System diagram (K8s)
 
-When running with `--provider k8s`, the tool deploys the following into a Kind cluster. Port-forwards expose services on localhost: Jest (gravitee-am-test) uses **8093** (Management API) and **8091** (Gateway dp1). Port **8002** (Management UI) is for local browser testing only; Jest does not access it.
+When running with `--provider k8s`, the tool deploys the following into a Kind cluster. Port-forwards expose services on localhost: Jest (gravitee-am-test) uses **8093** (Management API), **8091** (Gateway dp1) and **8092** (Gateway dp2). Port **8002** (Management UI) is for local browser testing only; Jest does not access it.
 
 ```mermaid
 flowchart LR
@@ -55,7 +80,7 @@ flowchart LR
     end
 
     subgraph kind["Kind cluster"]
-        subgraph ns["namespace: gravitee-am"]
+        subgraph ns["namespace: gravitee-am (default)"]
             DB[(MongoDB or\nPostgreSQL)]
             MAPI["am-mapi\nManagement API"]
             UI["am-mapi\nManagement UI\n(8002: local UI only)"]
@@ -70,10 +95,10 @@ flowchart LR
 
     Jest -->|"localhost:8093"| MAPI
     Jest -->|"localhost:8091\n(AM_GATEWAY_URL)"| DP1
-    Jest -.->|"localhost:8092"| DP2
+    Jest -->|"localhost:8092\n(AM_GATEWAY_URL_DP2)"| DP2
 ```
 
-*(Dashed line: dp2 is forwarded but gateway tests currently target dp1 only. UI on 8002 is for manual/browser testing, not Jest.)*
+*(Gateway specs run against both dp1 and dp2, each with its own seeded domain. UI on 8002 is for manual/browser testing, not Jest.)*
 
 ### Common and specific values (base + override)
 
@@ -91,7 +116,7 @@ Override via env: `AM_HELM_VALUES_PATH_MONGO_MAPI=path1,path2` or `AM_HELM_VALUE
 ### Limitations and known issues
 
 - **Docker Compose:** The Docker Compose provider is **not functional** at the moment. The full migration flow (deploy → verify → upgrade → verify) does not work with `--provider docker-compose`. Use `--provider k8s` for migration runs. Next step: fix Docker Compose (compose file, env, and provider logic) so it can run the same stages as K8s.
-- **Jest with K8s:** Jest tests (gravitee-am-test) are **not fully working** with the K8s environment; some environment or wiring fix is required (e.g. URLs, ports, dataplane IDs, or test timeout/readiness). Management and gateway specs may pass with a test filter or after manual env tweaks, but the full suite is not yet reliable. Next step: identify and fix the remaining environment/configuration gaps so all relevant Jest tests pass against the K8s-deployed AM.
+- **Jest with K8s:** The migration flow runs the focused `specs/migration` suite by default. Broader management and gateway specs may still require explicit `--test-filter` selection or additional environment fixes.
 
 ### Configuration
 - Release definitions (which Helm releases and values files to use) come from `Config.getK8sReleases(dbType)` in `lib/core/Config.mjs`.
@@ -113,7 +138,7 @@ Clean, run K8s setup (DB + namespace + secrets), deploy “from” version. No c
 ```
 
 ### Run full migration
-Runs all stages (clean → setup → deploy-from → verify-baseline → … → verify-all, and optionally downgrade stages).
+Runs all stages (clean → setup → deploy-from → seed-alpha → verify-all-alpha → upgrade-mapi → seed-beta → verify-mapi-alpha/beta → upgrade-gw → verify-all-alpha/beta, and optionally downgrade stages). Floating tags (e.g. `latest`, `4.11`) are resolved automatically.
 ```bash
 ./scripts/migration-test.mjs --provider k8s run
 ./scripts/migration-test.mjs --provider k8s run --db-type postgres --with-downgrade
@@ -127,7 +152,7 @@ Docker Compose (single API + single Gateway). **Not functional at the moment**; 
 Useful for debugging.
 ```bash
 ./scripts/migration-test.mjs --provider k8s run --stage deploy-from
-./scripts/migration-test.mjs --provider k8s run --stage verify-baseline --test-filter specs/management/certificates/certificates.jest.spec.ts
+./scripts/migration-test.mjs --provider k8s run --stage verify --test-filter specs/management/certificates/certificates.jest.spec.ts
 ```
 
 ### Trigger CircleCI migration pipeline
@@ -146,10 +171,15 @@ Requires `CIRCLECI_TOKEN`. Sends parameters (from-tag, to-tag, db-type, provider
 | `--to-tag` | Target AM version after upgrade | `latest` |
 | `--db-type` | Database: `mongodb` or `postgres` (K8s) | `mongodb` |
 | `--provider` | Infrastructure: `k8s` or `docker-compose` | `docker-compose` |
+| `--namespace` | K8s namespace to deploy into (overrides `AM_K8S_NAMESPACE`) | `gravitee-am` |
+| `--registry` | Override AM image repositories, e.g. `graviteeio.azurecr.io` for unpublished images | (none) |
 | `--stage` | Run only this stage (see list above) | (all stages) |
 | `--test-filter` | Jest path pattern (e.g. `specs/management/certificates/certificates.jest.spec.ts`) | (none) |
-| `--with-downgrade` | After verify-all, downgrade to from-tag and run downgrade verification | `false` (CLI); CircleCI migration workflow may default to `true` |
+| `--test-label` | Seed channel (`alpha`/`beta`) asserted by ad-hoc migration Jest tests | `alpha` |
+| `--with-downgrade` | After the full upgrade, downgrade back to from-tag and re-verify | `false` (CLI); CircleCI migration workflow may default to `true` |
 | `--test-dir` | Test suite directory (relative or absolute); overrides config default | From `Config.test.dir` or `AM_MIGRATION_TEST_DIR` |
+| `--no-seed-worktree` | Seed from the current checkout for all tags (disable per-tag worktree seeding) | worktree seeding on |
+| `--keep-worktrees` | Keep the `.worktrees/seed-<ref>` dirs after the run (debugging) | `false` (removed) |
 
 ---
 
@@ -157,7 +187,7 @@ Requires `CIRCLECI_TOKEN`. Sends parameters (from-tag, to-tag, db-type, provider
 
 **`--stage <name>`** runs **only that one stage** instead of the full pipeline. Use it to re-run or debug a single step without redoing earlier stages.
 
-- **Without `--stage`:** the tool runs the full list of stages (clean → k8s:setup → deploy-from → … → verify-all, and optionally the downgrade stages if you pass `--with-downgrade`).
+- **Without `--stage`:** the tool runs the full list of stages (clean → k8s:setup → deploy-from → … → verify-all-beta, and optionally the downgrade stages if you pass `--with-downgrade`).
 - **With `--stage <name>`:** only the stage you name runs; no other stages run.
 
 **Valid stage names:**
@@ -167,17 +197,21 @@ Requires `CIRCLECI_TOKEN`. Sends parameters (from-tag, to-tag, db-type, provider
 | `clean` | Tear down: uninstall Helm releases, delete secrets/namespace (K8s) or compose stack (Docker). |
 | `k8s:setup` | (K8s only) Create namespace, deploy DB (Mongo/Postgres), create auth secrets. Skipped for Docker Compose. |
 | `deploy-from` | Deploy AM at `--from-tag` (e.g. 4.10.0). K8s also starts port-forwards. |
-| `verify-baseline` | Run Jest management tests against the “from” version. |
+| `seed-alpha` | Seed deterministic data for the “from” minor version (alpha domain). Starts port-forwards if not already up. *(alias: `seed`)* |
+| `verify-all-alpha` | Verify the **`--from-tag`** (alpha) domain. |
+| `verify-all-beta` | Verify the **`--to-tag`** (beta) domain. |
 | `upgrade-mapi` | Upgrade Management API (and UI) to `--to-tag`. |
-| `verify-mapi` | Run Jest management tests after MAPI upgrade. |
+| `seed-beta` | Seed deterministic data for the “to” minor version (beta domain). Floating `--to-tag` values are resolved before this stage runs. *(alias: `seed-upgrade`)* |
+| `verify-mapi-alpha` | Verify the **`--from-tag`** (alpha) domain after MAPI upgrade (Gateways still on “from”). |
+| `verify-mapi-beta` | Verify the **`--to-tag`** (beta) domain after MAPI upgrade (Gateways still on “from”). |
 | `upgrade-gw` | Upgrade Gateways to `--to-tag`. |
-| `verify-all` | Run Jest gateway tests (e.g. against dp1). |
 | `downgrade-mapi` | Downgrade MAPI back to `--from-tag`. |
-| `verify-after-downgrade-mapi` | Run Jest management tests after MAPI downgrade. |
 | `downgrade-gw` | Downgrade Gateways back to `--from-tag`. |
-| `verify-after-downgrade` | Run Jest gateway tests after full downgrade. |
+| `verify` | Generic ad-hoc verify (not in the default pipeline); asserts the channel from `--test-label` (default: `alpha`). |
 
-**Caveat:** `--stage` does **not** run previous stages. If you use `--stage verify-baseline`, the tool assumes the cluster is already set up and “from” is already deployed (e.g. you ran `deploy-from` earlier or used `setup`). It is mainly for re-running or debugging one step in an already-prepared environment.
+> `verify-all-alpha` / `verify-all-beta` are reused at several points in the pipeline (initial alpha, post-full-upgrade, and post-downgrade). The stage name picks **which** seeded domain is asserted (`alpha` → `--from-tag`, `beta` → `--to-tag`), independent of where it runs.
+
+**Caveat:** `--stage` does **not** run previous stages. If you use `--stage verify-all-alpha`, the tool assumes the cluster is already set up and the relevant version is deployed (e.g. you ran `deploy-from`/`upgrade-*` earlier or used `setup`). It is mainly for re-running or debugging one step in an already-prepared environment. Single verify stages start the port-forwards themselves.
 
 **Examples:**
 
@@ -185,12 +219,81 @@ Requires `CIRCLECI_TOKEN`. Sends parameters (from-tag, to-tag, db-type, provider
 # Only tear down and redeploy “from” version (no tests, no upgrade)
 ./scripts/migration-test.mjs run --provider k8s --stage deploy-from
 
-# Only run baseline Jest tests (assumes env already deployed)
-./scripts/migration-test.mjs run --provider k8s --stage verify-baseline --test-filter specs/management/certificates/certificates.jest.spec.ts
+# Only verify the alpha (from-tag) domain (assumes env already deployed)
+./scripts/migration-test.mjs run --provider k8s --stage verify-all-alpha
+
+# Only verify the beta (to-tag) domain (assumes MAPI already upgraded + seed-beta run)
+./scripts/migration-test.mjs run --provider k8s --to-tag 4.11.8 --stage verify-mapi-beta
+
+# Ad-hoc: verify a specific seeded channel via --test-label (alpha or beta)
+./scripts/migration-test.mjs run --provider k8s --stage verify --test-label beta
 
 # Only run the “upgrade MAPI” step (assumes deploy-from already done)
 ./scripts/migration-test.mjs run --provider k8s --stage upgrade-mapi
 ```
+
+---
+
+## Migration seeding
+
+The migration tool seeds deterministic data through the generated Management API SDK in `gravitee-am-test/api/management`.
+
+Seed files live in `gravitee-am-test/migration-seeding/versions/<major.minor>/seed.ts`. Each seed file must be idempotent and use stable identifiers, names, or metadata so migration specs can find the same objects after upgrade and downgrade. A seed file exposes `seed(label)` and names every entity by that **label** (not the version), so the same version's data can be seeded twice under different labels without colliding.
+
+The seed runner takes `--version <major.minor>` (which seed module / data shape to run) and `--label <name>` (the channel suffix used for naming). The `seed-alpha` stage runs the `--from-tag` module under label `alpha`; the `seed-beta` stage runs the `--to-tag` module under label `beta`. Because each channel targets a single version+label, this works for patch migrations too (e.g. `4.10.7 → 4.10.8` seeds the `4.10` module twice, as `alpha` and `beta`).
+
+For each channel, the seed duplicates the full data set onto every data plane id listed by `AM_DOMAIN_DATA_PLANE_ID` (primary) and `AM_DOMAIN_DATA_PLANE_ID_DP2` (second, set automatically by the k8s tool). Entities are named by an **instance label** (`<channel>-<dataPlaneId>`), so a single `seed(label)` call produces one isolated domain per data plane. With no second-data-plane env (local runs) it seeds just one.
+
+Seed and verify through the orchestrator so the version (`--version`)/label/`AM_MIGRATION_TEST_LABEL` wiring — and the git-worktree seeding below — happen automatically. Each `--stage` assumes the environment is already deployed (see the single-stage caveat above):
+
+```bash
+# Seed the from-tag (alpha) channel into an already-deployed environment
+./scripts/migration-test.mjs run --provider k8s --from-tag 4.10.3 --stage seed-alpha
+
+# Seed the to-tag (beta) channel
+./scripts/migration-test.mjs run --provider k8s --to-tag 4.11.8 --stage seed-beta
+
+# Verify an already-seeded channel (alpha = from-tag, beta = to-tag)
+./scripts/migration-test.mjs run --provider k8s --stage verify-all-alpha
+```
+
+When running through the migration tool, `AM_MIGRATION_TEST_LABEL` is set automatically per stage (`alpha` for `*-alpha` stages, `beta` for `*-beta` stages; ad-hoc generic verify stages use `--test-label`, default `alpha`).
+
+> **Low-level escape hatch (debugging only).** The orchestrator stages ultimately invoke the `gravitee-am-test` npm scripts directly, which you can run by hand — but these run from the **current checkout** and bypass the worktree seeding below, so the version-correct SDK/scripts are *not* used:
+> ```bash
+> npm --prefix gravitee-am-test run migration:seed -- --version 4.10 --label alpha
+> AM_MIGRATION_TEST_LABEL=alpha npm --prefix gravitee-am-test run ci:migration
+> ```
+
+### Version-correct seeding via git worktrees
+
+By default each tag is seeded from a **git worktree of that tag**, so the seed runs against that
+version's *own* committed Management API SDK (`gravitee-am-test/api/management`) and
+`migration-seeding` scripts rather than the current branch's. The `seed-alpha` stage uses a worktree
+of `--from-tag`; `seed-beta` uses a worktree of `--to-tag`. AM itself still runs from the published
+`graviteeio/am-*:<tag>` Docker image — the worktree provides **only** the TS seed tooling, so there
+is no Maven build.
+
+Mechanics (`lib/core/SeedWorktree.mjs`):
+
+- Worktrees are cached under `<repoRoot>/.worktrees/seed-<ref>` (git-ignored). The ref is fetched
+  (`git fetch --tags`) if not present locally; tags, branches, and commits are all accepted.
+- `npm ci` runs **once** per worktree (skipped when `node_modules` already exists), installing that
+  tag's exact committed lockfile.
+- Worktrees are removed after the run unless `--keep-worktrees` is passed.
+
+**Going-forward fallback.** If a tag predates the `migration-seeding/` framework (i.e. the directory
+is absent in that tag — today's `4.10.x`/`4.11.x`/`4.12.x`), the tool logs a notice and seeds from
+the **current checkout** instead. So newer-vs-newer migrations get version-correct seeding while
+older from-tags transparently keep working. Pass `--no-seed-worktree` to force current-checkout
+seeding for every tag.
+
+Because no published tag ships the framework yet, the mechanism can be exercised today by passing a
+ref that *does* contain it — e.g. the current branch — as `--from-tag`.
+
+Prefer adding seeds before or during the release where the data shape is introduced, so that release's
+tag carries a version-correct seed. For older releases (fallback to current checkout), keep seed data
+to API fields accepted by that older AM version.
 
 ---
 
@@ -251,7 +354,7 @@ See also `docs/agent-standards/commands.md` for canonical build/test and migrati
 
 ## Next steps
 
-- **Fix Docker Compose** – Make the Docker Compose provider functional so the full migration flow (clean → setup → deploy-from → verify-baseline → … → verify-all) runs with `--provider docker-compose`. Requires fixing compose file, env, and provider logic to align with the K8s flow.
+- **Fix Docker Compose** – Make the Docker Compose provider functional so the full migration flow (clean → setup → deploy-from → seed → verify-all-alpha → … → verify-all-beta) runs with `--provider docker-compose`. Requires fixing compose file, env, and provider logic to align with the K8s flow.
 - **Fix Jest/K8s environment** – Resolve remaining environment or wiring issues so Jest tests (gravitee-am-test) run reliably against the K8s-deployed AM (management and gateway specs, URLs, ports, dataplane IDs, timeouts). Aim for the full suite (or a well-defined subset) to pass without manual tweaks.
 - **Integrate Gatling performance tests** – Consider integrating the existing Gatling performance tests into the migration flow: use them for data seeding (organisations, applications, users, tokens) before migration runs, and extend the scope of Gatling scenarios to cover migration-specific cases (e.g. upgrade/downgrade behaviour, schema compatibility). Prefer this over creating a new test project dedicated to the migration tool.
 - **Add a `teardown` command** – Add a new command (e.g. `teardown`) that removes the entire Kind cluster (e.g. `kind delete cluster --name am-migration`), so users can fully tear down the K8s environment from the tool instead of running Kind commands manually.

--- a/scripts/migration-tool/env/k8s/am/am-mongodb-common.yaml
+++ b/scripts/migration-tool/env/k8s/am/am-mongodb-common.yaml
@@ -40,7 +40,7 @@ mapiEnv: &mapiEnv
   - name: gravitee_dataPlanes_1_type
     value: mongodb
   - name: gravitee_dataPlanes_1_mongodb_uri
-    value: "mongodb://gravitee:gravitee-password@mongo-mongodb:27017/gravitee-dp1?serverSelectionTimeoutMS=30000"
+    value: "mongodb://gravitee:gravitee-password@mongo-mongodb:27017/gravitee-dp1?serverSelectionTimeoutMS=30000&authSource=gravitee"
   - name: gravitee_dataPlanes_1_mongodb_dbname
     value: "gravitee-dp1"
   - name: gravitee_dataPlanes_2_id
@@ -48,7 +48,7 @@ mapiEnv: &mapiEnv
   - name: gravitee_dataPlanes_2_type
     value: mongodb
   - name: gravitee_dataPlanes_2_mongodb_uri
-    value: "mongodb://gravitee:gravitee-password@mongo-mongodb:27017/gravitee-dp2?serverSelectionTimeoutMS=30000"
+    value: "mongodb://gravitee:gravitee-password@mongo-mongodb:27017/gravitee-dp2?serverSelectionTimeoutMS=30000&authSource=gravitee"
   - name: gravitee_dataPlanes_2_mongodb_dbname
     value: "gravitee-dp2"
 

--- a/scripts/migration-tool/env/k8s/db/db-mongodb.yaml
+++ b/scripts/migration-tool/env/k8s/db/db-mongodb.yaml
@@ -2,7 +2,7 @@
 # Single source: db/db-mongodb.yaml (replaces root mongodb-values.yaml)
 # Credentials are provided via auth.existingSecret (no plain-text passwords in repo).
 # The migration tool creates the secret at deploy time from MONGODB_ROOT_PASSWORD env (or safe default for local).
-# databases: gravitee (CP), gravitee-dp1 and gravitee-dp2 for multi-dataplane gateways; user 'gravitee' gets access to all.
+# databases: gravitee (CP), gravitee-dp1 and gravitee-dp2 for multi-dataplane gateways; user 'gravitee' is granted access to all (see initdbScripts).
 
 architecture: standalone
 fullnameOverride: mongo-mongodb
@@ -11,9 +11,18 @@ auth:
   enabled: true
   # Bitnami chart key: K8s secret *name* only (no credentials in repo). Aqua false positive: not a password.
   existingSecret: "mongo-mongodb-auth"
-  # One user 'gravitee' with access to each dataplane DB (parallel arrays: usernames[i], passwords[i], databases[i])
-  usernames: ["gravitee", "gravitee", "gravitee"]
-  databases: ["gravitee", "gravitee-dp1", "gravitee-dp2"]
+  usernames: ["gravitee"]
+  databases: ["gravitee"]
+
+# Grant the gravitee user readWrite on the data-plane databases. Runs as root on first init,
+# after Bitnami creates the gravitee user. persistence is disabled, so every (re)deploy is a
+# fresh init and re-runs this script.
+initdbScripts:
+  grant-dataplane-roles.js: |
+    db.getSiblingDB('gravitee').grantRolesToUser('gravitee', [
+      { role: 'readWrite', db: 'gravitee-dp1' },
+      { role: 'readWrite', db: 'gravitee-dp2' },
+    ]);
 
 persistence:
   enabled: false
@@ -25,5 +34,3 @@ resources:
   requests:
     cpu: 200m
     memory: 512Mi
-
-namespaceOverride: "gravitee-am"

--- a/scripts/migration-tool/index.mjs
+++ b/scripts/migration-tool/index.mjs
@@ -31,6 +31,8 @@ import { CircleCI } from './lib/CircleCI.mjs';
 import { K8sProvider } from './lib/providers/K8sProvider.mjs';
 import { DockerComposeProvider } from './lib/providers/DockerComposeProvider.mjs';
 import { Config } from './lib/core/Config.mjs';
+import { resolveFloatingTag } from './lib/core/VersionResolver.mjs';
+import { SeedWorktree } from './lib/core/SeedWorktree.mjs';
 import { Helm } from './lib/infra/kubernetes/Helm.mjs';
 import { Kubectl } from './lib/infra/kubernetes/Kubectl.mjs';
 import { MongoK8sStrategy } from './lib/strategies/database/MongoK8sStrategy.mjs';
@@ -50,10 +52,15 @@ const parsed = parseArgs({
         'to-tag': { type: 'string' },
         'db-type': { type: 'string' },
         provider: { type: 'string' },
+        namespace: { type: 'string' },
+        registry: { type: 'string' },
         stage: { type: 'string' },
         'test-filter': { type: 'string' },
+        'test-label': { type: 'string' },
         'test-dir': { type: 'string' },
         'with-downgrade': { type: 'boolean', default: false },
+        'no-seed-worktree': { type: 'boolean', default: false },
+        'keep-worktrees': { type: 'boolean', default: false },
     },
     allowPositionals: true,
     strict: false,
@@ -81,10 +88,15 @@ if (firstIsCommand) {
         'to-tag': zxArgv['to-tag'],
         'db-type': zxArgv['db-type'],
         provider: zxArgv.provider,
+        namespace: zxArgv.namespace,
+        registry: zxArgv.registry,
         stage: zxArgv.stage,
         'test-filter': zxArgv['test-filter'],
+        'test-label': zxArgv['test-label'],
         'test-dir': zxArgv['test-dir'],
         'with-downgrade': zxArgv['with-downgrade'],
+        'no-seed-worktree': zxArgv['no-seed-worktree'],
+        'keep-worktrees': zxArgv['keep-worktrees'],
     };
 } else {
     command = positionals.length > 0 ? positionals[0] : undefined;
@@ -99,18 +111,46 @@ const options = {
     toTag: raw['to-tag'] ?? 'latest',
     dbType: raw['db-type'] ?? 'mongodb',
     providerName: raw.provider ?? 'docker-compose',
+    // K8s namespace: --namespace overrides AM_K8S_NAMESPACE, which overrides the 'gravitee-am' default.
+    namespace: raw.namespace ?? Config.k8s.namespace,
+    registry: raw.registry ?? undefined,
     stage: raw.stage ?? undefined,
     testFilter: (raw['test-filter'] ?? '').trim() || undefined,
+    testLabel: (raw['test-label'] ?? '').trim() || undefined,
     testDir,
     withDowngrade: raw['with-downgrade'] === true,
+    // Seed each tag from a git worktree of that tag (its own SDK + scripts); on by default.
+    seedFromWorktree: raw['no-seed-worktree'] !== true,
+    keepWorktrees: raw['keep-worktrees'] === true,
     token: process.env.CIRCLECI_TOKEN,
 };
+
+// Resolve floating tags (latest, 4, 4.11, ...) to the concrete X.Y.Z they point to, so deploy,
+// seeding, worktrees and the CircleCI trigger all run against a real version. Fails fast.
+// Only runs for commands that actually consume fromTag/toTag — teardown only uses the provider
+// and must remain offline-tolerant. The help/no-command path must also stay network-free.
+const COMMANDS_NEEDING_TAGS = ['run', 'setup', 'trigger'];
+if (command && COMMANDS_NEEDING_TAGS.includes(command)) {
+    for (const key of ['fromTag', 'toTag']) {
+        const tag = options[key];
+        try {
+            const resolved = await resolveFloatingTag(tag);
+            if (resolved !== tag) {
+                console.log(`🔖 Resolved --${key === 'fromTag' ? 'from' : 'to'}-tag ${tag} → ${resolved}`);
+                options[key] = resolved;
+            }
+        } catch (e) {
+            console.error(`❌ ${e.message}`);
+            process.exit(1);
+        }
+    }
+}
 
 // 1. Initialize Infrastructure Provider
 let provider;
 switch (options.providerName) {
     case 'k8s': {
-        const namespace = Config.k8s.namespace;
+        const namespace = options.namespace;
         const helm = new Helm({ namespace });
         const kubectl = new Kubectl({ namespace });
         let databaseStrategy;
@@ -141,7 +181,8 @@ switch (options.providerName) {
             helm,
             kubectl,
             databaseStrategy,
-            releases
+            releases,
+            registry: options.registry
         });
         break;
     }
@@ -169,7 +210,8 @@ const commands = {
             dbType: options.dbType,
             provider: options.providerName,
             testFilter: options.testFilter,
-            withDowngrade: options.withDowngrade
+            withDowngrade: options.withDowngrade,
+            registry: options.registry
         });
         return 0;
     },
@@ -205,18 +247,25 @@ const commands = {
         if (typeof provider.ensureCluster === 'function') {
             await provider.ensureCluster();
         }
-        const orchestrator = new Orchestrator(provider, options);
+        const seedWorktree = options.seedFromWorktree
+            ? await SeedWorktree.create({ keep: options.keepWorktrees })
+            : null;
+        const orchestrator = new Orchestrator(provider, options, seedWorktree);
         const allStages = [
             'clean',
             'k8s:setup',
             'deploy-from',
-            'verify-baseline',
+            'seed-alpha',
+            'verify-alpha',
             'upgrade-mapi',
-            'verify-mapi',
+            'seed-beta',
+            'verify-alpha',
+            'verify-beta',
             'upgrade-gw',
-            'verify-all',
+            'verify-alpha',
+            'verify-beta',
             ...(options.withDowngrade
-                ? ['downgrade-mapi', 'verify-after-downgrade-mapi', 'downgrade-gw', 'verify-after-downgrade']
+                ? ['downgrade-gw', 'verify-alpha', 'verify-beta', 'downgrade-mapi', 'verify-alpha', 'verify-beta']
                 : [])
         ];
         const stagesToRun = options.stage ? [options.stage] : allStages;
@@ -247,14 +296,30 @@ function printHelp() {
     console.log('  run        Run migration orchestration');
     console.log('\nOptions (use --key <value> or --key=<value>):');
     console.log('  --from-tag <tag>   Initial AM version (default: 4.10.0)');
-    console.log('  --to-tag <tag>     Target AM version (default: latest)');
+    console.log('  --to-tag <tag>     Target AM version (default: latest). Floating tags (latest, 4, 4.11) are resolved to a concrete X.Y.Z.');
     console.log('  --db-type <type>  Database: mongodb or postgres (default: mongodb)');
     console.log('  --provider <name> Infrastructure: docker-compose or k8s (default: docker-compose)');
+    console.log('  --namespace <ns>  K8s namespace to deploy into (default: gravitee-am, or AM_K8S_NAMESPACE)');
+    console.log('  --registry <host> Override AM image repositories, e.g. graviteeio.azurecr.io');
     console.log('  --stage <name>    Run only this stage');
     console.log('  --test-filter <path>  Run only Jest tests matching path (e.g. specs/gateway/refresh-token.jest.spec.ts)');
+    console.log('  --test-label <alpha|beta>  Seed channel asserted by ad-hoc migration Jest tests (default: alpha)');
     console.log('  --test-dir <path>   Test suite directory (default from config; use full path to override)');
-    console.log('  --with-downgrade  After verify-all, downgrade back to from-tag and verify');
-    console.log('\nStages:');
-    console.log('  clean, k8s:setup, deploy-from, verify-baseline, upgrade-mapi, verify-mapi, upgrade-gw, verify-all');
-    console.log('  (+ with --with-downgrade: downgrade-mapi, verify-after-downgrade-mapi, downgrade-gw, verify-after-downgrade)');
+    console.log('  --with-downgrade  After the full upgrade, downgrade back to from-tag and re-verify');
+    console.log('  --no-seed-worktree  Seed from the current checkout for all tags (disable per-tag worktree seeding)');
+    console.log('  --keep-worktrees  Do not delete the .worktrees/seed-<ref> dirs after the run (debugging)');
+    console.log('\nSeeding source:');
+    console.log('  By default each tag is seeded from a git worktree of that tag (its own SDK + scripts),');
+    console.log('  so alpha reflects --from-tag and beta reflects --to-tag. AM itself runs from the published');
+    console.log('  Docker image; the worktree only provides the TS seed tooling (npm ci once per worktree).');
+    console.log('  Going-forward: tags predating the migration-seeding framework transparently fall back to');
+    console.log('  the current checkout. Use --no-seed-worktree to force current-checkout seeding everywhere.');
+    console.log('\nStages (default pipeline order):');
+    console.log('  clean, k8s:setup, deploy-from, seed-alpha, verify-alpha, upgrade-mapi, seed-beta,');
+    console.log('  verify-alpha, verify-beta, upgrade-gw, verify-alpha, verify-beta');
+    console.log('  (+ with --with-downgrade: downgrade-gw, verify-alpha, verify-beta, downgrade-mapi, verify-alpha, verify-beta)');
+    console.log('  alpha = the --from-tag seeded domain; beta = the --to-tag seeded domain');
+    console.log('  aliases: seed → seed-alpha, seed-upgrade → seed-beta');
+    console.log('  Ad-hoc single-stage verify (honors --test-label): verify');
+    console.log('  Note: floating tags (latest, 4, 4.11) on --from-tag/--to-tag are resolved to the concrete X.Y.Z they point to before the run.');
 }

--- a/scripts/migration-tool/lib/CircleCI.mjs
+++ b/scripts/migration-tool/lib/CircleCI.mjs
@@ -22,6 +22,7 @@ export class CircleCI {
                 migration_test_db_type: options.dbType,
                 migration_test_provider: options.provider,
                 ...(options.testFilter != null && options.testFilter !== '' ? { migration_test_filter: options.testFilter } : {}),
+                ...(options.registry != null && options.registry !== '' ? { migration_test_registry: options.registry } : {}),
                 ...(options.withDowngrade ? { migration_test_with_downgrade: 'true' } : {})
             }
         };

--- a/scripts/migration-tool/lib/Orchestrator.mjs
+++ b/scripts/migration-tool/lib/Orchestrator.mjs
@@ -6,10 +6,16 @@ import { once } from 'node:events';
  * testDir and test env come from options and provider; it has no knowledge of a specific test suite.
  */
 export class Orchestrator {
-    constructor(provider, options) {
+    constructor(provider, options, seedWorktree = null) {
         this.provider = provider;
         this.options = options;
         this.projectRoot = process.cwd();
+        // Optional: when set (and options.seedFromWorktree), seed stages run from a git worktree of
+        // the from/to tag so each version seeds with its own SDK + scripts. null => current checkout.
+        this.seedWorktree = seedWorktree;
+        // Timestamp of the last log scan; each verify scan only covers logs since then so the
+        // summary stays focused and the same ERROR lines aren't re-printed every stage.
+        this._lastScanAt = Date.now();
     }
 
     async run(stages, options = {}) {
@@ -27,9 +33,30 @@ export class Orchestrator {
             if (error.stderr) console.error(`Stderr: ${error.stderr}`);
             throw error;
         } finally {
+            // Final log sweep before cleanup so an error mid-pipeline still gets surfaced.
+            await this.scanProviderLogs();
             if (!skipCleanup && typeof this.provider.cleanup === 'function') {
                 await this.provider.cleanup();
             }
+            if (!skipCleanup && this.seedWorktree) {
+                await this.seedWorktree.cleanup();
+            }
+        }
+    }
+
+    /**
+     * Scan the provider's component logs for ERROR lines (report-only). No-op for providers
+     * that don't implement scanLogsForErrors (e.g. DockerComposeProvider). Covers logs since
+     * the previous scan so each call's summary stays focused.
+     */
+    async scanProviderLogs() {
+        if (typeof this.provider.scanLogsForErrors !== 'function') return;
+        const elapsedSec = Math.max(1, Math.ceil((Date.now() - this._lastScanAt) / 1000));
+        this._lastScanAt = Date.now();
+        try {
+            await this.provider.scanLogsForErrors({ since: `${elapsedSec}s` });
+        } catch (e) {
+            console.warn(`⚠️  Log scan skipped: ${e.message}`);
         }
     }
 
@@ -48,39 +75,46 @@ export class Orchestrator {
             case 'deploy-from':
                 await this.provider.deploy(this.options.fromTag);
                 break;
-            case 'verify-baseline':
-                await this.runTests('🔍 Running baseline tests...', 'ci:management:parallel', 'specs/management');
+            case 'seed':
+            case 'seed-alpha':
+                await this.seedStage(this.options.fromTag, 'alpha');
                 break;
             case 'upgrade-mapi':
                 await this.provider.upgradeMapi(this.options.toTag);
                 break;
-            case 'verify-mapi':
-                await this.runTests('🔍 Verifying MAPI upgrade...', 'ci:management:parallel', 'specs/management');
-                break;
             case 'upgrade-gw':
                 await this.provider.upgradeGw(this.options.toTag);
                 break;
-            case 'verify-all':
-                await this.runTests('🔍 Final verification...', 'ci:gateway', 'specs/gateway');
+            case 'seed-upgrade':
+            case 'seed-beta':
+                await this.seedStage(this.options.toTag, 'beta');
                 break;
             case 'downgrade-mapi':
                 await this.provider.upgradeMapi(this.options.fromTag);
                 break;
-            case 'verify-after-downgrade-mapi':
-                await this.runTests('🔍 Verifying after MAPI downgrade...', 'ci:management:parallel', 'specs/management');
-                break;
             case 'downgrade-gw':
                 await this.provider.upgradeGw(this.options.fromTag);
                 break;
-            case 'verify-after-downgrade':
-                await this.runTests('🔍 Verifying after downgrade...', 'ci:gateway', 'specs/gateway');
+            // Structured verification: the "alpha" channel is the --from-tag seeded domain; the "beta"
+            // channel is the --to-tag seeded domain. The same verify runs at several points in the
+            // pipeline (post-mapi-upgrade, post-gw-upgrade, post-downgrade) — pipeline order says which.
+            case 'verify-alpha':
+                await this.runTests('🔍 Verifying alpha domain...', 'ci:migration', 'specs/migration', 'alpha');
+                break;
+            case 'verify-beta':
+                await this.runTests('🔍 Verifying beta domain...', 'ci:migration', 'specs/migration', 'beta');
+                break;
+            // Generic verify stage for ad-hoc / single-stage debugging; the asserted channel comes from
+            // --test-label (falling back to "alpha"). Not part of the default pipeline.
+            case 'verify':
+                await this.runTests('🔍 Running migration verification...', 'ci:migration', 'specs/migration');
                 break;
             default:
                 throw new Error(`Unknown stage: ${stage}`);
         }
     }
 
-    async runTests(message, npmScript, specPath) {
+    async runTests(message, npmScript, specPath, label) {
         console.log(message);
         const testDir = this.options.testDir;
         if (!testDir) {
@@ -88,7 +122,11 @@ export class Orchestrator {
         }
         const filter = (this.options.testFilter || '').trim();
 
-        const jestEnv = { ...process.env, ...(typeof this.provider.getTestEnv === 'function' ? this.provider.getTestEnv() : {}) };
+        const jestEnv = {
+            ...process.env,
+            ...(typeof this.provider.getTestEnv === 'function' ? this.provider.getTestEnv() : {}),
+            AM_MIGRATION_TEST_LABEL: label || this.getMigrationTestLabel()
+        };
         Object.assign(process.env, jestEnv);
 
         if (typeof this.provider.prepareTests === 'function') {
@@ -106,6 +144,51 @@ export class Orchestrator {
                 await $`npm run ${npmScript} -- ${specPath || ''}`;
             }
         });
+
+        // After the verify stage, surface any ERROR lines logged by Gateway/MAPI (report-only).
+        await this.scanProviderLogs();
+    }
+
+    /**
+     * Seed one version under a channel label. When a SeedWorktree is configured (and enabled), the
+     * seed runs from a worktree of `tag` so it uses that version's own SDK + scripts; otherwise (or
+     * when the tag predates the seeding framework) it falls back to the current checkout.
+     */
+    async seedStage(tag, label) {
+        const args = ['--version', toMinorVersion(tag), '--label', label];
+        let seedDir = null;
+        if (this.seedWorktree && this.options.seedFromWorktree) {
+            seedDir = await this.seedWorktree.resolveSeedDir(tag);
+        }
+        if (seedDir) {
+            console.log(`🌱 Seeding ${label} from worktree: ${seedDir}`);
+            await this.runSeed(args, seedDir);
+        } else {
+            await this.runSeed(args);
+        }
+    }
+
+    async runSeed(args, seedDir) {
+        const testDir = seedDir || this.options.testDir;
+        if (!testDir) {
+            throw new Error('options.testDir is required to run migration seed');
+        }
+        const env = { ...process.env, ...(typeof this.provider.getTestEnv === 'function' ? this.provider.getTestEnv() : {}) };
+        // Ensure the MAPI/gateway port-forwards are up so the seed can reach localhost:8093.
+        // Mirrors runTests(); idempotent when tunnels are already started (e.g. after deploy-from).
+        if (typeof this.provider.prepareTests === 'function') {
+            await this.provider.prepareTests();
+        }
+        const child = spawn('npm', ['run', 'migration:seed', '--', ...args], {
+            cwd: testDir,
+            env,
+            stdio: 'inherit',
+            shell: false,
+        });
+        const [code] = await once(child, 'exit');
+        if (code !== 0) {
+            throw new Error(`Seed process exited with code ${code}`);
+        }
     }
 
     async _runJestWithEnv(testDir, env, args) {
@@ -120,4 +203,16 @@ export class Orchestrator {
             throw new Error(`Jest exited with code ${code}`);
         }
     }
+
+    getMigrationTestLabel() {
+        return this.options.testLabel || 'alpha';
+    }
+}
+
+function toMinorVersion(version) {
+    const match = String(version).match(/^(\d+)\.(\d+)/);
+    if (!match) {
+        throw new Error(`Invalid AM version: ${version}`);
+    }
+    return `${match[1]}.${match[2]}`;
 }

--- a/scripts/migration-tool/lib/core/SeedWorktree.mjs
+++ b/scripts/migration-tool/lib/core/SeedWorktree.mjs
@@ -1,0 +1,106 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * SeedWorktree materializes a git worktree for a given ref (tag/branch/commit) so the migration
+ * seed step can run that version's *own* seed tooling — its committed Management API SDK and
+ * migration-seeding scripts — rather than the current checkout's.
+ *
+ * The AM instance itself still runs from the published Docker image for the ref; only the seed
+ * tooling comes from the worktree. Worktrees are cached under <repoRoot>/.worktrees and `npm ci`
+ * runs once per worktree (skipped when node_modules already exists).
+ *
+ * Going-forward contract: refs that predate the migration-seeding framework (no migration-seeding/
+ * directory) are NOT used — resolveSeedDir() returns null so the caller falls back to the current
+ * checkout. Relies on zx globals ($, cd, within) — only ever constructed under the zx-run CLI.
+ */
+export class SeedWorktree {
+    constructor({ repoRoot, worktreeBase, testDirName = 'gravitee-am-test', keep = false } = {}) {
+        this.repoRoot = repoRoot;
+        this.worktreeBase = worktreeBase;
+        this.testDirName = testDirName;
+        this.keep = keep;
+        this.created = [];
+    }
+
+    /** Build an instance rooted at the repository top-level. */
+    static async create({ keep = false } = {}) {
+        const repoRoot = (await $`git rev-parse --show-toplevel`).stdout.trim();
+        return new SeedWorktree({ repoRoot, worktreeBase: join(repoRoot, '.worktrees'), keep });
+    }
+
+    sanitize(ref) {
+        return ref.replace(/[^A-Za-z0-9._-]/g, '-');
+    }
+
+    /**
+     * Materialize (or reuse) a worktree for `ref` and return the absolute gravitee-am-test directory
+     * to seed from. Returns null when `ref` predates the migration-seeding framework, signalling the
+     * caller to seed from the current checkout instead.
+     */
+    async resolveSeedDir(ref) {
+        await this.ensureRef(ref);
+
+        const worktreePath = join(this.worktreeBase, `seed-${this.sanitize(ref)}`);
+        const justCreated = !existsSync(worktreePath);
+        if (justCreated) {
+            mkdirSync(this.worktreeBase, { recursive: true });
+            console.log(`🌿 Creating seed worktree for ${ref} at ${worktreePath}`);
+            await $`git -C ${this.repoRoot} worktree add --detach --force ${worktreePath} ${ref}`;
+            this.created.push(worktreePath);
+        }
+
+        const seedDir = join(worktreePath, this.testDirName);
+        if (!existsSync(join(seedDir, 'migration-seeding'))) {
+            console.log(`ℹ️  Ref ${ref} predates the migration-seeding framework; seeding from current checkout instead.`);
+            if (justCreated) {
+                await this.removeWorktree(worktreePath);
+            }
+            return null;
+        }
+
+        if (!existsSync(join(seedDir, 'node_modules'))) {
+            console.log(`📦 Installing seed dependencies for ${ref} (npm ci)...`);
+            await within(async () => {
+                cd(seedDir);
+                await $`npm ci`;
+            });
+        }
+
+        return seedDir;
+    }
+
+    /** Ensure `ref` resolves to a commit locally, fetching tags once if needed. */
+    async ensureRef(ref) {
+        const spec = `${ref}^{commit}`;
+        if ((await $`git -C ${this.repoRoot} rev-parse --verify --quiet ${spec}`.quiet().nothrow()).exitCode === 0) {
+            return;
+        }
+        await $`git -C ${this.repoRoot} fetch --tags --quiet`.quiet().nothrow();
+        if ((await $`git -C ${this.repoRoot} rev-parse --verify --quiet ${spec}`.quiet().nothrow()).exitCode !== 0) {
+            throw new Error(`Cannot resolve git ref '${ref}' for seeding worktree (not a tag/branch/commit, and fetch did not find it)`);
+        }
+    }
+
+    async removeWorktree(worktreePath) {
+        try {
+            await $`git -C ${this.repoRoot} worktree remove --force ${worktreePath}`;
+        } catch (error) {
+            console.log(`⚠️  Could not remove seed worktree ${worktreePath}: ${error.message}`);
+        }
+        this.created = this.created.filter((p) => p !== worktreePath);
+    }
+
+    /** Remove every worktree this instance created, unless --keep-worktrees was requested. */
+    async cleanup() {
+        if (this.keep) {
+            if (this.created.length) {
+                console.log(`🧹 Keeping ${this.created.length} seed worktree(s) (--keep-worktrees).`);
+            }
+            return;
+        }
+        for (const worktreePath of [...this.created]) {
+            await this.removeWorktree(worktreePath);
+        }
+    }
+}

--- a/scripts/migration-tool/lib/core/VersionResolver.mjs
+++ b/scripts/migration-tool/lib/core/VersionResolver.mjs
@@ -1,0 +1,64 @@
+/**
+ * Resolves floating AM Docker tags (latest, 4, 4.11, ...) to the concrete X.Y.Z version they
+ * currently point to, using the public Docker Hub v2 API (same source as VersionValidator).
+ *
+ * A floating tag and the concrete version it points to share the same manifest digest, so we read
+ * the floating tag's digest and find the plain X.Y.Z tag with a matching digest. No registry auth
+ * or manifest-blob fetch is needed. Variant-suffixed tags (latest-debian) do not share a digest
+ * with a plain X.Y.Z and therefore fail to resolve (by design — fail fast).
+ */
+const REGISTRY = 'graviteeio';
+const CONCRETE = /^\d+\.\d+\.\d+$/;
+const MAX_PAGES = 5;
+const PAGE_SIZE = 100;
+
+/** True iff `tag` is a plain X.Y.Z version (no floating alias, no variant suffix). */
+export function isConcreteVersion(tag) {
+    return CONCRETE.test(String(tag));
+}
+
+/**
+ * Resolve a floating tag to a concrete X.Y.Z. Concrete tags are returned unchanged with no network
+ * call. Throws on no match or fetch failure.
+ * @param {string} tag
+ * @param {{imageName?: string}} [opts]
+ * @returns {Promise<string>}
+ */
+export async function resolveFloatingTag(tag, { imageName = 'am-management-api' } = {}) {
+    if (isConcreteVersion(tag)) return tag;
+
+    const base = `https://hub.docker.com/v2/repositories/${REGISTRY}/${imageName}`;
+
+    const tagRes = await fetch(`${base}/tags/${encodeURIComponent(tag)}/`, { method: 'GET' });
+    if (!tagRes.ok) {
+        throw new Error(
+            `Could not look up floating tag "${tag}" for ${REGISTRY}/${imageName} ` +
+            `(HTTP ${tagRes.status}). Check the tag exists at https://hub.docker.com/r/${REGISTRY}/${imageName}/tags.`
+        );
+    }
+    const { digest } = await tagRes.json();
+    if (!digest) {
+        throw new Error(`Floating tag "${tag}" for ${REGISTRY}/${imageName} has no manifest digest to match.`);
+    }
+
+    for (let page = 1; page <= MAX_PAGES; page++) {
+        const url = `${base}/tags/?page_size=${PAGE_SIZE}&ordering=last_updated&page=${page}`;
+        const res = await fetch(url, { method: 'GET' });
+        if (!res.ok) {
+            throw new Error(
+                `Could not list tags for ${REGISTRY}/${imageName} while resolving "${tag}" ` +
+                `(HTTP ${res.status} on page ${page}).`
+            );
+        }
+        const data = await res.json();
+        const results = data.results || [];
+        const match = results.find((t) => isConcreteVersion(t.name) && t.digest === digest);
+        if (match) return match.name;
+        if (!data.next) break;
+    }
+
+    throw new Error(
+        `Could not resolve floating tag "${tag}" to a concrete version for ${REGISTRY}/${imageName}. ` +
+        `No X.Y.Z tag shares its image digest. Use a concrete version tag (e.g. 4.11.9).`
+    );
+}

--- a/scripts/migration-tool/lib/infra/LogScanner.mjs
+++ b/scripts/migration-tool/lib/infra/LogScanner.mjs
@@ -1,0 +1,22 @@
+/**
+ * LogScanner — find ERROR-level lines in captured process/pod stdout.
+ *
+ * The standalone Gateway/MAPI logback pattern is:
+ *   %d{HH:mm:ss.SSS} [%thread] [%X{domain}] %-5level %logger{36} - %msg
+ * so an ERROR line contains the level token ` ERROR `. The regex below matches that token
+ * standalone (tolerant of the `kubectl logs --prefix` pod tag prepended to each line) and
+ * also catches JSON logging's `"level":"ERROR"` shape, should pods ever switch format.
+ */
+const ERROR_LINE = /(^|\s)ERROR(\s|$)/;
+
+/**
+ * Scan text for ERROR lines.
+ * @param {string} text - combined stdout to scan
+ * @param {string} [source] - label for where the text came from (e.g. release/pod name)
+ * @returns {{ source: string, count: number, lines: string[] }}
+ */
+export function scanForErrors(text, source = '') {
+    const lines = (text || '').split('\n');
+    const hits = lines.filter((l) => ERROR_LINE.test(l)).map((l) => l.trim());
+    return { source, count: hits.length, lines: hits };
+}

--- a/scripts/migration-tool/lib/infra/kubernetes/Helm.mjs
+++ b/scripts/migration-tool/lib/infra/kubernetes/Helm.mjs
@@ -16,7 +16,7 @@ export class Helm {
     }
 
     async installOrUpgrade(releaseName, chartName, options = {}) {
-        const { valuesFile, valuesFiles, wait = false, createNamespace = false, version, set = {}, reuseValues = false } = options;
+        const { valuesFile, valuesFiles, wait = false, createNamespace = false, version, set = {}, reuseValues = false, timeout } = options;
         const flags = ['--install', releaseName, chartName, '-n', this.namespace];
 
         if (valuesFiles?.length) {
@@ -28,6 +28,7 @@ export class Helm {
         if (createNamespace) flags.push('--create-namespace');
         if (reuseValues) flags.push('--reuse-values');
         if (version) flags.push('--version', version);
+        if (timeout) flags.push('--timeout', timeout);
 
         for (const [key, value] of Object.entries(set)) {
             flags.push('--set', `${key}=${value}`);

--- a/scripts/migration-tool/lib/infra/kubernetes/Kubectl.mjs
+++ b/scripts/migration-tool/lib/infra/kubernetes/Kubectl.mjs
@@ -65,6 +65,31 @@ export class Kubectl {
     }
 
     /**
+     * Fetch logs for pods matching a label selector. Returns combined stdout as a string
+     * (empty string on failure — log fetching must never break a run).
+     * @param {string} selector - label selector, e.g. 'app.kubernetes.io/component=gateway'
+     * @param {{ since?: string, previous?: boolean }} [opts] - since: e.g. '120s' (passed as --since);
+     *        previous: also pull the crashed/restarted container's logs (--previous)
+     * @returns {Promise<string>}
+     */
+    async logs(selector, opts = {}) {
+        const args = ['logs', '-n', this.namespace, '-l', selector,
+            '--all-containers=true', '--prefix=true', '--tail=-1'];
+        if (opts.since) args.push(`--since=${opts.since}`);
+        try {
+            const cur = await this.shell`kubectl ${args}`.quiet().nothrow();
+            let out = cur.stdout ?? '';
+            if (opts.previous) {
+                const prev = await this.shell`kubectl ${[...args, '--previous']}`.quiet().nothrow();
+                if (prev.stdout) out += '\n' + prev.stdout;
+            }
+            return out;
+        } catch (e) {
+            return '';
+        }
+    }
+
+    /**
      * Wait for at least one pod matching the label selector to be ready.
      * @param {string} selector - e.g. 'app.kubernetes.io/name=mongodb'
      * @param {number} [timeoutSeconds=120]

--- a/scripts/migration-tool/lib/providers/K8sProvider.mjs
+++ b/scripts/migration-tool/lib/providers/K8sProvider.mjs
@@ -9,6 +9,7 @@ import { Kubectl } from '../infra/kubernetes/Kubectl.mjs';
 import { Helm } from '../infra/kubernetes/Helm.mjs';
 import { LicenseManager } from '../infra/kubernetes/LicenseManager.mjs';
 import { PortForwarder } from '../infra/kubernetes/PortForwarder.mjs';
+import { scanForErrors } from '../infra/LogScanner.mjs';
 
 /**
  * K8sProvider version 2.0 - Refactored for modularity and TDD.
@@ -38,6 +39,7 @@ export class K8sProvider extends BaseProvider {
         // Multi-dataplane: list of { name, valuesPath, component } (am-mapi, am-gateway-dp1, am-gateway-dp2)
         this.releases = options.releases || [];
         this.valuesPath = options.valuesPath || Config.k8s.valuesPath;
+        this.registry = options.registry;
 
         this.clusterName = options.clusterName || 'am-migration';
         this.pids = { mapi: null, gatewayDp1: null, gatewayDp2: null, ui: null };
@@ -138,13 +140,58 @@ export class K8sProvider extends BaseProvider {
      * Orchestrator merges this into process.env before running tests; test setup files use these or defaults.
      */
     getTestEnv() {
+        const env = typeof this.databaseStrategy?.getSeedEnv === 'function' ? { ...this.databaseStrategy.getSeedEnv() } : {};
         if (this.releases?.length > 0) {
-            return {
-                AM_GATEWAY_URL: 'http://localhost:8091',
-                AM_DOMAIN_DATA_PLANE_ID: 'dp1',
-            };
+            env.AM_GATEWAY_URL = 'http://localhost:8091';
+            env.AM_DOMAIN_DATA_PLANE_ID = 'dp1';
+            // Second data plane (dp2 gateway port-forwarded to 8092): drives the seed to create a
+            // duplicate domain on dp2 and lets the gateway tests target it.
+            if (this.releases.some((r) => r.name === 'am-gateway-dp2')) {
+                env.AM_GATEWAY_URL_DP2 = 'http://localhost:8092';
+                env.AM_DOMAIN_DATA_PLANE_ID_DP2 = 'dp2';
+            }
         }
-        return {};
+        return env;
+    }
+
+    /**
+     * Scan Gateway/MAPI pod logs for ERROR-level lines and print a non-fatal summary.
+     * Report-only: never throws on findings; the returned count is informational.
+     * @param {{ since?: string }} [opts] - since: time window passed to `kubectl logs --since`
+     * @returns {Promise<number>} total ERROR lines found across all components
+     */
+    async scanLogsForErrors({ since } = {}) {
+        // Map releases -> component label selectors. The gravitee/am chart labels pods with
+        // app.kubernetes.io/component = management-api | gateway, scoped to the release instance.
+        const targets = [];
+        if (this.releases.length > 0) {
+            for (const r of this.releases) {
+                const comp = r.component === 'mapi' ? 'management-api' : 'gateway';
+                targets.push({
+                    name: r.name,
+                    selector: `app.kubernetes.io/instance=${r.name},app.kubernetes.io/component=${comp}`
+                });
+            }
+        } else {
+            targets.push({ name: 'am-management-api', selector: 'app.kubernetes.io/component=management-api' });
+            targets.push({ name: 'am-gateway', selector: 'app.kubernetes.io/component=gateway' });
+        }
+
+        let total = 0;
+        for (const t of targets) {
+            const text = await this.kubectl.logs(t.selector, { since, previous: true });
+            const { count, lines } = scanForErrors(text, t.name);
+            if (count > 0) {
+                total += count;
+                console.warn(`⚠️  ${count} ERROR line(s) in ${t.name}:`);
+                for (const l of lines.slice(0, 50)) console.warn(`    ${l}`);
+                if (count > 50) console.warn(`    …(${count - 50} more)`);
+            }
+        }
+        if (total === 0) {
+            console.log('✅ No ERROR lines in Gateway/MAPI logs for this window.');
+        }
+        return total; // returned but NOT thrown on — report-only
     }
 
     async setup() {
@@ -217,7 +264,9 @@ export class K8sProvider extends BaseProvider {
 
     async deploy(version) {
         console.log(`🚀 Deploying AM version ${version}...`);
-        await validateAmImageTag(version);
+        if (!this.registry) {
+            await validateAmImageTag(version);
+        }
 
         const licenseBase64 = await this.licenseManager.getLicenseBase64();
 
@@ -232,8 +281,10 @@ export class K8sProvider extends BaseProvider {
                     set['api.image.tag'] = version;
                     set['gateway.image.tag'] = version;
                     set['ui.image.tag'] = version;
+                    Object.assign(set, this.getRegistrySet(['api', 'gateway', 'ui']));
                 } else {
                     set['gateway.image.tag'] = version;
+                    Object.assign(set, this.getRegistrySet(['gateway']));
                 }
                 const valuesOpt = Array.isArray(r.valuesPath) ? { valuesFiles: r.valuesPath } : { valuesFile: r.valuesPath };
                 await this.helm.installOrUpgrade(r.name, 'graviteeio/am', {
@@ -241,6 +292,7 @@ export class K8sProvider extends BaseProvider {
                     wait: true,
                     createNamespace: true,
                     version: Config.k8s.amChartVersion,
+                    timeout: '15m',
                     set
                 });
             }
@@ -251,12 +303,14 @@ export class K8sProvider extends BaseProvider {
                 wait: true,
                 createNamespace: true,
                 version: Config.k8s.amChartVersion,
+                timeout: '15m',
                 set: {
                     'api.image.tag': version,
                     'gateway.image.tag': version,
                     'ui.image.tag': version,
                     'license.key': licenseBase64,
-                    'license.name': 'am-license-v4'
+                    'license.name': 'am-license-v4',
+                    ...this.getRegistrySet(['api', 'gateway', 'ui'])
                 }
             });
         }
@@ -287,9 +341,17 @@ export class K8sProvider extends BaseProvider {
         }
     }
 
+    async prepareTests() {
+        if (!this.pids.mapi && !this.pids.gatewayDp1 && !this.pids.gatewayDp2 && !this.pids.ui) {
+            await this.startTunnels();
+        }
+    }
+
     async upgradeMapi(toTag) {
         console.log(`🆙 Updating Management API to ${toTag}...`);
-        await validateAmImageTag(toTag);
+        if (!this.registry) {
+            await validateAmImageTag(toTag);
+        }
         if (this.releases.length > 0) {
             const mapiRelease = this.releases.find(r => r.component === 'mapi');
             if (mapiRelease) {
@@ -297,7 +359,8 @@ export class K8sProvider extends BaseProvider {
                 await this.helm.installOrUpgrade(mapiRelease.name, 'graviteeio/am', {
                     ...valuesOpt,
                     version: Config.k8s.amChartVersion,
-                    set: { 'api.image.tag': toTag, 'ui.image.tag': toTag },
+                    timeout: '15m',
+                    set: { 'api.image.tag': toTag, 'ui.image.tag': toTag, ...this.getRegistrySet(['api', 'ui']) },
                     reuseValues: true,
                     wait: true
                 });
@@ -307,12 +370,13 @@ export class K8sProvider extends BaseProvider {
             await this.helm.installOrUpgrade('am', 'graviteeio/am', {
                 ...valuesOpt,
                 version: Config.k8s.amChartVersion,
-                set: { 'api.image.tag': toTag, 'ui.image.tag': toTag },
+                timeout: '15m',
+                set: { 'api.image.tag': toTag, 'ui.image.tag': toTag, ...this.getRegistrySet(['api', 'ui']) },
                 reuseValues: true,
                 wait: true
             });
         }
-        // Restart API/UI port-forwards so they target the new pod; otherwise verify-mapi gets "socket hang up"
+        // Restart API/UI port-forwards so they target the new pod; otherwise the post-mapi-upgrade verify stages get "socket hang up"
         await this.restartApiTunnels();
     }
 
@@ -369,7 +433,9 @@ export class K8sProvider extends BaseProvider {
 
     async upgradeGw(toTag) {
         console.log(`🆙 Updating Gateway to ${toTag}...`);
-        await validateAmImageTag(toTag);
+        if (!this.registry) {
+            await validateAmImageTag(toTag);
+        }
         if (this.releases.length > 0) {
             const gatewayReleases = this.releases.filter(r => r.component === 'gateway');
             for (const r of gatewayReleases) {
@@ -377,7 +443,8 @@ export class K8sProvider extends BaseProvider {
                 await this.helm.installOrUpgrade(r.name, 'graviteeio/am', {
                     ...valuesOpt,
                     version: Config.k8s.amChartVersion,
-                    set: { 'gateway.image.tag': toTag },
+                    timeout: '15m',
+                    set: { 'gateway.image.tag': toTag, ...this.getRegistrySet(['gateway']) },
                     reuseValues: true,
                     wait: true
                 });
@@ -387,12 +454,28 @@ export class K8sProvider extends BaseProvider {
             await this.helm.installOrUpgrade('am', 'graviteeio/am', {
                 ...valuesOpt,
                 version: Config.k8s.amChartVersion,
-                set: { 'gateway.image.tag': toTag },
+                timeout: '15m',
+                set: { 'gateway.image.tag': toTag, ...this.getRegistrySet(['gateway']) },
                 reuseValues: true,
                 wait: true
             });
         }
-        // Restart gateway port-forwards so they target the new pods; otherwise verify-all gets "socket hang up"
+        // Restart gateway port-forwards so they target the new pods; otherwise the post-gw-upgrade verify stages get "socket hang up"
         await this.restartGatewayTunnels();
+    }
+
+    getRegistrySet(components) {
+        if (!this.registry) {
+            return {};
+        }
+        const repositories = {
+            api: `${this.registry}/graviteeio/am-management-api`,
+            gateway: `${this.registry}/graviteeio/am-gateway`,
+            ui: `${this.registry}/graviteeio/am-management-ui`
+        };
+        return components.reduce((set, component) => ({
+            ...set,
+            [`${component}.image.repository`]: repositories[component]
+        }), {});
     }
 }

--- a/scripts/migration-tool/lib/strategies/database/MongoK8sStrategy.mjs
+++ b/scripts/migration-tool/lib/strategies/database/MongoK8sStrategy.mjs
@@ -26,11 +26,11 @@ export class MongoK8sStrategy extends DatabaseStrategy {
             const rootPassword = process.env.MONGODB_ROOT_PASSWORD || 'migration-test-only';
             // Inject via env in CI to avoid hardcoded secrets (Aqua scan); default for local only.
             const graviteePassword = process.env.MONGODB_GRAVITEE_PASSWORD || 'gravitee-password';
-            // Bitnami chart expects one password per user (parallel to auth.usernames); comma-separated when multiple; same password for gravitee on all three DBs
-            const passwordsForUsers = [graviteePassword, graviteePassword, graviteePassword].join(',');
+            // Single 'gravitee' user (parallel to auth.usernames in db-mongodb.yaml). Access to the
+            // dataplane DBs (gravitee-dp1/dp2) is granted via initdbScripts, so only one password is needed.
             await this.kubectl.createSecretGeneric(MONGODB_AUTH_SECRET_NAME, {
                 'mongodb-root-password': rootPassword,
-                'mongodb-passwords': passwordsForUsers
+                'mongodb-passwords': graviteePassword
             });
         }
 
@@ -39,7 +39,9 @@ export class MongoK8sStrategy extends DatabaseStrategy {
         await this.helm.installOrUpgrade(this.releaseName, this.chartName, {
             valuesFile: this.config.k8s.mongoValuesPath,
             wait: true,
-            createNamespace: true
+            createNamespace: true,
+            timeout: '10m',
+            set: { namespaceOverride: this.namespace }
         });
     }
 
@@ -54,5 +56,19 @@ export class MongoK8sStrategy extends DatabaseStrategy {
     async waitForReady() {
         if (!this.kubectl) return;
         await this.kubectl.waitForPodReady('app.kubernetes.io/name=mongodb', 120);
+    }
+
+    /**
+     * Connection details for the seed's custom Mongo identity provider.
+     * Consumed by the AM pods (not the test process), so it must use in-cluster DNS
+     * (mongo-mongodb), the gravitee user's credentials, and a database that user can
+     * access (gravitee/gravitee-dp1/gravitee-dp2 per db-mongodb.yaml).
+     */
+    getSeedEnv() {
+        const graviteePassword = process.env.MONGODB_GRAVITEE_PASSWORD || 'gravitee-password';
+        return {
+            AM_INTERNAL_MONGODB_URI: `mongodb://gravitee:${graviteePassword}@mongo-mongodb:27017/gravitee?serverSelectionTimeoutMS=30000`,
+            AM_INTERNAL_MONGODB_DATABASE: 'gravitee',
+        };
     }
 }

--- a/scripts/migration-tool/lib/strategies/database/PostgresK8sStrategy.mjs
+++ b/scripts/migration-tool/lib/strategies/database/PostgresK8sStrategy.mjs
@@ -32,4 +32,22 @@ export class PostgresK8sStrategy extends DatabaseStrategy {
         if (!this.kubectl) return;
         await this.kubectl.waitForPodReady('app.kubernetes.io/name=postgres', 120);
     }
+
+    /**
+     * Connection details for the seed's custom JDBC identity provider, plus the REPOSITORY_TYPE
+     * discriminator the seed reads to build a Postgres (rather than Mongo) IdP. Consumed by the
+     * AM pods (not the test process), so the host uses in-cluster DNS (postgres-postgresql) and
+     * the gravitee user's credentials against a database that user owns (gravitee-am).
+     */
+    getSeedEnv() {
+        const password = process.env.POSTGRES_GRAVITEE_PASSWORD || 'gravitee-password';
+        return {
+            REPOSITORY_TYPE: 'jdbc',
+            AM_INTERNAL_POSTGRES_HOST: 'postgres-postgresql',
+            AM_INTERNAL_POSTGRES_PORT: '5432',
+            AM_INTERNAL_POSTGRES_DATABASE: 'gravitee-am',
+            AM_INTERNAL_POSTGRES_USER: 'gravitee',
+            AM_INTERNAL_POSTGRES_PASSWORD: password,
+        };
+    }
 }

--- a/scripts/migration-tool/test/unit/Helm.test.mjs
+++ b/scripts/migration-tool/test/unit/Helm.test.mjs
@@ -69,6 +69,17 @@ describe('Helm', () => {
         expect(flags[fIndexes[1] + 1]).toBe('am-mongodb-mapi.yaml');
     });
 
+    test('should pass a custom wait timeout to Helm', async () => {
+        await helm.installOrUpgrade('mongo', 'bitnami/mongodb', {
+            wait: true,
+            timeout: '10m'
+        });
+
+        const flags = mockShell.mock.calls[0][1];
+        expect(flags).toContain('--timeout');
+        expect(flags).toContain('10m');
+    });
+
     test('should add a repository', async () => {
         await helm.repoAdd('bitnami', 'https://charts.bitnami.com/bitnami');
 

--- a/scripts/migration-tool/test/unit/K8sProvider.test.mjs
+++ b/scripts/migration-tool/test/unit/K8sProvider.test.mjs
@@ -5,6 +5,7 @@ jest.unstable_mockModule('../../lib/core/VersionValidator.mjs', () => ({
 }));
 
 const { K8sProvider } = await import('../../lib/providers/K8sProvider.mjs');
+const { validateAmImageTag } = await import('../../lib/core/VersionValidator.mjs');
 
 /**
  * TDD for Refactored K8sProvider
@@ -18,6 +19,7 @@ describe('K8sProvider', () => {
     let mockDatabaseStrategy;
 
     beforeEach(() => {
+        jest.clearAllMocks();
         mockHelm = {
             repoAdd: jest.fn(),
             repoUpdate: jest.fn(),
@@ -42,7 +44,11 @@ describe('K8sProvider', () => {
         mockDatabaseStrategy = {
             deploy: jest.fn(),
             clean: jest.fn(),
-            waitForReady: jest.fn()
+            waitForReady: jest.fn(),
+            getSeedEnv: jest.fn().mockReturnValue({
+                AM_INTERNAL_MONGODB_URI: 'mongodb://gravitee:gravitee-password@mongo-mongodb:27017/gravitee',
+                AM_INTERNAL_MONGODB_DATABASE: 'gravitee'
+            })
         };
 
         provider = new K8sProvider({
@@ -76,6 +82,12 @@ describe('K8sProvider', () => {
         await provider.cleanup();
         expect(mockPortForwarder.stop).toHaveBeenCalledWith(123);
         expect(mockPortForwarder.stop).toHaveBeenCalledWith(456);
+    });
+
+    test('getTestEnv exposes the database strategy seed env so the seed Mongo IDP gets a valid uri', () => {
+        const env = provider.getTestEnv();
+        expect(env.AM_INTERNAL_MONGODB_URI).toBe('mongodb://gravitee:gravitee-password@mongo-mongodb:27017/gravitee');
+        expect(env.AM_INTERNAL_MONGODB_DATABASE).toBe('gravitee');
     });
 
     test('ensureCluster returns when cluster is reachable (no kind create)', async () => {
@@ -163,12 +175,40 @@ describe('K8sProvider', () => {
             valuesFiles: ['scripts/migration-tool/env/k8s/am/am-mongodb-common.yaml', 'scripts/migration-tool/env/k8s/am/am-mongodb-mapi.yaml'],
             createNamespace: true,
             version: '4.7.0',
+            timeout: '15m',
             set: expect.objectContaining({
                 'api.image.tag': appVersion,
                 'gateway.image.tag': appVersion,
                 'ui.image.tag': appVersion,
                 'license.key': 'dGVzdC1saWNlbnNl',
                 'license.name': 'am-license-v4'
+            })
+        }));
+    });
+
+    test('should override image repositories and skip Docker Hub validation when registry is configured', async () => {
+        provider = new K8sProvider({
+            namespace: 'gravitee-am',
+            valuesPath: ['scripts/migration-tool/env/k8s/am/am-mongodb-common.yaml', 'scripts/migration-tool/env/k8s/am/am-mongodb-mapi.yaml'],
+            helm: mockHelm,
+            kubectl: mockKubectl,
+            licenseManager: mockLicenseManager,
+            portForwarder: mockPortForwarder,
+            databaseStrategy: mockDatabaseStrategy,
+            registry: 'graviteeio.azurecr.io'
+        });
+
+        await provider.deploy('master-latest');
+
+        expect(validateAmImageTag).not.toHaveBeenCalledWith('master-latest');
+        expect(mockHelm.installOrUpgrade).toHaveBeenCalledWith('am', 'graviteeio/am', expect.objectContaining({
+            set: expect.objectContaining({
+                'api.image.repository': 'graviteeio.azurecr.io/graviteeio/am-management-api',
+                'gateway.image.repository': 'graviteeio.azurecr.io/graviteeio/am-gateway',
+                'ui.image.repository': 'graviteeio.azurecr.io/graviteeio/am-management-ui',
+                'api.image.tag': 'master-latest',
+                'gateway.image.tag': 'master-latest',
+                'ui.image.tag': 'master-latest'
             })
         }));
     });
@@ -207,7 +247,11 @@ describe('K8sProvider with releases (multi-dataplane)', () => {
         mockDatabaseStrategy = {
             deploy: jest.fn(),
             clean: jest.fn(),
-            waitForReady: jest.fn()
+            waitForReady: jest.fn(),
+            getSeedEnv: jest.fn().mockReturnValue({
+                AM_INTERNAL_MONGODB_URI: 'mongodb://gravitee:gravitee-password@mongo-mongodb:27017/gravitee',
+                AM_INTERNAL_MONGODB_DATABASE: 'gravitee'
+            })
         };
 
         provider = new K8sProvider({
@@ -236,11 +280,20 @@ describe('K8sProvider with releases (multi-dataplane)', () => {
         expect(mockPortForwarder.forceKillPort).toHaveBeenCalledWith(8002);
     });
 
+    test('getTestEnv exposes both data planes (gateway URLs + ids) for seeding and gateway tests', () => {
+        const env = provider.getTestEnv();
+        expect(env.AM_GATEWAY_URL).toBe('http://localhost:8091');
+        expect(env.AM_DOMAIN_DATA_PLANE_ID).toBe('dp1');
+        expect(env.AM_GATEWAY_URL_DP2).toBe('http://localhost:8092');
+        expect(env.AM_DOMAIN_DATA_PLANE_ID_DP2).toBe('dp2');
+    });
+
     test('deploy should installOrUpgrade three releases with per-release license secret name', async () => {
         await provider.deploy('4.10.0');
         expect(mockHelm.installOrUpgrade).toHaveBeenCalledTimes(3);
         expect(mockHelm.installOrUpgrade).toHaveBeenNthCalledWith(1, 'am-mapi', 'graviteeio/am', expect.objectContaining({
             valuesFile: '/am/am-mapi.yaml',
+            timeout: '15m',
             set: expect.objectContaining({
                 'api.image.tag': '4.10.0',
                 'gateway.image.tag': '4.10.0',
@@ -250,6 +303,7 @@ describe('K8sProvider with releases (multi-dataplane)', () => {
         }));
         expect(mockHelm.installOrUpgrade).toHaveBeenNthCalledWith(2, 'am-gateway-dp1', 'graviteeio/am', expect.objectContaining({
             valuesFile: '/am/am-gw-dp1.yaml',
+            timeout: '15m',
             set: expect.objectContaining({
                 'gateway.image.tag': '4.10.0',
                 'license.name': 'am-gateway-dp1-license'
@@ -257,6 +311,7 @@ describe('K8sProvider with releases (multi-dataplane)', () => {
         }));
         expect(mockHelm.installOrUpgrade).toHaveBeenNthCalledWith(3, 'am-gateway-dp2', 'graviteeio/am', expect.objectContaining({
             valuesFile: '/am/am-gw-dp2.yaml',
+            timeout: '15m',
             set: expect.objectContaining({
                 'gateway.image.tag': '4.10.0',
                 'license.name': 'am-gateway-dp2-license'
@@ -271,5 +326,14 @@ describe('K8sProvider with releases (multi-dataplane)', () => {
         expect(mockPortForwarder.start).toHaveBeenCalledWith('svc/am-gateway-dp1-gateway', 8091, 82);
         expect(mockPortForwarder.start).toHaveBeenCalledWith('svc/am-gateway-dp2-gateway', 8092, 82);
         expect(mockPortForwarder.start).toHaveBeenCalledTimes(4);
+    });
+
+    test('prepareTests should start tunnels when running a verify stage in a new process', async () => {
+        await provider.prepareTests();
+
+        expect(mockPortForwarder.start).toHaveBeenCalledWith('svc/am-mapi-management-api', 8093, 83);
+        expect(mockPortForwarder.start).toHaveBeenCalledWith('svc/am-mapi-management-ui', 8002, 8002);
+        expect(mockPortForwarder.start).toHaveBeenCalledWith('svc/am-gateway-dp1-gateway', 8091, 82);
+        expect(mockPortForwarder.start).toHaveBeenCalledWith('svc/am-gateway-dp2-gateway', 8092, 82);
     });
 });

--- a/scripts/migration-tool/test/unit/Kubectl.test.mjs
+++ b/scripts/migration-tool/test/unit/Kubectl.test.mjs
@@ -114,4 +114,53 @@ describe('Kubectl', () => {
             'Kubernetes cluster unreachable. Start a local cluster first (e.g. kind create cluster --name am-migration).'
         );
     });
+
+    test('logs returns pod stdout for a selector', async () => {
+        mockShell.mockImplementation(() => {
+            const session = Promise.resolve({ stdout: 'line1\nERROR boom' });
+            session.quiet = () => session;
+            session.nothrow = () => session;
+            return session;
+        });
+
+        const out = await kubectl.logs('app.kubernetes.io/component=gateway');
+
+        expect(out).toContain('ERROR boom');
+        const args = mockShell.mock.calls[0][1]; // first interpolated value = args array
+        expect(args).toEqual(expect.arrayContaining(['logs', '-l', 'app.kubernetes.io/component=gateway']));
+        expect(args).not.toContain('--previous');
+    });
+
+    test('logs appends previous-container logs when previous:true', async () => {
+        const responses = [
+            { stdout: 'current ERROR a' },
+            { stdout: 'previous ERROR b' }
+        ];
+        let call = 0;
+        mockShell.mockImplementation(() => {
+            const session = Promise.resolve(responses[call++] ?? { stdout: '' });
+            session.quiet = () => session;
+            session.nothrow = () => session;
+            return session;
+        });
+
+        const out = await kubectl.logs('app=gateway', { since: '120s', previous: true });
+
+        expect(out).toContain('current ERROR a');
+        expect(out).toContain('previous ERROR b');
+        const firstArgs = mockShell.mock.calls[0][1];
+        expect(firstArgs).toContain('--since=120s');
+        const secondArgs = mockShell.mock.calls[1][1];
+        expect(secondArgs).toContain('--previous');
+    });
+
+    test('logs returns empty string on failure (never throws)', async () => {
+        mockShell.mockImplementation(() => {
+            const session = Promise.reject(new Error('no such pod'));
+            session.quiet = () => session;
+            session.nothrow = () => session;
+            return session;
+        });
+        await expect(kubectl.logs('app=gateway')).resolves.toBe('');
+    });
 });

--- a/scripts/migration-tool/test/unit/LogScanner.test.mjs
+++ b/scripts/migration-tool/test/unit/LogScanner.test.mjs
@@ -1,0 +1,52 @@
+import { scanForErrors } from '../../lib/infra/LogScanner.mjs';
+
+/**
+ * Unit tests for the ERROR-line scanner used to surface Gateway/MAPI stdout errors.
+ */
+describe('LogScanner.scanForErrors', () => {
+    const errorBlock = [
+        '10:23:45.123 [vert.x-eventloop-thread-1] [domain-1] INFO  i.g.a.g.Handler - started',
+        '10:23:46.001 [vert.x-eventloop-thread-1] [domain-1] WARN  i.g.a.g.Handler - slow response',
+        '10:23:47.456 [vert.x-eventloop-thread-1] [domain-1] ERROR i.g.a.g.Handler - NullPointerException',
+        '\tat io.gravitee.am.gateway.Handler.handle(Handler.java:42)'
+    ].join('\n');
+
+    test('finds a single ERROR line in a logback block', () => {
+        const { count, lines } = scanForErrors(errorBlock, 'am-gateway-dp1');
+        expect(count).toBe(1);
+        expect(lines[0]).toContain('ERROR i.g.a.g.Handler - NullPointerException');
+    });
+
+    test('returns the source label', () => {
+        const { source } = scanForErrors(errorBlock, 'am-gateway-dp1');
+        expect(source).toBe('am-gateway-dp1');
+    });
+
+    test('returns zero for a clean INFO/WARN block', () => {
+        const clean = [
+            '10:23:45.123 [thread] [domain-1] INFO  i.g.a.Boot - ready',
+            '10:23:46.001 [thread] [domain-1] WARN  i.g.a.Boot - deprecated config',
+            '10:23:46.500 [thread] [domain-1] DEBUG i.g.a.Boot - ERRORS=0 retries' // "ERRORS" must not match
+        ].join('\n');
+        const { count } = scanForErrors(clean, 'am-mapi');
+        expect(count).toBe(0);
+    });
+
+    test('matches even with a kubectl --prefix pod tag prepended', () => {
+        const prefixed = '[pod/am-gateway-dp1-abc/gateway] 10:23:47.456 [t] [d] ERROR i.g.a.X - boom';
+        const { count } = scanForErrors(prefixed);
+        expect(count).toBe(1);
+    });
+
+    test('counts multiple ERROR lines', () => {
+        const text = errorBlock + '\n10:24:00.000 [t] [d] ERROR i.g.a.Y - second failure';
+        const { count } = scanForErrors(text);
+        expect(count).toBe(2);
+    });
+
+    test('handles empty / nullish input safely', () => {
+        expect(scanForErrors('').count).toBe(0);
+        expect(scanForErrors(undefined).count).toBe(0);
+        expect(scanForErrors(null).count).toBe(0);
+    });
+});

--- a/scripts/migration-tool/test/unit/MongoK8sStrategy.test.mjs
+++ b/scripts/migration-tool/test/unit/MongoK8sStrategy.test.mjs
@@ -36,7 +36,8 @@ describe('MongoK8sStrategy', () => {
             expect.objectContaining({
                 valuesFile: 'scripts/migration-tool/env/k8s/db/db-mongodb.yaml',
                 createNamespace: true,
-                wait: true
+                wait: true,
+                timeout: '10m'
             })
         );
     });
@@ -44,6 +45,22 @@ describe('MongoK8sStrategy', () => {
     test('should clean mongo', async () => {
         await strategy.clean();
         expect(mockHelm.uninstall).toHaveBeenCalledWith('mongo');
+    });
+
+    test('deploy sets the chart namespaceOverride to the configured namespace (not hardcoded gravitee-am)', async () => {
+        strategy = new MongoK8sStrategy({
+            helm: mockHelm,
+            namespace: 'custom-ns',
+            config: mockConfig
+        });
+        await strategy.deploy();
+        expect(mockHelm.installOrUpgrade).toHaveBeenCalledWith(
+            'mongo',
+            'bitnami/mongodb',
+            expect.objectContaining({
+                set: expect.objectContaining({ namespaceOverride: 'custom-ns' })
+            })
+        );
     });
 
     test('when kubectl is provided, should ensure namespace and create auth secret before deploy', async () => {
@@ -64,7 +81,7 @@ describe('MongoK8sStrategy', () => {
             'mongo-mongodb-auth',
             expect.objectContaining({
                 'mongodb-root-password': expect.any(String),
-                'mongodb-passwords': 'gravitee-password,gravitee-password,gravitee-password'
+                'mongodb-passwords': 'gravitee-password'
             })
         );
         expect(mockHelm.installOrUpgrade).toHaveBeenCalled();
@@ -87,6 +104,25 @@ describe('MongoK8sStrategy', () => {
         expect(mockKubectl.deleteSecret).toHaveBeenCalledWith('mongo-mongodb-auth');
     });
 
+    test('getSeedEnv exposes in-cluster mongo uri and accessible database for the seed', () => {
+        const env = strategy.getSeedEnv();
+        expect(env.AM_INTERNAL_MONGODB_URI).toBe(
+            'mongodb://gravitee:gravitee-password@mongo-mongodb:27017/gravitee?serverSelectionTimeoutMS=30000'
+        );
+        expect(env.AM_INTERNAL_MONGODB_DATABASE).toBe('gravitee');
+    });
+
+    test('getSeedEnv uses injected gravitee password in the uri', () => {
+        const prev = process.env.MONGODB_GRAVITEE_PASSWORD;
+        process.env.MONGODB_GRAVITEE_PASSWORD = 'injected-secret';
+        try {
+            expect(strategy.getSeedEnv().AM_INTERNAL_MONGODB_URI).toContain('gravitee:injected-secret@mongo-mongodb:27017');
+        } finally {
+            if (prev !== undefined) process.env.MONGODB_GRAVITEE_PASSWORD = prev;
+            else delete process.env.MONGODB_GRAVITEE_PASSWORD;
+        }
+    });
+
     test('when MONGODB_GRAVITEE_PASSWORD is set, secret uses injected password', async () => {
         const prev = process.env.MONGODB_GRAVITEE_PASSWORD;
         process.env.MONGODB_GRAVITEE_PASSWORD = 'injected-secret';
@@ -106,7 +142,7 @@ describe('MongoK8sStrategy', () => {
             expect(mockKubectl.createSecretGeneric).toHaveBeenCalledWith(
                 'mongo-mongodb-auth',
                 expect.objectContaining({
-                    'mongodb-passwords': 'injected-secret,injected-secret,injected-secret'
+                    'mongodb-passwords': 'injected-secret'
                 })
             );
         } finally {

--- a/scripts/migration-tool/test/unit/Orchestrator.test.mjs
+++ b/scripts/migration-tool/test/unit/Orchestrator.test.mjs
@@ -58,4 +58,70 @@ describe('Orchestrator', () => {
         expect(mockProvider.upgradeMapi).toHaveBeenCalledWith('4.10.0');
         expect(mockProvider.upgradeGw).toHaveBeenCalledWith('4.10.0');
     });
+
+    test('seed-alpha stage seeds the from-tag version under the alpha label', async () => {
+        orchestrator.runSeed = jest.fn();
+
+        await orchestrator.run(['seed-alpha']);
+
+        expect(orchestrator.runSeed).toHaveBeenCalledWith(['--version', '4.10', '--label', 'alpha']);
+    });
+
+    test('seed-beta stage seeds the to-tag version under the beta label', async () => {
+        options.toTag = '4.11.0';
+        orchestrator.runSeed = jest.fn();
+
+        await orchestrator.run(['seed-beta']);
+
+        expect(orchestrator.runSeed).toHaveBeenCalledWith(['--version', '4.11', '--label', 'beta']);
+    });
+
+    test('seed-beta seeds the to-tag version even for a same-minor (patch) migration', async () => {
+        options.fromTag = '4.10.7';
+        options.toTag = '4.10.8';
+        orchestrator.runSeed = jest.fn();
+
+        await orchestrator.run(['seed-beta']);
+
+        expect(orchestrator.runSeed).toHaveBeenCalledWith(['--version', '4.10', '--label', 'beta']);
+    });
+
+    test('seed / seed-upgrade remain available as backward-compatible aliases', async () => {
+        options.toTag = '4.11.0';
+        orchestrator.runSeed = jest.fn();
+
+        await orchestrator.run(['seed']);
+        await orchestrator.run(['seed-upgrade']);
+
+        expect(orchestrator.runSeed).toHaveBeenNthCalledWith(1, ['--version', '4.10', '--label', 'alpha']);
+        expect(orchestrator.runSeed).toHaveBeenNthCalledWith(2, ['--version', '4.11', '--label', 'beta']);
+    });
+
+    test('verify-alpha asserts the alpha channel', async () => {
+        options.toTag = '4.11.8';
+        orchestrator.runTests = jest.fn();
+
+        await orchestrator.run(['verify-alpha']);
+
+        expect(orchestrator.runTests).toHaveBeenCalledWith(expect.any(String), 'ci:migration', 'specs/migration', 'alpha');
+    });
+
+    test('verify-beta asserts the beta channel', async () => {
+        options.toTag = '4.11.8';
+        orchestrator.runTests = jest.fn();
+
+        await orchestrator.run(['verify-beta']);
+
+        expect(orchestrator.runTests).toHaveBeenCalledWith(expect.any(String), 'ci:migration', 'specs/migration', 'beta');
+    });
+
+    test('migration tests should default to the alpha label', () => {
+        expect(orchestrator.getMigrationTestLabel()).toBe('alpha');
+    });
+
+    test('migration tests should use explicit testLabel when provided', () => {
+        options.testLabel = 'beta';
+
+        expect(orchestrator.getMigrationTestLabel()).toBe('beta');
+    });
 });

--- a/scripts/migration-tool/test/unit/PostgresK8sStrategy.test.mjs
+++ b/scripts/migration-tool/test/unit/PostgresK8sStrategy.test.mjs
@@ -41,4 +41,25 @@ describe('PostgresK8sStrategy', () => {
         await strategy.clean();
         expect(mockHelm.uninstall).toHaveBeenCalledWith('postgres');
     });
+
+    test('getSeedEnv signals jdbc mode and exposes in-cluster postgres connection for the seed', () => {
+        const env = strategy.getSeedEnv();
+        expect(env.REPOSITORY_TYPE).toBe('jdbc');
+        expect(env.AM_INTERNAL_POSTGRES_HOST).toBe('postgres-postgresql');
+        expect(env.AM_INTERNAL_POSTGRES_PORT).toBe('5432');
+        expect(env.AM_INTERNAL_POSTGRES_DATABASE).toBe('gravitee-am');
+        expect(env.AM_INTERNAL_POSTGRES_USER).toBe('gravitee');
+        expect(env.AM_INTERNAL_POSTGRES_PASSWORD).toBe('gravitee-password');
+    });
+
+    test('getSeedEnv uses injected gravitee password when provided', () => {
+        const prev = process.env.POSTGRES_GRAVITEE_PASSWORD;
+        process.env.POSTGRES_GRAVITEE_PASSWORD = 'injected-secret';
+        try {
+            expect(strategy.getSeedEnv().AM_INTERNAL_POSTGRES_PASSWORD).toBe('injected-secret');
+        } finally {
+            if (prev !== undefined) process.env.POSTGRES_GRAVITEE_PASSWORD = prev;
+            else delete process.env.POSTGRES_GRAVITEE_PASSWORD;
+        }
+    });
 });

--- a/scripts/migration-tool/test/unit/VersionResolver.test.mjs
+++ b/scripts/migration-tool/test/unit/VersionResolver.test.mjs
@@ -1,0 +1,89 @@
+import { jest } from '@jest/globals';
+
+const { isConcreteVersion, resolveFloatingTag } = await import('../../lib/core/VersionResolver.mjs');
+
+describe('isConcreteVersion', () => {
+    it('accepts plain X.Y.Z', () => {
+        expect(isConcreteVersion('4.11.9')).toBe(true);
+    });
+    it('rejects floating and variant tags', () => {
+        for (const t of ['latest', '4', '4.11', '4.11.9-debian', 'latest-noble']) {
+            expect(isConcreteVersion(t)).toBe(false);
+        }
+    });
+});
+
+describe('resolveFloatingTag', () => {
+    afterEach(() => {
+        delete global.fetch;
+        jest.restoreAllMocks();
+    });
+
+    function mockHub({ tagDigest, pages }) {
+        // pages: array of arrays of {name, digest}
+        global.fetch = jest.fn(async (url) => {
+            if (url.includes('/tags/latest/') || url.includes('/tags/4.11/')) {
+                return { ok: true, json: async () => ({ name: 'x', digest: tagDigest }) };
+            }
+            const m = url.match(/[?&]page=(\d+)/);
+            const pageNum = m ? Number(m[1]) : 1;
+            const results = pages[pageNum - 1] || [];
+            return { ok: true, json: async () => ({ results, next: pageNum < pages.length ? 'more' : null }) };
+        });
+    }
+
+    it('returns concrete tag unchanged without any fetch', async () => {
+        global.fetch = jest.fn();
+        await expect(resolveFloatingTag('4.11.9')).resolves.toBe('4.11.9');
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('resolves latest to the X.Y.Z sharing its digest', async () => {
+        mockHub({
+            tagDigest: 'sha256:abc',
+            pages: [[
+                { name: 'latest', digest: 'sha256:abc' },
+                { name: '4', digest: 'sha256:abc' },
+                { name: '4.11', digest: 'sha256:abc' },
+                { name: '4.11.9', digest: 'sha256:abc' },
+                { name: '4.11.8', digest: 'sha256:other' },
+            ]],
+        });
+        await expect(resolveFloatingTag('latest')).resolves.toBe('4.11.9');
+    });
+
+    it('finds a match on a later page', async () => {
+        mockHub({
+            tagDigest: 'sha256:abc',
+            pages: [
+                [{ name: '4.10.5', digest: 'sha256:nope' }],
+                [{ name: '4.11.9', digest: 'sha256:abc' }],
+            ],
+        });
+        await expect(resolveFloatingTag('latest')).resolves.toBe('4.11.9');
+    });
+
+    it('throws when no X.Y.Z shares the digest', async () => {
+        mockHub({
+            tagDigest: 'sha256:abc',
+            pages: [[{ name: '4.11.9', digest: 'sha256:different' }]],
+        });
+        await expect(resolveFloatingTag('latest')).rejects.toThrow(/Could not resolve floating tag "latest"/);
+    });
+
+    it('throws when the tag lookup 404s', async () => {
+        global.fetch = jest.fn(async () => ({ ok: false, status: 404, json: async () => ({}) }));
+        await expect(resolveFloatingTag('latest')).rejects.toThrow(/latest/);
+    });
+
+    it('throws with HTTP status when a list-page returns a non-OK response', async () => {
+        global.fetch = jest.fn(async (url) => {
+            if (url.includes('/tags/latest/')) {
+                return { ok: true, json: async () => ({ name: 'latest', digest: 'sha256:abc' }) };
+            }
+            // First list page returns an error
+            return { ok: false, status: 500, json: async () => ({}) };
+        });
+        await expect(resolveFloatingTag('latest')).rejects.toThrow(/HTTP 500/);
+    });
+});


### PR DESCRIPTION
To test create local K8s cluster or use remote
`kind create cluster`

Mongo:
`AM_LICENSE_PATH=/home/lgw/Downloads/gravitee-universe-v4.key ./scripts/migration-test.mjs --from-tag 4.10.15 --to-tag 4.11.8 --provider k8s  run`

Postgres:
`AM_LICENSE_PATH=/home/lgw/Downloads/gravitee-universe-v4.key ./scripts/migration-test.mjs --from-tag 4.10.15 --to-tag 4.11.8 --provider k8s --db-type postgres run`

You can apply --namespace param to override default `gravitee-am` 

Sample output
```
🛠️ Running Migration Orchestration
📝 Tags: 4.10.15 -> 4.11.8

▶️ Stage: clean
🧹 Cleaning up K8s environment...
🗑️  Uninstalling Helm releases...
🧹 Cleaning up MongoDB...
🗝️  Cleaning up secrets...
💀 Deleting namespace: gravitee-am...
✅ Cleanup complete.

▶️ Stage: k8s:setup
🏗️  Setting up K8s environment...
🍃 Deploying standalone MongoDB...

▶️ Stage: deploy-from
🚀 Deploying AM version 4.10.15...
🔌 Starting port-forward: svc/am-mapi-management-api 8093:83...
🔌 Starting port-forward: svc/am-mapi-management-ui 8002:8002...
🔌 Starting port-forward: svc/am-gateway-dp1-gateway 8091:82...
🔌 Starting port-forward: svc/am-gateway-dp2-gateway 8092:82...

▶️ Stage: seed-baseline

> gravitee-am-test@4.10.0-SNAPSHOT migration:seed
> cross-env TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register -r tsconfig-paths/register migration-seeding/bootstrap.ts --version 4.10 --label alpha


▶️ Stage: verify-all-alpha
🔍 Verifying alpha domain — full stack...
PASS specs/migration/gateway.jest.spec.ts (33.787 s)
  migration Gateway data [data plane dp1]
    ✓ logs in the user and redirects to an MFA step (2754 ms)
    ✓ logs in with MFA, creates a token and introspects it (3160 ms)
    ✓ grants consent for a requested scope and creates a token carrying it (1616 ms)
    ✓ logs in a user backed by the custom identity provider and creates a token (1731 ms)
    ✓ exchanges a JWT assertion for a token via the seeded jwt-bearer extension grant and introspects it (232 ms)
  migration Gateway data [data plane dp2]
    ✓ logs in the user and redirects to an MFA step (2633 ms)
    ✓ logs in with MFA, creates a token and introspects it (2700 ms)
    ✓ grants consent for a requested scope and creates a token carrying it (1287 ms)
    ✓ logs in a user backed by the custom identity provider and creates a token (1583 ms)
    ✓ exchanges a JWT assertion for a token via the seeded jwt-bearer extension grant and introspects it (214 ms)

PASS specs/migration/mapi-data.jest.spec.ts
  migration MAPI data [data plane dp1]
    ✓ keeps the versioned MAPI data readable through the generated SDK (560 ms)
  migration MAPI data [data plane dp2]
    ✓ keeps the versioned MAPI data readable through the generated SDK (369 ms)

Test Suites: 2 passed, 2 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        35.865 s
Ran all test suites matching /specs\/migration|specs\/migration/i.
⚠️  7 ERROR line(s) in am-mapi:
    [pod/am-mapi-management-api-8595bdccb-xvwdt/am-mapi-management-api] 10:15:23.109 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-mapi-management-api-8595bdccb-xvwdt/am-mapi-management-api] 10:15:29.100 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-mapi-management-api-8595bdccb-xvwdt/am-mapi-management-api] 10:15:36.695 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-mapi-management-api-8595bdccb-xvwdt/am-mapi-management-api] 10:15:37.288 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-mapi-management-api-8595bdccb-xvwdt/am-mapi-management-api] 10:15:37.593 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-mapi-management-api-8595bdccb-xvwdt/am-mapi-management-api] 10:18:05.507 [RxComputationThreadPool-1] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-mapi-management-api-8595bdccb-xvwdt/am-mapi-management-api] 10:18:10.603 [RxComputationThreadPool-1] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
⚠️  58 ERROR line(s) in am-gateway-dp1:
    [pod/am-gateway-dp1-gateway-797786d994-8cr25/am-gateway-dp1-gateway] 10:16:46.420 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-gateway-dp1-gateway-797786d994-8cr25/am-gateway-dp1-gateway] 10:16:46.429 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-gateway-dp1-gateway-797786d994-8cr25/am-gateway-dp1-gateway] 10:16:46.430 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-gateway-dp1-gateway-797786d994-8cr25/am-gateway-dp1-gateway] 10:16:46.430 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)
    [pod/am-gateway-dp1-gateway-797786d994-8cr25/am-gateway-dp1-gateway] 10:16:46.430 [graviteeio-node] [] ERROR i.g.node.monitoring.metrics.Metrics - Gravitee metrics is disabled. You need to enable it first (services.metrics.enabled=true)

  migration MAPI data [data plane dp2]
    ✓ keeps the versioned MAPI data readable through the generated SDK (501 ms)
