### PR TITLE
fix: make vhost domain comparison case-insensitive

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostRouter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostRouter.java
@@ -84,7 +84,7 @@ public class VHostRouter extends RouterImpl {
         super(vertx);
         this.domain = domain;
         this.vhost = vhost;
-        this.vhostPattern = Pattern.compile(Pattern.quote(vhost.getHost()));
+        this.vhostPattern = Pattern.compile(Pattern.quote(vhost.getHost()), Pattern.CASE_INSENSITIVE);
         this.pathPattern = Pattern.compile(Pattern.quote(vhost.getPath()) + ".*");
         this.delegate = delegate;
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostRouterTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostRouterTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.reactor.impl.router;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.VirtualHost;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class VHostRouterTest {
+
+    private Vertx vertx;
+
+    @Before
+    public void setUp() {
+        vertx = Vertx.vertx();
+    }
+
+    @After
+    public void tearDown() {
+        vertx.close();
+    }
+
+    @Test
+    public void shouldMatchVhostHostIgnoringCase() throws Exception {
+        Router delegate = mock(Router.class);
+        RoutingContext routingContext = routingContext("VALID.HOST.GRAVITEE.IO", "/test/login");
+        VHostRouter router = router(delegate, "valid.host.gravitee.io", "/test");
+
+        router.handleContext(routingContext);
+
+        verify(delegate).handleContext(routingContext);
+        verify(routingContext, never()).next();
+    }
+
+    private RoutingContext routingContext(String host, String path) {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.host()).thenReturn(host);
+        when(request.path()).thenReturn(path);
+
+        RoutingContext routingContext = mock(RoutingContext.class);
+        when(routingContext.request()).thenReturn(request);
+
+        return routingContext;
+    }
+
+    private VHostRouter router(Router delegate, String host, String path) throws Exception {
+        VirtualHost virtualHost = new VirtualHost();
+        virtualHost.setHost(host);
+        virtualHost.setPath(path);
+
+        Constructor<VHostRouter> constructor = VHostRouter.class.getDeclaredConstructor(Vertx.class, Domain.class, VirtualHost.class, Router.class);
+        constructor.setAccessible(true);
+
+        return constructor.newInstance(vertx, new Domain(), virtualHost, delegate);
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/virtualhost/VirtualHostValidatorImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/virtualhost/VirtualHostValidatorImpl.java
@@ -102,7 +102,7 @@ public class VirtualHostValidatorImpl implements VirtualHostValidator {
             // Get paths of all other domains on the same host.
             paths = domain.getVhosts().stream()
                     .flatMap(virtualHost -> otherVhosts.stream()
-                            .filter(otherVhost -> virtualHost.getHost().equals(otherVhost.getHost())))
+                            .filter(otherVhost -> virtualHost.getHost().equalsIgnoreCase(otherVhost.getHost())))
                     .map(VirtualHost::getPath).collect(Collectors.toList());
 
             for (VirtualHost vhost : domain.getVhosts()) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/VirtualHostValidatorTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/VirtualHostValidatorTest.java
@@ -265,6 +265,24 @@ public class VirtualHostValidatorTest {
     }
 
     @Test
+    public void validateDomainVhosts_pathOverlapWithDifferentHostCase() {
+
+        Domain domain = getValidDomain();
+        domain.setVhostMode(true);
+
+        Domain otherDomain = getValidDomain();
+        otherDomain.setId("otherDomain");
+        otherDomain.setVhostMode(true);
+        otherDomain.getVhosts().get(0).setHost("VALID.HOST.GRAVITEE.IO");
+        otherDomain.getVhosts().get(0).setPath("/test/subPath");
+
+        List<Domain> otherDomains = new ArrayList<>();
+        otherDomains.add(otherDomain);
+
+        virtualHostValidator.validateDomainVhosts(domain, otherDomains).test().assertError(InvalidVirtualHostException.class);
+    }
+
+    @Test
     public void validateDomainVhosts_pathIsOverlapped() {
 
         Domain domain = getValidDomain();


### PR DESCRIPTION
## Summary
- Make gateway VHost host matching case-insensitive.
- Make VHost validation detect overlapping paths when the same host uses different casing.
- Add regression coverage for routing and validation.

## How to test
Automated tests:
- `mvn test -pl gravitee-am-service -Dtest=VirtualHostValidatorTest`
- `mvn test -pl gravitee-am-gateway/gravitee-am-gateway-reactor -Dtest=VHostRouterTest`

Manual local test:
1. Start a local AM stack with the Gateway available on `localhost:8092`.
2. In the AM Console, open a security domain and go to `Settings` > `Entrypoints`.
3. Enable VHost mode and add a virtual host, for example:
   - Host: `am-test.localhost`
   - Path: `/my-domain` or `/`
4. Save the domain and wait for the Gateway to redeploy/reload it.
5. Verify both host casings route to the same domain response:
   - `curl -i -H "Host: am-test.localhost" http://localhost:8092/my-domain/.well-known/openid-configuration`
   - `curl -i -H "Host: AM-TEST.LOCALHOST" http://localhost:8092/my-domain/.well-known/openid-configuration`
6. If testing in a browser, add `127.0.0.1 am-test.localhost` to `/etc/hosts` and open `http://am-test.localhost:8092/my-domain/.well-known/openid-configuration`. Prefer curl with an explicit `Host` header to verify uppercase host casing because browsers may normalize displayed hostnames.

fixes AM-6973
