### PR TITLE
fix: prevent domains from being silently dropped during gateway startup

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
@@ -251,13 +251,15 @@ public class SyncManager implements InitializingBean, DisposableBean {
         Completable deployAll = domainRepository.findAll()
                 .filter(Domain::isEnabled)
                 .filter(this::canHandle)
-                .flatMapCompletable(domain ->
-                        deployOne(domain)
-                                .subscribeOn(deploymentScheduler)
-                                .doOnComplete(() -> domainReadinessService.updateDomainStatus(domain.getId(), DomainState.Status.DEPLOYED))
-                                .doOnError(ex -> logger.error("Unable to deploy security domain {}", domain.getId(), ex))
-                                .onErrorComplete(),
-                        false, deployParallelism);
+                .toList()
+                .flatMapCompletable(domains ->
+                        Flowable.fromIterable(domains)
+                                .flatMapCompletable(domain -> deployOne(domain)
+                                                .subscribeOn(deploymentScheduler)
+                                                .doOnComplete(() -> domainReadinessService.updateDomainStatus(domain.getId(), DomainState.Status.DEPLOYED))
+                                                .doOnError(ex -> logger.error("Unable to deploy security domain {}", domain.getId(), ex))
+                                                .onErrorComplete(),
+                                        false, deployParallelism));
         if (initDomainTimeOut > 0) {
             deployAll = deployAll.timeout(initDomainTimeOut, TimeUnit.MILLISECONDS);
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/event/EventManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/event/EventManagerImpl.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.am.gateway.event;
 
-import com.google.common.collect.Lists;
 import io.gravitee.am.common.event.DomainEvent;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.event.ReporterEvent;
@@ -33,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
@@ -82,7 +82,9 @@ public class EventManagerImpl implements EventManager {
             }
         }
         List<EventListenerWrapper> listeners = getEventListeners(event.type().getClass(), domain);
-        List<EventListenerWrapper> safeConcurrentListeners = Lists.newArrayList(listeners.iterator());
+        // listeners is a CopyOnWriteArrayList: this snapshot is safe to iterate even while other
+        // threads concurrently subscribe (add) during parallel domain deployment.
+        List<EventListenerWrapper> safeConcurrentListeners = new ArrayList<>(listeners);
 
         if (isEmpty(safeConcurrentListeners)) {
             LOGGER.warn("Event received but no listeners available (Domain: {}, contentClass: {}, eventType: {})",
@@ -170,14 +172,7 @@ public class EventManagerImpl implements EventManager {
                 new ComparableEventType(eventType, null) :
                 new ComparableEventType(eventType, domain) ;
 
-        List<EventListenerWrapper> listeners = this.listenersMap.get(key);
-
-        if (listeners == null) {
-            listeners = Collections.synchronizedList(new ArrayList<>());
-            this.listenersMap.put(new ComparableEventType(eventType, domain), listeners);
-        }
-
-        return listeners;
+        return this.listenersMap.computeIfAbsent(key, k -> new CopyOnWriteArrayList<>());
     }
 
     private class EventListenerWrapper<T extends Enum<T>> {

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/test/java/io/gravitee/am/gateway/event/EventManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/test/java/io/gravitee/am/gateway/event/EventManagerTest.java
@@ -21,8 +21,18 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -34,6 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static java.util.Arrays.stream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -145,6 +156,108 @@ public class EventManagerTest {
                 .map(event -> event instanceof DomainEvent || event instanceof ReporterEvent?
                         Arguments.of(event, predicateNonull) :
                         Arguments.of(event, predicateNull));
+    }
+
+    /**
+     * During parallel domain deployment one thread publishes
+     * {@code DomainEvent.DEPLOY} (iterating the shared listener list) while another subscribes
+     * (mutating it), which aborted the publish and silently dropped the domain.
+     */
+    @Test
+    public void must_not_throw_when_publishing_while_subscribing_concurrently() throws InterruptedException {
+        final EventManagerImpl eventManager = new EventManagerImpl();
+        // Seed a few listeners so publish has something to iterate over.
+        for (int i = 0; i < 10; i++) {
+            eventManager.subscribeForEvents(new TestEventListener(), DomainEvent.class);
+        }
+
+        final int threads = 16;
+        final int iterations = 2000;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+        final List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+        final Payload payload = new Payload(UUID.randomUUID().toString(), ReferenceType.DOMAIN, UUID.randomUUID().toString(), Action.UPDATE);
+
+        final List<Future<?>> futures = new ArrayList<>();
+        for (int t = 0; t < threads; t++) {
+            final boolean publisher = (t % 2 == 0);
+            futures.add(pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < iterations; i++) {
+                        if (publisher) {
+                            eventManager.publishEvent(DomainEvent.DEPLOY, payload);
+                        } else {
+                            eventManager.subscribeForEvents(new TestEventListener(), DomainEvent.class);
+                        }
+                    }
+                } catch (Throwable th) {
+                    failures.add(th);
+                }
+            }));
+        }
+
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "concurrent workload did not finish in time");
+        for (Future<?> future : futures) {
+            try {
+                future.get();
+            } catch (ExecutionException e) {
+                failures.add(e.getCause());
+            }
+        }
+
+        assertTrue(failures.isEmpty(), () -> "concurrent publish/subscribe raised: " + failures);
+    }
+
+    /**
+     * two threads creating
+     * the listener list for the same key could each build a separate list, with one overwriting the
+     * other and silently dropping the listeners registered on the discarded one.
+     */
+    @Test
+    public void must_not_lose_listeners_when_subscribing_concurrently() throws InterruptedException {
+        final EventManagerImpl eventManager = new EventManagerImpl();
+        final int listenerCount = 500;
+        final ExecutorService pool = Executors.newFixedThreadPool(16);
+        final CountDownLatch start = new CountDownLatch(1);
+        final AtomicInteger received = new AtomicInteger();
+
+        for (int i = 0; i < listenerCount; i++) {
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    eventManager.subscribeForEvents(new CountingEventListener(received), DomainEvent.class);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "concurrent subscription did not finish in time");
+
+        final Payload payload = new Payload(UUID.randomUUID().toString(), ReferenceType.DOMAIN, UUID.randomUUID().toString(), Action.UPDATE);
+        eventManager.publishEvent(DomainEvent.DEPLOY, payload);
+
+        assertEquals(listenerCount, received.get(),
+                "some listeners were lost during concurrent subscription (get-then-put race)");
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static class CountingEventListener implements EventListener {
+        private final AtomicInteger counter;
+
+        public CountingEventListener(AtomicInteger counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public void onEvent(Event event) {
+            counter.incrementAndGet();
+        }
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})


### PR DESCRIPTION
## Summary

The gateway's `EventManagerImpl` had a thread-safety bug where `DomainEvent.DEPLOY` publishes would race with concurrent listener subscriptions during parallel domain deployment, causing a `ConcurrentModificationException` that silently aborted the event delivery. This meant some domains never reached the reactor and were lost — a non-deterministic subset per instance, since thread interleaving differed each run.

## Changes

- **EventManagerImpl**: Use `computeIfAbsent + CopyOnWriteArrayList` so listeners can be added concurrently while events are published, and fix the get-then-put race that could drop listeners.
- **SyncManager**: Materialize `findAll()` with `.toList()` before deploying, so the management cursor is not held open for the full deployment duration (removing exposure to the MongoDB `cursorMaxTime` 60s timeout).
- **EventManagerTest**: Add concurrency regression tests for the CME and listener-loss races.

## Fix for

Fixes [AM-7179](https://jira.graviteesource.com/browse/AM-7179) — domains silently dropping during startup sync on multi-instance deployments.

## Testing

- All existing `EventManagerTest` cases pass (134 parameterized + 2 new concurrency tests).
- Concurrency tests hammer publish + subscribe for 2000 iterations on 16 threads; assert no `ConcurrentModificationException` and no lost listeners.

## Deployment

Domains will now load reliably during gateway startup, with no silent loss due to event-delivery races.

[AM-7179]: https://gravitee.atlassian.net/browse/AM-7179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ