### PR TITLE
chore: create github action to enforce documentation label on PR

### DIFF
--- a/.github/workflows/doc-label-requirement.yml
+++ b/.github/workflows/doc-label-requirement.yml
@@ -1,0 +1,29 @@
+name: Check Required Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+    branches:
+      - main
+
+jobs:
+  verify-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for required doc label
+        uses: actions/github-script@v7
+        with:
+          script: |
+              const labels = context.payload.pull_request.labels.map(l => l.name);
+              const requiredLabels = ['no-docs', 'doc-needs'];
+              
+              // Check if at least one required label exists on the PR
+              const hasRequiredLabel = requiredLabels.some(label => labels.includes(label));
+              
+              if (!hasRequiredLabel) {
+                core.setFailed(
+                  `PR is missing a documentation label! Please attach either 'no-docs' or 'doc-needs' to proceed.`
+                );
+              } else {
+                console.log('Documentation label found. Proceeding...');
+              }


### PR DESCRIPTION
## :id: Reference related issue. 


## :pencil2: A description of the changes proposed in the pull request


## :memo: Test scenarios 


## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822
