### PR TITLE
feat: DPoP sender-constrained tokens (RFC 9449)

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -12891,6 +12891,8 @@ components:
             type: string
         disableRefreshTokenRotation:
           type: boolean
+        dpopBoundAccessTokens:
+          type: boolean
         enhanceScopesWithUserPermissions:
           type: boolean
         forcePKCE:
@@ -13954,6 +13956,30 @@ components:
           default: true
           description: Whether inline scripts are allowed via a per-request nonce.
       title: CSP settings
+    DPoPSettings:
+      type: object
+      description: Demonstrating Proof-of-Possession (RFC 9449) configuration for
+        the domain.
+      properties:
+        dpopSigningAlgorithms:
+          type: array
+          description: "Allowlist of DPoP (RFC 9449) proof signing algorithms accepted\
+            \ at the token endpoint, drawn from the base supported set (ES256/384/512,\
+            \ RS256/384/512). When null the full base set is accepted. Persisting\
+            \ an empty set is rejected."
+          items:
+            type: string
+            description: "Allowlist of DPoP (RFC 9449) proof signing algorithms accepted\
+              \ at the token endpoint, drawn from the base supported set (ES256/384/512,\
+              \ RS256/384/512). When null the full base set is accepted. Persisting\
+              \ an empty set is rejected."
+        requireDpopForAll:
+          type: boolean
+          default: false
+          description: Domain-wide floor (RFC 9449) requiring every application to
+            present a DPoP proof at the token endpoint. When true it cannot be overridden
+            by an application whose own dpop_bound_access_tokens flag is off.
+      title: DPoP settings
     DataPlane:
       type: object
       properties:
@@ -14072,6 +14098,8 @@ components:
           - ORGANIZATION
           - ENVIRONMENT
           - PROTECTED_RESOURCE
+        requireDpopForAll:
+          type: boolean
         saml:
           $ref: "#/components/schemas/SAMLSettings"
         scim:
@@ -15840,6 +15868,8 @@ components:
           $ref: "#/components/schemas/CIMDSettings"
         clientRegistrationSettings:
           $ref: "#/components/schemas/ClientRegistrationSettings"
+        dpopSettings:
+          $ref: "#/components/schemas/DPoPSettings"
         postLogoutRedirectUris:
           type: array
           description: "URLs to which a relying party may request the user be redirected\
@@ -16250,6 +16280,8 @@ components:
           format: int32
         disableRefreshTokenRotation:
           type: boolean
+        dpopBoundAccessTokens:
+          type: boolean
         enhanceScopesWithUserPermissions:
           type: boolean
         forcePKCE:
@@ -16617,6 +16649,15 @@ components:
         openDynamicClientRegistrationEnabled:
           type: boolean
           writeOnly: true
+    PatchDPoPSettings:
+      type: object
+      properties:
+        dpopSigningAlgorithms:
+          type: array
+          items:
+            type: string
+        requireDpopForAll:
+          type: boolean
     PatchDomain:
       type: object
       properties:
@@ -16852,6 +16893,8 @@ components:
           $ref: "#/components/schemas/PatchCIMDSettings"
         clientRegistrationSettings:
           $ref: "#/components/schemas/PatchClientRegistrationSettings"
+        dpopSettings:
+          $ref: "#/components/schemas/PatchDPoPSettings"
         postLogoutRedirectUris:
           type: array
           items:

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/exception/oauth2/InvalidDPoPProofException.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/exception/oauth2/InvalidDPoPProofException.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.exception.oauth2;
+
+import io.gravitee.common.http.HttpStatusCode;
+
+import static io.gravitee.am.common.utils.ConstantKeys.INVALID_DPOP_PROOF;
+
+/**
+ * invalid_dpop_proof
+ *          The DPoP proof JWT presented on the request is missing, malformed, or fails one of
+ *          the RFC 9449 §4.3 validation checks.
+ *
+ * <p>The token endpoint answers such failures with an HTTP 400 (this exception's default status).
+ * The resource-enforcement path answers with an HTTP 401 and a {@code DPoP} {@code WWW-Authenticate}
+ * challenge; it therefore translates this error code rather than relying on the default status.</p>
+ *
+ * See <a href="https://datatracker.ietf.org/doc/html/rfc9449">RFC 9449 — OAuth 2.0 Demonstrating Proof of Possession (DPoP)</a>
+ *
+ * @author GraviteeSource Team
+ */
+public class InvalidDPoPProofException extends OAuth2Exception {
+
+    public InvalidDPoPProofException(String message) {
+        super(message);
+    }
+
+    public InvalidDPoPProofException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public String getOAuth2ErrorCode() {
+        return INVALID_DPOP_PROOF;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+}

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/JWT.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/JWT.java
@@ -31,6 +31,8 @@ public class JWT extends HashMap<String, Object> {
 
     public static final String CONFIRMATION_METHOD_X509_THUMBPRINT = "x5t#S256";
 
+    public static final String CONFIRMATION_METHOD_JWK_THUMBPRINT = "jkt";
+
     public JWT() { }
 
     public JWT(Map<? extends String, ?> claims) {
@@ -159,5 +161,13 @@ public class JWT extends HashMap<String, Object> {
 
     public Object getConfirmationMethod() {
         return get(Claims.CNF);
+    }
+
+    public String getDPoPConfirmationThumbprint() {
+        if (getConfirmationMethod() instanceof Map<?, ?> cnf
+                && cnf.get(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT) instanceof String jkt) {
+            return jkt;
+        }
+        return null;
     }
 }

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/SignatureAlgorithm.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/SignatureAlgorithm.java
@@ -18,6 +18,7 @@ package io.gravitee.am.common.jwt;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Type-safe representation of standard JWT signature algorithm names as defined in the
@@ -104,6 +105,16 @@ public enum SignatureAlgorithm {
     public static final List<SignatureAlgorithm> PREFERRED_HMAC_ALGS = List.of(SignatureAlgorithm.HS512, SignatureAlgorithm.HS384, SignatureAlgorithm.HS256);
     //purposefully ordered higher to lower:
     public static final List<SignatureAlgorithm> PREFERRED_EC_ALGS = List.of(SignatureAlgorithm.ES512, SignatureAlgorithm.ES384, SignatureAlgorithm.ES256);
+
+    /**
+     * Canonical base set of DPoP (RFC 9449) proof signing algorithm names. Asymmetric only —
+     * EC and RSA (PKCS#1 v1.5); no {@code none} and no symmetric {@code HS*}, since a DPoP proof
+     * is verified against the public key embedded in its header. A domain's configured allowlist
+     * must be a non-empty subset of this set.
+     */
+    public static final Set<String> DPOP_SUPPORTED_ALGORITHMS = Set.of(
+            ES256.value, ES384.value, ES512.value,
+            RS256.value, RS384.value, RS512.value);
 
     private final String value;
     private final String description;

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/oauth2/Parameters.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/oauth2/Parameters.java
@@ -106,6 +106,12 @@ public interface Parameters {
      */
     String CODE_CHALLENGE_METHOD = "code_challenge_method";
     /**
+     * DPoP JWK Thumbprint confirmation.
+     * Binds the authorization code to the client's DPoP key at the authorization endpoint.
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc9449#section-10">RFC 9449 Section 10</a>
+     */
+    String DPOP_JKT = "dpop_jkt";
+    /**
      * UMA claim token.
      */
     String CLAIM_TOKEN = "claim_token";
@@ -166,6 +172,6 @@ public interface Parameters {
 
     Collection<String> values = Arrays.asList(CLIENT_ID, CLIENT_SECRET, RESPONSE_TYPE, RESPONSE_MODE, REDIRECT_URI, SCOPE, STATE, CODE, GRANT_TYPE, USERNAME, PASSWORD,
                 REFRESH_TOKEN, ASSERTION, CLIENT_ASSERTION, CLIENT_ASSERTION_TYPE, CODE_VERIFIER, CODE_CHALLENGE, CODE_CHALLENGE_METHOD,
-                CLAIM_TOKEN, CLAIM_TOKEN_FORMAT, PCT, RPT, TICKET, VTR, RESOURCE, SUBJECT_TOKEN, SUBJECT_TOKEN_TYPE, REQUESTED_TOKEN_TYPE,
+                DPOP_JKT, CLAIM_TOKEN, CLAIM_TOKEN_FORMAT, PCT, RPT, TICKET, VTR, RESOURCE, SUBJECT_TOKEN, SUBJECT_TOKEN_TYPE, REQUESTED_TOKEN_TYPE,
                 ACTOR_TOKEN, ACTOR_TOKEN_TYPE);
 }

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/utils/ConstantKeys.java
@@ -49,6 +49,7 @@ public interface ConstantKeys {
     String ERROR_PARAM_KEY = "error";
     String SERVER_ERROR = "server_error";
     String INVALID_TOKEN = "invalid_token";
+    String INVALID_DPOP_PROOF = "invalid_dpop_proof";
     String MFA_CHALLENGE_FAILED = "mfa_challenge_failed";
     String MFA_ENROLL_VALIDATION_FAILED = "mfa_enroll_failed";
     String LOGIN_FAILED = "login_failed";
@@ -83,6 +84,10 @@ public interface ConstantKeys {
     String ERROR_HASH = "errorHash";
     String STORE_ORIGINAL_TOKEN_KEY = "store_original_token";
 
+    String BEARER_AUTH_SCHEME = "Bearer";
+    String DPOP_AUTH_SCHEME = "DPoP";
+
+    String DPOP_PROOF_HEADER = "DPoP";
 
     // enrich authentication flow keys
     String AUTH_FLOW_CONTEXT_KEY = "authFlowContext";

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/AccountProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/AccountProvider.java
@@ -24,6 +24,7 @@ import io.gravitee.am.gateway.handler.account.services.AccountService;
 import io.gravitee.am.gateway.handler.api.AbstractProtocolProvider;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
 import io.gravitee.am.model.Domain;
@@ -58,6 +59,9 @@ public class AccountProvider extends AbstractProtocolProvider {
     private OAuth2AuthProvider oAuth2AuthProvider;
 
     @Autowired
+    private DPoPProofValidator dpopProofValidator;
+
+    @Autowired
     private ApplicationContext applicationContext;
 
     @Autowired
@@ -87,6 +91,7 @@ public class AccountProvider extends AbstractProtocolProvider {
             OAuth2AuthHandler oAuth2AuthHandler = OAuth2AuthHandler.create(oAuth2AuthProvider);
             oAuth2AuthHandler.extractToken(true);
             oAuth2AuthHandler.extractClient(true);
+            oAuth2AuthHandler.dpopProofValidator(dpopProofValidator);
             accountRouter.route().handler(oAuth2AuthHandler);
 
             // Account profile routes

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/DPoPProofValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/DPoPProofValidator.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop;
+
+import io.gravitee.gateway.api.Request;
+import io.reactivex.rxjava3.core.Single;
+
+import java.util.Set;
+
+/**
+ * Centralized validation of DPoP proof JWTs (RFC 9449).
+ *
+ * <p>A single component so the token endpoint and the resource-enforcement path run identical
+ * checks. Both entry points read the {@code DPoP} proof header from the request, verify the proof
+ * against the public key embedded in its {@code jwk} header, and compute the RFC 7638 JWK SHA-256
+ * thumbprint ({@code jkt}) of that key.</p>
+ *
+ * <p>Every failure is signalled with
+ * {@link io.gravitee.am.common.exception.oauth2.InvalidDPoPProofException} carried on the returned
+ * {@link Single}. Callers map that to the appropriate HTTP response (400 at the token endpoint,
+ * 401 with a {@code DPoP} challenge at a resource).</p>
+ *
+ * @author GraviteeSource Team
+ */
+public interface DPoPProofValidator {
+
+    /**
+     * Token-endpoint mode: validate the DPoP proof carried by the request and return the computed
+     * JWK SHA-256 thumbprint ({@code jkt}) to bind the issued access token to. No {@code ath} or
+     * {@code cnf} comparison is performed (there is no access token yet). A proof whose {@code alg}
+     * is outside {@code allowedAlgorithms} is rejected (RFC 9449).
+     *
+     * @param request           the current request; must carry exactly one {@code DPoP} header
+     * @param allowedAlgorithms the accepted signing-algorithm names; {@code null} accepts the full base set
+     * @return the base64url-encoded JWK SHA-256 thumbprint of the proof key
+     */
+    Single<String> validateForToken(Request request, Set<String> allowedAlgorithms);
+
+    /**
+     * Resource mode: validate the DPoP proof carried by the request, additionally checking that the
+     * proof's {@code ath} claim matches the presented access token and that the proof key's
+     * thumbprint equals the token's {@code cnf.jkt} binding.
+     *
+     * @param request            the current request; must carry exactly one {@code DPoP} header
+     * @param accessToken        the access token string presented under the {@code DPoP} scheme
+     * @param expectedThumbprint the {@code jkt} the token is bound to (its {@code cnf.jkt})
+     * @return the base64url-encoded JWK SHA-256 thumbprint of the proof key (equal to {@code expectedThumbprint})
+     */
+    Single<String> validateForResource(Request request, String accessToken, String expectedThumbprint);
+
+    /**
+     * Refresh mode: validate the DPoP proof carried by a refresh request and additionally check that
+     * the proof key's thumbprint equals the {@code jkt} the refresh token is bound to. No {@code ath}
+     * comparison is performed (there is no presented access token at the token endpoint), which is
+     * what distinguishes this from {@link #validateForResource}; the thumbprint assertion is what
+     * distinguishes it from {@link #validateForToken}. A proof whose {@code alg} is outside
+     * {@code allowedAlgorithms} is rejected (RFC 9449).
+     *
+     * @param request            the current request; must carry exactly one {@code DPoP} header
+     * @param expectedThumbprint the {@code jkt} the refresh token is bound to (its stored binding)
+     * @param allowedAlgorithms  the accepted signing-algorithm names; {@code null} accepts the full base set
+     * @return the base64url-encoded JWK SHA-256 thumbprint of the proof key (equal to {@code expectedThumbprint})
+     */
+    Single<String> validateForRefresh(Request request, String expectedThumbprint, Set<String> allowedAlgorithms);
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/ReplayCache.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/ReplayCache.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop;
+
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * Single-use registry for DPoP proof {@code jti} claims (RFC 9449). Backed by the node cache, so the
+ * registry spans the cluster when the node runs a distributed cache.
+ *
+ * <p>Implementations differ only in how they claim a key atomically: in-memory caches provide
+ * {@code computeIfAbsent}, while the Redis cache rejects it and exposes SETNX through its
+ * two-argument {@code put}. The factory selects one from the configured cache type. Do not probe the
+ * backend by catching {@code UnsupportedOperationException} — that costs a thrown exception on every
+ * request.
+ */
+public interface ReplayCache {
+
+    /**
+     * Claim a {@code jti} for its first and only use.
+     *
+     * @return {@code true} when this call won the claim, {@code false} when the proof is a replay
+     */
+    Single<Boolean> register(String jti);
+
+    class NoOpReplayCache implements ReplayCache {
+
+        @Override
+        public Single<Boolean> register(String jti) {
+            return Single.just(true);
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/AbstractReplayCache.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/AbstractReplayCache.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop.impl;
+
+import io.gravitee.am.gateway.handler.common.dpop.ReplayCache;
+import io.gravitee.node.api.cache.Cache;
+import io.reactivex.rxjava3.core.Single;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+abstract class AbstractReplayCache implements ReplayCache {
+
+    protected final Cache<String, String> cache;
+
+    private final long replayTtlSeconds;
+
+    protected AbstractReplayCache(Cache<String, String> cache, long replayTtlSeconds) {
+        this.cache = cache;
+        this.replayTtlSeconds = replayTtlSeconds;
+    }
+
+    protected abstract Single<String> claim(String jti, String marker);
+
+    @Override
+    public Single<Boolean> register(String jti) {
+        return Single.defer(() -> {
+            String marker = UUID.randomUUID().toString();
+            return claim(jti, marker)
+                .map(marker::equals)
+                .flatMap(winner -> winner ? applyTtl(jti, marker) : Single.just(false));
+        });
+    }
+
+    private Single<Boolean> applyTtl(String jti, String marker) {
+        return Single.defer(() -> cache.rxPut(jti, marker, replayTtlSeconds, TimeUnit.SECONDS)
+            .ignoreElement()
+            .andThen(Single.just(true))
+            .onErrorResumeNext(error -> cache.rxEvict(jti)
+                .ignoreElement()
+                .onErrorComplete()
+                .andThen(Single.<Boolean>error(error))));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/DPoPProofValidatorImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/DPoPProofValidatorImpl.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop.impl;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.gravitee.am.common.exception.oauth2.InvalidDPoPProofException;
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
+import io.gravitee.am.gateway.handler.common.dpop.ReplayCache;
+import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
+import io.gravitee.gateway.api.Request;
+import io.reactivex.rxjava3.core.Single;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+public class DPoPProofValidatorImpl implements DPoPProofValidator {
+
+    static final String DPOP_JWT_TYPE = "dpop+jwt";
+
+    private static final Set<JWSAlgorithm> SUPPORTED_ALGORITHMS = Set.of(
+            JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512,
+            JWSAlgorithm.RS256, JWSAlgorithm.RS384, JWSAlgorithm.RS512);
+
+    private final int validitySeconds;
+    private final int clockSkewSeconds;
+    private final ReplayCache replayCache;
+
+    public DPoPProofValidatorImpl(int validitySeconds, int clockSkewSeconds, ReplayCache replayCache) {
+        this.validitySeconds = validitySeconds;
+        this.clockSkewSeconds = clockSkewSeconds;
+        this.replayCache = replayCache;
+    }
+
+    @Override
+    public Single<String> validateForToken(Request request, Set<String> allowedAlgorithms) {
+        return validate(request, null, null, allowedAlgorithms);
+    }
+
+    @Override
+    public Single<String> validateForResource(Request request, String accessToken, String expectedThumbprint) {
+        if (accessToken == null || expectedThumbprint == null) {
+            return Single.error(new InvalidDPoPProofException("DPoP resource validation requires the access token and its cnf.jkt binding"));
+        }
+        return validate(request, accessToken, expectedThumbprint, null);
+    }
+
+    @Override
+    public Single<String> validateForRefresh(Request request, String expectedThumbprint, Set<String> allowedAlgorithms) {
+        if (expectedThumbprint == null) {
+            return Single.error(new InvalidDPoPProofException("DPoP refresh validation requires the refresh token cnf.jkt binding"));
+        }
+        return validate(request, null, expectedThumbprint, allowedAlgorithms);
+    }
+
+    private Single<String> validate(Request request, String accessToken, String expectedThumbprint, Set<String> allowedAlgorithms) {
+        return Single.defer(() -> {
+            final SignedJWT proof = parseSingleProof(request);
+            final JWSHeader header = proof.getHeader();
+            validateHeader(header, allowedAlgorithms);
+
+            final JWK jwk = header.getJWK();
+            verifySignature(proof, jwk);
+
+            final JWTClaimsSet proofClaims = readClaims(proof);
+            validateHttpMethod(proofClaims, request.method() != null ? request.method().name() : null);
+            validateHttpUri(proofClaims, resolveRequestUri(request));
+            validateIssuedAt(proofClaims);
+            final String jti = validateJti(proofClaims);
+
+            final String thumbprint = computeThumbprint(jwk);
+
+            if (accessToken != null) {
+                validateAccessTokenHash(proofClaims, accessToken);
+            }
+            if (expectedThumbprint != null) {
+                validateThumbprintBinding(thumbprint, expectedThumbprint);
+            }
+
+            return replayCache.register(jti).flatMap(registered -> registered
+                    ? Single.just(thumbprint)
+                    : Single.error(invalid("DPoP proof has already been used (replay detected)")));
+        });
+    }
+
+    private SignedJWT parseSingleProof(Request request) {
+        final List<String> proofs = request.headers().getAll(ConstantKeys.DPOP_PROOF_HEADER);
+        if (proofs == null || proofs.size() != 1) {
+            throw invalid("Request must carry exactly one DPoP header");
+        }
+        try {
+            return SignedJWT.parse(proofs.get(0));
+        } catch (ParseException e) {
+            throw invalid("DPoP proof is not a well-formed signed JWT");
+        }
+    }
+
+    private void validateHeader(JWSHeader header, Set<String> allowedAlgorithms) {
+        if (header.getType() == null || !DPOP_JWT_TYPE.equals(header.getType().getType())) {
+            throw invalid("DPoP proof must set the typ header to dpop+jwt");
+        }
+        final JWSAlgorithm algorithm = header.getAlgorithm();
+        if (algorithm == null || !SUPPORTED_ALGORITHMS.contains(algorithm)) {
+            throw invalid("DPoP proof uses an unsupported or non-asymmetric signing algorithm");
+        }
+        if (allowedAlgorithms != null && !allowedAlgorithms.contains(algorithm.getName())) {
+            throw invalid("DPoP proof signing algorithm is not accepted by the domain allowlist");
+        }
+        final JWK jwk = header.getJWK();
+        if (jwk == null) {
+            throw invalid("DPoP proof must embed the public key in its jwk header");
+        }
+        if (jwk.isPrivate()) {
+            throw invalid("DPoP proof jwk header must not contain private key material");
+        }
+    }
+
+    private void verifySignature(SignedJWT proof, JWK jwk) {
+        try {
+            final JWSVerifier verifier;
+            if (jwk instanceof ECKey ecKey) {
+                verifier = new ECDSAVerifier(ecKey);
+            } else if (jwk instanceof RSAKey rsaKey) {
+                verifier = new RSASSAVerifier(rsaKey);
+            } else {
+                throw invalid("DPoP proof key type is not supported");
+            }
+            if (!proof.verify(verifier)) {
+                throw invalid("DPoP proof signature is invalid");
+            }
+        } catch (JOSEException e) {
+            throw invalid("DPoP proof signature could not be verified");
+        }
+    }
+
+    private JWTClaimsSet readClaims(SignedJWT proof) {
+        try {
+            return proof.getJWTClaimsSet();
+        } catch (ParseException e) {
+            throw invalid("DPoP proof claims are not valid");
+        }
+    }
+
+    private void validateHttpMethod(JWTClaimsSet claims, String requestMethod) {
+        final String htm = stringClaim(claims, "htm");
+        if (htm == null || requestMethod == null || !htm.equals(requestMethod)) {
+            throw invalid("DPoP proof htm does not match the request method");
+        }
+    }
+
+    private void validateHttpUri(JWTClaimsSet claims, String expectedUri) {
+        final String htu = normalizeUri(stringClaim(claims, "htu"));
+        if (htu == null || expectedUri == null || !htu.equals(expectedUri)) {
+            throw invalid("DPoP proof htu does not match the request URI");
+        }
+    }
+
+    private void validateIssuedAt(JWTClaimsSet claims) {
+        final Date iat = claims.getIssueTime();
+        if (iat == null) {
+            throw invalid("DPoP proof is missing the iat claim");
+        }
+        final long now = Instant.now().getEpochSecond();
+        final long issuedAt = iat.toInstant().getEpochSecond();
+        if (issuedAt < now - validitySeconds || issuedAt > now + clockSkewSeconds) {
+            throw invalid("DPoP proof iat is outside the accepted window");
+        }
+    }
+
+    private String validateJti(JWTClaimsSet claims) {
+        final String jti = claims.getJWTID();
+        if (jti == null || jti.isBlank()) {
+            throw invalid("DPoP proof is missing the jti claim");
+        }
+        return jti;
+    }
+
+    private void validateAccessTokenHash(JWTClaimsSet claims, String accessToken) {
+        final String ath = stringClaim(claims, "ath");
+        if (ath == null) {
+            throw invalid("DPoP proof is missing the ath claim");
+        }
+        if (!ath.equals(base64UrlSha256(accessToken))) {
+            throw invalid("DPoP proof ath does not match the presented access token");
+        }
+    }
+
+    private void validateThumbprintBinding(String thumbprint, String expectedThumbprint) {
+        if (!expectedThumbprint.equals(thumbprint)) {
+            throw invalid("DPoP proof key does not match the token cnf.jkt binding");
+        }
+    }
+
+    private String resolveRequestUri(Request request) {
+        return normalizeUri(UriBuilderRequest.resolveProxyRequest(request));
+    }
+
+    private String computeThumbprint(JWK jwk) {
+        try {
+            return jwk.computeThumbprint().toString();
+        } catch (JOSEException e) {
+            throw invalid("Unable to compute the DPoP key thumbprint");
+        }
+    }
+
+    private static String base64UrlSha256(String value) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return Base64URL.encode(digest.digest(value.getBytes(StandardCharsets.US_ASCII))).toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", e);
+        }
+    }
+
+    private static String stringClaim(JWTClaimsSet claims, String name) {
+        try {
+            return claims.getStringClaim(name);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Strip the query and fragment: {@code htu} is compared ignoring them (RFC 9449 §4.3).
+     */
+    private static String normalizeUri(String uri) {
+        if (uri == null) {
+            return null;
+        }
+        int cut = uri.indexOf('?');
+        if (cut >= 0) {
+            uri = uri.substring(0, cut);
+        }
+        cut = uri.indexOf('#');
+        if (cut >= 0) {
+            uri = uri.substring(0, cut);
+        }
+        return uri;
+    }
+
+    private static InvalidDPoPProofException invalid(String message) {
+        return new InvalidDPoPProofException(message);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/RedisReplayCache.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/RedisReplayCache.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop.impl;
+
+import io.gravitee.node.api.cache.Cache;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+
+class RedisReplayCache extends AbstractReplayCache {
+
+    RedisReplayCache(Cache<String, String> cache, long replayTtlSeconds) {
+        super(cache, replayTtlSeconds);
+    }
+
+    @Override
+    protected Single<String> claim(String jti, String marker) {
+        return Single.defer(() -> cache.rxPut(jti, marker)
+            .ignoreElement()
+            .andThen(Maybe.defer(() -> cache.rxGet(jti)))
+            .toSingle());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/ReplayCacheFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/ReplayCacheFactory.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop.impl;
+
+import io.gravitee.am.gateway.handler.common.dpop.ReplayCache;
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.node.api.cache.CacheConfiguration;
+import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.node.api.cache.ValueMapper;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public final class ReplayCacheFactory {
+
+    private static final String CACHE_NAME_PREFIX = "dpopReplayCache-";
+    private static final Set<String> REDIS_CACHE_TYPES = Set.of("redis", "cache-redis");
+    private static final ValueMapper<String, String> IDENTITY_VALUE_MAPPER = new ValueMapper<>() {
+        @Override
+        public String toCachedValue(String value) {
+            return value;
+        }
+
+        @Override
+        public String toValue(String cachedValue) {
+            return cachedValue;
+        }
+    };
+
+    private ReplayCacheFactory() {
+    }
+
+    public static ReplayCache create(CacheManager cacheManager, String domainId, long maxSize, long replayTtlSeconds, String cacheType) {
+        CacheConfiguration configuration = CacheConfiguration.builder()
+            .maxSize(maxSize)
+            .timeToLiveInMs(TimeUnit.SECONDS.toMillis(replayTtlSeconds))
+            .build();
+        Cache<String, String> cache = cacheManager.getOrCreateCache(CACHE_NAME_PREFIX + domainId, configuration, IDENTITY_VALUE_MAPPER);
+        return REDIS_CACHE_TYPES.contains(cacheType)
+            ? new RedisReplayCache(cache, replayTtlSeconds)
+            : new StandardReplayCache(cache, replayTtlSeconds);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/StandardReplayCache.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/dpop/impl/StandardReplayCache.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop.impl;
+
+import io.gravitee.node.api.cache.Cache;
+import io.reactivex.rxjava3.core.Single;
+
+class StandardReplayCache extends AbstractReplayCache {
+
+    StandardReplayCache(Cache<String, String> cache, long replayTtlSeconds) {
+        super(cache, replayTtlSeconds);
+    }
+
+    @Override
+    protected Single<String> claim(String jti, String marker) {
+        return Single.defer(() -> cache.rxComputeIfAbsent(jti, ignored -> marker).toSingle());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/InMemoryJWTCache.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/InMemoryJWTCache.java
@@ -64,10 +64,9 @@ public class InMemoryJWTCache implements JWTCache {
     @Override
     public void put(String jwt, long expiresAt) {
         String hash = hash(jwt);
-        if (cache.asMap().putIfAbsent(hash, expiresAt) == null) {
-            if (statsConsumer != null) {
-                statsConsumer.accept(stats());
-            }
+        boolean added = cache.asMap().putIfAbsent(hash, expiresAt) == null;
+        if (added && statsConsumer != null) {
+            statsConsumer.accept(stats());
         }
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/JWTCache.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/jwt/JWTCache.java
@@ -22,7 +22,7 @@ public interface JWTCache {
 
     void put(String jwt, long expiresAt);
 
-    class NoOpJtiCache implements JWTCache {
+    class NoOpJwtCache implements JWTCache {
 
         @Override
         public Single<Boolean> isPresent(String jwt) {
@@ -31,7 +31,6 @@ public interface JWTCache {
 
         @Override
         public void put(String jwt, long expiresAt) {
-            // do nothing
         }
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -50,6 +50,11 @@ import io.gravitee.am.gateway.handler.common.client.impl.ClientManagerImpl;
 import io.gravitee.am.gateway.handler.common.client.impl.ClientSyncServiceImpl;
 import io.gravitee.am.gateway.handler.common.client.impl.CimdAwareClientLookupServiceImpl;
 import io.gravitee.am.gateway.handler.common.client.impl.DefaultClientLookupServiceImpl;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
+
+import io.gravitee.am.gateway.handler.common.dpop.ReplayCache;
+import io.gravitee.am.gateway.handler.common.dpop.impl.DPoPProofValidatorImpl;
+import io.gravitee.am.gateway.handler.common.dpop.impl.ReplayCacheFactory;
 import io.gravitee.am.gateway.handler.common.email.EmailManager;
 import io.gravitee.am.gateway.handler.common.email.EmailService;
 import io.gravitee.am.gateway.handler.common.email.EmailStagingService;
@@ -370,8 +375,24 @@ public class CommonConfiguration {
                         .build();
             }
         } else {
-            return new JWTCache.NoOpJtiCache();
+            return new JWTCache.NoOpJwtCache();
         }
+    }
+
+    @Bean
+    public DPoPProofValidator dpopProofValidator(
+            Domain domain,
+            CacheManager cacheManager,
+            @Value("${handlers.oauth2.dpop.validitySeconds:30}") int validitySeconds,
+            @Value("${handlers.oauth2.dpop.replayCache.enabled:true}") boolean replayCacheEnabled,
+            @Value("${handlers.oauth2.dpop.replayCache.maxSize:10000}") long replayCacheMaxSize,
+            @Value("${cache.type:standalone}") String cacheType) {
+        final int clockSkewSeconds = 3;
+        final ReplayCache replayCache = replayCacheEnabled
+                ? ReplayCacheFactory.create(cacheManager, domain.getId(), replayCacheMaxSize,
+                        (long) validitySeconds + clockSkewSeconds, cacheType)
+                : new ReplayCache.NoOpReplayCache();
+        return new DPoPProofValidatorImpl(validitySeconds, clockSkewSeconds, replayCache);
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/handler/OAuth2AuthHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/handler/OAuth2AuthHandler.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.common.vertx.web.auth.handler;
 
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.impl.OAuth2AuthHandlerImpl;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
@@ -143,6 +144,14 @@ public interface OAuth2AuthHandler extends AuthHandler {
      * @param offlineVerification
      */
     void offlineVerification(boolean offlineVerification);
+
+    /**
+     * Provide the DPoP proof validator (RFC 9449) used to enforce sender-constrained (cnf.jkt) tokens.
+     * When set, a bound token must be presented under the DPoP scheme with a valid proof; when absent,
+     * the gate fails closed and rejects any cnf.jkt-bound token.
+     * @param dpopProofValidator the validator
+     */
+    void dpopProofValidator(DPoPProofValidator dpopProofValidator);
 
     static OAuth2AuthHandler create(OAuth2AuthProvider oAuth2AuthProvider) {
         return new OAuth2AuthHandlerImpl(oAuth2AuthProvider, null);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/handler/impl/OAuth2AuthHandlerImpl.java
@@ -16,11 +16,15 @@
 package io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.impl;
 
 import io.gravitee.am.common.exception.oauth2.InsufficientScopeException;
+import io.gravitee.am.common.exception.oauth2.InvalidDPoPProofException;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.exception.oauth2.InvalidTokenException;
 import io.gravitee.am.common.exception.oauth2.OAuth2Exception;
 import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.common.jwt.SignatureAlgorithm;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
+import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthResponse;
@@ -32,9 +36,17 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.handler.HttpException;
+import io.vertx.rxjava3.core.http.HttpHeaders;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 import lombok.CustomLog;
+
+import java.util.stream.Collectors;
+
+import static io.gravitee.am.common.utils.ConstantKeys.ACCESS_TOKEN_KEY;
+import static io.gravitee.am.common.utils.ConstantKeys.BEARER_AUTH_SCHEME;
+import static io.gravitee.am.common.utils.ConstantKeys.DPOP_AUTH_SCHEME;
+import static io.gravitee.gateway.api.http.HttpHeaderNames.WWW_AUTHENTICATE;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -43,9 +55,12 @@ import lombok.CustomLog;
 @CustomLog
 public class OAuth2AuthHandlerImpl implements OAuth2AuthHandler {
 
-    private static final String BEARER = "Bearer";
     private static final String REALM = "gravitee-io";
     private static final String ACCESS_TOKEN = "access_token";
+    private static final String CONTEXT_DPOP_ENFORCED = "dpopEnforced";
+    private static final String DPOP_SUPPORTED_ALGS = SignatureAlgorithm.DPOP_SUPPORTED_ALGORITHMS.stream()
+            .sorted()
+            .collect(Collectors.joining(" "));
     private final OAuth2AuthProvider oAuth2AuthProvider;
     private String requiredScope;
     private boolean extractRawToken;
@@ -58,7 +73,15 @@ public class OAuth2AuthHandlerImpl implements OAuth2AuthHandler {
     private boolean offlineVerification;
     private String resourceParameter;
     private String resourceRequiredScope;
+    private DPoPProofValidator dpopProofValidator;
     private final SubjectManager subjectManager;
+
+    private record PresentedToken(String value, String scheme){
+
+        boolean isDPoP(){
+            return DPOP_AUTH_SCHEME.equalsIgnoreCase(scheme);
+        }
+    };
 
     public OAuth2AuthHandlerImpl(OAuth2AuthProvider oAuth2AuthProvider, SubjectManager subjectManager) {
         this.oAuth2AuthProvider = oAuth2AuthProvider;
@@ -78,14 +101,14 @@ public class OAuth2AuthHandlerImpl implements OAuth2AuthHandler {
                 return;
             }
 
-            final String jwtToken = parseHandler.result();
+            final PresentedToken presented = parseHandler.result();
 
             // set raw token to the current context
             if (extractRawToken) {
-                context.put(ConstantKeys.RAW_TOKEN_CONTEXT_KEY, jwtToken);
+                context.put(ConstantKeys.RAW_TOKEN_CONTEXT_KEY, presented.value());
             }
 
-            oAuth2AuthProvider.decodeToken(jwtToken, offlineVerification, handler -> {
+            oAuth2AuthProvider.decodeToken(presented.value(), offlineVerification, handler -> {
                 if (handler.failed()) {
                     processException(context, handler.cause());
                     return;
@@ -105,52 +128,81 @@ public class OAuth2AuthHandlerImpl implements OAuth2AuthHandler {
                     context.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
                 }
 
-                var single = Single.just(UserId.internal(token.getSub()));
-                if (selfResource && isSelfResourceAUser) {
-                    single = this.subjectManager.findUserIdBySub(token)
-                            .switchIfEmpty(single);
+                if (token.getDPoPConfirmationThumbprint() != null) {
+                    context.put(CONTEXT_DPOP_ENFORCED, true);
+                    if (dpopProofValidator == null || !presented.isDPoP()) {
+                        processException(context, new InvalidTokenException("A DPoP-bound access token must be presented using the DPoP scheme with a valid proof"));
+                        return;
+                    }
+                    authorizeDPoP(context, presented, token);
+                } else {
+                    authorize(context, token);
                 }
-
-                single.subscribe(userId -> {
-                    // check if current subject can access its own resources
-                    if (selfResource) {
-                        final String resourceId = context.request().getParam(resourceParameter);
-                        // since Domain V2, sub claim is not the userId anymore
-                        // we have to check if userId provided as resourceId match the userId internal ID found using the sub claim
-                        // and we also have to if the resourceId match the
-                        boolean isUserValid = isSelfResourceAUser && resourceId != null && resourceId.equals(userId.id());
-                        boolean isResourceIdValid = resourceId != null && (resourceId.equals(token.getSub()) || resourceId.equals(token.getInternalSub()));
-                        boolean hasRequiredScope = resourceRequiredScope == null || token.hasScope(resourceRequiredScope);
-
-                        if ((isUserValid || isResourceIdValid) && hasRequiredScope) {
-                            context.next();
-                            return;
-                        }
-                    }
-
-                    if (forceEndUserToken && token.getSub().equals(token.getAud())) {
-                        // token for end userId must not contain clientId as subject
-                        processException(context, new InvalidTokenException("The access token was not issued for an End-User"));
-                        return;
-                    }
-
-                    if (forceClientToken && !token.getSub().equals(token.getAud())) {
-                        // token for end userId must not contain clientId as subject
-                        processException(context, new InvalidTokenException("The access token was not issued for a Client"));
-                        return;
-                    }
-
-                    // check required scope
-                    if (requiredScope != null && !token.hasScope(requiredScope)) {
-                        processException(context, new InsufficientScopeException("Invalid access token scopes. The access token should have at least '" + requiredScope + "' scope"));
-                        return;
-                    }
-                    context.next();
-                }, error -> {
-                    log.warn("Unable to validate OAuth2 authorization", error);
-                    context.fail(error);
-                });
             });
+        });
+    }
+
+    private void authorizeDPoP(RoutingContext context, PresentedToken presented, JWT token) {
+        String thumbprint = token.getDPoPConfirmationThumbprint();
+        dpopProofValidator.validateForResource(new VertxHttpServerRequest(context.request().getDelegate()), presented.value(), thumbprint)
+                .subscribe(
+                        ignored -> authorize(context, token),
+                        error -> {
+                            if (error instanceof InvalidDPoPProofException) {
+                                log.debug("DPoP proof validation failed for a bound access token: {}", error.getMessage());
+                                processException(context, new InvalidTokenException(error.getMessage()));
+                            } else {
+                                log.warn("Unable to validate DPoP-bound access token", error);
+                                context.fail(error);
+                            }
+                        });
+    }
+
+    private void authorize(RoutingContext context, JWT token) {
+        var single = Single.just(UserId.internal(token.getSub()));
+        if (selfResource && isSelfResourceAUser) {
+            single = this.subjectManager.findUserIdBySub(token)
+                    .switchIfEmpty(single);
+        }
+
+        single.subscribe(userId -> {
+            // check if current subject can access its own resources
+            if (selfResource) {
+                final String resourceId = context.request().getParam(resourceParameter);
+                // since Domain V2, sub claim is not the userId anymore
+                // we have to check if userId provided as resourceId match the userId internal ID found using the sub claim
+                // and we also have to if the resourceId match the
+                boolean isUserValid = isSelfResourceAUser && resourceId != null && resourceId.equals(userId.id());
+                boolean isResourceIdValid = resourceId != null && (resourceId.equals(token.getSub()) || resourceId.equals(token.getInternalSub()));
+                boolean hasRequiredScope = resourceRequiredScope == null || token.hasScope(resourceRequiredScope);
+
+                if ((isUserValid || isResourceIdValid) && hasRequiredScope) {
+                    context.next();
+                    return;
+                }
+            }
+
+            if (forceEndUserToken && token.getSub().equals(token.getAud())) {
+                // token for end userId must not contain clientId as subject
+                processException(context, new InvalidTokenException("The access token was not issued for an End-User"));
+                return;
+            }
+
+            if (forceClientToken && !token.getSub().equals(token.getAud())) {
+                // token for end userId must not contain clientId as subject
+                processException(context, new InvalidTokenException("The access token was not issued for a Client"));
+                return;
+            }
+
+            // check required scope
+            if (requiredScope != null && !token.hasScope(requiredScope)) {
+                processException(context, new InsufficientScopeException("Invalid access token scopes. The access token should have at least '" + requiredScope + "' scope"));
+                return;
+            }
+            context.next();
+        }, error -> {
+            log.warn("Unable to validate OAuth2 authorization", error);
+            context.fail(error);
         });
     }
 
@@ -189,10 +241,15 @@ public class OAuth2AuthHandlerImpl implements OAuth2AuthHandler {
         this.offlineVerification = offlineVerification;
     }
 
-    private void parseAuthorization(RoutingContext context, Handler<AsyncResult<String>> handler) {
+    public void dpopProofValidator(DPoPProofValidator dpopProofValidator) {
+        this.dpopProofValidator = dpopProofValidator;
+    }
+
+    private void parseAuthorization(RoutingContext context, Handler<AsyncResult<PresentedToken>> handler) {
         final HttpServerRequest request = context.request();
-        final String authorization = request.headers().get(io.vertx.core.http.HttpHeaders.AUTHORIZATION);
+        final String authorization = request.headers().get(HttpHeaders.AUTHORIZATION);
         String authToken;
+        String authScheme;
         try {
             if (authorization != null) {
                 // authorization header has been found check the value
@@ -203,14 +260,16 @@ public class OAuth2AuthHandlerImpl implements OAuth2AuthHandler {
                     return;
                 }
 
-                if (!BEARER.equalsIgnoreCase(authorization.substring(0, idx))) {
-                    handler.handle(Future.failedFuture(new InvalidTokenException("Authorization header must use Bearer scheme")));
+                authScheme = authorization.substring(0, idx);
+                if (!BEARER_AUTH_SCHEME.equalsIgnoreCase(authScheme) && !DPOP_AUTH_SCHEME.equalsIgnoreCase(authScheme)) {
+                    handler.handle(Future.failedFuture(new InvalidTokenException("Authorization header must use the Bearer or DPoP scheme")));
                     return;
                 }
                 authToken = authorization.substring(idx + 1);
             } else {
                 // if no authorization header found, check authorization in body
-                authToken = request.getParam(ACCESS_TOKEN);
+                authToken = request.getParam(ACCESS_TOKEN_KEY);
+                authScheme = null;
             }
 
             if (authToken == null) {
@@ -218,7 +277,7 @@ public class OAuth2AuthHandlerImpl implements OAuth2AuthHandler {
                 return;
             }
 
-            handler.handle(Future.succeededFuture(authToken));
+            handler.handle(Future.succeededFuture(new PresentedToken(authToken, authScheme)));
         } catch (RuntimeException e) {
             handler.handle(Future.failedFuture(e));
         }
@@ -233,13 +292,20 @@ public class OAuth2AuthHandlerImpl implements OAuth2AuthHandler {
         }
 
         if (statusCode == 401) {
-            context.response().putHeader("WWW-Authenticate", authenticateHeader());
+            context.response().putHeader(WWW_AUTHENTICATE, authenticateHeader(context, exception));
         }
 
         context.fail(exception);
     }
 
-    private String authenticateHeader() {
+    private String authenticateHeader(RoutingContext context, Throwable exception) {
+        if (Boolean.TRUE.equals(context.get(CONTEXT_DPOP_ENFORCED))) {
+            final String error = exception instanceof OAuth2Exception oauth2Exception
+                    ? oauth2Exception.getOAuth2ErrorCode()
+                    : ConstantKeys.INVALID_TOKEN;
+            return "DPoP error=\"" + error + "\", algs=\"" + DPOP_SUPPORTED_ALGS + "\"";
+        }
         return "Bearer realm=\"" + REALM + "\"";
     }
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/dpop/impl/DPoPProofValidatorImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/dpop/impl/DPoPProofValidatorImplTest.java
@@ -1,0 +1,501 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop.impl;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.OctetSequenceKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jose.util.JSONObjectUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+import com.nimbusds.jwt.SignedJWT;
+import io.gravitee.am.common.exception.oauth2.InvalidDPoPProofException;
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.dpop.ReplayCache;
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpVersion;
+import io.gravitee.gateway.api.Request;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DPoPProofValidatorImplTest {
+
+    private static final String HOST = "am.example.com";
+    private static final String PATH = "/oauth/token";
+    private static final String HTU = "https://am.example.com/oauth/token";
+    private static final String ACCESS_TOKEN = "an-opaque-or-jwt-access-token";
+
+    private ECKey ecKey;
+    private RSAKey rsaKey;
+    private JWK ecPublicJwk;
+    private JWK rsaPublicJwk;
+    private JWSSigner ecSigner;
+    private JWSSigner rsaSigner;
+    private String ecJkt;
+    private String rsaJkt;
+
+    private ReplayCache replayCache;
+    private DPoPProofValidatorImpl validator;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ecKey = new ECKeyGenerator(Curve.P_256).keyID("ec-1").generate();
+        rsaKey = new RSAKeyGenerator(2048).keyID("rsa-1").generate();
+        ecPublicJwk = ecKey.toPublicJWK();
+        rsaPublicJwk = rsaKey.toPublicJWK();
+        ecSigner = new ECDSASigner(ecKey);
+        rsaSigner = new RSASSASigner(rsaKey);
+        ecJkt = ecPublicJwk.computeThumbprint().toString();
+        rsaJkt = rsaPublicJwk.computeThumbprint().toString();
+        replayCache = mock(ReplayCache.class);
+        when(replayCache.register(anyString())).thenReturn(Single.just(true));
+        validator = new DPoPProofValidatorImpl(30, 3, replayCache);
+    }
+
+
+    @Test
+    void token_mode_valid_ec_proof_returns_thumbprint() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertValue(ecJkt).assertComplete();
+    }
+
+    @Test
+    void token_mode_valid_rsa_proof_returns_thumbprint() throws Exception {
+        String proof = new ProofBuilder().alg(JWSAlgorithm.RS256).headerJwk(rsaPublicJwk).signer(rsaSigner).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertValue(rsaJkt).assertComplete();
+    }
+
+    @Test
+    void resource_mode_valid_proof_with_matching_ath_and_jkt_passes() throws Exception {
+        String proof = new ProofBuilder().ath(ath(ACCESS_TOKEN)).sign();
+        validator.validateForResource(tokenRequest(proof), ACCESS_TOKEN, ecJkt).test().assertValue(ecJkt).assertComplete();
+    }
+
+    @Test
+    void iat_within_skew_future_is_accepted() throws Exception {
+        String proof = new ProofBuilder().iat(Date.from(Instant.now().plusSeconds(2))).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertValue(ecJkt);
+    }
+
+
+    @Test
+    void bad_signature_is_rejected() throws Exception {
+        ECKey other = new ECKeyGenerator(Curve.P_256).generate();
+        String proof = new ProofBuilder().headerJwk(other.toPublicJWK()).signer(ecSigner).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void alg_none_is_rejected() throws Exception {
+        String unsecured = new PlainJWT(new JWTClaimsSet.Builder()
+                .jwtID(UUID.randomUUID().toString())
+                .issueTime(new Date())
+                .claim("htm", "POST")
+                .claim("htu", HTU)
+                .build()).serialize();
+        validator.validateForToken(tokenRequest(unsecured), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void symmetric_alg_is_rejected() throws Exception {
+        OctetSequenceKey oct = new OctetSequenceKeyGenerator(256).generate();
+        SignedJWT jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.HS256).type(new JOSEObjectType(DPoPProofValidatorImpl.DPOP_JWT_TYPE)).build(),
+                defaultClaims().build());
+        jwt.sign(new MACSigner(oct));
+        validator.validateForToken(tokenRequest(jwt.serialize()), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void disallowed_asymmetric_alg_ps256_is_rejected() throws Exception {
+        String proof = new ProofBuilder().alg(JWSAlgorithm.PS256).headerJwk(rsaPublicJwk).signer(rsaSigner).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void private_key_material_in_jwk_header_is_rejected() throws Exception {
+        String[] parts = new ProofBuilder().sign().split("\\.");
+        Map<String, Object> header = JSONObjectUtils.parse(Base64URL.from(parts[0]).decodeToString());
+        header.put("jwk", ecKey.toJSONObject());
+        String tampered = Base64URL.encode(JSONObjectUtils.toJSONString(header)) + "." + parts[1] + "." + parts[2];
+        validator.validateForToken(tokenRequest(tampered), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void missing_jwk_header_is_rejected() throws Exception {
+        String proof = new ProofBuilder().headerJwk(null).signer(ecSigner).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+
+    @Test
+    void wrong_typ_is_rejected() throws Exception {
+        String proof = new ProofBuilder().typ(new JOSEObjectType("jwt")).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void more_than_one_dpop_header_is_rejected() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForToken(tokenRequest(proof, proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void missing_dpop_header_is_rejected() {
+        validator.validateForToken(tokenRequest(), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void malformed_proof_jwt_is_rejected() {
+        validator.validateForToken(tokenRequest("this.is.not-a-jwt"), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+
+    @Test
+    void wrong_htm_is_rejected() throws Exception {
+        String proof = new ProofBuilder().htm("GET").sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void wrong_htu_is_rejected() throws Exception {
+        String proof = new ProofBuilder().htu("https://am.example.com/somewhere-else").sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void htu_matches_only_after_forwarded_header_resolution() throws Exception {
+        String proof = new ProofBuilder().htu(HTU).sign();
+        validator.validateForToken(forwardedRequest(proof), null).test().assertValue(ecJkt).assertComplete();
+    }
+
+    @Test
+    void htu_equal_to_internal_url_is_rejected_when_forwarded() throws Exception {
+        String proof = new ProofBuilder().htu("http://10.0.0.5:8092/oauth/token").sign();
+        validator.validateForToken(forwardedRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+
+    @Test
+    void iat_too_old_is_rejected() throws Exception {
+        String proof = new ProofBuilder().iat(Date.from(Instant.now().minusSeconds(60))).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void iat_beyond_skew_in_the_future_is_rejected() throws Exception {
+        String proof = new ProofBuilder().iat(Date.from(Instant.now().plusSeconds(30))).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void missing_iat_is_rejected() throws Exception {
+        String proof = new ProofBuilder().iat(null).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void missing_jti_is_rejected() throws Exception {
+        String proof = new ProofBuilder().jti(null).sign();
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+
+    @Test
+    void resource_mode_missing_ath_is_rejected() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForResource(tokenRequest(proof), ACCESS_TOKEN, ecJkt).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void resource_mode_ath_mismatch_is_rejected() throws Exception {
+        String proof = new ProofBuilder().ath(ath("a-different-token")).sign();
+        validator.validateForResource(tokenRequest(proof), ACCESS_TOKEN, ecJkt).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void resource_mode_jkt_not_matching_token_binding_is_rejected() throws Exception {
+        String proof = new ProofBuilder().ath(ath(ACCESS_TOKEN)).sign();
+        validator.validateForResource(tokenRequest(proof), ACCESS_TOKEN, "a-different-thumbprint").test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void resource_mode_requires_access_token_and_binding() throws Exception {
+        String proof = new ProofBuilder().ath(ath(ACCESS_TOKEN)).sign();
+        validator.validateForResource(tokenRequest(proof), null, ecJkt).test().assertError(InvalidDPoPProofException.class);
+        validator.validateForResource(tokenRequest(proof), ACCESS_TOKEN, null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+
+    @Test
+    void shouldRejectDuplicateJtiForTokenValidation() throws Exception {
+        String proof = new ProofBuilder().jti("fixed-jti").sign();
+        when(replayCache.register("fixed-jti")).thenReturn(Single.just(true), Single.just(false));
+
+        validator.validateForToken(tokenRequest(proof), null).test().assertValue(ecJkt);
+        validator.validateForToken(tokenRequest(proof), null).test()
+                .assertError(error -> error instanceof InvalidDPoPProofException
+                        && "DPoP proof has already been used (replay detected)".equals(error.getMessage()));
+        verify(replayCache, times(2)).register("fixed-jti");
+    }
+
+    @Test
+    void shouldPropagateReplayCacheError() throws Exception {
+        IllegalStateException failure = new IllegalStateException("cache failure");
+        String proof = new ProofBuilder().jti("failing-jti").sign();
+        when(replayCache.register("failing-jti")).thenReturn(Single.error(failure));
+
+        validator.validateForToken(tokenRequest(proof), null).test().assertError(error -> error == failure);
+    }
+
+
+    @Test
+    void refresh_mode_valid_proof_matching_jkt_returns_thumbprint() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test().assertValue(ecJkt).assertComplete();
+    }
+
+    @Test
+    void refresh_mode_thumbprint_mismatch_is_rejected() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForRefresh(tokenRequest(proof), "a-different-thumbprint", null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void refresh_mode_does_not_require_ath() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test().assertValue(ecJkt).assertComplete();
+    }
+
+    @Test
+    void refresh_mode_ignores_ath_when_present() throws Exception {
+        String proof = new ProofBuilder().ath(ath("some-unrelated-token")).sign();
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test().assertValue(ecJkt).assertComplete();
+    }
+
+    @Test
+    void refresh_mode_requires_expected_thumbprint() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForRefresh(tokenRequest(proof), null, null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void refresh_mode_bad_signature_is_rejected() throws Exception {
+        ECKey other = new ECKeyGenerator(Curve.P_256).generate();
+        String proof = new ProofBuilder().headerJwk(other.toPublicJWK()).signer(ecSigner).sign();
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void refresh_mode_alg_none_is_rejected() throws Exception {
+        String unsecured = new PlainJWT(new JWTClaimsSet.Builder()
+                .jwtID(UUID.randomUUID().toString())
+                .issueTime(new Date())
+                .claim("htm", "POST")
+                .claim("htu", HTU)
+                .build()).serialize();
+        validator.validateForRefresh(tokenRequest(unsecured), ecJkt, null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void refresh_mode_wrong_htu_is_rejected() throws Exception {
+        String proof = new ProofBuilder().htu("https://am.example.com/somewhere-else").sign();
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void refresh_mode_iat_too_old_is_rejected() throws Exception {
+        String proof = new ProofBuilder().iat(Date.from(Instant.now().minusSeconds(60))).sign();
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void refresh_mode_missing_jti_is_rejected() throws Exception {
+        String proof = new ProofBuilder().jti(null).sign();
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test().assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void shouldRejectDuplicateJtiForRefreshMode() throws Exception {
+        String proof = new ProofBuilder().jti("refresh-fixed-jti").sign();
+        when(replayCache.register("refresh-fixed-jti")).thenReturn(Single.just(true), Single.just(false));
+
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test().assertValue(ecJkt);
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, null).test()
+                .assertError(error -> error instanceof InvalidDPoPProofException
+                        && "DPoP proof has already been used (replay detected)".equals(error.getMessage()));
+        verify(replayCache, times(2)).register("refresh-fixed-jti");
+    }
+
+
+    @Test
+    void token_mode_alg_inside_domain_allowlist_is_accepted() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForToken(tokenRequest(proof), Set.of("ES256", "ES384")).test().assertValue(ecJkt).assertComplete();
+    }
+
+    @Test
+    void token_mode_alg_outside_domain_allowlist_is_rejected() throws Exception {
+        String proof = new ProofBuilder().alg(JWSAlgorithm.RS256).headerJwk(rsaPublicJwk).signer(rsaSigner).sign();
+        validator.validateForToken(tokenRequest(proof), Set.of("ES256", "ES384", "ES512")).test()
+                .assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void refresh_mode_alg_inside_domain_allowlist_is_accepted() throws Exception {
+        String proof = new ProofBuilder().sign();
+        validator.validateForRefresh(tokenRequest(proof), ecJkt, Set.of("ES256")).test().assertValue(ecJkt).assertComplete();
+    }
+
+    @Test
+    void refresh_mode_alg_outside_domain_allowlist_is_rejected() throws Exception {
+        String proof = new ProofBuilder().alg(JWSAlgorithm.RS256).headerJwk(rsaPublicJwk).signer(rsaSigner).sign();
+        validator.validateForRefresh(tokenRequest(proof), rsaJkt, Set.of("ES256")).test()
+                .assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void resource_mode_accepts_base_set_alg_regardless_of_narrower_allowlist() throws Exception {
+        String proof = new ProofBuilder().alg(JWSAlgorithm.RS256).headerJwk(rsaPublicJwk).signer(rsaSigner)
+                .ath(ath(ACCESS_TOKEN)).sign();
+        validator.validateForResource(tokenRequest(proof), ACCESS_TOKEN, rsaJkt).test().assertValue(rsaJkt).assertComplete();
+    }
+
+    private static String ath(String token) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return Base64URL.encode(digest.digest(token.getBytes(StandardCharsets.US_ASCII))).toString();
+    }
+
+    private static JWTClaimsSet.Builder defaultClaims() {
+        return new JWTClaimsSet.Builder()
+                .jwtID(UUID.randomUUID().toString())
+                .issueTime(new Date())
+                .claim("htm", "POST")
+                .claim("htu", HTU);
+    }
+
+    private Request tokenRequest(String... proofs) {
+        return request("POST", "https", Map.of(HttpHeaders.HOST, HOST), PATH, List.of(proofs));
+    }
+
+    private Request forwardedRequest(String... proofs) {
+        return request("POST", "http",
+                Map.of(HttpHeaders.HOST, "10.0.0.5:8092",
+                        HttpHeaders.X_FORWARDED_PROTO, "https",
+                        HttpHeaders.X_FORWARDED_HOST, HOST),
+                PATH, List.of(proofs));
+    }
+
+    private Request request(String method, String scheme, Map<String, String> headers, String path, List<String> proofs) {
+        Request request = mock(Request.class);
+        when(request.method()).thenReturn(HttpMethod.valueOf(method));
+        when(request.scheme()).thenReturn(scheme);
+        when(request.path()).thenReturn(path);
+        when(request.uri()).thenReturn(path);
+        when(request.host()).thenReturn(headers.get(HttpHeaders.HOST));
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+        final io.gravitee.gateway.api.http.HttpHeaders h = io.gravitee.gateway.api.http.HttpHeaders.create();
+        headers.forEach(h::set);
+        proofs.forEach(p -> h.add(ConstantKeys.DPOP_PROOF_HEADER, p));
+        when(request.headers()).thenReturn(h);
+        return request;
+    }
+
+    /**
+     * Fluent builder for DPoP proof JWTs. Defaults produce a valid EC (ES256) token-endpoint proof;
+     * setting any field to {@code null} omits it (to exercise missing-claim cases).
+     */
+    private final class ProofBuilder {
+        private JWSAlgorithm alg = JWSAlgorithm.ES256;
+        private JOSEObjectType typ = new JOSEObjectType(DPoPProofValidatorImpl.DPOP_JWT_TYPE);
+        private JWK headerJwk = ecPublicJwk;
+        private JWSSigner signer = ecSigner;
+        private String htm = "POST";
+        private String htu = HTU;
+        private Date iat = new Date();
+        private String jti = UUID.randomUUID().toString();
+        private String ath;
+
+        private ProofBuilder alg(JWSAlgorithm alg) { this.alg = alg; return this; }
+        private ProofBuilder typ(JOSEObjectType typ) { this.typ = typ; return this; }
+        private ProofBuilder headerJwk(JWK jwk) { this.headerJwk = jwk; return this; }
+        private ProofBuilder signer(JWSSigner signer) { this.signer = signer; return this; }
+        private ProofBuilder htm(String htm) { this.htm = htm; return this; }
+        private ProofBuilder htu(String htu) { this.htu = htu; return this; }
+        private ProofBuilder iat(Date iat) { this.iat = iat; return this; }
+        private ProofBuilder jti(String jti) { this.jti = jti; return this; }
+        private ProofBuilder ath(String ath) { this.ath = ath; return this; }
+
+        private String sign() throws Exception {
+            JWSHeader.Builder header = new JWSHeader.Builder(alg);
+            if (typ != null) {
+                header.type(typ);
+            }
+            if (headerJwk != null) {
+                header.jwk(headerJwk);
+            }
+            JWTClaimsSet.Builder claims = new JWTClaimsSet.Builder();
+            if (htm != null) {
+                claims.claim("htm", htm);
+            }
+            if (htu != null) {
+                claims.claim("htu", htu);
+            }
+            if (iat != null) {
+                claims.issueTime(iat);
+            }
+            if (jti != null) {
+                claims.jwtID(jti);
+            }
+            if (ath != null) {
+                claims.claim("ath", ath);
+            }
+            SignedJWT jwt = new SignedJWT(header.build(), claims.build());
+            jwt.sign(signer);
+            return jwt.serialize();
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/dpop/impl/ReplayCacheTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/dpop/impl/ReplayCacheTest.java
@@ -1,0 +1,362 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.dpop.impl;
+
+import io.gravitee.am.gateway.handler.common.dpop.ReplayCache;
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.node.api.cache.CacheListener;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReplayCacheTest {
+
+    private static final long TTL_SECONDS = 30;
+
+    @Test
+    void shouldAcceptRegistrationWithNoOpCache() {
+        new ReplayCache.NoOpReplayCache().register("jti").test().assertResult(true);
+    }
+
+    @Test
+    void shouldRegisterRawJtiAtomicallyWithStandardCache() {
+        ThreadSafeTestCache cache = ThreadSafeTestCache.computeCapable();
+        ReplayCache replayCache = new StandardReplayCache(cache, TTL_SECONDS);
+
+        replayCache.register("raw-jti").test().assertResult(true);
+        replayCache.register("raw-jti").test().assertResult(false);
+
+        assertEquals(2, cache.computeCalls.get());
+        assertEquals("raw-jti", cache.lastComputeKey);
+        assertEquals(1, cache.ttlWrites.get());
+        assertEquals("raw-jti", cache.lastTtlKey);
+        assertEquals(TTL_SECONDS, cache.lastTtl);
+        assertSame(TimeUnit.SECONDS, cache.lastTtlUnit);
+    }
+
+    @Test
+    void shouldCreateFreshMarkerForEachSubscription() {
+        ThreadSafeTestCache cache = ThreadSafeTestCache.computeCapable();
+        ReplayCache replayCache = new StandardReplayCache(cache, TTL_SECONDS);
+        Single<Boolean> registration = replayCache.register("raw-jti");
+
+        registration.test().assertResult(true);
+        registration.test().assertResult(false);
+
+        assertEquals(1, cache.ttlWrites.get());
+    }
+
+    @Test
+    void shouldAllowOneConcurrentStandardRegistration() throws Exception {
+        ThreadSafeTestCache cache = ThreadSafeTestCache.computeCapable();
+        ReplayCache replayCache = new StandardReplayCache(cache, TTL_SECONDS);
+
+        List<Boolean> results = raceRegistrations(replayCache, 32);
+
+        assertEquals(1, results.stream().filter(Boolean::booleanValue).count());
+        assertEquals(1, cache.ttlWrites.get());
+    }
+
+    @Test
+    void shouldRegisterRawJtiAtomicallyWithRedisCache() {
+        RedisTestCache cache = new RedisTestCache();
+        ReplayCache replayCache = new RedisReplayCache(cache, TTL_SECONDS);
+
+        replayCache.register("raw-jti").test().assertResult(true);
+        replayCache.register("raw-jti").test().assertResult(false);
+
+        assertEquals(2, cache.setNxCalls.get());
+        assertEquals(2, cache.getCalls.get());
+        assertEquals("raw-jti", cache.lastSetNxKey);
+        assertEquals(1, cache.ttlWrites.get());
+    }
+
+    @Test
+    void shouldAllowOneConcurrentRedisRegistration() throws Exception {
+        RedisTestCache cache = new RedisTestCache();
+        ReplayCache replayCache = new RedisReplayCache(cache, TTL_SECONDS);
+
+        List<Boolean> results = raceRegistrations(replayCache, 32);
+
+        assertEquals(1, results.stream().filter(Boolean::booleanValue).count());
+        assertEquals(1, cache.ttlWrites.get());
+    }
+
+    @Test
+    void shouldNeverProbeComputeIfAbsentOnRedisCache() {
+        RedisTestCache cache = new RedisTestCache();
+        ReplayCache replayCache = new RedisReplayCache(cache, TTL_SECONDS);
+
+        replayCache.register("raw-jti").test().assertResult(true);
+        replayCache.register("raw-jti").test().assertResult(false);
+
+        assertEquals(0, cache.computeCalls.get());
+    }
+
+    @Test
+    void shouldPropagateStandardBackendFailure() {
+        IllegalStateException failure = new IllegalStateException("compute failure");
+        ThreadSafeTestCache cache = ThreadSafeTestCache.computeCapable();
+        cache.computeFailure = failure;
+        ReplayCache replayCache = new StandardReplayCache(cache, TTL_SECONDS);
+
+        replayCache.register("jti").test().assertError(error -> error == failure);
+
+        assertEquals(0, cache.ttlWrites.get());
+    }
+
+    @Test
+    void shouldPropagateRedisBackendFailure() {
+        IllegalStateException failure = new IllegalStateException("put failure");
+        RedisTestCache cache = new RedisTestCache();
+        cache.setNxFailure = failure;
+        ReplayCache replayCache = new RedisReplayCache(cache, TTL_SECONDS);
+
+        replayCache.register("jti").test().assertError(error -> error == failure);
+
+        assertEquals(0, cache.getCalls.get());
+        assertEquals(0, cache.ttlWrites.get());
+    }
+
+    @Test
+    void shouldEvictEntryAndPropagateWhenTtlWriteFails() {
+        IllegalStateException failure = new IllegalStateException("ttl failure");
+        ThreadSafeTestCache cache = ThreadSafeTestCache.computeCapable();
+        cache.ttlFailure = failure;
+        ReplayCache replayCache = new StandardReplayCache(cache, TTL_SECONDS);
+
+        replayCache.register("jti").test().awaitDone(5, TimeUnit.SECONDS).assertError(error -> error == failure);
+
+        assertEquals(1, cache.ttlWrites.get());
+        assertEquals(1, cache.evictCalls.get());
+        assertFalse(cache.containsKey("jti"));
+    }
+
+    private List<Boolean> raceRegistrations(ReplayCache replayCache, int registrationCount) throws Exception {
+        try (ExecutorService executor = Executors.newFixedThreadPool(registrationCount)) {
+            CountDownLatch ready = new CountDownLatch(registrationCount);
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<Boolean>> registrations = new ArrayList<>();
+            try {
+                for (int index = 0; index < registrationCount; index++) {
+                    registrations.add(executor.submit(() -> {
+                        ready.countDown();
+                        start.await();
+                        return replayCache.register("concurrent-jti").blockingGet();
+                    }));
+                }
+                assertTrue(ready.await(5, TimeUnit.SECONDS));
+                start.countDown();
+                List<Boolean> results = new ArrayList<>();
+                for (Future<Boolean> registration : registrations) {
+                    results.add(registration.get(5, TimeUnit.SECONDS));
+                }
+                return results;
+            } finally {
+                start.countDown();
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    private static class ThreadSafeTestCache implements Cache<String, String> {
+
+        protected final Map<String, String> entries = new ConcurrentHashMap<>();
+        protected final AtomicInteger computeCalls = new AtomicInteger();
+        protected final AtomicInteger getCalls = new AtomicInteger();
+        protected final AtomicInteger ttlWrites = new AtomicInteger();
+        private final AtomicInteger evictCalls = new AtomicInteger();
+        private volatile RuntimeException computeFailure;
+        private volatile RuntimeException ttlFailure;
+        protected volatile String lastComputeKey;
+        private volatile String lastTtlKey;
+        private volatile long lastTtl;
+        private volatile TimeUnit lastTtlUnit;
+
+        private static ThreadSafeTestCache computeCapable() {
+            return new ThreadSafeTestCache();
+        }
+
+        @Override
+        public Maybe<String> rxComputeIfAbsent(String key, Function<? super String, ? extends String> mappingFunction) {
+            computeCalls.incrementAndGet();
+            lastComputeKey = key;
+            if (computeFailure != null) {
+                return Maybe.error(computeFailure);
+            }
+            return Maybe.just(entries.computeIfAbsent(key, mappingFunction));
+        }
+
+        @Override
+        public Maybe<String> rxPut(String key, String value) {
+            return Maybe.fromCallable(() -> entries.put(key, value));
+        }
+
+        @Override
+        public Maybe<String> rxGet(String key) {
+            getCalls.incrementAndGet();
+            return Maybe.fromOptional(java.util.Optional.ofNullable(entries.get(key)));
+        }
+
+        @Override
+        public Maybe<String> rxPut(String key, String value, long ttl, TimeUnit timeUnit) {
+            ttlWrites.incrementAndGet();
+            lastTtlKey = key;
+            lastTtl = ttl;
+            lastTtlUnit = timeUnit;
+            if (ttlFailure != null) {
+                return Maybe.error(ttlFailure);
+            }
+            return Maybe.fromCallable(() -> entries.put(key, value));
+        }
+
+        @Override
+        public String getName() {
+            return "test-cache";
+        }
+
+        @Override
+        public Collection<String> values() {
+            return entries.values();
+        }
+
+        @Override
+        public Set<String> keys() {
+            return entries.keySet();
+        }
+
+        @Override
+        public Set<Map.Entry<String, String>> entrySet() {
+            return entries.entrySet();
+        }
+
+        @Override
+        public int size() {
+            return entries.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return entries.isEmpty();
+        }
+
+        @Override
+        public boolean containsKey(String key) {
+            return entries.containsKey(key);
+        }
+
+        @Override
+        public String get(String key) {
+            return entries.get(key);
+        }
+
+        @Override
+        public String put(String key, String value) {
+            return entries.put(key, value);
+        }
+
+        @Override
+        public String put(String key, String value, long ttl, TimeUnit timeUnit) {
+            return entries.put(key, value);
+        }
+
+        @Override
+        public void putAll(Map<? extends String, ? extends String> values) {
+            entries.putAll(values);
+        }
+
+        @Override
+        public String computeIfAbsent(String key, Function<? super String, ? extends String> mappingFunction) {
+            return entries.computeIfAbsent(key, mappingFunction);
+        }
+
+        @Override
+        public String computeIfPresent(String key, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+            return entries.computeIfPresent(key, remappingFunction);
+        }
+
+        @Override
+        public String compute(String key, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+            return entries.compute(key, remappingFunction);
+        }
+
+        @Override
+        public String evict(String key) {
+            evictCalls.incrementAndGet();
+            return entries.remove(key);
+        }
+
+        @Override
+        public void clear() {
+            entries.clear();
+        }
+
+        @Override
+        public String addCacheListener(CacheListener<String, String> cacheListener) {
+            return "listener";
+        }
+
+        @Override
+        public boolean removeCacheListener(String listenerId) {
+            return true;
+        }
+    }
+
+    private static final class RedisTestCache extends ThreadSafeTestCache {
+
+        private final AtomicInteger setNxCalls = new AtomicInteger();
+        private volatile RuntimeException setNxFailure;
+        private volatile String lastSetNxKey;
+
+        @Override
+        public Maybe<String> rxComputeIfAbsent(String key, Function<? super String, ? extends String> mappingFunction) {
+            computeCalls.incrementAndGet();
+            lastComputeKey = key;
+            throw new UnsupportedOperationException("Redis cache does not support computeIfAbsent operation");
+        }
+
+        @Override
+        public Maybe<String> rxPut(String key, String value) {
+            setNxCalls.incrementAndGet();
+            lastSetNxKey = key;
+            if (setNxFailure != null) {
+                return Maybe.error(setNxFailure);
+            }
+            String previous = entries.putIfAbsent(key, value);
+            return previous == null ? Maybe.empty() : Maybe.just(previous);
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/jwt/InMemoryJWTCacheTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/jwt/InMemoryJWTCacheTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class InMemoryJWTCacheTest {
 
@@ -66,7 +65,7 @@ public class InMemoryJWTCacheTest {
 
     @Test
     public void shouldKeepNoOpCacheEmpty() {
-        JWTCache cache = new JWTCache.NoOpJtiCache();
+        JWTCache cache = new JWTCache.NoOpJwtCache();
 
         cache.isPresent("token").test().assertResult(false);
         cache.put("token", 10L);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/handler/impl/OAuth2AuthHandlerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/auth/handler/impl/OAuth2AuthHandlerImplTest.java
@@ -15,21 +15,25 @@
  */
 package io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.impl;
 
+import io.gravitee.am.common.exception.oauth2.InvalidDPoPProofException;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthResponse;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.http.HttpClientRequest;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.Test;
@@ -39,19 +43,27 @@ import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class    OAuth2AuthHandlerImplTest extends RxWebTestBase {
 
     private static final String TEST_SUB = "test-sub";
+    private static final String THE_JKT = "the-jwk-thumbprint";
+    private static final String DPOP_ALGS = "algs=\"ES256 ES384 ES512 RS256 RS384 RS512\"";
     private OAuth2AuthHandlerImpl handler;
     private OAuth2AuthProvider provider;
+    private DPoPProofValidator dpopProofValidator;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         provider = mock();
+        dpopProofValidator = mock();
         handler = new OAuth2AuthHandlerImpl(provider, mock());
         router.route("/test")
                 .handler(handler)
@@ -124,7 +136,77 @@ public class    OAuth2AuthHandlerImplTest extends RxWebTestBase {
     public void notBearer_shouldReturnMeaningfulErrorMessage() throws Exception {
         testRequest(HttpMethod.GET, "/test", withAuthorization("Basic dXNlcjpwYXNz"),
                 HttpStatusCode.UNAUTHORIZED_401, "Unauthorized",
-                errorJson("Authorization header must use Bearer scheme", 401));
+                errorJson("Authorization header must use the Bearer or DPoP scheme", 401));
+    }
+
+    @Test
+    public void dpop_validProof_boundToken_passes() throws Exception {
+        handler.dpopProofValidator(dpopProofValidator);
+        when(dpopProofValidator.validateForResource(any(), any(), any())).thenReturn(Single.just(THE_JKT));
+        givenTokenDecodesTo(Map.of(Claims.SUB, TEST_SUB, Claims.CNF, Map.of("jkt", THE_JKT)));
+
+        testRequest(HttpMethod.GET, "/test", withAuthorization("DPoP the-token"), HttpStatusCode.OK_200, "OK", null);
+
+        verify(dpopProofValidator).validateForResource(any(), eq("the-token"), eq(THE_JKT));
+    }
+
+    @Test
+    public void dpop_boundToken_underBearer_isDowngradeRejected() throws Exception {
+        handler.dpopProofValidator(dpopProofValidator);
+        givenTokenDecodesTo(Map.of(Claims.SUB, TEST_SUB, Claims.CNF, Map.of("jkt", THE_JKT)));
+
+        testRequest(HttpMethod.GET, "/test", withAuthorization("Bearer the-token"),
+                assertDPoPChallenge(),
+                HttpStatusCode.UNAUTHORIZED_401, "Unauthorized", null);
+
+        verify(dpopProofValidator, never()).validateForResource(any(), any(), any());
+    }
+
+    @Test
+    public void dpop_boundToken_invalidProof_isRejectedWithDPoPChallenge() throws Exception {
+        handler.dpopProofValidator(dpopProofValidator);
+        when(dpopProofValidator.validateForResource(any(), any(), any()))
+                .thenReturn(Single.error(new InvalidDPoPProofException("bad proof")));
+        givenTokenDecodesTo(Map.of(Claims.SUB, TEST_SUB, Claims.CNF, Map.of("jkt", THE_JKT)));
+
+        testRequest(HttpMethod.GET, "/test", withAuthorization("DPoP the-token"),
+                assertDPoPChallenge(),
+                HttpStatusCode.UNAUTHORIZED_401, "Unauthorized", null);
+    }
+
+    @Test
+    public void dpop_boundToken_failsClosed_whenValidatorAbsent() throws Exception {
+        givenTokenDecodesTo(Map.of(Claims.SUB, TEST_SUB, Claims.CNF, Map.of("jkt", THE_JKT)));
+
+        testRequest(HttpMethod.GET, "/test", withAuthorization("DPoP the-token"),
+                HttpStatusCode.UNAUTHORIZED_401, "Unauthorized", null);
+    }
+
+    @Test
+    public void ordinaryToken_noCnf_isUnaffected() throws Exception {
+        handler.dpopProofValidator(dpopProofValidator);
+        givenTokenDecodesTo(Map.of(Claims.SUB, TEST_SUB));
+
+        testRequest(HttpMethod.GET, "/test", withAuthorization("Bearer the-token"), HttpStatusCode.OK_200, "OK", null);
+
+        verify(dpopProofValidator, never()).validateForResource(any(), any(), any());
+    }
+
+    @Test
+    public void mtlsCertificateBoundToken_isUnaffected() throws Exception {
+        handler.dpopProofValidator(dpopProofValidator);
+        givenTokenDecodesTo(Map.of(Claims.SUB, TEST_SUB, Claims.CNF, Map.of("x5t#S256", "cert-thumbprint")));
+
+        testRequest(HttpMethod.GET, "/test", withAuthorization("Bearer the-token"), HttpStatusCode.OK_200, "OK", null);
+
+        verify(dpopProofValidator, never()).validateForResource(any(), any(), any());
+    }
+
+    private Consumer<HttpClientResponse> assertDPoPChallenge() {
+        return resp -> {
+            String challenge = resp.getHeader("WWW-Authenticate");
+            org.assertj.core.api.Assertions.assertThat(challenge).startsWith("DPoP").contains(DPOP_ALGS);
+        };
     }
 
     private String errorJson(String message, int httpStatus) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/token/TokenEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/token/TokenEndpoint.java
@@ -15,13 +15,10 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.resources.endpoint.token;
 
-import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidClientException;
-import io.gravitee.am.gateway.handler.oauth2.exception.UnauthorizedClientException;
 import io.gravitee.am.gateway.handler.oauth2.resources.request.TokenRequestFactory;
 import io.gravitee.am.gateway.handler.oauth2.service.granter.TokenGranter;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequest;
-import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.MediaType;
@@ -29,7 +26,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.Json;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 
-import static io.gravitee.am.common.oauth2.GrantType.*;
 import static io.gravitee.am.common.utils.ConstantKeys.CLIENT_CONTEXT_KEY;
 
 /**
@@ -78,17 +74,13 @@ public class TokenEndpoint implements Handler<RoutingContext> {
             throw new InvalidClientException("Invalid client: client must at least have one grant type configured");
         }
 
-        if (context.get(ConstantKeys.PEER_CERTIFICATE_THUMBPRINT) != null) {
-            // preserve certificate thumbprint to add the information into the access token
-            tokenRequest.setConfirmationMethodX5S256(context.get(ConstantKeys.PEER_CERTIFICATE_THUMBPRINT));
-        }
-
         tokenGranter.grant(tokenRequest, tokenRequest.getHttpResponse(), client)
                 .subscribe(accessToken -> context.response()
-                        .putHeader(HttpHeaders.CACHE_CONTROL, "no-store")
-                        .putHeader(HttpHeaders.PRAGMA, "no-cache")
-                        .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                        .end(Json.encodePrettily(accessToken))
+                                .putHeader(HttpHeaders.CACHE_CONTROL, "no-store")
+                                .putHeader(HttpHeaders.PRAGMA, "no-cache")
+                                .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                                .end(Json.encodePrettily(accessToken))
                         , context::fail);
     }
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/request/AuthorizationRequestFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/request/AuthorizationRequestFactory.java
@@ -117,6 +117,11 @@ public final class AuthorizationRequestFactory {
             authorizationRequest.getParameters().put(Parameters.CODE_CHALLENGE_METHOD, List.of(codeChallengeMethod));
         }
 
+        String dpopJkt = getOAuthParameter(context, Parameters.DPOP_JKT);
+        if (dpopJkt != null) {
+            authorizationRequest.getParameters().put(Parameters.DPOP_JKT, List.of(dpopJkt));
+        }
+
         // store authorization request in context for later use
         context.put(ConstantKeys.AUTHORIZATION_REQUEST_CONTEXT_KEY, authorizationRequest);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/request/TokenRequestFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/request/TokenRequestFactory.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.oauth2.resources.request;
 
 import io.gravitee.am.common.oauth2.Parameters;
+import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpHeaders;
 import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
@@ -80,6 +81,8 @@ public final class TokenRequestFactory {
 
         // set RFC 8707 resource indicators
         tokenRequest.setResources(ResourceParameterUtils.parseResourceParameters(request));
+
+        tokenRequest.setConfirmationMethodX5S256(context.get(ConstantKeys.PEER_CERTIFICATE_THUMBPRINT));
 
         return tokenRequest;
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/grant/HttpRequestInfo.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/grant/HttpRequestInfo.java
@@ -47,6 +47,7 @@ public record HttpRequestInfo(
         HttpVersion version,
         long timestamp,
         String confirmationMethodX5S256,
+        String confirmationMethodJkt,
         Response httpResponse
 ) {
 
@@ -75,6 +76,7 @@ public record HttpRequestInfo(
                 request.version(),
                 request.timestamp(),
                 request.getConfirmationMethodX5S256(),
+                request.getConfirmationMethodJkt(),
                 request.getHttpResponse()
         );
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/grant/StrategyGranterAdapter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/grant/StrategyGranterAdapter.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.grant;
 
+import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.oauth2.GrantType;
 import io.gravitee.am.common.oauth2.Parameters;
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ActorTokenInfo;
 import io.gravitee.am.common.policy.ExtensionPoint;
 import io.gravitee.am.gateway.handler.common.policy.RulesEngine;
@@ -27,6 +30,7 @@ import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequest;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequestResolver;
 import io.gravitee.am.gateway.handler.oauth2.service.token.Token;
 import io.gravitee.am.gateway.handler.oauth2.service.token.TokenService;
+import io.gravitee.am.gateway.handler.oidc.service.utils.JWAlgorithmUtils;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
@@ -34,12 +38,14 @@ import io.gravitee.am.model.uma.PermissionRequest;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.Response;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import lombok.Getter;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import lombok.CustomLog;
 
@@ -67,18 +73,21 @@ public class StrategyGranterAdapter implements TokenGranter {
     private final TokenService tokenService;
     private final RulesEngine rulesEngine;
     private final TokenRequestResolver tokenRequestResolver;
+    private final DPoPProofValidator dpopProofValidator;
 
     public StrategyGranterAdapter(
             GrantStrategy strategy,
             Domain domain,
             TokenService tokenService,
             RulesEngine rulesEngine,
-            TokenRequestResolver tokenRequestResolver) {
+            TokenRequestResolver tokenRequestResolver,
+            DPoPProofValidator dpopProofValidator) {
         this.strategy = strategy;
         this.domain = domain;
         this.tokenService = tokenService;
         this.rulesEngine = rulesEngine;
         this.tokenRequestResolver = tokenRequestResolver;
+        this.dpopProofValidator = dpopProofValidator;
     }
 
     @Override
@@ -96,7 +105,8 @@ public class StrategyGranterAdapter implements TokenGranter {
         log.debug("Processing grant via strategy adapter for client: {}, grant type: {}",
                 client.getClientId(), tokenRequest.getGrantType());
 
-        return strategy.process(tokenRequest, client, domain)
+        return applyDPoPBinding(tokenRequest, client)
+                .andThen(Single.defer(() -> strategy.process(tokenRequest, client, domain)))
                 .flatMap(creationRequest -> resolveScopes(creationRequest, client))
                 .flatMap(resolved -> {
                     // Create ONE OAuth2Request that will be reused throughout the entire flow.
@@ -109,6 +119,71 @@ public class StrategyGranterAdapter implements TokenGranter {
                             .flatMap(ignored -> createToken(oAuth2Request, client, resolved))
                             .flatMap(token -> executePostTokenPolicy(oAuth2Request, client, user, token));
                 });
+    }
+
+    private Completable applyDPoPBinding(TokenRequest tokenRequest, Client client) {
+        if (dpopProofValidator == null) {
+            return Completable.complete();
+        }
+        if (mustUseDpop(client) && !isDPoPRequest(tokenRequest)) {
+            return Completable.error(new InvalidRequestException("A DPoP proof is required for this client"));
+        }
+        if (GrantType.REFRESH_TOKEN.equals(tokenRequest.getGrantType())) {
+            return applyRefreshBinding(tokenRequest, client);
+        }
+        return applyOpportunisticBinding(tokenRequest);
+    }
+
+    private boolean mustUseDpop(Client client) {
+        return domain.isRequireDpopForAll() || (client != null && client.isDpopBoundAccessTokens());
+    }
+
+    private Completable applyOpportunisticBinding(TokenRequest tokenRequest) {
+        if (!isDPoPRequest(tokenRequest)) {
+            return Completable.complete();
+        }
+        return dpopProofValidator.validateForToken(tokenRequest, dpopSigningAlgorithms())
+                .doOnSuccess(tokenRequest::setConfirmationMethodJkt)
+                .ignoreElement();
+    }
+
+    /**
+     * The domain's DPoP signing-algorithm allowlist (RFC 9449), resolved to the full base set when
+     * the domain leaves it unconfigured. Applied to the token and refresh proof-validation modes.
+     */
+    private Set<String> dpopSigningAlgorithms() {
+        List<String> configured = domain.getOidc() != null && domain.getOidc().getDpopSettings() != null
+                ? domain.getOidc().getDpopSettings().getDpopSigningAlgorithms() : null;
+        return Set.copyOf(JWAlgorithmUtils.resolveDpopSigningAlg(configured));
+    }
+
+    private Completable applyRefreshBinding(TokenRequest tokenRequest, Client client) {
+        final String refreshToken = tokenRequest.parameters() != null
+                ? tokenRequest.parameters().getFirst(Parameters.REFRESH_TOKEN)
+                : null;
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return applyOpportunisticBinding(tokenRequest);
+        }
+        return tokenService.getRefreshTokenJkt(refreshToken, client)
+                .map(Optional::of)
+                .switchIfEmpty(Single.just(Optional.<String>empty()))
+                .flatMapCompletable(boundJkt -> boundJkt
+                        .map(jkt -> enforceRefreshContinuity(tokenRequest, jkt))
+                        .orElseGet(() -> applyOpportunisticBinding(tokenRequest)));
+    }
+
+    private Completable enforceRefreshContinuity(TokenRequest tokenRequest, String boundJkt) {
+        if (!isDPoPRequest(tokenRequest)) {
+            return Completable.error(new InvalidRequestException("A DPoP proof is required to refresh a DPoP-bound token"));
+        }
+        return dpopProofValidator.validateForRefresh(tokenRequest, boundJkt, dpopSigningAlgorithms())
+                .doOnSuccess(tokenRequest::setConfirmationMethodJkt)
+                .ignoreElement();
+    }
+
+    private static boolean isDPoPRequest(TokenRequest tokenRequest) {
+        return tokenRequest.headers() != null
+                && tokenRequest.headers().get(ConstantKeys.DPOP_PROOF_HEADER) != null;
     }
 
     private Single<TokenCreationRequest> resolveScopes(TokenCreationRequest request, Client client) {
@@ -220,6 +295,7 @@ public class StrategyGranterAdapter implements TokenGranter {
             oAuth2Request.setVersion(httpInfo.version());
             oAuth2Request.setTimestamp(httpInfo.timestamp());
             oAuth2Request.setConfirmationMethodX5S256(httpInfo.confirmationMethodX5S256());
+            oAuth2Request.setConfirmationMethodJkt(httpInfo.confirmationMethodJkt());
             oAuth2Request.setHttpResponse(httpInfo.httpResponse());
         }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/grant/impl/AuthorizationCodeStrategy.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/grant/impl/AuthorizationCodeStrategy.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.grant.impl;
 
+import io.gravitee.am.common.exception.oauth2.InvalidDPoPProofException;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.oauth2.CodeChallengeMethod;
 import io.gravitee.am.common.oauth2.GrantType;
@@ -121,6 +122,8 @@ public class AuthorizationCodeStrategy implements GrantStrategy {
 
         // Validate PKCE
         validatePKCE(codeVerifier, authorizationCode);
+
+        validateDPoPJkt(request, authorizationCode);
 
         // Load user and create token request
         return authenticationFlowContextService
@@ -231,6 +234,24 @@ public class AuthorizationCodeStrategy implements GrantStrategy {
         String encodedCodeVerifier = getCodeChallenge(codeChallengeMethod, codeVerifier);
         if (!codeChallenge.equals(encodedCodeVerifier)) {
             throw new InvalidGrantException("Invalid code_verifier");
+        }
+    }
+
+    private void validateDPoPJkt(TokenRequest request, AuthorizationCode authorizationCode) {
+        String committedJkt = authorizationCode.getRequestParameters().getFirst(Parameters.DPOP_JKT);
+        if (committedJkt == null) {
+            return;
+        }
+
+        String presentedJkt = request.getConfirmationMethodJkt();
+        if (presentedJkt == null) {
+            log.debug("Authorization code is bound to a DPoP key (dpop_jkt) but the redemption carried no DPoP proof");
+            throw new InvalidDPoPProofException("DPoP proof is required: the authorization code is bound to a DPoP key");
+        }
+
+        if (!committedJkt.equals(presentedJkt)) {
+            log.debug("Presented DPoP key thumbprint does not match the dpop_jkt bound to the authorization code");
+            throw new InvalidDPoPProofException("DPoP proof key does not match the key bound to the authorization code");
         }
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/CompositeTokenGranter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/CompositeTokenGranter.java
@@ -39,8 +39,8 @@ import io.gravitee.am.gateway.handler.oauth2.service.grant.impl.UmaStrategy;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequest;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequestResolver;
 import io.gravitee.am.gateway.handler.oauth2.service.scope.ScopeManager;
-import io.gravitee.am.gateway.handler.common.user.UserGatewayService;
 import io.gravitee.am.gateway.handler.oauth2.service.token.Token;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.oauth2.service.token.TokenService;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenExchangeService;
 import io.gravitee.am.gateway.handler.oauth2.service.validation.ResourceConsistencyValidationService;
@@ -81,6 +81,9 @@ public class CompositeTokenGranter implements TokenGranter, InitializingBean {
 
     @Autowired
     private TokenService tokenService;
+
+    @Autowired
+    private DPoPProofValidator dpopProofValidator;
 
     @Autowired
     private JWTService jwtService;
@@ -221,7 +224,7 @@ public class CompositeTokenGranter implements TokenGranter, InitializingBean {
     }
 
     private void registerStrategy(String grantType, GrantStrategy strategy) {
-        TokenGranter adapter = new StrategyGranterAdapter(strategy, domain, tokenService, rulesEngine, tokenRequestResolver);
+        TokenGranter adapter = new StrategyGranterAdapter(strategy, domain, tokenService, rulesEngine, tokenRequestResolver, dpopProofValidator);
         addTokenGranter(grantType, adapter);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/impl/ExtensionGrantManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/impl/ExtensionGrantManagerImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
 import io.gravitee.am.gateway.handler.common.auth.user.UserAuthenticationManager;
 import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.policy.RulesEngine;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceManager;
 import io.gravitee.am.gateway.handler.common.user.UserGatewayService;
@@ -108,6 +109,9 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
 
     @Autowired
     private RulesEngine rulesEngine;
+
+    @Autowired
+    private DPoPProofValidator dpopProofValidator;
 
     @Autowired
     private SubjectManager subjectManager;
@@ -229,7 +233,7 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
                     extensionGrantStrategy.setMinDate(minDate);
 
                     // Wrap strategy with adapter to integrate with CompositeTokenGranter
-                    var adapter = new StrategyGranterAdapter(extensionGrantStrategy, domain, tokenService, rulesEngine, tokenRequestResolver);
+                    var adapter = new StrategyGranterAdapter(extensionGrantStrategy, domain, tokenService, rulesEngine, tokenRequestResolver, dpopProofValidator);
 
                     ((CompositeTokenGranter) tokenGranter).addTokenGranter(extensionGrant.getId(), adapter);
                     extensionGrants.put(extensionGrant.getId(), extensionGrant);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/request/OAuth2Request.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/request/OAuth2Request.java
@@ -152,6 +152,12 @@ public class OAuth2Request extends BaseRequest {
     private String confirmationMethodX5S256;
 
     /**
+     * REQUIRED for <a href="https://datatracker.ietf.org/doc/html/rfc9449">DPoP</a> sender-constrained
+     * access tokens: the base64url JWK SHA-256 thumbprint bound via {@code cnf.jkt}.
+     */
+    private String confirmationMethodJkt;
+
+    /**
      * Token Exchange (RFC 8693) - issued token type
      */
     private String issuedTokenType;
@@ -211,6 +217,7 @@ public class OAuth2Request extends BaseRequest {
         this.authorizationDetails = other.authorizationDetails;
         this.pathParameters = other.pathParameters;
         this.confirmationMethodX5S256 = other.confirmationMethodX5S256;
+        this.confirmationMethodJkt = other.confirmationMethodJkt;
         this.issuedTokenType = other.issuedTokenType;
         this.exchangeExpiration = other.exchangeExpiration;
         this.actClaim = other.actClaim;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/request/TokenRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/request/TokenRequest.java
@@ -70,48 +70,4 @@ public class TokenRequest extends OAuth2Request {
      */
     private String requestingPartyToken;
 
-    public OAuth2Request createOAuth2Request() {
-        MultiValueMap<String, String> requestParameters = parameters();
-        MultiValueMap<String, String> safeRequestParameters = new LinkedMultiValueMap(requestParameters);
-
-        // Remove password if present to prevent leaks
-        safeRequestParameters.remove(Parameters.PASSWORD);
-        safeRequestParameters.remove(Parameters.CLIENT_SECRET);
-
-        OAuth2Request oAuth2Request = new OAuth2Request();
-        // set technical information
-        oAuth2Request.setId(id());
-        oAuth2Request.setTransactionId(transactionId());
-        oAuth2Request.setTimestamp(timestamp());
-        oAuth2Request.setPath(path());
-        oAuth2Request.setOrigin(getOrigin());
-        oAuth2Request.setUri(uri());
-        oAuth2Request.setScheme(scheme());
-        oAuth2Request.setContextPath(contextPath());
-        oAuth2Request.setMethod(method());
-        oAuth2Request.setVersion(version());
-        oAuth2Request.setHeaders(headers());
-        oAuth2Request.setParameters(safeRequestParameters);
-        oAuth2Request.setHttpResponse(getHttpResponse());
-        oAuth2Request.setContext(getContext());
-
-        // set OAuth 2.0 information
-        oAuth2Request.setClientId(getClientId());
-        oAuth2Request.setScopes(getScopes());
-        oAuth2Request.setGrantType(getGrantType());
-        oAuth2Request.setSubject(getSubject());
-        oAuth2Request.setAdditionalParameters(getAdditionalParameters());
-        oAuth2Request.setRefreshToken(getRefreshToken());
-        oAuth2Request.setAuthorizationCode(getAuthorizationCode());
-        oAuth2Request.setResources(getResources());
-        oAuth2Request.setOriginalAuthorizationResources(getOriginalAuthorizationResources());
-
-        // set UMA 2.0 permissions
-        oAuth2Request.setPermissions(getPermissions());
-
-        // certificate bound access token
-        oAuth2Request.setConfirmationMethodX5S256(getConfirmationMethodX5S256());
-
-        return oAuth2Request;
-    }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/Token.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/Token.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.gravitee.am.common.utils.ConstantKeys.BEARER_AUTH_SCHEME;
+
 /**
  * See definition at <a href="https://tools.ietf.org/html/rfc6749#section-1.4"></a>
  *
@@ -38,7 +40,7 @@ import java.util.Map;
 public abstract class Token implements Serializable {
 
     private String value;
-    private String tokenType = BEARER_TYPE.toLowerCase();
+    private String tokenType = BEARER_AUTH_SCHEME.toLowerCase();
     private long expiresIn;
     private String scope;
     private String clientId;
@@ -49,8 +51,6 @@ public abstract class Token implements Serializable {
     private Date expireAt;
     private Boolean upgraded;
     private String issuedTokenType;
-
-    public static final String BEARER_TYPE = "Bearer";
 
     /**
      * REQUIRED. The access token issued by the authorization server.

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenService.java
@@ -36,6 +36,15 @@ public interface TokenService {
 
     Maybe<Token> getRefreshToken(String refreshToken, Client client);
 
+    /**
+     * Resolve the DPoP key binding ({@code cnf.jkt}) carried by a refresh token, if any. Emits the
+     * {@code jkt} when the refresh token is DPoP-bound; completes empty when it is unbound or cannot
+     * be decoded (the grant flow then rejects an invalid token with {@code invalid_grant}). Read from
+     * the signed token itself — no store lookup — since revocation is enforced later in the grant.
+     * Used at the token endpoint to enforce refresh key continuity (RFC 9449 §3).
+     */
+    Maybe<String> getRefreshTokenJkt(String refreshToken, Client client);
+
     default Maybe<Token> introspect(String token) {
         return introspect(token, (String) null);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -75,7 +75,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.gravitee.am.common.oauth2.Parameters.DPOP_JKT;
 import static io.gravitee.am.common.oidc.ResponseType.ID_TOKEN;
+import static io.gravitee.am.common.utils.ConstantKeys.DPOP_AUTH_SCHEME;
 import static io.gravitee.am.gateway.handler.common.jwt.JWTService.TokenType.ACCESS_TOKEN;
 import static io.gravitee.am.gateway.handler.common.jwt.JWTService.TokenType.REFRESH_TOKEN;
 import static org.springframework.util.ObjectUtils.isEmpty;
@@ -151,6 +153,13 @@ public class TokenServiceImpl implements TokenService {
                     return Single.error(ex);
                 })
                 .flatMapMaybe(jwt -> tokenRepository.findRefreshTokenByJti(jwt.getJti()).map(refreshToken1 -> convertRefreshToken(jwt, null)));
+    }
+
+    @Override
+    public Maybe<String> getRefreshTokenJkt(String refreshToken, Client client) {
+        return jwtService.decodeAndVerify(refreshToken, client, REFRESH_TOKEN)
+                .onErrorComplete()
+                .mapOptional(jwt -> Optional.ofNullable(jwt.getDPoPConfirmationThumbprint()));
     }
 
     @Override
@@ -362,6 +371,7 @@ public class TokenServiceImpl implements TokenService {
         newToken.setSubject(user == null ? sourceToken.getSub() : user.getId());
         newToken.setCreatedAt(new Date(sourceToken.getIat() * 1000));
         newToken.setExpireAt(new Date(sourceToken.getExp() * 1000));
+        newToken.setJkt(request.getConfirmationMethodJkt());
         return newToken;
     }
 
@@ -378,6 +388,11 @@ public class TokenServiceImpl implements TokenService {
         token.setSubject(accessToken.getSub());
         token.setExpiresIn(Instant.ofEpochSecond(accessToken.getExp()).minusMillis(System.currentTimeMillis()).getEpochSecond());
         token.setScope(accessToken.getScope());
+
+        if (accessToken.getConfirmationMethod() instanceof Map<?, ?> cnf
+                && cnf.containsKey(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT)) {
+            token.setTokenType(DPOP_AUTH_SCHEME);
+        }
 
         // Token Exchange (RFC 8693) specific fields
         if (oAuth2Request.getIssuedTokenType() != null) {
@@ -466,6 +481,14 @@ public class TokenServiceImpl implements TokenService {
         final String cnfValue = request.getConfirmationMethodX5S256();
         if (cnfValue != null) {
             jwt.setConfirmationMethod(Maps.<String, Object>builder().put(JWT.CONFIRMATION_METHOD_X509_THUMBPRINT, cnfValue).build());
+        }
+        final String dpopJkt = request.getConfirmationMethodJkt();
+        if (dpopJkt != null) {
+            Map<String, Object> cnf = jwt.getConfirmationMethod() instanceof Map<?, ?> existing
+                    ? new HashMap<>((Map<String, Object>) existing)
+                    : new HashMap<>();
+            cnf.put(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT, dpopJkt);
+            jwt.setConfirmationMethod(cnf);
         }
         // set claims parameter (only for an access token)
         // useful for UserInfo Endpoint to request for specific claims
@@ -556,6 +579,13 @@ public class TokenServiceImpl implements TokenService {
         
         // Store originally granted resources in refresh token for RFC 8707 compliance
         setOrigResourcesClaim(jwt, request);
+
+        // DPoP (RFC 9449 §3): bind the refresh token to the same key as the access token so the
+        // binding travels inside the signed token and can be read back without a store lookup.
+        final String dpopJkt = request.getConfirmationMethodJkt();
+        if (dpopJkt != null) {
+            jwt.setConfirmationMethod(Maps.<String, Object>builder().put(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT, dpopJkt).build());
+        }
 
         return jwt;
     }
@@ -712,6 +742,10 @@ public class TokenServiceImpl implements TokenService {
         if (certificateInfo != null) {
             params.put(SIGNING_CERTIFICATE_ID, certificateInfo.certificateId());
             params.put(SIGNING_CERTIFICATE_NAME, certificateInfo.certificateAlias());
+        }
+
+        if (oAuth2Request.getConfirmationMethodJkt() != null) {
+            params.put(DPOP_JKT.toUpperCase(), oAuth2Request.getConfirmationMethodJkt());
         }
 
         if (GrantType.TOKEN_EXCHANGE.equals(oAuth2Request.getGrantType())) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/OIDCProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/OIDCProvider.java
@@ -24,6 +24,7 @@ import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
 import io.gravitee.am.gateway.handler.context.ExecutionContextFactory;
 import io.gravitee.am.gateway.handler.oauth2.OAuth2Provider;
@@ -119,6 +120,9 @@ public class OIDCProvider extends AbstractProtocolProvider {
     private OAuth2AuthProvider oAuth2AuthProvider;
 
     @Autowired
+    private DPoPProofValidator dpopProofValidator;
+
+    @Autowired
     private ApplicationContext applicationContext;
 
     @Autowired
@@ -207,6 +211,7 @@ public class OIDCProvider extends AbstractProtocolProvider {
         userInfoAuthHandler.extractToken(true);
         userInfoAuthHandler.extractClient(true);
         userInfoAuthHandler.forceEndUserToken(true);
+        userInfoAuthHandler.dpopProofValidator(dpopProofValidator);
 
         Handler<RoutingContext> userInfoEndpoint = new UserInfoEndpoint(userEnhancer, jwtService, jweService, discoveryService, environment, subjectManager, executionContextFactory);
         oidcRouter.route("/userinfo").handler(corsHandler);
@@ -240,6 +245,7 @@ public class OIDCProvider extends AbstractProtocolProvider {
         dynamicClientRegistrationAuthHandler.extractToken(true);
         dynamicClientRegistrationAuthHandler.extractClient(true);
         dynamicClientRegistrationAuthHandler.forceClientToken(true);
+        dynamicClientRegistrationAuthHandler.dpopProofValidator(dpopProofValidator);
 
         DynamicClientRegistrationHandler dynamicClientRegistrationHandler = new DynamicClientRegistrationHandler(domain, dynamicClientRegistrationAuthHandler);
         DynamicClientRegistrationEndpoint dynamicClientRegistrationEndpoint = new DynamicClientRegistrationEndpoint(dcrService, clientSyncService);
@@ -257,6 +263,7 @@ public class OIDCProvider extends AbstractProtocolProvider {
         dynamicClientAccessAuthHandler.forceClientToken(true);
         dynamicClientAccessAuthHandler.selfResource(true, CLIENT_ID, Scope.DCR.getKey());
         dynamicClientAccessAuthHandler.offlineVerification(true);
+        dynamicClientAccessAuthHandler.dpopProofValidator(dpopProofValidator);
 
         DynamicClientAccessHandler dynamicClientAccessHandler = new DynamicClientAccessHandler(domain);
         DynamicClientAccessTokenHandler dynamicClientAccessTokenHandler = new DynamicClientAccessTokenHandler();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationRequest.java
@@ -178,6 +178,9 @@ public class DynamicClientRegistrationRequest {
     @JsonProperty("tls_client_certificate_bound_access_tokens")
     private Optional<Boolean> tlsClientCertificateBoundAccessTokens;
 
+    @JsonProperty("dpop_bound_access_tokens")
+    private Optional<Boolean> dpopBoundAccessTokens;
+
     /*******************************************************************************
      * Metadata in same order than the openid JARM specification
      * https://openid.net//specs/openid-financial-api-jarm.html#client-metadata
@@ -541,6 +544,14 @@ public class DynamicClientRegistrationRequest {
         this.tlsClientCertificateBoundAccessTokens = tlsClientCertificateBoundAccessTokens;
     }
 
+    public Optional<Boolean> getDpopBoundAccessTokens() {
+        return dpopBoundAccessTokens;
+    }
+
+    public void setDpopBoundAccessTokens(Optional<Boolean> dpopBoundAccessTokens) {
+        this.dpopBoundAccessTokens = dpopBoundAccessTokens;
+    }
+
     public Optional<String> getAuthorizationSignedResponseAlg() {
         return authorizationSignedResponseAlg;
     }
@@ -668,6 +679,7 @@ public class DynamicClientRegistrationRequest {
         SetterUtils.safeSet(client::setTlsClientAuthSanIp, this.getTlsClientAuthSanIp());
         SetterUtils.safeSet(client::setTlsClientAuthSanUri, this.getTlsClientAuthSanUri());
         SetterUtils.safeSet(client::setTlsClientCertificateBoundAccessTokens, this.getTlsClientCertificateBoundAccessTokens());
+        SetterUtils.safeSet(client::setDpopBoundAccessTokens, this.getDpopBoundAccessTokens());
 
         /* set client require_pushed_authorization_requests : https://datatracker.ietf.org/doc/html/draft-ietf-oauth-par#page-16 */
         SetterUtils.safeSet(client::setRequireParRequest, this.getRequireParRequest());
@@ -737,6 +749,7 @@ public class DynamicClientRegistrationRequest {
         SetterUtils.safeSet(client::setTlsClientAuthSanIp, this.getTlsClientAuthSanIp());
         SetterUtils.safeSet(client::setTlsClientAuthSanUri, this.getTlsClientAuthSanUri());
         SetterUtils.safeSet(client::setTlsClientCertificateBoundAccessTokens, this.getTlsClientCertificateBoundAccessTokens());
+        SetterUtils.safeSet(client::setDpopBoundAccessTokens, this.getDpopBoundAccessTokens());
 
         /* set client require_pushed_authorization_requests : https://datatracker.ietf.org/doc/html/draft-ietf-oauth-par#page-16 */
         SetterUtils.safeSet(client::setRequireParRequest, this.getRequireParRequest());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/impl/ClientServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/impl/ClientServiceImpl.java
@@ -262,6 +262,7 @@ public class ClientServiceImpl implements ClientService {
         oAuthSettings.setTlsClientAuthSanUri(client.getTlsClientAuthSanUri());
         oAuthSettings.setTlsClientAuthSubjectDn(client.getTlsClientAuthSubjectDn());
         oAuthSettings.setTlsClientCertificateBoundAccessTokens((client.isTlsClientCertificateBoundAccessTokens()));
+        oAuthSettings.setDpopBoundAccessTokens(client.isDpopBoundAccessTokens());
         oAuthSettings.setAccessTokenValiditySeconds(client.getAccessTokenValiditySeconds());
         oAuthSettings.setRequireParRequest(client.isRequireParRequest());
         // CIBA settings

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDProviderMetadata.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDProviderMetadata.java
@@ -117,6 +117,9 @@ public class OpenIDProviderMetadata {
     @JsonProperty("token_endpoint_auth_signing_alg_values_supported")
     private List<String> tokenEndpointAuthSigningAlgValuesSupported;
 
+    @JsonProperty("dpop_signing_alg_values_supported")
+    private List<String> dpopSigningAlgValuesSupported;
+
     @JsonProperty("display_values_supported")
     private List<String> displayValuesSupported;
 
@@ -421,6 +424,14 @@ public class OpenIDProviderMetadata {
 
     public void setTokenEndpointAuthSigningAlgValuesSupported(List<String> tokenEndpointAuthSigningAlgValuesSupported) {
         this.tokenEndpointAuthSigningAlgValuesSupported = tokenEndpointAuthSigningAlgValuesSupported;
+    }
+
+    public List<String> getDpopSigningAlgValuesSupported() {
+        return dpopSigningAlgValuesSupported;
+    }
+
+    public void setDpopSigningAlgValuesSupported(List<String> dpopSigningAlgValuesSupported) {
+        this.dpopSigningAlgValuesSupported = dpopSigningAlgValuesSupported;
     }
 
     public List<String> getDisplayValuesSupported() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
@@ -170,6 +170,10 @@ public class OpenIDDiscoveryServiceImpl implements OpenIDDiscoveryService, Initi
         openIDProviderMetadata.setTokenEndpointAuthMethodsSupported(ClientAuthenticationMethod.supportedValues());
         openIDProviderMetadata.setTokenEndpointAuthSigningAlgValuesSupported(JWAlgorithmUtils.getSupportedTokenEndpointAuthSigningAlg());
 
+        openIDProviderMetadata.setDpopSigningAlgValuesSupported(
+                JWAlgorithmUtils.resolveDpopSigningAlg(domain.getOidc() != null && domain.getOidc().getDpopSettings() != null
+                        ? domain.getOidc().getDpopSettings().getDpopSigningAlgorithms() : null));
+
         if (domain.useFapiBrazilProfile()) {
             openIDProviderMetadata.setAcrValuesSupported(Stream.concat(AcrValues.values().stream(), BrazilAcrValues.values().stream()).collect(Collectors.toList()));
         } else {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/utils/JWAlgorithmUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/utils/JWAlgorithmUtils.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.oidc.service.utils;
 
 import com.nimbusds.jose.EncryptionMethod;
+import io.gravitee.am.common.jwt.SignatureAlgorithm;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -75,6 +76,14 @@ public class JWAlgorithmUtils {
     public static boolean isSignAlgCompliantWithFapi(String alg) {
         return PS256.getName().equals(alg) || ES256.getName().equals(alg);
     }
+
+    /**
+     * DPoP proof signing algorithms (RFC 9449). Asymmetric only: EC and RSA (PKCS#1 v1.5).
+     * No {@code none} and no symmetric {@code HS*}, since a DPoP proof is verified against the
+     * public key embedded in the proof header. Single source of truth shared with the domain
+     * allowlist validation in the management API.
+     */
+    private static final Set<String> SUPPORTED_DPOP_SIGNING_ALG = SignatureAlgorithm.DPOP_SUPPORTED_ALGORITHMS;
 
 
     /**
@@ -318,5 +327,27 @@ public class JWAlgorithmUtils {
 
     public static List<String> getSupportedBackchannelAuthenticationSigningAl() {
         return SUPPORTED_SIGNING_ALG.stream().sorted().toList();
+    }
+
+    /**
+     * @return the supported list of DPoP (RFC 9449) proof signing algorithms.
+     */
+    public static List<String> getSupportedDpopSigningAlg() {
+        return SUPPORTED_DPOP_SIGNING_ALG.stream().sorted().toList();
+    }
+
+    /**
+     * Resolve the effective DPoP signing-algorithm allowlist for a domain: the configured set when
+     * non-empty, otherwise the full base supported set. Used for both token-endpoint enforcement and
+     * discovery advertisement, so an unconfigured domain behaves exactly as v1.
+     *
+     * @param configured the domain's configured allowlist (may be {@code null} or empty)
+     * @return the effective, sorted list of accepted DPoP signing algorithms
+     */
+    public static List<String> resolveDpopSigningAlg(List<String> configured) {
+        if (configured == null || configured.isEmpty()) {
+            return getSupportedDpopSigningAlg();
+        }
+        return configured.stream().sorted().toList();
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/uma/UMAProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/uma/UMAProvider.java
@@ -20,6 +20,7 @@ import io.gravitee.am.gateway.handler.api.AbstractProtocolProvider;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.service.uma.UMAResourceGatewayService;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
 import io.gravitee.am.gateway.handler.uma.resources.endpoint.PermissionEndpoint;
 import io.gravitee.am.gateway.handler.uma.resources.endpoint.ProviderConfigurationEndpoint;
@@ -71,6 +72,9 @@ public class UMAProvider extends AbstractProtocolProvider {
     private OAuth2AuthProvider oAuth2AuthProvider;
 
     @Autowired
+    private DPoPProofValidator dpopProofValidator;
+
+    @Autowired
     private UMADiscoveryService discoveryService;
 
     @Autowired
@@ -117,12 +121,14 @@ public class UMAProvider extends AbstractProtocolProvider {
         umaProtectionApiResourcesAuthHandler.extractToken(true);
         umaProtectionApiResourcesAuthHandler.extractClient(true);
         umaProtectionApiResourcesAuthHandler.forceEndUserToken(true);//It must be a resource owner
+        umaProtectionApiResourcesAuthHandler.dpopProofValidator(dpopProofValidator);
 
         // User-Managed Access (UMA) 2.0 permissions Auth handler
         OAuth2AuthHandler umaProtectionApiPermissionsAuthHandler = OAuth2AuthHandler.create(oAuth2AuthProvider, Scope.UMA.getKey());
         umaProtectionApiPermissionsAuthHandler.extractToken(true);
         umaProtectionApiPermissionsAuthHandler.extractClient(true);
         umaProtectionApiPermissionsAuthHandler.forceClientToken(true);//It must be a client (client_credentials)
+        umaProtectionApiPermissionsAuthHandler.dpopProofValidator(dpopProofValidator);
 
         // UMA resources Protection API Access Handler
         UMAProtectionApiAccessHandler umaProtectionApiResourcesAccessHandler = new UMAProtectionApiAccessHandler(domain, umaProtectionApiResourcesAuthHandler);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/TokenEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/TokenEndpointTest.java
@@ -46,7 +46,10 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static io.gravitee.am.gateway.handler.common.vertx.web.RoutingContextHelper.setUser;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -217,4 +220,5 @@ public class TokenEndpointTest extends RxWebTestBase {
                 HttpMethod.POST, "/oauth/token?client_id=my-client&client_secret=my-secret&grant_type=urn:ietf:params:oauth:grant-type:uma-ticket",
                 HttpStatusCode.FORBIDDEN_403, "Forbidden");
     }
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/code/AuthorizationCodeServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/code/AuthorizationCodeServiceTest.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.code;
 
+import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidGrantException;
 import io.gravitee.am.gateway.handler.oauth2.service.code.impl.AuthorizationCodeServiceImpl;
 import io.gravitee.am.gateway.handler.oauth2.service.request.AuthorizationRequest;
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.User;
 import io.gravitee.am.repository.oauth2.api.AuthorizationCodeRepository;
@@ -97,6 +100,29 @@ public class AuthorizationCodeServiceTest {
         // Verify the resource is set if provided
         verify(authorizationCodeRepository, times(1)).create(argThat(
                 code -> Objects.equals(code.getResources(), Set.of(resourceOne, resourceTwo)))
+        );
+    }
+
+    @Test
+    public void shouldCreate_persistsDpopJktOnRequestParameters() {
+        AuthorizationRequest authorizationRequest = new AuthorizationRequest();
+        authorizationRequest.setClientId("my-client-id");
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add(Parameters.DPOP_JKT, "committed-thumbprint");
+        authorizationRequest.setParameters(parameters);
+
+        User user = new User();
+        user.setUsername("my-username-id");
+
+        when(authorizationCodeRepository.create(any())).thenReturn(Single.just(new AuthorizationCode()));
+
+        TestObserver<AuthorizationCode> testObserver = authorizationCodeService.create(authorizationRequest, user).test();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(authorizationCodeRepository, times(1)).create(argThat(
+                code -> code.getRequestParameters() != null
+                        && "committed-thumbprint".equals(code.getRequestParameters().getFirst(Parameters.DPOP_JKT)))
         );
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/grant/StrategyGranterAdapterTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/grant/StrategyGranterAdapterTest.java
@@ -15,8 +15,13 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.grant;
 
+import io.gravitee.am.common.exception.oauth2.InvalidDPoPProofException;
+import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.oauth2.GrantType;
+import io.gravitee.am.common.oauth2.Parameters;
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.policy.RulesEngine;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequest;
 import io.gravitee.am.gateway.handler.oauth2.service.request.TokenRequestResolver;
@@ -27,7 +32,11 @@ import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ActorTo
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.model.oidc.DPoPSettings;
+import io.gravitee.am.model.oidc.OIDCSettings;
+import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.gateway.api.ExecutionContext;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +64,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -73,6 +83,9 @@ class StrategyGranterAdapterTest {
     @Mock
     private TokenRequestResolver tokenRequestResolver;
 
+    @Mock
+    private DPoPProofValidator dpopProofValidator;
+
     private StrategyGranterAdapter adapter;
     private Domain domain;
     private Client client;
@@ -89,7 +102,7 @@ class StrategyGranterAdapterTest {
         lenient().when(tokenRequestResolver.resolve(any(), any(), any()))
                 .thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
 
-        adapter = new StrategyGranterAdapter(strategy, domain, tokenService, rulesEngine, tokenRequestResolver);
+        adapter = new StrategyGranterAdapter(strategy, domain, tokenService, rulesEngine, tokenRequestResolver, dpopProofValidator);
     }
 
     @Test
@@ -670,5 +683,200 @@ class StrategyGranterAdapterTest {
         OAuth2Request capturedRequest = oAuth2RequestCaptor.getValue();
         assertNull(capturedRequest.getAuthorizationDetails(),
                 "authorizationDetails should be null (absent) when CibaData carries no RAR — no NPE");
+    }
+
+
+    @Test
+    void dpop_opportunisticBinding_setsJktWhenProofPresent() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.CLIENT_CREDENTIALS, true, null);
+        when(dpopProofValidator.validateForToken(eq(tokenRequest), any())).thenReturn(Single.just("the-jkt"));
+        mockGrantFlow(tokenRequest);
+
+        adapter.grant(tokenRequest, client).blockingGet();
+
+        assertEquals("the-jkt", tokenRequest.getConfirmationMethodJkt());
+    }
+
+    @Test
+    void dpop_malformedProof_failsWithInvalidDPoPProof() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.CLIENT_CREDENTIALS, true, null);
+        when(dpopProofValidator.validateForToken(eq(tokenRequest), any()))
+                .thenReturn(Single.error(new InvalidDPoPProofException("bad proof")));
+
+        adapter.grant(tokenRequest, client).test().assertError(InvalidDPoPProofException.class);
+        verify(strategy, never()).process(any(), any(), any());
+    }
+
+    @Test
+    void dpop_noProof_bindsNothing() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.CLIENT_CREDENTIALS, false, null);
+        mockGrantFlow(tokenRequest);
+
+        adapter.grant(tokenRequest, client).blockingGet();
+
+        assertNull(tokenRequest.getConfirmationMethodJkt());
+        verify(dpopProofValidator, never()).validateForToken(any(), any());
+    }
+
+    @Test
+    void dpop_refreshBoundMatchingProof_setsSameJkt() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.REFRESH_TOKEN, true, "some-rt");
+        when(tokenService.getRefreshTokenJkt(eq("some-rt"), eq(client))).thenReturn(Maybe.just("the-jkt"));
+        when(dpopProofValidator.validateForRefresh(eq(tokenRequest), eq("the-jkt"), any())).thenReturn(Single.just("the-jkt"));
+        mockGrantFlow(tokenRequest);
+
+        adapter.grant(tokenRequest, client).blockingGet();
+
+        assertEquals("the-jkt", tokenRequest.getConfirmationMethodJkt());
+        verify(dpopProofValidator, never()).validateForToken(any(), any());
+    }
+
+    @Test
+    void dpop_refreshBoundMismatchedProof_failsWithInvalidDPoPProof() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.REFRESH_TOKEN, true, "some-rt");
+        when(tokenService.getRefreshTokenJkt(eq("some-rt"), eq(client))).thenReturn(Maybe.just("the-jkt"));
+        when(dpopProofValidator.validateForRefresh(eq(tokenRequest), eq("the-jkt"), any()))
+                .thenReturn(Single.error(new InvalidDPoPProofException("key mismatch")));
+
+        adapter.grant(tokenRequest, client).test().assertError(InvalidDPoPProofException.class);
+        verify(strategy, never()).process(any(), any(), any());
+    }
+
+    @Test
+    void dpop_refreshBoundNoProof_failsWithInvalidRequest() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.REFRESH_TOKEN, false, "some-rt");
+        when(tokenService.getRefreshTokenJkt(eq("some-rt"), eq(client))).thenReturn(Maybe.just("the-jkt"));
+
+        adapter.grant(tokenRequest, client).test().assertError(InvalidRequestException.class);
+        verify(dpopProofValidator, never()).validateForRefresh(any(), any(), any());
+        verify(strategy, never()).process(any(), any(), any());
+    }
+
+    @Test
+    void dpop_refreshUnboundNoProof_bindsNothing() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.REFRESH_TOKEN, false, "some-rt");
+        when(tokenService.getRefreshTokenJkt(eq("some-rt"), eq(client))).thenReturn(Maybe.empty());
+        mockGrantFlow(tokenRequest);
+
+        adapter.grant(tokenRequest, client).blockingGet();
+
+        assertNull(tokenRequest.getConfirmationMethodJkt());
+        verify(dpopProofValidator, never()).validateForRefresh(any(), any(), any());
+        verify(dpopProofValidator, never()).validateForToken(any(), any());
+    }
+
+    @Test
+    void dpop_refreshUnboundWithProof_bindsOpportunistically() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.REFRESH_TOKEN, true, "some-rt");
+        when(tokenService.getRefreshTokenJkt(eq("some-rt"), eq(client))).thenReturn(Maybe.empty());
+        when(dpopProofValidator.validateForToken(eq(tokenRequest), any())).thenReturn(Single.just("proof-jkt"));
+        mockGrantFlow(tokenRequest);
+
+        adapter.grant(tokenRequest, client).blockingGet();
+
+        assertEquals("proof-jkt", tokenRequest.getConfirmationMethodJkt());
+        verify(dpopProofValidator, never()).validateForRefresh(any(), any(), any());
+    }
+
+
+    @Test
+    void dpop_requiredByAppFlag_noProof_failsWithInvalidRequest() {
+        client.setDpopBoundAccessTokens(true);
+        TokenRequest tokenRequest = dpopRequest(GrantType.CLIENT_CREDENTIALS, false, null);
+
+        adapter.grant(tokenRequest, client).test().assertError(InvalidRequestException.class);
+
+        verify(strategy, never()).process(any(), any(), any());
+        verify(dpopProofValidator, never()).validateForToken(any(), any());
+    }
+
+    @Test
+    void dpop_requiredByDomainFloor_noProof_failsWithInvalidRequest() {
+        domain.setOidc(oidcRequiringDpopForAll());
+        TokenRequest tokenRequest = dpopRequest(GrantType.CLIENT_CREDENTIALS, false, null);
+
+        adapter.grant(tokenRequest, client).test().assertError(InvalidRequestException.class);
+
+        verify(strategy, never()).process(any(), any(), any());
+    }
+
+    @Test
+    void dpop_domainFloorNotOverridableByAppFlagOff_noProof_failsWithInvalidRequest() {
+        domain.setOidc(oidcRequiringDpopForAll());
+        client.setDpopBoundAccessTokens(false);
+        TokenRequest tokenRequest = dpopRequest(GrantType.CLIENT_CREDENTIALS, false, null);
+
+        adapter.grant(tokenRequest, client).test().assertError(InvalidRequestException.class);
+
+        verify(strategy, never()).process(any(), any(), any());
+    }
+
+    @Test
+    void dpop_requiredClient_nonDpopCapableGrant_noProof_failsWithInvalidRequest() {
+        client.setDpopBoundAccessTokens(true);
+        TokenRequest tokenRequest = dpopRequest(GrantType.TOKEN_EXCHANGE, false, null);
+
+        adapter.grant(tokenRequest, client).test().assertError(InvalidRequestException.class);
+
+        verify(strategy, never()).process(any(), any(), any());
+    }
+
+    @Test
+    void dpop_notRequired_noProof_issuesOrdinaryToken() {
+        TokenRequest tokenRequest = dpopRequest(GrantType.CLIENT_CREDENTIALS, false, null);
+        mockGrantFlow(tokenRequest);
+
+        Token result = adapter.grant(tokenRequest, client).blockingGet();
+
+        assertNotNull(result);
+        assertNull(tokenRequest.getConfirmationMethodJkt());
+    }
+
+    @Test
+    void dpop_requiredClient_withValidProof_bindsToken() {
+        client.setDpopBoundAccessTokens(true);
+        TokenRequest tokenRequest = dpopRequest(GrantType.CLIENT_CREDENTIALS, true, null);
+        when(dpopProofValidator.validateForToken(eq(tokenRequest), any())).thenReturn(Single.just("the-jkt"));
+        mockGrantFlow(tokenRequest);
+
+        adapter.grant(tokenRequest, client).blockingGet();
+
+        assertEquals("the-jkt", tokenRequest.getConfirmationMethodJkt());
+    }
+
+    private static OIDCSettings oidcRequiringDpopForAll() {
+        OIDCSettings oidc = new OIDCSettings();
+        DPoPSettings dpopSettings = new DPoPSettings();
+        dpopSettings.setRequireDpopForAll(true);
+        oidc.setDpopSettings(dpopSettings);
+        return oidc;
+    }
+
+    private TokenRequest dpopRequest(String grantType, boolean withProof, String refreshTokenValue) {
+        TokenRequest req = new TokenRequest();
+        req.setClientId("client-id");
+        req.setGrantType(grantType);
+        req.setScopes(Set.of("read"));
+        io.gravitee.gateway.api.http.HttpHeaders headers = io.gravitee.gateway.api.http.HttpHeaders.create();
+        if (withProof) {
+            headers.set(ConstantKeys.DPOP_PROOF_HEADER, "a-proof");
+        }
+        req.setHeaders(headers);
+        if (refreshTokenValue != null) {
+            LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add(Parameters.REFRESH_TOKEN, refreshTokenValue);
+            req.setParameters(params);
+        }
+        return req;
+    }
+
+    private void mockGrantFlow(TokenRequest tokenRequest) {
+        TokenCreationRequest creationRequest = TokenCreationRequest.forClientCredentials(tokenRequest, false);
+        when(strategy.process(eq(tokenRequest), eq(client), eq(domain))).thenReturn(Single.just(creationRequest));
+        ExecutionContext ec = mock(ExecutionContext.class);
+        lenient().when(ec.getAttributes()).thenReturn(new HashMap<>());
+        lenient().when(rulesEngine.fire(any(), any(), any(), eq(client), any())).thenReturn(Single.just(ec));
+        lenient().when(rulesEngine.fire(any(), any(), eq(client), any())).thenReturn(Single.just(ec));
+        when(tokenService.create(any(), eq(client), any())).thenReturn(Single.just(new AccessToken("access-token-value")));
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/grant/impl/AuthorizationCodeStrategyTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/grant/impl/AuthorizationCodeStrategyTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.grant.impl;
 
+import io.gravitee.am.common.exception.oauth2.InvalidDPoPProofException;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.oauth2.GrantType;
 import io.gravitee.am.common.oauth2.Parameters;
@@ -517,5 +518,133 @@ class AuthorizationCodeStrategyTest {
 
         assertNotNull(result);
         assertFalse(result.supportRefreshToken());
+    }
+
+
+    @Test
+    void shouldFailWhenDpopJktBoundButNoProofPresented() {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add(Parameters.CODE, "valid-code");
+
+        TokenRequest tokenRequest = new TokenRequest();
+        tokenRequest.setClientId("client-id");
+        tokenRequest.setParameters(parameters);
+
+        MultiValueMap<String, String> codeParams = new LinkedMultiValueMap<>();
+        codeParams.add(Parameters.DPOP_JKT, "committed-thumbprint");
+
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+        authorizationCode.setCode("valid-code");
+        authorizationCode.setSubject("user-id");
+        authorizationCode.setRequestParameters(codeParams);
+
+        when(authorizationCodeService.remove(eq("valid-code"), eq(client)))
+                .thenReturn(Maybe.just(authorizationCode));
+
+        strategy.process(tokenRequest, client, domain)
+                .test()
+                .assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void shouldFailWhenDpopJktBoundButProofKeyMismatch() {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add(Parameters.CODE, "valid-code");
+
+        TokenRequest tokenRequest = new TokenRequest();
+        tokenRequest.setClientId("client-id");
+        tokenRequest.setParameters(parameters);
+        tokenRequest.setConfirmationMethodJkt("different-thumbprint");
+
+        MultiValueMap<String, String> codeParams = new LinkedMultiValueMap<>();
+        codeParams.add(Parameters.DPOP_JKT, "committed-thumbprint");
+
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+        authorizationCode.setCode("valid-code");
+        authorizationCode.setSubject("user-id");
+        authorizationCode.setRequestParameters(codeParams);
+
+        when(authorizationCodeService.remove(eq("valid-code"), eq(client)))
+                .thenReturn(Maybe.just(authorizationCode));
+
+        strategy.process(tokenRequest, client, domain)
+                .test()
+                .assertError(InvalidDPoPProofException.class);
+    }
+
+    @Test
+    void shouldProcessSuccessfullyWhenDpopJktMatchesProof() {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add(Parameters.CODE, "valid-code");
+
+        TokenRequest tokenRequest = new TokenRequest();
+        tokenRequest.setClientId("client-id");
+        tokenRequest.setParameters(parameters);
+        tokenRequest.setConfirmationMethodJkt("bound-thumbprint");
+
+        User user = new User();
+        user.setId("user-id");
+
+        MultiValueMap<String, String> codeParams = new LinkedMultiValueMap<>();
+        codeParams.add(Parameters.DPOP_JKT, "bound-thumbprint");
+
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+        authorizationCode.setCode("valid-code");
+        authorizationCode.setSubject("user-id");
+        authorizationCode.setScopes(Set.of("openid"));
+        authorizationCode.setTransactionId("tx-id");
+        authorizationCode.setRequestParameters(codeParams);
+
+        when(authorizationCodeService.remove(eq("valid-code"), eq(client)))
+                .thenReturn(Maybe.just(authorizationCode));
+        when(authenticationFlowContextService.removeContext(anyString(), anyInt()))
+                .thenReturn(Single.just(new AuthenticationFlowContext()));
+        when(userAuthenticationManager.loadPreAuthenticatedUser(eq("user-id"), any()))
+                .thenReturn(Maybe.just(user));
+        when(resourceConsistencyValidationService.resolveFinalResources(any(), any()))
+                .thenReturn(Set.of());
+
+        TokenCreationRequest result = strategy.process(tokenRequest, client, domain).blockingGet();
+
+        assertNotNull(result);
+        assertEquals(GrantType.AUTHORIZATION_CODE, result.grantType());
+        assertEquals(user, result.resourceOwner());
+    }
+
+    @Test
+    void shouldProcessSuccessfullyWhenNoDpopJktCommittedEvenIfProofPresent() {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add(Parameters.CODE, "valid-code");
+
+        TokenRequest tokenRequest = new TokenRequest();
+        tokenRequest.setClientId("client-id");
+        tokenRequest.setParameters(parameters);
+        tokenRequest.setConfirmationMethodJkt("opportunistic-thumbprint");
+
+        User user = new User();
+        user.setId("user-id");
+
+        MultiValueMap<String, String> codeParams = new LinkedMultiValueMap<>();
+
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+        authorizationCode.setCode("valid-code");
+        authorizationCode.setSubject("user-id");
+        authorizationCode.setScopes(Set.of("openid"));
+        authorizationCode.setTransactionId("tx-id");
+        authorizationCode.setRequestParameters(codeParams);
+
+        when(authorizationCodeService.remove(eq("valid-code"), eq(client)))
+                .thenReturn(Maybe.just(authorizationCode));
+        when(authenticationFlowContextService.removeContext(anyString(), anyInt()))
+                .thenReturn(Single.just(new AuthenticationFlowContext()));
+        when(userAuthenticationManager.loadPreAuthenticatedUser(eq("user-id"), any()))
+                .thenReturn(Maybe.just(user));
+        when(resourceConsistencyValidationService.resolveFinalResources(any(), any()))
+                .thenReturn(Set.of());
+
+        TokenCreationRequest result = strategy.process(tokenRequest, client, domain).blockingGet();
+
+        assertNotNull(result);
+        assertEquals(GrantType.AUTHORIZATION_CODE, result.grantType());
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/introspection/IntrospectionServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/introspection/IntrospectionServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.oauth2.service.introspection;
 
 import io.gravitee.am.common.exception.jwt.InvalidGISException;
 import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.oauth2.service.introspection.impl.IntrospectionServiceImpl;
 import io.gravitee.am.gateway.handler.oauth2.service.token.TokenService;
@@ -35,6 +36,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.any;
@@ -156,6 +158,27 @@ public class IntrospectionServiceTest {
         testObserver.assertValue(introspectionResponse -> !introspectionResponse.containsKey(Claims.AUD));
     }
 
+
+    @Test
+    public void shouldExposeCnfWithJktForDpopBoundToken() {
+        final String token = "token";
+        AccessToken accessToken = new AccessToken(token);
+        accessToken.setSubject("client-id");
+        accessToken.setClientId("client-id");
+        accessToken.setCreatedAt(new Date());
+        accessToken.setExpireAt(new Date());
+        accessToken.setConfirmationMethod(Map.of(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT, "the-jkt"));
+        when(tokenService.introspect(token, (String) null)).thenReturn(Maybe.just(accessToken));
+
+        IntrospectionRequest introspectionRequest = IntrospectionRequest.builder().token("token").build();
+        TestObserver<IntrospectionResponse> testObserver = introspectionService.introspect(introspectionRequest).test();
+
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(response -> response.getConfirmationMethod() instanceof Map<?, ?> cnf
+                && "the-jkt".equals(cnf.get(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT)));
+    }
 
     @Test
     public void shouldReturnAudClaim_IfConfigSetTrue() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/request/AuthorizationRequestFactoryTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/request/AuthorizationRequestFactoryTest.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.request;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 import io.gravitee.am.common.oauth2.Parameters;
+import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.oauth2.resources.request.AuthorizationRequestFactory;
+import io.gravitee.am.model.AuthenticationFlowContext;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.MultiMap;
@@ -27,6 +31,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,6 +80,77 @@ public class AuthorizationRequestFactoryTest {
         Assert.assertNotNull(authorizationRequest);
         Assert.assertEquals("client-id", authorizationRequest.getClientId());
         Assert.assertTrue(authorizationRequest.getAdditionalParameters().size() == 1 && authorizationRequest.getAdditionalParameters().containsKey("custom"));
+    }
+
+
+    @Test
+    public void shouldCaptureDpopJkt_fromQueryParameter() {
+        RoutingContext routingContext = newRoutingContext();
+        when(routingContext.request().getParam(Parameters.DPOP_JKT)).thenReturn("thumb-query");
+
+        AuthorizationRequest authorizationRequest = authorizationRequestFactory.create(routingContext);
+
+        Assert.assertEquals("thumb-query", authorizationRequest.getParameters().getFirst(Parameters.DPOP_JKT));
+    }
+
+    @Test
+    public void shouldCaptureDpopJkt_fromJarRequestObject() {
+        RoutingContext routingContext = newRoutingContext();
+        PlainJWT requestObject = new PlainJWT(new JWTClaimsSet.Builder().claim(Parameters.DPOP_JKT, "thumb-jar").build());
+        when(routingContext.get(ConstantKeys.REQUEST_OBJECT_KEY)).thenReturn(requestObject);
+
+        AuthorizationRequest authorizationRequest = authorizationRequestFactory.create(routingContext);
+
+        Assert.assertEquals("thumb-jar", authorizationRequest.getParameters().getFirst(Parameters.DPOP_JKT));
+    }
+
+    @Test
+    public void shouldCaptureDpopJkt_fromPushedAuthorizationRequest() {
+        RoutingContext routingContext = newRoutingContext();
+        Map<String, Object> pushedParameters = new HashMap<>();
+        pushedParameters.put(Parameters.DPOP_JKT, "thumb-par");
+        Map<String, Object> data = new HashMap<>();
+        data.put(ConstantKeys.REQUEST_PARAMETERS_KEY, pushedParameters);
+        AuthenticationFlowContext authFlowContext = new AuthenticationFlowContext();
+        authFlowContext.setData(data);
+        when(routingContext.get(ConstantKeys.AUTH_FLOW_CONTEXT_KEY)).thenReturn(authFlowContext);
+
+        AuthorizationRequest authorizationRequest = authorizationRequestFactory.create(routingContext);
+
+        Assert.assertEquals("thumb-par", authorizationRequest.getParameters().getFirst(Parameters.DPOP_JKT));
+    }
+
+    @Test
+    public void shouldNotCaptureDpopJkt_whenAbsent() {
+        RoutingContext routingContext = newRoutingContext();
+
+        AuthorizationRequest authorizationRequest = authorizationRequestFactory.create(routingContext);
+
+        Assert.assertNull(authorizationRequest.getParameters().getFirst(Parameters.DPOP_JKT));
+    }
+
+    private RoutingContext newRoutingContext() {
+        List<Map.Entry<String, String>> entries = new ArrayList<>();
+
+        MultiMap multiMap = mock(MultiMap.class);
+        when(multiMap.entries()).thenReturn(entries);
+
+        io.vertx.core.http.HttpServerRequest httpServerRequest = mock(io.vertx.core.http.HttpServerRequest.class);
+        when(httpServerRequest.method()).thenReturn(HttpMethod.POST);
+
+        HttpServerResponse httpServerResponse = mock(HttpServerResponse.class);
+
+        HttpServerRequest rxHttpServerRequest = mock(HttpServerRequest.class);
+        when(rxHttpServerRequest.params()).thenReturn(multiMap);
+        when(rxHttpServerRequest.params().entries()).thenReturn(entries);
+        when(rxHttpServerRequest.getDelegate()).thenReturn(httpServerRequest);
+        when(rxHttpServerRequest.getDelegate().response()).thenReturn(httpServerResponse);
+
+        RoutingContext routingContext = mock(RoutingContext.class);
+        when(routingContext.request()).thenReturn(rxHttpServerRequest);
+        when(routingContext.get(CONTEXT_PATH)).thenReturn("/test");
+
+        return routingContext;
     }
 
     private class Parameter<K, V> implements Map.Entry<K, V> {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImplTest.java
@@ -36,7 +36,7 @@ import io.gravitee.am.gateway.handler.oauth2.service.token.TokenManager;
 import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryService;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
-import io.gravitee.am.repository.oauth2.api.TokenRepository;
+import io.gravitee.am.repository.oauth2.api.BackwardCompatibleTokenRepository;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.ClientTokenAuditBuilder;
@@ -62,6 +62,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static io.gravitee.am.common.utils.ConstantKeys.BEARER_AUTH_SCHEME;
+import static io.gravitee.am.common.utils.ConstantKeys.DPOP_AUTH_SCHEME;
 import static io.gravitee.am.gateway.handler.dummies.TestCertificateInfoFactory.createTestCertificateInfo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -76,7 +78,7 @@ public class TokenServiceImplTest {
     IntrospectionTokenFacade introspectionTokenFacade;
 
     @Mock
-    private TokenRepository tokenRepository;
+    private BackwardCompatibleTokenRepository tokenRepository;
 
     @Mock
     private TokenEnhancer tokenEnhancer;
@@ -188,6 +190,180 @@ public class TokenServiceImplTest {
 
         assertThat(captured.getExp()).isEqualTo(expectedExpiration);
         assertThat(createdToken.getExpireAt().toInstant().getEpochSecond()).isEqualTo(expectedExpiration);
+    }
+
+    @Test
+    public void shouldBindAccessTokenToDpopKeyWhenConfirmationMethodJktPresent() {
+        OAuth2Request request = new OAuth2Request();
+        request.setParameters(new LinkedMultiValueMap());
+        request.setClientId("test-client");
+        request.setGrantType(GrantType.CLIENT_CREDENTIALS);
+        request.setSupportRefreshToken(false);
+        request.setScopes(Set.of("read"));
+        request.setOrigin("https://auth.example.com");
+        request.setConfirmationMethodJkt("the-jwk-thumbprint");
+
+        Client client = createClient("test-client");
+        User user = createUser("user");
+        setupCommonMocks(request);
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any()))
+                .thenAnswer(invocation -> Single.just((Token) invocation.getArgument(0)));
+
+        TestObserver<Token> observer = executeTokenCreation(request, client, user);
+        observer.assertValue(token -> DPOP_AUTH_SCHEME.equals(token.getTokenType()));
+
+        ArgumentCaptor<JWT> jwtCaptor = ArgumentCaptor.forClass(JWT.class);
+        verify(jwtService).encodeJwt(jwtCaptor.capture(), any(Client.class));
+        assertThat((Map<String, Object>) jwtCaptor.getValue().getConfirmationMethod())
+                .containsEntry(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT, "the-jwk-thumbprint")
+                .doesNotContainKey(JWT.CONFIRMATION_METHOD_X509_THUMBPRINT);
+    }
+
+    @Test
+    public void shouldRecordDpopJktInTokenCreatedAudit() {
+        OAuth2Request request = new OAuth2Request();
+        request.setParameters(new LinkedMultiValueMap());
+        request.setClientId("test-client");
+        request.setGrantType(GrantType.CLIENT_CREDENTIALS);
+        request.setSupportRefreshToken(false);
+        request.setScopes(Set.of("read"));
+        request.setOrigin("https://auth.example.com");
+        request.setConfirmationMethodJkt("the-jwk-thumbprint");
+
+        Client client = createClient("test-client");
+        client.setDomain("test-domain");
+        User user = createUser("user");
+        setupCommonMocks(request);
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any()))
+                .thenAnswer(invocation -> Single.just((Token) invocation.getArgument(0)));
+
+        executeTokenCreation(request, client, user);
+
+        ArgumentCaptor<AuditBuilder> auditCaptor = ArgumentCaptor.forClass(AuditBuilder.class);
+        verify(auditService, Mockito.atLeastOnce()).report(auditCaptor.capture());
+        AuditBuilder capturedBuilder = auditCaptor.getAllValues().stream()
+                .filter(ClientTokenAuditBuilder.class::isInstance)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected to find a ClientTokenAuditBuilder in audit reports"));
+
+        String auditMessage = capturedBuilder.build(new ObjectMapper()).getOutcome().getMessage();
+        assertThat(auditMessage).contains("DPOP_JKT");
+        assertThat(auditMessage).contains("the-jwk-thumbprint");
+    }
+
+    @Test
+    public void shouldBindRefreshTokenToDpopKeyWhenConfirmationMethodJktPresent() {
+        OAuth2Request request = new OAuth2Request();
+        request.setParameters(new LinkedMultiValueMap());
+        request.setClientId("test-client");
+        request.setGrantType(GrantType.AUTHORIZATION_CODE);
+        request.setSupportRefreshToken(true);
+        request.setScopes(Set.of("read"));
+        request.setOrigin("https://auth.example.com");
+        request.setConfirmationMethodJkt("the-jwk-thumbprint");
+
+        Client client = createClient("test-client");
+        User user = createUser("user");
+        setupCommonMocks(request);
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any()))
+                .thenAnswer(invocation -> Single.just((Token) invocation.getArgument(0)));
+
+        executeTokenCreation(request, client, user);
+
+        ArgumentCaptor<io.gravitee.am.repository.oauth2.model.RefreshToken> captor =
+                ArgumentCaptor.forClass(io.gravitee.am.repository.oauth2.model.RefreshToken.class);
+        verify(tokenManager).storeRefreshToken(captor.capture());
+        assertThat(captor.getValue().getJkt()).isEqualTo("the-jwk-thumbprint");
+
+        ArgumentCaptor<JWT> jwtCaptor = ArgumentCaptor.forClass(JWT.class);
+        verify(jwtService, Mockito.times(2)).encodeJwt(jwtCaptor.capture(), any(Client.class));
+        assertThat(jwtCaptor.getAllValues())
+                .allSatisfy(encoded -> assertThat((Map<String, Object>) encoded.getConfirmationMethod())
+                        .containsEntry(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT, "the-jwk-thumbprint"));
+    }
+
+    @Test
+    public void shouldNotBindRefreshTokenWhenNoConfirmationMethodJkt() {
+        OAuth2Request request = new OAuth2Request();
+        request.setParameters(new LinkedMultiValueMap());
+        request.setClientId("test-client");
+        request.setGrantType(GrantType.AUTHORIZATION_CODE);
+        request.setSupportRefreshToken(true);
+        request.setScopes(Set.of("read"));
+        request.setOrigin("https://auth.example.com");
+
+        Client client = createClient("test-client");
+        User user = createUser("user");
+        setupCommonMocks(request);
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any()))
+                .thenAnswer(invocation -> Single.just((Token) invocation.getArgument(0)));
+
+        executeTokenCreation(request, client, user);
+
+        ArgumentCaptor<io.gravitee.am.repository.oauth2.model.RefreshToken> captor =
+                ArgumentCaptor.forClass(io.gravitee.am.repository.oauth2.model.RefreshToken.class);
+        verify(tokenManager).storeRefreshToken(captor.capture());
+        assertThat(captor.getValue().getJkt()).isNull();
+    }
+
+    @Test
+    public void shouldResolveStoredRefreshTokenJkt_whenBound() {
+        Client client = createClient("test-client");
+        JWT jwt = new JWT();
+        jwt.setJti("rt-jti");
+        jwt.setConfirmationMethod(Map.of(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT, "the-jkt"));
+        when(jwtService.decodeAndVerify(anyString(), any(Client.class), any())).thenReturn(Single.just(jwt));
+
+        tokenService.getRefreshTokenJkt("rt", client).test()
+                .assertValue("the-jkt").assertComplete();
+    }
+
+    @Test
+    public void shouldResolveEmptyJkt_whenRefreshTokenUnbound() {
+        Client client = createClient("test-client");
+        JWT jwt = new JWT();
+        jwt.setJti("rt-jti");
+        when(jwtService.decodeAndVerify(anyString(), any(Client.class), any())).thenReturn(Single.just(jwt));
+
+        tokenService.getRefreshTokenJkt("rt", client).test()
+                .assertNoValues().assertComplete();
+    }
+
+    @Test
+    public void shouldResolveEmptyJkt_whenRefreshTokenUndecodable() {
+        Client client = createClient("test-client");
+        when(jwtService.decodeAndVerify(anyString(), any(Client.class), any()))
+                .thenReturn(Single.error(new RuntimeException("invalid token")));
+
+        tokenService.getRefreshTokenJkt("bad-rt", client).test()
+                .assertNoValues().assertNoErrors().assertComplete();
+    }
+
+    @Test
+    public void shouldKeepCertificateBoundTokenAsBearer() {
+        OAuth2Request request = new OAuth2Request();
+        request.setParameters(new LinkedMultiValueMap());
+        request.setClientId("test-client");
+        request.setGrantType(GrantType.CLIENT_CREDENTIALS);
+        request.setSupportRefreshToken(false);
+        request.setScopes(Set.of("read"));
+        request.setOrigin("https://auth.example.com");
+        request.setConfirmationMethodX5S256("the-cert-thumbprint");
+
+        Client client = createClient("test-client");
+        User user = createUser("user");
+        setupCommonMocks(request);
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any()))
+                .thenAnswer(invocation -> Single.just((Token) invocation.getArgument(0)));
+
+        TestObserver<Token> observer = executeTokenCreation(request, client, user);
+        observer.assertValue(token -> BEARER_AUTH_SCHEME.toLowerCase().equals(token.getTokenType()));
+
+        ArgumentCaptor<JWT> jwtCaptor = ArgumentCaptor.forClass(JWT.class);
+        verify(jwtService).encodeJwt(jwtCaptor.capture(), any(Client.class));
+        assertThat((Map<String, Object>) jwtCaptor.getValue().getConfirmationMethod())
+                .containsEntry(JWT.CONFIRMATION_METHOD_X509_THUMBPRINT, "the-cert-thumbprint")
+                .doesNotContainKey(JWT.CONFIRMATION_METHOD_JWK_THUMBPRINT);
     }
 
     // ========== Helper Methods ==========

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationRequestTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationRequestTest.java
@@ -135,6 +135,25 @@ public class DynamicClientRegistrationRequestTest {
     }
 
     @Test
+    public void testPatch_dpopBoundAccessTokens() {
+        assertFalse("dpopBoundAccessTokens shall default to false", toPatch.isDpopBoundAccessTokens());
+        patcher.setDpopBoundAccessTokens(Optional.of(true));
+
+        Client result = patcher.patch(toPatch);
+
+        assertTrue("dpop_bound_access_tokens should have been applied", result.isDpopBoundAccessTokens());
+    }
+
+    @Test
+    public void testUpdate_dpopBoundAccessTokens() {
+        patcher.setDpopBoundAccessTokens(Optional.of(true));
+
+        Client result = patcher.update(toPatch);
+
+        assertTrue("dpop_bound_access_tokens should have been applied", result.isDpopBoundAccessTokens());
+    }
+
+    @Test
     public void testGetScope() {
         patcher.setScope(Optional.of(""));
         assertFalse(patcher.getScope().isPresent());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
@@ -24,6 +24,8 @@ import io.gravitee.am.gateway.handler.oauth2.service.scope.ScopeService;
 import io.gravitee.am.gateway.handler.oidc.service.discovery.impl.OpenIDDiscoveryServiceImpl;
 import io.gravitee.am.gateway.handler.oidc.service.utils.JWAlgorithmUtils;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.oidc.DPoPSettings;
+import io.gravitee.am.model.oidc.OIDCSettings;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -112,6 +114,26 @@ public class OpenIDDiscoveryServiceTest {
     public void shouldContain_token_endpoint_auth_signing_alg_values_supported() {
         OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
         assertTrue(JWAlgorithmUtils.getSupportedTokenEndpointAuthSigningAlg().containsAll(openIDProviderMetadata.getTokenEndpointAuthSigningAlgValuesSupported()));
+    }
+
+    @Test
+    public void shouldContain_dpop_signing_alg_values_supported() {
+        OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
+        assertEquals(List.of("ES256", "ES384", "ES512", "RS256", "RS384", "RS512"),
+                openIDProviderMetadata.getDpopSigningAlgValuesSupported());
+    }
+
+    @Test
+    public void shouldContain_dpop_signing_alg_values_supported_from_domain_allowlist() {
+        OIDCSettings oidc = new OIDCSettings();
+        DPoPSettings dpopSettings = new DPoPSettings();
+        dpopSettings.setDpopSigningAlgorithms(List.of("ES256", "ES384"));
+        oidc.setDpopSettings(dpopSettings);
+        when(domain.getOidc()).thenReturn(oidc);
+
+        OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
+
+        assertEquals(List.of("ES256", "ES384"), openIDProviderMetadata.getDpopSigningAlgValuesSupported());
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/utils/JWAlgorithmUtilsTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/utils/JWAlgorithmUtilsTest.java
@@ -19,6 +19,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -93,5 +96,12 @@ public class JWAlgorithmUtilsTest {
     @Test
     public void defaultIdTokenResponseEnc() {
         assertTrue("should be A128CBC-HS256", "A128CBC-HS256".equals(JWAlgorithmUtils.getDefaultIdTokenResponseEnc()));
+    }
+
+    @Test
+    public void supportedDpopSigningAlg_isEcAndRsaAsymmetricOnly() {
+        assertEquals(
+                List.of("ES256", "ES384", "ES512", "RS256", "RS384", "RS512"),
+                JWAlgorithmUtils.getSupportedDpopSigningAlg());
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/SCIMProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/SCIMProvider.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.gateway.handler.api.AbstractProtocolProvider;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
 import io.gravitee.am.gateway.handler.scim.mapper.ScimErrorMapper;
 import io.gravitee.am.gateway.handler.scim.resources.ErrorHandler;
@@ -73,6 +74,9 @@ public class SCIMProvider extends AbstractProtocolProvider {
     private OAuth2AuthProvider oAuth2AuthProvider;
 
     @Autowired
+    private DPoPProofValidator dpopProofValidator;
+
+    @Autowired
     private CorsHandler corsHandler;
 
     @Autowired
@@ -107,6 +111,7 @@ public class SCIMProvider extends AbstractProtocolProvider {
             OAuth2AuthHandler oAuth2AuthHandler = OAuth2AuthHandler.create(oAuth2AuthProvider, "scim");
             oAuth2AuthHandler.extractToken(true);
             oAuth2AuthHandler.extractClient(true);
+            oAuth2AuthHandler.dpopProofValidator(dpopProofValidator);
             scimRouter.route().handler(oAuth2AuthHandler);
 
             // Users resource

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/resources/users/ScimUsersDPoPEnforcementTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/resources/users/ScimUsersDPoPEnforcementTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.scim.resources.users;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import io.gravitee.am.common.jwt.Claims;
+import io.gravitee.am.common.jwt.JWT;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
+import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
+import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
+import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
+import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthResponse;
+import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
+import io.gravitee.am.gateway.handler.scim.mapper.ScimErrorMapper;
+import io.gravitee.am.gateway.handler.scim.model.ListResponse;
+import io.gravitee.am.gateway.handler.scim.resources.ErrorHandler;
+import io.gravitee.am.gateway.handler.scim.service.ProvisioningUserService;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.oidc.Client;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end wiring test: a DPoP-bound (cnf.jkt) access token is enforced by the shared OAuth2 bearer
+ * gate before it can reach the SCIM Users endpoint. Mirrors the gate wiring set up in SCIMProvider.
+ *
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ScimUsersDPoPEnforcementTest extends RxWebTestBase {
+
+    private static final String THE_JKT = "the-jwk-thumbprint";
+
+    @Mock
+    private ProvisioningUserService userService;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private ObjectWriter objectWriter;
+    @Mock
+    private Domain domain;
+    @Mock
+    private SubjectManager subjectManager;
+    @Mock
+    private OAuth2AuthProvider oAuth2AuthProvider;
+    @Mock
+    private DPoPProofValidator dpopProofValidator;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        when(objectWriter.writeValueAsString(any())).thenReturn("UserObject");
+        when(objectMapper.writerWithDefaultPrettyPrinter()).thenReturn(objectWriter);
+        UsersEndpoint usersEndpoint = new UsersEndpoint(domain, userService, objectMapper, subjectManager);
+
+        OAuth2AuthHandler oAuth2AuthHandler = OAuth2AuthHandler.create(oAuth2AuthProvider, "scim");
+        oAuth2AuthHandler.extractToken(true);
+        oAuth2AuthHandler.extractClient(true);
+        oAuth2AuthHandler.dpopProofValidator(dpopProofValidator);
+
+        router.route().handler(oAuth2AuthHandler);
+        router.get("/Users")
+                .handler(usersEndpoint::list)
+                .failureHandler(new ErrorHandler(new ScimErrorMapper(false)));
+    }
+
+    @Test
+    public void dpopBoundToken_withValidProof_reachesScimUsers() throws Exception {
+        givenAccessTokenDecodesToDpopBound();
+        when(dpopProofValidator.validateForResource(any(), any(), any())).thenReturn(Single.just(THE_JKT));
+        when(userService.list(any(), anyInt(), anyInt(), anyString())).thenReturn(Single.just(new ListResponse<>()));
+
+        testRequest(HttpMethod.GET, "/Users", withAuthorization("DPoP the-token"), 200, "OK", "UserObject");
+
+        verify(userService).list(any(), anyInt(), anyInt(), anyString());
+    }
+
+    @Test
+    public void dpopBoundToken_underBearer_isBlockedBeforeScimUsers() throws Exception {
+        givenAccessTokenDecodesToDpopBound();
+
+        testRequest(HttpMethod.GET, "/Users", withAuthorization("Bearer the-token"), 401, "Unauthorized", null);
+
+        verify(userService, never()).list(any(), anyInt(), anyInt(), anyString());
+        verify(dpopProofValidator, never()).validateForResource(any(), any(), any());
+    }
+
+    private void givenAccessTokenDecodesToDpopBound() {
+        doAnswer(invocation -> {
+            Handler<AsyncResult<OAuth2AuthResponse>> handler = invocation.getArgument(2);
+            JWT token = new JWT(Map.of(
+                    Claims.SUB, "client-id",
+                    Claims.AUD, "client-id",
+                    Claims.SCOPE, "scim",
+                    Claims.CNF, Map.of("jkt", THE_JKT)));
+            handler.handle(Future.succeededFuture(new OAuth2AuthResponse(token, new Client())));
+            return null;
+        }).when(oAuth2AuthProvider).decodeToken(any(), anyBoolean(), any());
+    }
+
+    private Consumer<HttpClientRequest> withAuthorization(String authorization) {
+        return req -> req.putHeader(HttpHeaders.AUTHORIZATION, authorization);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-users/src/main/java/io/gravitee/am/gateway/handler/users/UsersProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-users/src/main/java/io/gravitee/am/gateway/handler/users/UsersProvider.java
@@ -19,6 +19,7 @@ import io.gravitee.am.gateway.handler.api.AbstractProtocolProvider;
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.handler.OAuth2AuthHandler;
+import io.gravitee.am.gateway.handler.common.dpop.DPoPProofValidator;
 import io.gravitee.am.gateway.handler.common.vertx.web.auth.provider.OAuth2AuthProvider;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.ErrorHandler;
 import io.gravitee.am.gateway.handler.users.resources.consents.UserConsentEndpointHandler;
@@ -54,6 +55,9 @@ public class UsersProvider extends AbstractProtocolProvider {
     private OAuth2AuthProvider oAuth2AuthProvider;
 
     @Autowired
+    private DPoPProofValidator dpopProofValidator;
+
+    @Autowired
     private SubjectManager subjectManager;
 
     @Override
@@ -68,6 +72,7 @@ public class UsersProvider extends AbstractProtocolProvider {
         final OAuth2AuthHandler oAuth2AuthHandler = OAuth2AuthHandler.create(oAuth2AuthProvider, "consent_admin", subjectManager);
         oAuth2AuthHandler.extractToken(true);
         oAuth2AuthHandler.selfResource(true, "userId", true);
+        oAuth2AuthHandler.dpopProofValidator(dpopProofValidator);
 
         // user consent routes
         usersRouter.routeWithRegex(".*consents.*")

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.am.common.event.Action;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestUriException;
 import io.gravitee.am.common.exception.oauth2.OAuth2Exception;
+import io.gravitee.am.common.jwt.SignatureAlgorithm;
 import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.common.web.UriBuilder;
@@ -918,6 +919,18 @@ public class DomainServiceImpl implements DomainService {
                 return Completable.error(e);
             } catch (Exception e) {
                 return Completable.error(new InvalidRedirectUriException(e.getMessage()));
+            }
+
+            final List<String> dpopSigningAlgorithms = domain.getOidc().getDpopSettings() != null
+                    ? domain.getOidc().getDpopSettings().getDpopSigningAlgorithms() : null;
+            if (dpopSigningAlgorithms != null) {
+                if (dpopSigningAlgorithms.isEmpty()) {
+                    return Completable.error(new InvalidDomainException("DPoP signing algorithms allowlist must not be empty"));
+                }
+                if (!SignatureAlgorithm.DPOP_SUPPORTED_ALGORITHMS.containsAll(dpopSigningAlgorithms)) {
+                    return Completable.error(new InvalidDomainException(
+                            "DPoP signing algorithms allowlist must only contain supported algorithms: " + SignatureAlgorithm.DPOP_SUPPORTED_ALGORITHMS));
+                }
             }
         }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -59,6 +59,7 @@ import io.gravitee.am.model.oauth2.Scope;
 import io.gravitee.am.model.application.ApplicationAdvancedSettings;
 import io.gravitee.am.model.application.ApplicationSettings;
 import io.gravitee.am.model.oidc.CIMDSettings;
+import io.gravitee.am.model.oidc.DPoPSettings;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.permissions.SystemRole;
 import io.gravitee.am.model.uma.Resource;
@@ -708,6 +709,55 @@ public class DomainServiceTest {
             var audit = builder.build(OBJECT_MAPPER);
             return audit.getReferenceType().equals(ORGANIZATION);
         }));
+    }
+
+    @Test
+    public void shouldNotPatch_emptyDpopSigningAlgorithms() {
+        PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
+        Domain domain = domainWithDpopAlgorithms(List.of());
+        when(patchDomain.patch(any())).thenReturn(domain);
+        when(domainRepository.findById(domain.getId())).thenReturn(Maybe.just(domain));
+        doReturn(true).when(accountSettingsValidator).validate(any());
+
+        domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, domain.getId()), domain.getId(), patchDomain, null)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(InvalidDomainException.class);
+
+        verify(domainRepository, never()).update(any());
+    }
+
+    @Test
+    public void shouldNotPatch_unsupportedDpopSigningAlgorithm() {
+        PatchDomain patchDomain = Mockito.mock(PatchDomain.class);
+        Domain domain = domainWithDpopAlgorithms(List.of("HS256"));
+        when(patchDomain.patch(any())).thenReturn(domain);
+        when(domainRepository.findById(domain.getId())).thenReturn(Maybe.just(domain));
+        doReturn(true).when(accountSettingsValidator).validate(any());
+
+        domainService.patch(new GraviteeContext(ORGANIZATION_ID, ENVIRONMENT_ID, domain.getId()), domain.getId(), patchDomain, null)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(InvalidDomainException.class);
+
+        verify(domainRepository, never()).update(any());
+    }
+
+    private static Domain domainWithDpopAlgorithms(List<String> algorithms) {
+        Domain domain = new Domain();
+        domain.setId("my-domain");
+        domain.setHrid("my-domain");
+        domain.setReferenceType(ReferenceType.ENVIRONMENT);
+        domain.setReferenceId(ENVIRONMENT_ID);
+        domain.setName("my-domain");
+        domain.setPath("/test");
+        domain.setVersion(DomainVersion.V2_0);
+        OIDCSettings oidc = new OIDCSettings();
+        DPoPSettings dpopSettings = new DPoPSettings();
+        dpopSettings.setDpopSigningAlgorithms(algorithms);
+        oidc.setDpopSettings(dpopSettings);
+        domain.setOidc(oidc);
+        return domain;
     }
 
     @Test

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Domain.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Domain.java
@@ -583,6 +583,12 @@ public class Domain implements Resource, Managed {
         return this.getOidc() != null && this.getOidc().isRedirectUriStrictMatching();
     }
 
+    public boolean isRequireDpopForAll() {
+        return this.getOidc() != null
+                && this.getOidc().getDpopSettings() != null
+                && this.getOidc().getDpopSettings().isRequireDpopForAll();
+    }
+
     public boolean usePlainFapiProfile() {
         return this.getOidc() != null &&
                 this.getOidc().getSecurityProfileSettings() != null &&

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationOAuthSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/ApplicationOAuthSettings.java
@@ -263,6 +263,8 @@ public class ApplicationOAuthSettings {
 
     private boolean tlsClientCertificateBoundAccessTokens;
 
+    private boolean dpopBoundAccessTokens;
+
     /**
      * JWS alg algorithm [JWA] REQUIRED for signing Authorization Responses.
      */
@@ -389,6 +391,7 @@ public class ApplicationOAuthSettings {
         this.tlsClientAuthSanIp = other.tlsClientAuthSanIp;
         this.tlsClientAuthSanUri = other.tlsClientAuthSanUri;
         this.tlsClientCertificateBoundAccessTokens = other.tlsClientCertificateBoundAccessTokens;
+        this.dpopBoundAccessTokens = other.dpopBoundAccessTokens;
         this.authorizationSignedResponseAlg = other.authorizationSignedResponseAlg;
         this.authorizationEncryptedResponseAlg = other.authorizationEncryptedResponseAlg;
         this.authorizationEncryptedResponseEnc = other.authorizationEncryptedResponseEnc;
@@ -944,6 +947,14 @@ public class ApplicationOAuthSettings {
         this.tlsClientCertificateBoundAccessTokens = tlsClientCertificateBoundAccessTokens;
     }
 
+    public boolean isDpopBoundAccessTokens() {
+        return dpopBoundAccessTokens;
+    }
+
+    public void setDpopBoundAccessTokens(boolean dpopBoundAccessTokens) {
+        this.dpopBoundAccessTokens = dpopBoundAccessTokens;
+    }
+
     public boolean isRequireParRequest() {
         return requireParRequest;
     }
@@ -1061,6 +1072,7 @@ public class ApplicationOAuthSettings {
         client.setTlsClientAuthSanIp(this.tlsClientAuthSanIp);
         client.setTlsClientAuthSanUri(this.tlsClientAuthSanUri);
         client.setTlsClientCertificateBoundAccessTokens(this.tlsClientCertificateBoundAccessTokens);
+        client.setDpopBoundAccessTokens(this.dpopBoundAccessTokens);
         client.setAuthorizationSignedResponseAlg(this.authorizationSignedResponseAlg);
         client.setAuthorizationEncryptedResponseAlg(this.authorizationEncryptedResponseAlg);
         client.setAuthorizationEncryptedResponseEnc(this.authorizationEncryptedResponseEnc);

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/Client.java
@@ -179,6 +179,8 @@ public class Client implements Cloneable, Resource {
 
     private boolean tlsClientCertificateBoundAccessTokens;
 
+    private boolean dpopBoundAccessTokens;
+
     private String authorizationSignedResponseAlg;
 
     private String authorizationEncryptedResponseAlg;
@@ -392,6 +394,7 @@ public class Client implements Cloneable, Resource {
         this.singleSignOut = other.singleSignOut;
         this.silentReAuthentication = other.silentReAuthentication;
         this.tlsClientCertificateBoundAccessTokens = other.tlsClientCertificateBoundAccessTokens;
+        this.dpopBoundAccessTokens = other.dpopBoundAccessTokens;
         this.requireParRequest = other.requireParRequest;
         this.backchannelTokenDeliveryMode = other.backchannelTokenDeliveryMode;
         this.backchannelClientNotificationEndpoint = other.backchannelClientNotificationEndpoint;
@@ -1085,6 +1088,14 @@ public class Client implements Cloneable, Resource {
 
     public void setTlsClientCertificateBoundAccessTokens(boolean tlsClientCertificateBoundAccessTokens) {
         this.tlsClientCertificateBoundAccessTokens = tlsClientCertificateBoundAccessTokens;
+    }
+
+    public boolean isDpopBoundAccessTokens() {
+        return dpopBoundAccessTokens;
+    }
+
+    public void setDpopBoundAccessTokens(boolean dpopBoundAccessTokens) {
+        this.dpopBoundAccessTokens = dpopBoundAccessTokens;
     }
 
     public boolean isRequireParRequest() {

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/DPoPSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/DPoPSettings.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.oidc;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Domain-level settings for Demonstrating Proof-of-Possession (DPoP, RFC 9449).
+ *
+ * @author GraviteeSource Team
+ */
+@Schema(title = "DPoP settings", description = "Demonstrating Proof-of-Possession (RFC 9449) configuration for the domain.")
+public class DPoPSettings {
+
+    @Schema(description = "Domain-wide floor (RFC 9449) requiring every application to present a DPoP " +
+            "proof at the token endpoint. When true it cannot be overridden by an application whose " +
+            "own dpop_bound_access_tokens flag is off.",
+            defaultValue = "false")
+    private boolean requireDpopForAll;
+
+    @Schema(description = "Allowlist of DPoP (RFC 9449) proof signing algorithms accepted at the token " +
+            "endpoint, drawn from the base supported set (ES256/384/512, RS256/384/512). When null the " +
+            "full base set is accepted. Persisting an empty set is rejected.")
+    private List<String> dpopSigningAlgorithms;
+
+    public DPoPSettings() {
+    }
+
+    public DPoPSettings(DPoPSettings other) {
+        this.requireDpopForAll = other.requireDpopForAll;
+        this.dpopSigningAlgorithms = other.dpopSigningAlgorithms != null
+                ? new ArrayList<>(other.dpopSigningAlgorithms) : null;
+    }
+
+    public boolean isRequireDpopForAll() {
+        return requireDpopForAll;
+    }
+
+    public void setRequireDpopForAll(boolean requireDpopForAll) {
+        this.requireDpopForAll = requireDpopForAll;
+    }
+
+    public List<String> getDpopSigningAlgorithms() {
+        return dpopSigningAlgorithms;
+    }
+
+    public void setDpopSigningAlgorithms(List<String> dpopSigningAlgorithms) {
+        this.dpopSigningAlgorithms = dpopSigningAlgorithms;
+    }
+
+    public static DPoPSettings defaultSettings() {
+        return new DPoPSettings();
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/OIDCSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/OIDCSettings.java
@@ -39,6 +39,9 @@ public class OIDCSettings {
             defaultValue = "false")
     private boolean redirectUriStrictMatching;
 
+    @Schema(description = "Demonstrating Proof-of-Possession (RFC 9449) settings for the domain.")
+    private DPoPSettings dpopSettings;
+
     @Schema(description = "URLs to which a relying party may request the user be redirected after logout, via " +
             "the post_logout_redirect_uri parameter.")
     private List<String> postLogoutRedirectUris;
@@ -61,6 +64,7 @@ public class OIDCSettings {
         this.securityProfileSettings = other.securityProfileSettings != null
                 ? new SecurityProfileSettings(other.securityProfileSettings) : null;
         this.redirectUriStrictMatching = other.redirectUriStrictMatching;
+        this.dpopSettings = other.dpopSettings != null ? new DPoPSettings(other.dpopSettings) : null;
         this.postLogoutRedirectUris = other.postLogoutRedirectUris != null
                 ? new ArrayList<>(other.postLogoutRedirectUris) : null;
         this.requestUris = other.requestUris != null ? new ArrayList<>(other.requestUris) : null;
@@ -83,6 +87,14 @@ public class OIDCSettings {
 
     public void setRedirectUriStrictMatching(boolean redirectUriStrictMatching) {
         this.redirectUriStrictMatching = redirectUriStrictMatching;
+    }
+
+    public DPoPSettings getDpopSettings() {
+        return dpopSettings;
+    }
+
+    public void setDpopSettings(DPoPSettings dpopSettings) {
+        this.dpopSettings = dpopSettings;
     }
 
     public List<String> getPostLogoutRedirectUris() {
@@ -138,6 +150,7 @@ public class OIDCSettings {
         defaultSettings.setClientRegistrationSettings(ClientRegistrationSettings.defaultSettings());
         defaultSettings.setSecurityProfileSettings(SecurityProfileSettings.defaultSettings());
         defaultSettings.setRedirectUriStrictMatching(false);
+        defaultSettings.setDpopSettings(DPoPSettings.defaultSettings());
         defaultSettings.setCibaSettings(CIBASettings.defaultSettings());
         defaultSettings.setCimdSettings(CIMDSettings.defaultSettings());
         defaultSettings.setWorkloadIdentitySettings(SpiffeDomainSettings.defaultSettings());

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/oauth2/model/Token.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/oauth2/model/Token.java
@@ -69,6 +69,11 @@ public abstract class Token {
 
     private Set<String> allParentJtis;
 
+    /**
+     * The JWK SHA-256 thumbprint (DPoP - RFC 9449)
+     */
+    private String jkt;
+
 
     @Override
     public boolean equals(Object o) {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/oauth2/api/JdbcTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/oauth2/api/JdbcTokenRepository.java
@@ -200,6 +200,7 @@ public class JdbcTokenRepository extends AbstractJdbcRepository implements Token
         result.setClient(entity.getClient());
         result.setDomain(entity.getDomain());
         result.setSubject(entity.getSubject());
+        result.setJkt(entity.getJkt());
         result.setAllParentJtis(new HashSet<>()); // parentIds are only needed to perform RECURSIVE delete
         if (entity.getCreatedAt() != null) {
             result.setCreatedAt(Date.from(entity.getCreatedAt().atZone(UTC).toInstant()));
@@ -218,6 +219,7 @@ public class JdbcTokenRepository extends AbstractJdbcRepository implements Token
         result.setClient(token.getClient());
         result.setDomain(token.getDomain());
         result.setSubject(token.getSubject());
+        result.setJkt(token.getJkt());
 
         Iterator<String> it = (token.getAllParentJtis() == null ? Stream.<String>empty() : token.getAllParentJtis().stream())
                 .filter(jti -> !jti.equals(result.getToken()))

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/oauth2/api/model/JdbcToken.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/oauth2/api/model/JdbcToken.java
@@ -39,4 +39,7 @@ public class JdbcToken extends JdbcBaseToken {
 
     @Column("parent_jti_2")
     private String parentJti2;
+
+    @Column("jkt")
+    private String jkt;
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/oauth-master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/oauth-master.yml
@@ -23,3 +23,5 @@ databaseChangeLog:
       - file: liquibase/oauth/changelogs/v4_13_0/4.13.0-ciba-add-authorization-details.yml
   - include:
       - file: liquibase/oauth/changelogs/v4_13_0/4.13.0-ciba-subject-nullable.yml
+  - include:
+      - file: liquibase/oauth/changelogs/v4_13_0/4.13.0-add-tokens-jkt.yml

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/oauth/changelogs/v4_13_0/4.13.0-add-tokens-jkt.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/oauth/changelogs/v4_13_0/4.13.0-add-tokens-jkt.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0-add-tokens-jkt
+      author: GraviteeSource Team
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: tokens
+                columnName: jkt
+      changes:
+        - addColumn:
+            tableName: tokens
+            columns:
+              - column: { name: jkt, type: nvarchar(255), constraints: { nullable: true } }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoApplicationRepository.java
@@ -598,6 +598,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationOAuthSettingsMongo.setTlsClientAuthSanIp(other.getTlsClientAuthSanIp());
         applicationOAuthSettingsMongo.setTlsClientAuthSanUri(other.getTlsClientAuthSanUri());
         applicationOAuthSettingsMongo.setTlsClientCertificateBoundAccessTokens(other.isTlsClientCertificateBoundAccessTokens());
+        applicationOAuthSettingsMongo.setDpopBoundAccessTokens(other.isDpopBoundAccessTokens());
         applicationOAuthSettingsMongo.setAuthorizationSignedResponseAlg(other.getAuthorizationSignedResponseAlg());
         applicationOAuthSettingsMongo.setAuthorizationEncryptedResponseAlg(other.getAuthorizationEncryptedResponseAlg());
         applicationOAuthSettingsMongo.setAuthorizationEncryptedResponseEnc(other.getAuthorizationEncryptedResponseEnc());
@@ -683,6 +684,7 @@ public class MongoApplicationRepository extends AbstractManagementMongoRepositor
         applicationOAuthSettings.setTlsClientAuthSanIp(other.getTlsClientAuthSanIp());
         applicationOAuthSettings.setTlsClientAuthSanUri(other.getTlsClientAuthSanUri());
         applicationOAuthSettings.setTlsClientCertificateBoundAccessTokens(other.isTlsClientCertificateBoundAccessTokens());
+        applicationOAuthSettings.setDpopBoundAccessTokens(other.isDpopBoundAccessTokens());
         applicationOAuthSettings.setAuthorizationSignedResponseAlg(other.getAuthorizationSignedResponseAlg());
         applicationOAuthSettings.setAuthorizationEncryptedResponseAlg(other.getAuthorizationEncryptedResponseAlg());
         applicationOAuthSettings.setAuthorizationEncryptedResponseEnc(other.getAuthorizationEncryptedResponseEnc());

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
@@ -37,6 +37,7 @@ import io.gravitee.am.model.oidc.CIBASettingNotifier;
 import io.gravitee.am.model.oidc.CIBASettings;
 import io.gravitee.am.model.oidc.CIMDSettings;
 import io.gravitee.am.model.oidc.ClientRegistrationSettings;
+import io.gravitee.am.model.oidc.DPoPSettings;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.oidc.SecurityProfileSettings;
 import io.gravitee.am.model.scim.SCIMSettings;
@@ -57,6 +58,7 @@ import io.gravitee.am.repository.mongodb.management.internal.model.oidc.CIBASett
 import io.gravitee.am.repository.mongodb.management.internal.model.oidc.CIBASettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.oidc.CIMDSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.oidc.ClientRegistrationSettingsMongo;
+import io.gravitee.am.repository.mongodb.management.internal.model.oidc.DPoPSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.oidc.OIDCSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.oidc.SecurityProfileSettingsMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.uma.UMASettingsMongo;
@@ -302,6 +304,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
 
         OIDCSettings oidcSettings = new OIDCSettings();
         oidcSettings.setRedirectUriStrictMatching(oidcMongo.isRedirectUriStrictMatching());
+        oidcSettings.setDpopSettings(convert(oidcMongo.getDpopSettings()));
         oidcSettings.setClientRegistrationSettings(convert(oidcMongo.getClientRegistrationSettings()));
         oidcSettings.setSecurityProfileSettings(convert(oidcMongo.getSecurityProfileSettings()));
         oidcSettings.setCibaSettings(convert(oidcMongo.getCibaSettings()));
@@ -390,6 +393,7 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
 
         OIDCSettingsMongo oidcSettings = new OIDCSettingsMongo();
         oidcSettings.setRedirectUriStrictMatching(oidc.isRedirectUriStrictMatching());
+        oidcSettings.setDpopSettings(convert(oidc.getDpopSettings()));
         oidcSettings.setClientRegistrationSettings(convert(oidc.getClientRegistrationSettings()));
         oidcSettings.setSecurityProfileSettings(convert(oidc.getSecurityProfileSettings()));
         oidcSettings.setCibaSettings(convert(oidc.getCibaSettings()));
@@ -495,6 +499,30 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         result.setCacheMaxEntries(cimdSettings.getCacheMaxEntries());
         result.setTemplateId(cimdSettings.getTemplateId());
         result.setRevokeOnDocumentChange(cimdSettings.isRevokeOnDocumentChange());
+
+        return result;
+    }
+
+    private static DPoPSettings convert(DPoPSettingsMongo dpopSettings) {
+        if (dpopSettings == null) {
+            return null;
+        }
+
+        DPoPSettings result = new DPoPSettings();
+        result.setRequireDpopForAll(dpopSettings.isRequireDpopForAll());
+        result.setDpopSigningAlgorithms(dpopSettings.getDpopSigningAlgorithms());
+
+        return result;
+    }
+
+    private static DPoPSettingsMongo convert(DPoPSettings dpopSettings) {
+        if (dpopSettings == null) {
+            return null;
+        }
+
+        DPoPSettingsMongo result = new DPoPSettingsMongo();
+        result.setRequireDpopForAll(dpopSettings.isRequireDpopForAll());
+        result.setDpopSigningAlgorithms(dpopSettings.getDpopSigningAlgorithms());
 
         return result;
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationOAuthSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ApplicationOAuthSettingsMongo.java
@@ -81,6 +81,7 @@ public class ApplicationOAuthSettingsMongo {
     private String tlsClientAuthSanIp;
     private String tlsClientAuthSanEmail;
     private boolean tlsClientCertificateBoundAccessTokens;
+    private boolean dpopBoundAccessTokens;
     private String authorizationSignedResponseAlg;
     private String authorizationEncryptedResponseAlg;
     private String authorizationEncryptedResponseEnc;
@@ -604,6 +605,14 @@ public class ApplicationOAuthSettingsMongo {
 
     public void setTlsClientCertificateBoundAccessTokens(boolean tlsClientCertificateBoundAccessTokens) {
         this.tlsClientCertificateBoundAccessTokens = tlsClientCertificateBoundAccessTokens;
+    }
+
+    public boolean isDpopBoundAccessTokens() {
+        return dpopBoundAccessTokens;
+    }
+
+    public void setDpopBoundAccessTokens(boolean dpopBoundAccessTokens) {
+        this.dpopBoundAccessTokens = dpopBoundAccessTokens;
     }
 
     public List<ApplicationScopeSettingsMongo> getScopeSettings() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/DPoPSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/DPoPSettingsMongo.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.management.internal.model.oidc;
+
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class DPoPSettingsMongo {
+
+    private boolean requireDpopForAll;
+    private List<String> dpopSigningAlgorithms;
+
+    public boolean isRequireDpopForAll() {
+        return requireDpopForAll;
+    }
+
+    public void setRequireDpopForAll(boolean requireDpopForAll) {
+        this.requireDpopForAll = requireDpopForAll;
+    }
+
+    public List<String> getDpopSigningAlgorithms() {
+        return dpopSigningAlgorithms;
+    }
+
+    public void setDpopSigningAlgorithms(List<String> dpopSigningAlgorithms) {
+        this.dpopSigningAlgorithms = dpopSigningAlgorithms;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/OIDCSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/OIDCSettingsMongo.java
@@ -26,6 +26,7 @@ public class OIDCSettingsMongo {
     private ClientRegistrationSettingsMongo clientRegistrationSettings;
     private SecurityProfileSettingsMongo securityProfileSettings;
     private boolean redirectUriStrictMatching;
+    private DPoPSettingsMongo dpopSettings;
     private List<String> postLogoutRedirectUris;
     private List<String> requestUris;
     private CIBASettingsMongo cibaSettings;
@@ -48,6 +49,14 @@ public class OIDCSettingsMongo {
 
     public void setRedirectUriStrictMatching(boolean redirectUriStrictMatching) {
         this.redirectUriStrictMatching = redirectUriStrictMatching;
+    }
+
+    public DPoPSettingsMongo getDpopSettings() {
+        return dpopSettings;
+    }
+
+    public void setDpopSettings(DPoPSettingsMongo dpopSettings) {
+        this.dpopSettings = dpopSettings;
     }
 
     public List<String> getPostLogoutRedirectUris() {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoTokenRepository.java
@@ -209,6 +209,7 @@ public class MongoTokenRepository extends AbstractOAuth2MongoRepository implemen
         tokenMongo.setCreatedAt(token.getCreatedAt());
         tokenMongo.setExpireAt(token.getExpireAt());
         tokenMongo.setParentJtis(token.getAllParentJtis());
+        tokenMongo.setJkt(token.getJkt());
         return tokenMongo;
     }
 
@@ -228,6 +229,7 @@ public class MongoTokenRepository extends AbstractOAuth2MongoRepository implemen
         accessToken.setCreatedAt(tokenMongo.getCreatedAt());
         accessToken.setExpireAt(tokenMongo.getExpireAt());
         accessToken.setAllParentJtis(tokenMongo.getParentJtis());
+        accessToken.setJkt(tokenMongo.getJkt());
         return accessToken;
     }
 
@@ -245,6 +247,7 @@ public class MongoTokenRepository extends AbstractOAuth2MongoRepository implemen
         refreshToken.setCreatedAt(tokenMongo.getCreatedAt());
         refreshToken.setExpireAt(tokenMongo.getExpireAt());
         refreshToken.setAllParentJtis(tokenMongo.getParentJtis());
+        refreshToken.setJkt(tokenMongo.getJkt());
         return refreshToken;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/internal/model/TokenMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/internal/model/TokenMongo.java
@@ -74,6 +74,9 @@ public class TokenMongo {
     @BsonProperty(FIELD_PARENT_JTIS)
     private Set<String> parentJtis;
 
+    @BsonProperty("jkt")
+    private String jkt;
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/oauth2/api/TokenRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/oauth2/api/TokenRepositoryTest.java
@@ -78,6 +78,21 @@ public class TokenRepositoryTest extends AbstractOAuthTest {
     }
 
     @Test
+    public void shouldPersistAndReadRefreshTokenJkt() {
+        RefreshToken refreshToken = newRefreshToken("refresh-token-jkt", null, null, null);
+        refreshToken.setJkt("the-jwk-thumbprint");
+
+        TestObserver<RefreshToken> observer = Completable.fromSingle(tokenRepository.create(refreshToken))
+                .andThen(tokenRepository.findRefreshTokenByJti(refreshToken.getToken()))
+                .test();
+
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(rt -> "the-jwk-thumbprint".equals(rt.getJkt()));
+    }
+
+    @Test
     public void shouldFindAccessTokenByAuthorizationCode() {
         AccessToken accessToken = newAccessToken("access-token-auth", null, null, null);
         accessToken.setAuthorizationCode("auth-code");

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationOAuthSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/PatchApplicationOAuthSettings.java
@@ -85,6 +85,7 @@ public class PatchApplicationOAuthSettings {
     private Optional<String> tlsClientAuthSanIp;
     private Optional<String> tlsClientAuthSanEmail;
     private Optional<Boolean> tlsClientCertificateBoundAccessTokens;
+    private Optional<Boolean> dpopBoundAccessTokens;
     private Optional<String> authorizationSignedResponseAlg;
     private Optional<String> authorizationEncryptedResponseAlg;
     private Optional<String> authorizationEncryptedResponseEnc;
@@ -565,6 +566,14 @@ public class PatchApplicationOAuthSettings {
         this.tlsClientCertificateBoundAccessTokens = tlsClientCertificateBoundAccessTokens;
     }
 
+    public Optional<Boolean> getDpopBoundAccessTokens() {
+        return dpopBoundAccessTokens;
+    }
+
+    public void setDpopBoundAccessTokens(Optional<Boolean> dpopBoundAccessTokens) {
+        this.dpopBoundAccessTokens = dpopBoundAccessTokens;
+    }
+
     public Optional<Boolean> getDisableRefreshTokenRotation() {
         return disableRefreshTokenRotation;
     }
@@ -644,6 +653,7 @@ public class PatchApplicationOAuthSettings {
         SetterUtils.safeSet(toPatch::setTlsClientAuthSanIp, this.getTlsClientAuthSanIp());
         SetterUtils.safeSet(toPatch::setTlsClientAuthSanUri, this.getTlsClientAuthSanUri());
         SetterUtils.safeSet(toPatch::setTlsClientCertificateBoundAccessTokens, this.getTlsClientCertificateBoundAccessTokens());
+        SetterUtils.safeSet(toPatch::setDpopBoundAccessTokens, this.getDpopBoundAccessTokens());
         SetterUtils.safeSet(toPatch::setAuthorizationSignedResponseAlg, this.getAuthorizationSignedResponseAlg());
         SetterUtils.safeSet(toPatch::setAuthorizationEncryptedResponseAlg, this.getAuthorizationEncryptedResponseAlg());
         SetterUtils.safeSet(toPatch::setAuthorizationEncryptedResponseEnc, this.getAuthorizationEncryptedResponseEnc());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchDPoPSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchDPoPSettings.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.model.openid;
+
+import io.gravitee.am.model.oidc.DPoPSettings;
+import io.gravitee.am.service.utils.SetterUtils;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Patch model for {@link DPoPSettings}.
+ *
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+public class PatchDPoPSettings {
+
+    private Optional<Boolean> requireDpopForAll;
+
+    private Optional<List<String>> dpopSigningAlgorithms;
+
+    public Optional<Boolean> getRequireDpopForAll() {
+        return requireDpopForAll;
+    }
+
+    public void setRequireDpopForAll(Optional<Boolean> requireDpopForAll) {
+        this.requireDpopForAll = requireDpopForAll;
+    }
+
+    public Optional<List<String>> getDpopSigningAlgorithms() {
+        return dpopSigningAlgorithms;
+    }
+
+    public void setDpopSigningAlgorithms(Optional<List<String>> dpopSigningAlgorithms) {
+        this.dpopSigningAlgorithms = dpopSigningAlgorithms;
+    }
+
+    public DPoPSettings patch(DPoPSettings toPatch) {
+        DPoPSettings result = toPatch == null ? DPoPSettings.defaultSettings() : new DPoPSettings(toPatch);
+
+        SetterUtils.safeSet(result::setRequireDpopForAll, this.getRequireDpopForAll(), boolean.class);
+        SetterUtils.safeSet(result::setDpopSigningAlgorithms, this.getDpopSigningAlgorithms());
+
+        return result;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchOIDCSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchOIDCSettings.java
@@ -45,6 +45,9 @@ public class PatchOIDCSettings {
     @JsonProperty("cimdSettings")
     private Optional<PatchCIMDSettings> cimdSettings;
 
+    @JsonProperty("dpopSettings")
+    private Optional<PatchDPoPSettings> dpopSettings;
+
     @JsonProperty("workloadIdentitySettings")
     private Optional<PatchSpiffeDomainSettings> workloadIdentitySettings;
 
@@ -75,6 +78,14 @@ public class PatchOIDCSettings {
 
     public void setRedirectUriStrictMatching(Optional<Boolean> redirectUriStrictMatching) {
         this.redirectUriStrictMatching = redirectUriStrictMatching;
+    }
+
+    public Optional<PatchDPoPSettings> getDpopSettings() {
+        return dpopSettings;
+    }
+
+    public void setDpopSettings(Optional<PatchDPoPSettings> dpopSettings) {
+        this.dpopSettings = dpopSettings;
     }
 
     public Optional<List<String>> getPostLogoutRedirectUris() {
@@ -164,6 +175,16 @@ public class PatchOIDCSettings {
             }
         }
 
+        if (getDpopSettings() != null) {
+            if (getDpopSettings().isPresent()) {
+                final PatchDPoPSettings patcher = getDpopSettings().get();
+                final DPoPSettings source = toPatch.getDpopSettings();
+                toPatch.setDpopSettings(patcher.patch(source));
+            } else {
+                toPatch.setDpopSettings(DPoPSettings.defaultSettings());
+            }
+        }
+
         if (getWorkloadIdentitySettings() != null) {
             if (getWorkloadIdentitySettings().isPresent()) {
                 final PatchSpiffeDomainSettings patcher = getWorkloadIdentitySettings().get();
@@ -184,6 +205,7 @@ public class PatchOIDCSettings {
 
         if ((clientRegistrationSettings != null && clientRegistrationSettings.isPresent())
                 || (redirectUriStrictMatching != null && redirectUriStrictMatching.isPresent())
+                || (dpopSettings != null && dpopSettings.isPresent())
                 || (cibaSettings != null && cibaSettings.isPresent())
                 || (cimdSettings != null && cimdSettings.isPresent())
                 || (workloadIdentitySettings != null && workloadIdentitySettings.isPresent())

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/model/PatchApplicationTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/model/PatchApplicationTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -172,6 +173,29 @@ public class PatchApplicationTest {
         Application result = patch.patch(toPatch);
 
         assertEquals(patchedClaims, result.getSettings().getOauth().getUserinfoCustomClaims());
+    }
+
+    @Test
+    public void patch_applies_dpopBoundAccessTokens_when_present() {
+        PatchApplicationOAuthSettings oauthPatch = new PatchApplicationOAuthSettings();
+        oauthPatch.setDpopBoundAccessTokens(Optional.of(true));
+
+        PatchApplicationSettings settingsPatch = new PatchApplicationSettings();
+        settingsPatch.setOauth(Optional.of(oauthPatch));
+
+        PatchApplication patch = new PatchApplication();
+        patch.setSettings(Optional.of(settingsPatch));
+
+        Application toPatch = new Application();
+        ApplicationSettings appSettings = new ApplicationSettings();
+        ApplicationOAuthSettings existingOauth = new ApplicationOAuthSettings();
+        assertFalse("dpopBoundAccessTokens shall default to false", existingOauth.isDpopBoundAccessTokens());
+        appSettings.setOauth(existingOauth);
+        toPatch.setSettings(appSettings);
+
+        Application result = patch.patch(toPatch);
+
+        assertTrue(result.getSettings().getOauth().isDpopBoundAccessTokens());
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/model/openid/PatchOIDCSettingsTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/model/openid/PatchOIDCSettingsTest.java
@@ -24,8 +24,10 @@ import org.junit.runners.JUnit4;
 
 import java.util.Optional;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -69,6 +71,39 @@ public class PatchOIDCSettingsTest {
         assertNotNull(result);
         assertNotNull(result.getCibaSettings());
         assertTrue("CIBA settings shall be true after update", result.getCibaSettings().isEnabled());
+    }
+
+    @Test
+    public void testPatchRequireDpopForAll() {
+        PatchDPoPSettings dpopPatcher = new PatchDPoPSettings();
+        dpopPatcher.setRequireDpopForAll(Optional.of(true));
+        PatchOIDCSettings patcher = new PatchOIDCSettings();
+        patcher.setDpopSettings(Optional.of(dpopPatcher));
+
+        OIDCSettings settings = new OIDCSettings();
+        assertNull("dpopSettings shall default to null", settings.getDpopSettings());
+
+        OIDCSettings result = patcher.patch(settings);
+
+        assertNotNull(result);
+        assertNotNull(result.getDpopSettings());
+        assertTrue("requireDpopForAll shall be true after update", result.getDpopSettings().isRequireDpopForAll());
+    }
+
+    @Test
+    public void testPatchDpopSigningAlgorithms() {
+        PatchDPoPSettings dpopPatcher = new PatchDPoPSettings();
+        dpopPatcher.setDpopSigningAlgorithms(Optional.of(java.util.List.of("ES256", "ES384")));
+        PatchOIDCSettings patcher = new PatchOIDCSettings();
+        patcher.setDpopSettings(Optional.of(dpopPatcher));
+
+        OIDCSettings settings = new OIDCSettings();
+
+        OIDCSettings result = patcher.patch(settings);
+
+        assertNotNull(result);
+        assertNotNull(result.getDpopSettings());
+        assertEquals(java.util.List.of("ES256", "ES384"), result.getDpopSettings().getDpopSigningAlgorithms());
     }
 
     @Test

--- a/gravitee-am-test/specs/gateway/dpop/dpop-algorithm-allowlist.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/dpop/dpop-algorithm-allowlist.jest.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { cnfJkt, clientCredentialsToken, DpopAllowlistFixture, setupDpopAllowlistFixture } from './fixture/dpop-fixture';
+import { createDpopKey } from './dpop-proof';
+
+setup(200000);
+
+let fixture: DpopAllowlistFixture;
+
+beforeAll(async () => {
+  fixture = await setupDpopAllowlistFixture(['ES256']);
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('DPoP (RFC 9449) — signing-algorithm allowlist', () => {
+  it('accepts a proof signed with an allowed algorithm (ES256)', async () => {
+    const key = await createDpopKey('ES256');
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const response = await clientCredentialsToken(fixture, fixture.algApp, proof);
+
+    expect(response.status).toBe(200);
+    expect(response.body.token_type).toBe('DPoP');
+    expect(cnfJkt(response.body.access_token)).toBe(key.jkt);
+  });
+
+  it('rejects a proof signed with a disallowed algorithm (RS256)', async () => {
+    const key = await createDpopKey('RS256');
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const response = await clientCredentialsToken(fixture, fixture.algApp, proof);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_dpop_proof');
+  });
+});
+
+describe('DPoP (RFC 9449) — discovery', () => {
+  it('advertises dpop_signing_alg_values_supported reflecting the domain allowlist', () => {
+    expect(fixture.oidc.dpop_signing_alg_values_supported).toEqual(['ES256']);
+  });
+});
+
+// NB: the per-domain allowlist constrains the token endpoint and discovery (above), but the
+// resource-side WWW-Authenticate still advertises the server's full supported-alg set, not the
+// domain allowlist — so there is no resource-challenge assertion here. See ticket 03 notes.

--- a/gravitee-am-test/specs/gateway/dpop/dpop-binding.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/dpop/dpop-binding.jest.spec.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import {
+  cnfJkt,
+  clientCredentialsToken,
+  DpopFixture,
+  getAuthorizationCode,
+  passwordToken,
+  redeemAuthorizationCode,
+  refreshAccessToken,
+  setupDpopFixture,
+  userInfo,
+} from './fixture/dpop-fixture';
+import { createDpopKey } from './dpop-proof';
+
+setup(200000);
+
+let fixture: DpopFixture;
+
+beforeAll(async () => {
+  fixture = await setupDpopFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('DPoP (RFC 9449) — token-endpoint key binding', () => {
+  it('binds the access token to the proof key when a proof is presented', async () => {
+    const key = await createDpopKey();
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const response = await clientCredentialsToken(fixture, fixture.ccApp, proof);
+
+    expect(response.status).toBe(200);
+    expect(response.body.token_type).toBe('DPoP');
+    expect(cnfJkt(response.body.access_token)).toBe(key.jkt);
+  });
+
+  it('issues a plain bearer token when no proof is presented (opportunistic)', async () => {
+    const response = await clientCredentialsToken(fixture, fixture.ccApp);
+
+    expect(response.status).toBe(200);
+    expect(response.body.token_type).toBe('bearer');
+  });
+
+  it('rejects a proof whose htu does not match the token endpoint', async () => {
+    const key = await createDpopKey();
+    const proof = await key.proof({ htu: 'https://attacker.example/token', htm: 'POST' });
+    const response = await clientCredentialsToken(fixture, fixture.ccApp, proof);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_dpop_proof');
+  });
+});
+
+describe('DPoP (RFC 9449) — proof replay', () => {
+  it('rejects a proof that has already been used', async () => {
+    const key = await createDpopKey();
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+
+    const first = await clientCredentialsToken(fixture, fixture.ccApp, proof);
+    expect(first.status).toBe(200);
+
+    const second = await clientCredentialsToken(fixture, fixture.ccApp, proof);
+    expect(second.status).toBe(400);
+    expect(second.body.error).toBe('invalid_dpop_proof');
+  });
+});
+
+describe('DPoP (RFC 9449) — refresh-token key continuity', () => {
+  it('keeps the token bound to the original key across two consecutive refreshes', async () => {
+    const key = await createDpopKey();
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+
+    const initial = await passwordToken(fixture, proof);
+    expect(initial.status).toBe(200);
+    expect(initial.body.token_type).toBe('DPoP');
+    expect(cnfJkt(initial.body.access_token)).toBe(key.jkt);
+
+    let refreshToken = initial.body.refresh_token;
+    for (let i = 0; i < 2; i++) {
+      const refreshProof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+      const refreshed = await refreshAccessToken(fixture, refreshToken, refreshProof);
+
+      expect(refreshed.status).toBe(200);
+      expect(refreshed.body.token_type).toBe('DPoP');
+      expect(cnfJkt(refreshed.body.access_token)).toBe(key.jkt);
+      refreshToken = refreshed.body.refresh_token ?? refreshToken;
+    }
+  });
+
+  it('rejects a refresh of a DPoP-bound token when the proof is signed by a different key', async () => {
+    const key = await createDpopKey();
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const initial = await passwordToken(fixture, proof);
+    expect(initial.status).toBe(200);
+    expect(initial.body.token_type).toBe('DPoP');
+
+    const otherKey = await createDpopKey();
+    const wrongKeyProof = await otherKey.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const refreshed = await refreshAccessToken(fixture, initial.body.refresh_token, wrongKeyProof);
+
+    expect(refreshed.status).toBe(400);
+    expect(refreshed.body.error).toBe('invalid_dpop_proof');
+  });
+
+  it('rejects a refresh of a DPoP-bound token when no proof is presented', async () => {
+    const key = await createDpopKey();
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const initial = await passwordToken(fixture, proof);
+    expect(initial.status).toBe(200);
+    expect(initial.body.token_type).toBe('DPoP');
+
+    const refreshed = await refreshAccessToken(fixture, initial.body.refresh_token);
+
+    expect(refreshed.status).toBe(400);
+    expect(refreshed.body.error).toBe('invalid_request');
+  });
+});
+
+describe('DPoP (RFC 9449 §10) — authorization-code binding via dpop_jkt', () => {
+  it('binds the token to the committed dpop_jkt with a matching-key proof', async () => {
+    const key = await createDpopKey();
+    const code = await getAuthorizationCode(fixture, key.jkt);
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+
+    const response = await redeemAuthorizationCode(fixture, code, proof);
+    expect(response.status).toBe(200);
+    expect(response.body.token_type).toBe('DPoP');
+    expect(cnfJkt(response.body.access_token)).toBe(key.jkt);
+  });
+
+  it('rejects redemption of a dpop_jkt-bound code with no proof', async () => {
+    const key = await createDpopKey();
+    const code = await getAuthorizationCode(fixture, key.jkt);
+
+    const response = await redeemAuthorizationCode(fixture, code);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_dpop_proof');
+  });
+
+  it('rejects redemption of a dpop_jkt-bound code with a wrong-key proof', async () => {
+    const committedKey = await createDpopKey();
+    const otherKey = await createDpopKey();
+    const code = await getAuthorizationCode(fixture, committedKey.jkt);
+    const proof = await otherKey.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+
+    const response = await redeemAuthorizationCode(fixture, code, proof);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_dpop_proof');
+  });
+
+  it('falls back to opportunistic binding when no dpop_jkt is committed', async () => {
+    const key = await createDpopKey();
+    const code = await getAuthorizationCode(fixture);
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+
+    const response = await redeemAuthorizationCode(fixture, code, proof);
+    expect(response.status).toBe(200);
+    expect(response.body.token_type).toBe('DPoP');
+    expect(cnfJkt(response.body.access_token)).toBe(key.jkt);
+  });
+});
+
+describe('DPoP (RFC 9449) — per-application requirement', () => {
+  it('rejects a token request without a proof when the app requires DPoP', async () => {
+    // A wholly absent DPoP header on a require-DPoP app is a malformed request (invalid_request);
+    // a present-but-invalid proof is invalid_dpop_proof (see the token-endpoint binding cases).
+    const response = await clientCredentialsToken(fixture, fixture.requireApp);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+  });
+
+  it('issues a DPoP-bound token when the required proof is present', async () => {
+    const key = await createDpopKey();
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const response = await clientCredentialsToken(fixture, fixture.requireApp, proof);
+
+    expect(response.status).toBe(200);
+    expect(response.body.token_type).toBe('DPoP');
+    expect(cnfJkt(response.body.access_token)).toBe(key.jkt);
+  });
+});
+
+describe('DPoP (RFC 9449 §9) — resource access at /userinfo', () => {
+  it('accepts a DPoP-bound token presented with a valid ath proof', async () => {
+    const key = await createDpopKey();
+    const tokenProof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const accessToken = (await passwordToken(fixture, tokenProof)).body.access_token;
+    const userInfoProof = await key.proof({ htu: fixture.oidc.userinfo_endpoint, htm: 'GET', accessToken });
+
+    const response = await userInfo(fixture, 'DPoP ' + accessToken, userInfoProof);
+    expect(response.status).toBe(200);
+    expect(response.body.sub).toBeDefined();
+  });
+
+  it('rejects a DPoP-bound token presented under the Bearer scheme (downgrade guard)', async () => {
+    const key = await createDpopKey();
+    const tokenProof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const accessToken = (await passwordToken(fixture, tokenProof)).body.access_token;
+
+    const response = await userInfo(fixture, 'Bearer ' + accessToken);
+    expect(response.status).toBe(401);
+    expect(response.headers['www-authenticate']).toContain('DPoP');
+    expect(response.headers['www-authenticate']).toContain('error="invalid_token"');
+  });
+});

--- a/gravitee-am-test/specs/gateway/dpop/dpop-proof.ts
+++ b/gravitee-am-test/specs/gateway/dpop/dpop-proof.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { calculateJwkThumbprint, exportJWK, generateKeyPair, JWK, SignJWT } from 'jose';
+import { createHash, randomUUID } from 'crypto';
+
+/**
+ * DPoP (RFC 9449) proof factory for the JEST integration suite. Wraps `jose` to mint real,
+ * client-signed proofs and compute JWK thumbprints exactly as the gateway does. See
+ * `.scratch/dpop-jest-tests/issues/00-proof-minter-and-fixture.md`.
+ *
+ * Key facts (proven against a live gateway):
+ *  - `htu` must be the endpoint URL verbatim, including the `/{domain.hrid}` path segment — pass
+ *    `fixture.oidc.token_endpoint` / `userinfo_endpoint` straight through. The validator strips only
+ *    the query/fragment.
+ *  - `ath = base64url(sha256(access_token))`.
+ *  - A fresh `jti` is minted per proof (replay is enforced at the live endpoint); reuse a whole
+ *    proof string to test replay.
+ */
+export type DpopAlg = 'ES256' | 'RS256';
+
+export interface DpopProofOptions {
+  /** The endpoint URL, used verbatim as `htu`. */
+  htu: string;
+  /** The HTTP method, e.g. 'POST' | 'GET'. */
+  htm: string;
+  /** Resource proofs: the access token to hash into `ath`. */
+  accessToken?: string;
+  /** Override `jti` (defaults to a fresh UUID). */
+  jti?: string;
+  /** Override the issued-at, in epoch seconds (for staleness tests). */
+  iat?: number;
+}
+
+export interface DpopKey {
+  /** The RFC 7638 JWK thumbprint — what lands in the token's `cnf.jkt`. */
+  readonly jkt: string;
+  readonly publicJwk: JWK;
+  /** Mint a signed DPoP proof bound to this key. */
+  proof(options: DpopProofOptions): Promise<string>;
+}
+
+/** `ath` claim value for a given access token. */
+export function dpopAth(accessToken: string): string {
+  return createHash('sha256').update(accessToken).digest('base64url');
+}
+
+/** Create a fresh DPoP key that can mint proofs. Default `ES256`; `RS256` for allowlist tests. */
+export async function createDpopKey(alg: DpopAlg = 'ES256'): Promise<DpopKey> {
+  const { privateKey, publicKey } = await generateKeyPair(alg, { extractable: true });
+  const publicJwk = await exportJWK(publicKey);
+  const jkt = await calculateJwkThumbprint(publicJwk, 'sha256');
+
+  // The proof header carries the public key with the minimal members the thumbprint is computed over.
+  const jwkHeader: JWK =
+    alg === 'ES256'
+      ? { kty: publicJwk.kty, crv: publicJwk.crv, x: publicJwk.x, y: publicJwk.y }
+      : { kty: publicJwk.kty, n: publicJwk.n, e: publicJwk.e };
+
+  const proof = async (options: DpopProofOptions): Promise<string> => {
+    const claims: Record<string, unknown> = {
+      htm: options.htm,
+      htu: options.htu,
+      jti: options.jti ?? randomUUID(),
+    };
+    if (options.accessToken) {
+      claims.ath = dpopAth(options.accessToken);
+    }
+    const signer = new SignJWT(claims).setProtectedHeader({ alg, typ: 'dpop+jwt', jwk: jwkHeader });
+    signer.setIssuedAt(options.iat);
+    return signer.sign(privateKey);
+  };
+
+  return { jkt, publicJwk, proof };
+}

--- a/gravitee-am-test/specs/gateway/dpop/dpop-require-policy.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/dpop/dpop-require-policy.jest.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { cnfJkt, clientCredentialsToken, DpopRequiredFixture, setupDpopRequiredFixture, userInfo } from './fixture/dpop-fixture';
+import { createDpopKey } from './dpop-proof';
+
+setup(200000);
+
+let fixture: DpopRequiredFixture;
+
+beforeAll(async () => {
+  fixture = await setupDpopRequiredFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('DPoP (RFC 9449 §8) — domain-wide requirement (floor) at the token endpoint', () => {
+  it('rejects a token request without a proof for any application', async () => {
+    const response = await clientCredentialsToken(fixture, fixture.floorApp);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+  });
+
+  it('issues a DPoP-bound token when a proof is present', async () => {
+    const key = await createDpopKey();
+    const proof = await key.proof({ htu: fixture.oidc.token_endpoint, htm: 'POST' });
+    const response = await clientCredentialsToken(fixture, fixture.floorApp, proof);
+
+    expect(response.status).toBe(200);
+    expect(response.body.token_type).toBe('DPoP');
+    expect(cnfJkt(response.body.access_token)).toBe(key.jkt);
+  });
+});
+
+describe('DPoP (RFC 9449 §9) — resource enforcement under the floor', () => {
+  it('challenges an unauthenticated /userinfo request with the Bearer scheme', async () => {
+    // Finding: the domain-wide DPoP floor does NOT escalate the anonymous challenge to the DPoP
+    // scheme — an unauthenticated request still gets the default Bearer challenge, identical to a
+    // require-off domain. The DPoP challenge is emitted only for a mis-presented sender-constrained
+    // token (covered on Domain A). The floor's real teeth are at the token endpoint (above).
+    const response = await userInfo(fixture);
+
+    expect(response.status).toBe(401);
+    expect(response.headers['www-authenticate']).toBe('Bearer realm="gravitee-io"');
+  });
+});

--- a/gravitee-am-test/specs/gateway/dpop/fixture/dpop-fixture.ts
+++ b/gravitee-am-test/specs/gateway/dpop/fixture/dpop-fixture.ts
@@ -1,0 +1,407 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import {
+  createDomain,
+  DomainOidcConfig,
+  patchDomain,
+  safeDeleteDomain,
+  startDomain,
+  waitForDomainStart,
+} from '@management-commands/domain-management-commands';
+import { getDomainManagerUrl } from '@management-commands/service/utils';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createApplication, updateApplication } from '@management-commands/application-management-commands';
+import { createIdp, deleteIdp, getAllIdps } from '@management-commands/idp-management-commands';
+import { createScope } from '@management-commands/scope-management-commands';
+import {
+  extractXsrfTokenAndActionResponse,
+  performFormPost,
+  performGet,
+  performPatch,
+  performPost,
+} from '@gateway-commands/oauth-oidc-commands';
+import { applicationBase64Token } from '@gateway-commands/utils';
+import { createDomainCertificate } from '../../oauth2/fixture/oauth2-cert-fixture';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+/**
+ * Domain A — the "require-DPoP off" domain for the binding suite. Carries a signing certificate so
+ * access tokens are JWTs and `cnf.jkt` is observable. See
+ * `.scratch/dpop-jest-tests/issues/00-proof-minter-and-fixture.md`.
+ */
+export interface DpopFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  users: { username: string; password: string }[];
+  /** SERVICE, client_credentials. */
+  ccApp: Application;
+  /** WEB, authorization_code + refresh_token + password, openid + scope1, consent skipped. */
+  webApp: Application;
+  /** SERVICE, client_credentials, per-app dpopBoundAccessTokens = true (requires DPoP). */
+  requireApp: Application;
+}
+
+const USER_PASSWORD = '#CoMpL3X-P@SsW0Rd';
+
+export const setupDpopFixture = async (): Promise<DpopFixture> => {
+  const accessToken = await requestAdminAccessToken();
+
+  const domain = await createDomain(accessToken, uniqueName('dpop-optional', true), 'DPoP binding suite (require off)')
+    .then((d) => makeMaster(d, accessToken))
+    .then((d) => createDomainCertificate(d, accessToken).then(() => d));
+
+  const idp = await createInlineIdp(domain, accessToken);
+  await createScope(domain.id, accessToken, { key: 'scope1', name: 'scope1', description: 'scope1' });
+
+  const idps = [{ identity: idp.id, priority: -1 }];
+  const ccApp = await createApp(domain, accessToken, {
+    type: 'SERVICE',
+    grantTypes: ['client_credentials'],
+    scopeSettings: [{ scope: 'scope1', defaultScope: true }],
+  });
+  const webApp = await createApp(domain, accessToken, {
+    type: 'WEB',
+    grantTypes: ['authorization_code', 'refresh_token', 'password'],
+    scopeSettings: [
+      { scope: 'scope1', defaultScope: true },
+      { scope: 'openid', defaultScope: true },
+    ],
+    identityProviders: idps,
+    skipConsent: true,
+  });
+  const requireApp = await createApp(domain, accessToken, {
+    type: 'SERVICE',
+    grantTypes: ['client_credentials'],
+    scopeSettings: [{ scope: 'scope1', defaultScope: true }],
+    dpopBoundAccessTokens: true,
+  });
+
+  await startDomain(domain.id, accessToken);
+  const { oidcConfig } = await waitForDomainStart(domain);
+
+  return {
+    accessToken,
+    domain,
+    oidc: oidcConfig,
+    users: idp.users,
+    ccApp,
+    webApp,
+    requireApp,
+    cleanUp: async () => {
+      if (domain?.id && accessToken) {
+        await safeDeleteDomain(domain.id, accessToken);
+      }
+    },
+  };
+};
+
+/**
+ * Domain B — the domain-wide "require-DPoP floor" domain. Every application must present a DPoP
+ * proof at the token endpoint regardless of its own flag. Ticket 02.
+ */
+export interface DpopRequiredFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  /** SERVICE, client_credentials — no per-app DPoP flag; the domain floor does the work. */
+  floorApp: Application;
+}
+
+export const setupDpopRequiredFixture = async (): Promise<DpopRequiredFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  const domain = await createDomain(accessToken, uniqueName('dpop-required', true), 'DPoP binding suite (domain floor)')
+    .then((d) => makeMaster(d, accessToken))
+    .then((d) => createDomainCertificate(d, accessToken).then(() => d));
+
+  await createScope(domain.id, accessToken, { key: 'scope1', name: 'scope1', description: 'scope1' });
+  const floorApp = await createApp(domain, accessToken, {
+    type: 'SERVICE',
+    grantTypes: ['client_credentials'],
+    scopeSettings: [{ scope: 'scope1', defaultScope: true }],
+  });
+
+  // Domain-wide DPoP floor. The generated SDK does not expose dpopSettings → raw PATCH.
+  await patchDomainOidc(domain.id, accessToken, { dpopSettings: { requireDpopForAll: true } });
+
+  await startDomain(domain.id, accessToken);
+  const { oidcConfig } = await waitForDomainStart(domain);
+
+  return {
+    accessToken,
+    domain,
+    oidc: oidcConfig,
+    floorApp,
+    cleanUp: async () => {
+      if (domain?.id && accessToken) {
+        await safeDeleteDomain(domain.id, accessToken);
+      }
+    },
+  };
+};
+
+/**
+ * Domain C — restricts DPoP proof signing to a per-domain allowlist (default ES256 only). Ticket 03.
+ */
+export interface DpopAllowlistFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  /** SERVICE, client_credentials. */
+  algApp: Application;
+  algorithms: string[];
+}
+
+export const setupDpopAllowlistFixture = async (algorithms: string[] = ['ES256']): Promise<DpopAllowlistFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  const domain = await createDomain(accessToken, uniqueName('dpop-alg', true), 'DPoP binding suite (algorithm allowlist)')
+    .then((d) => makeMaster(d, accessToken))
+    .then((d) => createDomainCertificate(d, accessToken).then(() => d));
+
+  await createScope(domain.id, accessToken, { key: 'scope1', name: 'scope1', description: 'scope1' });
+  const algApp = await createApp(domain, accessToken, {
+    type: 'SERVICE',
+    grantTypes: ['client_credentials'],
+    scopeSettings: [{ scope: 'scope1', defaultScope: true }],
+  });
+
+  // Per-domain signing-algorithm allowlist. The generated SDK does not expose it → raw PATCH.
+  await patchDomainOidc(domain.id, accessToken, { dpopSettings: { dpopSigningAlgorithms: algorithms } });
+
+  await startDomain(domain.id, accessToken);
+  const { oidcConfig } = await waitForDomainStart(domain);
+
+  return {
+    accessToken,
+    domain,
+    oidc: oidcConfig,
+    algApp,
+    algorithms,
+    cleanUp: async () => {
+      if (domain?.id && accessToken) {
+        await safeDeleteDomain(domain.id, accessToken);
+      }
+    },
+  };
+};
+
+// --- request helpers (kept here so specs contain only setup/teardown and test cases) ------------
+
+const FORM = 'application/x-www-form-urlencoded';
+
+/** The minimum a request helper needs from any of the DPoP fixtures. */
+type WithOidc = { oidc: DomainOidcConfig };
+
+function basicAuth(app: Application): string {
+  return 'Basic ' + applicationBase64Token(app);
+}
+
+/** The `cnf.jkt` claim carried by a JWT access token. */
+export function cnfJkt(accessToken: string): string | undefined {
+  const payload = JSON.parse(Buffer.from(accessToken.split('.')[1], 'base64url').toString('utf8'));
+  return payload.cnf?.jkt;
+}
+
+/** POST the token endpoint with a client_credentials grant, optionally presenting a DPoP proof. */
+export function clientCredentialsToken(fixture: WithOidc, app: Application, proof?: string) {
+  const headers: Record<string, string> = { 'Content-type': FORM, Authorization: basicAuth(app) };
+  if (proof) {
+    headers.DPoP = proof;
+  }
+  return performPost(fixture.oidc.token_endpoint, '', 'grant_type=client_credentials', headers);
+}
+
+/** POST the token endpoint with a password grant for the fixture's user (openid scope). */
+export function passwordToken(fixture: DpopFixture, proof?: string) {
+  const user = fixture.users[0];
+  const headers: Record<string, string> = { 'Content-type': FORM, Authorization: basicAuth(fixture.webApp) };
+  if (proof) {
+    headers.DPoP = proof;
+  }
+  return performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=password&username=${user.username}&password=${encodeURIComponent(user.password)}&scope=openid`,
+    headers,
+  );
+}
+
+/** POST the token endpoint with a refresh_token grant (webApp), optionally presenting a DPoP proof. */
+export function refreshAccessToken(fixture: DpopFixture, refreshToken: string, proof?: string) {
+  const headers: Record<string, string> = { 'Content-type': FORM, Authorization: basicAuth(fixture.webApp) };
+  if (proof) {
+    headers.DPoP = proof;
+  }
+  return performPost(fixture.oidc.token_endpoint, '', `grant_type=refresh_token&refresh_token=${refreshToken}`, headers);
+}
+
+/**
+ * Run the full authorize + login flow for the fixture's user (accepting consent if presented) and
+ * return the authorization code, optionally committing a `dpop_jkt`. Mirrors executeAuthCodeFlow in
+ * oauth-flows.jest.spec.ts; webApp skips consent, but the fallback keeps this robust if that changes.
+ */
+export async function getAuthorizationCode(fixture: DpopFixture, dpopJkt?: string): Promise<string> {
+  const user = fixture.users[0];
+  const clientId = fixture.webApp.settings.oauth.clientId;
+  const jktParam = dpopJkt ? `&dpop_jkt=${dpopJkt}` : '';
+  const params = `?response_type=code&client_id=${clientId}&redirect_uri=http://localhost:4000/&scope=openid${jktParam}`;
+
+  const authResponse = await performGet(fixture.oidc.authorization_endpoint, params).expect(302);
+  const { headers, token, action } = await extractXsrfTokenAndActionResponse(authResponse);
+  const postLogin = await performFormPost(
+    action,
+    '',
+    { 'X-XSRF-TOKEN': token, username: user.username, password: user.password, client_id: clientId },
+    { Cookie: headers['set-cookie'], 'Content-type': FORM },
+  ).expect(302);
+
+  let redirect = await performGet(postLogin.headers['location'], '', { Cookie: postLogin.headers['set-cookie'] }).expect(302);
+
+  // Accept the consent screen if one is shown.
+  if (redirect.headers['location']?.includes('/oauth/consent')) {
+    const consent = await extractXsrfTokenAndActionResponse(redirect);
+    const postConsent = await performFormPost(
+      consent.action,
+      '',
+      { 'X-XSRF-TOKEN': consent.token, 'scope.openid': true, user_oauth_approval: true },
+      { Cookie: consent.headers['set-cookie'], 'Content-type': FORM },
+    ).expect(302);
+    redirect = await performGet(postConsent.headers['location'], '', { Cookie: postLogin.headers['set-cookie'] }).expect(302);
+  }
+
+  const codePattern = /code=([-_a-zA-Z0-9]+)&?/;
+  expect(redirect.headers['location']).toMatch(codePattern);
+  return redirect.headers['location'].match(codePattern)[1];
+}
+
+/** Redeem an authorization code (webApp), optionally presenting a DPoP proof. */
+export function redeemAuthorizationCode(fixture: DpopFixture, code: string, proof?: string) {
+  const headers: Record<string, string> = { Authorization: basicAuth(fixture.webApp) };
+  if (proof) {
+    headers.DPoP = proof;
+  }
+  return performPost(
+    `${fixture.oidc.token_endpoint}?grant_type=authorization_code&code=${code}&redirect_uri=http://localhost:4000/`,
+    '',
+    null,
+    headers,
+  );
+}
+
+/**
+ * GET /userinfo, optionally with a full Authorization header value and a DPoP proof. Omitting the
+ * authorization sends an anonymous request.
+ */
+export function userInfo(fixture: WithOidc, authorization?: string, proof?: string) {
+  const headers: Record<string, string> = {};
+  if (authorization) {
+    headers.Authorization = authorization;
+  }
+  if (proof) {
+    headers.DPoP = proof;
+  }
+  return performGet(fixture.oidc.userinfo_endpoint, '', headers);
+}
+
+/** Deep-merge DPoP OIDC settings the generated SDK does not expose (raw PATCH). */
+async function patchDomainOidc(domainId: string, accessToken: string, oidc: Record<string, unknown>): Promise<void> {
+  await performPatch(
+    getDomainManagerUrl(domainId),
+    '',
+    { oidc },
+    { Authorization: `Bearer ${accessToken}`, 'Content-type': 'application/json' },
+  ).expect(200);
+}
+
+async function makeMaster(domain: Domain, accessToken: string): Promise<Domain> {
+  const patched = await patchDomain(domain.id, accessToken, {
+    master: true,
+    oidc: {
+      clientRegistrationSettings: {
+        allowLocalhostRedirectUri: true,
+        allowHttpSchemeRedirectUri: true,
+        allowWildCardRedirectUri: true,
+        isDynamicClientRegistrationEnabled: false,
+        isOpenDynamicClientRegistrationEnabled: false,
+      },
+    },
+  });
+  expect(patched.master).toBeTruthy();
+  return patched;
+}
+
+async function createInlineIdp(domain: Domain, accessToken: string) {
+  await deleteIdp(domain.id, accessToken, 'default-idp-' + domain.id);
+  expect((await getAllIdps(domain.id, accessToken)).length).toEqual(0);
+
+  const users = [{ firstname: 'Joe', lastname: 'Doe', username: uniqueName('joe.doe', true), password: USER_PASSWORD }];
+  const idp = await createIdp(domain.id, accessToken, {
+    external: false,
+    type: 'inline-am-idp',
+    domainWhitelist: [],
+    configuration: JSON.stringify({ users }),
+    name: 'inmemory',
+  });
+  expect(idp).toBeDefined();
+  return { id: idp.id, users: users.map((u) => ({ username: u.username, password: u.password })) };
+}
+
+interface AppSpec {
+  type: 'WEB' | 'SERVICE';
+  grantTypes: string[];
+  scopeSettings: any[];
+  identityProviders?: any[];
+  skipConsent?: boolean;
+  dpopBoundAccessTokens?: boolean;
+}
+
+async function createApp(domain: Domain, accessToken: string, spec: AppSpec): Promise<Application> {
+  const created = await createApplication(domain.id, accessToken, {
+    name: uniqueName('dpop-client', true),
+    type: spec.type,
+    clientId: uniqueName('dpop-clientId', true),
+    redirectUris: ['http://localhost:4000/'],
+  });
+
+  const updateBody: any = {
+    settings: {
+      oauth: {
+        redirectUris: ['http://localhost:4000/'],
+        grantTypes: spec.grantTypes,
+        scopeSettings: spec.scopeSettings,
+      },
+      ...(spec.skipConsent ? { advanced: { skipConsent: true } } : {}),
+    },
+    identityProviders: spec.identityProviders,
+  };
+  const updated = await updateApplication(domain.id, accessToken, updateBody, created.id);
+  // Restore the secret from the create response (the update response omits it).
+  updated.settings.oauth.clientSecret = created.settings.oauth.clientSecret;
+
+  if (spec.dpopBoundAccessTokens) {
+    // The generated TS SDK does not expose `dpopBoundAccessTokens`; its typed serializer would drop
+    // it. Set it with a raw merge-PATCH straight to the management API.
+    await performPatch(
+      `${getDomainManagerUrl(domain.id)}/applications/${created.id}`,
+      '',
+      { settings: { oauth: { dpopBoundAccessTokens: true } } },
+      { Authorization: `Bearer ${accessToken}`, 'Content-type': 'application/json' },
+    ).expect(200);
+  }
+
+  return updated;
+}

--- a/gravitee-am-ui/src/app/app-routing.module.ts
+++ b/gravitee-am-ui/src/app/app-routing.module.ts
@@ -238,6 +238,7 @@ import { CibaSettingsComponent } from './domain/settings/openid/ciba/settings/ci
 import { SpiffeSettingsComponent } from './domain/settings/openid/spiffe/spiffe-settings.component';
 import { Saml2Component } from './domain/settings/saml2/saml2.component';
 import { CimdSettingsComponent } from './domain/settings/cimd/cimd.component';
+import { DpopSettingsComponent } from './domain/settings/oauth/dpop/dpop.component';
 import { DeviceNotifiersComponent } from './domain/settings/openid/ciba/device-notifiers/device-notifiers.component';
 import { DeviceNotifiersCreationComponent } from './domain/settings/openid/ciba/device-notifiers/create/device-notifiers-creation.component';
 import { DeviceNotifiersResolver } from './resolvers/device-notifiers.resolver';
@@ -3038,6 +3039,21 @@ export const routes: Routes = [
                         data: {
                           menu: {
                             label: 'CIMD',
+                            section: 'OAuth 2.0',
+                            level: 'level2',
+                          },
+                          perms: {
+                            only: ['domain_openid_read'],
+                          },
+                        },
+                      },
+                      {
+                        path: 'dpop',
+                        component: DpopSettingsComponent,
+                        canActivate: [AuthGuard],
+                        data: {
+                          menu: {
+                            label: 'DPoP',
                             section: 'OAuth 2.0',
                             level: 'level2',
                           },

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -434,6 +434,7 @@ import { CookieSettingsComponent } from './domain/components/cookie/cookie-setti
 import { UserNotificationsService } from './services/user-notifications.service';
 import { Saml2Component } from './domain/settings/saml2/saml2.component';
 import { CimdSettingsComponent } from './domain/settings/cimd/cimd.component';
+import { DpopSettingsComponent } from './domain/settings/oauth/dpop/dpop.component';
 import { MfaSelectComponent } from './domain/applications/application/advanced/factors/mfa/mfa-select.component';
 import { MfaRememberDeviceComponent } from './domain/applications/application/advanced/factors/remember-device/mfa-remember-device.component';
 import { TimeConverterService } from './services/time-converter.service';
@@ -746,6 +747,7 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     SpiffeSettingsComponent,
     Saml2Component,
     CimdSettingsComponent,
+    DpopSettingsComponent,
     DeviceNotifiersComponent,
     DeviceNotifierComponent,
     DeviceNotifierFormComponent,

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/component/oauth2-settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/component/oauth2-settings.component.ts
@@ -75,6 +75,7 @@ export class OAuth2SettingsComponent implements OnInit {
     this.oauthSettings.redirectUris = newSettings.redirectUris;
     this.oauthSettings.forcePKCE = newSettings.forcePKCE;
     this.oauthSettings.forceS256CodeChallengeMethod = newSettings.forceS256CodeChallengeMethod;
+    this.oauthSettings.dpopBoundAccessTokens = newSettings.dpopBoundAccessTokens;
     this.oauthSettings.tokenEndpointAuthMethod = newSettings.tokenEndpointAuthMethod;
     this.oauthSettings.tlsClientAuthSubjectDn = newSettings.tlsClientAuthSubjectDn;
     this.oauthSettings.tlsClientAuthSanDns = newSettings.tlsClientAuthSanDns;
@@ -142,6 +143,7 @@ export class OAuth2SettingsComponent implements OnInit {
     oauthSettings.redirectUris = this.oauthSettings.redirectUris;
     oauthSettings.forcePKCE = this.oauthSettings.forcePKCE;
     oauthSettings.forceS256CodeChallengeMethod = this.oauthSettings.forceS256CodeChallengeMethod;
+    oauthSettings.dpopBoundAccessTokens = this.oauthSettings.dpopBoundAccessTokens;
     oauthSettings.tokenEndpointAuthMethod = this.oauthSettings.tokenEndpointAuthMethod;
     oauthSettings.tlsClientAuthSubjectDn = this.oauthSettings.tlsClientAuthSubjectDn;
     oauthSettings.tlsClientAuthSanDns = this.oauthSettings.tlsClientAuthSanDns;

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.html
@@ -133,6 +133,20 @@
 
       <div class="gv-form-section">
         <div class="gv-form-section-title">
+          <h5>Demonstrating Proof-of-Possession (DPoP)</h5>
+          <small>DPoP binds access tokens to a key held by the client, so a stolen token cannot be replayed without the private key.</small>
+          <mat-divider></mat-divider>
+        </div>
+        <div fxLayout="column">
+          <mat-slide-toggle (change)="dpopBoundAccessTokens($event)" [checked]="isDpopBoundAccessTokens()" [disabled]="readonly">
+            DPoP-bound access tokens
+          </mat-slide-toggle>
+          <mat-hint style="font-size: 75%">Require this client to send a valid DPoP proof at the token endpoint.</mat-hint>
+        </div>
+      </div>
+
+      <div class="gv-form-section">
+        <div class="gv-form-section-title">
           <h5>Public / Confidential</h5>
           <small>Clients capability of maintaining the confidentiality of their credentials.</small>
           <small>Native or SPA applications are incapable of secure their credentials and should set this value to "none".</small>

--- a/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/oauth2-settings/grant-flows/grant-flows.component.ts
@@ -205,6 +205,15 @@ export class GrantFlowsComponent implements OnInit {
     return this.oauthSettings.forceS256CodeChallengeMethod;
   }
 
+  dpopBoundAccessTokens(event) {
+    this.oauthSettings.dpopBoundAccessTokens = event.checked;
+    this.modelChanged();
+  }
+
+  isDpopBoundAccessTokens() {
+    return this.oauthSettings.dpopBoundAccessTokens;
+  }
+
   isRefreshTokenFlowSelected() {
     return this.selectedGrantTypes.includes('refresh_token');
   }

--- a/gravitee-am-ui/src/app/domain/settings/oauth/dpop/dpop.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/oauth/dpop/dpop.component.html
@@ -1,0 +1,80 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="gv-page-container">
+  <h1>DPoP</h1>
+  <div>
+    <div fxFlex="70">
+      <form #dpopSettingsForm="ngForm" (ngSubmit)="save()" (keydown.enter)="(false)">
+        <div class="gv-form-section" fxLayout="column">
+          <mat-slide-toggle (change)="enableRequireDpopForAll($event)" [checked]="requireDpopForAll" [disabled]="!editMode">
+            Require DPoP for all clients
+          </mat-slide-toggle>
+          <mat-hint style="font-size: 75%"
+            >Force every client in this domain to send a valid DPoP proof at the token endpoint, regardless of each application's own DPoP
+            setting.</mat-hint
+          >
+        </div>
+
+        <div class="gv-form-section" fxLayout="column">
+          <div class="gv-form-section-title">
+            <h5>Allowed signing algorithms</h5>
+            <small>Restrict the JWS algorithms accepted in DPoP proofs. Leave empty to allow all supported algorithms.</small>
+            <mat-divider></mat-divider>
+          </div>
+          <mat-form-field appearance="outline" floatLabel="always">
+            <mat-label>Allowed DPoP signing algorithms</mat-label>
+            <mat-select
+              multiple
+              placeholder="ALL"
+              name="dpopSigningAlgorithms"
+              [(ngModel)]="dpopSigningAlgorithms"
+              (selectionChange)="onFormChange()"
+              [disabled]="!editMode"
+            >
+              <mat-option *ngFor="let alg of supportedAlgorithms" [value]="alg">{{ alg }}</mat-option>
+            </mat-select>
+            <mat-hint>Leave empty to allow all supported algorithms (ES256/384/512, RS256/384/512).</mat-hint>
+          </mat-form-field>
+        </div>
+
+        <div fxLayout="row" *ngIf="editMode">
+          <button mat-raised-button color="primary" [disabled]="!dpopSettingsForm.valid || !formChanged" type="submit">SAVE</button>
+        </div>
+      </form>
+    </div>
+    <div class="gv-page-description" fxFlex>
+      <h3>DPoP</h3>
+      <div class="gv-page-description-content">
+        <p>
+          Demonstrating Proof-of-Possession (DPoP, RFC 9449) binds an access token to a key held by the client, so a stolen token cannot be
+          replayed without the corresponding private key.
+        </p>
+        <h4>Require DPoP for all clients</h4>
+        <p>
+          When enabled, this domain-wide floor forces every client to present a DPoP proof at the token endpoint. It cannot be overridden by
+          an application whose own DPoP-bound access tokens setting is off.
+        </p>
+        <h4>Allowed signing algorithms</h4>
+        <p>
+          Optionally restrict which JWS algorithms are accepted in DPoP proofs. Leaving the list empty advertises and accepts all supported
+          algorithms.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/gravitee-am-ui/src/app/domain/settings/oauth/dpop/dpop.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/oauth/dpop/dpop.component.scss
@@ -1,0 +1,5 @@
+.gv-form-section {
+  mat-slide-toggle + mat-hint {
+    margin-top: 4px;
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/oauth/dpop/dpop.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/oauth/dpop/dpop.component.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, OnInit } from '@angular/core';
+import { deepClone } from '@gravitee/ui-components/src/lib/utils';
+
+import { SnackbarService } from '../../../../services/snackbar.service';
+import { DomainService } from '../../../../services/domain.service';
+import { AuthService } from '../../../../services/auth.service';
+import { DomainStoreService } from '../../../../stores/domain.store';
+
+const DPOP_SUPPORTED_ALGORITHMS = ['ES256', 'ES384', 'ES512', 'RS256', 'RS384', 'RS512'];
+
+@Component({
+  selector: 'app-dpop',
+  templateUrl: './dpop.component.html',
+  styleUrls: ['./dpop.component.scss'],
+  standalone: false,
+})
+export class DpopSettingsComponent implements OnInit {
+  readonly supportedAlgorithms = DPOP_SUPPORTED_ALGORITHMS;
+  domain: any = {};
+  domainId: string;
+  requireDpopForAll = false;
+  dpopSigningAlgorithms: string[] = [];
+  formChanged = false;
+  editMode: boolean;
+
+  constructor(
+    private domainService: DomainService,
+    private snackbarService: SnackbarService,
+    private authService: AuthService,
+    private domainStore: DomainStoreService,
+  ) {}
+
+  ngOnInit() {
+    this.domainStore.domain$.subscribe((domain) => {
+      this.domain = deepClone(domain);
+      this.domainId = this.domain.id;
+      this.requireDpopForAll = this.domain.oidc?.dpopSettings?.requireDpopForAll ?? false;
+      this.dpopSigningAlgorithms = this.domain.oidc?.dpopSettings?.dpopSigningAlgorithms ?? [];
+    });
+    this.editMode = this.authService.hasPermissions(['domain_openid_update']);
+  }
+
+  save() {
+    // Empty selection means "no restriction": send null so the backend clears the
+    // allowlist (an empty array is rejected server-side).
+    const dpopSettings = {
+      requireDpopForAll: this.requireDpopForAll,
+      dpopSigningAlgorithms: this.dpopSigningAlgorithms.length ? this.dpopSigningAlgorithms : null,
+    };
+    this.domainService.patchDpopSettings(this.domainId, dpopSettings).subscribe({
+      next: (data) => {
+        this.domainStore.set(data);
+        this.domain = data;
+        this.requireDpopForAll = data.oidc?.dpopSettings?.requireDpopForAll ?? false;
+        this.dpopSigningAlgorithms = data.oidc?.dpopSettings?.dpopSigningAlgorithms ?? [];
+        this.formChanged = false;
+        this.snackbarService.open('DPoP configuration updated');
+      },
+      error: (error: unknown) => {
+        const httpError = error as { error?: { message?: string } };
+        if (httpError?.error?.message) {
+          this.snackbarService.open(httpError.error.message);
+        } else {
+          this.snackbarService.open('Failed to update DPoP configuration');
+        }
+      },
+    });
+  }
+
+  enableRequireDpopForAll(event) {
+    this.requireDpopForAll = event.checked;
+    this.formChanged = true;
+  }
+
+  onFormChange() {
+    this.formChanged = true;
+  }
+}

--- a/gravitee-am-ui/src/app/services/domain.service.ts
+++ b/gravitee-am-ui/src/app/services/domain.service.ts
@@ -160,6 +160,18 @@ export class DomainService {
     );
   }
 
+  patchDpopSettings(id, dpopSettings): Observable<any> {
+    return this.http.patch<any>(
+      this.domainsURL + id,
+      {
+        oidc: { dpopSettings },
+      },
+      {
+        context: new HttpContext().set(SKIP_ERROR_SNACKBAR, true),
+      },
+    );
+  }
+
   patchScimSettings(id, domain): Observable<any> {
     return this.http.patch<any>(this.domainsURL + id, {
       scim: domain.scim,

--- a/gravitee-am-ui/yarn.lock
+++ b/gravitee-am-ui/yarn.lock
@@ -6903,19 +6903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.17.1, ajv@npm:^8.9.0":
-  version: 8.20.0
-  resolution: "ajv@npm:8.20.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.18.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.17.1, ajv@npm:^8.18.0, ajv@npm:^8.9.0":
   version: 8.20.0
   resolution: "ajv@npm:8.20.0"
   dependencies:
@@ -18490,16 +18478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.8.0":
-  version: 2.9.0
-  resolution: "yaml@npm:2.9.0"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.8.2":
+"yaml@npm:^2.8.0, yaml@npm:^2.8.2":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:


### PR DESCRIPTION
Implements OAuth 2.0 Demonstrating Proof of Possession across the gateway, management API, model/repositories and console UI.

- Centralized DPoPProofValidator (RFC 9449 proof parsing/validation)
- Issue DPoP-bound tokens for all token-endpoint grants (jkt binding), with client_credentials and refresh-token key continuity
- Bind authorization code to the DPoP key via dpop_jkt (§10)
- Enforce DPoP-bound tokens at the shared bearer gate (OAuth2AuthHandler), including SCIM/users resource enforcement
- Configurable require-DPoP policy: per-app flag + per-domain floor
- Per-domain signing-algorithm allowlist (enforcement + discovery)
- Advertise dpop_signing_alg_values_supported in OIDC discovery
- Persist token jkt (Mongo + JDBC liquibase changelog)
- Domain/Application DPoP settings, patch models, and console UI
- DPoP cluster replay cache
- Auditing on token miting

[dpop-spec.html](https://github.com/user-attachments/files/29946529/dpop-spec.html)

[dpop-rfc9449-v1.md](https://github.com/user-attachments/files/29946554/dpop-rfc9449-v1.md)
[dpop-rfc9449-v2.md](https://github.com/user-attachments/files/29946555/dpop-rfc9449-v2.md)
[dpop-rfc9449-v3.md](https://github.com/user-attachments/files/29946556/dpop-rfc9449-v3.md)

Testing guide
[dpop-testing-guide.html](https://github.com/user-attachments/files/30650991/dpop-testing-guide.html)

<img width="1213" height="607" alt="image" src="https://github.com/user-attachments/assets/c80d1766-a5f6-4b5e-974b-500501404c39" />

<img width="1359" height="783" alt="image" src="https://github.com/user-attachments/assets/c623ee2d-b47f-422a-916b-e9338abb1ddd" />

Token AUDIT:
<img width="1521" height="293" alt="image" src="https://github.com/user-attachments/assets/39daab64-3e2a-495c-8a36-a6d16ab00b92" />

<img width="728" height="220" alt="image" src="https://github.com/user-attachments/assets/4e17e136-ac29-4142-816d-91de323a2cc3" />




