### PR TITLE
feat(cloud-mode): lock down entrypoint config and VHost mode in Cloud…

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -11552,6 +11552,18 @@ paths:
       summary: Get the alert service status
       tags:
       - platform
+  /platform/configuration/deployment:
+    get:
+      description: There is no particular permission needed. User must be authenticated.
+      operationId: getDeploymentConfiguration
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      summary: Get the deployment configuration of this instance
+      tags:
+      - platform
   /platform/configuration/flow/schema:
     get:
       description: There is no particular permission needed. User must be authenticated.

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -11552,18 +11552,6 @@ paths:
       summary: Get the alert service status
       tags:
       - platform
-  /platform/configuration/deployment:
-    get:
-      description: There is no particular permission needed. User must be authenticated.
-      operationId: getDeploymentConfiguration
-      responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
-      summary: Get the deployment configuration of this instance
-      tags:
-      - platform
   /platform/configuration/flow/schema:
     get:
       description: There is no particular permission needed. User must be authenticated.
@@ -11574,6 +11562,18 @@ paths:
             application/json: {}
           description: default response
       summary: Get the Policy Studio flow schema
+      tags:
+      - platform
+  /platform/configuration/installation:
+    get:
+      description: There is no particular permission needed. User must be authenticated.
+      operationId: getInstallationConfiguration
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      summary: Get the installation type of this instance
       tags:
       - platform
   /platform/configuration/spel/grammar:

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/env/CloudProperties.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/env/CloudProperties.java
@@ -23,6 +23,8 @@ import org.springframework.core.env.Environment;
  * @author GraviteeSource Team
  */
 public final class CloudProperties {
+    public static final String INSTALLATION_TYPE_STANDALONE = "standalone";
+    public static final String INSTALLATION_TYPE_MANAGED = "managed";
 
     private CloudProperties() {
     }
@@ -43,6 +45,6 @@ public final class CloudProperties {
     }
 
     private static boolean isManagedInstallation(Environment environment) {
-        return "managed".equalsIgnoreCase(environment.getProperty("installation.type", "standalone"));
+        return INSTALLATION_TYPE_MANAGED.equalsIgnoreCase(environment.getProperty("installation.type", INSTALLATION_TYPE_STANDALONE));
     }
 }

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/env/CloudPropertiesTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/env/CloudPropertiesTest.java
@@ -42,21 +42,21 @@ class CloudPropertiesTest {
 
     @Test
     void managedInstallationAloneIsNotEnough() {
-        assertFalse(CloudProperties.isManagedCloudEnabled(environmentWith(Map.of("installation.type", "managed"))));
+        assertFalse(CloudProperties.isManagedCloudEnabled(environmentWith(Map.of("installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED))));
     }
 
     @Test
     void requiresBothCloudEnabledAndManagedInstallation() {
         assertTrue(CloudProperties.isManagedCloudEnabled(environmentWith(Map.of(
                 "cloud.enabled", "true",
-                "installation.type", "managed"))));
+                "installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED))));
     }
 
     @Test
     void fallsBackToLegacyCockpitEnabled() {
         assertTrue(CloudProperties.isManagedCloudEnabled(environmentWith(Map.of(
                 "cockpit.enabled", "true",
-                "installation.type", "managed"))));
+                "installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED))));
     }
 
     @Test
@@ -64,21 +64,21 @@ class CloudPropertiesTest {
         assertFalse(CloudProperties.isManagedCloudEnabled(environmentWith(Map.of(
                 "cloud.enabled", "false",
                 "cockpit.enabled", "true",
-                "installation.type", "managed"))));
+                "installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED))));
     }
 
     @Test
     void installationTypeIsCaseInsensitive() {
         assertTrue(CloudProperties.isManagedCloudEnabled(environmentWith(Map.of(
                 "cloud.enabled", "true",
-                "installation.type", "MANAGED"))));
+                "installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED.toUpperCase()))));
     }
 
     @Test
     void standaloneInstallationIsNotManaged() {
         assertFalse(CloudProperties.isManagedCloudEnabled(environmentWith(Map.of(
                 "cloud.enabled", "true",
-                "installation.type", "standalone"))));
+                "installation.type", CloudProperties.INSTALLATION_TYPE_STANDALONE))));
     }
 
     private static Environment environmentWith(Map<String, Object> properties) {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/AbstractResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/AbstractResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.service.PermissionService;
 import io.gravitee.am.management.service.permissions.PermissionAcls;
@@ -25,6 +26,7 @@ import io.gravitee.am.model.permissions.Permission;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.SecurityContext;
@@ -53,6 +55,24 @@ public abstract class AbstractResource {
 
     @Autowired
     protected PermissionService permissionService;
+
+    @Autowired
+    protected org.springframework.core.env.Environment environment;
+
+    protected boolean isCloudModeEnabled() {
+        return CloudProperties.isManagedCloudEnabled(environment);
+    }
+
+    /**
+     * @return a Completable that errors with a 400 BadRequestException carrying the given message when Cloud Mode
+     * is enabled, or completes normally otherwise.
+     */
+    protected Completable checkNotCloudMode(String message) {
+        if (isCloudModeEnabled()) {
+            return Completable.error(new BadRequestException(message));
+        }
+        return Completable.complete();
+    }
 
     protected User getAuthenticatedUser() {
         if (isAuthenticated()) {

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/entrypoints/EntrypointResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/entrypoints/EntrypointResource.java
@@ -24,6 +24,8 @@ import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.EntrypointService;
 import io.gravitee.am.service.model.UpdateEntrypoint;
 import io.gravitee.common.http.MediaType;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -97,7 +99,8 @@ public class EntrypointResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_ENTRYPOINT, Acl.UPDATE)
-                .andThen(entrypointService.update(entrypointId, organizationId, entrypointToUpdate, authenticatedUser))
+                .andThen(checkNotCloudMode("Entrypoints cannot be updated: this instance is a managed installation"))
+                .andThen(Single.defer(() -> entrypointService.update(entrypointId, organizationId, entrypointToUpdate, authenticatedUser)))
                 .subscribe(response::resume, response::resume);
     }
 
@@ -116,7 +119,8 @@ public class EntrypointResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_ENTRYPOINT, Acl.DELETE)
-                .andThen(entrypointService.delete(entrypointId, organizationId, authenticatedUser))
+                .andThen(checkNotCloudMode("Entrypoints cannot be deleted: this instance is a managed installation"))
+                .andThen(Completable.defer(() -> entrypointService.delete(entrypointId, organizationId, authenticatedUser)))
                 .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/entrypoints/EntrypointsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/entrypoints/EntrypointsResource.java
@@ -24,6 +24,7 @@ import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.EntrypointService;
 import io.gravitee.am.service.model.NewEntrypoint;
 import io.gravitee.common.http.MediaType;
+import io.reactivex.rxjava3.core.Single;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -104,7 +105,8 @@ public class EntrypointsResource extends AbstractResource {
         final User authenticatedUser = getAuthenticatedUser();
 
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_ENTRYPOINT, Acl.CREATE)
-                .andThen(entrypointService.create(organizationId, newEntrypoint, authenticatedUser))
+                .andThen(checkNotCloudMode("Entrypoints cannot be created: this instance is a managed installation"))
+                .andThen(Single.defer(() -> entrypointService.create(organizationId, newEntrypoint, authenticatedUser)))
                 .subscribe(entrypoint -> response.resume(Response
                                 .created(URI.create("/organizations/" + organizationId + "/entrypoints/" + entrypoint.getId()))
                                 .entity(entrypoint)
@@ -124,6 +126,7 @@ public class EntrypointsResource extends AbstractResource {
         filteredEntrypoint.setUrl(entrypoint.getUrl());
         filteredEntrypoint.setDescription(entrypoint.getDescription());
         filteredEntrypoint.setDefaultEntrypoint(entrypoint.isDefaultEntrypoint());
+        filteredEntrypoint.setEnvironmentId(entrypoint.getEnvironmentId());
 
         return filteredEntrypoint;
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainResource.java
@@ -21,12 +21,14 @@ import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.CertificateSettings;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.Entrypoint;
+import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.model.PatchDomain;
 import io.gravitee.common.http.MediaType;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -49,6 +51,8 @@ import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Response;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -368,10 +372,49 @@ public class DomainResource extends AbstractDomainResource {
         } else {
             Completable.merge(requiredPermissions.stream()
                     .map(permission -> checkAnyPermission(organizationId, environmentId, domainId, permission, Acl.UPDATE)).collect(Collectors.toList()))
-                    .andThen(domainService.patch(new GraviteeContext(organizationId, environmentId, domainId), domainId, patchDomain, authenticatedUser)
+                    .andThen(checkVhostCloudModeChange(domainId, patchDomain))
+                    .andThen(Single.defer(() -> domainService.patch(new GraviteeContext(organizationId, environmentId, domainId), domainId, patchDomain, authenticatedUser)
                             .flatMap(domain -> findAllPermissions(authenticatedUser, organizationId, environmentId, domainId)
-                                    .map(userPermissions -> filterDomainInfos(domain, userPermissions))))
+                                    .map(userPermissions -> filterDomainInfos(domain, userPermissions)))))
                     .subscribe(response::resume, response::resume);
         }
+    }
+
+    private Completable checkVhostCloudModeChange(String domainId, PatchDomain patchDomain) {
+        boolean vhostModeTouched = patchDomain.getVhostMode() != null && patchDomain.getVhostMode().isPresent();
+        boolean vhostsTouched = patchDomain.getVhosts() != null && patchDomain.getVhosts().isPresent();
+
+        if (!isCloudModeEnabled() || (!vhostModeTouched && !vhostsTouched)) {
+            return Completable.complete();
+        }
+
+        return domainService.findById(domainId)
+                .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId)))
+                .flatMapCompletable(currentDomain -> {
+                    boolean vhostModeEnabled = vhostModeTouched
+                            && Boolean.TRUE.equals(patchDomain.getVhostMode().get())
+                            && !currentDomain.isVhostMode();
+
+                    boolean vhostsChanged = vhostsTouched
+                            && !sameVirtualHosts(currentDomain.getVhosts(), patchDomain.getVhosts().get());
+
+                    if (vhostModeEnabled || vhostsChanged) {
+                        return Completable.error(new BadRequestException("VHost mode cannot be changed: this instance is a managed installation"));
+                    }
+                    return Completable.complete();
+                });
+    }
+
+    private static boolean sameVirtualHosts(List<VirtualHost> current, List<VirtualHost> updated) {
+        List<VirtualHost> currentList = current == null ? List.of() : current;
+        if (currentList.size() != updated.size()) {
+            return false;
+        }
+        return currentList.stream().map(DomainResource::virtualHostKey).collect(Collectors.toList())
+                .equals(updated.stream().map(DomainResource::virtualHostKey).collect(Collectors.toList()));
+    }
+
+    private static String virtualHostKey(VirtualHost virtualHost) {
+        return Objects.toString(virtualHost.getHost(), "") + '|' + Objects.toString(virtualHost.getPath(), "") + '|' + virtualHost.isOverrideEntrypoint();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/platform/configuration/ConfigurationResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/platform/configuration/ConfigurationResource.java
@@ -104,14 +104,15 @@ public class ConfigurationResource {
     }
 
     @GET
-    @Path("deployment")
+    @Path("installation")
     @Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
     @Operation(
-            operationId = "getDeploymentConfiguration",
-            summary = "Get the deployment configuration of this instance",
+            operationId = "getInstallationConfiguration",
+            summary = "Get the installation type of this instance",
             description = "There is no particular permission needed. User must be authenticated.")
-    public void getDeployment(@Suspended final AsyncResponse response) {
-        response.resume(Map.of("managed", CloudProperties.isManagedCloudEnabled(environment)));
+    public void getInstallation(@Suspended final AsyncResponse response) {
+        var type = CloudProperties.isManagedCloudEnabled(environment) ? CloudProperties.INSTALLATION_TYPE_MANAGED : CloudProperties.INSTALLATION_TYPE_STANDALONE;
+        response.resume(Map.of("type", type));
     }
 
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/platform/configuration/ConfigurationResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/platform/configuration/ConfigurationResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources.platform.configuration;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.management.handlers.management.api.model.AlertServiceStatusEntity;
 import io.gravitee.am.management.service.AlertService;
 import io.gravitee.am.service.FlowService;
@@ -100,6 +101,17 @@ public class ConfigurationResource {
     public void getUserEmailRequired(@Suspended final AsyncResponse response) {
         var emailRequired = environment.getProperty(UserEmail.PROPERTY_USER_EMAIL_REQUIRED, boolean.class, true);
         response.resume(Map.of("emailRequired", emailRequired));
+    }
+
+    @GET
+    @Path("deployment")
+    @Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "getDeploymentConfiguration",
+            summary = "Get the deployment configuration of this instance",
+            description = "There is no particular permission needed. User must be authenticated.")
+    public void getDeployment(@Suspended final AsyncResponse response) {
+        response.resume(Map.of("managed", CloudProperties.isManagedCloudEnabled(environment)));
     }
 
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
@@ -65,7 +66,7 @@ public class DomainResourceTest extends JerseySpringTest {
 
     private void enableCloudMode() {
         System.setProperty("cloud.enabled", "true");
-        System.setProperty("installation.type", "managed");
+        System.setProperty("installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED);
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
@@ -35,6 +35,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -55,6 +56,17 @@ import static org.mockito.Mockito.doReturn;
  * @author GraviteeSource Team
  */
 public class DomainResourceTest extends JerseySpringTest {
+
+    @AfterEach
+    public void clearCloudModeProperties() {
+        System.clearProperty("cloud.enabled");
+        System.clearProperty("installation.type");
+    }
+
+    private void enableCloudMode() {
+        System.setProperty("cloud.enabled", "true");
+        System.setProperty("installation.type", "managed");
+    }
 
     @Test
     public void shouldGetDomain() {
@@ -223,6 +235,105 @@ public class DomainResourceTest extends JerseySpringTest {
         assertEquals(mockDomain.getTags(), domain.getTags());
         assertNotNull(domain.getCertificateSettings());
         assertEquals("fallback-cert-id", domain.getCertificateSettings().getFallbackCertificate());
+    }
+
+    @Test
+    public void shouldNotEnableVhostMode_cloudMode() {
+        enableCloudMode();
+
+        Domain mockDomain = buildDomainMock();
+        mockDomain.setVhostMode(false);
+        mockDomain.setVhosts(Collections.emptyList());
+
+        PatchDomain patchDomain = new PatchDomain();
+        patchDomain.setVhostMode(Optional.of(true));
+
+        doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+        doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(mockDomain.getId());
+
+        final Response response = put(target("domains").path(mockDomain.getId()), patchDomain);
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotAddVhostEntries_cloudMode() {
+        enableCloudMode();
+
+        ArrayList<VirtualHost> currentVhosts = new ArrayList<>();
+        VirtualHost existing = new VirtualHost();
+        existing.setHost("existing.host.gravitee.io");
+        existing.setPath("/existing");
+        currentVhosts.add(existing);
+
+        Domain mockDomain = buildDomainMock();
+        mockDomain.setVhostMode(true);
+        mockDomain.setVhosts(currentVhosts);
+
+        ArrayList<VirtualHost> newVhosts = new ArrayList<>(currentVhosts);
+        VirtualHost added = new VirtualHost();
+        added.setHost("new.host.gravitee.io");
+        added.setPath("/new");
+        newVhosts.add(added);
+
+        PatchDomain patchDomain = new PatchDomain();
+        patchDomain.setVhosts(Optional.of(newVhosts));
+
+        doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+        doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(mockDomain.getId());
+
+        final Response response = put(target("domains").path(mockDomain.getId()), patchDomain);
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldUpdateDomain_cloudMode_unrelatedField() {
+        enableCloudMode();
+
+        Domain mockDomain = buildDomainMock();
+        PatchDomain patchDomain = new PatchDomain();
+        patchDomain.setDescription(Optional.of("New description"));
+
+        doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+        doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
+        doReturn(Single.just(mockDomain)).when(domainService).patch(any(GraviteeContext.class), eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
+
+        final Response response = put(target("domains").path(mockDomain.getId()), patchDomain);
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+    }
+
+    @Test
+    public void shouldUpdateDomain_cloudMode_unchangedVhosts() {
+        enableCloudMode();
+
+        ArrayList<VirtualHost> currentVhosts = new ArrayList<>();
+        VirtualHost existing = new VirtualHost();
+        existing.setHost("existing.host.gravitee.io");
+        existing.setPath("/existing");
+        currentVhosts.add(existing);
+
+        Domain mockDomain = buildDomainMock();
+        mockDomain.setVhostMode(true);
+        mockDomain.setVhosts(currentVhosts);
+
+        ArrayList<VirtualHost> sameVhosts = new ArrayList<>();
+        VirtualHost same = new VirtualHost();
+        same.setHost("existing.host.gravitee.io");
+        same.setPath("/existing");
+        sameVhosts.add(same);
+
+        PatchDomain patchDomain = new PatchDomain();
+        patchDomain.setVhostMode(Optional.of(true));
+        patchDomain.setVhosts(Optional.of(sameVhosts));
+
+        doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+        doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(mockDomain.getId());
+        doReturn(Single.just(mockDomain)).when(domainService).patch(any(GraviteeContext.class), eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
+
+        final Response response = put(target("domains").path(mockDomain.getId()), patchDomain);
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointResourceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
 import io.gravitee.am.model.Entrypoint;
@@ -52,7 +53,7 @@ public class EntrypointResourceTest extends JerseySpringTest {
 
     private void enableCloudMode() {
         System.setProperty("cloud.enabled", "true");
-        System.setProperty("installation.type", "managed");
+        System.setProperty("installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED);
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointResourceTest.java
@@ -23,6 +23,7 @@ import io.gravitee.am.service.model.UpdateEntrypoint;
 import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -42,6 +43,17 @@ public class EntrypointResourceTest extends JerseySpringTest {
 
     public static final String ORGANIZATION_ID = "orga#1";
     public static final String ENTRYPOINT_ID = "entrypoint#1";
+
+    @AfterEach
+    public void clearCloudModeProperties() {
+        System.clearProperty("cloud.enabled");
+        System.clearProperty("installation.type");
+    }
+
+    private void enableCloudMode() {
+        System.setProperty("cloud.enabled", "true");
+        System.setProperty("installation.type", "managed");
+    }
 
     @Test
     public void shouldGetEntrypoint() {
@@ -128,5 +140,32 @@ public class EntrypointResourceTest extends JerseySpringTest {
                 .path("entrypoints").path(ENTRYPOINT_ID), updateEntrypoint);
 
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotUpdateEntrypoint_cloudMode() {
+        enableCloudMode();
+
+        UpdateEntrypoint updateEntrypoint = new UpdateEntrypoint();
+        updateEntrypoint.setName("name");
+        updateEntrypoint.setUrl("https://auth.gravitee.io");
+        updateEntrypoint.setTags(Collections.emptyList());
+
+        final Response response = put(target("organizations")
+                .path(ORGANIZATION_ID)
+                .path("entrypoints").path(ENTRYPOINT_ID), updateEntrypoint);
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotDeleteEntrypoint_cloudMode() {
+        enableCloudMode();
+
+        final Response response = target("organizations")
+                .path(ORGANIZATION_ID)
+                .path("entrypoints").path(ENTRYPOINT_ID).request().delete();
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointsResourceTest.java
@@ -26,6 +26,7 @@ import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -45,6 +46,17 @@ public class EntrypointsResourceTest extends JerseySpringTest {
 
     public static final String ORGANIZATION_ID = "orga-1";
     public static final String ENTRYPOINT_ID = "entrypoint-1";
+
+    @AfterEach
+    public void clearCloudModeProperties() {
+        System.clearProperty("cloud.enabled");
+        System.clearProperty("installation.type");
+    }
+
+    private void enableCloudMode() {
+        System.setProperty("cloud.enabled", "true");
+        System.setProperty("installation.type", "managed");
+    }
 
     @Test
     public void shouldGetEntrypoints() {
@@ -99,5 +111,22 @@ public class EntrypointsResourceTest extends JerseySpringTest {
         final Response response = post(path, newEntrypoint);
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
         assertEquals(path.getUri().toString() + "/"+ entrypoint.getId(), response.getHeaderString(HttpHeaders.LOCATION));
+    }
+
+    @Test
+    public void shouldNotCreate_cloudMode() {
+        enableCloudMode();
+
+        NewEntrypoint newEntrypoint = new NewEntrypoint();
+        newEntrypoint.setName("name");
+        newEntrypoint.setUrl("https://auth.gravitee.io");
+        newEntrypoint.setTags(Collections.emptyList());
+
+        WebTarget path = target("organizations")
+                .path(ORGANIZATION_ID)
+                .path("entrypoints");
+
+        final Response response = post(path, newEntrypoint);
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointsResourceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.handlers.management.api.resources;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
 import io.gravitee.am.model.Entrypoint;
@@ -55,7 +56,7 @@ public class EntrypointsResourceTest extends JerseySpringTest {
 
     private void enableCloudMode() {
         System.setProperty("cloud.enabled", "true");
-        System.setProperty("installation.type", "managed");
+        System.setProperty("installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED);
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.management.service.impl.commands;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.repository.exceptions.TechnicalException;
@@ -131,7 +132,7 @@ class EnvironmentCommandHandlerTest {
 
     private void enableCloudMode() {
         springEnvironment.setProperty("cloud.enabled", "true");
-        springEnvironment.setProperty("installation.type", "managed");
+        springEnvironment.setProperty("installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED);
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/PluginLicenseGateImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/PluginLicenseGateImplTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service.impl;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Reference;
@@ -99,7 +100,7 @@ class PluginLicenseGateImplTest {
 
     private PluginLicenseGateImpl cloudGate() {
         return new PluginLicenseGateImpl(pluginRegistry, licenseManager, licenseService, licenseFactory, domainReadService, environmentService,
-                new MockEnvironment().withProperty("cloud.enabled", "true").withProperty("installation.type", "managed"));
+                new MockEnvironment().withProperty("cloud.enabled", "true").withProperty("installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED));
     }
 
     @Test

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -260,6 +260,7 @@ import { TagComponent } from './settings/management/tags/tag/tag.component';
 import { EntrypointsResolver } from './resolvers/entrypoints.resolver';
 import { EntrypointResolver } from './resolvers/entrypoint.resolver';
 import { EntrypointService } from './services/entrypoint.service';
+import { CloudModeService } from './services/cloud-mode.service';
 import { EntrypointsComponent } from './settings/management/entrypoints/entrypoints.component';
 import { EntrypointCreationComponent } from './settings/management/entrypoints/creation/entrypoint-creation.component';
 import { EntrypointComponent } from './settings/management/entrypoints/entrypoint/entrypoint.component';
@@ -946,6 +947,7 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     TagsResolver,
     TagResolver,
     EntrypointService,
+    CloudModeService,
     EntrypointsResolver,
     EntrypointResolver,
     PolicyService,

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="gv-page-container">
   <h1 class="entrypoints-title">Entrypoints</h1>
-  <a (click)="switchMode()" class="switch-mode">Switch to {{ switchModeLabel }} mode</a>
+  <a *ngIf="!cloudModeEnabled" (click)="switchMode()" class="switch-mode">Switch to {{ switchModeLabel }} mode</a>
   <div class="gv-page-content">
     <div fxLayout="column" fxFlex="70">
       <form (ngSubmit)="update()" #domainForm="ngForm" fxLayout="column">
@@ -58,15 +58,19 @@
         <div class="gv-form-section" *ngIf="domain.vhostMode">
           <div class="entrypoints-actions">
             <span>Virtual hosts</span>
-            <button (click)="addVhost(); $event.preventDefault()" mat-button *hasPermission="['domain_settings_update']">
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
+            <ng-container *ngIf="!cloudModeEnabled">
+              <button (click)="addVhost(); $event.preventDefault()" mat-button *hasPermission="['domain_settings_update']">
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            </ng-container>
           </div>
           <ng-container *ngFor="let vhost of domain.vhosts; let i = index">
             <div fxLayout="row" style="padding-bottom: 40px" fxLayoutAlign="center start">
-              <button (click)="remove(vhost); $event.preventDefault()" mat-button *hasPermission="['domain_settings_update']">
-                <mat-icon>remove_circle_outline</mat-icon>
-              </button>
+              <ng-container *ngIf="!cloudModeEnabled">
+                <button (click)="remove(vhost); $event.preventDefault()" mat-button *hasPermission="['domain_settings_update']">
+                  <mat-icon>remove_circle_outline</mat-icon>
+                </button>
+              </ng-container>
               <mat-form-field appearance="outline" floatLabel="always" class="form-field">
                 <mat-label>Host</mat-label>
                 <input
@@ -122,9 +126,11 @@
           </ng-container>
         </div>
 
-        <div *hasPermission="['domain_settings_update']">
-          <button mat-raised-button color="primary" [disabled]="!domainForm.valid || !formChanged" type="submit">SAVE</button>
-        </div>
+        <ng-container *ngIf="!cloudModeEnabled">
+          <div *hasPermission="['domain_settings_update']">
+            <button mat-raised-button color="primary" [disabled]="!domainForm.valid || !formChanged" type="submit">SAVE</button>
+          </div>
+        </ng-container>
       </form>
     </div>
     <div class="gv-page-description" fxFlex>
@@ -137,11 +143,11 @@
         </p>
         <p>The current access url is :</p>
         <pre>{{ entrypoint.url }}{{ domain.path }}</pre>
-        <p>
+        <p *ngIf="!cloudModeEnabled">
           Notice that, in context-path mode, you can't use <code>'/'</code> path. However, it is possible to use <code>'/'</code> if you
           <a (click)="switchMode()">Switch to {{ switchModeLabel }} mode</a>
         </p>
-        <p>
+        <p *ngIf="!cloudModeEnabled">
           <small
             ><strong>Warning</strong>: changing the security domain's path involve to change endpoint URLs in your current
             applications.</small

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="gv-page-container">
   <h1 class="entrypoints-title">Entrypoints</h1>
-  <a *ngIf="!cloudModeEnabled" (click)="switchMode()" class="switch-mode">Switch to {{ switchModeLabel }} mode</a>
+  <a *ngIf="!isCloudMode" (click)="switchMode()" class="switch-mode">Switch to {{ switchModeLabel }} mode</a>
   <div class="gv-page-content">
     <div fxLayout="column" fxFlex="70">
       <form (ngSubmit)="update()" #domainForm="ngForm" fxLayout="column">
@@ -58,7 +58,7 @@
         <div class="gv-form-section" *ngIf="domain.vhostMode">
           <div class="entrypoints-actions">
             <span>Virtual hosts</span>
-            <ng-container *ngIf="!cloudModeEnabled">
+            <ng-container *ngIf="!isCloudMode">
               <button (click)="addVhost(); $event.preventDefault()" mat-button *hasPermission="['domain_settings_update']">
                 <mat-icon>add_circle_outline</mat-icon>
               </button>
@@ -66,7 +66,7 @@
           </div>
           <ng-container *ngFor="let vhost of domain.vhosts; let i = index">
             <div fxLayout="row" style="padding-bottom: 40px" fxLayoutAlign="center start">
-              <ng-container *ngIf="!cloudModeEnabled">
+              <ng-container *ngIf="!isCloudMode">
                 <button (click)="remove(vhost); $event.preventDefault()" mat-button *hasPermission="['domain_settings_update']">
                   <mat-icon>remove_circle_outline</mat-icon>
                 </button>
@@ -126,7 +126,7 @@
           </ng-container>
         </div>
 
-        <ng-container *ngIf="!cloudModeEnabled">
+        <ng-container *ngIf="!isCloudMode">
           <div *hasPermission="['domain_settings_update']">
             <button mat-raised-button color="primary" [disabled]="!domainForm.valid || !formChanged" type="submit">SAVE</button>
           </div>
@@ -143,11 +143,11 @@
         </p>
         <p>The current access url is :</p>
         <pre>{{ entrypoint.url }}{{ domain.path }}</pre>
-        <p *ngIf="!cloudModeEnabled">
+        <p *ngIf="!isCloudMode">
           Notice that, in context-path mode, you can't use <code>'/'</code> path. However, it is possible to use <code>'/'</code> if you
           <a (click)="switchMode()">Switch to {{ switchModeLabel }} mode</a>
         </p>
-        <p *ngIf="!cloudModeEnabled">
+        <p *ngIf="!isCloudMode">
           <small
             ><strong>Warning</strong>: changing the security domain's path involve to change endpoint URLs in your current
             applications.</small

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.spec.ts
@@ -22,6 +22,7 @@ import { ActivatedRoute } from '@angular/router';
 import { DomainService } from '../../../services/domain.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { AuthService } from '../../../services/auth.service';
+import { CloudModeService } from '../../../services/cloud-mode.service';
 import { DomainStoreService } from '../../../stores/domain.store';
 
 jest.mock('@gravitee/ui-components/src/lib/utils', () => ({
@@ -41,6 +42,7 @@ describe('DomainSettingsEntrypointsComponent', () => {
   let domainServiceStub: DomainService;
   let snackbarServiceStub: SnackbarService;
   let authServiceStub: AuthService;
+  let cloudModeServiceStub: CloudModeService;
   let domainStoreStub: DomainStoreService;
   let activatedRouteStub: ActivatedRoute;
 
@@ -57,6 +59,10 @@ describe('DomainSettingsEntrypointsComponent', () => {
     authServiceStub = {
       hasPermissions: jest.fn().mockReturnValue(true),
     } as Partial<AuthService> as AuthService;
+
+    cloudModeServiceStub = {
+      isCloudModeEnabled: jest.fn().mockReturnValue(of(false)),
+    } as Partial<CloudModeService> as CloudModeService;
 
     domainStoreStub = {
       domain$: new BehaviorSubject({ id: 'test-domain', name: 'Test Domain', vhosts: [] }),
@@ -86,6 +92,7 @@ describe('DomainSettingsEntrypointsComponent', () => {
         { provide: DomainService, useValue: domainServiceStub },
         { provide: SnackbarService, useValue: snackbarServiceStub },
         { provide: AuthService, useValue: authServiceStub },
+        { provide: CloudModeService, useValue: cloudModeServiceStub },
         { provide: DomainStoreService, useValue: domainStoreStub },
         { provide: ActivatedRoute, useValue: activatedRouteStub },
       ],

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.ts
@@ -35,7 +35,7 @@ export class DomainSettingsEntrypointsComponent implements OnInit {
   domain: any = {};
   entrypoint: any;
   readonly = false;
-  cloudModeEnabled = false;
+  isCloudMode = false;
   switchModeLabel: string;
   domainRestrictions: string[];
   domainRegexList: RegExp[] = [];
@@ -59,7 +59,7 @@ export class DomainSettingsEntrypointsComponent implements OnInit {
 
     this.readonly = !this.authService.hasPermissions(['domain_settings_update']);
     this.cloudModeService.isCloudModeEnabled().subscribe((enabled) => {
-      this.cloudModeEnabled = enabled;
+      this.isCloudMode = enabled;
       this.readonly = this.readonly || enabled;
     });
     this.changeSwitchModeLabel();

--- a/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/entrypoints/entrypoints.component.ts
@@ -21,6 +21,7 @@ import regexEscape from 'regex-escape';
 import { DomainService } from '../../../services/domain.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { AuthService } from '../../../services/auth.service';
+import { CloudModeService } from '../../../services/cloud-mode.service';
 import { DomainStoreService } from '../../../stores/domain.store';
 
 @Component({
@@ -34,6 +35,7 @@ export class DomainSettingsEntrypointsComponent implements OnInit {
   domain: any = {};
   entrypoint: any;
   readonly = false;
+  cloudModeEnabled = false;
   switchModeLabel: string;
   domainRestrictions: string[];
   domainRegexList: RegExp[] = [];
@@ -44,6 +46,7 @@ export class DomainSettingsEntrypointsComponent implements OnInit {
     private snackbarService: SnackbarService,
     private route: ActivatedRoute,
     private authService: AuthService,
+    private cloudModeService: CloudModeService,
     private domainStore: DomainStoreService,
   ) {}
 
@@ -55,6 +58,10 @@ export class DomainSettingsEntrypointsComponent implements OnInit {
     }
 
     this.readonly = !this.authService.hasPermissions(['domain_settings_update']);
+    this.cloudModeService.isCloudModeEnabled().subscribe((enabled) => {
+      this.cloudModeEnabled = enabled;
+      this.readonly = this.readonly || enabled;
+    });
     this.changeSwitchModeLabel();
 
     this.domainRestrictions = this.route.snapshot.data['environment'].domainRestrictions;

--- a/gravitee-am-ui/src/app/services/cloud-mode.service.ts
+++ b/gravitee-am-ui/src/app/services/cloud-mode.service.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map, shareReplay } from 'rxjs/operators';
+
+import { AppConfig } from '../../config/app.config';
+
+@Injectable()
+export class CloudModeService {
+  private platformURL = AppConfig.settings.baseURL + '/platform';
+  private isCloudModeEnabled$: Observable<boolean>;
+
+  constructor(private http: HttpClient) {}
+
+  isCloudModeEnabled(): Observable<boolean> {
+    if (!this.isCloudModeEnabled$) {
+      this.isCloudModeEnabled$ = this.http.get<any>(this.platformURL + '/configuration/deployment').pipe(
+        map((response) => response.managed),
+        shareReplay({ bufferSize: 1, refCount: true }),
+      );
+    }
+    return this.isCloudModeEnabled$;
+  }
+}

--- a/gravitee-am-ui/src/app/services/cloud-mode.service.ts
+++ b/gravitee-am-ui/src/app/services/cloud-mode.service.ts
@@ -29,8 +29,8 @@ export class CloudModeService {
 
   isCloudModeEnabled(): Observable<boolean> {
     if (!this.isCloudModeEnabled$) {
-      this.isCloudModeEnabled$ = this.http.get<any>(this.platformURL + '/configuration/deployment').pipe(
-        map((response) => response.managed),
+      this.isCloudModeEnabled$ = this.http.get<any>(this.platformURL + '/configuration/installation').pipe(
+        map((response) => response.type === 'managed'),
         shareReplay({ bufferSize: 1, refCount: true }),
       );
     }

--- a/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoint/entrypoint.component.html
+++ b/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoint/entrypoint.component.html
@@ -97,7 +97,7 @@
           </mat-form-field>
         </div>
 
-        <ng-container *ngIf="!cloudModeEnabled">
+        <ng-container *ngIf="!isCloudMode">
           <div fxLayout="row" *hasPermission="['organization_entrypoint_update']">
             <button
               mat-raised-button

--- a/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoint/entrypoint.component.html
+++ b/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoint/entrypoint.component.html
@@ -97,16 +97,18 @@
           </mat-form-field>
         </div>
 
-        <div fxLayout="row" *hasPermission="['organization_entrypoint_update']">
-          <button
-            mat-raised-button
-            color="primary"
-            [disabled]="(!entrypointForm.valid || entrypointForm.pristine) && !formChanged"
-            type="submit"
-          >
-            SAVE
-          </button>
-        </div>
+        <ng-container *ngIf="!cloudModeEnabled">
+          <div fxLayout="row" *hasPermission="['organization_entrypoint_update']">
+            <button
+              mat-raised-button
+              color="primary"
+              [disabled]="(!entrypointForm.valid || entrypointForm.pristine) && !formChanged"
+              type="submit"
+            >
+              SAVE
+            </button>
+          </div>
+        </ng-container>
       </form>
 
       <div class="gv-page-delete-zone" fxLayout="column" *ngIf="canDelete()">

--- a/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoint/entrypoint.component.ts
+++ b/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoint/entrypoint.component.ts
@@ -24,6 +24,7 @@ import { SnackbarService } from '../../../../services/snackbar.service';
 import { EntrypointService } from '../../../../services/entrypoint.service';
 import { DialogService } from '../../../../services/dialog.service';
 import { AuthService } from '../../../../services/auth.service';
+import { CloudModeService } from '../../../../services/cloud-mode.service';
 import { Tag } from '../../../../domain/settings/general/general.component';
 
 @Component({
@@ -38,6 +39,7 @@ export class EntrypointComponent implements OnInit {
   @ViewChild('chipInput', { static: true }) chipInput: MatInput;
   formChanged = false;
   readonly: boolean;
+  cloudModeEnabled = false;
   tags: Tag[];
   selectedTags: Tag[];
 
@@ -48,11 +50,16 @@ export class EntrypointComponent implements OnInit {
     private router: Router,
     private dialogService: DialogService,
     private authService: AuthService,
+    private cloudModeService: CloudModeService,
   ) {}
 
   ngOnInit() {
     this.entrypoint = this.route.snapshot.data['entrypoint'];
     this.readonly = !this.authService.hasPermissions(['organization_entrypoint_update']);
+    this.cloudModeService.isCloudModeEnabled().subscribe((enabled) => {
+      this.cloudModeEnabled = enabled;
+      this.readonly = this.readonly || enabled;
+    });
     this.initTags();
   }
 
@@ -103,6 +110,8 @@ export class EntrypointComponent implements OnInit {
   }
 
   canDelete() {
-    return !this.entrypoint.defaultEntrypoint && this.authService.hasPermissions(['organization_entrypoint_delete']);
+    return (
+      !this.cloudModeEnabled && !this.entrypoint.defaultEntrypoint && this.authService.hasPermissions(['organization_entrypoint_delete'])
+    );
   }
 }

--- a/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoint/entrypoint.component.ts
+++ b/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoint/entrypoint.component.ts
@@ -39,7 +39,7 @@ export class EntrypointComponent implements OnInit {
   @ViewChild('chipInput', { static: true }) chipInput: MatInput;
   formChanged = false;
   readonly: boolean;
-  cloudModeEnabled = false;
+  isCloudMode = false;
   tags: Tag[];
   selectedTags: Tag[];
 
@@ -57,7 +57,7 @@ export class EntrypointComponent implements OnInit {
     this.entrypoint = this.route.snapshot.data['entrypoint'];
     this.readonly = !this.authService.hasPermissions(['organization_entrypoint_update']);
     this.cloudModeService.isCloudModeEnabled().subscribe((enabled) => {
-      this.cloudModeEnabled = enabled;
+      this.isCloudMode = enabled;
       this.readonly = this.readonly || enabled;
     });
     this.initTags();
@@ -110,8 +110,6 @@ export class EntrypointComponent implements OnInit {
   }
 
   canDelete() {
-    return (
-      !this.cloudModeEnabled && !this.entrypoint.defaultEntrypoint && this.authService.hasPermissions(['organization_entrypoint_delete'])
-    );
+    return !this.isCloudMode && !this.entrypoint.defaultEntrypoint && this.authService.hasPermissions(['organization_entrypoint_delete']);
   }
 }

--- a/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoints.component.html
+++ b/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoints.component.html
@@ -41,10 +41,17 @@
           {{ row.url }}
         </ng-template>
       </ngx-datatable-column>
+      <ngx-datatable-column name="Environment" [flexGrow]="1">
+        <ng-template let-row="row" ngx-datatable-cell-template>
+          {{ environmentName(row) }}
+        </ng-template>
+      </ngx-datatable-column>
       <ngx-datatable-column name="Actions" [flexGrow]="1">
         <ng-template let-row="row" ngx-datatable-cell-template>
           <div fxLayout="row" class="gv-table-cell-actions">
-            <a mat-button [routerLink]="[row.id]" *hasPermission="['organization_entrypoint_read']"><mat-icon>settings</mat-icon></a>
+            <ng-container *ngIf="canEdit()">
+              <a mat-button [routerLink]="[row.id]" *hasPermission="['organization_entrypoint_read']"><mat-icon>settings</mat-icon></a>
+            </ng-container>
             <button *ngIf="canDelete(row)" mat-icon-button (click)="delete(row.id, $event)"><mat-icon>delete</mat-icon></button>
           </div>
         </ng-template>
@@ -59,9 +66,11 @@
     [icon]="'filter_none'"
   ></app-emptystate>
 
-  <div *hasPermission="['organization_entrypoint_create']" [ngClass]="{ 'gv-add-button': !isEmpty, 'gv-add-button-center': isEmpty }">
-    <a mat-fab color="primary" [routerLink]="['new']">
-      <mat-icon>add</mat-icon>
-    </a>
-  </div>
+  <ng-container *ngIf="canEdit()">
+    <div *hasPermission="['organization_entrypoint_create']" [ngClass]="{ 'gv-add-button': !isEmpty, 'gv-add-button-center': isEmpty }">
+      <a mat-fab color="primary" [routerLink]="['new']">
+        <mat-icon>add</mat-icon>
+      </a>
+    </div>
+  </ng-container>
 </div>

--- a/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoints.component.ts
+++ b/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoints.component.ts
@@ -21,6 +21,8 @@ import { EntrypointService } from '../../../services/entrypoint.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { DialogService } from '../../../services/dialog.service';
 import { AuthService } from '../../../services/auth.service';
+import { CloudModeService } from '../../../services/cloud-mode.service';
+import { EnvironmentService } from '../../../services/environment.service';
 
 @Component({
   selector: 'app-entrypoints',
@@ -30,6 +32,8 @@ import { AuthService } from '../../../services/auth.service';
 })
 export class EntrypointsComponent implements OnInit {
   public entrypoints: any[];
+  public cloudModeEnabled = false;
+  private environmentNameById: { [id: string]: string } = {};
 
   constructor(
     private entrypointService: EntrypointService,
@@ -37,14 +41,27 @@ export class EntrypointsComponent implements OnInit {
     private snackbarService: SnackbarService,
     private route: ActivatedRoute,
     private authService: AuthService,
+    private cloudModeService: CloudModeService,
+    private environmentService: EnvironmentService,
   ) {}
 
   ngOnInit() {
     this.entrypoints = this.route.snapshot.data['entrypoints'];
+    this.cloudModeService.isCloudModeEnabled().subscribe((enabled) => (this.cloudModeEnabled = enabled));
+    this.environmentService.getAllEnvironments().subscribe((environments) => {
+      this.environmentNameById = (environments || []).reduce((acc, environment) => {
+        acc[environment.id] = environment.name;
+        return acc;
+      }, {});
+    });
   }
 
   get isEmpty() {
     return !this.entrypoints || this.entrypoints.length === 0;
+  }
+
+  environmentName(entrypoint): string {
+    return this.environmentNameById[entrypoint.environmentId] || entrypoint.environmentId;
   }
 
   loadEntrypoints() {
@@ -67,6 +84,10 @@ export class EntrypointsComponent implements OnInit {
   }
 
   canDelete(entrypoint) {
-    return !entrypoint.defaultEntrypoint && this.authService.hasPermissions(['organization_entrypoint_delete']);
+    return !this.cloudModeEnabled && !entrypoint.defaultEntrypoint && this.authService.hasPermissions(['organization_entrypoint_delete']);
+  }
+
+  canEdit(): boolean {
+    return !this.cloudModeEnabled;
   }
 }

--- a/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoints.component.ts
+++ b/gravitee-am-ui/src/app/settings/management/entrypoints/entrypoints.component.ts
@@ -32,7 +32,7 @@ import { EnvironmentService } from '../../../services/environment.service';
 })
 export class EntrypointsComponent implements OnInit {
   public entrypoints: any[];
-  public cloudModeEnabled = false;
+  public isCloudMode = false;
   private environmentNameById: { [id: string]: string } = {};
 
   constructor(
@@ -47,7 +47,7 @@ export class EntrypointsComponent implements OnInit {
 
   ngOnInit() {
     this.entrypoints = this.route.snapshot.data['entrypoints'];
-    this.cloudModeService.isCloudModeEnabled().subscribe((enabled) => (this.cloudModeEnabled = enabled));
+    this.cloudModeService.isCloudModeEnabled().subscribe((enabled) => (this.isCloudMode = enabled));
     this.environmentService.getAllEnvironments().subscribe((environments) => {
       this.environmentNameById = (environments || []).reduce((acc, environment) => {
         acc[environment.id] = environment.name;
@@ -84,10 +84,10 @@ export class EntrypointsComponent implements OnInit {
   }
 
   canDelete(entrypoint) {
-    return !this.cloudModeEnabled && !entrypoint.defaultEntrypoint && this.authService.hasPermissions(['organization_entrypoint_delete']);
+    return !this.isCloudMode && !entrypoint.defaultEntrypoint && this.authService.hasPermissions(['organization_entrypoint_delete']);
   }
 
   canEdit(): boolean {
-    return !this.cloudModeEnabled;
+    return !this.isCloudMode;
   }
 }


### PR DESCRIPTION
… Mode

In Cloud Mode, entrypoint configuration and gateway URL routing must be managed exclusively by Cockpit. This blocks entrypoint CRUD and VHost changes at the REST layer (Cockpit's own command handlers are unaffected) and reflects the restriction in the management UI.

fix AM-7228