### PR TITLE
fix: AM-7198 honour application-level permissions

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -1523,11 +1523,12 @@ paths:
       - domain
       summary: List registered flows for an application
       description: "User must have the APPLICATION_FLOW[LIST] permission on the specified\
-        \ domain or APPLICATION_FLOW[LIST] permission on the specified environment\
-        \ or APPLICATION_FLOW[LIST] permission on the specified organization. Except\
-        \ if user has APPLICATION_FLOW[READ] permission on the domain, environment\
-        \ or organization, each returned flow is filtered and contains only basic\
-        \ information such as id and name and isEnabled."
+        \ application or APPLICATION_FLOW[LIST] permission on the specified domain\
+        \ or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST]\
+        \ permission on the specified organization. Except if user has APPLICATION_FLOW[READ]\
+        \ permission on the application, domain, environment or organization, each\
+        \ returned flow is filtered and contains only basic information such as id\
+        \ and name and isEnabled."
       operationId: listAppFlows
       parameters:
       - name: organizationId
@@ -1567,8 +1568,9 @@ paths:
       - domain
       summary: Create or update list of flows
       description: "User must have the APPLICATION_FLOW[UPDATE] permission on the\
-        \ specified domain or APPLICATION_FLOW[UPDATE] permission on the specified\
-        \ environment or APPLICATION_FLOW[UPDATE] permission on the specified organization"
+        \ specified application or APPLICATION_FLOW[UPDATE] permission on the specified\
+        \ domain or APPLICATION_FLOW[UPDATE] permission on the specified environment\
+        \ or APPLICATION_FLOW[UPDATE] permission on the specified organization"
       operationId: defineAppFlows
       parameters:
       - name: organizationId

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/AbstractResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/AbstractResource.java
@@ -121,6 +121,14 @@ public abstract class AbstractResource {
                 of(ReferenceType.ORGANIZATION, organizationId, permission, acls)));
     }
 
+    protected Single<Boolean> hasAnyPermission(User user, String organizationId, String environmentId, String domainId, ReferenceType resourceType, String resourceId, Permission permission, Acl... acls) {
+
+        return hasPermission(user, or(of(resourceType, resourceId, permission, acls),
+                of(ReferenceType.DOMAIN, domainId, permission, acls),
+                of(ReferenceType.ENVIRONMENT, environmentId, permission, acls),
+                of(ReferenceType.ORGANIZATION, organizationId, permission, acls)));
+    }
+
     protected Single<Boolean> hasPermission(User user, PermissionAcls permissionAcls) {
 
         return permissionService.hasPermission(user, permissionAcls);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationFlowsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ApplicationFlowsResource.java
@@ -79,10 +79,11 @@ public class ApplicationFlowsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "List registered flows for an application",
             operationId = "listAppFlows",
-            description = "User must have the APPLICATION_FLOW[LIST] permission on the specified domain " +
+            description = "User must have the APPLICATION_FLOW[LIST] permission on the specified application " +
+                    "or APPLICATION_FLOW[LIST] permission on the specified domain " +
                     "or APPLICATION_FLOW[LIST] permission on the specified environment " +
                     "or APPLICATION_FLOW[LIST] permission on the specified organization. " +
-                    "Except if user has APPLICATION_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.")
+                    "Except if user has APPLICATION_FLOW[READ] permission on the application, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "List registered flows for an application",
                     content = @Content(mediaType =  "application/json",
@@ -97,8 +98,8 @@ public class ApplicationFlowsResource extends AbstractResource {
 
         User authenticatedUser = getAuthenticatedUser();
 
-        checkAnyPermission(organizationId, environmentId, domain, Permission.APPLICATION_FLOW, Acl.LIST)
-                .andThen(hasAnyPermission(authenticatedUser, organizationId, environmentId, domain, Permission.APPLICATION_FLOW, Acl.READ)
+        checkAnyPermission(organizationId, environmentId, domain, application, Permission.APPLICATION_FLOW, Acl.LIST)
+                .andThen(hasAnyPermission(authenticatedUser, organizationId, environmentId, domain, ReferenceType.APPLICATION, application, Permission.APPLICATION_FLOW, Acl.READ)
                         .flatMapPublisher(hasPermission ->
                                 flowService.findByApplication(ReferenceType.DOMAIN, domain, application).map(flow -> filterFlowInfos(hasPermission, flow)))
                         .toList())
@@ -110,7 +111,8 @@ public class ApplicationFlowsResource extends AbstractResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Create or update list of flows",
             operationId = "defineAppFlows",
-            description = "User must have the APPLICATION_FLOW[UPDATE] permission on the specified domain " +
+            description = "User must have the APPLICATION_FLOW[UPDATE] permission on the specified application " +
+                    "or APPLICATION_FLOW[UPDATE] permission on the specified domain " +
                     "or APPLICATION_FLOW[UPDATE] permission on the specified environment " +
                     "or APPLICATION_FLOW[UPDATE] permission on the specified organization")
     @ApiResponses({
@@ -128,7 +130,7 @@ public class ApplicationFlowsResource extends AbstractResource {
 
         final User authenticatedUser = getAuthenticatedUser();
 
-        checkAnyPermission(organizationId, environmentId, domain, Permission.APPLICATION_FLOW, Acl.UPDATE)
+        checkAnyPermission(organizationId, environmentId, domain, application, Permission.APPLICATION_FLOW, Acl.UPDATE)
                 .andThen(FlowUtils.checkPoliciesDeployed(policyPluginService, flows))
                 .andThen(flowValidator.validateAll(flows))
                 .andThen(domainService.findById(domain)


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7198](https://gravitee.atlassian.net/browse/AM-7198)
gravitee-io/issues/issues/11592

## :pencil2: A description of the changes proposed in the pull request
Ensure users with application-level permissions can access Flows.

See also https://github.com/gravitee-io/gravitee-access-management/pull/8145.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7198]: https://gravitee.atlassian.net/browse/AM-7198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ