### PR TITLE
fix: preserve value containing '&' in URLParametersUtils.parse

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/web/URLParametersUtils.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/web/URLParametersUtils.java
@@ -21,6 +21,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -30,8 +31,15 @@ import java.util.Map;
 public class URLParametersUtils {
 
     public static final String CONTENT_TYPE = "application/x-www-form-urlencoded";
-    private static final char QP_SEP_A = '&';
+    private static final String QP_SEP_A = "&";
     private static final String NAME_VALUE_SEPARATOR = "=";
+
+    /**
+     * Splits a query string on a '&' only when it introduces a new "name=" pair (positive lookahead).
+     * Any other '&' — e.g. one embedded, unencoded, inside a value — is left untouched, so values
+     * may safely contain one or several '&'.
+     */
+    private static final Pattern PAIR_SEPARATOR = Pattern.compile("&(?=[^&=]+=)");
 
     public static String format(final Iterable<? extends Pair<String,String>> parameters) {
         final StringBuilder result = new StringBuilder();
@@ -52,9 +60,12 @@ public class URLParametersUtils {
 
     public static Map<String, String> parse(String query) {
         Map<String, String> queryPairs = new LinkedHashMap<>();
-        String[] pairs = query.split("&");
-        for (String pair : pairs) {
-            int idx = pair.indexOf("=");
+        for (String pair : PAIR_SEPARATOR.split(query)) {
+            int idx = pair.indexOf(NAME_VALUE_SEPARATOR);
+            if (idx < 0) {
+                // Not a name=value pair (no leading key to attach it to): ignore.
+                continue;
+            }
             queryPairs.put(pair.substring(0, idx), pair.substring(idx + 1));
         }
         return queryPairs;

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/web/URLParametersUtilsTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/web/URLParametersUtilsTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.web;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class URLParametersUtilsTest {
+
+    @Test
+    public void parse_shouldReadNameValuePairs() {
+        Map<String, String> result = URLParametersUtils.parse("code=abc&state=xyz");
+
+        assertEquals("abc", result.get("code"));
+        assertEquals("xyz", result.get("state"));
+    }
+
+    @Test
+    public void parse_shouldKeepAmpersandInValue_whenFragmentHasNoSeparator() {
+        // An unencoded '&' inside a value must stay part of that value, not split into a new pair.
+        Map<String, String> result = URLParametersUtils.parse("access_token=abc&raw&state=xyz");
+
+        assertEquals("abc&raw", result.get("access_token"));
+        assertEquals("xyz", result.get("state"));
+        assertFalse(result.containsKey("raw"));
+    }
+
+    @Test
+    public void parse_shouldKeepMultipleAmpersandsInValue() {
+        // Several unencoded '&' in a row inside a value are all preserved.
+        Map<String, String> result = URLParametersUtils.parse("access_token=abc&raw&more&state=xyz");
+
+        assertEquals("abc&raw&more", result.get("access_token"));
+        assertEquals("xyz", result.get("state"));
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    public void parse_shouldKeepMultipleAmpersandsInValueEvenInFinalValue() {
+        // Several unencoded '&' in a row inside a value are all preserved.
+        Map<String, String> result = URLParametersUtils.parse("access_token=abc&raw&more&state=xy&zz");
+
+        assertEquals("abc&raw&more", result.get("access_token"));
+        assertEquals("xy&zz", result.get("state"));
+        assertEquals(2, result.size());
+    }
+}


### PR DESCRIPTION
An unencoded '&' inside a query parameter value produces a bare fragment without a '=' separator once the query is split, which made pair.substring(0, idx) throw StringIndexOutOfBoundsException. Such a fragment belongs to the previous value, so re-attach it (with its '&') instead of crashing.

fixes AM-7256