### PR TITLE
feat(AM-7193): expose enrolled factor target for SMS, email and call factors

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -14117,6 +14117,8 @@ components:
           type: string
         name:
           type: string
+        target:
+          type: string
         type:
           type: string
         updatedAt:

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/EnrolledFactorEntity.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/model/EnrolledFactorEntity.java
@@ -29,6 +29,7 @@ public class EnrolledFactorEntity {
     private String id;
     private String type;
     private String name;
+    private String target;
     @Schema(type = "java.lang.Long")
     private Date createdAt;
     @Schema(type = "java.lang.Long")
@@ -41,6 +42,9 @@ public class EnrolledFactorEntity {
         id = enrolledFactor.getFactorId();
         createdAt = enrolledFactor.getCreatedAt();
         updatedAt = enrolledFactor.getUpdatedAt();
+        if (enrolledFactor.getChannel() != null) {
+            target = enrolledFactor.getChannel().getTarget();
+        }
     }
 
     public String getId() {
@@ -65,6 +69,14 @@ public class EnrolledFactorEntity {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
     }
 
     public Date getCreatedAt() {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/model/EnrolledFactorEntityTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/model/EnrolledFactorEntityTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.model.factor.EnrolledFactor;
+import io.gravitee.am.model.factor.EnrolledFactorChannel;
+import io.gravitee.am.model.factor.EnrolledFactorSecurity;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class EnrolledFactorEntityTest {
+
+    @Test
+    public void shouldExposeTargetButHideSecurityValues() throws Exception {
+        EnrolledFactor enrolledFactor = new EnrolledFactor();
+        enrolledFactor.setFactorId("factor-id");
+
+        EnrolledFactorSecurity security = new EnrolledFactorSecurity();
+        security.setType("SHARED_SECRET");
+        security.setValue("super-secret-otp-key");
+        Map<String, Object> securityAdditionalData = new HashMap<>();
+        securityAdditionalData.put("secretKey", "another-secret-value");
+        security.setAdditionalData(securityAdditionalData);
+        enrolledFactor.setSecurity(security);
+
+        EnrolledFactorChannel channel = new EnrolledFactorChannel(EnrolledFactorChannel.Type.SMS, "+33612345678");
+        Map<String, Object> channelAdditionalData = new HashMap<>();
+        channelAdditionalData.put("token", "channel-secret-token");
+        channel.setAdditionalData(channelAdditionalData);
+        enrolledFactor.setChannel(channel);
+
+        EnrolledFactorEntity entity = new EnrolledFactorEntity(enrolledFactor);
+
+        // relevant information is exposed
+        assertEquals("factor-id", entity.getId());
+        assertEquals("+33612345678", entity.getTarget());
+
+        // sensitive data is not exposed, even via serialization
+        String json = new ObjectMapper().writeValueAsString(entity);
+        assertFalse(json.contains("super-secret-otp-key"));
+        assertFalse(json.contains("another-secret-value"));
+        assertFalse(json.contains("channel-secret-token"));
+        assertFalse(json.toLowerCase().contains("security"));
+    }
+}

--- a/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.html
@@ -36,6 +36,11 @@
           </div>
         </ng-template>
       </ngx-datatable-column>
+      <ngx-datatable-column name="Target" [flexGrow]="2">
+        <ng-template let-row="row" ngx-datatable-cell-template>
+          {{ row.target }}
+        </ng-template>
+      </ngx-datatable-column>
       <ngx-datatable-column name="Last update" [flexGrow]="2">
         <ng-template let-row="row" ngx-datatable-cell-template>
           {{ row.updatedAt | humanDate }}

--- a/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.html
@@ -36,7 +36,7 @@
           </div>
         </ng-template>
       </ngx-datatable-column>
-      <ngx-datatable-column name="Target" [flexGrow]="2">
+      <ngx-datatable-column name="Target" [flexGrow]="3">
         <ng-template let-row="row" ngx-datatable-cell-template>
           {{ row.target }}
         </ng-template>


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7193
](https://gravitee.atlassian.net/browse/AM-7193)

## :pencil2: A description of the changes proposed in the pull request
Exposes the enrolled factor target (phone number or email address) for SMS, Email, and Call MFA factors in the admin console user factors page.

Previously, admins had to query the database directly to find the target of an enrolled factor. This change surfaces that information in the UI.

**Changes**
  - Added `target` field to `EnrolledFactorEntity`, populated from `channel.target`
  - Added Target column to the factors table in the user profile

## :memo: Test scenarios 
**Happy path**
- Enroll a user with an Email factor → Target column shows the email address
- Enroll a user with an SMS factor → Target column shows the phone number
- Enroll a user with a Call factor → Target column shows the phone number

  
**Blank target**
- Enroll a user with OTP/TOTP factor → Target column shows blank
- Enroll a user with Recovery Codes → Target column shows blank

## :computer: Add screenshots for UI

<img width="1714" height="639" alt="Screenshot 2026-07-02 at 10 50 33" src="https://github.com/user-attachments/assets/21a89798-b5ed-42a9-b551-50aed940bde3" />
<img width="1709" height="582" alt="Screenshot 2026-07-02 at 10 50 24" src="https://github.com/user-attachments/assets/4d629e1a-b4b8-4ad0-97c9-f175ea4a3a6f" />


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
