### PR TITLE
fix: indefinitely fetching OIDC cfg metadata

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/ProvisioningUserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/ProvisioningUserServiceImpl.java
@@ -82,7 +82,7 @@ import io.gravitee.am.service.exception.UserProviderNotFoundException;
 import io.gravitee.am.service.impl.PasswordHistoryService;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.management.UserAuditBuilder;
-import io.gravitee.am.service.utils.RetryAtMostWithDelay;
+import io.gravitee.am.service.utils.RetryWithDelay;
 import io.gravitee.am.service.utils.UserFactorUpdater;
 import io.gravitee.am.service.validators.user.UserValidator;
 import io.reactivex.rxjava3.core.Completable;
@@ -104,6 +104,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.isNull;
@@ -384,7 +385,11 @@ public class ProvisioningUserServiceImpl implements ProvisioningUserService, Ini
 
     private void pushStagingEmail(io.gravitee.am.model.User user1, Client resolvedClient) {
         emailStagingService.push(new EmailContainer(user1, resolvedClient), Template.REGISTRATION_CONFIRMATION)
-                .retryWhen(new RetryAtMostWithDelay(2, 1000))
+                .retryWhen(RetryWithDelay.builder()
+                        .maxRetries(2)
+                        .initialDelay(1000, TimeUnit.MILLISECONDS)
+                        .linear()
+                        .build())
                 .onErrorComplete(error -> {
                     LOGGER.warn("The email cannot be push on staging on domain {} for user {}",
                             domain.getName(), user1.getUsername(), error);

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/java/io/gravitee/am/identityprovider/oauth2/authentication/OAuth2GenericAuthenticationProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/main/java/io/gravitee/am/identityprovider/oauth2/authentication/OAuth2GenericAuthenticationProvider.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.identityprovider.oauth2.authentication;
 
 import com.nimbusds.jwt.proc.JWTProcessor;
+import io.gravitee.am.identityprovider.api.AuthenticationProvider;
 import io.gravitee.am.identityprovider.api.IdentityProviderGroupMapper;
 import io.gravitee.am.identityprovider.api.IdentityProviderMapper;
 import io.gravitee.am.identityprovider.api.IdentityProviderRoleMapper;
@@ -25,12 +26,11 @@ import io.gravitee.am.identityprovider.common.oauth2.authentication.AbstractOpen
 import io.gravitee.am.identityprovider.oauth2.OAuth2GenericIdentityProviderConfiguration;
 import io.gravitee.am.identityprovider.api.social.ProviderResponseType;
 import io.gravitee.am.identityprovider.oauth2.authentication.spring.OAuth2GenericAuthenticationProviderConfiguration;
+import io.gravitee.am.service.utils.RetryWithDelay;
 import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.vertx.rxjava3.ext.web.client.WebClient;
-import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Import;
@@ -69,6 +69,8 @@ public class OAuth2GenericAuthenticationProvider extends AbstractOpenIDConnectAu
     @Autowired
     private OAuth2GenericIdentityProviderConfiguration configuration;
 
+    private Disposable initializationDisposable;
+
     @Override
     public OpenIDConnectIdentityProviderConfiguration getConfiguration() {
         return this.configuration;
@@ -103,15 +105,29 @@ public class OAuth2GenericAuthenticationProvider extends AbstractOpenIDConnectAu
             throw new IllegalArgumentException("A client_secret must be supplied in order to use the Authorization Code flow");
         }
 
-        initializeAuthProvider().subscribe();
+        this.initializationDisposable = initializeAuthProvider().subscribe();
+    }
+
+    @Override
+    public AuthenticationProvider stop() throws Exception {
+        if (initializationDisposable != null && !initializationDisposable.isDisposed()) {
+            initializationDisposable.dispose();
+        }
+        if (client != null) {
+            client.close();
+        }
+        return super.stop();
     }
 
     protected Completable initializeAuthProvider() {
-        // fetch OpenID Provider information
-        final RetryWithDelay retryHandler = new RetryWithDelay();
         return getOpenIDProviderConfiguration(configuration)
                 .doOnError(error -> LOGGER.warn("Unable to load configuration from '{}' due to : {}", configuration.getWellKnownUri(), error.getMessage()))
-                .retryWhen(retryHandler)
+                .retryWhen(RetryWithDelay.builder()
+                        .unlimitedRetries()
+                        .initialDelay(1, TimeUnit.SECONDS)
+                        .maxDelay(60)
+                        .exponential()
+                        .build())
                 .andThen(Completable.fromAction(this::generateJWTProcessor));
     }
 
@@ -163,24 +179,6 @@ public class OAuth2GenericAuthenticationProvider extends AbstractOpenIDConnectAu
                                     return Single.just(providerConfiguration);
                                 }
                         ).ignoreElement();
-    }
-
-    /**
-     * trigger a retry with a delay of 1 second up to 60 seconds.
-     */
-    private static class RetryWithDelay implements Function<Flowable<Throwable>, Publisher<?>> {
-
-        private int delayInSec = 0;
-
-        @Override
-        public Publisher<?> apply(Flowable<Throwable> throwableFlowable) throws Exception {
-            return throwableFlowable.flatMap(err-> {
-                if (delayInSec < 60) {
-                    delayInSec = delayInSec + Math.max(delayInSec, 1);
-                }
-                return Flowable.timer(delayInSec, TimeUnit.SECONDS);
-            });
-        }
     }
 
     void setJwtProcessor(JWTProcessor jwtProcessor) {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/test/java/io/gravitee/am/identityprovider/oauth2/authentication/OAuth2GenericAuthenticationProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/test/java/io/gravitee/am/identityprovider/oauth2/authentication/OAuth2GenericAuthenticationProviderTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.identityprovider.oauth2.authentication;
 
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.proc.JWTProcessor;
@@ -27,6 +28,7 @@ import io.gravitee.am.identityprovider.api.DummyAuthenticationContext;
 import io.gravitee.am.identityprovider.api.DummyRequest;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.common.web.URLParametersUtils;
+import io.gravitee.am.identityprovider.oauth2.OAuth2GenericIdentityProviderConfiguration;
 import io.gravitee.am.identityprovider.oauth2.authentication.spring.OAuth2GenericAuthenticationProviderConfiguration;
 import io.gravitee.common.http.HttpHeaders;
 import io.reactivex.rxjava3.observers.TestObserver;
@@ -36,6 +38,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
@@ -46,9 +49,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
@@ -57,6 +62,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.unauthorized;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -76,6 +82,9 @@ public class OAuth2GenericAuthenticationProviderTest {
 
     @Autowired
     private DefaultIdentityProviderRoleMapper roleMapper;
+
+    @Autowired
+    private OAuth2GenericIdentityProviderConfiguration configuration;
 
     private JWTProcessor jwtProcessor = mock(JWTProcessor.class);
 
@@ -119,6 +128,25 @@ public class OAuth2GenericAuthenticationProviderTest {
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValue(u -> "bob".equals(u.getUsername()));
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    public void shouldStopRetryingWhenProviderStopped() throws Exception {
+        OAuth2GenericAuthenticationProvider provider = (OAuth2GenericAuthenticationProvider) authenticationProvider;
+        configuration.setWellKnownUri("http://localhost:19999/.well-known/openid-configuration");
+        stubFor(any(urlPathEqualTo("/.well-known/openid-configuration"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        provider.afterPropertiesSet();
+        Thread.sleep(600);
+        provider.stop();
+
+        int afterStop = wireMockRule.findAll(getRequestedFor(urlPathEqualTo("/.well-known/openid-configuration"))).size();
+        Thread.sleep(2000);
+        int later = wireMockRule.findAll(getRequestedFor(urlPathEqualTo("/.well-known/openid-configuration"))).size();
+
+        assertEquals("provider must stop retrying after stop()", afterStop, later);
     }
 
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/SystemTaskUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/SystemTaskUpgrader.java
@@ -20,7 +20,7 @@ import io.gravitee.am.model.SystemTask;
 import io.gravitee.am.model.SystemTaskStatus;
 import io.gravitee.am.model.SystemTaskTypes;
 import io.gravitee.am.repository.management.api.SystemTaskRepository;
-import io.gravitee.am.service.utils.RetryAtMostWithDelay;
+import io.gravitee.am.service.utils.RetryWithDelay;
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Flowable;
@@ -74,7 +74,11 @@ public abstract class SystemTaskUpgrader implements Upgrader {
                             // SUCCESS case
                             return Single.just(true);
                     }
-                }).retryWhen(new RetryAtMostWithDelay(3, 5000)).blockingGet();
+                }).retryWhen(RetryWithDelay.builder()
+                        .maxRetries(3)
+                        .initialDelay(5000, TimeUnit.MILLISECONDS)
+                        .linear()
+                        .build()).blockingGet();
 
         if (!upgraded) {
             throw getIllegalStateException();

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AuthenticationFlowContextServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AuthenticationFlowContextServiceImpl.java
@@ -19,13 +19,9 @@ import io.gravitee.am.model.AuthenticationFlowContext;
 import io.gravitee.am.repository.gateway.api.AuthenticationFlowContextRepository;
 import io.gravitee.am.service.AuthenticationFlowContextService;
 import io.gravitee.am.service.exception.AuthenticationFlowConsistencyException;
-import io.reactivex.rxjava3.annotations.NonNull;
+import io.gravitee.am.service.utils.RetryWithDelay;
 import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.functions.Function;
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,7 +80,12 @@ public class AuthenticationFlowContextServiceImpl implements AuthenticationFlowC
                 throw new AuthenticationFlowConsistencyException();
             }
             return context;
-        }).retryWhen(new RetryWithDelay(consistencyRetries, retryDelay));
+        }).retryWhen(RetryWithDelay.builder()
+                .maxRetries(consistencyRetries)
+                .initialDelay(retryDelay, TimeUnit.MILLISECONDS)
+                .linear()
+                .retryOn(AuthenticationFlowConsistencyException.class::isInstance)
+                .build());
     }
 
     @Override
@@ -111,39 +112,6 @@ public class AuthenticationFlowContextServiceImpl implements AuthenticationFlowC
             return authContextRepository.replace(authContext);
         } else {
             return authContextRepository.create(authContext);
-        }
-    }
-
-    /**
-     * Retry load context with delay
-     * from : https://stackoverflow.com/a/25292833
-     */
-    private class RetryWithDelay implements Function<Flowable<Throwable>, Publisher<?>> {
-        private final int maxRetries;
-        private final int retryDelayMillis;
-        private int retryCount;
-
-        public RetryWithDelay(int retries, int delay) {
-            this.maxRetries = retries;
-            this.retryDelayMillis = delay;
-            this.retryCount = 0;
-        }
-
-        @Override
-        public Publisher<?> apply(@NonNull Flowable<Throwable> attempts) {
-            return attempts
-                    .flatMap((throwable) -> {
-                        // perform retry only on Consistency exception
-                        if (throwable instanceof AuthenticationFlowConsistencyException && ++retryCount < maxRetries) {
-                                // When this Observable calls onNext, the original
-                                // Observable will be retried (i.e. re-subscribed).
-                                return Flowable.timer((long) retryDelayMillis * (retryCount + 1),
-                                        TimeUnit.MILLISECONDS);
-                            }
-
-                        // Max retries hit. Just pass the error along.
-                        return Flowable.error(throwable);
-                    });
         }
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/RetryAtMostWithDelay.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/RetryAtMostWithDelay.java
@@ -25,7 +25,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author Eric Leleu (eric.leleu@graviteesource.com)
  * @author GraviteeSource Team
+ * @deprecated use {@link RetryWithDelay} (linear backoff with a retry cap)
  */
+@Deprecated
 public class RetryAtMostWithDelay implements Function<Flowable<Throwable>, Publisher<?>> {
         private final int maxRetries;
         private final int retryDelayMillis;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/RetryWithDelay.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/RetryWithDelay.java
@@ -23,27 +23,149 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 
 public class RetryWithDelay implements Function<Flowable<Throwable>, Publisher<?>> {
     private static final Logger LOGGER = LoggerFactory.getLogger(RetryWithDelay.class);
 
-    private final AtomicInteger delayInSec = new AtomicInteger(1);
+    private static final int DEFAULT_MAX_RETRIES = 50;
+    private static final long DEFAULT_INITIAL_DELAY = 1;
+    private static final long DEFAULT_MAX_DELAY = 60;
+
+    public enum Backoff {
+        EXPONENTIAL, LINEAR
+    }
+
+    private final int maxRetries;
+    private final long initialDelay;
+    private final long maxDelay;
+    private final TimeUnit unit;
+    private final Backoff backoff;
+    private final Predicate<Throwable> retryOn;
+
     private final AtomicInteger counter = new AtomicInteger(0);
+    private final AtomicLong currentDelay;
+
+    public RetryWithDelay() {
+        this(builder()
+                .maxRetries(DEFAULT_MAX_RETRIES)
+                .initialDelay(DEFAULT_INITIAL_DELAY, TimeUnit.SECONDS)
+                .maxDelay(DEFAULT_MAX_DELAY)
+                .backoff(Backoff.EXPONENTIAL));
+    }
+
+    private RetryWithDelay(Builder builder) {
+        TimeUnit initialUnit = builder.unit;
+        TimeUnit maxUnit = builder.maxDelayUnit != null ? builder.maxDelayUnit : builder.unit;
+        TimeUnit common = initialUnit.compareTo(maxUnit) <= 0 ? initialUnit : maxUnit;
+
+        this.maxRetries = builder.maxRetries;
+        this.unit = common;
+        this.initialDelay = common.convert(builder.initialDelay, initialUnit);
+        this.maxDelay = builder.maxDelay <= 0 ? builder.maxDelay : common.convert(builder.maxDelay, maxUnit);
+        this.backoff = builder.backoff;
+        this.retryOn = builder.retryOn;
+        this.currentDelay = new AtomicLong(this.initialDelay);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
 
     @Override
-    public Publisher<?> apply(Flowable<Throwable> throwableFlowable) {
-        return throwableFlowable.flatMap(err -> {
-            if (counter.getAndIncrement() < 50) {
-                int delay = delayInSec.get();
-                LOGGER.warn("Initialization failed, attempt={}/50, delay={}", counter.get(), delay);
-                if (delay < 60) {
-                    delayInSec.set(delay * 2);
+    public Publisher<?> apply(Flowable<Throwable> attempts) {
+        return attempts.flatMap(error -> {
+            int attempt = counter.getAndIncrement();
+            boolean unlimited = maxRetries < 0;
+            boolean limitExceeded = !unlimited && attempt >= maxRetries;
+            if (limitExceeded || !retryOn.test(error)) {
+                if (limitExceeded) {
+                    LOGGER.error("Retry limit exceeded (maxRetries={})", maxRetries);
                 }
-                return Flowable.timer(delay, TimeUnit.SECONDS);
-            } else {
-                LOGGER.error("Retry limit exceeded");
-                return Flowable.error(err);
+                return Flowable.error(error);
             }
+            long delay = nextDelay(attempt);
+            if (unlimited) {
+                LOGGER.warn("Retry attempt {} in {} {}", attempt + 1, delay, unit.name().toLowerCase());
+            } else {
+                LOGGER.warn("Retry attempt {}/{} in {} {}", attempt + 1, maxRetries, delay, unit.name().toLowerCase());
+            }
+            return Flowable.timer(delay, unit);
         });
+    }
+
+    long nextDelay(int attempt) {
+        if (backoff == Backoff.LINEAR) {
+            long delay = initialDelay * (attempt + 1L);
+            return maxDelay > 0 ? Math.min(delay, maxDelay) : delay;
+        }
+        long delay = currentDelay.get();
+        if (maxDelay <= 0 || delay < maxDelay) {
+            currentDelay.set(delay * 2);
+        }
+        return maxDelay > 0 ? Math.min(delay, maxDelay) : delay;
+    }
+
+    public static final class Builder {
+        private int maxRetries = DEFAULT_MAX_RETRIES;
+        private long initialDelay = DEFAULT_INITIAL_DELAY;
+        private long maxDelay = 0;
+        private TimeUnit unit = TimeUnit.SECONDS;
+        private TimeUnit maxDelayUnit = null;
+        private Backoff backoff = Backoff.EXPONENTIAL;
+        private Predicate<Throwable> retryOn = throwable -> true;
+
+        public Builder maxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder unlimitedRetries() {
+            this.maxRetries = -1;
+            return this;
+        }
+
+        public Builder initialDelay(long delay, TimeUnit unit) {
+            this.initialDelay = delay;
+            this.unit = unit;
+            return this;
+        }
+
+        public Builder maxDelay(long maxDelay) {
+            this.maxDelay = maxDelay;
+            this.maxDelayUnit = null;
+            return this;
+        }
+
+        public Builder maxDelay(long maxDelay, TimeUnit unit) {
+            this.maxDelay = maxDelay;
+            this.maxDelayUnit = unit;
+            return this;
+        }
+
+        public Builder backoff(Backoff backoff) {
+            this.backoff = backoff;
+            return this;
+        }
+
+        public Builder linear() {
+            this.backoff = Backoff.LINEAR;
+            return this;
+        }
+
+        public Builder exponential() {
+            this.backoff = Backoff.EXPONENTIAL;
+            return this;
+        }
+
+        public Builder retryOn(Predicate<Throwable> retryOn) {
+            this.retryOn = retryOn;
+            return this;
+        }
+
+        public RetryWithDelay build() {
+            return new RetryWithDelay(this);
+        }
     }
 }


### PR DESCRIPTION
How to test:

before:
Create an OIDC IdP and set the OpenID Connect Well-Known Endpoint to the one from jwt.io.
Check the logs. You should see failures that continue even after the IdP has been removed.

after:
no logs anymore