### PR TITLE
feat: AM-7235 handle licenses in organization commands

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/OrganizationCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/OrganizationCommandHandler.java
@@ -54,6 +54,7 @@ public class OrganizationCommandHandler implements CommandHandler<OrganizationCo
         newOrganization.setHrids(organizationPayload.hrids());
         newOrganization.setName(organizationPayload.name());
         newOrganization.setDescription(organizationPayload.description());
+        newOrganization.setLicense(organizationPayload.license());
         if (organizationPayload.accessPoints() != null) {
             newOrganization.setDomainRestrictions(organizationPayload.accessPoints()
                     .stream()

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/OrganizationCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/OrganizationCommandHandlerTest.java
@@ -18,6 +18,7 @@ package io.gravitee.am.management.service.impl.commands;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.service.OrganizationService;
+import io.gravitee.am.service.exception.InvalidLicenseException;
 import io.gravitee.am.service.model.NewOrganization;
 import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -43,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -75,6 +78,7 @@ class OrganizationCommandHandlerTest {
                 .hrids(Collections.singletonList("orga-1"))
                 .description("Organization description")
                 .name("Organization name")
+                .license(Base64.getEncoder().encodeToString("license-content".getBytes()))
                 .accessPoints(List.of(AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build(),
                         AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction2.io").build()))
                 .build();
@@ -84,6 +88,7 @@ class OrganizationCommandHandlerTest {
                 argThat(newOrganization -> newOrganization.getHrids().equals(organizationPayload.hrids())
                         && newOrganization.getDescription().equals(organizationPayload.description())
                         && newOrganization.getName().equals(organizationPayload.name())
+                        && newOrganization.getLicense().equals(organizationPayload.license())
                         && newOrganization.getDomainRestrictions().equals(organizationPayload.accessPoints().stream()
                         .map(AccessPoint::getHost).collect(Collectors.toList()))),
                 isNull())).thenReturn(Single.just(new Organization()));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/LicenseService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/LicenseService.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service;
+
+import io.gravitee.am.model.License;
+import io.gravitee.am.model.ReferenceType;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface LicenseService {
+
+    Single<License> createOrUpdate(ReferenceType referenceType, String referenceId, String license);
+
+    Completable delete(ReferenceType referenceType, String referenceId);
+
+    /**
+     * @throws io.gravitee.am.service.exception.InvalidLicenseException if the license is not a non-blank base64-encoded value
+     */
+    void validate(String license);
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/InvalidLicenseException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/InvalidLicenseException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.exception;
+
+import io.gravitee.common.http.HttpStatusCode;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class InvalidLicenseException extends AbstractManagementException {
+
+    public InvalidLicenseException(String msg) {
+        super(msg);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/LicenseServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/LicenseServiceImpl.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.impl;
+
+import io.gravitee.am.model.License;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.management.api.LicenseRepository;
+import io.gravitee.am.service.LicenseService;
+import io.gravitee.am.service.exception.InvalidLicenseException;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@Component
+public class LicenseServiceImpl implements LicenseService {
+
+    private final LicenseRepository licenseRepository;
+
+    public LicenseServiceImpl(@Lazy LicenseRepository licenseRepository) {
+        this.licenseRepository = licenseRepository;
+    }
+
+    @Override
+    public Single<License> createOrUpdate(ReferenceType referenceType, String referenceId, String license) {
+        log.debug("Create or update license for {} [{}]", referenceType, referenceId);
+        return Single.defer(() -> {
+            validate(license);
+            return licenseRepository.findById(referenceId, referenceType)
+                    .flatMap(existing -> {
+                        existing.setLicense(license);
+                        existing.setUpdatedAt(new Date());
+                        return licenseRepository.update(existing).toMaybe();
+                    })
+                    .switchIfEmpty(Single.defer(() -> {
+                        License toCreate = new License();
+                        toCreate.setReferenceId(referenceId);
+                        toCreate.setReferenceType(referenceType);
+                        toCreate.setLicense(license);
+                        Date now = new Date();
+                        toCreate.setCreatedAt(now);
+                        toCreate.setUpdatedAt(now);
+                        return licenseRepository.create(toCreate);
+                    }));
+        });
+    }
+
+    @Override
+    public Completable delete(ReferenceType referenceType, String referenceId) {
+        log.debug("Delete license for {} [{}]", referenceType, referenceId);
+        return licenseRepository.delete(referenceId, referenceType);
+    }
+
+    @Override
+    public void validate(String license) {
+        if (license == null || license.isBlank()) {
+            throw new InvalidLicenseException("License must be a non-blank base64-encoded value");
+        }
+        try {
+            Base64.getDecoder().decode(license);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidLicenseException("License is not a valid base64-encoded value");
+        }
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/OrganizationServiceImpl.java
@@ -18,9 +18,11 @@ package io.gravitee.am.service.impl;
 import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Organization;
+import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.repository.management.api.OrganizationRepository;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.EntrypointService;
+import io.gravitee.am.service.LicenseService;
 import io.gravitee.am.service.OrganizationService;
 import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.exception.OrganizationNotFoundException;
@@ -57,14 +59,18 @@ public class OrganizationServiceImpl implements OrganizationService {
 
     private final AuditService auditService;
 
+    private final LicenseService licenseService;
+
     public OrganizationServiceImpl(@Lazy OrganizationRepository organizationRepository,
                                    RoleService roleService,
                                    EntrypointService entrypointService,
-                                   AuditService auditService) {
+                                   AuditService auditService,
+                                   LicenseService licenseService) {
         this.organizationRepository = organizationRepository;
         this.roleService = roleService;
         this.entrypointService = entrypointService;
         this.auditService = auditService;
+        this.licenseService = licenseService;
     }
 
     @Override
@@ -98,26 +104,40 @@ public class OrganizationServiceImpl implements OrganizationService {
     @Override
     public Single<Organization> createOrUpdate(String organizationId, NewOrganization newOrganization, User byUser) {
 
-        return organizationRepository.findById(organizationId)
-                .flatMap(organization -> {
-                    Organization toUpdate = new Organization(organization);
-                    toUpdate.setName(newOrganization.getName());
-                    toUpdate.setDescription(newOrganization.getDescription());
-                    toUpdate.setDomainRestrictions(newOrganization.getDomainRestrictions());
-                    toUpdate.setHrids(newOrganization.getHrids());
+        return Single.defer(() -> {
+            if (newOrganization.getLicense() != null) {
+                licenseService.validate(newOrganization.getLicense());
+            }
+            return organizationRepository.findById(organizationId)
+                    .flatMap(organization -> {
+                        Organization toUpdate = new Organization(organization);
+                        toUpdate.setName(newOrganization.getName());
+                        toUpdate.setDescription(newOrganization.getDescription());
+                        toUpdate.setDomainRestrictions(newOrganization.getDomainRestrictions());
+                        toUpdate.setHrids(newOrganization.getHrids());
 
-                    return updateInternal(toUpdate, byUser, organization).toMaybe();
-                })
-                .switchIfEmpty(Single.defer(() -> {
-                    Organization toCreate = new Organization();
-                    toCreate.setId(organizationId);
-                    toCreate.setHrids(newOrganization.getHrids());
-                    toCreate.setName(newOrganization.getName());
-                    toCreate.setDescription(newOrganization.getDescription());
-                    toCreate.setDomainRestrictions(newOrganization.getDomainRestrictions());
+                        return updateInternal(toUpdate, byUser, organization).toMaybe();
+                    })
+                    .switchIfEmpty(Single.defer(() -> {
+                        Organization toCreate = new Organization();
+                        toCreate.setId(organizationId);
+                        toCreate.setHrids(newOrganization.getHrids());
+                        toCreate.setName(newOrganization.getName());
+                        toCreate.setDescription(newOrganization.getDescription());
+                        toCreate.setDomainRestrictions(newOrganization.getDomainRestrictions());
 
-                    return createInternal(toCreate, byUser);
-                }));
+                        return createInternal(toCreate, byUser);
+                    }))
+                    .flatMap(organization -> syncLicense(organizationId, newOrganization.getLicense()).andThen(Single.just(organization)));
+        });
+    }
+
+    private Completable syncLicense(String organizationId, String license) {
+        if (license == null) {
+            return licenseService.delete(ReferenceType.ORGANIZATION, organizationId);
+        }
+        return licenseService.createOrUpdate(ReferenceType.ORGANIZATION, organizationId, license)
+                .ignoreElement();
     }
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewOrganization.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewOrganization.java
@@ -37,7 +37,12 @@ public class NewOrganization {
 
     private List<String> domainRestrictions;
 
-    
+    /**
+     * Desired-state license from Cockpit (base64-encoded).
+     * Null removes any persisted organization license.
+     */
+    private String license;
+
     public String getName() {
         return name;
     }
@@ -90,5 +95,13 @@ public class NewOrganization {
 
     public void setHrids(List<String> hrids) {
         this.hrids = hrids;
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public void setLicense(String license) {
+        this.license = license;
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/LicenseServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/LicenseServiceTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service;
+
+import io.gravitee.am.model.License;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.repository.management.api.LicenseRepository;
+import io.gravitee.am.service.exception.InvalidLicenseException;
+import io.gravitee.am.service.impl.LicenseServiceImpl;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Base64;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class LicenseServiceTest {
+
+    private static final String ORGANIZATION_ID = "orga#1";
+    private static final String LICENSE = Base64.getEncoder().encodeToString("license-content".getBytes());
+
+    @Mock
+    private LicenseRepository licenseRepository;
+
+    private LicenseServiceImpl cut;
+
+    @BeforeEach
+    void before() {
+        cut = new LicenseServiceImpl(licenseRepository);
+    }
+
+    @Test
+    void createWhenAbsent() {
+        when(licenseRepository.findById(ORGANIZATION_ID, ReferenceType.ORGANIZATION)).thenReturn(Maybe.empty());
+        when(licenseRepository.create(any(License.class))).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+
+        TestObserver<License> obs = cut.createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, LICENSE).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(license -> license.getReferenceId().equals(ORGANIZATION_ID)
+                && license.getReferenceType() == ReferenceType.ORGANIZATION
+                && license.getLicense().equals(LICENSE)
+                && license.getCreatedAt() != null
+                && license.getCreatedAt().equals(license.getUpdatedAt()));
+        verify(licenseRepository, never()).update(any(License.class));
+    }
+
+    @Test
+    void updateWhenPresent() {
+        License existing = new License();
+        existing.setReferenceId(ORGANIZATION_ID);
+        existing.setReferenceType(ReferenceType.ORGANIZATION);
+        existing.setLicense(Base64.getEncoder().encodeToString("old-license".getBytes()));
+        Date createdAt = new Date(0);
+        existing.setCreatedAt(createdAt);
+        existing.setUpdatedAt(createdAt);
+
+        when(licenseRepository.findById(ORGANIZATION_ID, ReferenceType.ORGANIZATION)).thenReturn(Maybe.just(existing));
+        when(licenseRepository.update(any(License.class))).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+
+        TestObserver<License> obs = cut.createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, LICENSE).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(license -> license.getLicense().equals(LICENSE)
+                && license.getCreatedAt().equals(createdAt)
+                && license.getUpdatedAt().after(createdAt));
+        verify(licenseRepository).update(argThat(license -> license.getReferenceId().equals(ORGANIZATION_ID)));
+        verify(licenseRepository, never()).create(any(License.class));
+    }
+
+    @Test
+    void createOrUpdateWithNullLicense() {
+        TestObserver<License> obs = cut.createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, null).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertError(InvalidLicenseException.class);
+        verifyNoInteractions(licenseRepository);
+    }
+
+    @Test
+    void createOrUpdateWithBlankLicense() {
+        TestObserver<License> obs = cut.createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "  ").test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertError(InvalidLicenseException.class);
+        verifyNoInteractions(licenseRepository);
+    }
+
+    @Test
+    void createOrUpdateWithInvalidBase64License() {
+        TestObserver<License> obs = cut.createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "not-base64!!!").test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertError(InvalidLicenseException.class);
+        verifyNoInteractions(licenseRepository);
+    }
+
+    @Test
+    void validateAcceptsBase64License() {
+        assertDoesNotThrow(() -> cut.validate(LICENSE));
+    }
+
+    @Test
+    void validateRejectsInvalidLicense() {
+        assertThrows(InvalidLicenseException.class, () -> cut.validate(null));
+        assertThrows(InvalidLicenseException.class, () -> cut.validate("  "));
+        assertThrows(InvalidLicenseException.class, () -> cut.validate("not-base64!!!"));
+    }
+
+    @Test
+    void delete() {
+        when(licenseRepository.delete(ORGANIZATION_ID, ReferenceType.ORGANIZATION)).thenReturn(Completable.complete());
+
+        TestObserver<Void> obs = cut.delete(ReferenceType.ORGANIZATION, ORGANIZATION_ID).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertComplete();
+        verify(licenseRepository).delete(ORGANIZATION_ID, ReferenceType.ORGANIZATION);
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/OrganizationServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/OrganizationServiceTest.java
@@ -20,11 +20,13 @@ import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.common.audit.Status;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.model.Entrypoint;
+import io.gravitee.am.model.License;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.reporter.api.audit.model.Audit;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.repository.management.api.OrganizationRepository;
+import io.gravitee.am.service.exception.InvalidLicenseException;
 import io.gravitee.am.service.exception.OrganizationNotFoundException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.OrganizationServiceImpl;
@@ -43,6 +45,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -52,8 +55,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -66,6 +72,7 @@ public class OrganizationServiceTest {
 
     public static final String ORGANIZATION_ID = "orga#1";
     public static final String USER_ID = "user#1";
+    private static final String LICENSE = Base64.getEncoder().encodeToString("license-content".getBytes());
 
     @Mock
     private OrganizationRepository organizationRepository;
@@ -79,12 +86,15 @@ public class OrganizationServiceTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private LicenseService licenseService;
+
     private OrganizationService cut;
 
     @BeforeEach
     public void before() {
 
-        cut = new OrganizationServiceImpl(organizationRepository, roleService, entrypointService, auditService);
+        cut = new OrganizationServiceImpl(organizationRepository, roleService, entrypointService, auditService, licenseService);
     }
 
     @Test
@@ -200,12 +210,14 @@ public class OrganizationServiceTest {
         when(organizationRepository.create(argThat(organization -> organization.getId().equals(ORGANIZATION_ID)))).thenAnswer(i -> Single.just(i.getArgument(0)));
         when(roleService.createDefaultRoles(ORGANIZATION_ID)).thenReturn(Completable.complete());
         when(entrypointService.createDefaults(any(Organization.class))).thenReturn(Flowable.just(new Entrypoint()));
+        when(licenseService.createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, LICENSE)).thenReturn(Single.just(new License()));
 
         NewOrganization newOrganization = new NewOrganization();
         newOrganization.setName("TestName");
         newOrganization.setDescription("TestDescription");
         newOrganization.setDomainRestrictions(Collections.singletonList("TestDomainRestriction"));
         newOrganization.setHrids(Collections.singletonList("testOrgHRID"));
+        newOrganization.setLicense(LICENSE);
 
         DefaultUser createdBy = new DefaultUser("test");
         createdBy.setId(USER_ID);
@@ -223,6 +235,8 @@ public class OrganizationServiceTest {
             return true;
         });
 
+        verify(licenseService).createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, LICENSE);
+        verify(licenseService, never()).delete(any(), any());
         verify(auditService, times(1)).report(argThat(builder -> {
             Audit audit = builder.build(new ObjectMapper());
             assertEquals(ReferenceType.ORGANIZATION, audit.getReferenceType());
@@ -245,6 +259,7 @@ public class OrganizationServiceTest {
         newOrganization.setName("TestName");
         newOrganization.setDescription("TestDescription");
         newOrganization.setDomainRestrictions(Collections.singletonList("TestDomainRestriction"));
+        newOrganization.setLicense(LICENSE);
 
         DefaultUser createdBy = new DefaultUser("test");
         createdBy.setId(USER_ID);
@@ -254,6 +269,8 @@ public class OrganizationServiceTest {
         obs.awaitDone(10, TimeUnit.SECONDS);
         obs.assertError(TechnicalManagementException.class);
 
+        verify(licenseService, never()).createOrUpdate(any(), any(), any());
+        verify(licenseService, never()).delete(any(), any());
         verify(auditService, times(1)).report(argThat(builder -> {
             Audit audit = builder.build(new ObjectMapper());
             assertEquals(ReferenceType.ORGANIZATION, audit.getReferenceType());
@@ -274,12 +291,14 @@ public class OrganizationServiceTest {
 
         when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Maybe.just(existingOrganization));
         when(organizationRepository.update(argThat(organization -> organization.getId().equals(ORGANIZATION_ID)))).thenAnswer(i -> Single.just(i.getArgument(0)));
+        when(licenseService.createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, LICENSE)).thenReturn(Single.just(new License()));
 
         NewOrganization newOrganization = new NewOrganization();
         newOrganization.setName("TestName");
         newOrganization.setDescription("TestDescription");
         newOrganization.setDomainRestrictions(Collections.singletonList("TestDomainRestriction"));
         newOrganization.setHrids(Collections.singletonList("TestHridUpdate"));
+        newOrganization.setLicense(LICENSE);
 
         DefaultUser createdBy = new DefaultUser("test");
         createdBy.setId(USER_ID);
@@ -297,6 +316,8 @@ public class OrganizationServiceTest {
             return true;
         });
 
+        verify(licenseService).createOrUpdate(ReferenceType.ORGANIZATION, ORGANIZATION_ID, LICENSE);
+        verify(licenseService, never()).delete(any(), any());
         verify(auditService, times(1)).report(argThat(builder -> {
             Audit audit = builder.build(new ObjectMapper());
             assertEquals(ReferenceType.ORGANIZATION, audit.getReferenceType());
@@ -307,6 +328,49 @@ public class OrganizationServiceTest {
 
             return true;
         }));
+    }
+
+    @Test
+    public void shouldDeleteLicenseWhenNull() {
+
+        Organization existingOrganization = new Organization();
+        existingOrganization.setId(ORGANIZATION_ID);
+
+        when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Maybe.just(existingOrganization));
+        when(organizationRepository.update(argThat(organization -> organization.getId().equals(ORGANIZATION_ID)))).thenAnswer(i -> Single.just(i.getArgument(0)));
+        when(licenseService.delete(ReferenceType.ORGANIZATION, ORGANIZATION_ID)).thenReturn(Completable.complete());
+
+        NewOrganization newOrganization = new NewOrganization();
+        newOrganization.setName("TestName");
+        newOrganization.setLicense(null);
+
+        TestObserver<Organization> obs = cut.createOrUpdate(ORGANIZATION_ID, newOrganization, new DefaultUser("test")).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertComplete();
+
+        verify(licenseService).delete(ReferenceType.ORGANIZATION, ORGANIZATION_ID);
+        verify(licenseService, never()).createOrUpdate(any(), any(), any());
+    }
+
+    @Test
+    public void shouldFailWhenLicenseInvalid() {
+
+        doThrow(new InvalidLicenseException("License is not a valid base64-encoded value"))
+                .when(licenseService).validate("not-base64!!!");
+
+        NewOrganization newOrganization = new NewOrganization();
+        newOrganization.setName("TestName");
+        newOrganization.setLicense("not-base64!!!");
+
+        TestObserver<Organization> obs = cut.createOrUpdate(ORGANIZATION_ID, newOrganization, new DefaultUser("test")).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertError(InvalidLicenseException.class);
+
+        verifyNoInteractions(organizationRepository);
+        verify(licenseService, never()).createOrUpdate(any(), any(), any());
+        verify(licenseService, never()).delete(any(), any());
     }
 
     @Test
@@ -322,6 +386,7 @@ public class OrganizationServiceTest {
         newOrganization.setName("TestName");
         newOrganization.setDescription("TestDescription");
         newOrganization.setDomainRestrictions(Collections.singletonList("TestDomainRestriction"));
+        newOrganization.setLicense(LICENSE);
 
         DefaultUser createdBy = new DefaultUser("test");
         createdBy.setId(USER_ID);
@@ -331,6 +396,8 @@ public class OrganizationServiceTest {
         obs.awaitDone(10, TimeUnit.SECONDS);
         obs.assertError(TechnicalManagementException.class);
 
+        verify(licenseService, never()).createOrUpdate(any(), any(), any());
+        verify(licenseService, never()).delete(any(), any());
         verify(auditService, times(1)).report(argThat(builder -> {
             Audit audit = builder.build(new ObjectMapper());
             assertEquals(ReferenceType.ORGANIZATION, audit.getReferenceType());
@@ -360,6 +427,7 @@ public class OrganizationServiceTest {
 
         obs.awaitDone(10, TimeUnit.SECONDS);
         obs.assertValue(updated -> updated.getIdentities().equals(identities));
+        verifyNoInteractions(licenseService);
     }
 
     @Test


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7235](https://gravitee.atlassian.net/browse/AM-7235)

## :pencil2: A description of the changes proposed in the pull request
Persist licenses provided in `ORGANIZATION` commands from Gravitee Cloud.

- Validate base64 format
- Create or update license associated with organization idempotently
- Remove any associated license when command payload omits it

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7235]: https://gravitee.atlassian.net/browse/AM-7235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ