### PR TITLE
fix: hmac token introspection by app with different cert

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/impl/JWTServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/impl/JWTServiceImpl.java
@@ -173,7 +173,7 @@ public class JWTServiceImpl implements JWTService {
         return Stream.concat(certs, Stream.of(certificateManager.defaultCertificateProvider()))
                 .filter(Objects::nonNull)
                 .filter(provider -> kid.equals(provider.getKeyId()))
-                .filter(provider -> issuerDomain == null || issuerDomain.equals(provider.getDomain()) || (domain.isMaster() && provider.isDefaultCertificate()))
+                .filter(provider -> issuerDomain == null || issuerDomain.equals(provider.getDomain()) || provider.isDefaultCertificate())
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
fixes AM-7195

1. Select HMAC Cert (None) on applcation
2. Generate token
3. Select Default Cert on application
4. Introspect token

The result should be true