### PR TITLE
test(reporter-file): retry audit log check when the file is not yet flushed

### DIFF
--- a/gravitee-am-reporter/gravitee-am-reporter-file/src/test/java/io/gravitee/am/reporter/file/audit/FileAuditReporterTest.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-file/src/test/java/io/gravitee/am/reporter/file/audit/FileAuditReporterTest.java
@@ -101,6 +101,9 @@ public abstract class FileAuditReporterTest {
                 return;
             } catch (AssertionError e) {
                 lastError = e;
+            } catch (RuntimeException | IOException e) {
+                // A not-yet-flushed file surfaces as e.g. IndexOutOfBounds while indexing lines; retry.
+                lastError = new AssertionError("Audit log check failed on attempt " + attempt, e);
             }
         }
         throw lastError;


### PR DESCRIPTION
## :id: Reference related issue.

AM-7309

## :pencil2: A description of the changes proposed in the pull request

`FileAuditReporterTest` was flaky. It reports 10 audits then reads them back off disk, but the writes are async (Vert.x `AsyncFile`, nothing awaits a flush), so under CI I/O load the file can still have fewer than 10 lines when the test reads it.

There's already a retry loop meant to cover exactly this, but it only catches `AssertionError`. The under-flush actually surfaces as `IndexOutOfBoundsException` from `lines.get(i)`, which sailed straight past the catch, so the retry never engaged and the test died on the first attempt.

The fix is one place in the base class: also catch `RuntimeException`/`IOException` and wrap it so the retry absorbs a not-yet-flushed file. That covers the msgpack, json and elastic variants, which all index `lines` the same way.

## :memo: Test scenarios

Reproduced the ticket failure deterministically by simulating the under-flush (7 of the 10 expected lines present). Byte-for-byte match with the ticket:

```
ticket:  testReporter:100->checkAuditLogs:78 » IndexOutOfBounds Index 7 out of bounds for length 7
repro:   testReporter:100->checkAuditLogs:78 » IndexOutOfBounds Index 7 out of bounds for length 7
```

It came through as an Error (not a Failure), confirming the root cause: the exception escaped `catch (AssertionError)` and the retry loop was skipped.

Then validated red to green with a transient-shortfall harness (7 records land now, the other 3 land 1.5s later to mimic flush lag):

- unfixed retry: ERROR `IndexOutOfBounds` at 2.4s, no retry
- fixed retry: PASS at 4.2s, retried and found all 10 (the extra ~2s is the retry engaging)

Removed the harness and ran the real tests, all green:

```
Msgpack: run 1,  0 fail, 0 err
Json:    run 1,  0 fail, 0 err
Csv:     run 1,  0 fail, 0 err
Elastic: run 10, 0 fail, 0 err
```

## :computer: Add screenshots for UI

n/a, backend test only.

## :books: Any other comments that will help with documentation

None.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am-team
