### PR TITLE
fix: stop InMemoryRoleManager on security domain undeploy

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
@@ -28,9 +28,11 @@ import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.flow.FlowManager;
 import io.gravitee.am.gateway.handler.common.password.PasswordPolicyManager;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceManager;
+import io.gravitee.am.gateway.handler.common.role.impl.InMemoryRoleManager;
 import io.gravitee.am.gateway.handler.common.service.RevokeTokenGatewayService;
 import io.gravitee.am.gateway.handler.common.service.mfa.UserEventListener;
 import io.gravitee.am.gateway.handler.common.service.mfa.impl.DomainEventListenerImpl;
+import io.gravitee.am.gateway.handler.common.utils.ConfigurationHelper;
 import io.gravitee.am.gateway.handler.manager.authdevice.notifier.AuthenticationDeviceNotifierManager;
 import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
 import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
@@ -246,6 +248,9 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
         components.add(DomainEventListenerImpl.class);
         components.add(ProtectedResourceManager.class);
 
+        if (ConfigurationHelper.useInMemoryRoleAndGroupManager(environment)) {
+            components.add(InMemoryRoleManager.class);
+        }
 
         components.forEach(componentClass -> {
             LifecycleComponent lifecyclecomponent = applicationContext.getBean(componentClass);


### PR DESCRIPTION
## Description

`SecurityDomainRouterFactory.startComponents()` conditionally starts `InMemoryRoleManager` (when `useInMemoryRoleAndGroupManager` is enabled), but `VertxSecurityDomainHandler.stopComponents()` never stopped it. On domain undeploy the manager stayed subscribed to `RoleEvent`s on the gateway event manager, leaking the listener (and its role cache) for every undeployed/redeployed domain.

Mirror the start-side conditional registration in `stopComponents()` so the manager unsubscribes on undeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)