### PR TITLE
feat(entrypoint): resolve domain entrypoint URL from environment in cloud mode

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -132,7 +132,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -276,7 +275,6 @@ public class DomainServiceImpl implements DomainService {
     @Autowired
     private EntryPointManager entryPointManager;
 
-    // Spring environment (node config), distinct from the io.gravitee.am.model.Environment used elsewhere in this class.
     @Autowired
     private org.springframework.core.env.Environment springEnvironment;
 
@@ -809,30 +807,26 @@ public class DomainServiceImpl implements DomainService {
                 });
     }
 
-    /**
-     * Managed cloud mode: the domain's entrypoint is scoped to its environment and resolved from the
-     * {@link EntryPointManager} cache rather than the org-wide default/tags filter. Self-contained -
-     * never falls through to the non-cloud path (which would return the org default's gateway URL,
-     * the wrong URL in cloud). See ADR 0001.
-     */
     private Single<List<Entrypoint>> listEnvironmentEntryPoint(Domain domain) {
         return Single.defer(() -> {
             List<Entrypoint> environmentEntrypoints = entryPointManager.findByEnvironmentId(domain.getReferenceId());
             if (environmentEntrypoints.isEmpty()) {
-                // Not synced yet: return a single entrypoint carrying the gateway URL so the page still
-                // renders (the UI selects the single element and reads its url). Never return an empty list.
                 Entrypoint fallback = new Entrypoint();
-                fallback.setUrl(dataPlaneRegistry.getDescription(domain).gatewayUrl());
+                ofNullable(dataPlaneRegistry.getDescription(domain).gatewayUrl()).ifPresent(fallback::setUrl);
                 return Single.just(List.of(fallback));
             }
-            if (environmentEntrypoints.size() > 1) {
-                LOGGER.warn("Environment {} resolves to {} entrypoints, expected one; picking deterministically until the override flag (AM-7298) lands", domain.getReferenceId(), environmentEntrypoints.size());
-            }
-            // Non-empty by the guard above: min() always yields a value.
+
+            // Cockpit recreates every environment entrypoint on each environment command, so createdAt/id
+            // churn and are not stable to order on. Prefer the one flagged default (the overridden access
+            // point), otherwise take the first in the list received from the command.
             Entrypoint selected = environmentEntrypoints.stream()
-                    .min(Comparator.comparing(Entrypoint::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder()))
-                            .thenComparing(Entrypoint::getId, Comparator.nullsLast(Comparator.naturalOrder())))
-                    .orElseThrow();
+                    .filter(Entrypoint::isDefaultEntrypoint)
+                    .findFirst()
+                    .orElseGet(() -> environmentEntrypoints.get(0));
+
+            if (environmentEntrypoints.size() > 1 && !selected.isDefaultEntrypoint()) {
+                LOGGER.warn("Environment {} resolves to {} entrypoints and none is flagged default; using the first", domain.getReferenceId(), environmentEntrypoints.size());
+            }
             return Single.just(List.of(selected));
         });
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -786,8 +786,12 @@ public class DomainServiceImpl implements DomainService {
     @Override
     public Single<List<Entrypoint>> listEntryPoint(Domain domain, String organizationId) {
         if (CloudProperties.isManagedCloudEnabled(springEnvironment)) {
-            return listEnvironmentEntryPoint(domain);
+            return listEnvironmentEntryPoint(domain, organizationId);
         }
+        return listOrganizationEntryPoint(domain, organizationId);
+    }
+
+    private Single<List<Entrypoint>> listOrganizationEntryPoint(Domain domain, String organizationId) {
         return entrypointService.findAll(organizationId)
                 .filter(entrypoint -> entrypoint.isDefaultEntrypoint()
                         || (entrypoint.getTags() != null && !entrypoint.getTags().isEmpty() && domain.getTags() != null && entrypoint.getTags().stream().anyMatch(tag -> domain.getTags().contains(tag))))
@@ -807,13 +811,13 @@ public class DomainServiceImpl implements DomainService {
                 });
     }
 
-    private Single<List<Entrypoint>> listEnvironmentEntryPoint(Domain domain) {
+    private Single<List<Entrypoint>> listEnvironmentEntryPoint(Domain domain, String organizationId) {
         return Single.defer(() -> {
             List<Entrypoint> environmentEntrypoints = entryPointManager.findByEnvironmentId(domain.getReferenceId());
             if (environmentEntrypoints.isEmpty()) {
-                Entrypoint fallback = new Entrypoint();
-                ofNullable(dataPlaneRegistry.getDescription(domain).gatewayUrl()).ifPresent(fallback::setUrl);
-                return Single.just(List.of(fallback));
+                // No environment entrypoint synced yet: degrade to the organization resolution, whose
+                // default entrypoint always carries a url (the UI builds links from it, never null).
+                return listOrganizationEntryPoint(domain, organizationId);
             }
 
             // Cockpit recreates every environment entrypoint on each environment command, so createdAt/id
@@ -822,11 +826,12 @@ public class DomainServiceImpl implements DomainService {
             Entrypoint selected = environmentEntrypoints.stream()
                     .filter(Entrypoint::isDefaultEntrypoint)
                     .findFirst()
-                    .orElseGet(() -> environmentEntrypoints.get(0));
-
-            if (environmentEntrypoints.size() > 1 && !selected.isDefaultEntrypoint()) {
-                LOGGER.warn("Environment {} resolves to {} entrypoints and none is flagged default; using the first", domain.getReferenceId(), environmentEntrypoints.size());
-            }
+                    .orElseGet(() -> {
+                        if (environmentEntrypoints.size() > 1) {
+                            LOGGER.warn("Environment {} resolves to {} entrypoints and none is flagged default; using the first", domain.getReferenceId(), environmentEntrypoints.size());
+                        }
+                        return environmentEntrypoints.get(0);
+                    });
             return Single.just(List.of(selected));
         });
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.management.service.impl;
 
 import io.gravitee.am.common.audit.EventType;
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.common.event.Action;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestUriException;
@@ -65,6 +66,7 @@ import io.gravitee.am.service.CimdClientStateService;
 import io.gravitee.am.service.DeviceIdentifierService;
 import io.gravitee.am.service.DomainReadService;
 import io.gravitee.am.service.EmailTemplateService;
+import io.gravitee.am.service.EntryPointManager;
 import io.gravitee.am.service.EntrypointService;
 import io.gravitee.am.service.EnvironmentService;
 import io.gravitee.am.service.EventService;
@@ -130,6 +132,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -269,6 +272,13 @@ public class DomainServiceImpl implements DomainService {
 
     @Autowired
     private EntrypointService entrypointService;
+
+    @Autowired
+    private EntryPointManager entryPointManager;
+
+    // Spring environment (node config), distinct from the io.gravitee.am.model.Environment used elsewhere in this class.
+    @Autowired
+    private org.springframework.core.env.Environment springEnvironment;
 
     @Autowired
     private DefaultIdentityProviderService defaultIdentityProviderService;
@@ -777,6 +787,9 @@ public class DomainServiceImpl implements DomainService {
 
     @Override
     public Single<List<Entrypoint>> listEntryPoint(Domain domain, String organizationId) {
+        if (CloudProperties.isManagedCloudEnabled(springEnvironment)) {
+            return listEnvironmentEntryPoint(domain);
+        }
         return entrypointService.findAll(organizationId)
                 .filter(entrypoint -> entrypoint.isDefaultEntrypoint()
                         || (entrypoint.getTags() != null && !entrypoint.getTags().isEmpty() && domain.getTags() != null && entrypoint.getTags().stream().anyMatch(tag -> domain.getTags().contains(tag))))
@@ -794,6 +807,34 @@ public class DomainServiceImpl implements DomainService {
 
                     return filteredEntrypoints;
                 });
+    }
+
+    /**
+     * Managed cloud mode: the domain's entrypoint is scoped to its environment and resolved from the
+     * {@link EntryPointManager} cache rather than the org-wide default/tags filter. Self-contained -
+     * never falls through to the non-cloud path (which would return the org default's gateway URL,
+     * the wrong URL in cloud). See ADR 0001.
+     */
+    private Single<List<Entrypoint>> listEnvironmentEntryPoint(Domain domain) {
+        return Single.defer(() -> {
+            List<Entrypoint> environmentEntrypoints = entryPointManager.findByEnvironmentId(domain.getReferenceId());
+            if (environmentEntrypoints.isEmpty()) {
+                // Not synced yet: return a single entrypoint carrying the gateway URL so the page still
+                // renders (the UI selects the single element and reads its url). Never return an empty list.
+                Entrypoint fallback = new Entrypoint();
+                fallback.setUrl(dataPlaneRegistry.getDescription(domain).gatewayUrl());
+                return Single.just(List.of(fallback));
+            }
+            if (environmentEntrypoints.size() > 1) {
+                LOGGER.warn("Environment {} resolves to {} entrypoints, expected one; picking deterministically until the override flag (AM-7298) lands", domain.getReferenceId(), environmentEntrypoints.size());
+            }
+            // Non-empty by the guard above: min() always yields a value.
+            Entrypoint selected = environmentEntrypoints.stream()
+                    .min(Comparator.comparing(Entrypoint::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                            .thenComparing(Entrypoint::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+                    .orElseThrow();
+            return Single.just(List.of(selected));
+        });
     }
 
     private Single<Domain> createSystemScopes(Domain domain) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -135,7 +135,6 @@ import io.gravitee.am.service.EntryPointManager;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -193,7 +192,6 @@ public class DomainServiceTest {
     @InjectMocks
     private DomainServiceImpl domainService = new DomainServiceImpl();
 
-    // Real Spring environment so CloudProperties resolves defaults (non-cloud) without stubbing.
     @Spy
     private MockEnvironment springEnvironment = new MockEnvironment();
 
@@ -1905,27 +1903,62 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldGetEntrypoint_cloud_multipleEnvironmentEntrypoints_picksEarliestDeterministically() {
+    public void shouldGetEntrypoint_cloud_multipleEntrypoints_picksDefaultFlagged() {
         enableCloudMode();
 
-        final Entrypoint newer = new Entrypoint();
-        newer.setId("b-entrypoint");
-        newer.setEnvironmentId(ENVIRONMENT_ID);
-        newer.setUrl("https://newer.gravitee.io");
-        newer.setCreatedAt(new Date(2000));
+        final Entrypoint first = new Entrypoint();
+        first.setId("first-entrypoint");
+        first.setEnvironmentId(ENVIRONMENT_ID);
+        first.setUrl("https://first.gravitee.io");
 
-        final Entrypoint older = new Entrypoint();
-        older.setId("a-entrypoint");
-        older.setEnvironmentId(ENVIRONMENT_ID);
-        older.setUrl("https://older.gravitee.io");
-        older.setCreatedAt(new Date(1000));
+        final Entrypoint flagged = new Entrypoint();
+        flagged.setId("flagged-entrypoint");
+        flagged.setEnvironmentId(ENVIRONMENT_ID);
+        flagged.setUrl("https://flagged.gravitee.io");
+        flagged.setDefaultEntrypoint(true);
 
-        // Cache order (newer first) must not influence the result: earliest createdAt wins.
-        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(newer, older));
+        // The default-flagged entrypoint wins even when it is not first in the list.
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(first, flagged));
 
         final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
         subscriber.assertValue(entrypoints -> entrypoints.size() == 1
-                && entrypoints.get(0).getId().equals("a-entrypoint"));
+                && entrypoints.get(0).getId().equals("flagged-entrypoint"));
+    }
+
+    @Test
+    public void shouldGetEntrypoint_cloud_noEnvironmentEntrypoint_nullGatewayUrl_returnsNonEmpty() {
+        enableCloudMode();
+
+        final Domain mockDomain = cloudDomain();
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(dataPlaneRegistry.getDescription(mockDomain))
+                .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", null));
+
+        final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
+        // Even with no gateway URL the list must never be empty (the UI dereferences the single element).
+        subscriber.assertValue(entrypoints -> entrypoints.size() == 1 && entrypoints.get(0).getUrl() == null);
+    }
+
+    @Test
+    public void shouldGetEntrypoint_cloud_multipleEntrypoints_noneDefault_picksFirstInList() {
+        enableCloudMode();
+
+        final Entrypoint first = new Entrypoint();
+        first.setId("first-entrypoint");
+        first.setEnvironmentId(ENVIRONMENT_ID);
+        first.setUrl("https://first.gravitee.io");
+
+        final Entrypoint second = new Entrypoint();
+        second.setId("second-entrypoint");
+        second.setEnvironmentId(ENVIRONMENT_ID);
+        second.setUrl("https://second.gravitee.io");
+
+        // None flagged default: fall back to the first in the list received from the command.
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(first, second));
+
+        final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
+        subscriber.assertValue(entrypoints -> entrypoints.size() == 1
+                && entrypoints.get(0).getId().equals("first-entrypoint"));
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -127,10 +127,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
+
+import io.gravitee.am.service.EntryPointManager;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -187,6 +192,13 @@ public class DomainServiceTest {
 
     @InjectMocks
     private DomainServiceImpl domainService = new DomainServiceImpl();
+
+    // Real Spring environment so CloudProperties resolves defaults (non-cloud) without stubbing.
+    @Spy
+    private MockEnvironment springEnvironment = new MockEnvironment();
+
+    @Mock
+    private EntryPointManager entryPointManager;
 
     @Mock
     private DataPlaneRegistry dataPlaneRegistry;
@@ -1844,6 +1856,102 @@ public class DomainServiceTest {
         subscriber.assertValue(entrypoints -> entrypoints.size() == 2 &&
                 entrypoints.stream().anyMatch(e -> e.getId().equals(ENTRYPOINT_ID1)) &&
                 entrypoints.stream().anyMatch(e -> e.getId().equals(ENTRYPOINT_ID2)));
+    }
+
+    private void enableCloudMode() {
+        springEnvironment.setProperty("cloud.enabled", "true");
+        springEnvironment.setProperty("installation.type", "managed");
+    }
+
+    private Domain cloudDomain() {
+        Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        domain.setReferenceType(ReferenceType.ENVIRONMENT);
+        domain.setReferenceId(ENVIRONMENT_ID);
+        return domain;
+    }
+
+    @Test
+    public void shouldGetEntrypoint_cloud_singleEnvironmentEntrypoint() {
+        enableCloudMode();
+
+        final Entrypoint envEntrypoint = new Entrypoint();
+        envEntrypoint.setId("env-entrypoint-1");
+        envEntrypoint.setEnvironmentId(ENVIRONMENT_ID);
+        envEntrypoint.setUrl("https://acme.gravitee.io");
+
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(envEntrypoint));
+
+        final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
+        subscriber.assertValue(entrypoints -> entrypoints.size() == 1
+                && entrypoints.get(0).getId().equals("env-entrypoint-1")
+                && entrypoints.get(0).getUrl().equals("https://acme.gravitee.io"));
+        verify(entrypointService, never()).findAll(anyString());
+    }
+
+    @Test
+    public void shouldGetEntrypoint_cloud_noEnvironmentEntrypoint_synthesizesGatewayUrl() {
+        enableCloudMode();
+
+        final Domain mockDomain = cloudDomain();
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(dataPlaneRegistry.getDescription(mockDomain))
+                .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", "http://gateway:8092"));
+
+        final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
+        // Never an empty list (the UI would crash); a single entrypoint carrying the gateway URL.
+        subscriber.assertValue(entrypoints -> entrypoints.size() == 1
+                && "http://gateway:8092".equals(entrypoints.get(0).getUrl()));
+    }
+
+    @Test
+    public void shouldGetEntrypoint_cloud_multipleEnvironmentEntrypoints_picksEarliestDeterministically() {
+        enableCloudMode();
+
+        final Entrypoint newer = new Entrypoint();
+        newer.setId("b-entrypoint");
+        newer.setEnvironmentId(ENVIRONMENT_ID);
+        newer.setUrl("https://newer.gravitee.io");
+        newer.setCreatedAt(new Date(2000));
+
+        final Entrypoint older = new Entrypoint();
+        older.setId("a-entrypoint");
+        older.setEnvironmentId(ENVIRONMENT_ID);
+        older.setUrl("https://older.gravitee.io");
+        older.setCreatedAt(new Date(1000));
+
+        // Cache order (newer first) must not influence the result: earliest createdAt wins.
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(newer, older));
+
+        final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
+        subscriber.assertValue(entrypoints -> entrypoints.size() == 1
+                && entrypoints.get(0).getId().equals("a-entrypoint"));
+    }
+
+    @Test
+    public void shouldGetEntrypoint_nonCloud_usesOrgEntrypointsAndSkipsEnvironmentManager() {
+        // springEnvironment defaults to non-cloud (no cloud.enabled / installation.type).
+        final Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setId(ENTRYPOINT_ID1);
+        entrypoint.setTags(Arrays.asList(TAG_ID2));
+        entrypoint.setOrganizationId(ORGANIZATION_ID);
+
+        final Entrypoint defaultEntrypoint = new Entrypoint();
+        defaultEntrypoint.setId(ENTRYPOINT_ID_DEFAULT);
+        defaultEntrypoint.setDefaultEntrypoint(true);
+        defaultEntrypoint.setTags(Collections.emptyList());
+        defaultEntrypoint.setOrganizationId(ORGANIZATION_ID);
+
+        Domain mockDomain = new Domain();
+        mockDomain.setId(DOMAIN_ID);
+        mockDomain.setTags(new HashSet<>(Arrays.asList(TAG_ID1, TAG_ID2)));
+
+        doReturn(Flowable.just(entrypoint, defaultEntrypoint)).when(entrypointService).findAll(ORGANIZATION_ID);
+
+        final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
+        subscriber.assertValue(entrypoints -> entrypoints.size() == 1
+                && entrypoints.get(0).getId().equals(ENTRYPOINT_ID1));
+        verify(entryPointManager, never()).findByEnvironmentId(anyString());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -1888,7 +1888,7 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldGetEntrypoint_cloud_noEnvironmentEntrypoint_synthesizesGatewayUrl() {
+    public void shouldGetEntrypoint_cloud_noEnvironmentEntrypoint_fallsBackToOrgEntrypointWithGatewayUrl() {
         enableCloudMode();
 
         final Domain mockDomain = cloudDomain();
@@ -1896,8 +1896,15 @@ public class DomainServiceTest {
         when(dataPlaneRegistry.getDescription(mockDomain))
                 .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", "http://gateway:8092"));
 
+        final Entrypoint defaultEntrypoint = new Entrypoint();
+        defaultEntrypoint.setId(ENTRYPOINT_ID_DEFAULT);
+        defaultEntrypoint.setDefaultEntrypoint(true);
+        defaultEntrypoint.setUrl("https://default.gravitee.io");
+        defaultEntrypoint.setOrganizationId(ORGANIZATION_ID);
+        doReturn(Flowable.just(defaultEntrypoint)).when(entrypointService).findAll(ORGANIZATION_ID);
+
         final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
-        // Never an empty list (the UI would crash); a single entrypoint carrying the gateway URL.
+        // Never an empty list (the UI would crash); the org default entrypoint carrying the gateway URL.
         subscriber.assertValue(entrypoints -> entrypoints.size() == 1
                 && "http://gateway:8092".equals(entrypoints.get(0).getUrl()));
     }
@@ -1926,7 +1933,7 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldGetEntrypoint_cloud_noEnvironmentEntrypoint_nullGatewayUrl_returnsNonEmpty() {
+    public void shouldGetEntrypoint_cloud_noEnvironmentEntrypoint_nullGatewayUrl_fallsBackToOrgDefaultUrl() {
         enableCloudMode();
 
         final Domain mockDomain = cloudDomain();
@@ -1934,9 +1941,17 @@ public class DomainServiceTest {
         when(dataPlaneRegistry.getDescription(mockDomain))
                 .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", null));
 
+        final Entrypoint defaultEntrypoint = new Entrypoint();
+        defaultEntrypoint.setId(ENTRYPOINT_ID_DEFAULT);
+        defaultEntrypoint.setDefaultEntrypoint(true);
+        defaultEntrypoint.setUrl("https://default.gravitee.io");
+        defaultEntrypoint.setOrganizationId(ORGANIZATION_ID);
+        doReturn(Flowable.just(defaultEntrypoint)).when(entrypointService).findAll(ORGANIZATION_ID);
+
         final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
-        // Even with no gateway URL the list must never be empty (the UI dereferences the single element).
-        subscriber.assertValue(entrypoints -> entrypoints.size() == 1 && entrypoints.get(0).getUrl() == null);
+        // Even with no data-plane gateway URL the single entrypoint keeps the org default's url — never null.
+        subscriber.assertValue(entrypoints -> entrypoints.size() == 1
+                && "https://default.gravitee.io".equals(entrypoints.get(0).getUrl()));
     }
 
     @Test

--- a/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
@@ -80,19 +80,20 @@ describe('Cloud domain entrypoint URL (management API)', () => {
     expect(urls).toEqual([expectedUrl]);
   });
 
-  it('never returns an empty list when the environment has no access points', async () => {
+  it('falls back to an organization entrypoint when the environment has no access points', async () => {
     await fixture.resyncAccessPoints([]);
 
-    // Once the environment entrypoint is evicted, the endpoint must still return exactly one
-    // entrypoint (the fallback), never an empty list — an empty list would crash the UI. In managed
-    // cloud the DataPlane gatewayUrl may be absent, so the fallback entrypoint can have no url; the
-    // guarantee under test is that the list stays non-empty and is no longer an environment host.
+    // Once the environment entrypoint is evicted, the endpoint degrades to the organization
+    // resolution: still exactly one entrypoint (never an empty list — that would crash the UI),
+    // carrying the DataPlane gatewayUrl or the org default entrypoint's url. Either way the url
+    // is a real URL, never null (the UI builds links from it), and no longer an environment host.
     const urls = await retryUntil(
       () => domainEntrypointUrls(),
-      (resolved) => resolved.length === 1 && (resolved[0] == null || !resolved[0].endsWith('.example.com')),
+      (resolved) => resolved.length === 1 && resolved[0] != null && !resolved[0].endsWith('.example.com'),
       POLL,
     );
 
     expect(urls).toHaveLength(1);
+    expect(urls[0]).toMatch(/^https?:\/\//);
   });
 });

--- a/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { waitForCockpitConnection } from '@cloud-commands/cockpit-commands';
+import { getDomainApi } from '@management-commands/service/utils';
+import { retryUntil } from '@utils-commands/retry';
+import { setup } from '../test-fixture';
+import { CloudEntrypointFixture, setupCloudEntrypointFixture } from './fixtures/cloud-entrypoint-fixture';
+
+setup(120000);
+
+const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
+
+let accessToken: string;
+let fixture: CloudEntrypointFixture;
+
+beforeAll(async () => {
+  accessToken = await requestAdminAccessToken();
+  await waitForCockpitConnection();
+  fixture = await setupCloudEntrypointFixture(accessToken);
+});
+
+afterAll(async () => {
+  await fixture?.cleanup();
+});
+
+// The urls the management API resolves for the domain's Overview/Endpoints pages
+// (GET /organizations/{org}/environments/{env}/domains/{domain}/entrypoints).
+const domainEntrypointUrls = async (): Promise<string[]> => {
+  const entrypoints = await getDomainApi(accessToken).getDomainEntrypoints({
+    organizationId: fixture.organizationId,
+    environmentId: fixture.environmentId,
+    domain: fixture.domainId,
+  });
+  return (entrypoints ?? []).map((e: any) => e.url);
+};
+
+// These specs share one environment/domain and run in order (jest --runInBand): several access points
+// first, then re-synced to a single one. In cloud mode the endpoint resolves the environment entrypoint,
+// not the internal data-plane gateway URL. retryUntil covers the management API sync-tick cache latency.
+describe('Cloud domain entrypoint URL (management API)', () => {
+  it('resolves a single environment access-point URL when the environment has several access points', async () => {
+    // The fixture provisions two GATEWAY access points; cloud mode returns exactly one, chosen
+    // deterministically, and always one of the environment URLs (never the gateway fallback).
+    const urls = await retryUntil(
+      () => domainEntrypointUrls(),
+      (resolved) => resolved.length === 1 && fixture.expectedUrls.includes(resolved[0]),
+      POLL,
+    );
+
+    expect(urls).toHaveLength(1);
+    expect(fixture.expectedUrls).toContain(urls[0]);
+  });
+
+  it('resolves the environment access-point URL when the environment has a single access point', async () => {
+    const [expectedUrl] = await fixture.resyncAccessPoints([fixture.uniqueHost()]);
+
+    const urls = await retryUntil(
+      () => domainEntrypointUrls(),
+      (resolved) => resolved.length === 1 && resolved[0] === expectedUrl,
+      POLL,
+    );
+
+    expect(urls).toEqual([expectedUrl]);
+  });
+});

--- a/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
@@ -55,8 +55,9 @@ const domainEntrypointUrls = async (): Promise<string[]> => {
 // not the internal data-plane gateway URL. retryUntil covers the management API sync-tick cache latency.
 describe('Cloud domain entrypoint URL (management API)', () => {
   it('resolves a single environment access-point URL when the environment has several access points', async () => {
-    // The fixture provisions two GATEWAY access points; cloud mode returns exactly one, chosen
-    // deterministically, and always one of the environment URLs (never the gateway fallback).
+    // The fixture provisions two GATEWAY access points; cloud mode returns exactly one (the
+    // default-flagged access point if any, otherwise the first), always one of the environment
+    // URLs (never the gateway fallback).
     const urls = await retryUntil(
       () => domainEntrypointUrls(),
       (resolved) => resolved.length === 1 && fixture.expectedUrls.includes(resolved[0]),
@@ -77,5 +78,21 @@ describe('Cloud domain entrypoint URL (management API)', () => {
     );
 
     expect(urls).toEqual([expectedUrl]);
+  });
+
+  it('never returns an empty list when the environment has no access points', async () => {
+    await fixture.resyncAccessPoints([]);
+
+    // Once the environment entrypoint is evicted, the endpoint must still return exactly one
+    // entrypoint (the fallback), never an empty list — an empty list would crash the UI. In managed
+    // cloud the DataPlane gatewayUrl may be absent, so the fallback entrypoint can have no url; the
+    // guarantee under test is that the list stays non-empty and is no longer an environment host.
+    const urls = await retryUntil(
+      () => domainEntrypointUrls(),
+      (resolved) => resolved.length === 1 && (resolved[0] == null || !resolved[0].endsWith('.example.com')),
+      POLL,
+    );
+
+    expect(urls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7268

## :pencil2: A description of the changes proposed in the pull request

In managed cloud the app Overview and Endpoints pages showed the internal gateway URL instead of the environment's Cockpit access point. Both pages read the same `listEntryPoint` endpoint so I fixed it there once. In cloud mode it resolves the entrypoint by environment from the `EntryPointManager` cache, falls back to the gateway URL if the env entrypoint hasn't synced yet, and picks one deterministically if an environment somehow has more than one access point. Non-cloud behaviour is unchanged.

## :memo: Test scenarios

Unit (`DomainServiceTest`) covers the four cases: single access point, none/fallback, several, and non-cloud.

Cloud jest (`gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts`) provisions env access points through the cockpit mock and asserts the endpoint resolves the environment URL: several then one, single, and a non-empty fallback when there are none.

Full manual QA steps for the handover are on the ticket. They drive `GET .../domains/{domain}/entrypoints` on a `--cloud` stack with curl + jq (single access point, several, pre-sync fallback), plus an optional Console check on the Overview/Endpoints pages and a non-cloud regression. Verified by hand on a local cloud stack, both pages render the environment URL.

## :computer: Add screenshots for UI

No UI code changes. The Overview and Endpoints pages are untouched, they just receive the corrected URL from the endpoint. The user-facing UI check is Test D in the ticket QA steps.

## :books: Any other comments that will help with documentation

Nothing extra. The fix lives in `DomainServiceImpl`, behind the cloud-mode check, so self-managed installs see no change.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
