### PR TITLE
fix(AM-7243): truncate enrolled factor target with ellipsis and show full valu…

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.html
@@ -38,7 +38,7 @@
       </ngx-datatable-column>
       <ngx-datatable-column name="Target" [flexGrow]="3">
         <ng-template let-row="row" ngx-datatable-cell-template>
-          <span class="factor-target" [matTooltip]="row.target">{{ row.target }}</span>
+          <span class="factor-target" [matTooltip]="row.target" [matTooltipDisabled]="!row.target">{{ row.target }}</span>
         </ng-template>
       </ngx-datatable-column>
       <ngx-datatable-column name="Last update" [flexGrow]="2">

--- a/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.html
@@ -38,7 +38,7 @@
       </ngx-datatable-column>
       <ngx-datatable-column name="Target" [flexGrow]="3">
         <ng-template let-row="row" ngx-datatable-cell-template>
-          {{ row.target }}
+          <span class="factor-target" [matTooltip]="row.target">{{ row.target }}</span>
         </ng-template>
       </ngx-datatable-column>
       <ngx-datatable-column name="Last update" [flexGrow]="2">

--- a/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/factors/factors.component.scss
@@ -1,4 +1,13 @@
 ngx-datatable {
+  .factor-target {
+    display: block;
+    overflow: hidden;
+    min-width: 0;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .factor-header {
     align-items: center;
     margin: 5px;


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7243

## :pencil2: A description of the changes proposed in the pull request
Long email addresses in the enrolled factor Target column were being cut off with no way to see the full value.

Added CSS ellipsis truncation and a tooltip on hover to display the full target value.

## :memo: Test scenarios 
Refer to Jira ticket.

## :computer: Add screenshots for UI
<img width="1264" height="441" alt="Screenshot 2026-07-06 at 10 03 13" src="https://github.com/user-attachments/assets/0d0b86f7-9ea9-4f34-86f1-a5c0315efc66" />


## :books: Any other comments that will help with documentation
NA

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
NA