### PR TITLE
ci: halt pipeline on mergify branches with unresolved conflict markers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,20 +129,23 @@ workflows:
           name: "Standard CI"
           # On Mergify backport branches, halt before continuation while unresolved
           # conflict markers are committed in the tree; the resolution push retriggers CI.
+          # The when-condition scopes the extra checkout to those branches only.
           pre-steps:
-            - checkout
-            - run:
-                name: Halt on unresolved Mergify conflicts
-                command: |
-                  case "$CIRCLE_BRANCH" in
-                    mergify/bp/*|mergify/copy/*)
-                      # conflict marker written as a regex repetition: consecutive angle brackets break CircleCI config parsing
-                      if git grep -IlqE '^<{7} ' -- .; then
-                        echo "Unresolved Mergify conflict markers found - skipping CI until conflicts are resolved and pushed."
-                        circleci-agent step halt
-                      fi
-                      ;;
-                  esac
+            - when:
+                condition:
+                  matches:
+                    pattern: "^mergify/(bp|copy)/.*"
+                    value: << pipeline.git.branch >>
+                steps:
+                  - checkout
+                  - run:
+                      name: Halt on unresolved Mergify conflicts
+                      command: |
+                        # conflict marker written as a regex repetition: consecutive angle brackets break CircleCI config parsing
+                        if git grep -IlqE '^<{7} ' -- .; then
+                          echo "Unresolved Mergify conflict markers found - skipping CI until conflicts are resolved and pushed."
+                          circleci-agent step halt
+                        fi
           base-revision: << pipeline.git.branch >>
           config-path: .circleci/workflows.yml
           mapping: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,22 @@ workflows:
     jobs:
       - path-filtering/filter:
           name: "Standard CI"
+          # On Mergify backport branches, halt before continuation while unresolved
+          # conflict markers are committed in the tree; the resolution push retriggers CI.
+          pre-steps:
+            - checkout
+            - run:
+                name: Halt on unresolved Mergify conflicts
+                command: |
+                  case "$CIRCLE_BRANCH" in
+                    mergify/bp/*|mergify/copy/*)
+                      # conflict marker written as a regex repetition: consecutive angle brackets break CircleCI config parsing
+                      if git grep -IlqE '^<{7} ' -- .; then
+                        echo "Unresolved Mergify conflict markers found - skipping CI until conflicts are resolved and pushed."
+                        circleci-agent step halt
+                      fi
+                      ;;
+                  esac
           base-revision: << pipeline.git.branch >>
           config-path: .circleci/workflows.yml
           mapping: |


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-7304

## :pencil2: A description of the changes proposed in the pull request

When a mergify backport hits conflicts it pushes the branch with the conflict markers committed, and today that push burns a full CI run that can only fail. This adds a pre-step to the setup job that halts the pipeline on `mergify/bp/*` and `mergify/copy/*` branches while committed conflict markers are present in the tree. Nothing downstream runs, so the required checks stay pending and the PR can't be merged until someone resolves the conflicts. The resolution push then triggers a normal pipeline, no label fiddling or manual rerun needed.

I went with detecting the markers rather than the mergify conflict label because CircleCI starts the pipeline on the push, before the label lands, and removing a label never retriggers a build anyway.

The pre-steps are wrapped in a config-level `when` matching the mergify branch pattern, so on normal branches they compile out entirely and the setup job doesn't pay the extra checkout.

One quirk: the marker is written as the regex `^<{7} ` because a literal `<<` anywhere in the config breaks CircleCI's parser (it reads it as an unclosed parameter tag).

## :memo: Test scenarios 

Verified live on a throwaway `mergify/bp/stc-test` branch (deleted since):

- with fake conflict markers committed in README.md: [pipeline 31504](https://app.circleci.com/pipelines/github/gravitee-io/gravitee-access-management/31504) halted in the setup job ("Unresolved Mergify conflict markers found - skipping CI until conflicts are resolved and pushed"), no workflows ran
- after pushing the resolution commit: [pipeline 31505](https://app.circleci.com/pipelines/github/gravitee-io/gravitee-access-management/31505) continued into full CI (pull_requests + both sonarcloud workflows)
- normal branches are untouched: this branch's own pipeline went through the same pre-step and ran full CI
- also checked the tree has no files with lines starting `<<<<<<<` that could false-positive, and the check is scoped to mergify branches anyway

Re-verified after scoping the pre-steps with the `when` condition, on a throwaway `mergify/bp/stc-test2` branch (deleted since):

- marker commit: [setup job](https://circleci.com/gh/gravitee-io/gravitee-access-management/448788) halted, zero downstream jobs after a 60s grace window
- resolution push: [setup job](https://circleci.com/gh/gravitee-io/gravitee-access-management/448789) continued into full CI
- normal branches now skip the pre-steps entirely (`circleci config process` compiles them out without a mergify branch), confirmed by this branch's own pipeline running full CI untouched

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

Nothing extra.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
