### PR TITLE
feat: AM-7200 required scopes for consent

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -12997,6 +12997,8 @@ components:
       properties:
         defaultScope:
           type: boolean
+        requiredScope:
+          type: boolean
         scope:
           type: string
         scopeApproval:

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -32,6 +32,8 @@ public interface ConstantKeys {
     String IDENTITY_PROVIDER_CONTEXT_KEY = "identityProvider";
     String PARAM_CONTEXT_KEY = "param";
     String SCOPES_CONTEXT_KEY = "scopes";
+    String REQUIRED_SCOPES_CONTEXT_KEY = "requiredScopes";
+    String OPTIONAL_SCOPES_CONTEXT_KEY = "optionalScopes";
     String PRESELECT_ALL_SCOPES = "preselectAllScopes";
     String AUTHORIZATION_REQUEST_CONTEXT_KEY = "authorization_request";
     String ID_TOKEN_CONTEXT_KEY = "idToken";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/main.css
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/assets/css/main.css
@@ -441,6 +441,12 @@ div.section > form {
     background: var(--primary-background-color, #DA3B00);
 }
 
+.scope-consent-main-section {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
 .scope-consent-table {
     width: 100%;
     border: 2px solid var(--scope-consent-border-color, #ededed);
@@ -469,8 +475,19 @@ div.section > form {
     white-space: nowrap;
 }
 
+.scope-consent-table .scope-consent-cell-name {
+    padding-left: 0;
+}
+
+.scope-consent-name-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
 .scope-consent-cell-description {
-    width: 66%;
+    width: 60%;
     color: var(--scope-consent-description-color, #6b6b6b);
 }
 
@@ -478,13 +495,68 @@ div.section > form {
     width: 18px;
     height: 18px;
     margin: 0;
+    top: 2px;
+    position: relative;
     accent-color: var(--primary-background-color);
     cursor: pointer;
+}
+
+.scope-consent-checkbox:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
 }
 
 .scope-consent-cell-name label {
     font-weight: 600;
     cursor: pointer;
+    overflow-wrap: anywhere;
+}
+
+.scope-consent-cell-name label.grey {
+    cursor: not-allowed;
+}
+
+.scope-consent-required-chip {
+    display: inline-block;
+    padding: 2px 6px;
+    font-size: 11px;
+    color: var(--scope-consent-description-color, #6b6b6b);
+    background: var(--item-background-color, #f0f0f0);
+    border: 1px solid var(--scope-consent-border-color, #ededed);
+    border-radius: 999px;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.scope-consent-required-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.scope-consent-required-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 10px 12px;
+    border: 2px solid var(--scope-consent-border-color, #ededed);
+    border-radius: 8px;
+    background: var(--item-background-color, #f7f7f7);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.scope-consent-required-header .icons {
+    font-size: 20px;
+    color: var(--scope-consent-description-color, #6b6b6b);
+}
+
+.scope-consent-required-section.is-collapsed .scope-consent-table {
+    display: none;
 }
 
 .scope-consent-buttons {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/oauth2_user_consent.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/oauth2_user_consent.html
@@ -32,42 +32,80 @@
         </div>
     </div>
     <div class="section">
-        <form class="form" role="form" th:id="confirmationForm" th:action="${action}" method="post">
+        <form class="form" role="form" th:id="confirmationForm" th:action="${action}" method="post"
+              th:with="splitRequired=${not #lists.isEmpty(requiredScopes) and #lists.size(scopes) > 10},tableScopes=${splitRequired ? optionalScopes : scopes}">
             <span class="header-description start" th:text="#{oauth.consent.instructions}"></span>
-            <div class="scope-consent-search" th:if="${scopes != null and #lists.size(scopes) > 10}">
-                <span class="icons scope-consent-search-icon" aria-hidden="true">search</span>
-                <input type="text" id="scopeSearchInput" class="scope-consent-search-input" autocomplete="off"
-                       th:attr="placeholder=#{oauth.consent.scope.search_placeholder}"/>
-            </div>
-            <div class="scope-consent-toolbar" th:if="${scopes != null and #lists.size(scopes) > 1}">
-                <div class="scope-consent-filter" role="group" th:if="${scopes != null and #lists.size(scopes) > 10}">
-                    <button type="button" class="scope-consent-filter-option is-active" data-filter="all" id="filterAll" th:text="#{oauth.consent.scope.filter_all}"></button>
-                    <button type="button" class="scope-consent-filter-option" data-filter="selected" id="filterSelected" th:text="#{oauth.consent.scope.filter_selected}"></button>
-                    <button type="button" class="scope-consent-filter-option" data-filter="unselected" id="filterUnselected" th:text="#{oauth.consent.scope.filter_unselected}"></button>
+
+            <div class="scope-consent-required-section" id="requiredScopesSection" th:if="${splitRequired}">
+                <div class="scope-consent-required-header" id="requiredScopesToggle" role="button" tabindex="0" aria-expanded="true">
+                    <span id="requiredScopesHeaderLabel"
+                          th:attr="data-template=#{oauth.consent.scope.required_table_header},data-count=${#lists.size(requiredScopes)}"></span>
+                    <span class="icons" id="requiredScopesToggleIcon" aria-hidden="true">expand_less</span>
                 </div>
-                <div class="scope-consent-actions">
-                    <button type="button" class="button secondary scope-consent-control" id="selectAllScopes" th:text="#{oauth.consent.scope.select_all}"></button>
-                    <button type="button" class="button secondary scope-consent-control" id="clearAllScopes" th:text="#{oauth.consent.scope.clear_all}"></button>
-                </div>
-                <span class="scope-consent-count" id="scopeSelectionCount"
-                      th:attr="data-template=#{oauth.consent.scope.selected_count},data-total=${#lists.size(scopes)}"></span>
+                <table class="scope-consent-table" id="requiredScopesTable">
+                    <tbody>
+                        <tr class="scope-consent-row" th:each="scope : ${requiredScopes}">
+                            <td class="scope-consent-cell-checkbox">
+                                <input type="checkbox" class="scope-consent-checkbox" th:id="'scope-'+${scope.key}"
+                                       th:name="'scope.'+${scope.key}" value="true" checked="checked" disabled="disabled"/>
+                                <input type="hidden" th:name="'scope.'+${scope.key}" value="true"/>
+                            </td>
+                            <td class="scope-consent-cell-name">
+                                <div class="scope-consent-name-wrap">
+                                    <label th:for="'scope-'+${scope.key}" class="grey" th:text="${scope.key}"></label>
+                                    <span class="scope-consent-required-chip" th:text="#{oauth.consent.scope.required_label}"></span>
+                                </div>
+                            </td>
+                            <td class="scope-consent-cell-description">
+                                <span class="grey" th:text="${scope.description}"></span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
-            <table class="scope-consent-table" th:if="${scopes != null and not #lists.isEmpty(scopes)}">
-                <tbody>
-                    <tr class="scope-consent-row" th:each="scope : ${scopes}">
-                        <td class="scope-consent-cell-checkbox">
-                            <input type="checkbox" class="scope-consent-checkbox" th:id="'scope-'+${scope.key}"
-                                   th:name="'scope.'+${scope.key}" value="true" th:checked="${preselectAllScopes}"/>
-                        </td>
-                        <td class="scope-consent-cell-name">
-                            <label th:for="'scope-'+${scope.key}" th:text="${scope.key}"></label>
-                        </td>
-                        <td class="scope-consent-cell-description">
-                            <span class="grey" th:text="${scope.description}"></span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+
+            <div class="scope-consent-main-section" id="mainScopesSection" th:if="${not #lists.isEmpty(tableScopes)}">
+                <div class="scope-consent-search" th:if="${#lists.size(scopes) > 10}">
+                    <span class="icons scope-consent-search-icon" aria-hidden="true">search</span>
+                    <input type="text" id="scopeSearchInput" class="scope-consent-search-input" autocomplete="off"
+                           th:attr="placeholder=#{oauth.consent.scope.search_placeholder}"/>
+                </div>
+                <div class="scope-consent-toolbar" th:if="${#lists.size(scopes) > 1}">
+                    <div class="scope-consent-filter" role="group" th:if="${#lists.size(scopes) > 10}">
+                        <button type="button" class="scope-consent-filter-option is-active" data-filter="all" id="filterAll" th:text="#{oauth.consent.scope.filter_all}"></button>
+                        <button type="button" class="scope-consent-filter-option" data-filter="selected" id="filterSelected" th:text="#{oauth.consent.scope.filter_selected}"></button>
+                        <button type="button" class="scope-consent-filter-option" data-filter="unselected" id="filterUnselected" th:text="#{oauth.consent.scope.filter_unselected}"></button>
+                    </div>
+                    <div class="scope-consent-actions">
+                        <button type="button" class="button secondary scope-consent-control" id="selectAllScopes" th:text="#{oauth.consent.scope.select_all}"></button>
+                        <button type="button" class="button secondary scope-consent-control" id="clearAllScopes" th:text="#{oauth.consent.scope.clear_all}"></button>
+                    </div>
+                    <span class="scope-consent-count" id="scopeSelectionCount"
+                          th:attr="data-template=#{oauth.consent.scope.selected_count},data-total=${#lists.size(tableScopes)}"></span>
+                </div>
+                <table class="scope-consent-table">
+                    <tbody>
+                        <tr class="scope-consent-row" th:each="scope : ${tableScopes}" th:with="rowRequired=${#lists.contains(requiredScopes, scope)}">
+                            <td class="scope-consent-cell-checkbox">
+                                <input type="checkbox" class="scope-consent-checkbox" th:id="'scope-'+${scope.key}"
+                                       th:name="'scope.'+${scope.key}" value="true"
+                                       th:checked="${rowRequired ? true : preselectAllScopes}"
+                                       th:disabled="${rowRequired}"/>
+                                <input type="hidden" th:if="${rowRequired}" th:name="'scope.'+${scope.key}" value="true"/>
+                            </td>
+                            <td class="scope-consent-cell-name">
+                                <div class="scope-consent-name-wrap">
+                                    <label th:for="'scope-'+${scope.key}" th:classappend="${rowRequired ? 'grey' : ''}" th:text="${scope.key}"></label>
+                                    <span class="scope-consent-required-chip" th:if="${rowRequired}" th:text="#{oauth.consent.scope.required_label}"></span>
+                                </div>
+                            </td>
+                            <td class="scope-consent-cell-description">
+                                <span class="grey" th:text="${scope.description}"></span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
 
             <span class="header-description start" th:text="${client.clientName} + ' ' + #{oauth.disclaimer}"></span>
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
@@ -88,8 +126,10 @@
     <script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
         /*<![CDATA[*/
         (function () {
-            var checkboxes = Array.prototype.slice.call(document.querySelectorAll('.scope-consent-checkbox'));
-            var rows = Array.prototype.slice.call(document.querySelectorAll('.scope-consent-row'));
+            var allCheckboxes = Array.prototype.slice.call(document.querySelectorAll('.scope-consent-checkbox'));
+            var mainSection = document.getElementById('mainScopesSection');
+            var checkboxes = mainSection ? Array.prototype.slice.call(mainSection.querySelectorAll('.scope-consent-checkbox')) : [];
+            var rows = mainSection ? Array.prototype.slice.call(mainSection.querySelectorAll('.scope-consent-row')) : [];
             var allowButton = document.getElementById('allowButton');
             var selectAll = document.getElementById('selectAllScopes');
             var clearAll = document.getElementById('clearAllScopes');
@@ -97,19 +137,30 @@
             var searchInput = document.getElementById('scopeSearchInput');
             var filterButtons = Array.prototype.slice.call(document.querySelectorAll('.scope-consent-filter-option'));
             var cimdLogo = document.querySelector('.cimd-consent-client-logo');
+            var requiredToggle = document.getElementById('requiredScopesToggle');
+            var requiredSection = document.getElementById('requiredScopesSection');
+            var requiredToggleIcon = document.getElementById('requiredScopesToggleIcon');
+            var requiredHeaderLabel = document.getElementById('requiredScopesHeaderLabel');
+
+            if (requiredHeaderLabel) {
+                var headerTemplate = requiredHeaderLabel.getAttribute('data-template') || '{0} required permissions (always included)';
+                var requiredCount = requiredHeaderLabel.getAttribute('data-count') || '0';
+                requiredHeaderLabel.textContent = headerTemplate.replace('{0}', requiredCount);
+            }
 
             var activeFilter = 'all';
             var searchTerm = '';
 
             function refreshCount() {
                 var selected = checkboxes.filter(function (checkbox) { return checkbox.checked; }).length;
-                if (allowButton && checkboxes.length > 0) {
-                    allowButton.disabled = selected === 0;
-                }
                 if (countLabel) {
                     var template = countLabel.getAttribute('data-template') || '{0} of {1} selected';
                     var total = countLabel.getAttribute('data-total') || String(checkboxes.length);
                     countLabel.textContent = template.replace('{0}', selected).replace('{1}', total);
+                }
+                if (allowButton && allCheckboxes.length > 0) {
+                    var anySelected = allCheckboxes.some(function (checkbox) { return checkbox.checked; });
+                    allowButton.disabled = !anySelected;
                 }
             }
 
@@ -141,13 +192,13 @@
             checkboxes.forEach(function (checkbox) { checkbox.addEventListener('change', refresh); });
             if (selectAll) {
                 selectAll.addEventListener('click', function () {
-                    checkboxes.forEach(function (checkbox) { checkbox.checked = true; });
+                    checkboxes.forEach(function (checkbox) { if (!checkbox.disabled) { checkbox.checked = true; } });
                     refresh();
                 });
             }
             if (clearAll) {
                 clearAll.addEventListener('click', function () {
-                    checkboxes.forEach(function (checkbox) { checkbox.checked = false; });
+                    checkboxes.forEach(function (checkbox) { if (!checkbox.disabled) { checkbox.checked = false; } });
                     refresh();
                 });
             }
@@ -165,6 +216,21 @@
                     applyFilters();
                 });
             });
+            if (requiredToggle && requiredSection) {
+                requiredToggle.addEventListener('click', function () {
+                    var collapsed = requiredSection.classList.toggle('is-collapsed');
+                    requiredToggle.setAttribute('aria-expanded', String(!collapsed));
+                    if (requiredToggleIcon) {
+                        requiredToggleIcon.textContent = collapsed ? 'expand_more' : 'expand_less';
+                    }
+                });
+                requiredToggle.addEventListener('keydown', function (event) {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        requiredToggle.click();
+                    }
+                });
+            }
             if (cimdLogo) {
                 cimdLogo.addEventListener('error', function () {
                     cimdLogo.style.display = 'none';

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/UserConsentEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/UserConsentEndpoint.java
@@ -20,6 +20,7 @@ import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User;
 import io.gravitee.am.gateway.handler.oauth2.service.consent.UserConsentService;
 import io.gravitee.am.gateway.handler.oauth2.service.request.AuthorizationRequest;
+import io.gravitee.am.gateway.handler.oauth2.service.utils.RequiredScopeUtils;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.Template;
 import io.gravitee.am.model.oauth2.Scope;
@@ -35,6 +36,7 @@ import io.vertx.rxjava3.ext.web.templ.thymeleaf.ThymeleafTemplateEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -74,7 +76,15 @@ public class UserConsentEndpoint implements Handler<RoutingContext> {
                 return;
             }
             List<Scope> requestedScopes = h.result();
-            routingContext.put(ConstantKeys.SCOPES_CONTEXT_KEY, requestedScopes);
+            Set<String> requiredScopeKeys = RequiredScopeUtils.requiredScopeKeys(client);
+            List<Scope> requiredScopes = requestedScopes.stream().filter(scope -> requiredScopeKeys.contains(scope.getKey())).collect(Collectors.toList());
+            List<Scope> optionalScopes = requestedScopes.stream().filter(scope -> !requiredScopeKeys.contains(scope.getKey())).collect(Collectors.toList());
+            // required scopes are always displayed first
+            List<Scope> orderedScopes = new ArrayList<>(requiredScopes);
+            orderedScopes.addAll(optionalScopes);
+            routingContext.put(ConstantKeys.SCOPES_CONTEXT_KEY, orderedScopes);
+            routingContext.put(ConstantKeys.REQUIRED_SCOPES_CONTEXT_KEY, requiredScopes);
+            routingContext.put(ConstantKeys.OPTIONAL_SCOPES_CONTEXT_KEY, optionalScopes);
             routingContext.put(ConstantKeys.ACTION_KEY, action);
             routingContext.put(ConstantKeys.PRESELECT_ALL_SCOPES, client == null || !client.isOptInScopeSelection());
             CimdConsentPageAttributes.putIfApplicable(routingContext, domain, client);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/consent/UserConsentProcessHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/consent/UserConsentProcessHandler.java
@@ -18,8 +18,10 @@ package io.gravitee.am.gateway.handler.oauth2.resources.handler.authorization.co
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.user.User;
+import io.gravitee.am.gateway.handler.oauth2.exception.AccessDeniedException;
 import io.gravitee.am.gateway.handler.oauth2.service.consent.UserConsentService;
 import io.gravitee.am.gateway.handler.oauth2.service.request.AuthorizationRequest;
+import io.gravitee.am.gateway.handler.oauth2.service.utils.RequiredScopeUtils;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oauth2.ScopeApproval;
@@ -98,13 +100,23 @@ public class UserConsentProcessHandler implements Handler<RoutingContext> {
         final MultiMap params = request.formAttributes();
         final boolean userRejected = "false".equalsIgnoreCase(params.get(USER_OAUTH_APPROVAL));
 
+        // Unless the user rejected the request outright, every required scope that is being presented must
+        // come back explicitly approved in the submission. Otherwise, bounce back to login with access_denied.
+        if (!userRejected) {
+            final Set<String> requiredScopes = RequiredScopeUtils.requiredScopeKeys(client);
+            for (String presentedScope : presentedConsent) {
+                if (requiredScopes.contains(presentedScope) && !isApproved(params.get(SCOPE_PREFIX + presentedScope))) {
+                    routingContext.fail(new AccessDeniedException("Consent could not be verified"));
+                    return;
+                }
+            }
+        }
+
         // derive each scope's outcome from its own submitted field value
         Set<String> approvedConsent = new HashSet<>();
         List<ScopeApproval> approvals = new ArrayList<>();
         for (String presentedScope : presentedConsent) {
-            String value = userRejected ? "false" : params.get(SCOPE_PREFIX + presentedScope);
-            value = value == null ? "" : value.toLowerCase();
-            if ("true".equals(value) || value.startsWith("approve")) {
+            if (!userRejected && isApproved(params.get(SCOPE_PREFIX + presentedScope))) {
                 approvedConsent.add(presentedScope);
                 approvals.add(new ScopeApproval(authorizationRequest.transactionId(), user.getFullId(), client.getClientId(), domain.getId(),
                         presentedScope, ScopeApproval.ApprovalStatus.APPROVED));
@@ -141,6 +153,14 @@ public class UserConsentProcessHandler implements Handler<RoutingContext> {
                         approvals1 -> handler.handle(Future.succeededFuture(approvals1)),
                         error -> handler.handle(Future.failedFuture(error))
                 );
+    }
+
+    private static boolean isApproved(String submittedValue) {
+        if (submittedValue == null) {
+            return false;
+        }
+        final String normalized = submittedValue.toLowerCase();
+        return "true".equals(normalized) || normalized.startsWith("approve");
     }
 
     private io.gravitee.am.identityprovider.api.User getAuthenticatedUser(RoutingContext context,

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/utils/RequiredScopeUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/utils/RequiredScopeUtils.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oauth2.service.utils;
+
+import io.gravitee.am.model.application.ApplicationScopeSettings;
+import io.gravitee.am.model.oidc.Client;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RequiredScopeUtils {
+
+    /**
+     * Gets the scope keys flagged as required in the client's scope settings.
+     */
+    public static Set<String> requiredScopeKeys(Client client) {
+        if (client == null || client.getScopeSettings() == null) {
+            return Collections.emptySet();
+        }
+        return client.getScopeSettings().stream()
+                .filter(ApplicationScopeSettings::isRequiredScope)
+                .map(ApplicationScopeSettings::getScope)
+                .collect(Collectors.toSet());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/UserConsentEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/authorization/consent/UserConsentEndpointTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oauth2.resources.endpoint.authorization.consent;
+
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.handler.oauth2.service.consent.UserConsentService;
+import io.gravitee.am.gateway.handler.oauth2.service.request.AuthorizationRequest;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.application.ApplicationScopeSettings;
+import io.gravitee.am.model.oauth2.Scope;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import io.vertx.rxjava3.ext.web.templ.thymeleaf.ThymeleafTemplateEngine;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UserConsentEndpointTest extends RxWebTestBase {
+
+    @Mock
+    private UserConsentService userConsentService;
+
+    @Mock
+    private ThymeleafTemplateEngine templateEngine;
+
+    @Mock
+    private Domain domain;
+
+    private Client client;
+    private AuthorizationRequest authorizationRequest;
+    private RoutingContext capturedContext;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        client = new Client();
+        client.setClientId("client-id");
+
+        authorizationRequest = new AuthorizationRequest();
+        authorizationRequest.setPrompts(Set.of("consent"));
+
+        when(templateEngine.render(anyMap(), any())).thenReturn(Single.just(Buffer.buffer()));
+
+        router.route().order(-1)
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+                    rc.put(ConstantKeys.AUTHORIZATION_REQUEST_CONTEXT_KEY, authorizationRequest);
+                    rc.next();
+                });
+
+        router.route(HttpMethod.GET, "/oauth/confirm_access")
+                .handler(rc -> {
+                    capturedContext = rc;
+                    new UserConsentEndpoint(userConsentService, templateEngine, domain).handle(rc);
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Scope> requiredScopes() {
+        return (List<Scope>) capturedContext.get(ConstantKeys.REQUIRED_SCOPES_CONTEXT_KEY);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Scope> optionalScopes() {
+        return (List<Scope>) capturedContext.get(ConstantKeys.OPTIONAL_SCOPES_CONTEXT_KEY);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Scope> orderedScopes() {
+        return (List<Scope>) capturedContext.get(ConstantKeys.SCOPES_CONTEXT_KEY);
+    }
+
+    private static Scope scope(String key) {
+        Scope scope = new Scope(key);
+        scope.setDescription(key + "-description");
+        return scope;
+    }
+
+    private static Set<String> keys(List<Scope> scopes) {
+        return scopes.stream().map(Scope::getKey).collect(Collectors.toSet());
+    }
+
+    private static ApplicationScopeSettings requiredScopeSetting(String scope) {
+        ApplicationScopeSettings settings = new ApplicationScopeSettings(scope);
+        settings.setRequiredScope(true);
+        return settings;
+    }
+
+    @Test
+    public void shouldSplitRequiredAndOptionalScopes_andOrderRequiredFirst() throws Exception {
+        authorizationRequest.setScopes(Set.of("read", "write", "admin"));
+        client.setScopeSettings(List.of(requiredScopeSetting("admin")));
+        when(userConsentService.getConsentInformation(authorizationRequest.getScopes()))
+                .thenReturn(Single.just(List.of(scope("read"), scope("write"), scope("admin"))));
+
+        testRequest(HttpMethod.GET, "/oauth/confirm_access", HttpStatusCode.OK_200, "OK");
+
+        assertEquals(Set.of("admin"), keys(requiredScopes()));
+        assertEquals(Set.of("read", "write"), keys(optionalScopes()));
+        assertEquals(List.of("admin", "read", "write"), orderedScopes().stream().map(Scope::getKey).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void shouldTreatAllScopesAsOptional_whenNoneAreRequired() throws Exception {
+        authorizationRequest.setScopes(Set.of("read", "write"));
+        client.setScopeSettings(List.of(new ApplicationScopeSettings("read"), new ApplicationScopeSettings("write")));
+        when(userConsentService.getConsentInformation(authorizationRequest.getScopes()))
+                .thenReturn(Single.just(List.of(scope("read"), scope("write"))));
+
+        testRequest(HttpMethod.GET, "/oauth/confirm_access", HttpStatusCode.OK_200, "OK");
+
+        assertEquals(Set.of(), keys(requiredScopes()));
+        assertEquals(Set.of("read", "write"), keys(optionalScopes()));
+    }
+
+    @Test
+    public void shouldIgnoreRequiredScopeSetting_whenScopeIsNotRequested() throws Exception {
+        // "admin" is flagged required on the application, but the client did not request it this time
+        authorizationRequest.setScopes(Set.of("read"));
+        client.setScopeSettings(List.of(requiredScopeSetting("admin")));
+        when(userConsentService.getConsentInformation(authorizationRequest.getScopes()))
+                .thenReturn(Single.just(List.of(scope("read"))));
+
+        testRequest(HttpMethod.GET, "/oauth/confirm_access", HttpStatusCode.OK_200, "OK");
+
+        assertEquals(Set.of(), keys(requiredScopes()));
+        assertEquals(Set.of("read"), keys(optionalScopes()));
+    }
+
+    @Test
+    public void shouldHandleAbsentScopeSettings_treatingEverythingAsOptional() throws Exception {
+        authorizationRequest.setScopes(Set.of("read"));
+        client.setScopeSettings(null);
+        when(userConsentService.getConsentInformation(authorizationRequest.getScopes()))
+                .thenReturn(Single.just(List.of(scope("read"))));
+
+        testRequest(HttpMethod.GET, "/oauth/confirm_access", HttpStatusCode.OK_200, "OK");
+
+        assertEquals(Set.of(), keys(requiredScopes()));
+        assertEquals(Set.of("read"), keys(optionalScopes()));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/consent/UserConsentProcessHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/consent/UserConsentProcessHandlerTest.java
@@ -15,12 +15,14 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.resources.handler.authorization.consent;
 
+import io.gravitee.am.common.exception.oauth2.OAuth2Exception;
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
 import io.gravitee.am.gateway.handler.oauth2.service.consent.UserConsentService;
 import io.gravitee.am.gateway.handler.oauth2.service.request.AuthorizationRequest;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.User;
+import io.gravitee.am.model.application.ApplicationScopeSettings;
 import io.gravitee.am.model.oauth2.ScopeApproval;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.common.http.HttpStatusCode;
@@ -46,6 +48,7 @@ import java.util.stream.Collectors;
 import static io.gravitee.am.gateway.handler.common.vertx.web.RoutingContextHelper.setUser;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -98,7 +101,14 @@ public class UserConsentProcessHandlerTest extends RxWebTestBase {
 
         router.route(HttpMethod.POST, "/oauth/consent")
                 .handler(new UserConsentProcessHandler(userConsentService, domain))
-                .handler(rc -> rc.response().setStatusCode(200).end());
+                .handler(rc -> rc.response().setStatusCode(200).end())
+                .failureHandler(rc -> {
+                    if (rc.failure() instanceof OAuth2Exception oAuth2Exception) {
+                        rc.response().setStatusCode(oAuth2Exception.getHttpStatusCode()).end(oAuth2Exception.getOAuth2ErrorCode());
+                    } else {
+                        rc.response().setStatusCode(500).end();
+                    }
+                });
     }
 
     private List<ScopeApproval> captureSavedApprovals() {
@@ -214,6 +224,75 @@ public class UserConsentProcessHandlerTest extends RxWebTestBase {
         List<ScopeApproval> approvals = captureSavedApprovals();
         assertEquals(Set.of("read"), approvedScopes(approvals));
         assertEquals(Set.of("write"), deniedScopes(approvals));
+    }
+
+    @Test
+    public void shouldApproveRequiredScope_whenSubmittedTrue() throws Exception {
+        authorizationRequest.setScopes(new HashSet<>(Set.of("read", "admin")));
+        client.setScopeSettings(List.of(requiredScopeSetting("admin")));
+        when(userConsentService.checkConsent(any(), any())).thenReturn(Single.just(Collections.emptySet()));
+
+        testRequest(HttpMethod.POST, "/oauth/consent",
+                req -> writeForm(req, "scope.read=true&scope.admin=true&user_oauth_approval=true"),
+                HttpStatusCode.OK_200, "OK", null);
+
+        List<ScopeApproval> approvals = captureSavedApprovals();
+        assertEquals(Set.of("read", "admin"), approvedScopes(approvals));
+        assertTrue(deniedScopes(approvals).isEmpty());
+        assertEquals(Set.of("read", "admin"), authorizationRequest.getScopes());
+    }
+
+    @Test
+    public void shouldRejectWithAccessDenied_whenRequiredScopeIsMissing() throws Exception {
+        // a presented required scope with no submitted value means it was not shown/approved
+        // (rendering issue or tampering): consent must not be persisted
+        authorizationRequest.setScopes(new HashSet<>(Set.of("read", "admin")));
+        client.setScopeSettings(List.of(requiredScopeSetting("admin")));
+        when(userConsentService.checkConsent(any(), any())).thenReturn(Single.just(Collections.emptySet()));
+
+        testRequest(HttpMethod.POST, "/oauth/consent",
+                req -> writeForm(req, "scope.read=true&user_oauth_approval=true"),
+                403, "Forbidden", "access_denied");
+
+        verify(userConsentService, never()).saveConsent(any(), anyList(), any());
+        assertFalse(authorizationRequest.isApproved());
+    }
+
+    @Test
+    public void shouldRejectWithAccessDenied_whenRequiredScopeIsSubmittedFalse() throws Exception {
+        // a tampered payload sets the required scope to false
+        authorizationRequest.setScopes(new HashSet<>(Set.of("read", "admin")));
+        client.setScopeSettings(List.of(requiredScopeSetting("admin")));
+        when(userConsentService.checkConsent(any(), any())).thenReturn(Single.just(Collections.emptySet()));
+
+        testRequest(HttpMethod.POST, "/oauth/consent",
+                req -> writeForm(req, "scope.read=true&scope.admin=false&user_oauth_approval=true"),
+                403, "Forbidden", "access_denied");
+
+        verify(userConsentService, never()).saveConsent(any(), anyList(), any());
+    }
+
+    @Test
+    public void shouldDenyRequiredScope_whenUserRejectsOverall() throws Exception {
+        // the required-scope check is skipped on an outright rejection: everything is denied, no access_denied
+        authorizationRequest.setScopes(new HashSet<>(Set.of("read", "admin")));
+        client.setScopeSettings(List.of(requiredScopeSetting("admin")));
+        when(userConsentService.checkConsent(any(), any())).thenReturn(Single.just(Collections.emptySet()));
+
+        testRequest(HttpMethod.POST, "/oauth/consent",
+                req -> writeForm(req, "user_oauth_approval=false"),
+                HttpStatusCode.OK_200, "OK", null);
+
+        List<ScopeApproval> approvals = captureSavedApprovals();
+        assertTrue(approvedScopes(approvals).isEmpty());
+        assertEquals(Set.of("read", "admin"), deniedScopes(approvals));
+        assertFalse(authorizationRequest.isApproved());
+    }
+
+    private static ApplicationScopeSettings requiredScopeSetting(String scope) {
+        ApplicationScopeSettings settings = new ApplicationScopeSettings(scope);
+        settings.setRequiredScope(true);
+        return settings;
     }
 
     private void writeForm(io.vertx.rxjava3.core.http.HttpClientRequest req, String body) {

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -230,6 +230,8 @@ oauth.consent.scope.search_placeholder=Search permissions...
 oauth.consent.scope.filter_all=All
 oauth.consent.scope.filter_selected=Selected
 oauth.consent.scope.filter_unselected=Unselected
+oauth.consent.scope.required_label=Required
+oauth.consent.scope.required_table_header={0} required permissions (always included)
 
 identifier_first.description=Don't have an account yet?
 identifier_first.button.submit=Sign in

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
@@ -230,6 +230,8 @@ oauth.consent.scope.search_placeholder=Rechercher des permissions...
 oauth.consent.scope.filter_all=Toutes
 oauth.consent.scope.filter_selected=Sélectionnées
 oauth.consent.scope.filter_unselected=Non sélectionnées
+oauth.consent.scope.required_label=Obligatoire
+oauth.consent.scope.required_table_header={0} autorisations obligatoires (toujours incluses)
 
 identifier_first.description=Vous n'avez pas encore de compte ?
 identifier_first.button.submit=Connexion

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/preview/PreviewBuilder.java
@@ -29,6 +29,7 @@ import io.gravitee.am.model.Form;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.Template;
 import io.gravitee.am.model.account.FormField;
+import io.gravitee.am.model.oauth2.Scope;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.safe.ClientProperties;
 import io.gravitee.am.model.safe.DomainProperties;
@@ -290,9 +291,21 @@ public class PreviewBuilder {
                 variables.put(ConstantKeys.TEMPLATE_KEY_REMEMBER_ME_KEY, Boolean.TRUE.toString());
                 break;
 
+            case OAUTH2_USER_CONSENT:
+                final Scope requiredScope = previewScope("profile", "Access to the End-User default profile Claims");
+                final Scope optionalScope1 = previewScope("read:orders", "View your orders");
+                final Scope optionalScope2 = previewScope("write:orders", "Create and update your orders");
+                final List<Scope> requiredScopes = List.of(requiredScope);
+                final List<Scope> optionalScopes = List.of(optionalScope1, optionalScope2);
+                // required scopes are displayed first, mirroring the gateway ordering
+                variables.put(ConstantKeys.SCOPES_CONTEXT_KEY, List.of(requiredScope, optionalScope1, optionalScope2));
+                variables.put(ConstantKeys.REQUIRED_SCOPES_CONTEXT_KEY, requiredScopes);
+                variables.put(ConstantKeys.OPTIONAL_SCOPES_CONTEXT_KEY, optionalScopes);
+                variables.put(ConstantKeys.PRESELECT_ALL_SCOPES, Boolean.TRUE);
+                break;
+
             // template without specific variables
             case RESET_PASSWORD:
-            case OAUTH2_USER_CONSENT:
             case BLOCKED_ACCOUNT:
             case COMPLETE_PROFILE:
             case WEBAUTHN_REGISTER:
@@ -302,6 +315,12 @@ public class PreviewBuilder {
                 break;
         }
         return variables;
+    }
+
+    private static Scope previewScope(String key, String description) {
+        final Scope scope = new Scope(key);
+        scope.setDescription(description);
+        return scope;
     }
 
     private UserProperties generateFakeUser() {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/assets/preview/css/main.css
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/assets/preview/css/main.css
@@ -441,6 +441,12 @@ div.section > form {
     background: var(--primary-background-color, #DA3B00);
 }
 
+.scope-consent-main-section {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
 .scope-consent-table {
     width: 100%;
     border: 2px solid var(--scope-consent-border-color, #ededed);
@@ -469,8 +475,19 @@ div.section > form {
     white-space: nowrap;
 }
 
+.scope-consent-table .scope-consent-cell-name {
+    padding-left: 0;
+}
+
+.scope-consent-name-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
 .scope-consent-cell-description {
-    width: 66%;
+    width: 60%;
     color: var(--scope-consent-description-color, #6b6b6b);
 }
 
@@ -478,13 +495,68 @@ div.section > form {
     width: 18px;
     height: 18px;
     margin: 0;
+    top: 2px;
+    position: relative;
     accent-color: var(--primary-background-color);
     cursor: pointer;
+}
+
+.scope-consent-checkbox:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
 }
 
 .scope-consent-cell-name label {
     font-weight: 600;
     cursor: pointer;
+    overflow-wrap: anywhere;
+}
+
+.scope-consent-cell-name label.grey {
+    cursor: not-allowed;
+}
+
+.scope-consent-required-chip {
+    display: inline-block;
+    padding: 2px 6px;
+    font-size: 11px;
+    color: var(--scope-consent-description-color, #6b6b6b);
+    background: var(--item-background-color, #f0f0f0);
+    border: 1px solid var(--scope-consent-border-color, #ededed);
+    border-radius: 999px;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.scope-consent-required-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.scope-consent-required-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 10px 12px;
+    border: 2px solid var(--scope-consent-border-color, #ededed);
+    border-radius: 8px;
+    background: var(--item-background-color, #f7f7f7);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.scope-consent-required-header .icons {
+    font-size: 20px;
+    color: var(--scope-consent-description-color, #6b6b6b);
+}
+
+.scope-consent-required-section.is-collapsed .scope-consent-table {
+    display: none;
 }
 
 .scope-consent-buttons {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/oauth2_user_consent.html
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/resources/views/default/oauth2_user_consent.html
@@ -32,42 +32,80 @@
         </div>
     </div>
     <div class="section">
-        <form class="form" role="form" th:id="confirmationForm" th:action="${action}" method="post">
+        <form class="form" role="form" th:id="confirmationForm" th:action="${action}" method="post"
+              th:with="splitRequired=${not #lists.isEmpty(requiredScopes) and #lists.size(scopes) > 10},tableScopes=${splitRequired ? optionalScopes : scopes}">
             <span class="header-description start" th:text="#{oauth.consent.instructions}"></span>
-            <div class="scope-consent-search" th:if="${scopes != null and #lists.size(scopes) > 10}">
-                <span class="icons scope-consent-search-icon" aria-hidden="true">search</span>
-                <input type="text" id="scopeSearchInput" class="scope-consent-search-input" autocomplete="off"
-                       th:attr="placeholder=#{oauth.consent.scope.search_placeholder}"/>
-            </div>
-            <div class="scope-consent-toolbar" th:if="${scopes != null and #lists.size(scopes) > 1}">
-                <div class="scope-consent-filter" role="group" th:if="${scopes != null and #lists.size(scopes) > 10}">
-                    <button type="button" class="scope-consent-filter-option is-active" data-filter="all" id="filterAll" th:text="#{oauth.consent.scope.filter_all}"></button>
-                    <button type="button" class="scope-consent-filter-option" data-filter="selected" id="filterSelected" th:text="#{oauth.consent.scope.filter_selected}"></button>
-                    <button type="button" class="scope-consent-filter-option" data-filter="unselected" id="filterUnselected" th:text="#{oauth.consent.scope.filter_unselected}"></button>
+
+            <div class="scope-consent-required-section" id="requiredScopesSection" th:if="${splitRequired}">
+                <div class="scope-consent-required-header" id="requiredScopesToggle" role="button" tabindex="0" aria-expanded="true">
+                    <span id="requiredScopesHeaderLabel"
+                          th:attr="data-template=#{oauth.consent.scope.required_table_header},data-count=${#lists.size(requiredScopes)}"></span>
+                    <span class="icons" id="requiredScopesToggleIcon" aria-hidden="true">expand_less</span>
                 </div>
-                <div class="scope-consent-actions">
-                    <button type="button" class="button secondary scope-consent-control" id="selectAllScopes" th:text="#{oauth.consent.scope.select_all}"></button>
-                    <button type="button" class="button secondary scope-consent-control" id="clearAllScopes" th:text="#{oauth.consent.scope.clear_all}"></button>
-                </div>
-                <span class="scope-consent-count" id="scopeSelectionCount"
-                      th:attr="data-template=#{oauth.consent.scope.selected_count},data-total=${#lists.size(scopes)}"></span>
+                <table class="scope-consent-table" id="requiredScopesTable">
+                    <tbody>
+                        <tr class="scope-consent-row" th:each="scope : ${requiredScopes}">
+                            <td class="scope-consent-cell-checkbox">
+                                <input type="checkbox" class="scope-consent-checkbox" th:id="'scope-'+${scope.key}"
+                                       th:name="'scope.'+${scope.key}" value="true" checked="checked" disabled="disabled"/>
+                                <input type="hidden" th:name="'scope.'+${scope.key}" value="true"/>
+                            </td>
+                            <td class="scope-consent-cell-name">
+                                <div class="scope-consent-name-wrap">
+                                    <label th:for="'scope-'+${scope.key}" class="grey" th:text="${scope.key}"></label>
+                                    <span class="scope-consent-required-chip" th:text="#{oauth.consent.scope.required_label}"></span>
+                                </div>
+                            </td>
+                            <td class="scope-consent-cell-description">
+                                <span class="grey" th:text="${scope.description}"></span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
-            <table class="scope-consent-table" th:if="${scopes != null and not #lists.isEmpty(scopes)}">
-                <tbody>
-                    <tr class="scope-consent-row" th:each="scope : ${scopes}">
-                        <td class="scope-consent-cell-checkbox">
-                            <input type="checkbox" class="scope-consent-checkbox" th:id="'scope-'+${scope.key}"
-                                   th:name="'scope.'+${scope.key}" value="true" th:checked="${preselectAllScopes}"/>
-                        </td>
-                        <td class="scope-consent-cell-name">
-                            <label th:for="'scope-'+${scope.key}" th:text="${scope.key}"></label>
-                        </td>
-                        <td class="scope-consent-cell-description">
-                            <span class="grey" th:text="${scope.description}"></span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+
+            <div class="scope-consent-main-section" id="mainScopesSection" th:if="${not #lists.isEmpty(tableScopes)}">
+                <div class="scope-consent-search" th:if="${#lists.size(scopes) > 10}">
+                    <span class="icons scope-consent-search-icon" aria-hidden="true">search</span>
+                    <input type="text" id="scopeSearchInput" class="scope-consent-search-input" autocomplete="off"
+                           th:attr="placeholder=#{oauth.consent.scope.search_placeholder}"/>
+                </div>
+                <div class="scope-consent-toolbar" th:if="${#lists.size(scopes) > 1}">
+                    <div class="scope-consent-filter" role="group" th:if="${#lists.size(scopes) > 10}">
+                        <button type="button" class="scope-consent-filter-option is-active" data-filter="all" id="filterAll" th:text="#{oauth.consent.scope.filter_all}"></button>
+                        <button type="button" class="scope-consent-filter-option" data-filter="selected" id="filterSelected" th:text="#{oauth.consent.scope.filter_selected}"></button>
+                        <button type="button" class="scope-consent-filter-option" data-filter="unselected" id="filterUnselected" th:text="#{oauth.consent.scope.filter_unselected}"></button>
+                    </div>
+                    <div class="scope-consent-actions">
+                        <button type="button" class="button secondary scope-consent-control" id="selectAllScopes" th:text="#{oauth.consent.scope.select_all}"></button>
+                        <button type="button" class="button secondary scope-consent-control" id="clearAllScopes" th:text="#{oauth.consent.scope.clear_all}"></button>
+                    </div>
+                    <span class="scope-consent-count" id="scopeSelectionCount"
+                          th:attr="data-template=#{oauth.consent.scope.selected_count},data-total=${#lists.size(tableScopes)}"></span>
+                </div>
+                <table class="scope-consent-table">
+                    <tbody>
+                        <tr class="scope-consent-row" th:each="scope : ${tableScopes}" th:with="rowRequired=${#lists.contains(requiredScopes, scope)}">
+                            <td class="scope-consent-cell-checkbox">
+                                <input type="checkbox" class="scope-consent-checkbox" th:id="'scope-'+${scope.key}"
+                                       th:name="'scope.'+${scope.key}" value="true"
+                                       th:checked="${rowRequired ? true : preselectAllScopes}"
+                                       th:disabled="${rowRequired}"/>
+                                <input type="hidden" th:if="${rowRequired}" th:name="'scope.'+${scope.key}" value="true"/>
+                            </td>
+                            <td class="scope-consent-cell-name">
+                                <div class="scope-consent-name-wrap">
+                                    <label th:for="'scope-'+${scope.key}" th:classappend="${rowRequired ? 'grey' : ''}" th:text="${scope.key}"></label>
+                                    <span class="scope-consent-required-chip" th:if="${rowRequired}" th:text="#{oauth.consent.scope.required_label}"></span>
+                                </div>
+                            </td>
+                            <td class="scope-consent-cell-description">
+                                <span class="grey" th:text="${scope.description}"></span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
 
             <span class="header-description start" th:text="${client.clientName} + ' ' + #{oauth.disclaimer}"></span>
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
@@ -88,8 +126,10 @@
     <script th:inline="javascript" th:attr="nonce=${script_inline_nonce}">
         /*<![CDATA[*/
         (function () {
-            var checkboxes = Array.prototype.slice.call(document.querySelectorAll('.scope-consent-checkbox'));
-            var rows = Array.prototype.slice.call(document.querySelectorAll('.scope-consent-row'));
+            var allCheckboxes = Array.prototype.slice.call(document.querySelectorAll('.scope-consent-checkbox'));
+            var mainSection = document.getElementById('mainScopesSection');
+            var checkboxes = mainSection ? Array.prototype.slice.call(mainSection.querySelectorAll('.scope-consent-checkbox')) : [];
+            var rows = mainSection ? Array.prototype.slice.call(mainSection.querySelectorAll('.scope-consent-row')) : [];
             var allowButton = document.getElementById('allowButton');
             var selectAll = document.getElementById('selectAllScopes');
             var clearAll = document.getElementById('clearAllScopes');
@@ -97,19 +137,30 @@
             var searchInput = document.getElementById('scopeSearchInput');
             var filterButtons = Array.prototype.slice.call(document.querySelectorAll('.scope-consent-filter-option'));
             var cimdLogo = document.querySelector('.cimd-consent-client-logo');
+            var requiredToggle = document.getElementById('requiredScopesToggle');
+            var requiredSection = document.getElementById('requiredScopesSection');
+            var requiredToggleIcon = document.getElementById('requiredScopesToggleIcon');
+            var requiredHeaderLabel = document.getElementById('requiredScopesHeaderLabel');
+
+            if (requiredHeaderLabel) {
+                var headerTemplate = requiredHeaderLabel.getAttribute('data-template') || '{0} required permissions (always included)';
+                var requiredCount = requiredHeaderLabel.getAttribute('data-count') || '0';
+                requiredHeaderLabel.textContent = headerTemplate.replace('{0}', requiredCount);
+            }
 
             var activeFilter = 'all';
             var searchTerm = '';
 
             function refreshCount() {
                 var selected = checkboxes.filter(function (checkbox) { return checkbox.checked; }).length;
-                if (allowButton && checkboxes.length > 0) {
-                    allowButton.disabled = selected === 0;
-                }
                 if (countLabel) {
                     var template = countLabel.getAttribute('data-template') || '{0} of {1} selected';
                     var total = countLabel.getAttribute('data-total') || String(checkboxes.length);
                     countLabel.textContent = template.replace('{0}', selected).replace('{1}', total);
+                }
+                if (allowButton && allCheckboxes.length > 0) {
+                    var anySelected = allCheckboxes.some(function (checkbox) { return checkbox.checked; });
+                    allowButton.disabled = !anySelected;
                 }
             }
 
@@ -141,13 +192,13 @@
             checkboxes.forEach(function (checkbox) { checkbox.addEventListener('change', refresh); });
             if (selectAll) {
                 selectAll.addEventListener('click', function () {
-                    checkboxes.forEach(function (checkbox) { checkbox.checked = true; });
+                    checkboxes.forEach(function (checkbox) { if (!checkbox.disabled) { checkbox.checked = true; } });
                     refresh();
                 });
             }
             if (clearAll) {
                 clearAll.addEventListener('click', function () {
-                    checkboxes.forEach(function (checkbox) { checkbox.checked = false; });
+                    checkboxes.forEach(function (checkbox) { if (!checkbox.disabled) { checkbox.checked = false; } });
                     refresh();
                 });
             }
@@ -165,6 +216,21 @@
                     applyFilters();
                 });
             });
+            if (requiredToggle && requiredSection) {
+                requiredToggle.addEventListener('click', function () {
+                    var collapsed = requiredSection.classList.toggle('is-collapsed');
+                    requiredToggle.setAttribute('aria-expanded', String(!collapsed));
+                    if (requiredToggleIcon) {
+                        requiredToggleIcon.textContent = collapsed ? 'expand_more' : 'expand_less';
+                    }
+                });
+                requiredToggle.addEventListener('keydown', function (event) {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        requiredToggle.click();
+                    }
+                });
+            }
             if (cimdLogo) {
                 cimdLogo.addEventListener('error', function () {
                     cimdLogo.style.display = 'none';

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/preview/PreviewServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/preview/PreviewServiceTest.java
@@ -176,6 +176,29 @@ public class PreviewServiceTest {
     }
 
     @Test
+    public void shouldRenderConsentForm_withSampleScopes() {
+        when(domainService.findById(DOMAIN_ID)).thenReturn(Maybe.just(new Domain()));
+        when(themeService.findByReference(ReferenceType.DOMAIN, DOMAIN_ID)).thenReturn(Maybe.empty());
+        when(i18nDictionaryService.findAll(any(), any())).thenReturn(Flowable.empty());
+
+        final PreviewRequest previewRequest = new PreviewRequest();
+        previewRequest.setContent(
+                "<html lang=\"en\" xmlns:th=\"http://www.thymeleaf.org\"><body>" +
+                        "<span class=\"required-count\" th:text=\"${#lists.size(requiredScopes)}\"></span>" +
+                        "<span class=\"scope\" th:each=\"scope : ${scopes}\" th:text=\"${scope.key}\"></span>" +
+                        "</body></html>");
+        previewRequest.setTemplate(Template.OAUTH2_USER_CONSENT.template());
+        final TestObserver<PreviewResponse> observer = previewService.previewDomainForm(DOMAIN_ID, previewRequest, Locale.ENGLISH, BASE_URL).test();
+
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertNoErrors();
+        observer.assertValue(response -> response.getContent() != null && response.getContent().contains("profile"));
+        observer.assertValue(response -> response.getContent() != null && response.getContent().contains("read:orders"));
+        observer.assertValue(response -> response.getContent() != null && response.getContent().contains("write:orders"));
+        observer.assertValue(response -> response.getContent() != null && response.getContent().contains(">1<"));
+    }
+
+    @Test
     public void shouldNotRenderDomainForm_missingValues() {
         when(domainService.findById(DOMAIN_ID)).thenReturn(Maybe.just(new Domain()));
         when(themeService.findByReference(ReferenceType.DOMAIN, DOMAIN_ID)).thenReturn(Maybe.empty());

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_en.properties
@@ -222,6 +222,8 @@ oauth.consent.scope.search_placeholder=Search permissions...
 oauth.consent.scope.filter_all=All
 oauth.consent.scope.filter_selected=Selected
 oauth.consent.scope.filter_unselected=Unselected
+oauth.consent.scope.required_label=Required
+oauth.consent.scope.required_table_header={0} required permissions (always included)
 
 identifier_first.description=Don't have an account yet?
 identifier_first.button.submit=Sign in

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/templates/i18n/messages_fr.properties
@@ -222,6 +222,8 @@ oauth.consent.scope.search_placeholder=Rechercher des permissions...
 oauth.consent.scope.filter_all=Toutes
 oauth.consent.scope.filter_selected=Sélectionnées
 oauth.consent.scope.filter_unselected=Non sélectionnées
+oauth.consent.scope.required_label=Obligatoire
+oauth.consent.scope.required_table_header={0} autorisations obligatoires (toujours incluses)
 
 identifier_first.description=Vous n'avez pas encore de compte ?
 identifier_first.button.submit=Connexion

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationScopeSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationScopeSettings.java
@@ -29,6 +29,11 @@ public class ApplicationScopeSettings {
      * Scope approval duration times
      */
     private Integer scopeApproval;
+    /**
+     * True if the scope is required: it cannot be deselected by the user during consent
+     * and has to be granted to allow the authorization request.
+     */
+    private boolean requiredScope;
 
     public ApplicationScopeSettings() {
     }
@@ -41,6 +46,7 @@ public class ApplicationScopeSettings {
         this.scope = other.scope;
         this.defaultScope = other.defaultScope;
         this.scopeApproval = other.scopeApproval;
+        this.requiredScope = other.requiredScope;
     }
 
     public String getScope() {
@@ -65,5 +71,13 @@ public class ApplicationScopeSettings {
 
     public void setScopeApproval(Integer scopeApproval) {
         this.scopeApproval = scopeApproval;
+    }
+
+    public boolean isRequiredScope() {
+        return requiredScope;
+    }
+
+    public void setRequiredScope(boolean requiredScope) {
+        this.requiredScope = requiredScope;
     }
 }

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/application/ApplicationScopeSettingsTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/application/ApplicationScopeSettingsTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.application;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApplicationScopeSettingsTest {
+
+    @Test
+    public void requiredScope_defaultsToFalse() {
+        assertFalse(new ApplicationScopeSettings("read").isRequiredScope());
+    }
+
+    @Test
+    public void copyConstructor_propagates_requiredScope() {
+        ApplicationScopeSettings source = new ApplicationScopeSettings("read");
+        source.setRequiredScope(true);
+
+        ApplicationScopeSettings copy = new ApplicationScopeSettings(source);
+
+        assertTrue(copy.isRequiredScope());
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcApplicationRepository.java
@@ -640,11 +640,12 @@ public class JdbcApplicationRepository extends AbstractJdbcRepository implements
         final List<ApplicationScopeSettings> scopeSettings = Optional.ofNullable(app.getSettings()).map(ApplicationSettings::getOauth).map(ApplicationOAuthSettings::getScopeSettings).orElse(Collections.emptyList());
         if (scopeSettings != null && !scopeSettings.isEmpty()) {
             actionFlow = actionFlow.then(Flux.fromIterable(scopeSettings).concatMap(value -> {
-                String INSERT_STMT = "INSERT INTO application_scope_settings(application_id, scope, is_default, scope_approval) VALUES (:app, :scope, :default, :approval)";
+                String INSERT_STMT = "INSERT INTO application_scope_settings(application_id, scope, is_default, scope_approval, is_required) VALUES (:app, :scope, :default, :approval, :required)";
                 DatabaseClient.GenericExecuteSpec sql = getTemplate().getDatabaseClient()
                         .sql(INSERT_STMT)
                         .bind("app", app.getId())
-                        .bind("default", value.isDefaultScope());
+                        .bind("default", value.isDefaultScope())
+                        .bind("required", value.isRequiredScope());
                 sql = value.getScope() == null ? sql.bindNull("scope", String.class) : sql.bind("scope", value.getScope());
                 sql = value.getScopeApproval() == null ? sql.bindNull("approval", Integer.class) : sql.bind("approval", value.getScopeApproval());
                 return sql.fetch().rowsUpdated();

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcApplication.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcApplication.java
@@ -342,6 +342,8 @@ public class JdbcApplication {
         private boolean defaultScope;
         @Column("scope_approval")
         private Integer scopeApproval;
+        @Column("is_required")
+        private boolean requiredScope;
 
         public String getApplicationId() {
             return applicationId;
@@ -373,6 +375,14 @@ public class JdbcApplication {
 
         public void setScopeApproval(Integer scopeApproval) {
             this.scopeApproval = scopeApproval;
+        }
+
+        public boolean isRequiredScope() {
+            return requiredScope;
+        }
+
+        public void setRequiredScope(boolean requiredScope) {
+            this.requiredScope = requiredScope;
         }
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-application-scope-settings-add-required.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-application-scope-settings-add-required.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0-ApplicationScopeSettings-AddRequired
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: application_scope_settings
+            columns:
+              - column: { name: is_required, type: boolean, constraints: { nullable: false }, defaultValueBoolean: false }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
@@ -221,3 +221,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_12_0/4.12.0-automation-initial-columns.yml
   - include:
       - file: liquibase/changelogs/v4_12_0/4.12.0-applications-cursor-indexes.yml
+  - include:
+      - file: liquibase/changelogs/v4_13_0/4.13.0-application-scope-settings-add-required.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -790,6 +790,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationScopeSettings.setScope(other.getScope());
         applicationScopeSettings.setScopeApproval(other.getScopeApproval());
         applicationScopeSettings.setDefaultScope(other.isDefaultScope());
+        applicationScopeSettings.setRequiredScope(other.isRequiredScope());
         return applicationScopeSettings;
     }
 
@@ -798,6 +799,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationScopeSettingsMongo.setScope(other.getScope());
         applicationScopeSettingsMongo.setScopeApproval(other.getScopeApproval());
         applicationScopeSettingsMongo.setDefaultScope(other.isDefaultScope());
+        applicationScopeSettingsMongo.setRequiredScope(other.isRequiredScope());
         return applicationScopeSettingsMongo;
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationScopeSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationScopeSettingsMongo.java
@@ -30,6 +30,10 @@ public class ApplicationScopeSettingsMongo {
      * Scope approval duration times
      */
     private Integer scopeApproval;
+    /**
+     * True if the scope is required: it cannot be deselected by the user during consent.
+     */
+    private boolean requiredScope;
 
     public String getScope() {
         return scope;
@@ -53,5 +57,13 @@ public class ApplicationScopeSettingsMongo {
 
     public void setScopeApproval(Integer scopeApproval) {
         this.scopeApproval = scopeApproval;
+    }
+
+    public boolean isRequiredScope() {
+        return requiredScope;
+    }
+
+    public void setRequiredScope(boolean requiredScope) {
+        this.requiredScope = requiredScope;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/ApplicationRepositoryTest.java
@@ -232,6 +232,7 @@ public class ApplicationRepositoryTest extends AbstractManagementTest {
         testObserver.assertValue(a -> a.getSettings().getOauth().getScopeSettings().get(0).isDefaultScope());
         testObserver.assertValue(a -> a.getSettings().getOauth().getScopeSettings().get(0).getScopeApproval() == 42);
         testObserver.assertValue(a -> a.getSettings().getOauth().getScopeSettings().get(0).getScope().equals("scopename"));
+        testObserver.assertValue(a -> a.getSettings().getOauth().getScopeSettings().get(0).isRequiredScope());
         testObserver.assertValue(a -> a.getMetadata() != null);
         testObserver.assertValue(a -> a.getMetadata().containsKey("key1"));
         testObserver.assertValue(a -> a.getSettings() != null && a.getSettings().getAccount() != null );
@@ -301,6 +302,7 @@ public class ApplicationRepositoryTest extends AbstractManagementTest {
         scopeSettings.setScope("scopename");
         scopeSettings.setDefaultScope(true);
         scopeSettings.setScopeApproval(42);
+        scopeSettings.setRequiredScope(true);
         oauth.setScopeSettings(List.of(scopeSettings));
         TokenExchangeOAuthSettings teSettings = new TokenExchangeOAuthSettings();
         teSettings.setInherited(false);

--- a/gravitee-am-test/api/management/apis/ApplicationApi.ts
+++ b/gravitee-am-test/api/management/apis/ApplicationApi.ts
@@ -921,7 +921,7 @@ export class ApplicationApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the APPLICATION_FLOW[UPDATE] permission on the specified domain or APPLICATION_FLOW[UPDATE] permission on the specified environment or APPLICATION_FLOW[UPDATE] permission on the specified organization
+   * User must have the APPLICATION_FLOW[UPDATE] permission on the specified application or APPLICATION_FLOW[UPDATE] permission on the specified domain or APPLICATION_FLOW[UPDATE] permission on the specified environment or APPLICATION_FLOW[UPDATE] permission on the specified organization
    * Create or update list of flows
    */
   async defineAppFlowsRaw(
@@ -996,7 +996,7 @@ export class ApplicationApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the APPLICATION_FLOW[UPDATE] permission on the specified domain or APPLICATION_FLOW[UPDATE] permission on the specified environment or APPLICATION_FLOW[UPDATE] permission on the specified organization
+   * User must have the APPLICATION_FLOW[UPDATE] permission on the specified application or APPLICATION_FLOW[UPDATE] permission on the specified domain or APPLICATION_FLOW[UPDATE] permission on the specified environment or APPLICATION_FLOW[UPDATE] permission on the specified organization
    * Create or update list of flows
    */
   async defineAppFlows(
@@ -2105,7 +2105,7 @@ export class ApplicationApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the APPLICATION_FLOW[LIST] permission on the specified domain or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST] permission on the specified organization. Except if user has APPLICATION_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
+   * User must have the APPLICATION_FLOW[LIST] permission on the specified application or APPLICATION_FLOW[LIST] permission on the specified domain or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST] permission on the specified organization. Except if user has APPLICATION_FLOW[READ] permission on the application, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
    * List registered flows for an application
    */
   async listAppFlowsRaw(
@@ -2170,7 +2170,7 @@ export class ApplicationApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the APPLICATION_FLOW[LIST] permission on the specified domain or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST] permission on the specified organization. Except if user has APPLICATION_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
+   * User must have the APPLICATION_FLOW[LIST] permission on the specified application or APPLICATION_FLOW[LIST] permission on the specified domain or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST] permission on the specified organization. Except if user has APPLICATION_FLOW[READ] permission on the application, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
    * List registered flows for an application
    */
   async listAppFlows(

--- a/gravitee-am-test/api/management/apis/DomainApi.ts
+++ b/gravitee-am-test/api/management/apis/DomainApi.ts
@@ -5095,7 +5095,7 @@ export class DomainApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the APPLICATION_FLOW[UPDATE] permission on the specified domain or APPLICATION_FLOW[UPDATE] permission on the specified environment or APPLICATION_FLOW[UPDATE] permission on the specified organization
+   * User must have the APPLICATION_FLOW[UPDATE] permission on the specified application or APPLICATION_FLOW[UPDATE] permission on the specified domain or APPLICATION_FLOW[UPDATE] permission on the specified environment or APPLICATION_FLOW[UPDATE] permission on the specified organization
    * Create or update list of flows
    */
   async defineAppFlowsRaw(
@@ -5170,7 +5170,7 @@ export class DomainApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the APPLICATION_FLOW[UPDATE] permission on the specified domain or APPLICATION_FLOW[UPDATE] permission on the specified environment or APPLICATION_FLOW[UPDATE] permission on the specified organization
+   * User must have the APPLICATION_FLOW[UPDATE] permission on the specified application or APPLICATION_FLOW[UPDATE] permission on the specified domain or APPLICATION_FLOW[UPDATE] permission on the specified environment or APPLICATION_FLOW[UPDATE] permission on the specified organization
    * Create or update list of flows
    */
   async defineAppFlows(
@@ -11834,7 +11834,7 @@ export class DomainApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the APPLICATION_FLOW[LIST] permission on the specified domain or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST] permission on the specified organization. Except if user has APPLICATION_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
+   * User must have the APPLICATION_FLOW[LIST] permission on the specified application or APPLICATION_FLOW[LIST] permission on the specified domain or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST] permission on the specified organization. Except if user has APPLICATION_FLOW[READ] permission on the application, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
    * List registered flows for an application
    */
   async listAppFlowsRaw(
@@ -11899,7 +11899,7 @@ export class DomainApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the APPLICATION_FLOW[LIST] permission on the specified domain or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST] permission on the specified organization. Except if user has APPLICATION_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
+   * User must have the APPLICATION_FLOW[LIST] permission on the specified application or APPLICATION_FLOW[LIST] permission on the specified domain or APPLICATION_FLOW[LIST] permission on the specified environment or APPLICATION_FLOW[LIST] permission on the specified organization. Except if user has APPLICATION_FLOW[READ] permission on the application, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
    * List registered flows for an application
    */
   async listAppFlows(
@@ -13331,7 +13331,7 @@ export class DomainApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the PROTECTED_RESOURCE_FLOW[LIST] permission on the specified resource or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified domain or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified environment or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified organization. Except if user has PROTECTED_RESOURCE_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
+   * User must have the PROTECTED_RESOURCE_FLOW[LIST] permission on the specified resource or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified domain or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified environment or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified organization. Except if user has PROTECTED_RESOURCE_FLOW[READ] permission on the resource, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
    * List registered flows for a protected resource
    */
   async listProtectedResourceFlowsRaw(
@@ -13396,7 +13396,7 @@ export class DomainApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the PROTECTED_RESOURCE_FLOW[LIST] permission on the specified resource or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified domain or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified environment or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified organization. Except if user has PROTECTED_RESOURCE_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
+   * User must have the PROTECTED_RESOURCE_FLOW[LIST] permission on the specified resource or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified domain or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified environment or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified organization. Except if user has PROTECTED_RESOURCE_FLOW[READ] permission on the resource, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
    * List registered flows for a protected resource
    */
   async listProtectedResourceFlows(

--- a/gravitee-am-test/api/management/apis/ProtectedResourceApi.ts
+++ b/gravitee-am-test/api/management/apis/ProtectedResourceApi.ts
@@ -1000,7 +1000,7 @@ export class ProtectedResourceApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the PROTECTED_RESOURCE_FLOW[LIST] permission on the specified resource or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified domain or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified environment or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified organization. Except if user has PROTECTED_RESOURCE_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
+   * User must have the PROTECTED_RESOURCE_FLOW[LIST] permission on the specified resource or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified domain or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified environment or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified organization. Except if user has PROTECTED_RESOURCE_FLOW[READ] permission on the resource, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
    * List registered flows for a protected resource
    */
   async listProtectedResourceFlowsRaw(
@@ -1065,7 +1065,7 @@ export class ProtectedResourceApi extends runtime.BaseAPI {
   }
 
   /**
-   * User must have the PROTECTED_RESOURCE_FLOW[LIST] permission on the specified resource or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified domain or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified environment or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified organization. Except if user has PROTECTED_RESOURCE_FLOW[READ] permission on the domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
+   * User must have the PROTECTED_RESOURCE_FLOW[LIST] permission on the specified resource or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified domain or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified environment or PROTECTED_RESOURCE_FLOW[LIST] permission on the specified organization. Except if user has PROTECTED_RESOURCE_FLOW[READ] permission on the resource, domain, environment or organization, each returned flow is filtered and contains only basic information such as id and name and isEnabled.
    * List registered flows for a protected resource
    */
   async listProtectedResourceFlows(

--- a/gravitee-am-test/api/management/models/ApplicationOAuthSettings.ts
+++ b/gravitee-am-test/api/management/models/ApplicationOAuthSettings.ts
@@ -253,6 +253,12 @@ export interface ApplicationOAuthSettings {
   logoUri?: string;
   /**
    *
+   * @type {boolean}
+   * @memberof ApplicationOAuthSettings
+   */
+  optInScopeSelection?: boolean;
+  /**
+   *
    * @type {string}
    * @memberof ApplicationOAuthSettings
    */
@@ -534,6 +540,7 @@ export function ApplicationOAuthSettingsFromJSONTyped(json: any, ignoreDiscrimin
     jwks: json['jwks'] == null ? undefined : JWKSetFromJSON(json['jwks']),
     jwksUri: json['jwksUri'] == null ? undefined : json['jwksUri'],
     logoUri: json['logoUri'] == null ? undefined : json['logoUri'],
+    optInScopeSelection: json['optInScopeSelection'] == null ? undefined : json['optInScopeSelection'],
     policyUri: json['policyUri'] == null ? undefined : json['policyUri'],
     postLogoutRedirectUris: json['postLogoutRedirectUris'] == null ? undefined : json['postLogoutRedirectUris'],
     redirectUris: json['redirectUris'] == null ? undefined : json['redirectUris'],
@@ -621,6 +628,7 @@ export function ApplicationOAuthSettingsToJSONTyped(value?: ApplicationOAuthSett
     jwks: JWKSetToJSON(value['jwks']),
     jwksUri: value['jwksUri'],
     logoUri: value['logoUri'],
+    optInScopeSelection: value['optInScopeSelection'],
     policyUri: value['policyUri'],
     postLogoutRedirectUris: value['postLogoutRedirectUris'],
     redirectUris: value['redirectUris'],

--- a/gravitee-am-test/api/management/models/ApplicationScopeSettings.ts
+++ b/gravitee-am-test/api/management/models/ApplicationScopeSettings.ts
@@ -40,6 +40,12 @@ export interface ApplicationScopeSettings {
   defaultScope?: boolean;
   /**
    *
+   * @type {boolean}
+   * @memberof ApplicationScopeSettings
+   */
+  requiredScope?: boolean;
+  /**
+   *
    * @type {string}
    * @memberof ApplicationScopeSettings
    */
@@ -69,6 +75,7 @@ export function ApplicationScopeSettingsFromJSONTyped(json: any, ignoreDiscrimin
   }
   return {
     defaultScope: json['defaultScope'] == null ? undefined : json['defaultScope'],
+    requiredScope: json['requiredScope'] == null ? undefined : json['requiredScope'],
     scope: json['scope'] == null ? undefined : json['scope'],
     scopeApproval: json['scopeApproval'] == null ? undefined : json['scopeApproval'],
   };
@@ -85,6 +92,7 @@ export function ApplicationScopeSettingsToJSONTyped(value?: ApplicationScopeSett
 
   return {
     defaultScope: value['defaultScope'],
+    requiredScope: value['requiredScope'],
     scope: value['scope'],
     scopeApproval: value['scopeApproval'],
   };

--- a/gravitee-am-test/api/management/models/PatchApplicationOAuthSettings.ts
+++ b/gravitee-am-test/api/management/models/PatchApplicationOAuthSettings.ts
@@ -205,6 +205,12 @@ export interface PatchApplicationOAuthSettings {
   logoUri?: string;
   /**
    *
+   * @type {boolean}
+   * @memberof PatchApplicationOAuthSettings
+   */
+  optInScopeSelection?: boolean;
+  /**
+   *
    * @type {string}
    * @memberof PatchApplicationOAuthSettings
    */
@@ -459,6 +465,7 @@ export function PatchApplicationOAuthSettingsFromJSONTyped(json: any, ignoreDisc
     jwks: json['jwks'] == null ? undefined : JWKSetFromJSON(json['jwks']),
     jwksUri: json['jwksUri'] == null ? undefined : json['jwksUri'],
     logoUri: json['logoUri'] == null ? undefined : json['logoUri'],
+    optInScopeSelection: json['optInScopeSelection'] == null ? undefined : json['optInScopeSelection'],
     policyUri: json['policyUri'] == null ? undefined : json['policyUri'],
     postLogoutRedirectUris: json['postLogoutRedirectUris'] == null ? undefined : json['postLogoutRedirectUris'],
     redirectUris: json['redirectUris'] == null ? undefined : json['redirectUris'],
@@ -538,6 +545,7 @@ export function PatchApplicationOAuthSettingsToJSONTyped(
     jwks: JWKSetToJSON(value['jwks']),
     jwksUri: value['jwksUri'],
     logoUri: value['logoUri'],
+    optInScopeSelection: value['optInScopeSelection'],
     policyUri: value['policyUri'],
     postLogoutRedirectUris: value['postLogoutRedirectUris'],
     redirectUris: value['redirectUris'],

--- a/gravitee-am-test/playwright/utils/oauth-callback-helpers.ts
+++ b/gravitee-am-test/playwright/utils/oauth-callback-helpers.ts
@@ -32,7 +32,12 @@ async function approveConsent(page: Page): Promise<void> {
     const checkboxes = page.locator(CONSENT_SCOPE_CHECKBOX_SELECTOR);
     const count = await checkboxes.count();
     for (let i = 0; i < count; i++) {
-      await checkboxes.nth(i).check();
+      const checkbox = checkboxes.nth(i);
+      // Required scopes render as checked+disabled; they can't (and needn't) be toggled.
+      if (await checkbox.isDisabled()) {
+        continue;
+      }
+      await checkbox.check();
     }
   }
   await page.locator(CONSENT_ALLOW_SELECTOR).click();

--- a/gravitee-am-test/specs/gateway/oauth2/fixture/oauth2-fixture.ts
+++ b/gravitee-am-test/specs/gateway/oauth2/fixture/oauth2-fixture.ts
@@ -38,6 +38,7 @@ export interface OAuth2Fixture extends Fixture {
   oidc: DomainOidcConfig;
   application: Application;
   anotherApplication: Application;
+  requiredScopeApplication?: Application;
   scope: Scope;
   shortLivingScope: Scope;
   users: { username: string; password: string }[];
@@ -47,6 +48,8 @@ export interface OAuth2ApplicationSettings {
   type: 'WEB' | 'SERVICE';
   withOpenidScope: boolean;
   grantTypes: string[];
+  // When true, provisions an extra application whose default scope is also marked as required
+  withRequiredScopeApp?: boolean;
 }
 
 export const setupFixture = async (appSettings: OAuth2ApplicationSettings): Promise<OAuth2Fixture> => {
@@ -73,6 +76,19 @@ export const setupFixture = async (appSettings: OAuth2ApplicationSettings): Prom
 
   const app = await createApp(domain, accessToken, appSettings.type, scopeSettings, appSettings.grantTypes, identityProviders);
   const anotherApp = await createApp(domain, accessToken, appSettings.type, scopeSettings, appSettings.grantTypes, identityProviders);
+  const requiredScopeApp = appSettings.withRequiredScopeApp
+    ? await createApp(
+        domain,
+        accessToken,
+        appSettings.type,
+        [
+          { scope: scope.key, defaultScope: true, requiredScope: true },
+          { scope: shortLivingScope.key, defaultScope: false },
+        ],
+        appSettings.grantTypes,
+        identityProviders,
+      )
+    : undefined;
 
   await startDomain(domain.id, accessToken);
 
@@ -83,6 +99,7 @@ export const setupFixture = async (appSettings: OAuth2ApplicationSettings): Prom
     oidc: domainWithOidc.oidcConfig,
     application: app,
     anotherApplication: anotherApp,
+    requiredScopeApplication: requiredScopeApp,
     users: idp.users,
     scope: scope,
     shortLivingScope: shortLivingScope,

--- a/gravitee-am-test/specs/gateway/oauth2/oauth2-grant-authorization-code.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/oauth2/oauth2-grant-authorization-code.jest.spec.ts
@@ -42,6 +42,7 @@ beforeAll(async () => {
     withOpenidScope: false,
     type: 'WEB',
     grantTypes: ['authorization_code'],
+    withRequiredScopeApp: true,
   });
   user = fixture.users[0];
 });
@@ -154,6 +155,62 @@ describe('OAuth2 - RFC 6746 - Authorization Code Grant', () => {
     expect(postConsentRedirect.headers['location']).toMatch(/code=[-_a-zA-Z0-9]+&?/);
 
     await logoutUser(fixture.oidc.end_session_endpoint, postConsentRedirect);
+  });
+
+  it('must reject consent with access_denied when a required scope is not approved', async () => {
+    const requiredScopeApp = fixture.requiredScopeApplication;
+    const clientId = requiredScopeApp.settings.oauth.clientId;
+    const params = `?response_type=code&client_id=${clientId}&redirect_uri=http://localhost:4000/`;
+
+    // Initiate the Login Flow
+    const authResponse = await performGet(fixture.oidc.authorization_endpoint, params).expect(302);
+
+    // Authentication
+    const loginResult = await extractXsrfTokenAndActionResponse(authResponse);
+    const postLogin = await performFormPost(
+      loginResult.action,
+      '',
+      {
+        'X-XSRF-TOKEN': loginResult.token,
+        username: user.username,
+        password: user.password,
+        client_id: clientId,
+      },
+      {
+        Cookie: loginResult.headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
+    ).expect(302);
+
+    // Post authentication redirect -> consent page
+    const postLoginRedirect = await performGet(postLogin.headers['location'], '', {
+      Cookie: postLogin.headers['set-cookie'],
+    }).expect(302);
+
+    expect(postLoginRedirect.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${fixture.masterDomain.hrid}/oauth/consent`);
+
+    const consentResult = await extractXsrfTokenAndActionResponse(postLoginRedirect);
+
+    // Submit consent WITHOUT the required scope's approval (scope.scope1). A correctly rendered page
+    // submits it via a hidden input; its absence here mimics a rendering issue or tampered payload.
+    // The server must refuse to persist consent and send the user back to login with access_denied.
+    const postConsent = await performFormPost(
+      consentResult.action,
+      '',
+      {
+        'X-XSRF-TOKEN': consentResult.token,
+        user_oauth_approval: true,
+      },
+      {
+        Cookie: consentResult.headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
+    ).expect(302);
+
+    // Bounced back to the login page carrying the access_denied error, not to the client redirect_uri
+    expect(postConsent.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${fixture.masterDomain.hrid}/login`);
+    expect(postConsent.headers['location']).toContain('access_denied');
+    expect(postConsent.headers['location']).not.toMatch(/\bcode=[-_a-zA-Z0-9]+/);
   });
 
   it('must handle code flow with fragment response_mode', async () => {

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/scopes/scopes.component.html
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/scopes/scopes.component.html
@@ -82,21 +82,30 @@
             [messages]="{ emptyMessage: 'There is no scopes' }"
             [rows]="selectedScopes"
           >
-            <ngx-datatable-column name="Scopes" [flexGrow]="3">
+            <ngx-datatable-column name="Scopes" [flexGrow]="4" [sortable]="false" [resizeable]="false" [draggable]="false">
               <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
                 <mat-icon style="vertical-align: middle">donut_large</mat-icon>
                 <span>{{ row.key }}</span> | <small>{{ row.name }}</small>
               </ng-template>
             </ngx-datatable-column>
-            <ngx-datatable-column name="Default" [flexGrow]="1">
+            <ngx-datatable-column name="Default" [flexGrow]="1" [sortable]="false" [resizeable]="false" [draggable]="false">
               <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
                 <mat-checkbox (change)="toggleDefaultScope($event, row.key)" [checked]="isDefaultScope(row.key)"></mat-checkbox>
               </ng-template>
             </ngx-datatable-column>
-            <ngx-datatable-column name="User consent" [flexGrow]="4">
+            <ngx-datatable-column name="Required" [flexGrow]="1" [sortable]="false" [resizeable]="false" [draggable]="false">
               <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
-                <div fxLayout="row" style="align-items: center; margin-top: -10px">
-                  <mat-form-field appearance="outline" floatLabel="always" fxFlex="35">
+                <mat-checkbox
+                  (change)="toggleRequiredScope($event, row.key)"
+                  [checked]="isRequiredScope(row.key)"
+                  [disabled]="readonly"
+                ></mat-checkbox>
+              </ng-template>
+            </ngx-datatable-column>
+            <ngx-datatable-column name="User consent" [flexGrow]="5" [sortable]="false" [resizeable]="false" [draggable]="false">
+              <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
+                <div fxLayout="row" style="align-items: center; margin-top: -10px; gap: 5px">
+                  <mat-form-field appearance="outline" floatLabel="always">
                     <input
                       #expiresInInput
                       matInput
@@ -109,7 +118,7 @@
                       (change)="onExpiresInEvent($event, row.key)"
                     />
                   </mat-form-field>
-                  <mat-form-field appearance="outline" floatLabel="always" fxFlex="40" style="margin-left: 5px">
+                  <mat-form-field appearance="outline" floatLabel="always">
                     <mat-select
                       #unitTimeInput
                       placeholder="Unit"
@@ -126,18 +135,20 @@
                       <mat-option value="years">YEARS</mat-option>
                     </mat-select>
                   </mat-form-field>
-                  <button
-                    *ngIf="scopeApprovalExists(row.key)"
-                    mat-icon-button
-                    (click)="removeScopeApproval($event, row.key, expiresInInput, unitTimeInput)"
-                    style="top: -9px"
-                  >
-                    <mat-icon>close</mat-icon>
-                  </button>
+                  <div style="width: 50px; flex-shrink: 0">
+                    <button
+                      *ngIf="scopeApprovalExists(row.key)"
+                      mat-icon-button
+                      (click)="removeScopeApproval($event, row.key, expiresInInput, unitTimeInput)"
+                      style="top: -7px"
+                    >
+                      <mat-icon>clear</mat-icon>
+                    </button>
+                  </div>
                 </div>
               </ng-template>
             </ngx-datatable-column>
-            <ngx-datatable-column name="Actions" [flexGrow]="1">
+            <ngx-datatable-column name="Actions" [flexGrow]="1" [sortable]="false" [resizeable]="false" [draggable]="false">
               <ng-template let-row="row" ngx-datatable-cell-template>
                 <div fxLayout="row" class="gv-table-cell-actions" *ngIf="!readonly">
                   <button mat-icon-button (click)="removeScope(row.key, $event)"><mat-icon>highlight_off</mat-icon></button>
@@ -153,7 +164,26 @@
     <h3>OAuth 2.0 / OpenID Connect</h3>
     <div class="gv-page-description-content">
       <h4>Scopes</h4>
-      <p>You can add default scopes to the tokens to control the client's access to protected resources/APIs.</p>
+      <p>
+        Add scopes to define which permissions this client is allowed to request. Only the scopes listed here can be granted during
+        authorization; any scope a client requests outside this list is rejected.
+      </p>
+      <p>Each scope can be refined with the following options:</p>
+      <ul>
+        <li>
+          <strong>Default</strong> — added to the authorization request automatically when the client starts an authorization flow without
+          requesting any specific scopes.
+          <small>
+            When <strong>Enhance scopes</strong> (above) is enabled, the authenticating user's role scopes are also granted when the request
+            carries no scope, or only <code>openid</code>.
+          </small>
+        </li>
+        <li>
+          <strong>Required</strong> — mandatory scopes that the user cannot deselect on the consent screen when they are requested; they
+          must be consented to for the authorization request to be allowed.
+        </li>
+        <li><strong>User consent</strong> — how long the user's approval of the scope is remembered before consent is requested again.</li>
+      </ul>
     </div>
   </div>
 </div>

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/scopes/scopes.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/scopes/scopes.component.ts
@@ -37,6 +37,7 @@ export class ScopesComponent implements OnInit {
   @Output() formChanged = new EventEmitter<boolean>();
 
   private defaultScopes: string[];
+  private requiredScopes: string[];
   selectedScopes: any[];
   selectedScopeApprovals: any;
 
@@ -55,6 +56,7 @@ export class ScopesComponent implements OnInit {
     // Merge with existing scope
     this.selectedScopes = [];
     this.defaultScopes = [];
+    this.requiredScopes = [];
     this.selectedScopeApprovals = {};
     if (this.oauthSettings.scopeSettings) {
       this.oauthSettings.scopeSettings.forEach((scopeSettings) => {
@@ -63,6 +65,9 @@ export class ScopesComponent implements OnInit {
           this.selectedScopes.push(definedScope);
           if (scopeSettings.defaultScope) {
             this.defaultScopes.push(scopeSettings.scope);
+          }
+          if (scopeSettings.requiredScope) {
+            this.requiredScopes.push(scopeSettings.scope);
           }
           if (scopeSettings.scopeApproval) {
             this.selectedScopeApprovals[scopeSettings.scope] = {
@@ -107,6 +112,10 @@ export class ScopesComponent implements OnInit {
     );
     this.selectedScopes = [...this.selectedScopes];
     delete this.selectedScopeApprovals[scopeKey];
+    const requiredIndex = this.requiredScopes.indexOf(scopeKey);
+    if (requiredIndex !== -1) {
+      this.requiredScopes.splice(requiredIndex, 1);
+    }
     this.modelChanged();
   }
 
@@ -154,6 +163,19 @@ export class ScopesComponent implements OnInit {
     return this.defaultScopes.indexOf(scope) !== -1;
   }
 
+  toggleRequiredScope(event, scope) {
+    if (event.checked) {
+      this.requiredScopes.push(scope);
+    } else {
+      this.requiredScopes.splice(this.requiredScopes.indexOf(scope), 1);
+    }
+    this.modelChanged();
+  }
+
+  isRequiredScope(scope) {
+    return this.requiredScopes.indexOf(scope) !== -1;
+  }
+
   onExpiresInEvent(event, scope) {
     this.selectedScopeApprovals[scope] = this.selectedScopeApprovals[scope] || {};
     this.selectedScopeApprovals[scope].expiresIn = event.target.value;
@@ -184,6 +206,7 @@ export class ScopesComponent implements OnInit {
       const setting = {
         scope: s.key,
         defaultScope: this.defaultScopes.indexOf(s.key) !== -1,
+        requiredScope: this.requiredScopes.indexOf(s.key) !== -1,
       };
 
       const approval = this.selectedScopeApprovals[s.key];


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7200](https://gravitee.atlassian.net/browse/AM-7200)

## :pencil2: A description of the changes proposed in the pull request
Introduce *required scopes*, configurable for OAuth 2.0 clients of applications. During OAuth2/OIDC authorisation flows when any user consent options are presented, those marked required are disabled and pre-selected.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
### Application scope settings
<img width="1918" height="962" alt="image" src="https://github.com/user-attachments/assets/46a8ee97-49ba-47ae-8559-6084b5e6922a" />

### Management "User consent" template preview
<img width="1916" height="963" alt="image" src="https://github.com/user-attachments/assets/b1427c41-2638-493c-836e-6e4cffc1580e" />

### Consent screen with >10 total scopes
<img width="607" height="926" alt="image" src="https://github.com/user-attachments/assets/ac514b92-744d-4503-b271-4f592f442c48" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-7200]: https://gravitee.atlassian.net/browse/AM-7200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ