### PR TITLE
feat: AM-7238 restrict gateway plugins by org license

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/audit/impl/GatewayAuditReporterManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/audit/impl/GatewayAuditReporterManager.java
@@ -21,6 +21,7 @@ import io.gravitee.am.common.event.ReporterEvent;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.gateway.handler.common.audit.AuditReporterManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.common.service.DomainAwareListener;
 import io.gravitee.am.gateway.handler.common.utils.Tuple;
 import io.gravitee.am.model.Domain;
@@ -34,6 +35,7 @@ import io.gravitee.am.plugins.reporter.core.ReporterPluginManager;
 import io.gravitee.am.plugins.reporter.core.ReporterProviderConfiguration;
 import io.gravitee.am.repository.management.api.ReporterRepository;
 import io.gravitee.am.service.EnvironmentService;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.service.reporter.impl.AuditReporterVerticle;
 import io.gravitee.am.service.reporter.vertx.EventBusReporterWrapper;
 import io.gravitee.common.event.Event;
@@ -81,6 +83,9 @@ public class GatewayAuditReporterManager extends AbstractService<AuditReporterMa
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     private final ConcurrentMap<String, io.gravitee.am.reporter.api.provider.Reporter> reporterPlugins = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Reporter> reporters = new ConcurrentHashMap<>();
@@ -244,6 +249,9 @@ public class GatewayAuditReporterManager extends AbstractService<AuditReporterMa
         }
         logger.info("\tInitializing reporter: {} [{}]", reporter.getName(), reporter.getType());
         domainReadinessService.initPluginSync(domain.getId(), reporter.getId(), io.gravitee.am.common.event.Type.REPORTER.name());
+        if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_REPORTER, reporter.getType(), reporter.getId())) {
+            return false;
+        }
         var providerConfiguration = new ReporterProviderConfiguration(reporter, context);
         io.gravitee.am.reporter.api.provider.Reporter reporterProvider = reporterPluginManager.create(providerConfiguration);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
@@ -20,6 +20,7 @@ import io.gravitee.am.common.event.IdentityProviderEvent;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.identityprovider.api.AuthenticationProvider;
 import io.gravitee.am.identityprovider.api.UserProvider;
 import io.gravitee.am.model.Domain;
@@ -31,6 +32,7 @@ import io.gravitee.am.plugins.idp.core.AuthenticationProviderConfiguration;
 import io.gravitee.am.plugins.idp.core.IdentityProviderPluginManager;
 import io.gravitee.am.repository.management.api.IdentityProviderRepository;
 import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
@@ -79,6 +81,9 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     private final ConcurrentMap<String, AuthenticationProvider> providers = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, IdentityProvider> identities = new ConcurrentHashMap<>();
@@ -178,7 +183,7 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
 
     private void removeIdentityProvider(String identityProviderId) {
         logger.info("Domain {} has received identity provider event, delete identity provider {}", domain.getName(), identityProviderId);
-        clearProvider(identityProviderId);
+        clearProvider(identityProviderId, true);
     }
 
     private Single<IdentityProvider> updateAuthenticationProvider(IdentityProvider identityProvider) {
@@ -193,6 +198,12 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
     private Single<IdentityProvider> forceUpdateAuthenticationProvider(IdentityProvider identityProvider) {
         String identityProviderId = identityProvider.getId();
         try {
+            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_IDENTITY_PROVIDER, identityProvider.getType(), identityProviderId)) {
+                if (hasExistingProvider(identityProviderId)) {
+                    clearProvider(identityProviderId, false);
+                }
+                return Single.just(identityProvider);
+            }
             if (hasExistingProvider(identityProviderId)) {
                 return redeployProvider(identityProvider).doOnError(error -> logger.error("An error occurs while redeploying the identity provider : {}", identityProvider.getName(), error));
             } else {
@@ -206,7 +217,7 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
     }
 
     private void clearProviders() {
-        providers.keySet().forEach(this::clearProvider);
+        providers.keySet().forEach(idpId -> clearProvider(idpId, true));
     }
 
     private Single<Providers> createProvider(IdentityProvider identityProvider) throws IOException {
@@ -345,11 +356,13 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
         }
     }
 
-    private void clearProvider(String identityProviderId) {
+    private void clearProvider(String identityProviderId, boolean updateReadiness) {
         AuthenticationProvider authenticationProvider = providers.remove(identityProviderId);
         UserProvider userProvider = userProviders.remove(identityProviderId);
         identities.remove(identityProviderId);
-        domainReadinessService.pluginUnloaded(domain.getId(), identityProviderId);
+        if (updateReadiness) {
+            domainReadinessService.pluginUnloaded(domain.getId(), identityProviderId);
+        }
         if (authenticationProvider != null) {
             // stop the authentication provider
             try {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/authorizationengine/impl/AuthorizationEngineManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/authorizationengine/impl/AuthorizationEngineManagerImpl.java
@@ -20,6 +20,8 @@ import io.gravitee.am.common.event.AuthorizationEngineEvent;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.gateway.handler.common.authorizationengine.AuthorizationEngineManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.model.AuthorizationEngine;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
@@ -62,6 +64,9 @@ public class AuthorizationEngineManagerImpl extends AbstractService implements A
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     private final ConcurrentMap<String, AuthorizationEngineProvider> providers = new ConcurrentHashMap<>();
 
@@ -172,6 +177,10 @@ public class AuthorizationEngineManagerImpl extends AbstractService implements A
             ProviderConfiguration config = new ProviderConfiguration(authorizationEngine.getType(), authorizationEngine.getConfiguration());
 
             domainReadinessService.initPluginSync(domain.getId(), authorizationEngine.getId(), Type.AUTHORIZATION_ENGINE.name());
+            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHORIZATION_ENGINE, authorizationEngine.getType(), authorizationEngine.getId())) {
+                clearProvider(authorizationEngine.getId(), false);
+                return Single.just(authorizationEngine);
+            }
             AuthorizationEngineProvider provider = authorizationEnginePluginManager.create(config);
             clearProvider(authorizationEngine.getId());
             if (provider != null) {
@@ -199,11 +208,17 @@ public class AuthorizationEngineManagerImpl extends AbstractService implements A
     }
 
     private void clearProvider(String authorizationEngineId) {
+        clearProvider(authorizationEngineId, true);
+    }
+
+    private void clearProvider(String authorizationEngineId, boolean updateReadiness) {
         AuthorizationEngineProvider provider = providers.remove(authorizationEngineId);
 
         if (provider != null) {
             try {
-                domainReadinessService.pluginUnloaded(domain.getId(), authorizationEngineId);
+                if (updateReadiness) {
+                    domainReadinessService.pluginUnloaded(domain.getId(), authorizationEngineId);
+                }
                 logger.info("Stopping authorization engine provider: {}", authorizationEngineId);
                 provider.stop();
             } catch (Exception e) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/certificate/impl/CertificateManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/certificate/impl/CertificateManagerImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.am.gateway.certificate.CertificateProvider;
 import io.gravitee.am.gateway.certificate.CertificateProviderManager;
 import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderCertificateReloader;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.model.Certificate;
 import io.gravitee.am.model.CertificateSettings;
 import io.gravitee.am.model.Domain;
@@ -30,6 +31,7 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.repository.management.api.CertificateRepository;
 import io.gravitee.am.repository.management.api.DomainRepository;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
@@ -78,6 +80,9 @@ public class CertificateManagerImpl extends AbstractService implements Certifica
 
     @Autowired
     private io.gravitee.am.monitoring.DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     @Autowired
     @Qualifier("defaultCertificate")
@@ -133,6 +138,9 @@ public class CertificateManagerImpl extends AbstractService implements Certifica
                 .subscribe(
                         certificate -> {
                             domainReadinessService.initPluginSync(domain.getId(), certificate.getId(), Type.CERTIFICATE.name());
+                            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_CERTIFICATE, certificate.getType(), certificate.getId())) {
+                                return;
+                            }
                             certificateProviderManager.create(certificate);
                             certificates.put(certificate.getId(), certificate);
                             logger.info("Certificate {} loaded for domain {}", certificate.getName(), domain.getName());
@@ -240,6 +248,10 @@ public class CertificateManagerImpl extends AbstractService implements Certifica
                 .subscribe(
                         certificate -> {
                             try {
+                                if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_CERTIFICATE, certificate.getType(), certificateId)) {
+                                    certificates.remove(certificateId);
+                                    return;
+                                }
                                 certificateProviderManager.create(certificate);
                                 certificates.put(certificateId, certificate);
                                 logger.info("Certificate {} loaded for domain {}", certificateId, domain.getName());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/factor/impl/FactorManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/factor/impl/FactorManagerImpl.java
@@ -20,6 +20,7 @@ import io.gravitee.am.common.event.FactorEvent;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.factor.api.FactorProvider;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.model.ApplicationFactorSettings;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.Factor;
@@ -30,6 +31,7 @@ import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.plugins.factor.core.FactorPluginManager;
 import io.gravitee.am.plugins.handlers.api.provider.ProviderConfiguration;
 import io.gravitee.am.service.FactorService;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
@@ -66,6 +68,9 @@ public class FactorManagerImpl extends AbstractService implements FactorManager,
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     @Override
     public void afterPropertiesSet() {
@@ -152,6 +157,11 @@ public class FactorManagerImpl extends AbstractService implements FactorManager,
     private void updateFactor(Factor factor) {
         domainReadinessService.initPluginSync(domain.getId(), factor.getId(), Type.FACTOR.name());
         try {
+            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_FACTOR, factor.getType(), factor.getId())) {
+                this.factorProviders.remove(factor.getId());
+                this.factors.remove(factor.getId());
+                return;
+            }
             if (needDeployment(factor)) {
                 var factorProviderConfig = new ProviderConfiguration(factor.getType(), factor.getConfiguration());
                 var factorProvider = factorPluginManager.create(factorProviderConfig);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/flow/impl/FlowManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/flow/impl/FlowManagerImpl.java
@@ -20,6 +20,7 @@ import io.gravitee.am.common.event.FlowEvent;
 import io.gravitee.am.common.policy.ExtensionPoint;
 import io.gravitee.am.gateway.handler.common.flow.ExecutionPredicate;
 import io.gravitee.am.gateway.handler.common.flow.FlowManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.common.flow.execution.ExecutionFlow;
 import io.gravitee.am.gateway.policy.Policy;
 import io.gravitee.am.model.Domain;
@@ -32,6 +33,7 @@ import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.plugins.policy.core.PolicyPluginManager;
 import io.gravitee.am.service.FlowService;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
@@ -96,6 +98,9 @@ public class FlowManagerImpl extends AbstractService implements FlowManager, Ini
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     private final ConcurrentMap<String, Flow> flows = new ConcurrentHashMap<>();
     private final ConcurrentMap<ExtensionPoint, Set<ExecutionFlow>> policies = new ConcurrentHashMap<>();
@@ -290,6 +295,9 @@ public class FlowManagerImpl extends AbstractService implements FlowManager, Ini
 
     private Policy createPolicy(Step step) {
         try {
+            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_POLICY, step.getPolicy(), step.getPolicy())) {
+                return null;
+            }
             logger.info("\tInitializing policy: {} [{}]", step.getName(), step.getPolicy());
             Policy policy = policyPluginManager.create(step.getPolicy(), step.getCondition(), step.getConfiguration());
             logger.info("\tPolicy : {} [{}] has been loaded", step.getName(), step.getPolicy());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/license/DomainPluginLicenseGate.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/license/DomainPluginLicenseGate.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.license;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Reference;
+import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.service.PluginLicenseGate;
+import io.gravitee.am.service.exception.LicenseFeatureRequiredException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Domain-scoped runtime license gate for plugin loading.
+ * <p>
+ * Managers call {@link #check(String, String, String)} before instantiating a plugin. When the
+ * organization license of the domain does not grant the plugin's feature, the plugin is skipped
+ * and recorded in the domain state as unlicensed (readiness stays healthy). Outside managed cloud
+ * mode the underlying {@link PluginLicenseGate} is a no-op and every plugin loads.
+ * <p>
+ * Blocking is acceptable here: checks run during domain (re)deployment on deployment threads,
+ * and the gate is in-memory except the first domain-to-organization resolution, which is cached.
+ *
+ * @author GraviteeSource Team
+ */
+public class DomainPluginLicenseGate {
+
+    private static final Logger logger = LoggerFactory.getLogger(DomainPluginLicenseGate.class);
+
+    @Autowired
+    private Domain domain;
+
+    @Autowired
+    private PluginLicenseGate pluginLicenseGate;
+
+    @Autowired
+    private DomainReadinessService domainReadinessService;
+
+    /**
+     * Checks that an instance of the given plugin may be loaded for the current domain.
+     * <p>
+     * Note that AM entities store the plugin id in their {@code type} field, so callers
+     * typically pass {@code entity.getType()} as {@code pluginId}.
+     *
+     * @param pluginType one of the {@link PluginLicenseGate} {@code TYPE_*} constants
+     * @param pluginId the plugin identifier (the {@code type} of the configured instance)
+     * @param instanceId the configured instance identifier, used to record the domain state
+     * @return {@code true} when the plugin may be loaded, {@code false} when it is not licensed
+     */
+    public boolean check(String pluginType, String pluginId, String instanceId) {
+        try {
+            pluginLicenseGate.check(Reference.domain(domain.getId()), pluginType, pluginId).blockingAwait();
+            return true;
+        } catch (LicenseFeatureRequiredException e) {
+            logger.warn("Skipping {} '{}' [{}] for domain {}: {}", pluginType, instanceId, pluginId, domain.getId(), e.getMessage());
+            domainReadinessService.pluginUnlicensed(domain.getId(), instanceId, e.getMessage());
+            return false;
+        } catch (Exception e) {
+            logger.error("Unexpected error while checking the license for {} '{}' [{}] for domain {}; loading the plugin anyway", pluginType, instanceId, pluginId, domain.getId(), e);
+            return true;
+        }
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -32,6 +32,7 @@ import io.gravitee.am.gateway.handler.common.auth.user.impl.UserAuthenticationMa
 import io.gravitee.am.gateway.handler.common.auth.user.impl.UserAuthenticationServiceImpl;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
 import io.gravitee.am.gateway.handler.common.certificate.impl.CertificateManagerImpl;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.common.client.ClientManager;
 import io.gravitee.am.gateway.handler.common.client.ClientLookupService;
 import io.gravitee.am.gateway.handler.common.client.ClientSyncService;
@@ -194,6 +195,11 @@ public class CommonConfiguration {
     @Bean
     public RuleEngine ruleEngine() {
         return new SpELRuleEngine();
+    }
+
+    @Bean
+    public DomainPluginLicenseGate domainPluginLicenseGate() {
+        return new DomainPluginLicenseGate();
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImplTest.java
@@ -15,21 +15,41 @@
  */
 package io.gravitee.am.gateway.handler.common.auth.idp.impl;
 
+import io.gravitee.am.common.event.IdentityProviderEvent;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
+import io.gravitee.am.identityprovider.api.AuthenticationProvider;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.monitoring.provider.GatewayMetricProvider;
+import io.gravitee.am.plugins.idp.core.AuthenticationProviderConfiguration;
 import io.gravitee.am.plugins.idp.core.IdentityProviderPluginManager;
 import io.gravitee.am.repository.management.api.IdentityProviderRepository;
+import io.gravitee.am.service.PluginLicenseGate;
+import io.gravitee.common.event.Event;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Date;
+import java.util.Optional;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -56,6 +76,24 @@ public class IdentityProviderManagerImplTest {
     @Mock
     private DomainReadinessService domainReadinessService;
 
+    @Mock
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
+    @Test
+    public void shouldSkipUnlicensedIdentityProviderWithoutFailingReadiness() {
+        when(domain.getId()).thenReturn("domain-id");
+        IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setId("ee-idp");
+        identityProvider.setType("kerberos-am-idp");
+        when(identityProviderRepository.findAll(ReferenceType.DOMAIN, "domain-id")).thenReturn(Flowable.just(identityProvider));
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_IDENTITY_PROVIDER, "kerberos-am-idp", "ee-idp")).thenReturn(false);
+
+        identityProviderManager.afterPropertiesSet();
+
+        verifyNoInteractions(identityProviderPluginManager);
+        verify(domainReadinessService, never()).pluginFailed(any(), any(), any());
+    }
+
     @Test
     public void shouldHandleTopLevelFailure() {
         when(domain.getId()).thenReturn("domain-id");
@@ -66,5 +104,50 @@ public class IdentityProviderManagerImplTest {
         identityProviderManager.afterPropertiesSet();
 
         verify(domainReadinessService).pluginInitFailed("domain-id", "IDENTITY_PROVIDER", "Database error");
+    }
+
+    @Test
+    public void shouldKeepReadinessRecordWhenLoadedIdpBecomesUnlicensedOnUpdate() throws Exception {
+        when(domain.getId()).thenReturn("domain-id");
+        when(domain.getName()).thenReturn("domain-name");
+
+        IdentityProvider initialIdp = new IdentityProvider();
+        initialIdp.setId("idp-id");
+        initialIdp.setType("kerberos-am-idp");
+        initialIdp.setConfiguration("{}");
+        initialIdp.setUpdatedAt(new Date(1000));
+
+        // a newer version so needDeployment() forces a redeployment on the update event
+        IdentityProvider updatedIdp = new IdentityProvider();
+        updatedIdp.setId("idp-id");
+        updatedIdp.setType("kerberos-am-idp");
+        updatedIdp.setConfiguration("{}");
+        updatedIdp.setUpdatedAt(new Date(2000));
+
+        AuthenticationProvider authenticationProvider = mock(AuthenticationProvider.class);
+        when(identityProviderRepository.findAll(ReferenceType.DOMAIN, "domain-id")).thenReturn(Flowable.just(initialIdp));
+        when(identityProviderRepository.findById("idp-id")).thenReturn(Maybe.just(updatedIdp));
+        when(identityProviderPluginManager.create(any(AuthenticationProviderConfiguration.class))).thenReturn(authenticationProvider);
+        when(identityProviderPluginManager.create(eq("kerberos-am-idp"), any(), any(IdentityProvider.class)))
+                .thenReturn(Single.just(Optional.empty()));
+        // licensed on the initial load, then unlicensed on the following update event
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_IDENTITY_PROVIDER, "kerberos-am-idp", "idp-id"))
+                .thenReturn(true, false);
+
+        // load the licensed provider
+        identityProviderManager.afterPropertiesSet();
+
+        // when - an update event arrives and the provider is now unlicensed
+        Payload payload = new Payload("idp-id", ReferenceType.DOMAIN, "domain-id", io.gravitee.am.common.event.Action.UPDATE);
+        Event<IdentityProviderEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(IdentityProviderEvent.UPDATE);
+        when(event.content()).thenReturn(payload);
+        identityProviderManager.onEvent(event);
+
+        // then - the running provider is stopped and no longer served, but the readiness record is left
+        // untouched so the unlicensed entry recorded by the gate survives (rather than being wiped by an unload)
+        verify(authenticationProvider, times(1)).stop();
+        verify(domainReadinessService, never()).pluginUnloaded("domain-id", "idp-id");
+        assertNull(identityProviderManager.getIdentityProvider("idp-id"));
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/authorizationengine/impl/AuthorizationEngineManagerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/authorizationengine/impl/AuthorizationEngineManagerImplTest.java
@@ -18,6 +18,8 @@ package io.gravitee.am.gateway.handler.common.authorizationengine.impl;
 import io.gravitee.am.authorizationengine.api.AuthorizationEngineProvider;
 import io.gravitee.am.common.event.AuthorizationEngineEvent;
 import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.model.AuthorizationEngine;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
@@ -46,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -77,6 +80,9 @@ class AuthorizationEngineManagerImplTest {
     @Mock
     private DomainReadinessService domainReadinessService;
 
+    @Mock
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
     @InjectMocks
     private AuthorizationEngineManagerImpl manager;
 
@@ -96,6 +102,7 @@ class AuthorizationEngineManagerImplTest {
 
     @BeforeEach
     void setUp() {
+        lenient().when(domainPluginLicenseGate.check(any(), any(), any())).thenReturn(true);
         testEngine = new AuthorizationEngine();
         testEngine.setId("engine-id");
         testEngine.setName("Test Engine");
@@ -123,6 +130,51 @@ class AuthorizationEngineManagerImplTest {
         verify(authorizationEnginePluginManager, timeout(1000).times(1)).create(any(ProviderConfiguration.class));
         verify(domainReadinessService, timeout(1000).times(1)).initPluginSync("domain-id", "engine-id", "AUTHORIZATION_ENGINE");
         verify(domainReadinessService, timeout(1000).times(1)).pluginLoaded("domain-id", "engine-id");
+    }
+
+    @Test
+    void shouldSkipUnlicensedEngineWithoutFailingReadiness() {
+        when(domain.getId()).thenReturn("domain-id");
+        when(domain.getName()).thenReturn("Test Domain");
+        when(authorizationEngineRepository.findByDomain("domain-id"))
+                .thenReturn(Flowable.just(testEngine));
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHORIZATION_ENGINE, "openfga", "engine-id")).thenReturn(false);
+
+        manager.afterPropertiesSet();
+
+        verify(domainReadinessService, timeout(1000).times(1)).initPluginSync("domain-id", "engine-id", "AUTHORIZATION_ENGINE");
+        verify(authorizationEnginePluginManager, never()).create(any(ProviderConfiguration.class));
+        verify(domainReadinessService, never()).pluginLoaded(any(), any());
+        verify(domainReadinessService, never()).pluginFailed(any(), any(), any());
+    }
+
+    @Test
+    void shouldKeepReadinessRecordWhenLoadedEngineBecomesUnlicensedOnUpdate() throws Exception {
+        // given - a licensed engine is deployed
+        when(domain.getId()).thenReturn("domain-id");
+        when(domain.getName()).thenReturn("Test Domain");
+        when(mockProvider.stop()).thenReturn(mockProvider);
+        when(authorizationEngineRepository.findByDomain("domain-id")).thenReturn(Flowable.just(testEngine));
+        when(authorizationEngineRepository.findById("engine-id")).thenReturn(Maybe.just(testEngine));
+        when(authorizationEnginePluginManager.create(any(ProviderConfiguration.class))).thenReturn(mockProvider);
+        // licensed on the initial load, then unlicensed on the following update event
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHORIZATION_ENGINE, "openfga", "engine-id"))
+                .thenReturn(true, false);
+
+        manager.afterPropertiesSet();
+
+        // when - an update event arrives and the engine is now unlicensed
+        Payload payload = new Payload("engine-id", ReferenceType.DOMAIN, "domain-id", io.gravitee.am.common.event.Action.UPDATE);
+        Event<AuthorizationEngineEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(AuthorizationEngineEvent.UPDATE);
+        when(event.content()).thenReturn(payload);
+        manager.onEvent(event);
+
+        // then - the running provider is stopped and no longer served, but the readiness record is left
+        // untouched so the unlicensed entry recorded by the gate survives (rather than being wiped by an unload)
+        verify(mockProvider, times(1)).stop();
+        verify(domainReadinessService, never()).pluginUnloaded("domain-id", "engine-id");
+        manager.get("engine-id").test().assertNoValues();
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/certificate/impl/CertificateManagerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/certificate/impl/CertificateManagerImplTest.java
@@ -88,6 +88,9 @@ public class CertificateManagerImplTest {
     @Mock
     private io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderCertificateReloader identityProviderReloader;
 
+    @Mock
+    private io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate domainPluginLicenseGate;
+
     private static final String DOMAIN_ID = "test-domain-id";
     private static final String CERTIFICATE_ID = "test-certificate-id";
 
@@ -96,6 +99,7 @@ public class CertificateManagerImplTest {
     @Before
     public void setUp() throws Exception {
         when(domain.getId()).thenReturn(DOMAIN_ID);
+        lenient().when(domainPluginLicenseGate.check(anyString(), Mockito.any(), anyString())).thenReturn(true);
 
         CertificateProvider rs256CertificateProvider = mock(CertificateProvider.class);
         CertificateProvider rs512CertificateProvider = mock(CertificateProvider.class);
@@ -296,6 +300,30 @@ public class CertificateManagerImplTest {
         // Assert - initPluginSync should be called, followed by pluginFailed
         verify(domainReadinessService, timeout(1000)).initPluginSync(DOMAIN_ID, CERTIFICATE_ID, Type.CERTIFICATE.name());
         verify(domainReadinessService, timeout(1000)).pluginFailed(eq(DOMAIN_ID), eq(CERTIFICATE_ID), anyString());
+    }
+
+    @Test
+    public void deployCertificate_shouldSkipUnlicensedCertificateWithoutFailingReadiness() throws InterruptedException {
+        Certificate certificate = new Certificate();
+        certificate.setId(CERTIFICATE_ID);
+        certificate.setName("EE Certificate");
+        certificate.setType("hsm-am-certificate");
+        certificate.setDomain(DOMAIN_ID);
+
+        when(certificateRepository.findById(CERTIFICATE_ID)).thenReturn(Maybe.just(certificate));
+        when(domainPluginLicenseGate.check(io.gravitee.am.service.PluginLicenseGate.TYPE_CERTIFICATE, "hsm-am-certificate", CERTIFICATE_ID)).thenReturn(false);
+
+        Event<CertificateEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(CertificateEvent.DEPLOY);
+        when(event.content()).thenReturn(new Payload(CERTIFICATE_ID, ReferenceType.DOMAIN, DOMAIN_ID, io.gravitee.am.common.event.Action.CREATE));
+
+        certificateManager.onEvent(event);
+
+        verify(domainReadinessService, timeout(1000)).initPluginSync(DOMAIN_ID, CERTIFICATE_ID, Type.CERTIFICATE.name());
+        TimeUnit.MILLISECONDS.sleep(200);
+        verify(certificateProviderManager, never()).create(Mockito.any(Certificate.class));
+        verify(domainReadinessService, never()).pluginLoaded(DOMAIN_ID, CERTIFICATE_ID);
+        verify(domainReadinessService, never()).pluginFailed(eq(DOMAIN_ID), eq(CERTIFICATE_ID), anyString());
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/factor/FactorManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/factor/FactorManagerTest.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.common.factor;
 
 import io.gravitee.am.factor.api.FactorProvider;
 import io.gravitee.am.gateway.handler.common.factor.impl.FactorManagerImpl;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.model.ApplicationFactorSettings;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.Factor;
@@ -43,7 +44,9 @@ import java.util.List;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -69,11 +72,15 @@ public class FactorManagerTest {
     @Mock
     private DomainReadinessService domainReadinessService;
 
+    @Mock
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
     @InjectMocks
     private FactorManagerImpl factorMng = new FactorManagerImpl();
 
     @Before
     public void prepare() {
+        lenient().when(domainPluginLicenseGate.check(any(), any(), any())).thenReturn(true);
         when(domain.getId()).thenReturn(DOMAIN_ID);
         final Factor factor = new Factor();
         factor.setId(FACTOR_ID);
@@ -155,6 +162,25 @@ public class FactorManagerTest {
 
         verify(domainReadinessService).initPluginSync(DOMAIN_ID, "error-factor", Type.FACTOR.name());
         verify(domainReadinessService).pluginFailed(DOMAIN_ID, "error-factor", "Error loading factor");
+    }
+
+    @Test
+    public void shouldSkipUnlicensedFactorWithoutFailingReadiness() {
+        Factor factor = new Factor();
+        factor.setId("ee-factor");
+        factor.setType("otp-sender-am-factor");
+        when(factorService.findById("ee-factor")).thenReturn(Maybe.just(factor));
+        when(domainPluginLicenseGate.check(io.gravitee.am.service.PluginLicenseGate.TYPE_FACTOR, "otp-sender-am-factor", "ee-factor")).thenReturn(false);
+
+        Event<FactorEvent, Payload> event = mock(Event.class);
+        when(event.type()).thenReturn(FactorEvent.UPDATE);
+        when(event.content()).thenReturn(new Payload("ee-factor", ReferenceType.DOMAIN, DOMAIN_ID, io.gravitee.am.common.event.Action.UPDATE));
+
+        factorMng.onEvent(event);
+
+        assertFalse(factorMng.getClientFactor(null, "ee-factor").isPresent());
+        verify(factorPluginManager, times(1)).create(any()); // only the factor loaded in prepare()
+        verify(domainReadinessService, never()).pluginFailed(any(), any(), any());
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/flow/FlowManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/flow/FlowManagerTest.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.common.flow;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.policy.ExtensionPoint;
 import io.gravitee.am.gateway.handler.common.flow.impl.FlowManagerImpl;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.policy.Policy;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.monitoring.DomainReadinessService;
@@ -67,8 +68,16 @@ public class FlowManagerTest {
     @Mock
     private DomainReadinessService domainReadinessService;
 
+    @Mock
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
     @InjectMocks
     private FlowManagerImpl flowManager = new FlowManagerImpl();
+
+    @org.junit.Before
+    public void prepareLicenseGate() {
+        lenient().when(domainPluginLicenseGate.check(anyString(), anyString(), anyString())).thenReturn(true);
+    }
 
     @Test
     public void shouldNoFindByExtensionPoint_noFlows() {
@@ -168,6 +177,31 @@ public class FlowManagerTest {
             return true;
         });
         verify(policyPluginManager, times(1)).create(anyString(), eq(null), anyString());
+    }
+
+    @Test
+    public void shouldSkipUnlicensedPolicyStep() {
+        Step step = mock(Step.class);
+        when(step.isEnabled()).thenReturn(true);
+        when(step.getPolicy()).thenReturn("ee-policy");
+
+        Flow flow = mock(Flow.class);
+        when(flow.getId()).thenReturn("flow-id");
+        when(flow.getType()).thenReturn(Type.CONSENT);
+        when(flow.isEnabled()).thenReturn(true);
+        when(flow.getPre()).thenReturn(Collections.singletonList(step));
+
+        when(domain.getId()).thenReturn("domain-id");
+        when(domainPluginLicenseGate.check(io.gravitee.am.service.PluginLicenseGate.TYPE_POLICY, "ee-policy", "ee-policy")).thenReturn(false);
+        when(flowService.findAll(ReferenceType.DOMAIN, domain.getId())).thenReturn(Flowable.just(flow));
+        flowManager.afterPropertiesSet();
+        TestObserver<List<Policy>> obs = flowManager.findByExtensionPoint(ExtensionPoint.PRE_CONSENT, null, null).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(policies -> {
+            Assert.assertTrue(policies.isEmpty());
+            return true;
+        });
+        verify(policyPluginManager, never()).create(anyString(), any(), anyString());
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/license/DomainPluginLicenseGateTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/license/DomainPluginLicenseGateTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.license;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Reference;
+import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.service.PluginLicenseGate;
+import io.gravitee.am.service.exception.LicenseFeatureRequiredException;
+import io.reactivex.rxjava3.core.Completable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DomainPluginLicenseGateTest {
+
+    private static final String DOMAIN_ID = "domain#1";
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private PluginLicenseGate pluginLicenseGate;
+
+    @Mock
+    private DomainReadinessService domainReadinessService;
+
+    @InjectMocks
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
+    @Before
+    public void setUp() {
+        when(domain.getId()).thenReturn(DOMAIN_ID);
+    }
+
+    @Test
+    public void shouldAllowLicensedPlugin() {
+        when(pluginLicenseGate.check(Reference.domain(DOMAIN_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
+                .thenReturn(Completable.complete());
+
+        assertTrue(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_FACTOR, "otp-sender", "factor-instance-1"));
+
+        verifyNoInteractions(domainReadinessService);
+    }
+
+    @Test
+    public void shouldSkipAndRecordUnlicensedPlugin() {
+        when(pluginLicenseGate.check(Reference.domain(DOMAIN_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
+                .thenReturn(Completable.error(new LicenseFeatureRequiredException("am-factor-otp-sender", "otp-sender")));
+
+        assertFalse(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_FACTOR, "otp-sender", "factor-instance-1"));
+
+        verify(domainReadinessService).pluginUnlicensed(eq(DOMAIN_ID), eq("factor-instance-1"), anyString());
+    }
+
+    @Test
+    public void shouldFailOpenOnUnexpectedErrors() {
+        when(pluginLicenseGate.check(Reference.domain(DOMAIN_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
+                .thenReturn(Completable.error(new IllegalStateException("cannot resolve organization")));
+
+        assertTrue(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_FACTOR, "otp-sender", "factor-instance-1"));
+
+        verifyNoInteractions(domainReadinessService);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/authdevice/notifier/impl/AuthenticationDeviceNotifierManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/authdevice/notifier/impl/AuthenticationDeviceNotifierManagerImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.am.authdevice.notifier.api.AuthenticationDeviceNotifierProvid
 import io.gravitee.am.common.event.AuthenticationDeviceNotifierEvent;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.event.Type;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.manager.authdevice.notifier.AuthenticationDeviceNotifierManager;
 import io.gravitee.am.model.AuthenticationDeviceNotifier;
 import io.gravitee.am.model.Domain;
@@ -29,6 +30,7 @@ import io.gravitee.am.monitoring.DomainState;
 import io.gravitee.am.plugins.authdevice.notifier.core.AuthenticationDeviceNotifierPluginManager;
 import io.gravitee.am.plugins.handlers.api.provider.ProviderConfiguration;
 import io.gravitee.am.service.AuthenticationDeviceNotifierService;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.service.exception.AuthenticationDeviceNotifierNotFoundException;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
@@ -69,6 +71,9 @@ public class AuthenticationDeviceNotifierManagerImpl extends AbstractService imp
     @Autowired
     private DomainReadinessService domainReadinessService;
 
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
     private final Map<String, AuthenticationDeviceNotifierProvider> deviceNotifierProviders = new ConcurrentHashMap<>();
     private final Map<String, AuthenticationDeviceNotifier> deviceNotifiers = new ConcurrentHashMap<>();
 
@@ -99,6 +104,9 @@ public class AuthenticationDeviceNotifierManagerImpl extends AbstractService imp
                 .subscribe(
                         notifier -> {
                             domainReadinessService.initPluginSync(domain.getId(), notifier.getId(), Type.AUTH_DEVICE_NOTIFIER.name());
+                            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHDEVICE_NOTIFIER, notifier.getType(), notifier.getId())) {
+                                return;
+                            }
                             var providerConfiguration = new ProviderConfiguration(notifier.getType(), notifier.getConfiguration());
                             var provider = deviceNotifierPluginManager.create(providerConfiguration);
                             provider.start();
@@ -146,6 +154,9 @@ public class AuthenticationDeviceNotifierManagerImpl extends AbstractService imp
                     if (needDeployment(notifier)) {
                         unloadDeviceNotifierProvider(notifierId);
                         domainReadinessService.initPluginSync(domain.getId(), notifier.getId(), Type.AUTH_DEVICE_NOTIFIER.name());
+                        if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHDEVICE_NOTIFIER, notifier.getType(), notifier.getId())) {
+                            return notifier;
+                        }
                         var provider = deviceNotifierPluginManager.create(new ProviderConfiguration(notifier.getType(), notifier.getConfiguration()));
                         provider.start();
                         this.deviceNotifierProviders.put(notifier.getId(), provider);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/botdetection/impl/BotDetectionManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/botdetection/impl/BotDetectionManagerImpl.java
@@ -22,6 +22,7 @@ import io.gravitee.am.botdetection.api.BotDetectionProvider;
 import io.gravitee.am.common.event.BotDetectionEvent;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.event.Type;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.manager.botdetection.BotDetectionManager;
 import io.gravitee.am.model.BotDetection;
 import io.gravitee.am.model.Domain;
@@ -34,6 +35,7 @@ import io.gravitee.am.monitoring.DomainState;
 import io.gravitee.am.plugins.botdetection.core.BotDetectionPluginManager;
 import io.gravitee.am.plugins.handlers.api.provider.ProviderConfiguration;
 import io.gravitee.am.service.BotDetectionService;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
@@ -82,6 +84,9 @@ public class BotDetectionManagerImpl extends AbstractService implements BotDetec
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     public ConcurrentMap<String, BotDetection> getBotDetections() {
         return botDetections;
@@ -193,6 +198,11 @@ public class BotDetectionManagerImpl extends AbstractService implements BotDetec
     private void updateBotDetection(BotDetection detection) {
         domainReadinessService.initPluginSync(domain.getId(), detection.getId(), Type.BOT_DETECTION.name());
         try {
+            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_BOT_DETECTION, detection.getType(), detection.getId())) {
+                stopBotDetectionProvider(this.providers.remove(detection.getId()));
+                this.botDetections.remove(detection.getId());
+                return;
+            }
             if (needDeployment(detection)) {
                 var providerConfig = new ProviderConfiguration(detection.getType(), detection.getConfiguration());
                 BotDetectionProvider botDetectionProvider = botDetectionPluginManager.create(providerConfig);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/deviceidentifiers/DeviceIdentifierManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/deviceidentifiers/DeviceIdentifierManagerImpl.java
@@ -29,7 +29,9 @@ import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.plugins.deviceidentifier.core.DeviceIdentifierPluginManager;
 import io.gravitee.am.plugins.handlers.api.provider.ProviderConfiguration;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.service.DeviceIdentifierService;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
@@ -73,6 +75,9 @@ public class DeviceIdentifierManagerImpl extends AbstractService implements Devi
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     public ConcurrentMap<String, DeviceIdentifier> getDeviceIdentifiers() {
         return deviceIdentifiers;
@@ -147,6 +152,11 @@ public class DeviceIdentifierManagerImpl extends AbstractService implements Devi
     private void updateDeviceIdentifier(DeviceIdentifier detection) {
         domainReadinessService.initPluginSync(domain.getId(), detection.getId(), Type.DEVICE_IDENTIFIER.name());
         try {
+            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_DEVICE_IDENTIFIER, detection.getType(), detection.getId())) {
+                this.deviceIdentifiers.remove(detection.getId());
+                this.providers.remove(detection.getId());
+                return;
+            }
             if (needDeployment(detection)) {
                 var providerConfig = new ProviderConfiguration(detection.getType(), detection.getConfiguration());
                 var provider = deviceIdentifierPluginManager.create(providerConfig);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/resource/impl/ResourceManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/resource/impl/ResourceManagerImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.manager.resource.impl;
 
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.event.ResourceEvent;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.manager.resource.ResourceManager;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
@@ -25,6 +26,7 @@ import io.gravitee.am.model.resource.ServiceResource;
 import io.gravitee.am.plugins.handlers.api.provider.ProviderConfiguration;
 import io.gravitee.am.plugins.resource.core.ResourcePluginManager;
 import io.gravitee.am.resource.api.ResourceProvider;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.service.ServiceResourceService;
 import io.gravitee.am.service.exception.ResourceNotFoundException;
 import io.gravitee.common.event.Event;
@@ -62,6 +64,9 @@ public class ResourceManagerImpl extends AbstractService implements ResourceMana
     @Autowired
     private ServiceResourceService resourceService;
 
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
     private final Map<String, ResourceProvider> resourceProviders = new ConcurrentHashMap<>();
     private final Map<String, ServiceResource> resources = new ConcurrentHashMap<>();
 
@@ -91,6 +96,9 @@ public class ResourceManagerImpl extends AbstractService implements ResourceMana
                 .subscribeOn(Schedulers.io())
                 .subscribe(
                         res -> {
+                            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_RESOURCE, res.getType(), res.getId())) {
+                                return;
+                            }
                             var providerConfiguration = new ProviderConfiguration(res.getType(), res.getConfiguration());
                             try {
                                 ResourceProvider provider = resourcePluginManager.create(providerConfiguration);
@@ -130,6 +138,9 @@ public class ResourceManagerImpl extends AbstractService implements ResourceMana
                 .map(res -> {
                     if (needDeployment(res)) {
                         unloadResource(res.getId());
+                        if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_RESOURCE, res.getType(), res.getId())) {
+                            return res;
+                        }
                         var provider = resourcePluginManager.create(new ProviderConfiguration(res.getType(), res.getConfiguration()));
                         provider.start();
                         this.resources.put(res.getId(), res);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
@@ -26,6 +26,7 @@ import io.gravitee.am.gateway.handler.common.client.ClientManager;
 import io.gravitee.am.gateway.handler.common.email.EmailManager;
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.flow.FlowManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.common.password.PasswordPolicyManager;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceManager;
 import io.gravitee.am.gateway.handler.common.service.RevokeTokenGatewayService;
@@ -44,6 +45,7 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.plugins.authenticator.core.AuthenticatorPluginManager;
 import io.gravitee.am.plugins.protocol.core.ProtocolPluginManager;
 import io.gravitee.am.plugins.protocol.core.ProtocolProviderConfiguration;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.common.component.LifecycleComponent;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
@@ -85,6 +87,9 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
 
     @Autowired
     private AuthenticatorPluginManager authenticatorPluginManager;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -172,6 +177,9 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
 
         PROTOCOLS.forEach(protocol -> {
             try {
+                if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_PROTOCOL, protocol, protocol)) {
+                    return;
+                }
                 var providerConfig = new ProtocolProviderConfiguration(protocol, applicationContext);
                 var protocolProvider = protocolPluginManager.create(providerConfig);
                 if (protocolProvider != null) {
@@ -187,7 +195,8 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
 
     private void startSecurityDomainAuthenticators() {
         logger.info("Start security domain authenticators");
-        List<AuthenticatorProvider> providers = authenticatorPluginManager.createAll(applicationContext);
+        List<AuthenticatorProvider> providers = authenticatorPluginManager.createAll(applicationContext,
+                pluginId -> domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHENTICATOR, pluginId, pluginId));
         providers.forEach(provider -> {
             try {
                 provider.start();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/botdetection/BotDetectionManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/botdetection/BotDetectionManagerTest.java
@@ -68,13 +68,33 @@ public class BotDetectionManagerTest {
     @Mock
     private Domain domain;
 
+    @Mock
+    private io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate domainPluginLicenseGate;
+
     private BotDetection botDetection = new BotDetection();
 
     @Before
     public void setUp() {
+        org.mockito.Mockito.lenient().when(domainPluginLicenseGate.check(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any())).thenReturn(true);
         botDetection.setConfiguration("{\"key\": \"value\"}");
         botDetection.setType(BOT_DETECTION_PLUGIN_TYPE);
         cut.getBotDetections().put(BOT_DETECTION_PLUGIN, botDetection);
+    }
+
+    @Test
+    public void shouldSkipUnlicensedBotDetectionWithoutFailingReadiness() {
+        when(domain.getId()).thenReturn("domain-id");
+        final BotDetection eeDetection = new BotDetection();
+        eeDetection.setId("ee-bot-detection");
+        eeDetection.setType("ee-bot-detection-plugin");
+        when(botDetectionService.findByDomain("domain-id")).thenReturn(io.reactivex.rxjava3.core.Flowable.just(eeDetection));
+        when(domainPluginLicenseGate.check(io.gravitee.am.service.PluginLicenseGate.TYPE_BOT_DETECTION, "ee-bot-detection-plugin", "ee-bot-detection")).thenReturn(false);
+
+        cut.afterPropertiesSet();
+
+        verify(domainReadinessService).initPluginSync("domain-id", "ee-bot-detection", io.gravitee.am.common.event.Type.BOT_DETECTION.name());
+        org.mockito.Mockito.verify(domainReadinessService, org.mockito.Mockito.never()).pluginFailed(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        assertFalse(cut.getBotDetections().containsKey("ee-bot-detection"));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/deviceidentifiers/DeviceIdentifierManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/deviceidentifiers/DeviceIdentifierManagerTest.java
@@ -49,12 +49,44 @@ public class DeviceIdentifierManagerTest {
     @Spy
     private DeviceIdentifierProvider deviceIdentifierProvider;
 
+    @org.mockito.Mock
+    private io.gravitee.am.model.Domain domain;
+
+    @org.mockito.Mock
+    private io.gravitee.am.service.DeviceIdentifierService deviceIdentifierService;
+
+    @org.mockito.Mock
+    private io.gravitee.am.monitoring.DomainReadinessService domainReadinessService;
+
+    @org.mockito.Mock
+    private io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate domainPluginLicenseGate;
+
     private DeviceIdentifier rememberDevice = new DeviceIdentifier();
 
     @Before
     public void setUp() {
         cut.getDeviceIdentifiers().put(REMEMBER_DEVICE_ID, rememberDevice);
         cut.getDeviceIdentifiersProviders().put(REMEMBER_DEVICE_ID, deviceIdentifierProvider);
+    }
+
+    @Test
+    public void shouldSkipUnlicensedDeviceIdentifierWithoutFailingReadiness() {
+        org.mockito.Mockito.when(domain.getId()).thenReturn("domain-id");
+        var eeIdentifier = new DeviceIdentifier();
+        eeIdentifier.setId("ee-device-identifier");
+        eeIdentifier.setType("ee-device-identifier-plugin");
+        org.mockito.Mockito.when(deviceIdentifierService.findByDomain("domain-id"))
+                .thenReturn(io.reactivex.rxjava3.core.Flowable.just(eeIdentifier));
+        org.mockito.Mockito.when(domainPluginLicenseGate.check(
+                io.gravitee.am.service.PluginLicenseGate.TYPE_DEVICE_IDENTIFIER, "ee-device-identifier-plugin", "ee-device-identifier"))
+                .thenReturn(false);
+
+        cut.afterPropertiesSet();
+
+        verify(domainReadinessService).initPluginSync("domain-id", "ee-device-identifier", io.gravitee.am.common.event.Type.DEVICE_IDENTIFIER.name());
+        org.mockito.Mockito.verify(domainReadinessService, org.mockito.Mockito.never()).pluginFailed(any(), any(), any());
+        assertFalse(cut.getDeviceIdentifiers().containsKey("ee-device-identifier"));
+        assertFalse(cut.getDeviceIdentifiersProviders().containsKey("ee-device-identifier"));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandlerTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.vertx;
+
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
+import io.gravitee.am.gateway.handler.root.RootProvider;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.plugins.authenticator.core.AuthenticatorPluginManager;
+import io.gravitee.am.plugins.protocol.core.ProtocolPluginManager;
+import io.gravitee.am.plugins.protocol.core.ProtocolProviderConfiguration;
+import io.gravitee.am.service.PluginLicenseGate;
+import io.vertx.rxjava3.ext.web.Route;
+import io.vertx.rxjava3.ext.web.Router;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class VertxSecurityDomainHandlerTest {
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private ProtocolPluginManager protocolPluginManager;
+
+    @Mock
+    private AuthenticatorPluginManager authenticatorPluginManager;
+
+    @Mock
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private Router router;
+
+    @Mock
+    private Environment environment;
+
+    @Captor
+    private ArgumentCaptor<Predicate<String>> authenticatorFilterCaptor;
+
+    @InjectMocks
+    private VertxSecurityDomainHandler handler;
+
+    @Before
+    public void setUp() {
+        org.springframework.test.util.ReflectionTestUtils.setField(handler, "applicationContext", applicationContext);
+        lenient().when(domain.getName()).thenReturn("domain-name");
+
+        Route route = mock(Route.class);
+        lenient().when(router.route()).thenReturn(route);
+        lenient().when(route.last()).thenReturn(route);
+        lenient().when(route.handler(any())).thenReturn(route);
+
+        lenient().when(applicationContext.getBean(RootProvider.class)).thenReturn(mock(RootProvider.class));
+        lenient().when(domainPluginLicenseGate.check(any(), any(), any())).thenReturn(true);
+        lenient().when(protocolPluginManager.create(any())).thenReturn(null);
+        lenient().when(authenticatorPluginManager.createAll(any(), any())).thenReturn(List.of());
+    }
+
+    @Test
+    public void shouldNotCreateUnlicensedProtocol() throws Exception {
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_PROTOCOL, "saml2-idp", "saml2-idp")).thenReturn(false);
+
+        handler.doStart();
+
+        ArgumentCaptor<ProtocolProviderConfiguration> configCaptor = ArgumentCaptor.forClass(ProtocolProviderConfiguration.class);
+        verify(protocolPluginManager, org.mockito.Mockito.atLeastOnce()).create(configCaptor.capture());
+        List<String> createdProtocols = configCaptor.getAllValues().stream().map(ProtocolProviderConfiguration::getType).toList();
+        assertFalse(createdProtocols.contains("saml2-idp"));
+        assertTrue(createdProtocols.contains("openid-connect"));
+    }
+
+    @Test
+    public void shouldFilterAuthenticatorsThroughLicenseGate() throws Exception {
+        handler.doStart();
+
+        verify(authenticatorPluginManager).createAll(eq(applicationContext), authenticatorFilterCaptor.capture());
+
+        Predicate<String> filter = authenticatorFilterCaptor.getValue();
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHENTICATOR, "ee-authenticator", "ee-authenticator")).thenReturn(false);
+        assertFalse(filter.test("ee-authenticator"));
+        assertTrue(filter.test("oss-authenticator"));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/impl/ExtensionGrantManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/impl/ExtensionGrantManagerImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.am.common.event.Type;
 import io.gravitee.am.extensiongrant.api.ExtensionGrantProvider;
 import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
 import io.gravitee.am.gateway.handler.common.auth.user.UserAuthenticationManager;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.common.policy.RulesEngine;
 import io.gravitee.am.gateway.handler.common.protectedresource.ProtectedResourceManager;
@@ -39,6 +40,7 @@ import io.gravitee.am.model.DomainVersion;
 import io.gravitee.am.model.ExtensionGrant;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.plugins.extensiongrant.core.ExtensionGrantPluginManager;
 import io.gravitee.am.plugins.extensiongrant.core.ExtensionGrantProviderConfiguration;
@@ -113,6 +115,9 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private DomainPluginLicenseGate domainPluginLicenseGate;
 
     @Override
     public void afterPropertiesSet() {
@@ -198,6 +203,10 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
         if (!needDeployment(extensionGrant)) {
             logger.info("Extension grant {} already loaded for domain {}", extensionGrant.getId(), domain.getName());
             domainReadinessService.pluginLoaded(domain.getId(), extensionGrant.getId());
+            return Completable.complete();
+        }
+        if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_EXTENSION_GRANT, extensionGrant.getType(), extensionGrant.getId())) {
+            removeExtensionGrant(extensionGrant.getId());
             return Completable.complete();
         }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/license/GatewayOrganizationLicenseManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/license/GatewayOrganizationLicenseManager.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.license;
+
+import io.gravitee.am.common.env.CloudProperties;
+import io.gravitee.am.common.event.LicenseEvent;
+import io.gravitee.am.gateway.reactor.SecurityDomainManager;
+import io.gravitee.am.model.Environment;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.service.EnvironmentService;
+import io.gravitee.am.service.LicenseService;
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.license.License;
+import io.gravitee.node.api.license.LicenseFactory;
+import io.gravitee.node.api.license.LicenseManager;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Feeds the node {@link LicenseManager} with the organization licenses persisted by the cockpit/cloud
+ * command flow, so runtime license gating can resolve an organization's license on the gateway.
+ * <p>
+ * In managed cloud mode, a license change or expiry triggers a redeployment of the affected
+ * organization's domains so their managers re-evaluate plugin gating against the new license.
+ *
+ * @author GraviteeSource Team
+ */
+public class GatewayOrganizationLicenseManager extends AbstractService<GatewayOrganizationLicenseManager> implements EventListener<LicenseEvent, Payload> {
+
+    private static final Logger logger = LoggerFactory.getLogger(GatewayOrganizationLicenseManager.class);
+
+    private final LicenseService licenseService;
+    private final LicenseFactory licenseFactory;
+    private final LicenseManager licenseManager;
+    private final EventManager eventManager;
+    private final SecurityDomainManager securityDomainManager;
+    private final EnvironmentService environmentService;
+    private final boolean managedCloudEnabled;
+
+    private ExecutorService redeployExecutor;
+    private Scheduler redeployScheduler;
+
+    public GatewayOrganizationLicenseManager(LicenseService licenseService,
+                                             LicenseFactory licenseFactory,
+                                             LicenseManager licenseManager,
+                                             EventManager eventManager,
+                                             SecurityDomainManager securityDomainManager,
+                                             EnvironmentService environmentService,
+                                             org.springframework.core.env.Environment environment) {
+        this.licenseService = licenseService;
+        this.licenseFactory = licenseFactory;
+        this.licenseManager = licenseManager;
+        this.eventManager = eventManager;
+        this.securityDomainManager = securityDomainManager;
+        this.environmentService = environmentService;
+        this.managedCloudEnabled = CloudProperties.isManagedCloudEnabled(environment);
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        if (!managedCloudEnabled) {
+            logger.debug("Not a managed cloud deployment, skipping organization license management");
+            return;
+        }
+
+        logger.info("Register event listener for license events for the gateway");
+        eventManager.subscribeForEvents(this, LicenseEvent.class);
+
+        // set up a single thread for redeploying domains
+        final ClassLoader deploymentClassLoader = SecurityDomainManager.class.getClassLoader();
+        redeployExecutor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "gio.license-redeployer");
+            t.setDaemon(true);
+            t.setContextClassLoader(deploymentClassLoader);
+            return t;
+        });
+        redeployScheduler = Schedulers.from(redeployExecutor);
+
+        // block here since licenses must be registered before the Reactor starts and the first domain deploys
+        try {
+            licenseService.findAll()
+                    .filter(license -> license.getReferenceType() == ReferenceType.ORGANIZATION)
+                    .doOnNext(license -> logger.info("Initializing license for organization={}", license.getReferenceId()))
+                    .blockingForEach(license -> register(license.getReferenceId(), license.getLicense()));
+        } catch (Exception e) {
+            // Degrade to OSS: domains deploy without EE plugins and the next license event heals it.
+            logger.error("An error occurred while loading organization licenses", e);
+        }
+
+        licenseManager.onLicenseExpires(license -> {
+            if (License.REFERENCE_TYPE_ORGANIZATION.equals(license.getReferenceType())) {
+                logger.info("License of organization={} has expired", license.getReferenceId());
+                redeployOrganizationDomains(license.getReferenceId());
+            }
+        });
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        eventManager.unsubscribeForEvents(this, LicenseEvent.class);
+        if (redeployExecutor != null) {
+            redeployExecutor.shutdown();
+        }
+        super.doStop();
+    }
+
+    @Override
+    public void onEvent(Event<LicenseEvent, Payload> event) {
+        if (event.content().getReferenceType() == ReferenceType.ORGANIZATION) {
+            final String organizationId = event.content().getReferenceId();
+            switch (event.type()) {
+                case DEPLOY, UPDATE -> deploy(organizationId);
+                case UNDEPLOY -> undeploy(organizationId);
+            }
+        }
+    }
+
+    private void deploy(String organizationId) {
+        licenseService.findByReference(ReferenceType.ORGANIZATION, organizationId)
+                .subscribe(license -> {
+                            register(organizationId, license.getLicense());
+                            redeployOrganizationDomains(organizationId);
+                        },
+                        ex -> logger.error("An error occurred while loading license for organization={}", organizationId, ex),
+                        () -> undeploy(organizationId));
+    }
+
+    private void undeploy(String organizationId) {
+        licenseManager.registerOrganizationLicense(organizationId, null);
+        redeployOrganizationDomains(organizationId);
+    }
+
+    private void register(String organizationId, String rawLicense) {
+        try {
+            // an invalid organization license degrades to the OSS license (DefaultLicenseFactory semantics);
+            // the factory only throws on undecodable input (e.g. a corrupted persisted row)
+            licenseManager.registerOrganizationLicense(organizationId,
+                    licenseFactory.create(ReferenceType.ORGANIZATION.name(), organizationId, rawLicense));
+        } catch (Exception e) {
+            logger.warn("License cannot be registered for organization={}", organizationId, e);
+        }
+    }
+
+    private void redeployOrganizationDomains(String organizationId) {
+        logger.info("Redeploying domains of organization={} following a license change", organizationId);
+        Flowable.fromIterable(securityDomainManager.domains())
+                .flatMapMaybe(domain -> environmentService.findById(domain.getReferenceId())
+                        .map(Environment::getOrganizationId)
+                        .filter(organizationId::equals)
+                        .map(orgId -> domain)
+                        .onErrorResumeNext(ex -> {
+                            logger.warn("Cannot resolve the organization of domain={}, skipping its redeployment", domain.getId(), ex);
+                            return Maybe.empty();
+                        }))
+                .observeOn(redeployScheduler)
+                // A concurrent sync cycle may update the same domain; worst case is a redundant rebuild.
+                .concatMapCompletable(domain -> securityDomainManager.updateReactive(domain)
+                        .doOnError(ex -> logger.error("Unable to redeploy domain={} following a license change", domain.getId(), ex))
+                        .onErrorComplete())
+                .subscribe(
+                        () -> logger.debug("Domains of organization={} redeployed", organizationId),
+                        ex -> logger.error("An error occurred while redeploying domains of organization={}", organizationId, ex));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/node/GatewayNode.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/node/GatewayNode.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.node;
 
+import io.gravitee.am.gateway.license.GatewayOrganizationLicenseManager;
 import io.gravitee.am.gateway.reactor.Reactor;
 import io.gravitee.am.gateway.core.upgrader.GatewayUpgraderConfiguration;
 import io.gravitee.am.gateway.vertx.VertxEmbeddedContainer;
@@ -57,6 +58,7 @@ public class GatewayNode extends AbstractNode {
         List<Class<? extends LifecycleComponent>> components = super.components();
 
         components.add(DataPlaneRegistryImpl.class);
+        components.add(GatewayOrganizationLicenseManager.class);
         components.addAll(GatewayUpgraderConfiguration.getComponents());
         components.add(Reactor.class);
         components.add(VertxEmbeddedContainer.class);

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
@@ -29,8 +29,10 @@ import io.gravitee.am.gateway.core.email.impl.EmailStagingStateProviderImpl;
 import io.gravitee.am.gateway.core.purge.GatewayPurgeServiceConfiguration;
 import io.gravitee.am.gateway.core.upgrader.GatewayUpgraderConfiguration;
 import io.gravitee.am.gateway.event.EventManagerImpl;
+import io.gravitee.am.gateway.license.GatewayOrganizationLicenseManager;
 import io.gravitee.am.gateway.node.GatewayNode;
 import io.gravitee.am.gateway.node.GatewayNodeMetadataResolver;
+import io.gravitee.am.gateway.reactor.SecurityDomainManager;
 import io.gravitee.am.gateway.reactor.spring.ReactorConfiguration;
 import io.gravitee.am.gateway.vertx.VertxServerConfiguration;
 import io.gravitee.am.password.dictionary.spring.PasswordDictionaryConfiguration;
@@ -64,12 +66,15 @@ import io.gravitee.am.repository.management.api.OrganizationRepository;
 import io.gravitee.am.gateway.entrypoint.GatewayEntryPointManager;
 import io.gravitee.am.service.EntryPointManager;
 import org.springframework.context.annotation.Lazy;
+import io.gravitee.am.service.EnvironmentService;
+import io.gravitee.am.service.LicenseService;
 import io.gravitee.am.service.secrets.SecretsConfiguration;
 import io.gravitee.am.service.spring.ServiceConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.license.LicenseFactory;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.node.plugin.cluster.standalone.StandaloneClusterManager;
 import io.gravitee.platform.repository.api.RepositoryScopeProvider;
@@ -247,5 +252,17 @@ public class StandaloneConfiguration {
     @Primary
     public PluginDeploymentContextFactory<?> pluginDeploymentContextFactory(LicenseManager licenseManager, Environment environment) {
         return new AmPluginDeploymentContextFactory(licenseManager, CloudProperties.isManagedCloudEnabled(environment));
+    }
+
+    @Bean
+    public GatewayOrganizationLicenseManager gatewayOrganizationLicenseManager(LicenseService licenseService,
+                                                                               LicenseFactory licenseFactory,
+                                                                               LicenseManager licenseManager,
+                                                                               EventManager eventManager,
+                                                                               SecurityDomainManager securityDomainManager,
+                                                                               EnvironmentService environmentService,
+                                                                               Environment environment) {
+        return new GatewayOrganizationLicenseManager(licenseService, licenseFactory, licenseManager,
+                eventManager, securityDomainManager, environmentService, environment);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/test/java/io/gravitee/am/gateway/license/GatewayOrganizationLicenseManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/test/java/io/gravitee/am/gateway/license/GatewayOrganizationLicenseManagerTest.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.license;
+
+import io.gravitee.am.common.event.Action;
+import io.gravitee.am.common.event.LicenseEvent;
+import io.gravitee.am.gateway.reactor.SecurityDomainManager;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.License;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.service.EnvironmentService;
+import io.gravitee.am.service.LicenseService;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.gravitee.node.api.license.LicenseFactory;
+import io.gravitee.node.api.license.LicenseManager;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.Environment;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class GatewayOrganizationLicenseManagerTest {
+
+    private static final String ORGANIZATION_ID = "orga#1";
+    private static final String OTHER_ORGANIZATION_ID = "orga#2";
+    private static final String ENVIRONMENT_ID = "env#1";
+    private static final String OTHER_ENVIRONMENT_ID = "env#2";
+
+    @Mock
+    private LicenseService licenseService;
+
+    @Mock
+    private LicenseFactory licenseFactory;
+
+    @Mock
+    private LicenseManager licenseManager;
+
+    @Mock
+    private EventManager eventManager;
+
+    @Mock
+    private SecurityDomainManager securityDomainManager;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private io.gravitee.node.api.license.License parsedLicense;
+
+    @Captor
+    private ArgumentCaptor<Consumer<io.gravitee.node.api.license.License>> expirationListenerCaptor;
+
+    private GatewayOrganizationLicenseManager manager;
+
+    @Before
+    public void setUp() {
+        when(licenseService.findAll()).thenReturn(Flowable.empty());
+        when(securityDomainManager.domains()).thenReturn(List.of());
+    }
+
+    @After
+    public void tearDown() {
+        if (manager != null) {
+            try {
+                manager.doStop();
+            } catch (Exception e) {
+                // already stopped by the test itself
+            }
+        }
+    }
+
+    private GatewayOrganizationLicenseManager manager(boolean managedCloud) {
+        lenient().when(environment.getProperty("cloud.enabled", Boolean.class)).thenReturn(managedCloud);
+        lenient().when(environment.getProperty("installation.type", "standalone")).thenReturn(managedCloud ? "managed" : "standalone");
+        manager = new GatewayOrganizationLicenseManager(licenseService, licenseFactory, licenseManager,
+                eventManager, securityDomainManager, environmentService, environment);
+        return manager;
+    }
+
+    @Test
+    public void shouldRegisterPersistedOrganizationLicensesOnStartBeforeReturning() throws Exception {
+        when(licenseService.findAll()).thenReturn(Flowable.just(
+                license(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "license-1"),
+                license(ReferenceType.PLATFORM, "platform", "license-2")));
+        when(licenseFactory.create(ReferenceType.ORGANIZATION.name(), ORGANIZATION_ID, "license-1")).thenReturn(parsedLicense);
+
+        manager(true).doStart();
+
+        verify(eventManager).subscribeForEvents(manager, LicenseEvent.class);
+        // blocking load: the license must be registered by the time doStart returns
+        verify(licenseManager).registerOrganizationLicense(ORGANIZATION_ID, parsedLicense);
+        verify(licenseFactory, never()).create(anyString(), org.mockito.ArgumentMatchers.eq("platform"), anyString());
+    }
+
+    @Test
+    public void shouldSkipUndecodableLicenseOnStart() throws Exception {
+        when(licenseService.findAll()).thenReturn(Flowable.just(
+                license(ReferenceType.ORGANIZATION, "bad-org", "corrupted"),
+                license(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "license-1")));
+        when(licenseFactory.create(ReferenceType.ORGANIZATION.name(), "bad-org", "corrupted"))
+                .thenThrow(new IllegalArgumentException("Illegal base64 character"));
+        when(licenseFactory.create(ReferenceType.ORGANIZATION.name(), ORGANIZATION_ID, "license-1")).thenReturn(parsedLicense);
+
+        manager(true).doStart();
+
+        verify(licenseManager).registerOrganizationLicense(ORGANIZATION_ID, parsedLicense);
+        verify(licenseManager, never()).registerOrganizationLicense(org.mockito.ArgumentMatchers.eq("bad-org"), any());
+    }
+
+    @Test
+    public void shouldTolerateInitialLoadFailure() throws Exception {
+        when(licenseService.findAll()).thenReturn(Flowable.error(new RuntimeException("database unavailable")));
+
+        manager(true).doStart();
+
+        verify(eventManager).subscribeForEvents(manager, LicenseEvent.class);
+        verify(licenseManager, never()).registerOrganizationLicense(anyString(), any());
+    }
+
+    @Test
+    public void shouldUnsubscribeOnStop() throws Exception {
+        manager(true).doStart();
+        manager.doStop();
+
+        verify(eventManager).unsubscribeForEvents(manager, LicenseEvent.class);
+    }
+
+    @Test
+    public void shouldRegisterLicenseAndRedeployAffectedDomainsOnDeployEvent() throws Exception {
+        givenDeployedDomains();
+        when(licenseService.findByReference(ReferenceType.ORGANIZATION, ORGANIZATION_ID))
+                .thenReturn(Maybe.just(license(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "license-1")));
+        when(licenseFactory.create(ReferenceType.ORGANIZATION.name(), ORGANIZATION_ID, "license-1")).thenReturn(parsedLicense);
+
+        manager(true).doStart();
+        manager.onEvent(new SimpleEvent<>(LicenseEvent.DEPLOY, payload(Action.CREATE)));
+
+        verify(licenseManager).registerOrganizationLicense(ORGANIZATION_ID, parsedLicense);
+        verify(securityDomainManager, timeout(2000)).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#1")));
+        verify(securityDomainManager, never()).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#2")));
+    }
+
+    @Test
+    public void shouldDeregisterLicenseAndRedeployOnUndeployEvent() throws Exception {
+        givenDeployedDomains();
+
+        manager(true).doStart();
+        manager.onEvent(new SimpleEvent<>(LicenseEvent.UNDEPLOY, payload(Action.DELETE)));
+
+        verify(licenseManager).registerOrganizationLicense(ORGANIZATION_ID, null);
+        verify(securityDomainManager, timeout(2000)).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#1")));
+    }
+
+    @Test
+    public void shouldDeregisterLicenseWhenDeployedLicenseIsMissing() throws Exception {
+        when(licenseService.findByReference(ReferenceType.ORGANIZATION, ORGANIZATION_ID)).thenReturn(Maybe.empty());
+
+        manager(true).doStart();
+        manager.onEvent(new SimpleEvent<>(LicenseEvent.DEPLOY, payload(Action.CREATE)));
+
+        verify(licenseManager).registerOrganizationLicense(ORGANIZATION_ID, null);
+    }
+
+    @Test
+    public void shouldIgnoreNonOrganizationEvent() throws Exception {
+        manager(true).doStart();
+        manager.onEvent(new SimpleEvent<>(LicenseEvent.DEPLOY, new Payload("domain#1", ReferenceType.DOMAIN, "domain#1", Action.CREATE)));
+
+        verify(licenseService, never()).findByReference(any(), anyString());
+        verify(licenseManager, never()).registerOrganizationLicense(anyString(), any());
+    }
+
+    @Test
+    public void shouldRedeployAffectedDomainsOnLicenseExpiry() throws Exception {
+        givenDeployedDomains();
+
+        manager(true).doStart();
+
+        verify(licenseManager).onLicenseExpires(expirationListenerCaptor.capture());
+        when(parsedLicense.getReferenceType()).thenReturn(io.gravitee.node.api.license.License.REFERENCE_TYPE_ORGANIZATION);
+        when(parsedLicense.getReferenceId()).thenReturn(ORGANIZATION_ID);
+        expirationListenerCaptor.getValue().accept(parsedLicense);
+
+        verify(securityDomainManager, timeout(2000)).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#1")));
+        verify(securityDomainManager, never()).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#2")));
+    }
+
+    @Test
+    public void shouldDoNothingWhenNotManagedCloud() throws Exception {
+        manager(false).doStart();
+
+        verifyNoInteractions(eventManager, licenseService, licenseManager);
+    }
+
+    private void givenDeployedDomains() {
+        Domain affectedDomain = domain("domain#1", ENVIRONMENT_ID);
+        Domain otherDomain = domain("domain#2", OTHER_ENVIRONMENT_ID);
+        when(securityDomainManager.domains()).thenReturn(List.of(affectedDomain, otherDomain));
+        when(securityDomainManager.updateReactive(any())).thenReturn(Completable.complete());
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(environment(ENVIRONMENT_ID, ORGANIZATION_ID)));
+        when(environmentService.findById(OTHER_ENVIRONMENT_ID)).thenReturn(Single.just(environment(OTHER_ENVIRONMENT_ID, OTHER_ORGANIZATION_ID)));
+    }
+
+    private static Domain domain(String id, String environmentId) {
+        Domain domain = new Domain();
+        domain.setId(id);
+        domain.setReferenceType(ReferenceType.ENVIRONMENT);
+        domain.setReferenceId(environmentId);
+        return domain;
+    }
+
+    private static io.gravitee.am.model.Environment environment(String id, String organizationId) {
+        io.gravitee.am.model.Environment env = new io.gravitee.am.model.Environment();
+        env.setId(id);
+        env.setOrganizationId(organizationId);
+        return env;
+    }
+
+    private static License license(ReferenceType referenceType, String referenceId, String rawLicense) {
+        License license = new License();
+        license.setReferenceType(referenceType);
+        license.setReferenceId(referenceId);
+        license.setLicense(rawLicense);
+        return license;
+    }
+
+    private static Payload payload(Action action) {
+        return new Payload(ORGANIZATION_ID, ReferenceType.ORGANIZATION, ORGANIZATION_ID, action);
+    }
+}

--- a/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/DomainReadinessService.java
+++ b/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/DomainReadinessService.java
@@ -61,6 +61,17 @@ public interface DomainReadinessService {
     void pluginInitFailed(String domainId, String pluginType, String message);
 
     /**
+     * Mark a plugin as skipped because the organization license does not grant its feature.
+     * The plugin counts as handled (readiness stays healthy) but the message is exposed
+     * so operators can see why the plugin is not available.
+     *
+     * @param domainId Domain ID.
+     * @param pluginId Plugin ID.
+     * @param message Reason the plugin was not loaded.
+     */
+    void pluginUnlicensed(String domainId, String pluginId, String message);
+
+    /**
      * Remove a plugin from matching.
      * @param domainId Domain ID.
      * @param pluginId Plugin ID.

--- a/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/DomainReadinessServiceImpl.java
+++ b/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/DomainReadinessServiceImpl.java
@@ -111,6 +111,20 @@ public class DomainReadinessServiceImpl implements DomainReadinessService {
     }
 
     @Override
+    public void pluginUnlicensed(String domainId, String pluginId, String message) {
+        if (domainId == null) {
+            logger.warn("Received pluginUnlicensed for null domainId. Plugin: {}, Reason: {}", pluginId, message);
+            return;
+        }
+
+        logger.info("[Domain: {}] Plugin not licensed: {} - {}", domainId, pluginId, message);
+
+        initPluginSync(domainId, pluginId, null);
+        // success=true: a licensing decision must not make the domain unstable or the readiness probe unhealthy.
+        updatePluginStatus(domainId, pluginId, true, message);
+    }
+
+    @Override
     public void pluginUnloaded(String domainId, String pluginId) {
         if (domainId == null) {
             logger.warn("Received pluginUnloaded for null domainId. Plugin: {}", pluginId);

--- a/gravitee-am-monitoring/src/test/java/io/gravitee/am/monitoring/DomainReadinessServiceImplTest.java
+++ b/gravitee-am-monitoring/src/test/java/io/gravitee/am/monitoring/DomainReadinessServiceImplTest.java
@@ -61,10 +61,39 @@ public class DomainReadinessServiceImplTest {
     }
 
     @Test
+    public void shouldKeepDomainStableWhenPluginIsUnlicensed() {
+        String domainId = "domain-1";
+        String pluginId = "ee-factor";
+
+        domainReadinessService.initPluginSync(domainId, pluginId, "FACTOR");
+        domainReadinessService.pluginUnlicensed(domainId, pluginId, "Plugin requires the feature 'am-factor-otp'");
+
+        verifyDomainState(domainId, DomainState.Status.DEPLOYED, true, 1);
+        DomainState domainState = domainReadinessService.getDomainState(domainId);
+        assertTrue(domainState.isSynchronized());
+        assertEquals("FACTOR", domainState.getCreationState().get(pluginId).getType());
+        assertEquals("Plugin requires the feature 'am-factor-otp'", domainState.getCreationState().get(pluginId).getMessage());
+        assertTrue(domainReadinessService.isAllDomainsReady());
+    }
+
+    @Test
+    public void shouldRecordUnlicensedPluginWithoutPriorInit() {
+        String domainId = "domain-1";
+        String pluginId = "ee-resource";
+
+        domainReadinessService.pluginUnlicensed(domainId, pluginId, "feature required");
+
+        verifyDomainState(domainId, DomainState.Status.DEPLOYED, true, 1);
+        assertEquals("feature required", domainReadinessService.getDomainState(domainId).getCreationState().get(pluginId).getMessage());
+        assertTrue(domainReadinessService.isAllDomainsReady());
+    }
+
+    @Test
     public void shouldHandleNullsSafely() {
         domainReadinessService.initPluginSync(null, "plugin", "type");
         domainReadinessService.pluginLoaded(null, "plugin");
         domainReadinessService.pluginFailed(null, "plugin", "error");
+        domainReadinessService.pluginUnlicensed(null, "plugin", "feature required");
         domainReadinessService.pluginUnloaded(null, "plugin");
         domainReadinessService.updateDomainStatus(null, DomainState.Status.DEPLOYED);
         domainReadinessService.removeDomain(null);

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-authenticator/src/main/java/io/gravitee/am/plugins/authenticator/core/AuthenticatorPluginManager.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-authenticator/src/main/java/io/gravitee/am/plugins/authenticator/core/AuthenticatorPluginManager.java
@@ -34,6 +34,7 @@ import org.springframework.core.env.Environment;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 public class AuthenticatorPluginManager extends
         ProviderPluginManager<AuthenticatorPlugin<?, AuthenticatorProvider>, AuthenticatorProvider, AuthenticatorProviderConfiguration>
@@ -49,8 +50,12 @@ public class AuthenticatorPluginManager extends
         this.pluginClassLoaderFactory = pluginClassLoaderFactory;
     }
 
-    public List<AuthenticatorProvider> createAll(ApplicationContext applicationContext){
+    /**
+     * Creates a provider for every deployed authenticator plugin whose id is accepted by the filter.
+     */
+    public List<AuthenticatorProvider> createAll(ApplicationContext applicationContext, Predicate<String> pluginFilter) {
         return findAll().stream()
+                .filter(auth -> pluginFilter.test(auth.id()))
                 .flatMap(auth -> create(auth, applicationContext).stream())
                 .toList();
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/PluginLicenseGate.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/PluginLicenseGate.java
@@ -46,6 +46,8 @@ public interface PluginLicenseGate {
     String TYPE_POLICY = "policy";
     String TYPE_AUTHORIZATION_ENGINE = "authorization-engine";
     String TYPE_NOTIFIER = "notifier";
+    String TYPE_PROTOCOL = "protocol";
+    String TYPE_AUTHENTICATOR = "authenticator";
 
     /**
      * Checks that an instance of the given plugin may be created or updated under the given reference.


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7238](https://gravitee.atlassian.net/browse/AM-7238)

## :pencil2: A description of the changes proposed in the pull request
In managed cloud mode, gate initialisation of EE features according to the active organization's license.
- Changes in an organization's license trigger a redeploy of dependant domains.
- `PluginLicenseGate` is wrapped for domain-specific license checks and synchronises its results with the `DomainReadinessService`.
  - The internal readiness endpoint serves unlicensed features as successful but caveated with a message about the restriction by licensing - e.g.
```
        ...
        "saml2-idp": {
            "id": "saml2-idp",
            "type": null,
            "success": true,
            "message": "Plugin 'saml2-idp' requires the feature 'am-idp-gateway-handler-saml' which is not included in your organization's license",
            "lastSync": 1784728625081
        },
        ...
```
- Restricted plugins are skipped, meaning behaviours and HTTP routes can become unavailable.
- License checks in the gateway run at midnight and when the server is restarted.

Non-cloud mode behaviour is unaffected.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7238]: https://gravitee.atlassian.net/browse/AM-7238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ