### PR TITLE
test: (AM-5417) add jest tests for application general settings

### DIFF
--- a/gravitee-am-test/specs/management/application-general-settings/application-general-settings.jest.spec.ts
+++ b/gravitee-am-test/specs/management/application-general-settings/application-general-settings.jest.spec.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { ApplicationGeneralSettingsFixture, initFixture } from './fixtures/application-general-settings-fixture';
+
+setup();
+
+let fixture: ApplicationGeneralSettingsFixture;
+
+beforeAll(async () => {
+  fixture = await initFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('Application General Settings', () => {
+  describe('Redirect URIs', () => {
+    it('should add a redirect URI', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { redirectUris: ['https://callback.example.com'] } },
+      });
+      expect(patched.settings.oauth.redirectUris).toContain('https://callback.example.com');
+    });
+
+    it('should add multiple redirect URIs', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { redirectUris: ['https://callback.example.com', 'https://callback2.example.com'] } },
+      });
+      expect(patched.settings.oauth.redirectUris).toEqual(
+        expect.arrayContaining(['https://callback.example.com', 'https://callback2.example.com']),
+      );
+    });
+
+    it('should remove a redirect URI by updating the list', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { redirectUris: ['https://callback.example.com'] } },
+      });
+      expect(patched.settings.oauth.redirectUris).toEqual(['https://callback.example.com']);
+      expect(patched.settings.oauth.redirectUris).not.toContain('https://callback2.example.com');
+    });
+
+    it('should persist redirect URIs across GET', async () => {
+      await fixture.patchApp({ settings: { oauth: { redirectUris: ['https://persist.example.com'] } } });
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings.oauth.redirectUris).toContain('https://persist.example.com');
+    });
+  });
+
+  describe('Post logout redirect URIs', () => {
+    it('should add a post logout redirect URI', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { postLogoutRedirectUris: ['https://logout.example.com'] } },
+      });
+      expect(patched.settings.oauth.postLogoutRedirectUris).toContain('https://logout.example.com');
+    });
+
+    it('should remove a post logout redirect URI by updating the list', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { postLogoutRedirectUris: [] } },
+      });
+      expect(patched.settings.oauth.postLogoutRedirectUris).toEqual([]);
+    });
+
+    it('should persist post logout redirect URIs across GET', async () => {
+      await fixture.patchApp({ settings: { oauth: { postLogoutRedirectUris: ['https://logout-persist.example.com'] } } });
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings.oauth.postLogoutRedirectUris).toContain('https://logout-persist.example.com');
+    });
+  });
+
+  describe('Request URIs', () => {
+    it('should add a request URI', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { requestUris: ['https://request.example.com'] } },
+      });
+      expect(patched.settings.oauth.requestUris).toContain('https://request.example.com');
+    });
+
+    it('should add multiple request URIs', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { requestUris: ['https://request.example.com', 'https://request2.example.com'] } },
+      });
+      expect(patched.settings.oauth.requestUris).toEqual(
+        expect.arrayContaining(['https://request.example.com', 'https://request2.example.com']),
+      );
+    });
+
+    it('should remove a request URI by updating the list', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { requestUris: ['https://request.example.com'] } },
+      });
+      expect(patched.settings.oauth.requestUris).toEqual(['https://request.example.com']);
+      expect(patched.settings.oauth.requestUris).not.toContain('https://request2.example.com');
+    });
+
+    it('should persist request URIs across GET', async () => {
+      await fixture.patchApp({ settings: { oauth: { requestUris: ['https://persist-request.example.com'] } } });
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings.oauth.requestUris).toContain('https://persist-request.example.com');
+    });
+  });
+
+  describe('Single Sign Out toggle', () => {
+    it('should enable single sign out', async () => {
+      const patched = await fixture.patchApp({ settings: { oauth: { singleSignOut: true } } });
+      expect(patched.settings.oauth.singleSignOut).toBe(true);
+    });
+
+    it('should disable single sign out', async () => {
+      const patched = await fixture.patchApp({ settings: { oauth: { singleSignOut: false } } });
+      expect(patched.settings.oauth.singleSignOut).toBe(false);
+    });
+
+    it('should persist single sign out setting across GET', async () => {
+      await fixture.patchApp({ settings: { oauth: { singleSignOut: true } } });
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings.oauth.singleSignOut).toBe(true);
+    });
+  });
+
+  describe('Silent re-authentication toggle', () => {
+    it('should enable silent re-authentication', async () => {
+      const patched = await fixture.patchApp({ settings: { oauth: { silentReAuthentication: true } } });
+      expect(patched.settings.oauth.silentReAuthentication).toBe(true);
+    });
+
+    it('should disable silent re-authentication', async () => {
+      const patched = await fixture.patchApp({ settings: { oauth: { silentReAuthentication: false } } });
+      expect(patched.settings.oauth.silentReAuthentication).toBe(false);
+    });
+  });
+
+  describe('Skip user consent toggle', () => {
+    it('should enable skip consent', async () => {
+      const patched = await fixture.patchApp({ settings: { advanced: { skipConsent: true } } });
+      expect(patched.settings.advanced.skipConsent).toBe(true);
+    });
+
+    it('should disable skip consent', async () => {
+      const patched = await fixture.patchApp({ settings: { advanced: { skipConsent: false } } });
+      expect(patched.settings.advanced.skipConsent).toBe(false);
+    });
+  });
+
+  describe('Template toggle', () => {
+    it('should set application as DCR template', async () => {
+      const patched = await fixture.patchApp({ template: true });
+      expect(patched.template).toBe(true);
+    });
+
+    it('should unset DCR template flag', async () => {
+      const patched = await fixture.patchApp({ template: false });
+      expect(patched.template).toBe(false);
+    });
+  });
+
+  describe('Application type and OAuth2 parameter differences', () => {
+    it('should switch from WEB to SERVICE (Backend to Backend) and set client_credentials grant type', async () => {
+      const updated = await fixture.setAppType('SERVICE');
+      expect(updated.settings.oauth.grantTypes).toEqual(['client_credentials']);
+      expect(updated.settings.oauth.responseTypes).toEqual([]);
+    });
+
+    it('should accept empty redirect URIs when type is SERVICE', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { redirectUris: [], grantTypes: ['client_credentials'], responseTypes: [] } },
+      });
+      expect(patched.settings.oauth.redirectUris).toEqual([]);
+      expect(patched.settings.oauth.grantTypes).toEqual(['client_credentials']);
+    });
+
+    it('should switch from SERVICE back to WEB and set authorization_code grant type', async () => {
+      const updated = await fixture.setAppType('WEB');
+      expect(updated.settings.oauth.grantTypes).toEqual(expect.arrayContaining(['authorization_code']));
+      expect(updated.settings.oauth.applicationType).toEqual('web');
+    });
+
+    it('should require redirect URIs when configuring WEB type with authorization_code', async () => {
+      const patched = await fixture.patchApp({
+        settings: { oauth: { redirectUris: ['https://callback.example.com'], grantTypes: ['authorization_code'] } },
+      });
+      expect(patched.settings.oauth.redirectUris).toContain('https://callback.example.com');
+      expect(patched.settings.oauth.grantTypes).toEqual(['authorization_code']);
+    });
+
+    it('should reject authorization_code grant with empty redirect URIs for WEB type', async () => {
+      await expect(
+        fixture.patchApp({
+          settings: { oauth: { redirectUris: [], grantTypes: ['authorization_code'] } },
+        }),
+      ).rejects.toMatchObject({ response: { status: 400 } });
+    });
+  });
+});

--- a/gravitee-am-test/specs/management/application-general-settings/fixtures/application-general-settings-fixture.ts
+++ b/gravitee-am-test/specs/management/application-general-settings/fixtures/application-general-settings-fixture.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import { PatchApplication } from '@management-models/PatchApplication';
+import { PatchApplicationTypeTypeEnum } from '@management-models/PatchApplicationType';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { safeDeleteDomain, setupDomainForTest } from '@management-commands/domain-management-commands';
+import {
+  createApplication,
+  deleteApplication,
+  getApplication,
+  patchApplication,
+  updateApplicationType,
+} from '@management-commands/application-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+
+export interface ApplicationGeneralSettingsFixture {
+  accessToken: string;
+  domain: Domain;
+  app: Application;
+  patchApp: (body: PatchApplication) => Promise<Application>;
+  fetchApp: () => Promise<Application>;
+  setAppType: (type: PatchApplicationTypeTypeEnum) => Promise<Application>;
+  cleanUp: () => Promise<void>;
+}
+
+export const initFixture = async (): Promise<ApplicationGeneralSettingsFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  const { domain } = await setupDomainForTest(uniqueName('app-gen-settings', true), { accessToken, waitForStart: false });
+
+  // Create as SERVICE first (no redirect URIs required on creation), then switch to WEB
+  const app = await createApplication(domain.id, accessToken, {
+    name: uniqueName('gen-settings-app', true),
+    type: 'SERVICE',
+  });
+  await updateApplicationType(domain.id, accessToken, app.id, 'WEB');
+
+  const patchApp = (body: PatchApplication): Promise<Application> => patchApplication(domain.id, accessToken, body, app.id);
+
+  const fetchApp = (): Promise<Application> => getApplication(domain.id, accessToken, app.id);
+
+  const setAppType = (type: PatchApplicationTypeTypeEnum): Promise<Application> =>
+    updateApplicationType(domain.id, accessToken, app.id, type);
+
+  const cleanUp = async (): Promise<void> => {
+    try {
+      await deleteApplication(domain.id, accessToken, app.id);
+    } catch (_) {
+      // ignore cleanup errors
+    }
+    await safeDeleteDomain(domain?.id, accessToken);
+  };
+
+  return { accessToken, domain, app, patchApp, fetchApp, setAppType, cleanUp };
+};


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-5417

## :pencil2: A description of the changes proposed in the pull request
Adds automated jest tests for the application general settings page (Domain → Application → General) as part of AM-5417.

The tests cover the management API behaviour for all settings available on that page:

- Adding and removing redirect URIs, post logout redirect URIs, and request URIs
- Enabling and disabling the single sign out, silent re-authentication, skip consent, and template toggles
- Switching application type between WEB and SERVICE (Backend to Backend) and verifying that OAuth2 parameters update correctly - SERVICE uses client_credentials with no redirect URIs required, WEB uses authorization_code and rejects an empty redirect URI list

## :memo: Test scenarios 
NA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
