### PR TITLE
feat: add License repository to persist a license linked to an organization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ Gravitee Access Management is an identity and access management (IAM) platform s
 - Keep changes small and reviewable; avoid unrelated refactors or reformatting.
 - Prefer existing patterns over inventing new ones.
 - Each new Java/Typescript file should contain the license header
+- For **new** Java models/POJOs: use Lombok for mutable types — prefer `@Data` when it covers all needs, otherwise compose `@Getter`/`@Setter`/`@ToString`/`@AllArgsConstructor` — and use `record`s for immutable/simple ones. Do not retrofit existing models.
 
 ---
 

--- a/docs/agent-standards/cursor-rules/30-architecture-backend.mdc
+++ b/docs/agent-standards/cursor-rules/30-architecture-backend.mdc
@@ -17,6 +17,10 @@ alwaysApply: true
 - Use `Single`/`Maybe` for I/O operations and `Completable` for side-effect operations.
 - Preserve error intent: expected 4xx must not become generic 5xx.
 
+## Models / POJOs
+
+- For **new** models: use Lombok for mutable types — prefer `@Data` when it covers all needs, otherwise compose `@Getter`/`@Setter`/`@ToString`/`@AllArgsConstructor` — and use `record`s for immutable/simple ones. Do not retrofit existing models.
+
 ## Audit Logging (Mandatory for C/U/D)
 
 Audit logging is mandatory for **CREATE/UPDATE/DELETE**:

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/License.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/License.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model;
+
+import lombok.Data;
+
+import java.util.Date;
+
+/**
+ * A Gravitee license attached to a reference (typically an organization).
+ * The entity is uniquely identified by the pair (referenceType, referenceId).
+ *
+ * @author GraviteeSource Team
+ */
+@Data
+public class License {
+
+    private String referenceId;
+
+    private ReferenceType referenceType;
+
+    private String license;
+
+    private Date createdAt;
+
+    private Date updatedAt;
+}

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/LicenseRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/LicenseRepository.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.management.api;
+
+import io.gravitee.am.model.License;
+import io.gravitee.am.model.ReferenceType;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * The {@link License} entity is identified by the composite key (referenceType, referenceId),
+ * so this repository does not extend {@code CrudRepository} (single identifier).
+ *
+ * @author GraviteeSource Team
+ */
+public interface LicenseRepository {
+
+    Flowable<License> findAll();
+
+    Maybe<License> findById(String referenceId, ReferenceType referenceType);
+
+    Single<License> create(License license);
+
+    Single<License> update(License license);
+
+    Completable delete(String referenceId, ReferenceType referenceType);
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcLicenseRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcLicenseRepository.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.management.api;
+
+import io.gravitee.am.model.License;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.jdbc.management.AbstractJdbcRepository;
+import io.gravitee.am.repository.jdbc.management.api.model.JdbcLicense;
+import io.gravitee.am.repository.management.api.LicenseRepository;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.relational.core.query.Query;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.data.relational.core.query.Criteria.where;
+import static reactor.adapter.rxjava.RxJava3Adapter.monoToCompletable;
+import static reactor.adapter.rxjava.RxJava3Adapter.monoToSingle;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Repository
+public class JdbcLicenseRepository extends AbstractJdbcRepository implements LicenseRepository, InitializingBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcLicenseRepository.class);
+
+    private static final String TABLE = "licenses";
+    private static final String COL_REFERENCE_ID = "reference_id";
+    private static final String COL_REFERENCE_TYPE = "reference_type";
+    private static final String COL_LICENSE = "license";
+    private static final String COL_CREATED_AT = "created_at";
+    private static final String COL_UPDATED_AT = "updated_at";
+
+    private static final List<String> COLUMNS = List.of(
+            COL_REFERENCE_ID,
+            COL_REFERENCE_TYPE,
+            COL_LICENSE,
+            COL_CREATED_AT,
+            COL_UPDATED_AT);
+
+    private static final List<String> KEY_COLUMNS = List.of(COL_REFERENCE_ID, COL_REFERENCE_TYPE);
+
+    private String insertStatement;
+    private String updateStatement;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.insertStatement = createInsertStatement(TABLE, COLUMNS);
+        // only the mutable columns are updated, the composite key is used in the WHERE clause
+        this.updateStatement = createUpdateStatement(TABLE, List.of(COL_LICENSE, COL_UPDATED_AT), KEY_COLUMNS);
+    }
+
+    @Override
+    public Flowable<License> findAll() {
+        LOGGER.debug("findAll()");
+        return findAll(Query.empty(), JdbcLicense.class)
+                .map(this::toEntity)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Maybe<License> findById(String referenceId, ReferenceType referenceType) {
+        LOGGER.debug("findById({}, {})", referenceId, referenceType);
+        return findOne(Query.query(where(COL_REFERENCE_ID).is(referenceId)
+                        .and(where(COL_REFERENCE_TYPE).is(referenceType.name()))), JdbcLicense.class)
+                .map(this::toEntity)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<License> create(License item) {
+        LOGGER.debug("create license for {} {}", item.getReferenceType(), item.getReferenceId());
+
+        DatabaseClient.GenericExecuteSpec insertSpec = getTemplate().getDatabaseClient().sql(insertStatement);
+        insertSpec = addQuotedField(insertSpec, COL_REFERENCE_ID, item.getReferenceId(), String.class);
+        insertSpec = addQuotedField(insertSpec, COL_REFERENCE_TYPE, item.getReferenceType() == null ? null : item.getReferenceType().name(), String.class);
+        insertSpec = addQuotedField(insertSpec, COL_LICENSE, item.getLicense(), String.class);
+        insertSpec = addQuotedField(insertSpec, COL_CREATED_AT, dateConverter.convertTo(item.getCreatedAt(), null), LocalDateTime.class);
+        insertSpec = addQuotedField(insertSpec, COL_UPDATED_AT, dateConverter.convertTo(item.getUpdatedAt(), null), LocalDateTime.class);
+
+        Mono<Long> action = insertSpec.fetch().rowsUpdated();
+        return monoToSingle(action)
+                .flatMap(i -> findById(item.getReferenceId(), item.getReferenceType()).toSingle())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<License> update(License item) {
+        LOGGER.debug("update license for {} {}", item.getReferenceType(), item.getReferenceId());
+
+        DatabaseClient.GenericExecuteSpec update = getTemplate().getDatabaseClient().sql(updateStatement);
+        update = addQuotedField(update, COL_LICENSE, item.getLicense(), String.class);
+        update = addQuotedField(update, COL_UPDATED_AT, dateConverter.convertTo(item.getUpdatedAt(), null), LocalDateTime.class);
+        update = addQuotedField(update, COL_REFERENCE_ID, item.getReferenceId(), String.class);
+        update = addQuotedField(update, COL_REFERENCE_TYPE, item.getReferenceType() == null ? null : item.getReferenceType().name(), String.class);
+
+        Mono<Long> action = update.fetch().rowsUpdated();
+        return monoToSingle(action)
+                .flatMap(i -> findById(item.getReferenceId(), item.getReferenceType()).toSingle())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable delete(String referenceId, ReferenceType referenceType) {
+        LOGGER.debug("delete license for {} {}", referenceType, referenceId);
+        Mono<Long> delete = getTemplate().delete(JdbcLicense.class)
+                .matching(Query.query(where(COL_REFERENCE_ID).is(referenceId)
+                        .and(where(COL_REFERENCE_TYPE).is(referenceType.name()))))
+                .all();
+        return monoToCompletable(delete)
+                .observeOn(Schedulers.computation());
+    }
+
+    private License toEntity(JdbcLicense entity) {
+        if (entity == null) {
+            return null;
+        }
+        License license = new License();
+        license.setReferenceId(entity.getReferenceId());
+        license.setReferenceType(entity.getReferenceType() == null ? null : ReferenceType.valueOf(entity.getReferenceType()));
+        license.setLicense(entity.getLicense());
+        license.setCreatedAt(dateConverter.convertFrom(entity.getCreatedAt(), null));
+        license.setUpdatedAt(dateConverter.convertFrom(entity.getUpdatedAt(), null));
+        return license;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcLicense.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcLicense.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.management.api.model;
+
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+/**
+ * The {@code licenses} table is keyed by the composite (reference_id, reference_type),
+ * hence no single {@code @Id} property.
+ *
+ * @author GraviteeSource Team
+ */
+@Table("licenses")
+public class JdbcLicense {
+
+    @Column("reference_id")
+    private String referenceId;
+
+    @Column("reference_type")
+    private String referenceType;
+
+    private String license;
+
+    @Column("created_at")
+    private LocalDateTime createdAt;
+
+    @Column("updated_at")
+    private LocalDateTime updatedAt;
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(String referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public void setLicense(String license) {
+        this.license = license;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-licenses-table.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-licenses-table.yml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0-licenses-table
+      author: GraviteeSource Team
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: licenses
+      changes:
+        - createTable:
+            tableName: licenses
+            columns:
+              - column: { name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: license, type: clob, constraints: { nullable: false } }
+              - column: { name: created_at, type: timestamp(6), constraints: { nullable: true } }
+              - column: { name: updated_at, type: timestamp(6), constraints: { nullable: true } }
+
+        - addPrimaryKey:
+            constraintName: pk_licenses
+            columnNames: reference_id, reference_type
+            tableName: licenses

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
@@ -223,3 +223,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_12_0/4.12.0-applications-cursor-indexes.yml
   - include:
       - file: liquibase/changelogs/v4_13_0/4.13.0-application-scope-settings-add-required.yml
+  - include:
+      - file: liquibase/changelogs/v4_13_0/4.13.0-licenses-table.yml

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/JdbcRepositoriesTestInitializer.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/common/JdbcRepositoriesTestInitializer.java
@@ -139,6 +139,7 @@ public class JdbcRepositoriesTestInitializer implements RepositoriesTestInitiali
                 
                 "authorization_engines",
                 "protected_resources",
+                "licenses",
                 "dp_action_lease",
                 "cp_action_lease",
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoLicenseRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoLicenseRepository.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.management;
+
+import com.mongodb.reactivestreams.client.MongoCollection;
+import io.gravitee.am.model.License;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.management.api.LicenseRepository;
+import io.gravitee.am.repository.mongodb.management.internal.model.LicenseMongo;
+import io.gravitee.am.repository.mongodb.management.internal.model.LicensePkMongo;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import jakarta.annotation.PostConstruct;
+import org.bson.conversions.Bson;
+import org.springframework.stereotype.Component;
+
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+public class MongoLicenseRepository extends AbstractManagementMongoRepository implements LicenseRepository {
+
+    private static final String COLLECTION_NAME = "licenses";
+    private static final String FIELD_ID_REFERENCE_TYPE = "_id.referenceType";
+    private static final String FIELD_ID_REFERENCE_ID = "_id.referenceId";
+
+    private MongoCollection<LicenseMongo> collection;
+
+    @PostConstruct
+    public void init() {
+        collection = mongoOperations.getCollection(COLLECTION_NAME, LicenseMongo.class);
+        super.init(collection);
+    }
+
+    @Override
+    public Flowable<License> findAll() {
+        return Flowable.fromPublisher(withMaxTime(collection.find()))
+                .map(this::convert)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Maybe<License> findById(String referenceId, ReferenceType referenceType) {
+        return Observable.fromPublisher(collection.find(referenceFilter(referenceId, referenceType)).first())
+                .firstElement()
+                .map(this::convert)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<License> create(License item) {
+        return Single.fromPublisher(collection.insertOne(convert(item)))
+                .map(success -> item)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Single<License> update(License item) {
+        return Single.fromPublisher(collection.replaceOne(referenceFilter(item.getReferenceId(), item.getReferenceType()), convert(item)))
+                .map(updateResult -> item)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable delete(String referenceId, ReferenceType referenceType) {
+        return Completable.fromPublisher(collection.deleteOne(referenceFilter(referenceId, referenceType)))
+                .observeOn(Schedulers.computation());
+    }
+
+    private Bson referenceFilter(String referenceId, ReferenceType referenceType) {
+        return and(
+                eq(FIELD_ID_REFERENCE_TYPE, referenceType == null ? null : referenceType.name()),
+                eq(FIELD_ID_REFERENCE_ID, referenceId));
+    }
+
+    private License convert(LicenseMongo licenseMongo) {
+        if (licenseMongo == null) {
+            return null;
+        }
+        License license = new License();
+        LicensePkMongo pk = licenseMongo.getId();
+        if (pk != null) {
+            license.setReferenceId(pk.getReferenceId());
+            license.setReferenceType(pk.getReferenceType() == null ? null : ReferenceType.valueOf(pk.getReferenceType()));
+        }
+        license.setLicense(licenseMongo.getLicense());
+        license.setCreatedAt(licenseMongo.getCreatedAt());
+        license.setUpdatedAt(licenseMongo.getUpdatedAt());
+        return license;
+    }
+
+    private LicenseMongo convert(License license) {
+        if (license == null) {
+            return null;
+        }
+        LicenseMongo licenseMongo = new LicenseMongo();
+        licenseMongo.setId(new LicensePkMongo(
+                license.getReferenceType() == null ? null : license.getReferenceType().name(),
+                license.getReferenceId()));
+        licenseMongo.setLicense(license.getLicense());
+        licenseMongo.setCreatedAt(license.getCreatedAt());
+        licenseMongo.setUpdatedAt(license.getUpdatedAt());
+        return licenseMongo;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/LicenseMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/LicenseMongo.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.management.internal.model;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * The document {@code _id} is the composite (referenceType, referenceId) pair.
+ *
+ * @author GraviteeSource Team
+ */
+public class LicenseMongo {
+
+    @BsonId
+    private LicensePkMongo id;
+
+    private String license;
+
+    private Date createdAt;
+
+    private Date updatedAt;
+
+    public LicensePkMongo getId() {
+        return id;
+    }
+
+    public void setId(LicensePkMongo id) {
+        this.id = id;
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public void setLicense(String license) {
+        this.license = license;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LicenseMongo)) return false;
+        LicenseMongo that = (LicenseMongo) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/LicensePkMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/LicensePkMongo.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.management.internal.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Composite {@code _id} for the {@code licenses} collection: the (referenceType, referenceId) pair.
+ *
+ * @author GraviteeSource Team
+ */
+public class LicensePkMongo implements Serializable {
+
+    private String referenceType;
+
+    private String referenceId;
+
+    public LicensePkMongo() {
+    }
+
+    public LicensePkMongo(String referenceType, String referenceId) {
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+    }
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(String referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LicensePkMongo)) return false;
+        LicensePkMongo that = (LicensePkMongo) o;
+        return Objects.equals(referenceType, that.referenceType) && Objects.equals(referenceId, that.referenceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(referenceType, referenceId);
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/LicenseRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/LicenseRepositoryTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.management.api;
+
+import io.gravitee.am.model.License;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.management.AbstractManagementTest;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class LicenseRepositoryTest extends AbstractManagementTest {
+
+    @Autowired
+    private LicenseRepository licenseRepository;
+
+    private License buildLicense(String referenceId, ReferenceType referenceType, String value) {
+        License license = new License();
+        license.setReferenceId(referenceId);
+        license.setReferenceType(referenceType);
+        license.setLicense(value);
+        license.setCreatedAt(new Date());
+        license.setUpdatedAt(new Date());
+        return license;
+    }
+
+    @Test
+    public void testCreate() {
+        License license = buildLicense("orga-1", ReferenceType.ORGANIZATION, "license-value");
+
+        TestObserver<License> obs = licenseRepository.create(license).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValue(l -> "orga-1".equals(l.getReferenceId()));
+        obs.assertValue(l -> ReferenceType.ORGANIZATION.equals(l.getReferenceType()));
+        obs.assertValue(l -> "license-value".equals(l.getLicense()));
+    }
+
+    @Test
+    public void testFindById() {
+        License license = buildLicense("orga-2", ReferenceType.ORGANIZATION, "license-value");
+        licenseRepository.create(license).blockingGet();
+
+        TestObserver<License> obs = licenseRepository.findById("orga-2", ReferenceType.ORGANIZATION).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValue(l -> "orga-2".equals(l.getReferenceId()));
+        obs.assertValue(l -> ReferenceType.ORGANIZATION.equals(l.getReferenceType()));
+        obs.assertValue(l -> "license-value".equals(l.getLicense()));
+    }
+
+    @Test
+    public void testNotFoundById() {
+        TestObserver<License> obs = licenseRepository.findById("unknown", ReferenceType.ORGANIZATION).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertNoValues();
+    }
+
+    @Test
+    public void testFindAllEmpty() {
+        TestObserver<List<License>> obs = licenseRepository.findAll().toList().test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValue(List::isEmpty);
+    }
+
+    @Test
+    public void testFindAll() {
+        licenseRepository.create(buildLicense("orga-all-1", ReferenceType.ORGANIZATION, "license-1")).blockingGet();
+        licenseRepository.create(buildLicense("orga-all-2", ReferenceType.ORGANIZATION, "license-2")).blockingGet();
+
+        TestObserver<List<License>> obs = licenseRepository.findAll().toList().test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValue(items -> items.size() == 2);
+        obs.assertValue(items -> items.stream().map(License::getReferenceId).toList()
+                .containsAll(List.of("orga-all-1", "orga-all-2")));
+    }
+
+    @Test
+    public void testUpdate() {
+        License license = buildLicense("orga-3", ReferenceType.ORGANIZATION, "license-value");
+        licenseRepository.create(license).blockingGet();
+
+        License updated = buildLicense("orga-3", ReferenceType.ORGANIZATION, "license-value-updated");
+
+        TestObserver<License> obs = licenseRepository.update(updated).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValue(l -> "orga-3".equals(l.getReferenceId()));
+        obs.assertValue(l -> "license-value-updated".equals(l.getLicense()));
+    }
+
+    @Test
+    public void testDelete() {
+        License license = buildLicense("orga-4", ReferenceType.ORGANIZATION, "license-value");
+        licenseRepository.create(license).blockingGet();
+
+        assertNotNull(licenseRepository.findById("orga-4", ReferenceType.ORGANIZATION).blockingGet());
+
+        TestObserver<Void> obs = licenseRepository.delete("orga-4", ReferenceType.ORGANIZATION).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertComplete();
+        obs.assertNoErrors();
+
+        assertNull(licenseRepository.findById("orga-4", ReferenceType.ORGANIZATION).blockingGet());
+    }
+
+    @Test
+    public void testCompositeKeyDistinctness() {
+        // same referenceId, different referenceType must be two distinct rows
+        licenseRepository.create(buildLicense("shared-id", ReferenceType.ORGANIZATION, "org-license")).blockingGet();
+        licenseRepository.create(buildLicense("shared-id", ReferenceType.PLATFORM, "platform-license")).blockingGet();
+
+        License org = licenseRepository.findById("shared-id", ReferenceType.ORGANIZATION).blockingGet();
+        License platform = licenseRepository.findById("shared-id", ReferenceType.PLATFORM).blockingGet();
+
+        assertNotNull(org);
+        assertNotNull(platform);
+        assertEquals("org-license", org.getLicense());
+        assertEquals("platform-license", platform.getLicense());
+    }
+}


### PR DESCRIPTION
## Description

Implements the management-scope **License** repository layer for AM-7234: persist a Gravitee license linked to an organization, for both MongoDB and JDBC/R2DBC.

The entity is keyed by the composite **(referenceType, referenceId)**, reusing `io.gravitee.am.model.ReferenceType`. The dedicated collection/table is named `licenses`. Shared tests in `gravitee-am-repository-tests` run against both backends.

## Changes

- **Model** `License` (`gravitee-am-model`) — plain POJO (referenceId, referenceType, license, createdAt, updatedAt).
- **Interface** `LicenseRepository` (`gravitee-am-repository-api`) — reactive; does not extend `CrudRepository` (composite key). Methods: `findAll`, `findById(referenceId, referenceType)`, `create`, `update`, `delete(referenceId, referenceType)`.
- **MongoDB** — `MongoLicenseRepository` + `LicenseMongo` with an embedded composite `_id` (`LicensePkMongo` = the (referenceType, referenceId) pair), which enforces uniqueness.
- **JDBC/R2DBC** — `JdbcLicenseRepository` + `JdbcLicense` (composite-key handling via the base template, no single `@Id`).
- **Liquibase** — `v4_13_0/4.13.0-licenses-table.yml` (composite primary key `pk_licenses`), registered in `management-master.yml`.
- **Tests** — shared `LicenseRepositoryTest`; added `licenses` to `JdbcRepositoriesTestInitializer` cleanup.

Out of scope (follow-ups): service layer + audit logging, resource/HTTP layer, OpenAPI/SDK, and UI.

## Testing

`LicenseRepositoryTest` passes 8/8 under both profiles:
- MongoDB — `mvn test -pl gravitee-am-repository/gravitee-am-repository-mongodb -Pcicd -Dtest=LicenseRepositoryTest`
- PostgreSQL — `mvn test -pl gravitee-am-repository/gravitee-am-repository-jdbc -Pcicd-jdbc -Ppostgres -Dtest=LicenseRepositoryTest`


fixes AM-7234