### PR TITLE
fix(AM-7197): nest MCP server flows under Design section for consistency with apps

### DIFF
--- a/gravitee-am-ui/src/app/app-routing.module.ts
+++ b/gravitee-am-ui/src/app/app-routing.module.ts
@@ -267,6 +267,7 @@ import { McpServerResolver } from './resolvers/mcp-server.resolver';
 import { McpServerFlowsResolver } from './resolvers/mcp-server-flows.resolver';
 import { DomainMcpServerOverviewComponent } from './domain/mcp-servers/mcp-server/overview/overview.component';
 import { DomainMcpServerToolsComponent } from './domain/mcp-servers/mcp-server/tools/tools.component';
+import { DomainMcpServerDesignComponent } from './domain/mcp-servers/mcp-server/design/design.component';
 import { DomainMcpServerAdvancedComponent } from './domain/mcp-servers/mcp-server/advanced/advanced.component';
 import { DomainMcpServerGeneralComponent } from './domain/mcp-servers/mcp-server/advanced/general/general.component';
 import { TokenExchangeContainerComponent } from './domain/settings/oauth/token-exchange/token-exchange-container.component';
@@ -1590,26 +1591,42 @@ export const routes: Routes = [
                             },
                           },
                           {
-                            path: 'flows',
-                            component: ApplicationFlowsComponent,
-                            canActivate: [AuthGuard],
-                            resolve: {
-                              flows: McpServerFlowsResolver,
-                              policies: PluginPoliciesResolver,
-                              flowSettingsForm: PlatformFlowSchemaResolver,
-                              factors: FactorsResolver,
-                            },
+                            path: 'design',
+                            component: DomainMcpServerDesignComponent,
                             data: {
                               menu: {
-                                label: 'Flows',
-                                section: 'Flows',
+                                label: 'Design',
+                                section: 'Design',
                                 level: 'level2',
                               },
                               perms: {
                                 only: ['protected_resource_flow_list', 'protected_resource_flow_read'],
                               },
-                              flowsContext: 'mcp',
                             },
+                            children: [
+                              {
+                                path: 'flows',
+                                component: ApplicationFlowsComponent,
+                                canActivate: [AuthGuard],
+                                resolve: {
+                                  flows: McpServerFlowsResolver,
+                                  policies: PluginPoliciesResolver,
+                                  flowSettingsForm: PlatformFlowSchemaResolver,
+                                  factors: FactorsResolver,
+                                },
+                                data: {
+                                  menu: {
+                                    label: 'Flows',
+                                    section: 'Design',
+                                    level: 'level3',
+                                  },
+                                  perms: {
+                                    only: ['protected_resource_flow_list', 'protected_resource_flow_read'],
+                                  },
+                                  flowsContext: 'mcp',
+                                },
+                              },
+                            ],
                           },
 
                           {

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -481,6 +481,7 @@ import { OpenFGAComponent } from './domain/authorization-engines/openfga/openfga
 import { McpServerResolver } from './resolvers/mcp-server.resolver';
 import { DomainMcpServerOverviewComponent } from './domain/mcp-servers/mcp-server/overview/overview.component';
 import { DomainMcpServerToolsComponent } from './domain/mcp-servers/mcp-server/tools/tools.component';
+import { DomainMcpServerDesignComponent } from './domain/mcp-servers/mcp-server/design/design.component';
 import { DomainMcpServerAdvancedComponent } from './domain/mcp-servers/mcp-server/advanced/advanced.component';
 import { DomainMcpServerGeneralComponent } from './domain/mcp-servers/mcp-server/advanced/general/general.component';
 import { DomainMcpServerMembershipsComponent } from './domain/mcp-servers/mcp-server/advanced/memberships/memberships.component';
@@ -551,6 +552,7 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     DomainNewMcpServerComponent,
     DomainMcpServerOverviewComponent,
     DomainMcpServerToolsComponent,
+    DomainMcpServerDesignComponent,
     DomainMcpServerAdvancedComponent,
     DomainMcpServerGeneralComponent,
     DomainMcpServerMembershipsComponent,

--- a/gravitee-am-ui/src/app/domain/mcp-servers/mcp-server/design/design.component.html
+++ b/gravitee-am-ui/src/app/domain/mcp-servers/mcp-server/design/design.component.html
@@ -1,0 +1,22 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div fxLayout="column" class="gv-page-container">
+  <gv-tab-navbar>
+    <router-outlet></router-outlet>
+  </gv-tab-navbar>
+</div>

--- a/gravitee-am-ui/src/app/domain/mcp-servers/mcp-server/design/design.component.ts
+++ b/gravitee-am-ui/src/app/domain/mcp-servers/mcp-server/design/design.component.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, OnDestroy } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
+
+import { AuthService } from '../../../../services/auth.service';
+
+@Component({
+  selector: 'app-domain-mcp-server-design',
+  templateUrl: './design.component.html',
+  standalone: false,
+})
+export class DomainMcpServerDesignComponent implements OnDestroy {
+  private subscription: Subscription;
+
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute,
+    private authService: AuthService,
+  ) {
+    this.subscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe((next: NavigationEnd) => {
+      if (next.url.endsWith('design')) {
+        this.loadPermissions();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+  private loadPermissions(): void {
+    if (this.canNavigate(['protected_resource_flow_list', 'protected_resource_flow_read'])) {
+      this.router.navigate(['flows'], { relativeTo: this.route });
+    }
+  }
+
+  private canNavigate(permissions): boolean {
+    return this.authService.hasAnyPermissions(permissions);
+  }
+}


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7197

## :pencil2: A description of the changes proposed in the pull request
**Problem**
MCP server Flows was a top-level menu item, inconsistent with how applications expose the same feature under Design > Flows.
  
 **Fix**
Added a Design section to MCP servers and nested Flows underneath it, matching the existing service app pattern.

## :memo: Test scenarios 
See Jira

## :computer: Add screenshots for UI
<img width="1498" height="822" alt="Screenshot 2026-06-30 at 10 53 31" src="https://github.com/user-attachments/assets/8d78320d-f17f-4e60-9422-5e253382a80f" />

## :books: Any other comments that will help with documentation
NA

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
NA

This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
