### PR TITLE
feat(AM-7225): sync entrypoints from cockpit environment commands in cloud mode

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
@@ -15,7 +15,10 @@
  */
 package io.gravitee.am.management.service.impl.commands;
 
+import io.gravitee.am.common.env.CloudProperties;
+import io.gravitee.am.service.EntrypointService;
 import io.gravitee.am.service.EnvironmentService;
+import io.gravitee.am.service.model.NewEntrypoint;
 import io.gravitee.am.service.model.NewEnvironment;
 import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
@@ -23,11 +26,14 @@ import io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommand;
 import io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommandPayload;
 import io.gravitee.cockpit.api.command.v1.environment.EnvironmentReply;
 import io.gravitee.exchange.api.command.CommandHandler;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -41,6 +47,8 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
 
 
     private final EnvironmentService environmentService;
+    private final EntrypointService entrypointService;
+    private final Environment environment;
 
     @Override
     public String supportType() {
@@ -55,7 +63,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         newEnvironment.setHrids(environmentPayload.hrids());
         newEnvironment.setName(environmentPayload.name());
         newEnvironment.setDescription(environmentPayload.description());
-        if (environmentPayload.accessPoints() != null) {
+        if (environmentPayload.accessPoints() != null && !CloudProperties.isManagedCloudEnabled(environment)) {
             newEnvironment.setDomainRestrictions(environmentPayload.accessPoints()
                     .stream()
                     .filter(accessPoint -> accessPoint.getTarget() == AccessPoint.Target.GATEWAY)
@@ -64,9 +72,40 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         }
 
         return environmentService.createOrUpdate(environmentPayload.organizationId(), environmentPayload.id(), newEnvironment, null)
+                .flatMap(env -> syncEntrypoints(environmentPayload).andThen(Single.just(env)))
                 .map(organization -> new EnvironmentReply(command.getId()))
                 .doOnSuccess(reply -> log.info("Environment [{}] handled with id [{}].", environmentPayload.name(), environmentPayload.id()))
                 .doOnError(error -> log.error("Error occurred when handling environment [{}] with id [{}].", environmentPayload.name(), environmentPayload.id(), error))
                 .onErrorReturn(throwable -> new EnvironmentReply(command.getId(), throwable.getMessage()));
+    }
+
+    private Completable syncEntrypoints(EnvironmentCommandPayload environmentPayload) {
+        if (!CloudProperties.isManagedCloudEnabled(environment)) {
+            return Completable.complete();
+        }
+
+        String organizationId = environmentPayload.organizationId();
+        String environmentId = environmentPayload.id();
+
+        List<AccessPoint> gatewayAccessPoints = environmentPayload.accessPoints() == null
+                ? List.of()
+                : environmentPayload.accessPoints().stream()
+                        .filter(accessPoint -> accessPoint.getTarget() == AccessPoint.Target.GATEWAY)
+                        .collect(Collectors.toList());
+
+        return entrypointService.findByEnvironment(organizationId, environmentId)
+                .flatMapCompletable(entrypoint -> entrypointService.delete(entrypoint.getId(), organizationId, null))
+                .andThen(Completable.defer(() -> Completable.merge(gatewayAccessPoints.stream()
+                        .map(accessPoint -> createEntrypoint(organizationId, environmentId, accessPoint))
+                        .collect(Collectors.toList()))));
+    }
+
+    private Completable createEntrypoint(String organizationId, String environmentId, AccessPoint accessPoint) {
+        NewEntrypoint newEntrypoint = new NewEntrypoint();
+        newEntrypoint.setUrl("https://" + accessPoint.getHost());
+        newEntrypoint.setName(accessPoint.getHost());
+        newEntrypoint.setEnvironmentId(environmentId);
+
+        return entrypointService.create(organizationId, newEntrypoint, null).ignoreElement();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.am.management.service.impl.commands;
 
+import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.repository.exceptions.TechnicalException;
+import io.gravitee.am.service.EntrypointService;
 import io.gravitee.am.service.EnvironmentService;
+import io.gravitee.am.service.model.NewEntrypoint;
 import io.gravitee.am.service.model.NewEnvironment;
 import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
@@ -25,6 +28,8 @@ import io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommand;
 import io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommandPayload;
 import io.gravitee.cockpit.api.command.v1.environment.EnvironmentReply;
 import io.gravitee.exchange.api.command.CommandStatus;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
 
 import java.util.Collections;
 import java.util.List;
@@ -42,6 +48,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -54,11 +64,17 @@ class EnvironmentCommandHandlerTest {
     @Mock
     private EnvironmentService environmentService;
 
+    @Mock
+    private EntrypointService entrypointService;
+
+    private MockEnvironment springEnvironment;
+
     public EnvironmentCommandHandler cut;
 
     @BeforeEach
     void before() {
-        cut = new EnvironmentCommandHandler(environmentService);
+        springEnvironment = new MockEnvironment();
+        cut = new EnvironmentCommandHandler(environmentService, entrypointService, springEnvironment);
     }
 
     @Test
@@ -89,6 +105,9 @@ class EnvironmentCommandHandlerTest {
 
         obs.awaitDone(10, TimeUnit.SECONDS);
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        // non-cloud mode: entrypoint sync must be entirely skipped
+        verifyNoInteractions(entrypointService);
     }
 
     @Test
@@ -102,6 +121,128 @@ class EnvironmentCommandHandlerTest {
                 .build();
         EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
         when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.error(new TechnicalException()));
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+    }
+
+    private void enableCloudMode() {
+        springEnvironment.setProperty("cloud.enabled", "true");
+        springEnvironment.setProperty("installation.type", "managed");
+    }
+
+    @Test
+    void handleCloudMode_syncsEntrypoints_deleteThenRecreate() {
+        enableCloudMode();
+
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .organizationId("orga#1")
+                .description("Environment description")
+                .name("Environment name")
+                .accessPoints(List.of(
+                        AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build(),
+                        AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction2.io").build(),
+                        AccessPoint.builder().target(AccessPoint.Target.CONSOLE).host("console.io").build()))
+                .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
+
+        Entrypoint existing1 = new Entrypoint();
+        existing1.setId("entrypoint#1");
+        Entrypoint existing2 = new Entrypoint();
+        existing2.setId("entrypoint#2");
+        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.just(existing1, existing2));
+        when(entrypointService.delete(eq("entrypoint#1"), eq("orga#1"), isNull())).thenReturn(Completable.complete());
+        when(entrypointService.delete(eq("entrypoint#2"), eq("orga#1"), isNull())).thenReturn(Completable.complete());
+        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(entrypointService, times(1)).delete("entrypoint#1", "orga#1", null);
+        verify(entrypointService, times(1)).delete("entrypoint#2", "orga#1", null);
+        verify(entrypointService, times(1)).create(eq("orga#1"), argThat(newEntrypoint ->
+                newEntrypoint.getUrl().equals("https://domain.restriction1.io")
+                        && newEntrypoint.getName().equals("domain.restriction1.io")
+                        && "env#1".equals(newEntrypoint.getEnvironmentId())), isNull());
+        verify(entrypointService, times(1)).create(eq("orga#1"), argThat(newEntrypoint ->
+                newEntrypoint.getUrl().equals("https://domain.restriction2.io")
+                        && newEntrypoint.getName().equals("domain.restriction2.io")
+                        && "env#1".equals(newEntrypoint.getEnvironmentId())), isNull());
+        // CONSOLE access point must not generate an entrypoint
+        verify(entrypointService, times(2)).create(eq("orga#1"), any(NewEntrypoint.class), isNull());
+    }
+
+    @Test
+    void handleCloudMode_noPriorEntrypoints_createsNewOnes() {
+        enableCloudMode();
+
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .organizationId("orga#1")
+                .description("Environment description")
+                .name("Environment name")
+                .accessPoints(List.of(AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build()))
+                .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
+        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.empty());
+        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(entrypointService, never()).delete(any(), any(), any());
+        verify(entrypointService, times(1)).create(eq("orga#1"), any(NewEntrypoint.class), isNull());
+    }
+
+    @Test
+    void handleNonCloudMode_doesNotCallEntrypointService() {
+
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .organizationId("orga#1")
+                .description("Environment description")
+                .name("Environment name")
+                .accessPoints(List.of(AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build()))
+                .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verifyNoInteractions(entrypointService);
+    }
+
+    @Test
+    void handleCloudMode_entrypointSyncFailure_propagatesAsErrorReply() {
+        enableCloudMode();
+
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .organizationId("orga#1")
+                .description("Environment description")
+                .name("Environment name")
+                .accessPoints(List.of(AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build()))
+                .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
+        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.error(new TechnicalException("boom")));
 
         TestObserver<EnvironmentReply> obs = cut.handle(command).test();
 

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/Entrypoint.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/Entrypoint.java
@@ -33,6 +33,7 @@ public class Entrypoint {
     private String url;
     private List<String> tags;
     private String organizationId;
+    private String environmentId;
     private boolean defaultEntrypoint;
     @Schema(type = "java.lang.Long")
     private Date createdAt;
@@ -48,6 +49,7 @@ public class Entrypoint {
         this.url = other.url;
         this.tags = other.tags;
         this.organizationId = other.organizationId;
+        this.environmentId = other.environmentId;
         this.defaultEntrypoint = other.defaultEntrypoint;
         this.createdAt = other.createdAt;
         this.updatedAt = other.updatedAt;
@@ -147,5 +149,13 @@ public class Entrypoint {
 
     public void setDefaultEntrypoint(boolean defaultEntrypoint) {
         this.defaultEntrypoint = defaultEntrypoint;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/EntrypointRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/EntrypointRepository.java
@@ -29,4 +29,6 @@ public interface EntrypointRepository extends CrudRepository<Entrypoint, String>
     Maybe<Entrypoint> findById(String id, String organizationId);
 
     Flowable<Entrypoint> findAll(String organizationId);
+
+    Flowable<Entrypoint> findByEnvironment(String organizationId, String environmentId);
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcEntrypointRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcEntrypointRepository.java
@@ -82,6 +82,16 @@ public class JdbcEntrypointRepository extends AbstractJdbcRepository implements 
                 .observeOn(Schedulers.computation());
     }
 
+    @Override
+    public Flowable<Entrypoint> findByEnvironment(String organizationId, String environmentId) {
+        LOGGER.debug("findByEnvironment({}, {})", organizationId, environmentId);
+
+        return entrypointRepository.findByEnvironment(organizationId, environmentId).map(this::toEntity)
+                .flatMap(entrypoint -> completeTags(entrypoint).toFlowable())
+                .doOnError(error -> LOGGER.error("Unable to list entrypoints with organization {} and environment {}", organizationId, environmentId, error))
+                .observeOn(Schedulers.computation());
+    }
+
     private Single<Entrypoint> completeTags(Entrypoint entrypoint) {
         return tagRepository.findAllByEntrypoint(entrypoint.getId())
                 .map(JdbcEntrypoint.Tag::getTag).toList().map(tags -> {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcEntrypoint.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcEntrypoint.java
@@ -34,6 +34,8 @@ public class JdbcEntrypoint {
     private String url;
     @Column("organization_id")
     private String organizationId;
+    @Column("environment_id")
+    private String environmentId;
     @Column("default_entrypoint")
     private boolean defaultEntrypoint;
     @Column("created_at")
@@ -87,6 +89,14 @@ public class JdbcEntrypoint {
 
     public void setDefaultEntrypoint(boolean defaultEntrypoint) {
         this.defaultEntrypoint = defaultEntrypoint;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/entrypoint/SpringEntrypointRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/entrypoint/SpringEntrypointRepository.java
@@ -34,4 +34,7 @@ public interface SpringEntrypointRepository extends RxJava3CrudRepository<JdbcEn
 
     @Query("select * from entrypoints e where e.organization_id = :org")
     Flowable<JdbcEntrypoint> findAllByOrganization(@Param("org") String organizationId);
+
+    @Query("select * from entrypoints e where e.organization_id = :org and e.environment_id = :env")
+    Flowable<JdbcEntrypoint> findByEnvironment(@Param("org") String organizationId, @Param("env") String environmentId);
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-entrypoints-add-environment-id-column.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-entrypoints-add-environment-id-column.yml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0-entrypoints-add-environment-id-column
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: entrypoints
+              columnName: environment_id
+      changes:
+        #############################
+        # entrypoints #
+        ############################
+        - addColumn:
+            tableName: entrypoints
+            columns:
+              - column: { name: environment_id, type: nvarchar(255), constraints: { nullable: true } }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
@@ -225,3 +225,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_13_0/4.13.0-application-scope-settings-add-required.yml
   - include:
       - file: liquibase/changelogs/v4_13_0/4.13.0-licenses-table.yml
+  - include:
+      - file: liquibase/changelogs/v4_13_0/4.13.0-entrypoints-add-environment-id-column.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEntrypointRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoEntrypointRepository.java
@@ -68,7 +68,13 @@ public class MongoEntrypointRepository extends AbstractManagementMongoRepository
 
     @Override
     public Flowable<Entrypoint> findAll(String organizationId) {
-        return Flowable.fromPublisher(withMaxTime(collection.find(eq("organizationId", organizationId)))).map(this::convert)
+        return Flowable.fromPublisher(withMaxTime(collection.find(eq(FIELD_ORGANIZATION_ID, organizationId)))).map(this::convert)
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Flowable<Entrypoint> findByEnvironment(String organizationId, String environmentId) {
+        return Flowable.fromPublisher(withMaxTime(collection.find(and(eq(FIELD_ORGANIZATION_ID, organizationId), eq("environmentId", environmentId))))).map(this::convert)
                 .observeOn(Schedulers.computation());
     }
 
@@ -105,6 +111,7 @@ public class MongoEntrypointRepository extends AbstractManagementMongoRepository
         entrypoint.setUrl(entrypointMongo.getUrl());
         entrypoint.setTags(entrypointMongo.getTags());
         entrypoint.setOrganizationId(entrypointMongo.getOrganizationId());
+        entrypoint.setEnvironmentId(entrypointMongo.getEnvironmentId());
         entrypoint.setDefaultEntrypoint(entrypointMongo.isDefaultEntrypoint());
         entrypoint.setCreatedAt(entrypointMongo.getCreatedAt());
         entrypoint.setUpdatedAt(entrypointMongo.getUpdatedAt());
@@ -124,6 +131,7 @@ public class MongoEntrypointRepository extends AbstractManagementMongoRepository
         entrypointMongo.setUrl(entrypoint.getUrl());
         entrypointMongo.setTags(entrypoint.getTags());
         entrypointMongo.setOrganizationId(entrypoint.getOrganizationId());
+        entrypointMongo.setEnvironmentId(entrypoint.getEnvironmentId());
         entrypointMongo.setDefaultEntrypoint(entrypoint.isDefaultEntrypoint());
         entrypointMongo.setCreatedAt(entrypoint.getCreatedAt());
         entrypointMongo.setUpdatedAt(entrypoint.getUpdatedAt());

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/EntrypointMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/EntrypointMongo.java
@@ -31,6 +31,7 @@ public class EntrypointMongo  extends Auditable {
     private String url;
     private List<String> tags;
     private String organizationId;
+    private String environmentId;
     private boolean defaultEntrypoint;
 
     public String getId() {
@@ -87,5 +88,13 @@ public class EntrypointMongo  extends Auditable {
 
     public void setDefaultEntrypoint(boolean defaultEntrypoint) {
         this.defaultEntrypoint = defaultEntrypoint;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/EntrypointRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/EntrypointRepositoryTest.java
@@ -78,6 +78,27 @@ public class EntrypointRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
+    public void testFindByEnvironment() {
+
+        Entrypoint entrypoint = buildEntrypoint();
+        entrypoint.setEnvironmentId("env#1");
+        Entrypoint createdEntrypoint = entrypointRepository.create(entrypoint).blockingGet();
+
+        Entrypoint otherEnvironmentEntrypoint = buildEntrypoint();
+        otherEnvironmentEntrypoint.setEnvironmentId("env#2");
+        entrypointRepository.create(otherEnvironmentEntrypoint).blockingGet();
+
+        TestSubscriber<Entrypoint> testSubscriber = entrypointRepository.findByEnvironment(ORGANIZATION_ID, "env#1").test();
+        testSubscriber.awaitDone(10, TimeUnit.SECONDS);
+
+        testSubscriber.assertComplete();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertValueCount(1);
+        assertEquals(entrypoint, createdEntrypoint.getId(), testSubscriber);
+        testSubscriber.assertValue(e -> "env#1".equals(e.getEnvironmentId()));
+    }
+
+    @Test
     public void testFindById() {
 
         Entrypoint entrypoint = buildEntrypoint();

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntrypointService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntrypointService.java
@@ -34,6 +34,8 @@ public interface EntrypointService {
 
     Flowable<Entrypoint> findAll(String organizationId);
 
+    Flowable<Entrypoint> findByEnvironment(String organizationId, String environmentId);
+
     Single<Entrypoint> create(String organizationId, NewEntrypoint entrypoint, User principal);
 
     Flowable<Entrypoint> createDefaults(Organization organization);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
@@ -93,12 +93,21 @@ public class EntrypointServiceImpl implements EntrypointService {
     }
 
     @Override
+    public Flowable<Entrypoint> findByEnvironment(String organizationId, String environmentId) {
+
+        log.debug("Find entrypoints by organizationId {} and environmentId {}", organizationId, environmentId);
+
+        return entrypointRepository.findByEnvironment(organizationId, environmentId);
+    }
+
+    @Override
     public Single<Entrypoint> create(String organizationId, NewEntrypoint newEntrypoint, User principal) {
 
         log.debug("Create a new entrypoint {} for organization {}", newEntrypoint, organizationId);
 
         Entrypoint toCreate = new Entrypoint();
         toCreate.setOrganizationId(organizationId);
+        toCreate.setEnvironmentId(newEntrypoint.getEnvironmentId());
         toCreate.setName(newEntrypoint.getName());
         toCreate.setDescription(newEntrypoint.getDescription());
         toCreate.setUrl(newEntrypoint.getUrl());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewEntrypoint.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewEntrypoint.java
@@ -36,6 +36,8 @@ public class NewEntrypoint {
     @NotNull
     private List<String> tags;
 
+    private String environmentId;
+
     public String getName() {
         return name;
     }
@@ -73,5 +75,13 @@ public class NewEntrypoint {
 
     public void setTags(List<String> tags) {
         this.tags = tags;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
@@ -124,6 +124,83 @@ public class EntrypointServiceTest {
     }
 
     @Test
+    public void shouldFindByEnvironment() {
+
+        Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setOrganizationId(ORGANIZATION_ID);
+        entrypoint.setEnvironmentId("env#1");
+        when(entrypointRepository.findByEnvironment(ORGANIZATION_ID, "env#1")).thenReturn(Flowable.just(entrypoint));
+
+        TestSubscriber<Entrypoint> obs = cut.findByEnvironment(ORGANIZATION_ID, "env#1").test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertComplete();
+        obs.assertValue(entrypoint);
+    }
+
+    @Test
+    public void shouldCreateWithEnvironmentId() {
+
+        Organization organization = new Organization();
+        organization.setId(ORGANIZATION_ID);
+
+        NewEntrypoint newEntrypoint = new NewEntrypoint();
+        newEntrypoint.setName("name");
+        newEntrypoint.setDescription("description");
+        newEntrypoint.setTags(Arrays.asList("tag#1", "tags#2"));
+        newEntrypoint.setUrl("https://auth.gravitee.io");
+        newEntrypoint.setEnvironmentId("env#1");
+
+        when(organizationService.findById(ORGANIZATION_ID)).thenReturn(Single.just(organization));
+        when(entrypointRepository.create(any(Entrypoint.class))).thenAnswer(i -> Single.just(i.getArgument(0)));
+        doReturn(true).when(virtualHostValidator).isValidDomainOrSubDomain("auth.gravitee.io", null);
+
+        TestObserver<Entrypoint> obs = cut.create(ORGANIZATION_ID, newEntrypoint, null).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(entrypoint -> entrypoint.getId() != null
+                && entrypoint.getOrganizationId().equals(ORGANIZATION_ID)
+                && "env#1".equals(entrypoint.getEnvironmentId()));
+
+        verify(auditService, times(1)).report(argThat(builder -> {
+            Audit audit = builder.build(new ObjectMapper());
+            assertEquals(EventType.ENTRYPOINT_CREATED, audit.getType());
+            assertEquals(ReferenceType.ORGANIZATION, audit.getReferenceType());
+            assertEquals(ORGANIZATION_ID, audit.getReferenceId());
+            assertEquals("system", audit.getActor().getId());
+
+            return true;
+        }));
+    }
+
+    @Test
+    public void shouldDeleteWithNullPrincipal() {
+
+        Entrypoint existingEntrypoint = new Entrypoint();
+        existingEntrypoint.setId(ENTRYPOINT_ID);
+        existingEntrypoint.setOrganizationId(ORGANIZATION_ID);
+        existingEntrypoint.setEnvironmentId("env#1");
+
+        when(entrypointRepository.findById(ENTRYPOINT_ID, ORGANIZATION_ID)).thenReturn(Maybe.just(existingEntrypoint));
+        when(entrypointRepository.delete(ENTRYPOINT_ID)).thenReturn(Completable.complete());
+
+        TestObserver<Void> obs = cut.delete(ENTRYPOINT_ID, ORGANIZATION_ID, null).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertComplete();
+
+        verify(auditService, times(1)).report(argThat(builder -> {
+            Audit audit = builder.build(new ObjectMapper());
+            assertEquals(EventType.ENTRYPOINT_DELETED, audit.getType());
+            assertEquals(ReferenceType.ORGANIZATION, audit.getReferenceType());
+            assertEquals(ORGANIZATION_ID, audit.getReferenceId());
+            assertEquals("system", audit.getActor().getId());
+
+            return true;
+        }));
+    }
+
+    @Test
     public void shouldCreateDefaults() {
 
         Organization organization = new Organization();


### PR DESCRIPTION
## Reference related issue
[AM-7225](https://gravitee.atlassian.net/browse/AM-7225)

## Description
In cloud mode, synchronize `Entrypoint` entities from Cockpit `EnvironmentCommand` accessPoints: on every environment command, delete existing entrypoints linked to the environment and recreate them from the current GATEWAY access points. Non-cloud mode behaviour is unchanged. Environment deletion cleanup is out of scope for this ticket.


## Changes
- `Entrypoint`/`NewEntrypoint` gain a nullable `environmentId`.
- `EntrypointRepository` (+ Mongo/JDBC impls) gains `findByEnvironment`.
- New Liquibase changeset adding the `environment_id` column.
- `EnvironmentCommandHandler` syncs entrypoints (delete-then-recreate) in cloud mode only, chained in the same reactive pipeline as the environment update.
- `docs/mapi/openapi.yaml`: `environmentId` exposed as read-only on `Entrypoint`.

## Test scenarios
See Jira.

[AM-7225]: https://gravitee.atlassian.net/browse/AM-7225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ