### PR TITLE
feat: AM-6736 login default redirect_uri

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/filter/CheckRedirectionCookieFilter.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/filter/CheckRedirectionCookieFilter.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static io.gravitee.am.management.handlers.management.api.authentication.provider.generator.RedirectCookieGenerator.DEFAULT_REDIRECT_COOKIE_NAME;
-import static io.gravitee.am.management.handlers.management.api.authentication.provider.generator.RedirectCookieGenerator.DEFAULT_REDIRECT_URL;
 
 /**
  * Extract the redirect cookie and add it to the current request attributes.
@@ -37,6 +36,12 @@ import static io.gravitee.am.management.handlers.management.api.authentication.p
  * @author GraviteeSource Team
  */
 public class CheckRedirectionCookieFilter extends GenericFilterBean {
+
+    private final String defaultRedirectUrl;
+
+    public CheckRedirectionCookieFilter(String defaultRedirectUrl) {
+        this.defaultRedirectUrl = defaultRedirectUrl;
+    }
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
@@ -50,7 +55,7 @@ public class CheckRedirectionCookieFilter extends GenericFilterBean {
             if (redirectionCookie.isPresent()) {
                 req.setAttribute(DEFAULT_REDIRECT_COOKIE_NAME, redirectionCookie.get().getValue());
             } else {
-                req.setAttribute(DEFAULT_REDIRECT_COOKIE_NAME, DEFAULT_REDIRECT_URL);
+                req.setAttribute(DEFAULT_REDIRECT_COOKIE_NAME, defaultRedirectUrl);
             }
         }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/provider/generator/RedirectCookieGenerator.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/authentication/provider/generator/RedirectCookieGenerator.java
@@ -30,10 +30,26 @@ public class RedirectCookieGenerator {
     public static final String DEFAULT_REDIRECT_COOKIE_PATH = "/";
     public static final String DEFAULT_REDIRECT_COOKIE_DOMAIN = "";
     public static final int DEFAULT_REDIRECT_COOKIE_EXPIRES= 604800;
-    public static final String DEFAULT_REDIRECT_URL = "/auth/authorize?redirect_uri=http://localhost:4200/login/callback";
+    public static final String DEFAULT_UI_URL = "http://localhost:4200";
 
     @Autowired
     private Environment environment;
+
+    /**
+     * Returns the sanitized Console UI base URL (from the {@code console.ui.url} property).
+     * Falls back to {@link #DEFAULT_UI_URL} when the property is unset or blank.
+     */
+    public String getConsoleUiUrl() {
+        String uiUrl = environment.getProperty("console.ui.url", DEFAULT_UI_URL);
+        if (uiUrl == null || uiUrl.isEmpty()) {
+            return DEFAULT_UI_URL;
+        }
+        return uiUrl.endsWith("/") ? uiUrl.substring(0, uiUrl.length() - 1) : uiUrl;
+    }
+
+    public String getDefaultRedirectUrl() {
+        return "/auth/authorize?redirect_uri=" + getConsoleUiUrl() + "/login/callback";
+    }
 
     public Cookie generateCookie(String redirectUrl) {
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/spring/security/filter/AuthSecurityConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/spring/security/filter/AuthSecurityConfiguration.java
@@ -29,6 +29,7 @@ import io.gravitee.am.management.handlers.management.api.authentication.handler.
 import io.gravitee.am.management.handlers.management.api.authentication.handler.CustomAuthenticationFailureHandler;
 import io.gravitee.am.management.handlers.management.api.authentication.handler.CustomAuthenticationSuccessHandler;
 import io.gravitee.am.management.handlers.management.api.authentication.handler.CustomLogoutSuccessHandler;
+import io.gravitee.am.management.handlers.management.api.authentication.provider.generator.RedirectCookieGenerator;
 import io.gravitee.am.management.handlers.management.api.authentication.web.LoginUrlAuthenticationEntryPoint;
 import io.gravitee.am.management.handlers.management.api.authentication.web.WebAuthenticationDetails;
 import io.gravitee.am.management.handlers.management.api.authentication.web.XForwardedAwareRedirectStrategy;
@@ -107,7 +108,8 @@ public class AuthSecurityConfiguration extends CsrfAwareConfiguration {
             OrganizationUserService userService,
             ReCaptchaService reCaptchaService,
             ObjectMapper objectMapper,
-            CookieCsrfSignedTokenRepository csrfTokenRepository
+            CookieCsrfSignedTokenRepository csrfTokenRepository,
+            RedirectCookieGenerator redirectCookieGenerator
     ) throws Exception {
 
         var pathRequestMatchers = Arrays.stream(MATCHER_ROUTES).map(AntPathRequestMatcher::antMatcher).toArray(AntPathRequestMatcher[]::new);
@@ -135,7 +137,7 @@ public class AuthSecurityConfiguration extends CsrfAwareConfiguration {
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(cockpitAuthenticationFilter(), AbstractPreAuthenticatedProcessingFilter.class)
                 .addFilterBefore(new RecaptchaFilter(reCaptchaService, objectMapper), AbstractPreAuthenticatedProcessingFilter.class)
-                .addFilterBefore(new CheckRedirectionCookieFilter(), AbstractPreAuthenticatedProcessingFilter.class)
+                .addFilterBefore(new CheckRedirectionCookieFilter(redirectCookieGenerator.getDefaultRedirectUrl()), AbstractPreAuthenticatedProcessingFilter.class)
                 .addFilterBefore(checkLoginRedirectUriFilter(), AbstractPreAuthenticatedProcessingFilter.class)
                 .addFilterBefore(checkLogoutRedirectUriFilter(), LogoutFilter.class)
                 .addFilterBefore(builtInAuthFilter(), AbstractPreAuthenticatedProcessingFilter.class)

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/authentication/filter/CheckRedirectionCookieFilterTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/authentication/filter/CheckRedirectionCookieFilterTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.authentication.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+import static io.gravitee.am.management.handlers.management.api.authentication.provider.generator.RedirectCookieGenerator.DEFAULT_REDIRECT_COOKIE_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CheckRedirectionCookieFilterTest {
+
+    private static final String DEFAULT_REDIRECT_URL = "/auth/authorize?redirect_uri=https://am.example.com/login/callback";
+
+    @Test
+    public void should_fallback_to_default_when_redirect_cookie_absent() throws Exception {
+        CheckRedirectionCookieFilter filter = new CheckRedirectionCookieFilter(DEFAULT_REDIRECT_URL);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Cookie otherCookie = mock(Cookie.class);
+        when(otherCookie.getName()).thenReturn("Some-Other-Cookie");
+        when(request.getCookies()).thenReturn(new Cookie[]{otherCookie});
+
+        filter.doFilter(request, mock(HttpServletResponse.class), mock(FilterChain.class));
+
+        verify(request).setAttribute(DEFAULT_REDIRECT_COOKIE_NAME, DEFAULT_REDIRECT_URL);
+    }
+
+    @Test
+    public void should_use_cookie_value_when_redirect_cookie_present() throws Exception {
+        CheckRedirectionCookieFilter filter = new CheckRedirectionCookieFilter(DEFAULT_REDIRECT_URL);
+
+        String cookieValue = "/auth/authorize?redirect_uri=http://localhost:4201/login/callback";
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Cookie redirectCookie = mock(Cookie.class);
+        when(redirectCookie.getName()).thenReturn(DEFAULT_REDIRECT_COOKIE_NAME);
+        when(redirectCookie.getValue()).thenReturn(cookieValue);
+        when(request.getCookies()).thenReturn(new Cookie[]{redirectCookie});
+
+        filter.doFilter(request, mock(HttpServletResponse.class), mock(FilterChain.class));
+
+        verify(request).setAttribute(DEFAULT_REDIRECT_COOKIE_NAME, cookieValue);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/authentication/provider/generator/RedirectCookieGeneratorTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/authentication/provider/generator/RedirectCookieGeneratorTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.authentication.provider.generator;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static io.gravitee.am.management.handlers.management.api.authentication.provider.generator.RedirectCookieGenerator.DEFAULT_UI_URL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class RedirectCookieGeneratorTest {
+
+    private RedirectCookieGenerator newGenerator(MockEnvironment environment) {
+        RedirectCookieGenerator generator = new RedirectCookieGenerator();
+        setField(generator, "environment", environment);
+        return generator;
+    }
+
+    @Test
+    public void should_use_default_ui_url_when_property_unset() {
+        RedirectCookieGenerator generator = newGenerator(new MockEnvironment());
+
+        assertEquals(DEFAULT_UI_URL, generator.getConsoleUiUrl());
+        assertEquals("/auth/authorize?redirect_uri=http://localhost:4200/login/callback", generator.getDefaultRedirectUrl());
+    }
+
+    @Test
+    public void should_use_default_ui_url_when_property_blank() {
+        RedirectCookieGenerator generator = newGenerator(new MockEnvironment().withProperty("console.ui.url", ""));
+
+        assertEquals(DEFAULT_UI_URL, generator.getConsoleUiUrl());
+        assertEquals("/auth/authorize?redirect_uri=http://localhost:4200/login/callback", generator.getDefaultRedirectUrl());
+    }
+
+    @Test
+    public void should_use_configured_console_ui_url() {
+        RedirectCookieGenerator generator = newGenerator(new MockEnvironment().withProperty("console.ui.url", "https://am.example.com"));
+
+        assertEquals("https://am.example.com", generator.getConsoleUiUrl());
+        assertEquals("/auth/authorize?redirect_uri=https://am.example.com/login/callback", generator.getDefaultRedirectUrl());
+    }
+
+    @Test
+    public void should_strip_single_trailing_slash() {
+        RedirectCookieGenerator generator = newGenerator(new MockEnvironment().withProperty("console.ui.url", "https://am.example.com/"));
+
+        assertEquals("https://am.example.com", generator.getConsoleUiUrl());
+        assertEquals("/auth/authorize?redirect_uri=https://am.example.com/login/callback", generator.getDefaultRedirectUrl());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -543,7 +543,9 @@ gateway:
 #cockpit:
 #  url: https://cockpit.gravitee.io
 
-# Specify the URL of the Management API and UI of this instance, mandatory if you want to connect it to Cockpit
+# Specify the URL of the Management API and UI of this instance.
+# Mandatory if you want to connect it to Cockpit.
+# console.ui.url is also used as the post-login fallback redirect URL of the console (default http://localhost:4200).
 #console:
 #  ui:
 #    url: http://localhost:4200

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -93,6 +93,20 @@ data:
       url: https://{{index .Values.gateway.ingress.hosts 0 }}{{ .Values.gateway.ingress.path }}
     {{- end }}
 
+    console:
+      ui:
+        {{- if .Values.console.ui.url }}
+        url: {{ .Values.console.ui.url }}
+        {{- else }}
+        url: https://{{ index .Values.ui.ingress.hosts 0 }}{{ .Values.ui.ingress.path }}
+        {{- end }}
+      api:
+        {{- if .Values.console.api.url }}
+        url: {{ .Values.console.api.url }}
+        {{- else }}
+        url: https://{{ index .Values.api.ingress.hosts 0 }}{{ .Values.api.ingress.path }}
+        {{- end }}
+
 
     {{- if .Values.reporters }}
     reporters:

--- a/helm/tests/api-configmap_test.yaml
+++ b/helm/tests/api-configmap_test.yaml
@@ -756,6 +756,37 @@ tests:
                 properties:
                   rounds: 10
 
+  - it: should derive console ui and api urls from ingress by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            console:
+              ui:
+                url: https://am\.example\.com/
+              api:
+                url: https://am\.example\.com/management
+
+  - it: should use explicit console ui and api url overrides
+    set:
+      console.ui.url: https://console.example.com
+      console.api.url: https://mapi.example.com/management
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{4}url: https://console\\.example\\.com"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{4}url: https://mapi\\.example\\.com/management"
+
   - it: should set custom password encoder for default idp
     set:
       api:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -260,6 +260,15 @@ applications:
     # "PBKDF2", "BCrypt", "SHA-512", "SHA-256", "None"
     algorithm: None
 
+# Public URLs of the Console UI and Management API.
+# Used to connect this instance to Cockpit, and console.ui.url is also the post-login fallback redirect URL of the console.
+# Leave empty to derive https://<ingress host><path> from ui.ingress / api.ingress.
+console:
+  ui:
+    url: ""
+  api:
+    url: ""
+
 api:
   enabled: true
   ## upgrader can be enabled


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-6736](https://gravitee.atlassian.net/browse/AM-6736)

## :pencil2: A description of the changes proposed in the pull request
Leverage `console.ui.url` (also used by Cockpit hello command) to generate a default `redirect_uri` for the management server login flow when it cannot be determined from cookies - rather than using hardcoded `http://localhost:4200`.

In helm, determine the `console.ui.url` (and `console.api.url`) values from the ingress definitions.

## :memo: Test scenarios 
See jira. Note that any `Redirect-Graviteeio-AM` cookie must be removed to exercise the new configurable fallback.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-6736]: https://gravitee.atlassian.net/browse/AM-6736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ