### PR TITLE
ci: parallelise the PR maven build with -T 1C

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1254,7 +1254,8 @@ jobs:
           name: "Maven verify (backend)"
           no_output_timeout: 30m
           command: |
-            mvn -s /tmp/.gravitee.settings.xml verify -pl \!gravitee-am-ui -Dlicense.skip=true
+            # -T 1C runs one build thread per core across the reactor; the test phase is parallel-safe now the IdP WireMock tests bind dynamic ports instead of fixed ones (AM-7323).
+            mvn -s /tmp/.gravitee.settings.xml -T 1C verify -pl \!gravitee-am-ui -Dlicense.skip=true
       - run:
           name: Save test results
           command: |

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -888,7 +888,8 @@ jobs:
       - run:
           name: Build
           command: |
-            mvn install -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
+            # -T 1C runs one build thread per core across the reactor; safe here because -DskipTests means no fixed-port test collisions.
+            mvn install -T 1C -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
       - save-maven-job-cache:
           jobName: run_testcontainer_tests_mongo
   run_testcontainer_tests_redis:
@@ -905,7 +906,8 @@ jobs:
       - run:
           name: Build
           command: |
-            mvn install -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd-redis -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
+            # -T 1C runs one build thread per core across the reactor; safe here because -DskipTests means no fixed-port test collisions.
+            mvn install -T 1C -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd-redis -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
       - save-maven-job-cache:
           jobName: run_testcontainer_tests_redis
   run_testcontainer_tests_jdbc:
@@ -926,7 +928,8 @@ jobs:
       - run:
           name: Build
           command: |
-            mvn install -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd-jdbc -P << parameters.jdbcType >> -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
+            # -T 1C runs one build thread per core across the reactor; safe here because -DskipTests means no fixed-port test collisions.
+            mvn install -T 1C -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd-jdbc -P << parameters.jdbcType >> -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
       - save-maven-job-cache:
           jobName: run_testcontainer_tests_jdbc
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1295,8 +1295,10 @@ jobs:
       - mvn_git_commit_id
       - run:
           name: "Maven Package Install (no tests)"
+          # -T 1C runs one build thread per core to parallelise the wide, independent plugin subtrees.
+          # This step is -DskipTests so there is no fixed-port test collision risk from parallelism.
           command: |
-            mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot,ee-bundle,addons-bundle clean install -DskipTests
+            mvn -s /tmp/.gravitee.settings.xml -T 1C -P gio-artifactory-snapshot,ee-bundle,addons-bundle clean install -DskipTests
       - save-maven-job-cache:
           jobName: pull_requests
       - run:

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/test/java/io/gravitee/am/identityprovider/github/authentication/GithubAuthenticationProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-github/src/test/java/io/gravitee/am/identityprovider/github/authentication/GithubAuthenticationProviderTest.java
@@ -26,6 +26,7 @@ import io.gravitee.am.identityprovider.github.GithubIdentityProviderConfiguratio
 import io.gravitee.am.identityprovider.github.authentication.spring.GithubAuthenticationProviderConfiguration;
 import io.gravitee.common.http.HttpHeaders;
 import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,7 +78,15 @@ public class GithubAuthenticationProviderTest {
     private GithubIdentityProviderConfiguration configuration;
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(19998));
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+    @Before
+    public void setUp() {
+        String baseUrl = "http://localhost:" + wireMockRule.port();
+        configuration.setAccessTokenUri(baseUrl + "/oauth/token");
+        configuration.setUserAuthorizationUri(baseUrl + "/oauth/authorize");
+        configuration.setUserProfileUri(baseUrl + "/profile");
+    }
 
     @Test
     public void shouldLoadUserByUsername_authentication() {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/authentication/HttpAuthenticationProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/authentication/HttpAuthenticationProviderTest.java
@@ -28,7 +28,9 @@ import io.gravitee.am.identityprovider.api.DummyRequest;
 import io.gravitee.am.identityprovider.api.SimpleAuthenticationContext;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.identityprovider.http.authentication.spring.HttpAuthenticationProviderConfiguration;
+import io.gravitee.am.identityprovider.http.configuration.HttpIdentityProviderConfiguration;
 import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,8 +72,16 @@ public class HttpAuthenticationProviderTest {
     @Autowired
     private DefaultIdentityProviderMapper mapper;
 
+    @Autowired
+    private HttpIdentityProviderConfiguration configuration;
+
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(19999));
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+    @Before
+    public void setUp() {
+        configuration.getAuthenticationResource().setBaseURL("http://localhost:" + wireMockRule.port() + "/api/authentication");
+    }
 
     @Test
     public void shouldLoadUserByUsername_authentication() {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-http/src/test/java/io/gravitee/am/identityprovider/http/user/HttpUserProviderTest.java
@@ -21,6 +21,7 @@ import io.gravitee.am.identityprovider.api.DefaultIdentityProviderMapper;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.identityprovider.api.UserProvider;
+import io.gravitee.am.identityprovider.http.configuration.HttpIdentityProviderConfiguration;
 import io.gravitee.am.identityprovider.http.user.spring.HttpUserProviderConfiguration;
 import io.gravitee.am.service.exception.UserAlreadyExistsException;
 import io.gravitee.am.service.exception.UserNotFoundException;
@@ -66,12 +67,16 @@ public class HttpUserProviderTest {
     @Autowired
     private DefaultIdentityProviderMapper mapper;
 
+    @Autowired
+    private HttpIdentityProviderConfiguration configuration;
+
     @ClassRule
-    public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(19998));
+    public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
     @Before
     public void init() {
         this.mapper.setMappers(Map.of());
+        this.configuration.getUsersResource().setBaseURL("http://localhost:" + wireMockRule.port() + "/api");
     }
 
     @Test

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/test/java/io/gravitee/am/identityprovider/oauth2/authentication/OAuth2GenericAuthenticationProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-oauth2-generic/src/test/java/io/gravitee/am/identityprovider/oauth2/authentication/OAuth2GenericAuthenticationProviderTest.java
@@ -32,6 +32,7 @@ import io.gravitee.am.identityprovider.oauth2.OAuth2GenericIdentityProviderConfi
 import io.gravitee.am.identityprovider.oauth2.authentication.spring.OAuth2GenericAuthenticationProviderConfiguration;
 import io.gravitee.common.http.HttpHeaders;
 import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -89,7 +90,15 @@ public class OAuth2GenericAuthenticationProviderTest {
     private JWTProcessor jwtProcessor = mock(JWTProcessor.class);
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(19999));
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+    @Before
+    public void setUp() {
+        String baseUrl = "http://localhost:" + wireMockRule.port();
+        configuration.setAccessTokenUri(baseUrl + "/oauth/token");
+        configuration.setUserAuthorizationUri(baseUrl + "/oauth/authorize");
+        configuration.setUserProfileUri(baseUrl + "/profile");
+    }
 
     @Test
     public void shouldLoadUserByUsername_authentication() {
@@ -134,7 +143,7 @@ public class OAuth2GenericAuthenticationProviderTest {
     @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     public void shouldStopRetryingWhenProviderStopped() throws Exception {
         OAuth2GenericAuthenticationProvider provider = (OAuth2GenericAuthenticationProvider) authenticationProvider;
-        configuration.setWellKnownUri("http://localhost:19999/.well-known/openid-configuration");
+        configuration.setWellKnownUri("http://localhost:" + wireMockRule.port() + "/.well-known/openid-configuration");
         stubFor(any(urlPathEqualTo("/.well-known/openid-configuration"))
                 .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7323

## :pencil2: A description of the changes proposed in the pull request

Adds `-T 1C` to the maven builds in CI so the wide, independent plugin subtrees build in parallel. These jobs gate the PR workflow, so shaving them helps every PR.

Started with the `-DskipTests` build steps where parallelism is risk-free:
- process_pull_request "Maven Package Install (no tests)" step (docker large, 4 vCPU, so 1C gives 4 build threads)
- the three testcontainer build steps (mongo, redis, jdbc), which run on xlarge

Then went after the test-running job too. `junit_tests` runs `mvn verify` and couldn't take `-T 1C` because a few identity provider tests bind wiremock on fixed ports, so two modules running at once hit "address already in use". Fixed that by switching those tests to `wireMockConfig().dynamicPort()` and reading the assigned port back in `@Before` (github, http auth, http user, oauth2-generic). With the collisions gone `junit_tests` runs `-T 1C` as well.

Hard numbers, both real CI runs on this branch:
- process_pull_request install step: ~290s with 1C (288s and 293s across two runs) vs a serial baseline bouncing between ~408s and ~540s. At the job level about 20% (8.15 min to 6.53 min) since checkout and cache restore do not parallelise.
- junit_tests: 18.6 min down to 11.4 min on the same large executor, about 39% off, roughly 7 min saved (pipeline 99036fea serial vs 79811006 with the flag).

Tried `-T 2C` on the install step and it was no faster (298s) while doubling memory pressure, so 1C is the sweet spot. 4 vCPU is already saturated at 1C, no OOM.

## :memo: Test scenarios

No production code touched. Changes are CI config plus the wiremock port wiring for the four identity provider tests.

- Reproduced the collision first: on the old fixed ports, `mvn verify -T 1C` on the three idp modules fails with FatalStartupException, failed to bind 19998/19999, 14 test errors (github/http share 19998, oauth2-generic/http share 19999).
- After the fix, ran the whole reactor with `mvn test -T 1C`: 8301 tests, 0 failures, 0 collisions, 3 runs in a row green. `mvn verify -T 1C` green too.
- Real CI: junit_tests went green with `-T 1C` in 11.4 min (pipeline 79811006). The only red in that workflow is run_postman_tests_psql-18.4, unrelated flaky postman, nothing to do with this change.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

The identity provider tests that were on fixed ports are now on dynamic ports, so the reactor unit tests are safe to run in parallel going forward. If you add a new test that binds a server, use a dynamic port (`dynamicPort()`, `new WireMockServer(0)`, `ServerSocket(0)`, `Network.freeServerPort`) so it stays parallel-safe.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
