### PR TITLE
test: (AM-5419) add jest tests for domain and application feature settings

### DIFF
--- a/gravitee-am-test/specs/management/application-general-settings/fixtures/application-general-settings-fixture.ts
+++ b/gravitee-am-test/specs/management/application-general-settings/fixtures/application-general-settings-fixture.ts
@@ -43,12 +43,11 @@ export const initFixture = async (): Promise<ApplicationGeneralSettingsFixture> 
   const accessToken = await requestAdminAccessToken();
   const { domain } = await setupDomainForTest(uniqueName('app-gen-settings', true), { accessToken, waitForStart: false });
 
-  // Create as SERVICE first (no redirect URIs required on creation), then switch to WEB
   const app = await createApplication(domain.id, accessToken, {
     name: uniqueName('gen-settings-app', true),
-    type: 'SERVICE',
+    type: 'WEB',
+    redirectUris: ['https://callback.example.com'],
   });
-  await updateApplicationType(domain.id, accessToken, app.id, 'WEB');
 
   const patchApp = (body: PatchApplication): Promise<Application> => patchApplication(domain.id, accessToken, body, app.id);
 

--- a/gravitee-am-test/specs/management/domain-application-feature-settings/domain-application-feature-settings.jest.spec.ts
+++ b/gravitee-am-test/specs/management/domain-application-feature-settings/domain-application-feature-settings.jest.spec.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { FeatureSettingsFixture, initFixture } from './fixtures/feature-settings-fixture';
+
+setup();
+
+let fixture: FeatureSettingsFixture;
+
+beforeAll(async () => {
+  fixture = await initFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('Domain and Application Feature Settings', () => {
+  describe('Domain login settings', () => {
+    it('should enable user registration', async () => {
+      const patched = await fixture.patchDomainSettings({ loginSettings: { registerEnabled: true } });
+      expect(patched.loginSettings.registerEnabled).toBe(true);
+    });
+
+    it('should disable user registration', async () => {
+      const patched = await fixture.patchDomainSettings({ loginSettings: { registerEnabled: false } });
+      expect(patched.loginSettings.registerEnabled).toBe(false);
+    });
+
+    it('should persist user registration setting across GET', async () => {
+      await fixture.patchDomainSettings({ loginSettings: { registerEnabled: true } });
+      const fetched = await fixture.fetchDomain();
+      expect(fetched.loginSettings.registerEnabled).toBe(true);
+    });
+
+    it('should enable identifier-first login', async () => {
+      const patched = await fixture.patchDomainSettings({ loginSettings: { identifierFirstEnabled: true } });
+      expect(patched.loginSettings.identifierFirstEnabled).toBe(true);
+    });
+
+    it('should disable identifier-first login', async () => {
+      const patched = await fixture.patchDomainSettings({ loginSettings: { identifierFirstEnabled: false } });
+      expect(patched.loginSettings.identifierFirstEnabled).toBe(false);
+    });
+
+    it('should enable hide login form', async () => {
+      const patched = await fixture.patchDomainSettings({ loginSettings: { hideForm: true } });
+      expect(patched.loginSettings.hideForm).toBe(true);
+    });
+
+    it('should disable hide login form', async () => {
+      const patched = await fixture.patchDomainSettings({ loginSettings: { hideForm: false } });
+      expect(patched.loginSettings.hideForm).toBe(false);
+    });
+  });
+
+  describe('Application login settings — inherited from domain', () => {
+    it('should default to inheriting domain login settings', async () => {
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings?.login?.inherited).not.toBe(false);
+    });
+
+    it('should reflect domain login settings when application is set to inherited', async () => {
+      await fixture.patchDomainSettings({ loginSettings: { registerEnabled: true, forgotPasswordEnabled: true } });
+      await fixture.patchApp({ settings: { login: { inherited: true } } });
+
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings.login.inherited).toBe(true);
+    });
+  });
+
+  describe('Application login settings — application override', () => {
+    it('should override login settings at application level when not inherited', async () => {
+      const patched = await fixture.patchApp({
+        settings: {
+          login: {
+            inherited: false,
+            registerEnabled: false,
+            forgotPasswordEnabled: false,
+          },
+        },
+      });
+      expect(patched.settings.login.inherited).toBe(false);
+      expect(patched.settings.login.registerEnabled).toBe(false);
+      expect(patched.settings.login.forgotPasswordEnabled).toBe(false);
+    });
+
+    it('should persist application login settings override across GET', async () => {
+      await fixture.patchApp({
+        settings: {
+          login: {
+            inherited: false,
+            registerEnabled: true,
+            forgotPasswordEnabled: false,
+          },
+        },
+      });
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings.login.inherited).toBe(false);
+      expect(fetched.settings.login.registerEnabled).toBe(true);
+      expect(fetched.settings.login.forgotPasswordEnabled).toBe(false);
+    });
+
+    it('should revert to inherited when switching application login settings back to inherited', async () => {
+      await fixture.patchApp({ settings: { login: { inherited: false, registerEnabled: false } } });
+      const patched = await fixture.patchApp({ settings: { login: { inherited: true } } });
+      expect(patched.settings.login.inherited).toBe(true);
+    });
+  });
+
+  describe('Application account settings — inherited from domain', () => {
+    it('should default to inheriting domain account settings', async () => {
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings?.account?.inherited).not.toBe(false);
+    });
+
+    it('should reflect inherited state when explicitly set to inherited', async () => {
+      const patched = await fixture.patchApp({ settings: { account: { inherited: true } } });
+      expect(patched.settings.account.inherited).toBe(true);
+    });
+  });
+
+  describe('Application account settings — application override', () => {
+    it('should override account settings at application level when not inherited', async () => {
+      const patched = await fixture.patchApp({
+        settings: {
+          account: {
+            inherited: false,
+            loginAttemptsDetectionEnabled: true,
+            maxLoginAttempts: 5,
+            loginAttemptsResetTime: 60,
+            accountBlockedDuration: 30,
+          },
+        },
+      });
+      expect(patched.settings.account.inherited).toBe(false);
+      expect(patched.settings.account.loginAttemptsDetectionEnabled).toBe(true);
+      expect(patched.settings.account.maxLoginAttempts).toBe(5);
+      expect(patched.settings.account.loginAttemptsResetTime).toBe(60);
+      expect(patched.settings.account.accountBlockedDuration).toBe(30);
+    });
+
+    it('should persist application account settings override across GET', async () => {
+      await fixture.patchApp({
+        settings: {
+          account: {
+            inherited: false,
+            loginAttemptsDetectionEnabled: true,
+            maxLoginAttempts: 3,
+            loginAttemptsResetTime: 120,
+            accountBlockedDuration: 60,
+          },
+        },
+      });
+      const fetched = await fixture.fetchApp();
+      expect(fetched.settings.account.inherited).toBe(false);
+      expect(fetched.settings.account.loginAttemptsDetectionEnabled).toBe(true);
+      expect(fetched.settings.account.maxLoginAttempts).toBe(3);
+    });
+
+    it('should revert to inherited when switching application account settings back to inherited', async () => {
+      await fixture.patchApp({ settings: { account: { inherited: false, loginAttemptsDetectionEnabled: true } } });
+      const patched = await fixture.patchApp({ settings: { account: { inherited: true } } });
+      expect(patched.settings.account.inherited).toBe(true);
+    });
+  });
+});

--- a/gravitee-am-test/specs/management/domain-application-feature-settings/fixtures/feature-settings-fixture.ts
+++ b/gravitee-am-test/specs/management/domain-application-feature-settings/fixtures/feature-settings-fixture.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import { PatchApplication } from '@management-models/PatchApplication';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { safeDeleteDomain, setupDomainForTest, patchDomain, getDomain } from '@management-commands/domain-management-commands';
+import {
+  createApplication,
+  deleteApplication,
+  getApplication,
+  patchApplication,
+  updateApplicationType,
+} from '@management-commands/application-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+
+export interface FeatureSettingsFixture {
+  accessToken: string;
+  domain: Domain;
+  app: Application;
+  patchDomainSettings: (settings: any) => Promise<Domain>;
+  fetchDomain: () => Promise<Domain>;
+  patchApp: (body: PatchApplication) => Promise<Application>;
+  fetchApp: () => Promise<Application>;
+  cleanUp: () => Promise<void>;
+}
+
+export const initFixture = async (): Promise<FeatureSettingsFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  const { domain } = await setupDomainForTest(uniqueName('feature-settings', true), { accessToken, waitForStart: false });
+
+  // Create as SERVICE first (no redirect URIs required on creation), then switch to WEB
+  const app = await createApplication(domain.id, accessToken, {
+    name: uniqueName('feature-settings-app', true),
+    type: 'SERVICE',
+  });
+  await updateApplicationType(domain.id, accessToken, app.id, 'WEB');
+  // WEB type requires at least one redirect URI for subsequent patches
+  await patchApplication(domain.id, accessToken, { settings: { oauth: { redirectUris: ['https://callback.example.com'] } } }, app.id);
+
+  const patchDomainSettings = (settings: any): Promise<Domain> => patchDomain(domain.id, accessToken, settings);
+
+  const fetchDomain = (): Promise<Domain> => getDomain(domain.id, accessToken);
+
+  const patchApp = (body: PatchApplication): Promise<Application> => patchApplication(domain.id, accessToken, body, app.id);
+
+  const fetchApp = (): Promise<Application> => getApplication(domain.id, accessToken, app.id);
+
+  const cleanUp = async (): Promise<void> => {
+    try {
+      await deleteApplication(domain.id, accessToken, app.id);
+    } catch (_) {
+      // ignore cleanup errors
+    }
+    await safeDeleteDomain(domain?.id, accessToken);
+  };
+
+  return { accessToken, domain, app, patchDomainSettings, fetchDomain, patchApp, fetchApp, cleanUp };
+};

--- a/gravitee-am-test/specs/management/domain-application-feature-settings/fixtures/feature-settings-fixture.ts
+++ b/gravitee-am-test/specs/management/domain-application-feature-settings/fixtures/feature-settings-fixture.ts
@@ -24,7 +24,6 @@ import {
   deleteApplication,
   getApplication,
   patchApplication,
-  updateApplicationType,
 } from '@management-commands/application-management-commands';
 import { uniqueName } from '@utils-commands/misc';
 
@@ -43,14 +42,11 @@ export const initFixture = async (): Promise<FeatureSettingsFixture> => {
   const accessToken = await requestAdminAccessToken();
   const { domain } = await setupDomainForTest(uniqueName('feature-settings', true), { accessToken, waitForStart: false });
 
-  // Create as SERVICE first (no redirect URIs required on creation), then switch to WEB
   const app = await createApplication(domain.id, accessToken, {
     name: uniqueName('feature-settings-app', true),
-    type: 'SERVICE',
+    type: 'WEB',
+    redirectUris: ['https://callback.example.com'],
   });
-  await updateApplicationType(domain.id, accessToken, app.id, 'WEB');
-  // WEB type requires at least one redirect URI for subsequent patches
-  await patchApplication(domain.id, accessToken, { settings: { oauth: { redirectUris: ['https://callback.example.com'] } } }, app.id);
 
   const patchDomainSettings = (settings: any): Promise<Domain> => patchDomain(domain.id, accessToken, settings);
 


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-5419

## :pencil2: A description of the changes proposed in the pull request
This PR adds Jest management API tests for AM-5419, covering the enabling and disabling of features at both domain and application level.

  **What is tested:**
  - Domain login settings — enabling/disabling user registration, identifier-first login, and hide login form, including persistence across GET
  - Application login settings (inherited) — verifies that applications default to inheriting domain login settings and correctly reflect the inherited state
  - Application login settings (override) — verifies that applications can override login settings independently, persist those overrides, and revert back to inherited
  - Application account settings (inherited) — verifies that applications default to inheriting domain account settings
  - Application account settings (override) — verifies that applications can override account settings (login attempts detection, max attempts, reset time, block duration),
  persist overrides, and revert back to inherited

  **Note:** Existing tests for magic link, passwordless, forgot password, and certificate-based auth at domain level were already covered in separate specs and are not duplicated
  here.

## :memo: Test scenarios 
NA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
NA

This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
