### PR TITLE
fix: AM-7171 hide list content until loaded to avoid flicker

### DIFF
--- a/gravitee-am-ui/src/app/domain/agents/agents.component.html
+++ b/gravitee-am-ui/src/app/domain/agents/agents.component.html
@@ -79,21 +79,23 @@
       </ngx-datatable>
     </div>
 
-    <div *ngIf="loadingAgents" class="agents-table-overlay">
+    <div *ngIf="loadingAgents && !isEmpty" class="agents-table-overlay">
       <div class="agents-table-spinner"></div>
     </div>
   </div>
 
   <app-emptystate
-    *ngIf="isEmpty && !loadingAgents"
+    *ngIf="isEmpty"
     [message]="'Agents will appear here'"
     [subMessage]="'No data to display'"
     [icon]="'smart_toy'"
   ></app-emptystate>
 
-  <div *hasPermission="['application_create']" [ngClass]="{ 'gv-add-button': !isEmpty, 'gv-add-button-center': isEmpty }">
-    <a mat-fab color="primary" [routerLink]="['new']">
-      <mat-icon>add</mat-icon>
-    </a>
-  </div>
+  <ng-container *hasPermission="['application_create']">
+    <div *ngIf="isEmpty || showTable" [ngClass]="{ 'gv-add-button': !isEmpty, 'gv-add-button-center': isEmpty }">
+      <a mat-fab color="primary" [routerLink]="['new']">
+        <mat-icon>add</mat-icon>
+      </a>
+    </div>
+  </ng-container>
 </div>

--- a/gravitee-am-ui/src/app/domain/agents/agents.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/agents/agents.component.spec.ts
@@ -112,8 +112,13 @@ describe('AgentsComponent', () => {
 
   it('should show an overlay spinner while the table request is pending', () => {
     const pendingRequest = new Subject<any>();
-    applicationService.cursorSearch.mockReturnValueOnce(pendingRequest.asObservable());
+    applicationService.cursorSearch
+      .mockReturnValueOnce(of({ totalCount: 1, data: [{ id: 'agent-id', name: 'agent-name' }], nextCursor: undefined, page: 0 }))
+      .mockReturnValueOnce(pendingRequest.asObservable());
 
+    fixture.detectChanges();
+
+    component.loadAgents();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.agents-table-overlay')).not.toBeNull();
@@ -123,5 +128,58 @@ describe('AgentsComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.agents-table-overlay')).toBeNull();
+  });
+
+  it('should show neither table nor empty state before the first response', () => {
+    const pendingRequest = new Subject<any>();
+    applicationService.cursorSearch.mockReturnValueOnce(pendingRequest.asObservable());
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).toBeNull();
+
+    pendingRequest.next({ totalCount: 0, data: [], nextCursor: undefined, page: 0 });
+    pendingRequest.complete();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).not.toBeNull();
+  });
+
+  it('should show the table after the first response when data exists', () => {
+    const pendingRequest = new Subject<any>();
+    applicationService.cursorSearch.mockReturnValueOnce(pendingRequest.asObservable());
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).toBeNull();
+
+    pendingRequest.next({ totalCount: 1, data: [{ id: 'agent-id', name: 'agent-name' }], nextCursor: undefined, page: 0 });
+    pendingRequest.complete();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).toBeNull();
+  });
+
+  it('should not show the empty state while reloading a populated list', () => {
+    const pendingRequest = new Subject<any>();
+    applicationService.cursorSearch
+      .mockReturnValueOnce(of({ totalCount: 1, data: [{ id: 'agent-id', name: 'agent-name' }], nextCursor: undefined, page: 0 }))
+      .mockReturnValueOnce(pendingRequest.asObservable());
+
+    fixture.detectChanges();
+
+    component.loadAgents();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).toBeNull();
+
+    pendingRequest.next({ totalCount: 1, data: [{ id: 'agent-id', name: 'agent-name' }], nextCursor: undefined, page: 0 });
+    pendingRequest.complete();
+    fixture.detectChanges();
   });
 });

--- a/gravitee-am-ui/src/app/domain/agents/agents.component.ts
+++ b/gravitee-am-ui/src/app/domain/agents/agents.component.ts
@@ -33,10 +33,11 @@ export class AgentsComponent implements OnInit, OnDestroy {
   private loadSubject = new Subject<{ cursor?: string }>();
   private searchSubscription: Subscription;
   private loadSubscription: Subscription;
-  agents: any[];
+  agents: any[] = [];
   private searchValue: string;
   domainId: string;
   loadingAgents = false;
+  private hasLoaded = false;
   page = {
     totalElements: 0,
     pageNumber: 0,
@@ -107,11 +108,17 @@ export class AgentsComponent implements OnInit, OnDestroy {
   }
 
   get isEmpty() {
-    return !this.agents || (this.agents.length === 0 && !this.searchValue);
+    if (!this.hasLoaded || this.searchValue) {
+      return false;
+    }
+    return this.agents.length === 0;
   }
 
   get showTable() {
-    return !this.isEmpty || this.loadingAgents;
+    if (!this.hasLoaded) {
+      return false;
+    }
+    return this.agents.length > 0 || !!this.searchValue;
   }
 
   setSort($event: any) {
@@ -146,5 +153,6 @@ export class AgentsComponent implements OnInit, OnDestroy {
     this.agents = pagedAgents.data;
     this.nextCursor = pagedAgents.nextCursor;
     this.page.pageNumber = pagedAgents.page;
+    this.hasLoaded = true;
   }
 }

--- a/gravitee-am-ui/src/app/domain/applications/applications.component.html
+++ b/gravitee-am-ui/src/app/domain/applications/applications.component.html
@@ -81,21 +81,23 @@
       </div>
     </div>
 
-    <div *ngIf="loadingApplications" class="applications-table-overlay">
+    <div *ngIf="loadingApplications && !isEmpty" class="applications-table-overlay">
       <div class="applications-table-spinner"></div>
     </div>
   </div>
 
   <app-emptystate
-    *ngIf="isEmpty && !loadingApplications"
+    *ngIf="isEmpty"
     [message]="'Applications will appear here'"
     [subMessage]="'No data to display'"
     [icon]="'devices'"
   ></app-emptystate>
 
-  <div *hasPermission="['application_create']" [ngClass]="{ 'gv-add-button': !isEmpty, 'gv-add-button-center': isEmpty }">
-    <a mat-fab color="primary" [routerLink]="['new']">
-      <mat-icon>add</mat-icon>
-    </a>
-  </div>
+  <ng-container *hasPermission="['application_create']">
+    <div *ngIf="isEmpty || showTable" [ngClass]="{ 'gv-add-button': !isEmpty, 'gv-add-button-center': isEmpty }">
+      <a mat-fab color="primary" [routerLink]="['new']">
+        <mat-icon>add</mat-icon>
+      </a>
+    </div>
+  </ng-container>
 </div>

--- a/gravitee-am-ui/src/app/domain/applications/applications.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/applications/applications.component.spec.ts
@@ -110,8 +110,13 @@ describe('ApplicationsComponent', () => {
 
   it('should show an overlay spinner while the table request is pending', () => {
     const pendingRequest = new Subject<any>();
-    applicationService.cursorSearch.mockReturnValueOnce(pendingRequest.asObservable());
+    applicationService.cursorSearch
+      .mockReturnValueOnce(of({ totalCount: 1, data: [{ id: 'app-id', name: 'app-name' }], nextCursor: undefined, page: 0 }))
+      .mockReturnValueOnce(pendingRequest.asObservable());
 
+    fixture.detectChanges();
+
+    component.loadApps();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.applications-table-overlay')).not.toBeNull();
@@ -121,5 +126,58 @@ describe('ApplicationsComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.applications-table-overlay')).toBeNull();
+  });
+
+  it('should show neither table nor empty state before the first response', () => {
+    const pendingRequest = new Subject<any>();
+    applicationService.cursorSearch.mockReturnValueOnce(pendingRequest.asObservable());
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).toBeNull();
+
+    pendingRequest.next({ totalCount: 0, data: [], nextCursor: undefined, page: 0 });
+    pendingRequest.complete();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).not.toBeNull();
+  });
+
+  it('should show the table after the first response when data exists', () => {
+    const pendingRequest = new Subject<any>();
+    applicationService.cursorSearch.mockReturnValueOnce(pendingRequest.asObservable());
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).toBeNull();
+
+    pendingRequest.next({ totalCount: 1, data: [{ id: 'app-id', name: 'app-name' }], nextCursor: undefined, page: 0 });
+    pendingRequest.complete();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).toBeNull();
+  });
+
+  it('should not show the empty state while reloading a populated list', () => {
+    const pendingRequest = new Subject<any>();
+    applicationService.cursorSearch
+      .mockReturnValueOnce(of({ totalCount: 1, data: [{ id: 'app-id', name: 'app-name' }], nextCursor: undefined, page: 0 }))
+      .mockReturnValueOnce(pendingRequest.asObservable());
+
+    fixture.detectChanges();
+
+    component.loadApps();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('ngx-datatable')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('app-emptystate')).toBeNull();
+
+    pendingRequest.next({ totalCount: 1, data: [{ id: 'app-id', name: 'app-name' }], nextCursor: undefined, page: 0 });
+    pendingRequest.complete();
+    fixture.detectChanges();
   });
 });

--- a/gravitee-am-ui/src/app/domain/applications/applications.component.ts
+++ b/gravitee-am-ui/src/app/domain/applications/applications.component.ts
@@ -32,10 +32,11 @@ export class ApplicationsComponent implements OnInit, OnDestroy {
   private loadSubject = new Subject<{ cursor?: string }>();
   private searchSubscription: Subscription;
   private loadSubscription: Subscription;
-  applications: any[];
+  applications: any[] = [];
   private searchValue: string;
   domainId: string;
   loadingApplications = false;
+  private hasLoaded = false;
   page = {
     totalElements: 0,
     pageNumber: 0,
@@ -102,11 +103,17 @@ export class ApplicationsComponent implements OnInit, OnDestroy {
   }
 
   get isEmpty() {
-    return !this.applications || (this.applications.length === 0 && !this.searchValue);
+    if (!this.hasLoaded || this.searchValue) {
+      return false;
+    }
+    return this.applications.length === 0;
   }
 
   get showTable() {
-    return !this.isEmpty || this.loadingApplications;
+    if (!this.hasLoaded) {
+      return false;
+    }
+    return this.applications.length > 0 || !!this.searchValue;
   }
 
   setSort($event: any) {
@@ -141,5 +148,6 @@ export class ApplicationsComponent implements OnInit, OnDestroy {
     this.applications = pagedApps.data;
     this.nextCursor = pagedApps.nextCursor;
     this.page.pageNumber = pagedApps.page;
+    this.hasLoaded = true;
   }
 }

--- a/gravitee-am-ui/src/app/domain/mcp-servers/mcp-servers.component.html
+++ b/gravitee-am-ui/src/app/domain/mcp-servers/mcp-servers.component.html
@@ -16,7 +16,7 @@
 
 -->
 <div class="gv-page-container">
-  <div class="gv-page-content" *ngIf="!isEmpty">
+  <div class="gv-page-content" *ngIf="showContent">
     <h1>MCP Servers</h1>
     <p>Manage your Model Context Protocol servers and their available tools.</p>
     <div class="mcp-servers-search">
@@ -87,9 +87,11 @@
 
   <app-emptystate *ngIf="isEmpty" [message]="'MCP Servers will appear here'" [subMessage]="'No data to display'"></app-emptystate>
 
-  <div *hasPermission="['protected_resource_create']" [ngClass]="{ 'gv-add-button': !isEmpty, 'gv-add-button-center': isEmpty }">
-    <a mat-fab color="primary" [routerLink]="['new']">
-      <mat-icon>add</mat-icon>
-    </a>
-  </div>
+  <ng-container *hasPermission="['protected_resource_create']">
+    <div *ngIf="isEmpty || showContent" [ngClass]="{ 'gv-add-button': !isEmpty, 'gv-add-button-center': isEmpty }">
+      <a mat-fab color="primary" [routerLink]="['new']">
+        <mat-icon>add</mat-icon>
+      </a>
+    </div>
+  </ng-container>
 </div>

--- a/gravitee-am-ui/src/app/domain/mcp-servers/mcp-servers.component.ts
+++ b/gravitee-am-ui/src/app/domain/mcp-servers/mcp-servers.component.ts
@@ -39,6 +39,7 @@ export class DomainMcpServersComponent implements OnInit, OnDestroy {
   sort: Sort = { dir: 'desc', prop: 'updatedAt' };
 
   searchValue: string;
+  private hasLoaded = false;
   private searchSubject = new Subject<string>();
   private searchSubscription: Subscription;
 
@@ -76,9 +77,10 @@ export class DomainMcpServersComponent implements OnInit, OnDestroy {
   fetchData() {
     // Add wildcards around search value for partial matching, consistent with application search behavior
     const searchTerm = this.searchValue ? '*' + this.searchValue + '*' : undefined;
-    this.service
-      .findByDomain(this.domainId, this.currentPage, this.PAGE_SIZE, this.sort, searchTerm)
-      .subscribe((page) => (this.page = page));
+    this.service.findByDomain(this.domainId, this.currentPage, this.PAGE_SIZE, this.sort, searchTerm).subscribe((page) => {
+      this.page = page;
+      this.hasLoaded = true;
+    });
   }
 
   update(event: any) {
@@ -111,7 +113,17 @@ export class DomainMcpServersComponent implements OnInit, OnDestroy {
   }
 
   get isEmpty(): boolean {
-    return (!this.page.data || this.page.data.length === 0) && !this.searchValue;
+    if (!this.hasLoaded || this.searchValue) {
+      return false;
+    }
+    return !this.page.data || this.page.data.length === 0;
+  }
+
+  get showContent(): boolean {
+    if (!this.hasLoaded) {
+      return false;
+    }
+    return this.page.data.length > 0 || !!this.searchValue;
   }
 
   protected readonly SortType = SortType;


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7171](https://gravitee.atlassian.net/browse/AM-7171)

## :pencil2: A description of the changes proposed in the pull request
Avoid console UI flicker when reloading pages: defer choosing between displaying empty-list and list states until background data query completes. Applies to:
- Applications
- Agents
- MCP Servers

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7171]: https://gravitee.atlassian.net/browse/AM-7171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ