### PR TITLE
feat: added IPV4_ONLY env var for management-ui

### DIFF
--- a/docker/management-ui/Dockerfile
+++ b/docker/management-ui/Dockerfile
@@ -39,10 +39,13 @@ RUN apk update \
 
 ADD config/constants.json /usr/share/nginx/html/constants.json
 ADD config/default.conf /etc/nginx/conf.d/default.conf
+ADD config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
+
+ADD config/check_ip_config.sh /
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 
-CMD ["sh", "/run.sh"]
+CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]
 
 USER nginx
 

--- a/docker/management-ui/Dockerfile-dev
+++ b/docker/management-ui/Dockerfile-dev
@@ -34,9 +34,12 @@ RUN mv /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}/* ${WWW_TARGET}
 
 ADD config/constants.json /usr/share/nginx/html/constants.json
 ADD config/default.conf /etc/nginx/conf.d/default.conf
+ADD config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
+
+ADD config/check_ip_config.sh /
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 
-CMD ["sh", "/run.sh"]
+CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]
 
 USER nginx

--- a/docker/management-ui/config/check_ip_config.sh
+++ b/docker/management-ui/config/check_ip_config.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+IPV4_ONLY=${IPV4_ONLY:-false}
+
+if [ "$IPV4_ONLY" = "true" ]; then
+    mv /etc/nginx/conf.d/default.no-ipv6.conf /etc/nginx/conf.d/default.conf
+fi

--- a/docker/management-ui/config/default.no-ipv6.conf
+++ b/docker/management-ui/config/default.no-ipv6.conf
@@ -1,0 +1,21 @@
+server {
+    listen $HTTP_PORT;
+    listen $HTTPS_PORT;
+    server_name $SERVER_NAME;
+
+    index index.html index.htm;
+    charset utf-8;
+
+    location / {
+        try_files $uri $uri/ /index.html =404;
+        root /rw.mount/www;
+        sub_filter '<base href="/"' '<base href="$MGMT_BASE_HREF"';
+        sub_filter_once on;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /rw.mount/www;
+    }
+}


### PR DESCRIPTION
closes AM-7169
closes gravitee-io/issues#11557

Based on APIM solution (https://github.com/gravitee-io/gravitee-api-management/blob/0af04d4f3b18fd4bdba8f06822bf05c7d0a7dc1d/gravitee-apim-portal-webui/docker/Dockerfile)

How to test:
build the Docker UI image:
```
cd docker/management-ui
docker build  --build-arg GRAVITEEAM_VERSION=4.10.1 -t am-ui .
```

# DEFAULT

```
docker run -d am-ui
dc exec -it <container_id> cat /etc/nginx/conf.d/default.conf
dc rm -f  <container_id>
```
Expected
```
server {
    listen $HTTP_PORT;
    listen $HTTPS_PORT;
    listen [::]:$HTTP_PORT;
    listen [::]:$HTTPS_PORT;
...
```

# IPV4_ONLY
```
docker run -e IPV4_ONLY=true -d am-ui
dc exec -it <container_id> cat /etc/nginx/conf.d/default.conf
dc rm -f  <container_id>
```
Expected (no  [::]:$HTTP_PORT)
```
server {
    listen $HTTP_PORT;
    listen $HTTPS_PORT;
...
```