### PR TITLE
feat: add cockpit WebSocket mock tool for AM integration testing

### DIFF
--- a/gravitee-am-cockpit-mock/.dockerignore
+++ b/gravitee-am-cockpit-mock/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+cockpit-state.json
+.git

--- a/gravitee-am-cockpit-mock/.gitignore
+++ b/gravitee-am-cockpit-mock/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+cockpit-state.json

--- a/gravitee-am-cockpit-mock/Dockerfile
+++ b/gravitee-am-cockpit-mock/Dockerfile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# --- build stage: compile TypeScript to plain JS ---
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npx tsc -p tsconfig.json --noEmit false --outDir dist
+
+# --- runtime stage: only production deps (ws) + compiled JS ---
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --chown=node:node package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=build --chown=node:node /app/dist ./dist
+
+# /app itself must be writable by 'node' too, so --state-file can create a new
+# file under a relative path (e.g. ./cockpit-state.json) as the non-root user.
+RUN chown node:node /app
+
+EXPOSE 8085
+USER node
+
+# Args passed to `docker run`/compose `command:` are appended (e.g. --state-file /data/state.json)
+ENTRYPOINT ["node", "dist/server.js"]

--- a/gravitee-am-cockpit-mock/README.md
+++ b/gravitee-am-cockpit-mock/README.md
@@ -1,0 +1,188 @@
+# gravitee-am-cockpit-mock
+
+A small standalone tool that **impersonates cockpit** so you can test Gravitee AM's
+WebSocket command integration end to end, without a real cockpit.
+
+AM is the WebSocket **client**: it dials *out* to cockpit at
+`<host>:<port>/exchange/controller`, upgrading an HTTP(S) connection to WebSocket.
+This tool is the server AM connects into. It auto-answers AM's `HELLO` handshake,
+lets you **inject** commands/replies toward AM over plain HTTP, and **queues**
+everything AM sends back so you can pop it with a GET.
+
+> **Endpoint scheme:** AM's endpoint configuration takes an `http://`/`https://` URL
+> (it builds a `java.net.URL`, which has no handler for a bare `ws`/`wss` scheme) and
+> upgrades it to a WebSocket connection internally. Configure AM with `http://`, not `ws://`.
+
+## How it works
+
+- Speaks the gravitee-exchange **V1** wire protocol:
+  `t:<COMMAND|REPLY>;;et:<type>;;e:<json>` — you only ever provide `type` + `payload`
+  as JSON; the framing is hidden.
+- On connect, AM sends a `HELLO` command and blocks on a `HELLO` reply. The tool
+  answers it automatically with a `SUCCEEDED` reply carrying the configured
+  installation identity, so the link comes up. `HELLO` is **not** placed on the queue.
+- Every other frame AM emits — replies to your commands **and** commands AM initiates
+  on its own — goes onto a single FIFO queue, tagged with `protocolType`.
+
+## Install & run
+
+Requires Node.js >= 20.
+
+```bash
+cd gravitee-am-cockpit-mock
+npm install
+npm start                       # listens on http://localhost:8085
+```
+
+Options:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port <n>` | `8085` | HTTP + WebSocket port |
+| `--ws-path <path>` | `/exchange/controller` | WebSocket upgrade path |
+| `--control-prefix <path>` | `/_control` | REST control-plane prefix |
+| `--state-file <path>` | *(none)* | persist installation identity to JSON and reload on restart |
+| `--installation-id <id>` | *(generated UUID)* | override the installation id |
+| `--installation-status <s>` | `ACCEPTED` | override the installation status |
+| `--installation-type <t>` | *(none)* | echoed as an extra field only — **inert on AM** (AM does not read it from the HELLO reply) |
+
+Example with stable, persisted identity:
+
+```bash
+npm start -- --port 8085 --state-file ./cockpit-state.json --installation-status ACCEPTED
+```
+
+## Run as a container
+
+```bash
+docker build -t gravitee-am-cockpit-mock:local .
+
+# ephemeral identity
+docker run --rm -p 8085:8085 gravitee-am-cockpit-mock:local
+
+# stable identity persisted to a mounted volume
+docker run --rm -p 8085:8085 -v "$PWD/data:/data" \
+  gravitee-am-cockpit-mock:local --state-file /data/state.json
+```
+
+Flags go after the image name (they are appended to the entrypoint).
+
+## Use in the local-stack
+
+Add the mock as a service in `docker/local-stack/dev/docker-compose.yml` (same compose
+network as `management`), then tell AM's management API to connect to it:
+
+```yaml
+  cockpit-mock:
+    build:
+      context: ../../../gravitee-am-cockpit-mock
+    command: ["--state-file", "/data/state.json"]
+    volumes:
+      - cockpit-mock-state:/data
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8085/_control/status"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+    ports:
+      - 8085:8085
+
+volumes:
+  cockpit-mock-state:
+```
+
+Point AM at it by adding these to the `management` service `environment:` (and `gateway`
+if you want the gateway's connector too):
+
+```yaml
+      - GRAVITEE_CLOUD_ENABLED=true
+      - GRAVITEE_CLOUD_CONNECTOR_WS_ENDPOINTS_0=http://cockpit-mock:8085
+```
+
+Inside the compose network AM reaches the mock at `http://cockpit-mock:8085` (upgraded to
+WebSocket internally); from your host the control API stays on `http://localhost:8085`.
+
+> **Requires the cockpit/cloud connector plugin** to be present in the AM image — the
+> connection is only attempted when that plugin is loaded and `cloud.enabled=true`.
+> Legacy config keys `GRAVITEE_COCKPIT_ENABLED` / `GRAVITEE_COCKPIT_WS_ENDPOINTS_0` also work.
+
+## Point AM at it
+
+In AM's `gravitee.yml` (or via env), plain `http://`, no TLS — see the endpoint-scheme
+note above:
+
+```yaml
+cloud:
+  enabled: true
+  connector:
+    ws:
+      endpoints:
+        - http://localhost:8085
+```
+
+(Legacy keys `cockpit.enabled` / `cockpit.ws.endpoints` also work.)
+
+## Control API
+
+### Send a command toward AM — `POST /_control/send`
+
+Fire-and-forget. Returns the generated command `id`; AM's reply arrives later on the queue.
+
+```bash
+curl -sX POST localhost:8085/_control/send \
+  -H 'content-type: application/json' \
+  -d '{ "type": "ORGANIZATION", "payload": { "id": "org-1", "name": "Acme" } }'
+# -> { "id": "3f1c...-generated-uuid" }
+```
+
+### Reply to an AM-initiated command — `POST /_control/send`
+
+When AM initiates a command toward cockpit, it appears on the queue as a `COMMAND`
+entry with a `commandId`. Answer it by POSTing a `REPLY` that references that id:
+
+```bash
+curl -sX POST localhost:8085/_control/send \
+  -H 'content-type: application/json' \
+  -d '{ "protocolType": "REPLY", "type": "V4_API", "commandId": "<id-from-queue>", "commandStatus": "SUCCEEDED", "payload": {} }'
+# -> { "ok": true }
+```
+
+`commandStatus` defaults to `SUCCEEDED`; use `ERROR` (with optional `errorDetails`) to
+exercise AM's failure paths.
+
+### Pop AM's next message — `GET /_control/queue`
+
+FIFO. Removes and returns the head; **204** when empty.
+
+```bash
+curl -i localhost:8085/_control/queue
+# 200 { "protocolType": "REPLY", "type": "ORGANIZATION", "commandId": "3f1c...",
+#       "commandStatus": "SUCCEEDED", "payload": { ... }, "receivedAt": "2026-07-13T..." }
+```
+
+### Inspect without consuming — `GET /_control/queue/peek`
+
+Returns the full queue as an array, non-destructively.
+
+### Connection status — `GET /_control/status`
+
+```bash
+curl -s localhost:8085/_control/status
+# { "connected": true, "installation": { ... }, "queueSize": 0 }
+```
+
+## Notes
+
+- **Single active connection.** One AM at a time; a reconnect (AM restart) takes over
+  the slot. `POST /_control/send` returns `409` when no AM is connected.
+- **`installationType` is inert.** AM's `HelloReplyAdapter` reads only `installationId`
+  and `installationStatus` from the reply. `installationType` is accepted and persisted
+  for convenience and sent as an extra field, but AM ignores it.
+- **HELLO reply also carries `targetId`.** Distinct from `installationId` — it's a field
+  on the base exchange `HelloReplyPayload` that AM's channel uses to key its connector
+  registry. The mock sets it to the same value as `installationId`; omitting it causes a
+  `NullPointerException` in AM's `DefaultExchangeConnectorManager` and the connector fails
+  to start.
+- The `type` you send must be a cockpit command type AM understands
+  (e.g. `ORGANIZATION`, `ENVIRONMENT`, `MEMBERSHIP`, `USER`, `INSTALLATION`, `V4_API`, …);
+  unknown types are handled by AM as an unknown command.

--- a/gravitee-am-cockpit-mock/package-lock.json
+++ b/gravitee-am-cockpit-mock/package-lock.json
@@ -1,0 +1,601 @@
+{
+  "name": "gravitee-am-cockpit-mock",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gravitee-am-cockpit-mock",
+      "version": "1.0.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "@types/ws": "^8.5.10",
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/gravitee-am-cockpit-mock/package.json
+++ b/gravitee-am-cockpit-mock/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "gravitee-am-cockpit-mock",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Mock cockpit WebSocket server to test Gravitee AM's cockpit command integration",
+  "scripts": {
+    "start": "tsx src/server.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/ws": "^8.5.10",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/gravitee-am-cockpit-mock/src/protocol.ts
+++ b/gravitee-am-cockpit-mock/src/protocol.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * gravitee-exchange V1 wire protocol.
+ *
+ * Each WebSocket frame is a `;;`-delimited envelope, NOT raw JSON:
+ *
+ *   t:<COMMAND|REPLY|UNKNOWN>;;et:<exchangeType>;;e:<json-serialized exchange>
+ *
+ * Mirrors io.gravitee.exchange.api.websocket.protocol.v1.V1ProtocolAdapter.
+ * The `e:` payload may itself contain the `;;` separator, so on decode the
+ * remainder after the `e:` marker is re-joined exactly like the Java adapter.
+ */
+
+const SEPARATOR = ';;';
+const TYPE_PREFIX = 't:';
+const EXCHANGE_TYPE_PREFIX = 'et:';
+const EXCHANGE_PREFIX = 'e:';
+
+export type ProtocolType = 'COMMAND' | 'REPLY' | 'UNKNOWN';
+
+export interface DecodedFrame {
+  protocolType: ProtocolType;
+  /** The `et:` marker — e.g. HELLO, ORGANIZATION, USER. */
+  exchangeType?: string;
+  /** The parsed `e:` JSON exchange body (id/commandId/type/payload/...). */
+  exchange?: any;
+}
+
+export interface EncodableFrame {
+  protocolType: ProtocolType;
+  exchangeType?: string;
+  exchange?: unknown;
+}
+
+/** Build a V1 frame string from a protocol type, exchange type and exchange object. */
+export function encodeFrame(frame: EncodableFrame): string {
+  const parts: string[] = [];
+  if (frame.protocolType) {
+    parts.push(`${TYPE_PREFIX}${frame.protocolType}`);
+  }
+  if (frame.exchangeType) {
+    parts.push(`${EXCHANGE_TYPE_PREFIX}${frame.exchangeType}`);
+  }
+  if (frame.exchange !== undefined && frame.exchange !== null) {
+    parts.push(`${EXCHANGE_PREFIX}${JSON.stringify(frame.exchange)}`);
+  }
+  return parts.join(SEPARATOR);
+}
+
+/** Parse a V1 frame string into its protocol type, exchange type and exchange object. */
+export function decodeFrame(raw: string): DecodedFrame {
+  const parts = raw.split(SEPARATOR);
+  const result: DecodedFrame = { protocolType: 'UNKNOWN' };
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part.startsWith(TYPE_PREFIX)) {
+      const value = part.substring(TYPE_PREFIX.length);
+      result.protocolType = value === 'COMMAND' || value === 'REPLY' ? value : 'UNKNOWN';
+    } else if (part.startsWith(EXCHANGE_TYPE_PREFIX)) {
+      result.exchangeType = part.substring(EXCHANGE_TYPE_PREFIX.length);
+    } else if (part.startsWith(EXCHANGE_PREFIX)) {
+      // The exchange JSON may contain `;;`; re-join the remaining parts.
+      const remainder = parts.slice(i).join(SEPARATOR);
+      const json = remainder.substring(EXCHANGE_PREFIX.length);
+      try {
+        result.exchange = JSON.parse(json);
+      } catch {
+        result.exchange = json;
+      }
+      break;
+    }
+  }
+  return result;
+}

--- a/gravitee-am-cockpit-mock/src/queue.ts
+++ b/gravitee-am-cockpit-mock/src/queue.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ProtocolType } from './protocol';
+
+/** One message AM emitted toward cockpit (a reply, or an AM-initiated command). */
+export interface QueueEntry {
+  protocolType: ProtocolType;
+  type?: string;
+  commandId?: string;
+  commandStatus?: string;
+  payload?: unknown;
+  errorDetails?: string;
+  receivedAt: string;
+}
+
+/** In-memory FIFO of everything AM sends, except the auto-handled HELLO. */
+export class ReplyQueue {
+  private readonly entries: QueueEntry[] = [];
+
+  push(entry: QueueEntry): void {
+    this.entries.push(entry);
+  }
+
+  /** Remove and return the head, or undefined when empty. */
+  pop(): QueueEntry | undefined {
+    return this.entries.shift();
+  }
+
+  /** Non-destructive snapshot of the whole queue in FIFO order. */
+  peek(): QueueEntry[] {
+    return [...this.entries];
+  }
+
+  get size(): number {
+    return this.entries.length;
+  }
+}

--- a/gravitee-am-cockpit-mock/src/server.ts
+++ b/gravitee-am-cockpit-mock/src/server.ts
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mock cockpit WebSocket server for testing Gravitee AM's cockpit integration.
+ *
+ * AM is the WebSocket *client*: it dials into `ws://<host>:<port>/exchange/controller`.
+ * This tool impersonates cockpit — it auto-answers AM's HELLO handshake, then lets
+ * you inject commands/replies toward AM over HTTP and read back everything AM emits.
+ *
+ *   POST /_control/send        send a COMMAND (default) or REPLY toward AM
+ *   GET  /_control/queue       pop the FIFO head of AM's messages (204 when empty)
+ *   GET  /_control/queue/peek  non-destructive snapshot of the queue
+ *   GET  /_control/status      connection + installation + queue summary
+ */
+
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { WebSocketServer, WebSocket } from 'ws';
+import { decodeFrame, encodeFrame, ProtocolType } from './protocol';
+import { loadInstallationState, InstallationState } from './state';
+import { ReplyQueue, QueueEntry } from './queue';
+
+interface Config {
+  port: number;
+  wsPath: string;
+  controlPrefix: string;
+  stateFile?: string;
+  installationId?: string;
+  installationStatus?: string;
+  installationType?: string;
+}
+
+function parseArgs(argv: string[]): Config {
+  const cfg: Config = {
+    port: 8085,
+    wsPath: '/exchange/controller',
+    controlPrefix: '/_control',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => {
+      const value = argv[++i];
+      if (value === undefined) {
+        console.error(`[args] missing value for ${arg}`);
+        process.exit(1);
+      }
+      return value;
+    };
+    switch (arg) {
+      case '--port': {
+        const raw = next();
+        const port = Number(raw);
+        if (!Number.isInteger(port) || port <= 0) {
+          console.error(`[args] invalid --port value: ${raw}`);
+          process.exit(1);
+        }
+        cfg.port = port;
+        break;
+      }
+      case '--ws-path':
+        cfg.wsPath = next();
+        break;
+      case '--control-prefix':
+        cfg.controlPrefix = next();
+        break;
+      case '--state-file':
+        cfg.stateFile = next();
+        break;
+      case '--installation-id':
+        cfg.installationId = next();
+        break;
+      case '--installation-status':
+        cfg.installationStatus = next();
+        break;
+      case '--installation-type':
+        cfg.installationType = next();
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        console.warn(`[args] ignoring unknown argument: ${arg}`);
+    }
+  }
+  return cfg;
+}
+
+function printUsage(): void {
+  console.log(`gravitee-am-cockpit-mock
+
+Usage: tsx src/server.ts [options]
+
+  --port <n>                   HTTP + WebSocket port (default 8085)
+  --ws-path <path>             WebSocket upgrade path (default /exchange/controller)
+  --control-prefix <path>      REST control-plane prefix (default /_control)
+  --state-file <path>          persist installation identity to this JSON file
+  --installation-id <id>       override installationId (else generated)
+  --installation-status <s>    override installationStatus (default ACCEPTED)
+  --installation-type <t>      override installationType (echoed only; inert on AM)
+`);
+}
+
+function log(scope: string, message: string): void {
+  console.log(`${new Date().toISOString()} [${scope}] ${message}`);
+}
+
+function main(): void {
+  const cfg = parseArgs(process.argv.slice(2));
+  const installation = loadInstallationState(cfg);
+  const queue = new ReplyQueue();
+
+  /** The single active AM connection (last-writer-wins on reconnect). */
+  let activeSocket: WebSocket | null = null;
+
+  const httpServer = createServer((req, res) => handleHttp(req, res));
+  const wss = new WebSocketServer({ noServer: true });
+
+  httpServer.on('upgrade', (req, socket, head) => {
+    const path = (req.url || '').split('?')[0];
+    if (path !== cfg.wsPath) {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
+  });
+
+  wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+    if (activeSocket && activeSocket.readyState === WebSocket.OPEN) {
+      log('ws', 'new AM connection; closing the previous one');
+      activeSocket.close(1000, 'replaced by a new connection');
+    }
+    activeSocket = ws;
+    log('ws', `AM connected from ${req.socket.remoteAddress}`);
+
+    ws.on('message', (data) => handleAmFrame(data.toString()));
+    ws.on('close', (code) => {
+      if (activeSocket === ws) activeSocket = null;
+      log('ws', `AM disconnected (code ${code})`);
+    });
+    ws.on('error', (err) => log('ws', `socket error: ${err.message}`));
+  });
+
+  /** Handle one inbound V1 frame from AM. */
+  function handleAmFrame(raw: string): void {
+    const frame = decodeFrame(raw);
+    const exchangeType = frame.exchangeType ?? frame.exchange?.type;
+
+    // Auto-handle the HELLO handshake so the link comes up; keep it off the queue.
+    if (frame.protocolType === 'COMMAND' && exchangeType === 'HELLO') {
+      replyToHello(frame.exchange?.id);
+      return;
+    }
+
+    const entry: QueueEntry = {
+      protocolType: frame.protocolType,
+      type: exchangeType,
+      commandId: frame.exchange?.commandId ?? frame.exchange?.id,
+      commandStatus: frame.exchange?.commandStatus,
+      payload: frame.exchange?.payload,
+      errorDetails: frame.exchange?.errorDetails,
+      receivedAt: new Date().toISOString(),
+    };
+    queue.push(entry);
+    log('ws', `queued ${entry.protocolType} ${entry.type ?? '?'} (queue size ${queue.size})`);
+  }
+
+  function replyToHello(commandId: string | undefined): void {
+    const payload: Record<string, unknown> = {
+      // targetId lives on the base exchange HelloReplyPayload (distinct from
+      // installationId below, which is cockpit's own field). AM's channel reads
+      // it via handleHelloCommand() and registers its connector under this id
+      // as a non-null map key — omitting it causes a NullPointerException in
+      // DefaultExchangeConnectorManager.register and the connector never starts.
+      targetId: installation.installationId,
+      installationId: installation.installationId,
+      installationStatus: installation.installationStatus,
+    };
+    if (installation.installationType) {
+      payload.installationType = installation.installationType;
+    }
+    const frame = encodeFrame({
+      protocolType: 'REPLY',
+      exchangeType: 'HELLO',
+      exchange: {
+        type: 'HELLO',
+        commandId,
+        commandStatus: 'SUCCEEDED',
+        payload,
+      },
+    });
+    sendFrame(frame);
+    log('ws', `auto-replied HELLO (installationId=${installation.installationId}, status=${installation.installationStatus})`);
+  }
+
+  /**
+   * Send a V1 frame to AM as a BINARY WebSocket message. The gravitee-exchange
+   * channel writes/reads binary frames (Vert.x Buffer); a text frame trips AM's
+   * textMessageHandler and the connection is closed with code 1003.
+   *
+   * `send` can throw synchronously if the socket is closing/closed; since this
+   * runs inside the WS message handler and HTTP request handlers, an uncaught
+   * throw here would crash the process.
+   */
+  function sendFrame(frame: string): void {
+    try {
+      activeSocket?.send(Buffer.from(frame, 'utf-8'), { binary: true });
+    } catch (err) {
+      log('ws', `failed to send frame: ${(err as Error).message}`);
+    }
+  }
+
+  function handleHttp(req: IncomingMessage, res: ServerResponse): void {
+    const path = (req.url || '').split('?')[0];
+
+    if (req.method === 'POST' && path === `${cfg.controlPrefix}/send`) {
+      return handleSend(req, res);
+    }
+    if (req.method === 'GET' && path === `${cfg.controlPrefix}/queue`) {
+      return handlePop(res);
+    }
+    if (req.method === 'GET' && path === `${cfg.controlPrefix}/queue/peek`) {
+      return sendJson(res, 200, queue.peek());
+    }
+    if (req.method === 'GET' && path === `${cfg.controlPrefix}/status`) {
+      return sendJson(res, 200, {
+        connected: !!activeSocket && activeSocket.readyState === WebSocket.OPEN,
+        installation,
+        queueSize: queue.size,
+      });
+    }
+    sendJson(res, 404, { error: 'not found' });
+  }
+
+  function handlePop(res: ServerResponse): void {
+    const head = queue.pop();
+    if (!head) {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    sendJson(res, 200, head);
+  }
+
+  function handleSend(req: IncomingMessage, res: ServerResponse): void {
+    readBody(req)
+      .then((body) => {
+        if (!activeSocket || activeSocket.readyState !== WebSocket.OPEN) {
+          return sendJson(res, 409, { error: 'no AM connection' });
+        }
+        const type: string | undefined = body.type;
+        if (!type) {
+          return sendJson(res, 400, { error: 'missing "type"' });
+        }
+        const protocolType: ProtocolType = body.protocolType === 'REPLY' ? 'REPLY' : 'COMMAND';
+
+        if (protocolType === 'REPLY') {
+          if (!body.commandId) {
+            return sendJson(res, 400, { error: 'REPLY requires "commandId"' });
+          }
+          const exchange: Record<string, unknown> = {
+            type,
+            commandId: body.commandId,
+            commandStatus: body.commandStatus ?? 'SUCCEEDED',
+          };
+          if (body.payload !== undefined) exchange.payload = body.payload;
+          if (body.errorDetails !== undefined) exchange.errorDetails = body.errorDetails;
+          sendFrame(encodeFrame({ protocolType, exchangeType: type, exchange }));
+          log('http', `sent REPLY ${type} for commandId=${body.commandId}`);
+          return sendJson(res, 200, { ok: true });
+        }
+
+        const id: string = body.id || randomUUID();
+        const exchange: Record<string, unknown> = { id, type };
+        if (body.payload !== undefined) exchange.payload = body.payload;
+        if (body.replyTimeoutMs !== undefined) exchange.replyTimeoutMs = body.replyTimeoutMs;
+        sendFrame(encodeFrame({ protocolType, exchangeType: type, exchange }));
+        log('http', `sent COMMAND ${type} (id=${id})`);
+        return sendJson(res, 200, { id });
+      })
+      .catch((err) => sendJson(res, 400, { error: `invalid request: ${err.message}` }));
+  }
+
+  httpServer.listen(cfg.port, () => {
+    log('boot', `listening on http://localhost:${cfg.port}`);
+    log('boot', `  WebSocket : ws://localhost:${cfg.port}${cfg.wsPath}`);
+    log('boot', `  control   : ${cfg.controlPrefix}/send | /queue | /queue/peek | /status`);
+    log('boot', `  installation: id=${installation.installationId} status=${installation.installationStatus}${installation.installationType ? ` type=${installation.installationType}` : ''}`);
+    if (cfg.stateFile) log('boot', `  state file: ${cfg.stateFile}`);
+    log('boot', `Point AM at it: cloud.connector.ws.endpoints=http://localhost:${cfg.port} + cloud.enabled=true`);
+  });
+}
+
+function readBody(req: IncomingMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(chunk as Buffer));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf-8').trim();
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err as Error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(payload);
+}
+
+main();

--- a/gravitee-am-cockpit-mock/src/state.ts
+++ b/gravitee-am-cockpit-mock/src/state.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * The installation identity this mock presents to AM in the HELLO reply.
+ *
+ * AM's HelloReplyAdapter only consumes `installationId` + `installationStatus`
+ * (persisted as COCKPIT_INSTALLATION_ID / COCKPIT_INSTALLATION_STATUS).
+ * `installationType` is NOT read from the reply by AM — it is kept here for
+ * completeness/persistence and echoed as a harmless extra field only.
+ */
+export interface InstallationState {
+  installationId: string;
+  installationStatus: string;
+  installationType?: string;
+}
+
+export interface StateOptions {
+  stateFile?: string;
+  installationId?: string;
+  installationStatus?: string;
+  installationType?: string;
+}
+
+const DEFAULT_STATUS = 'ACCEPTED';
+
+/**
+ * Resolve the installation identity: start from the persisted file (if any),
+ * apply explicit startup overrides (which always win), generate what is still
+ * missing, then persist back when a state file was configured.
+ */
+export function loadInstallationState(opts: StateOptions): InstallationState {
+  let state: Partial<InstallationState> = {};
+
+  if (opts.stateFile && existsSync(opts.stateFile)) {
+    try {
+      const parsed = JSON.parse(readFileSync(opts.stateFile, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        state = parsed;
+      } else {
+        console.warn(`[state] ${opts.stateFile} did not contain a JSON object, ignoring`);
+      }
+    } catch (err) {
+      console.warn(`[state] could not read ${opts.stateFile}, ignoring: ${(err as Error).message}`);
+    }
+  }
+
+  // Explicit CLI overrides take precedence over the persisted cache.
+  if (opts.installationId) state.installationId = opts.installationId;
+  if (opts.installationStatus) state.installationStatus = opts.installationStatus;
+  if (opts.installationType) state.installationType = opts.installationType;
+
+  const resolved: InstallationState = {
+    installationId: state.installationId || randomUUID(),
+    installationStatus: state.installationStatus || DEFAULT_STATUS,
+    installationType: state.installationType,
+  };
+
+  if (opts.stateFile) {
+    try {
+      writeFileSync(opts.stateFile, JSON.stringify(resolved, null, 2));
+    } catch (err) {
+      console.warn(`[state] could not persist ${opts.stateFile}: ${(err as Error).message}`);
+    }
+  }
+
+  return resolved;
+}

--- a/gravitee-am-cockpit-mock/tsconfig.json
+++ b/gravitee-am-cockpit-mock/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021"],
+    "types": ["node"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What

Adds **`gravitee-am-cockpit-mock`**, a standalone TypeScript tool that impersonates **cockpit** so AM's WebSocket command integration can be exercised end to end without a real cockpit.

AM is the WebSocket *client*: it dials out to `http://<host>:<port>/exchange/controller`. This tool is the server AM connects into. It auto-answers AM's `HELLO` handshake, lets you inject commands/replies toward AM over plain HTTP, and queues everything AM sends back.

## How it works

- Speaks the gravitee-exchange **V1** wire protocol (`t:<COMMAND|REPLY>;;et:<type>;;e:<json>`); callers only provide `type` + `payload` as JSON, framing is hidden.
- On connect, AM sends a `HELLO` command and blocks on a `HELLO` reply — the tool answers it automatically with a `SUCCEEDED` reply carrying a configurable, optionally persisted installation identity (`installationId` / `installationStatus`). `HELLO` is kept off the queue.
- Every other frame AM emits — replies to injected commands **and** AM-initiated commands — lands on a single FIFO queue, tagged by `protocolType`.

## Control API

| Endpoint | Purpose |
|----------|---------|
| `POST /_control/send` | send a `COMMAND` (default) or `REPLY` toward AM |
| `GET /_control/queue` | pop the FIFO head of AM's messages (`204` when empty) |
| `GET /_control/queue/peek` | non-destructive snapshot |
| `GET /_control/status` | connection + installation + queue summary |

## Container / local-stack

- Multi-stage `Dockerfile` (node:22-alpine → compile TS → runtime ships only `ws`, non-root `node` user, port `8085`).
- README documents the local-stack wiring: a `cockpit-mock` compose service plus AM env `GRAVITEE_CLOUD_ENABLED=true` / `GRAVITEE_CLOUD_CONNECTOR_WS_ENDPOINTS_0=http://cockpit-mock:8085`.

> Note: the WS connection is only attempted when AM's cockpit/cloud connector **plugin** is present and `cloud.enabled=true`.

## Verification

- Grounded the protocol against the real libs AM builds with (exchange-api 3.0.0 / cockpit-api 3.12.0): framing constants, `Command`/`Reply` field names, and AM's own `HelloReplyAdapter` (needs `commandStatus=SUCCEEDED` + `installationId` + `installationStatus`).
- `tsc --noEmit` clean.
- 22-assertion end-to-end smoke test passes both locally and through the built container; installation identity persists across restart via `--state-file`.

## Notes

- `installationType` is accepted/persisted but **inert on AM** — it exists only on the HELLO command AM *sends*, not the reply AM reads. Documented in code + README.
- Test tooling only; no changes to AM production code.