### PR TITLE
fix(users): allow adding additional information to an existing user

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/users/user/profile/profile.component.html
@@ -159,7 +159,7 @@
             </mat-slide-toggle>
           </div>
         </div>
-        <div class="gv-form-section" *ngIf="!isEmptyObject(user.additionalInformation)">
+        <div class="gv-form-section" *ngIf="canEdit || !isEmptyObject(user.additionalInformation)">
           <div class="gv-form-section-title">
             <h5>Additional information</h5>
             <small>Custom information about the user. These details are available in the user's profile.</small>


### PR DESCRIPTION
## Description

The **Additional information** section on the user profile page was gated by `*ngIf="!isEmptyObject(user.additionalInformation)"`. For a user created without any custom attributes, `additionalInformation` is an empty object `{}`, so the whole section — including the `(+) add user attribute` link and its `#dynamic` anchor — was hidden. This made it impossible to add additional information to a user after creation via the console (chicken-and-egg: no attributes → no section → no way to add).

## Fix

Show the section when the user is editable, so the add link is available even when `additionalInformation` is empty:

```diff
- *ngIf="!isEmptyObject(user.additionalInformation)"
+ *ngIf="canEdit || !isEmptyObject(user.additionalInformation)"
```

The existing-attributes `*ngFor` renders empty when there are no attributes, so no extra guarding is needed. Read-only users (no `domain_user_update` / `organization_user_update`) with an empty object still see nothing, as before.

## How to test

1. Create a new user **without** any additional information.
2. Open the user's profile/details page.
3. The **Additional information** section is now visible with the `(+) add user attribute` link.
4. Add an attribute, save, and confirm it persists.

## Reference

AM-7288
