### PR TITLE
fix: AM-7257 auto-resize data tables

### DIFF
--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -399,6 +399,7 @@ import { BotDetectionFormComponent } from './domain/settings/botdetections/bot-d
 import { BotDetectionResolver } from './resolvers/bot-detection.resolver';
 import { ScopesAllResolver } from './resolvers/scopes-all.resolver';
 import { GvFormControlDirective } from './directives/gv-form-control.directive';
+import { DatatableAutoResizeDirective } from './directives/datatable-auto-resize.directive';
 import { DomainSettingsDeviceIdentifiersComponent } from './domain/settings/deviceidentifiers/device-identifiers.component';
 import { DeviceIdentifierCreationComponent } from './domain/settings/deviceidentifiers/creation/device-identifier-creation.component';
 import { DeviceIdentifierCreationStep1Component } from './domain/settings/deviceidentifiers/creation/steps/step1/step1.component';
@@ -768,6 +769,7 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     ExpressionInfoDialogComponent,
     SelectionRuleDialogComponent,
     GvFormControlDirective,
+    DatatableAutoResizeDirective,
     IdpSelectionInfoDialogComponent,
     MfaSelectComponent,
     MfaRememberDeviceComponent,

--- a/gravitee-am-ui/src/app/directives/datatable-auto-resize.directive.ts
+++ b/gravitee-am-ui/src/app/directives/datatable-auto-resize.directive.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AfterViewInit, Directive, NgZone, OnDestroy } from '@angular/core';
+import { DatatableComponent } from '@swimlane/ngx-datatable';
+
+/**
+ * Keeps an ngx-datatable's column widths in sync with its container.
+ *
+ * ngx-datatable only recalculates on a window resize, so its columns go stale
+ * whenever the container changes width without one - e.g. when the side
+ * navigation is collapsed/expanded - leaving wasted space or truncated columns.
+ *
+ * This observes the datatable's own element (the element it measures in
+ * recalculateDims) and calls recalculate() on any width change. It must be the
+ * datatable element and not a component host: a component host defaults to
+ * display:inline, and a ResizeObserver on an inline element does not fire on
+ * width changes.
+ *
+ * Applied globally to every <ngx-datatable> via the element selector.
+ */
+@Directive({
+  selector: 'ngx-datatable',
+  standalone: false,
+})
+export class DatatableAutoResizeDirective implements AfterViewInit, OnDestroy {
+  private resizeObserver: ResizeObserver;
+  private rafHandle: number | null = null;
+
+  constructor(
+    private table: DatatableComponent,
+    private ngZone: NgZone,
+  ) {}
+
+  ngAfterViewInit(): void {
+    if (typeof ResizeObserver === 'undefined' || !this.table?.element) {
+      return;
+    }
+    // Run outside Angular: the observer fires on every animation frame while
+    // the sidenav transitions, so we coalesce to a single recalculate() per
+    // frame (which also avoids ResizeObserver feedback-loop warnings), then
+    // re-enter the zone so change detection paints the new widths.
+    this.ngZone.runOutsideAngular(() => {
+      this.resizeObserver = new ResizeObserver(() => {
+        if (this.rafHandle !== null) {
+          return;
+        }
+        this.rafHandle = requestAnimationFrame(() => {
+          this.rafHandle = null;
+          this.ngZone.run(() => this.table.recalculate());
+        });
+      });
+      this.resizeObserver.observe(this.table.element);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+    if (this.rafHandle !== null) {
+      cancelAnimationFrame(this.rafHandle);
+    }
+  }
+}

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/scopes/scopes.component.html
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/scopes/scopes.component.html
@@ -84,16 +84,43 @@
           >
             <ngx-datatable-column name="Scopes" [flexGrow]="4" [sortable]="false" [resizeable]="false" [draggable]="false">
               <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
-                <mat-icon style="vertical-align: middle">donut_large</mat-icon>
-                <span>{{ row.key }}</span> | <small>{{ row.name }}</small>
+                <div fxLayout="row" class="scope-cell">
+                  <mat-icon class="scope-cell__icon">donut_large</mat-icon>
+                  <span class="scope-cell__label" [matTooltip]="row.name ? row.key + ' | ' + row.name : row.key" matTooltipShowDelay="300">
+                    {{ row.key
+                    }}<ng-container *ngIf="row.name">
+                      | <small>{{ row.name }}</small></ng-container
+                    >
+                  </span>
+                </div>
               </ng-template>
             </ngx-datatable-column>
-            <ngx-datatable-column name="Default" [flexGrow]="1" [sortable]="false" [resizeable]="false" [draggable]="false">
+            <ngx-datatable-column
+              name="Default"
+              headerClass="checkbox-col"
+              cellClass="checkbox-col"
+              [flexGrow]="1"
+              [minWidth]="72"
+              [maxWidth]="72"
+              [sortable]="false"
+              [resizeable]="false"
+              [draggable]="false"
+            >
               <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
                 <mat-checkbox (change)="toggleDefaultScope($event, row.key)" [checked]="isDefaultScope(row.key)"></mat-checkbox>
               </ng-template>
             </ngx-datatable-column>
-            <ngx-datatable-column name="Required" [flexGrow]="1" [sortable]="false" [resizeable]="false" [draggable]="false">
+            <ngx-datatable-column
+              name="Required"
+              headerClass="checkbox-col"
+              cellClass="checkbox-col"
+              [flexGrow]="1"
+              [minWidth]="72"
+              [maxWidth]="72"
+              [sortable]="false"
+              [resizeable]="false"
+              [draggable]="false"
+            >
               <ng-template let-row="row" let-rowIndex="rowIndex" ngx-datatable-cell-template>
                 <mat-checkbox
                   (change)="toggleRequiredScope($event, row.key)"
@@ -148,7 +175,17 @@
                 </div>
               </ng-template>
             </ngx-datatable-column>
-            <ngx-datatable-column name="Actions" [flexGrow]="1" [sortable]="false" [resizeable]="false" [draggable]="false">
+            <ngx-datatable-column
+              name="Actions"
+              headerClass="checkbox-col"
+              cellClass="checkbox-col"
+              [flexGrow]="1"
+              [minWidth]="72"
+              [maxWidth]="72"
+              [sortable]="false"
+              [resizeable]="false"
+              [draggable]="false"
+            >
               <ng-template let-row="row" ngx-datatable-cell-template>
                 <div fxLayout="row" class="gv-table-cell-actions" *ngIf="!readonly">
                   <button mat-icon-button (click)="removeScope(row.key, $event)"><mat-icon>highlight_off</mat-icon></button>

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/scopes/scopes.component.scss
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/scopes/scopes.component.scss
@@ -5,3 +5,28 @@
 ::ng-deep .cdk-overlay-pane {
   width: auto !important;
 }
+
+.scope-cell {
+  min-width: 0; // allow the label flex item to shrink so ellipsis applies
+  align-items: center;
+  gap: 4px;
+
+  &__icon {
+    flex-shrink: 0;
+    vertical-align: middle;
+  }
+
+  &__label {
+    overflow: hidden;
+    min-width: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+::ng-deep .datatable-header .datatable-header-cell.checkbox-col,
+::ng-deep .datatable-body-row .datatable-body-cell.checkbox-col {
+  padding-right: 6px;
+  padding-left: 6px;
+  text-align: center;
+}


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7257](https://gravitee.atlassian.net/browse/AM-7257)

## :pencil2: A description of the changes proposed in the pull request
Automatically recalculate data table column sizing when the component is resized. Adjust application scopes table to avoid truncated headers (`Required` is no longer chopped to `Require`).
## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI

### Before
<img width="1672" height="444" alt="image" src="https://github.com/user-attachments/assets/54d8f67a-2df1-42d4-b861-d7406ccd2cea" />

### After
<img width="1728" height="920" alt="AM-7257 data table resizing" src="https://github.com/user-attachments/assets/4d8f2341-7686-49ce-b495-c527bab77bdf" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7257]: https://gravitee.atlassian.net/browse/AM-7257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ