### PR TITLE
fix(AM-7194): preload protected-resource permissions in AuthGuard to prevent blank page on refresh

### DIFF
--- a/gravitee-am-ui/src/app/guards/auth-guard.service.ts
+++ b/gravitee-am-ui/src/app/guards/auth-guard.service.ts
@@ -47,59 +47,40 @@ export class AuthGuard {
     const requiredPerms = route.data.perms.only;
     combineSources.push(!this.authService.isAuthenticated() ? this.authService.userInfo() : of(this.authService.user()));
 
-    if ((requiredPerms[0].startsWith('domain') || requiredPerms[0].startsWith('application')) && requiredPerms[0] !== 'domain_create') {
-      // check if the authenticated user can navigate to the next route (domain settings or application settings)
-      const environmentId = route.paramMap.get('envHrid');
-      const domainId = route.paramMap.get('domainId');
-      const appId = route.paramMap.get('appId');
+    const environmentId = route.paramMap.get('envHrid');
+    const domainId = route.paramMap.get('domainId');
+    const appId = route.paramMap.get('appId');
+    const mcpServerId = route.paramMap.get('mcpServerId');
+    const perm = requiredPerms[0];
 
-      if (environmentId && !this.authService.environmentPermissionsLoaded()) {
-        combineSources.push(this.environmentService.permissions(environmentId));
-      }
+    const needsEnv = !!environmentId && !this.authService.environmentPermissionsLoaded() && perm !== 'domain_create';
+    const needsDomain = !!domainId && !this.authService.domainPermissionsLoaded() && perm !== 'domain_create';
+    const needsApp = !!appId && !this.authService.applicationPermissionsLoaded() && perm.startsWith('application');
+    const needsProtectedResource =
+      !!mcpServerId && !this.authService.protectedResourcePermissionsLoaded() && perm.startsWith('protected_resource');
 
-      if (domainId && !this.authService.domainPermissionsLoaded()) {
-        combineSources.push(
-          this.domainService.getById(domainId).pipe(
-            mergeMap((domain) =>
-              this.domainService.permissions(domain.id).pipe(
-                mergeMap((__) => {
-                  if (appId && !this.authService.applicationPermissionsLoaded()) {
-                    return this.applicationService.permissions(domain.id, appId);
-                  } else {
-                    return of([]);
-                  }
-                }),
-              ),
+    if (needsEnv) {
+      combineSources.push(this.environmentService.permissions(environmentId));
+    }
+
+    if (needsDomain) {
+      combineSources.push(
+        this.domainService.getById(domainId).pipe(
+          mergeMap((domain) =>
+            this.domainService.permissions(domain.id).pipe(
+              mergeMap(() => {
+                if (needsApp) {
+                  return this.applicationService.permissions(domain.id, appId);
+                }
+                if (needsProtectedResource) {
+                  return this.protectedResourceService.permissions(domain.id, mcpServerId);
+                }
+                return of([]);
+              }),
             ),
           ),
-        );
-      }
-    } else if (requiredPerms[0].startsWith('protected_resource')) {
-      const environmentId = route.paramMap.get('envHrid');
-      const domainId = route.paramMap.get('domainId');
-      const mcpServerId = route.paramMap.get('mcpServerId');
-
-      if (environmentId && !this.authService.environmentPermissionsLoaded()) {
-        combineSources.push(this.environmentService.permissions(environmentId));
-      }
-
-      if (domainId && !this.authService.domainPermissionsLoaded()) {
-        combineSources.push(
-          this.domainService.getById(domainId).pipe(
-            mergeMap((domain) =>
-              this.domainService.permissions(domain.id).pipe(
-                mergeMap((__) => {
-                  if (mcpServerId && !this.authService.protectedResourcePermissionsLoaded()) {
-                    return this.protectedResourceService.permissions(domain.id, mcpServerId);
-                  } else {
-                    return of([]);
-                  }
-                }),
-              ),
-            ),
-          ),
-        );
-      }
+        ),
+      );
     }
     // check permissions
     return combineLatest(combineSources).pipe(

--- a/gravitee-am-ui/src/app/guards/auth-guard.service.ts
+++ b/gravitee-am-ui/src/app/guards/auth-guard.service.ts
@@ -75,11 +75,30 @@ export class AuthGuard {
         );
       }
     } else if (requiredPerms[0].startsWith('protected_resource')) {
+      const environmentId = route.paramMap.get('envHrid');
       const domainId = route.paramMap.get('domainId');
       const mcpServerId = route.paramMap.get('mcpServerId');
 
-      if (domainId && mcpServerId && !this.authService.protectedResourcePermissionsLoaded()) {
-        combineSources.push(this.protectedResourceService.permissions(domainId, mcpServerId));
+      if (environmentId && !this.authService.environmentPermissionsLoaded()) {
+        combineSources.push(this.environmentService.permissions(environmentId));
+      }
+
+      if (domainId && !this.authService.domainPermissionsLoaded()) {
+        combineSources.push(
+          this.domainService.getById(domainId).pipe(
+            mergeMap((domain) =>
+              this.domainService.permissions(domain.id).pipe(
+                mergeMap((__) => {
+                  if (mcpServerId && !this.authService.protectedResourcePermissionsLoaded()) {
+                    return this.protectedResourceService.permissions(domain.id, mcpServerId);
+                  } else {
+                    return of([]);
+                  }
+                }),
+              ),
+            ),
+          ),
+        );
       }
     }
     // check permissions

--- a/gravitee-am-ui/src/app/guards/auth-guard.service.ts
+++ b/gravitee-am-ui/src/app/guards/auth-guard.service.ts
@@ -66,19 +66,21 @@ export class AuthGuard {
     if (needsDomain) {
       combineSources.push(
         this.domainService.getById(domainId).pipe(
-          mergeMap((domain) =>
-            this.domainService.permissions(domain.id).pipe(
-              mergeMap(() => {
-                if (needsApp) {
-                  return this.applicationService.permissions(domain.id, appId);
-                }
-                if (needsProtectedResource) {
-                  return this.protectedResourceService.permissions(domain.id, mcpServerId);
-                }
-                return of([]);
-              }),
-            ),
-          ),
+          mergeMap((domain) => this.domainService.permissions(domain.id)),
+        ),
+      );
+    }
+    if (needsApp) {
+      combineSources.push(
+        this.domainService.getById(domainId).pipe(
+          mergeMap((domain) => this.applicationService.permissions(domain.id, appId)),
+        ),
+      );
+    }
+    if (needsProtectedResource) {
+      combineSources.push(
+        this.domainService.getById(domainId).pipe(
+          mergeMap((domain) => this.protectedResourceService.permissions(domain.id, mcpServerId)),
         ),
       );
     }

--- a/gravitee-am-ui/src/app/guards/auth-guard.service.ts
+++ b/gravitee-am-ui/src/app/guards/auth-guard.service.ts
@@ -64,24 +64,16 @@ export class AuthGuard {
     }
 
     if (needsDomain) {
-      combineSources.push(
-        this.domainService.getById(domainId).pipe(
-          mergeMap((domain) => this.domainService.permissions(domain.id)),
-        ),
-      );
+      combineSources.push(this.domainService.getById(domainId).pipe(mergeMap((domain) => this.domainService.permissions(domain.id))));
     }
     if (needsApp) {
       combineSources.push(
-        this.domainService.getById(domainId).pipe(
-          mergeMap((domain) => this.applicationService.permissions(domain.id, appId)),
-        ),
+        this.domainService.getById(domainId).pipe(mergeMap((domain) => this.applicationService.permissions(domain.id, appId))),
       );
     }
     if (needsProtectedResource) {
       combineSources.push(
-        this.domainService.getById(domainId).pipe(
-          mergeMap((domain) => this.protectedResourceService.permissions(domain.id, mcpServerId)),
-        ),
+        this.domainService.getById(domainId).pipe(mergeMap((domain) => this.protectedResourceService.permissions(domain.id, mcpServerId))),
       );
     }
     // check permissions

--- a/gravitee-am-ui/src/app/guards/auth-guard.service.ts
+++ b/gravitee-am-ui/src/app/guards/auth-guard.service.ts
@@ -22,6 +22,7 @@ import { AuthService } from '../services/auth.service';
 import { DomainService } from '../services/domain.service';
 import { ApplicationService } from '../services/application.service';
 import { EnvironmentService } from '../services/environment.service';
+import { ProtectedResourceService } from '../services/protected-resource.service';
 import { DomainStoreService } from '../stores/domain.store';
 
 @Injectable()
@@ -31,6 +32,7 @@ export class AuthGuard {
     private environmentService: EnvironmentService,
     private domainService: DomainService,
     private applicationService: ApplicationService,
+    private protectedResourceService: ProtectedResourceService,
     private domainStore: DomainStoreService,
   ) {}
 
@@ -71,6 +73,13 @@ export class AuthGuard {
             ),
           ),
         );
+      }
+    } else if (requiredPerms[0].startsWith('protected_resource')) {
+      const domainId = route.paramMap.get('domainId');
+      const mcpServerId = route.paramMap.get('mcpServerId');
+
+      if (domainId && mcpServerId && !this.authService.protectedResourcePermissionsLoaded()) {
+        combineSources.push(this.protectedResourceService.permissions(domainId, mcpServerId));
       }
     }
     // check permissions

--- a/gravitee-am-ui/src/app/services/auth.service.ts
+++ b/gravitee-am-ui/src/app/services/auth.service.ts
@@ -131,4 +131,8 @@ export class AuthService {
   applicationPermissionsLoaded(): boolean {
     return this.applicationPermissions != null;
   }
+
+  protectedResourcePermissionsLoaded(): boolean {
+    return this.protectedResourcePermissions != null;
+  }
 }


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-7194

## :pencil2: A description of the changes proposed in the pull request

**Root cause:** 
AuthGuard runs before McpServerPermissionsResolver loads protected_resource_* permissions, so the guard returns false and cancels navigation.

**Fix:** 
Added a protected_resource branch to AuthGuard to preload permissions inline, matching the existing pattern for domain and application permissions.

## :memo: Test scenarios 

NA
## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
