### PR TITLE
fix: AM-7305 cloud command validation

### DIFF
--- a/docker/local-stack/README.md
+++ b/docker/local-stack/README.md
@@ -42,6 +42,7 @@ Run `./local-stack.sh help` for the full reference.
 ```bash
 ./local-stack.sh up                 # lean, MongoDB
 ./local-stack.sh up --full          # full service set + Console UI
+./local-stack.sh up --cloud         # managed-cloud (cockpit mock)
 ./local-stack.sh up --db psql --ui  # PostgreSQL + Console UI
 ```
 
@@ -102,7 +103,8 @@ docker login graviteeio.azurecr.io
 | *(default lean)* | gateway, management, db, smtp, wiremock |
 | `--ui` | + Console UI (`:4200`) — needed for playwright & manual Console work |
 | `--full` | UI + wiremock + ciba + openfga + kafka + mtls (the jest-gateway + playwright union) |
-| `--with a,b,…` | opt-in individually: `ui,wiremock,ciba,openfga,kafka,mtls,spire` |
+| `--cloud` | cockpit mock; management API in managed-cloud mode (Cockpit command path) |
+| `--with a,b,…` | opt-in individually: `ui,wiremock,ciba,openfga,kafka,mtls,spire,cloud` |
 | `--db mongo\|psql` | choose the backend database (default `mongo`) |
 
 SPIRE is only needed by the env-guarded gateway tests (`RUN_SPIRE_TESTS=true`); start it with
@@ -133,6 +135,7 @@ for source-built and `--version` images.
 | Management API | http://localhost:8093/management | REST API |
 | Management node | http://localhost:18093/_node | health/metrics |
 | Console UI | http://localhost:4200 | with `--ui` / `--full` |
+| Cockpit mock | http://localhost:8085 | with `--cloud` |
 | Mailbox (fake SMTP) | http://localhost:5080 | SMTP on `:5025` |
 | WireMock | http://localhost:8181 | SFR/CIMD mocks |
 | MongoDB / PostgreSQL | `:27017` / `:5432` | per `--db` |
@@ -148,6 +151,9 @@ The suites live in `gravitee-am-test/` and default to the ports above.
 npm --prefix gravitee-am-test run ci:management:parallel
 npm --prefix gravitee-am-test run ci:gateway
 REPOSITORY_TYPE=jdbc npm --prefix gravitee-am-test run ci:management:parallel   # with --db psql
+
+# Cloud / Cockpit command specs (needs --cloud, distinct from --full)
+npm --prefix gravitee-am-test run ci:cloud
 
 # Playwright (needs --ui / --full)
 npm --prefix gravitee-am-test run pw            # interactive

--- a/docs/agent-standards/skills/local-stack/SKILL.md
+++ b/docs/agent-standards/skills/local-stack/SKILL.md
@@ -24,6 +24,7 @@ cd docker/local-stack
 
 ./local-stack.sh up                              # lean, MongoDB, built from source
 ./local-stack.sh up --full                       # full service set + Console UI
+./local-stack.sh up --cloud                      # managed-cloud (cockpit mock)
 ./local-stack.sh up --db psql --ui               # PostgreSQL + Console UI
 ./local-stack.sh up --version 4.12.x-latest --ui # pull a version instead of building
 ./local-stack.sh down                            # stop + remove (incl. volumes)
@@ -37,8 +38,9 @@ cd docker/local-stack
 | `--registry <host>` | Image registry (default `graviteeio` / Docker Hub). Private registry for nightlies. |
 | `--db mongo\|psql` | Backend database (default `mongo`). `psql` auto-downloads JDBC drivers. |
 | `--ui` | Also start the Console UI on `:4200` (required for playwright). |
-| `--full` | UI + wiremock + ciba + openfga + kafka + mtls (jest-gateway + playwright union). |
-| `--with a,b,…` | Opt-in extras: `ui,wiremock,ciba,openfga,kafka,mtls,spire`. |
+| `--full` | UI + wiremock + ciba + openfga + kafka + mtls (jest-gateway + playwright union). Does **not** include cloud. |
+| `--cloud` | Overlay: cockpit mock + management API in managed-cloud mode. |
+| `--with a,b,…` | Opt-in extras: `ui,wiremock,ciba,openfga,kafka,mtls,spire,cloud`. |
 | `--build` | Full clean rebuild: wipes stale source-tree plugin caches, `mvn clean install`, `make plugins`. Use when a container crashes on boot. |
 | `--quick` / `--no-build` | Skip Maven; reuse existing zips, just rebuild images. |
 | `--license <path>` | EE license file (default `dev/license/gravitee-universe-v4.key`). |
@@ -50,7 +52,8 @@ Other commands: `down`, `logs [svc]`, `status`, `pull --version <tag>`, `help`.
 - **Lean (default)** — `gateway, management, <db>, smtp, wiremock`. Enough for management
   jest specs and most manual work.
 - **`--ui`** — adds the Console (`:4200`); needed for **playwright** and manual Console work.
-- **`--full`** — the union the **jest gateway** and **playwright** suites need.
+- **`--full`** — the union the **jest gateway** and **playwright** suites need (not cloud).
+- **`--cloud`** — managed-cloud overlay (Cockpit mock) for the **cloud** jest suite.
 - **`--with spire`** — only for the env-guarded gateway specs (`RUN_SPIRE_TESTS=true`).
 
 ## URLs & credentials (once up)
@@ -60,6 +63,7 @@ Other commands: `down`, `logs [svc]`, `status`, `pull --version <tag>`, `help`.
 | Gateway | http://localhost:8092 |
 | Management API | http://localhost:8093/management |
 | Console UI (`--ui`/`--full`) | http://localhost:4200 |
+| Cockpit mock (`--cloud`) | http://localhost:8085 |
 | Mailbox (fake SMTP) | http://localhost:5080 |
 
 Admin login **`admin` / `adminadmin`**; organization & environment **`DEFAULT`**.
@@ -70,6 +74,7 @@ Admin login **`admin` / `adminadmin`**; organization & environment **`DEFAULT`**
 npm --prefix gravitee-am-test run ci:management:parallel
 npm --prefix gravitee-am-test run ci:gateway
 REPOSITORY_TYPE=jdbc npm --prefix gravitee-am-test run ci:management:parallel   # when started with --db psql
+npm --prefix gravitee-am-test run ci:cloud      # needs --cloud
 npm --prefix gravitee-am-test run pw            # playwright (needs --ui/--full)
 ```
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
@@ -34,6 +34,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -59,6 +60,18 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
     public Single<EnvironmentReply> handle(EnvironmentCommand command) {
 
         EnvironmentCommandPayload environmentPayload = command.getPayload();
+
+        Optional<String> validationError = RequiredPayloadFields.forType("Environment")
+                .string("organizationId", environmentPayload.organizationId())
+                .string("id", environmentPayload.id())
+                .string("name", environmentPayload.name())
+                .stringList("hrids", environmentPayload.hrids())
+                .validate();
+        if (validationError.isPresent()) {
+            log.warn(validationError.get());
+            return Single.just(new EnvironmentReply(command.getId(), validationError.get()));
+        }
+
         NewEnvironment newEnvironment = new NewEnvironment();
         newEnvironment.setHrids(environmentPayload.hrids());
         newEnvironment.setName(environmentPayload.name());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/InstallationCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/InstallationCommandHandler.java
@@ -27,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
@@ -46,6 +48,15 @@ public class InstallationCommandHandler implements CommandHandler<InstallationCo
     @Override
     public Single<InstallationReply> handle(InstallationCommand command) {
         InstallationCommandPayload installationPayload = command.getPayload();
+
+        Optional<String> validationError = RequiredPayloadFields.forType("Installation")
+                .string("status", installationPayload.status())
+                .validate();
+        if (validationError.isPresent()) {
+            log.warn(validationError.get());
+            return Single.just(new InstallationReply(command.getId(), validationError.get()));
+        }
+
         return installationService.getOrInitialize().map(Installation::getAdditionalInformation)
                 .doOnSuccess(additionalInfos -> additionalInfos.put(Installation.COCKPIT_INSTALLATION_STATUS, installationPayload.status()))
                 .flatMap(installationService::setAdditionalInformation)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/MembershipCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/MembershipCommandHandler.java
@@ -36,6 +36,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 import static io.gravitee.am.management.service.impl.commands.UserCommandHandler.COCKPIT_SOURCE;
 
 /**
@@ -60,6 +62,19 @@ public class MembershipCommandHandler implements CommandHandler<MembershipComman
     public Single<MembershipReply> handle(MembershipCommand command) {
 
         MembershipCommandPayload membershipPayload = command.getPayload();
+
+        Optional<String> validationError = RequiredPayloadFields.forType("Membership")
+                .string("organizationId", membershipPayload.organizationId())
+                .string("referenceType", membershipPayload.referenceType())
+                .string("referenceId", membershipPayload.referenceId())
+                .string("userId", membershipPayload.userId())
+                .string("role", membershipPayload.role())
+                .validate();
+        if (validationError.isPresent()) {
+            log.warn(validationError.get());
+            return Single.just(new MembershipReply(command.getId(), validationError.get()));
+        }
+
         ReferenceType assignableType;
 
         try {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/OrganizationCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/OrganizationCommandHandler.java
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -50,6 +51,17 @@ public class OrganizationCommandHandler implements CommandHandler<OrganizationCo
     public Single<OrganizationReply> handle(OrganizationCommand command) {
 
         OrganizationCommandPayload organizationPayload = command.getPayload();
+
+        Optional<String> validationError = RequiredPayloadFields.forType("Organization")
+                .string("id", organizationPayload.id())
+                .string("name", organizationPayload.name())
+                .stringList("hrids", organizationPayload.hrids())
+                .validate();
+        if (validationError.isPresent()) {
+            log.warn(validationError.get());
+            return Single.just(new OrganizationReply(command.getId(), validationError.get()));
+        }
+
         NewOrganization newOrganization = new NewOrganization();
         newOrganization.setHrids(organizationPayload.hrids());
         newOrganization.setName(organizationPayload.name());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/RequiredPayloadFields.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/RequiredPayloadFields.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Helper to validate and reject cockpit command payloads that are missing fields required to
+ * produce a usable entity.
+ *
+ * @author GraviteeSource Team
+ */
+final class RequiredPayloadFields {
+
+    private final String commandType;
+    private final List<String> missing = new ArrayList<>();
+
+    private RequiredPayloadFields(String commandType) {
+        this.commandType = commandType;
+    }
+
+    /**
+     * Starts a validation chain for the given command type.
+     *
+     * @param commandType human-readable command type used in the rejection message (e.g. "Organization")
+     * @return a new, empty validation chain
+     */
+    static RequiredPayloadFields forType(String commandType) {
+        return new RequiredPayloadFields(commandType);
+    }
+
+    /**
+     * Requires a non-null, non-blank string value.
+     *
+     * @param field the field name reported when the value is missing
+     * @param value the value to check
+     * @return this chain, for fluent use
+     */
+    RequiredPayloadFields string(String field, String value) {
+        if (value == null || value.isBlank()) {
+            missing.add(field);
+        }
+        return this;
+    }
+
+    /**
+     * Requires a non-null list holding at least one non-blank value.
+     *
+     * @param field the field name reported when the value is missing
+     * @param values the list to check
+     * @return this chain, for fluent use
+     */
+    RequiredPayloadFields stringList(String field, List<String> values) {
+        if (values == null || values.stream().allMatch(v -> v == null || v.isBlank())) {
+            missing.add(field);
+        }
+        return this;
+    }
+
+    /**
+     * Validates every field accumulated in the chain.
+     *
+     * @return an error message describing the missing fields, or empty if the payload is valid
+     */
+    Optional<String> validate() {
+        return missing.isEmpty()
+                ? Optional.empty()
+                : Optional.of(commandType + " command rejected due to missing or blank required field(s): " + missing);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/UserCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/UserCommandHandler.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Named;
 import java.util.HashMap;
+import java.util.Optional;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -54,10 +55,15 @@ public class UserCommandHandler implements CommandHandler<UserCommand, UserReply
     @Override
     public Single<UserReply> handle(UserCommand command) {
         UserCommandPayload userPayload = command.getPayload();
-        if (userPayload.username() == null) {
-            String errorMsg = "Request rejected due to null username.";
-            log.warn(errorMsg);
-            return Single.just(new UserReply(command.getId(), errorMsg));
+
+        Optional<String> validationError = RequiredPayloadFields.forType("User")
+                .string("id", userPayload.id())
+                .string("username", userPayload.username())
+                .string("organizationId", userPayload.organizationId())
+                .validate();
+        if (validationError.isPresent()) {
+            log.warn(validationError.get());
+            return Single.just(new UserReply(command.getId(), validationError.get()));
         }
 
         NewOrganizationUser newUser = new NewOrganizationUser();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
@@ -114,6 +114,7 @@ class EnvironmentCommandHandlerTest {
     void handleWithException() {
         EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
                 .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
                 .organizationId("orga#1")
                 .description("Environment description")
                 .name("Environment name")
@@ -129,6 +130,52 @@ class EnvironmentCommandHandlerTest {
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
     }
 
+    @Test
+    void shouldRejectEmptyPayload() {
+        EnvironmentCommand command = new EnvironmentCommand(EnvironmentCommandPayload.builder().build());
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(environmentService, entrypointService);
+    }
+
+    @Test
+    void shouldRejectMissingOrganizationId() {
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
+                .name("Environment name")
+                .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(environmentService, entrypointService);
+    }
+
+    @Test
+    void shouldRejectMissingHrids() {
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .organizationId("orga#1")
+                .name("Environment name")
+                .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(environmentService, entrypointService);
+    }
+
     private void enableCloudMode() {
         springEnvironment.setProperty("cloud.enabled", "true");
         springEnvironment.setProperty("installation.type", "managed");
@@ -140,6 +187,7 @@ class EnvironmentCommandHandlerTest {
 
         EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
                 .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
                 .organizationId("orga#1")
                 .description("Environment description")
                 .name("Environment name")
@@ -186,6 +234,7 @@ class EnvironmentCommandHandlerTest {
 
         EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
                 .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
                 .organizationId("orga#1")
                 .description("Environment description")
                 .name("Environment name")
@@ -211,6 +260,7 @@ class EnvironmentCommandHandlerTest {
 
         EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
                 .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
                 .organizationId("orga#1")
                 .description("Environment description")
                 .name("Environment name")
@@ -234,6 +284,7 @@ class EnvironmentCommandHandlerTest {
 
         EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
                 .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
                 .organizationId("orga#1")
                 .description("Environment description")
                 .name("Environment name")

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/InstallationCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/InstallationCommandHandlerTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -113,5 +114,17 @@ class InstallationCommandHandlerTest {
 
         obs.awaitDone(10, TimeUnit.SECONDS);
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+    }
+
+    @Test
+    void shouldRejectMissingStatus() {
+        InstallationCommand command = new InstallationCommand(InstallationCommandPayload.builder().id(INSTALLATION_ID).build());
+
+        TestObserver<InstallationReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(installationService);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/MembershipCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/MembershipCommandHandlerTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -183,6 +184,37 @@ class MembershipCommandHandlerTest {
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
 
         verify(membershipService, times(0)).addOrUpdate(any(), any());
+    }
+
+    @Test
+    void shouldRejectEmptyPayload() {
+        MembershipCommand command = new MembershipCommand(MembershipCommandPayload.builder().build());
+
+        TestObserver<MembershipReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(userService, roleService, membershipService);
+    }
+
+    @Test
+    void shouldRejectMissingUserId() {
+        MembershipCommandPayload membershipPayload = MembershipCommandPayload
+                .builder()
+                .organizationId("orga#1")
+                .referenceType(ReferenceType.ENVIRONMENT.name())
+                .referenceId("env#1")
+                .role(SystemRole.ENVIRONMENT_PRIMARY_OWNER.name())
+                .build();
+        MembershipCommand command = new MembershipCommand(membershipPayload);
+
+        TestObserver<MembershipReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(userService, roleService, membershipService);
     }
 
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/OrganizationCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/OrganizationCommandHandlerTest.java
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -104,6 +105,7 @@ class OrganizationCommandHandlerTest {
 
         OrganizationCommandPayload organizationPayload = OrganizationCommandPayload.builder()
                 .id("orga#1")
+                .hrids(Collections.singletonList("orga-1"))
                 .description("Organization description")
                 .name("Organization name")
                 .accessPoints(List.of(AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build(),
@@ -118,5 +120,50 @@ class OrganizationCommandHandlerTest {
         obs.awaitDone(10, TimeUnit.SECONDS);
         obs.assertNoErrors();
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+    }
+
+    @Test
+    void shouldRejectEmptyPayload() {
+        OrganizationCommand command = new OrganizationCommand(OrganizationCommandPayload.builder().build());
+
+        TestObserver<OrganizationReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(organizationService);
+    }
+
+    @Test
+    void shouldRejectMissingHrids() {
+        OrganizationCommandPayload organizationPayload = OrganizationCommandPayload.builder()
+                .id("orga#1")
+                .name("Organization name")
+                .build();
+        OrganizationCommand command = new OrganizationCommand(organizationPayload);
+
+        TestObserver<OrganizationReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(organizationService);
+    }
+
+    @Test
+    void shouldRejectBlankId() {
+        OrganizationCommandPayload organizationPayload = OrganizationCommandPayload.builder()
+                .id("   ")
+                .hrids(Collections.singletonList("orga-1"))
+                .name("Organization name")
+                .build();
+        OrganizationCommand command = new OrganizationCommand(organizationPayload);
+
+        TestObserver<OrganizationReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(organizationService);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/RequiredPayloadFieldsTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/RequiredPayloadFieldsTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.commands;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author GraviteeSource Team
+ */
+class RequiredPayloadFieldsTest {
+
+    @Test
+    void shouldPassWhenAllFieldsPresent() {
+        Optional<String> error = RequiredPayloadFields.forType("Organization")
+                .string("id", "id-1")
+                .string("name", "name")
+                .stringList("hrids", List.of("hrid-1"))
+                .validate();
+
+        assertTrue(error.isEmpty());
+    }
+
+    @Test
+    void shouldRejectNullEmptyAndBlankStrings() {
+        assertFalse(RequiredPayloadFields.forType("X").string("id", null).validate().isEmpty());
+        assertFalse(RequiredPayloadFields.forType("X").string("id", "").validate().isEmpty());
+        assertFalse(RequiredPayloadFields.forType("X").string("id", "   ").validate().isEmpty());
+    }
+
+    @Test
+    void shouldRejectNullEmptyOrAllBlankStringList() {
+        assertFalse(RequiredPayloadFields.forType("X").stringList("hrids", null).validate().isEmpty());
+        assertFalse(RequiredPayloadFields.forType("X").stringList("hrids", Collections.emptyList()).validate().isEmpty());
+        assertFalse(RequiredPayloadFields.forType("X").stringList("hrids", Arrays.asList(null, "  ")).validate().isEmpty());
+    }
+
+    @Test
+    void shouldAcceptStringListWithAtLeastOneNonBlankValue() {
+        assertTrue(RequiredPayloadFields.forType("X").stringList("hrids", Arrays.asList(null, "hrid-1")).validate().isEmpty());
+    }
+
+    @Test
+    void shouldListEveryMissingFieldInMessage() {
+        Optional<String> error = RequiredPayloadFields.forType("Organization")
+                .string("id", null)
+                .string("name", "name")
+                .stringList("hrids", Collections.emptyList())
+                .validate();
+
+        assertTrue(error.isPresent());
+        assertEquals("Organization command rejected due to missing or blank required field(s): [id, hrids]", error.get());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/UserCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/UserCommandHandlerTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -127,5 +128,34 @@ class UserCommandHandlerTest {
 
         obs.awaitDone(10, TimeUnit.SECONDS);
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    void shouldRejectMissingId() {
+        var command = new UserCommand(UserCommandPayload.builder()
+                .organizationId("orga#1")
+                .username("Username")
+                .build());
+
+        TestObserver<UserReply> obs = userCommandHandler.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    void shouldRejectMissingOrganizationId() {
+        var command = new UserCommand(UserCommandPayload.builder()
+                .id("user#1")
+                .username("Username")
+                .build());
+
+        TestObserver<UserReply> obs = userCommandHandler.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(userService);
     }
 }

--- a/gravitee-am-test/api/commands/cloud/cockpit-commands.ts
+++ b/gravitee-am-test/api/commands/cloud/cockpit-commands.ts
@@ -29,6 +29,15 @@ export interface CockpitCommand {
   payload: Record<string, any>;
 }
 
+/** A message AM emitted, as surfaced on the cockpit mock's FIFO queue. */
+export interface CockpitQueueEntry {
+  protocolType: 'COMMAND' | 'REPLY' | 'UNKNOWN';
+  type?: string;
+  commandId?: string;
+  commandStatus?: string;
+  errorDetails?: string;
+}
+
 /** POST a command toward AM. Returns the generated command id; AM's reply lands on the mock queue. */
 export const sendCockpitCommand = async (command: CockpitCommand): Promise<string> => {
   const response = await fetch(`${baseUrl}/_control/send`, {
@@ -41,6 +50,29 @@ export const sendCockpitCommand = async (command: CockpitCommand): Promise<strin
   }
   return (await response.json()).id;
 };
+
+/** Wait for AM's REPLY to the command identified by `commandId` and return it. */
+export const waitForCockpitReply = (
+  commandId: string,
+  options?: { timeoutMillis?: number; intervalMillis?: number },
+): Promise<CockpitQueueEntry> =>
+  retryUntil(
+    async (): Promise<CockpitQueueEntry | null> => {
+      const response = await fetch(`${baseUrl}/_control/queue`);
+      if (response.status === 204) {
+        return null;
+      }
+      if (response.status !== 200) {
+        throw new Error(`cockpit mock /_control/queue returned ${response.status}: ${await response.text()}`);
+      }
+      return (await response.json()) as CockpitQueueEntry;
+    },
+    (entry) => entry !== null && entry.protocolType === 'REPLY' && entry.commandId === commandId,
+    {
+      timeoutMillis: options?.timeoutMillis ?? 15000,
+      intervalMillis: options?.intervalMillis ?? 500,
+    },
+  ) as Promise<CockpitQueueEntry>;
 
 /** Whether an AM instance is currently connected to the cockpit mock. */
 export const isCockpitConnected = async (): Promise<boolean> => {

--- a/gravitee-am-test/specs/cloud/command-validation.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/command-validation.jest.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { sendCockpitCommand, waitForCockpitConnection, waitForCockpitReply } from '@cloud-commands/cockpit-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { setup } from '../test-fixture';
+
+setup(120000);
+
+describe('Cloud command payload validation (Cockpit -> AM)', () => {
+  beforeAll(async () => {
+    await waitForCockpitConnection();
+  });
+
+  it('rejects an ORGANIZATION command with an empty payload as ERROR', async () => {
+    const commandId = await sendCockpitCommand({ type: 'ORGANIZATION', payload: {} });
+
+    const reply = await waitForCockpitReply(commandId);
+
+    expect(reply.commandStatus).toBe('ERROR');
+    expect(reply.errorDetails).toContain('required field');
+  });
+
+  it('accepts a well-formed ORGANIZATION command as SUCCEEDED', async () => {
+    const id = uniqueName('org-validation', true);
+    const commandId = await sendCockpitCommand({
+      type: 'ORGANIZATION',
+      payload: { id, name: 'Command validation org', hrids: [id] },
+    });
+
+    const reply = await waitForCockpitReply(commandId);
+
+    expect(reply.commandStatus).toBe('SUCCEEDED');
+    // Note: organizations have no delete endpoint in the management API; this upserted org is left in place.
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7305](https://gravitee.atlassian.net/browse/AM-7305)

## :pencil2: A description of the changes proposed in the pull request
Validate mandatory fields in cockpit/cloud commands to avoid the creation of unusable entities.

Additionally, document `--cloud` mode in local-stack tooling.

## :memo: Test scenarios 
1. Run `docker/local-stack/local-stack.sh --cloud`
2. Send command with incomplete payload - for example `curl -sX POST localhost:8085/_control/send -H 'content-type: application/json' -d '{ "type": "ORGANIZATION", "payload": {}}'`

Example JSON validation error response:
```json
{"protocolType":"REPLY","type":"ORGANIZATION","commandId":"de7444f6-e52f-4740-a4ce-a29966114dad","commandStatus":"ERROR","errorDetails":"Organization command rejected due to missing or blank required field(s): [id, name, hrids]","receivedAt":"2026-07-23T11:18:45.369Z"}
```

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7305]: https://gravitee.atlassian.net/browse/AM-7305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ