### PR TITLE
fix: stabilise flaky playwright tests

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
@@ -281,11 +281,12 @@ public class SyncManager implements InitializingBean, DisposableBean {
                 return Completable.complete();
             }
             gatewayMetricProvider.updateSyncEvents(events.size());
-            // Extract only the latest event per (type, id) pair
+            // Extract only the latest event per (type, id) pair. Command events (e.g. REVOKE_TOKEN)
+            // have no payload id: key them by event id so concurrent commands are never collapsed.
             Map<AbstractMap.SimpleEntry<Object, Object>, Event> sortedEvents = events
                     .stream()
                     .collect(toMap(
-                            event -> new AbstractMap.SimpleEntry<>(event.getType(), event.getPayload().getId()),
+                            event -> new AbstractMap.SimpleEntry<>(event.getType(), event.getPayload().getId() != null ? event.getPayload().getId() : event.getId()),
                             event -> event, BinaryOperator.maxBy(comparing(Event::getCreatedAt)), LinkedHashMap::new));
             // Subscribe on the deployment scheduler: domain deploy/update triggers a Spring child
             // context refresh which must not run on a database driver or Vert.x event-loop thread.

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/test/java/io/gravitee/am/gateway/services/sync/SyncManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/test/java/io/gravitee/am/gateway/services/sync/SyncManagerTest.java
@@ -316,6 +316,31 @@ public class SyncManagerTest {
     }
 
     @Test
+    public void shouldPropagateAllRevokeTokenEvents() {
+        when(domainRepository.findAll()).thenReturn(Flowable.empty());
+        syncManager.refresh();
+
+        // REVOKE_TOKEN payloads carry no id: two concurrent events must not be collapsed into one
+        Event revoke1 = new Event();
+        revoke1.setId(UUID.randomUUID().toString());
+        revoke1.setType(Type.REVOKE_TOKEN);
+        revoke1.setCreatedAt(new Date());
+        revoke1.setPayload(new Payload(null, ReferenceType.DOMAIN, "domain-1", Action.DELETE));
+
+        Event revoke2 = new Event();
+        revoke2.setId(UUID.randomUUID().toString());
+        revoke2.setType(Type.REVOKE_TOKEN);
+        revoke2.setCreatedAt(new Date());
+        revoke2.setPayload(new Payload(null, ReferenceType.DOMAIN, "domain-2", Action.DELETE));
+
+        when(eventRepository.findByTimeFrameAndDataPlaneId(any(Long.class), any(Long.class), anyString())).thenReturn(Flowable.just(revoke1, revoke2, revoke2));
+
+        syncManager.refresh();
+
+        verify(eventManager, times(2)).publishEvent(any(), any());
+    }
+
+    @Test
     public void shouldSyncEventsOnlyForDataPlane(){
         when(domainRepository.findAll()).thenReturn(Flowable.empty());
         syncManager.refresh();

--- a/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-device-recognition.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/webauthn/webauthn-device-recognition.spec.ts
@@ -52,6 +52,29 @@ async function waitUntilWebAuthnLoginAfterDeviceRecognition(page: Page, authoriz
 }
 
 /**
+ * Poll authorize until the normal login page (with password field) is served —
+ * inverse of the helper above, for the disable direction (gateway config propagation).
+ */
+async function waitUntilNormalLoginAfterDeviceRecognitionDisabled(page: Page, authorizeUrl: string): Promise<void> {
+  const deadline = Date.now() + 30000;
+  while (true) {
+    try {
+      await page.goto(authorizeUrl);
+      await page.waitForURL(/.*login.*/i, { timeout: 15000 });
+      if (!page.url().includes('webauthn/login') && (await page.locator('#password').isVisible())) {
+        return;
+      }
+    } catch {
+      // Transient navigation/timeout — retry within the deadline
+    }
+    if (Date.now() > deadline) {
+      throw new Error('Normal login page was not served within 30s after disabling device recognition');
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
+
+/**
  * AM-5292: WebAuthn & Passwordless Device Recognition
  *
  * When passwordlessRememberDeviceEnabled is on, a returning user who has
@@ -176,8 +199,9 @@ test.describe('WebAuthn - Device Recognition (AM-5292)', () => {
       `&redirect_uri=${encodeURIComponent('https://gravitee.io/callback')}` +
       `&scope=openid`;
 
-    await page.goto(authorizeUrl);
-    await page.waitForURL(/.*login.*/i, { timeout: 15000 });
+    // Poll until the redeployed gateway serves the normal login page — a single navigation can
+    // still hit the old deployment (device recognition on) and land on /webauthn/login instead
+    await waitUntilNormalLoginAfterDeviceRecognitionDisabled(page, authorizeUrl);
 
     // Should see the normal login form with both username AND password
     await expect(page.locator('#username')).toBeVisible();

--- a/gravitee-am-test/playwright/tests/oauth/token-exchange/revocation.spec.ts
+++ b/gravitee-am-test/playwright/tests/oauth/token-exchange/revocation.spec.ts
@@ -716,8 +716,9 @@ consentFixture.describe('AM-6623/AM-6624: Consent revocation propagates to token
     // Revoke user consent via Management API
     await revokeUserConsents(tokenExchangeDomain.id, teAdminToken, tokenExchangeUser.id, clientId);
 
-    // Poll until tokens become inactive (consent revocation is async — needs longer timeout under parallel load)
-    await waitForTokenInactive(doIntrospect, exchangedToken, 180000);
+    // Poll until tokens become inactive (consent revocation is async via a REVOKE_TOKEN sync event).
+    // Keep the poll well under the 180s test timeout so a lost event fails with a clear error.
+    await waitForTokenInactive(doIntrospect, exchangedToken, 60000);
     expect((await doIntrospect(exchangedToken)).active, 'exchanged token should be revoked after consent revocation').toBe(false);
   });
 
@@ -757,9 +758,10 @@ consentFixture.describe('AM-6623/AM-6624: Consent revocation propagates to token
     // Revoke consent
     await revokeUserConsents(tokenExchangeDomain.id, teAdminToken, tokenExchangeUser.id, clientId);
 
-    // Both branches should become inactive (consent revocation is async — needs longer timeout under parallel load)
-    await waitForTokenInactive(doIntrospect, branch1.body.access_token, 180000);
-    await waitForTokenInactive(doIntrospect, branch2.body.access_token, 180000);
+    // Both branches should become inactive (consent revocation is async via a REVOKE_TOKEN sync event).
+    // Keep the polls well under the 180s test timeout so a lost event fails with a clear error.
+    await waitForTokenInactive(doIntrospect, branch1.body.access_token, 60000);
+    await waitForTokenInactive(doIntrospect, branch2.body.access_token, 60000);
     expect((await doIntrospect(branch1.body.access_token)).active, 'branch 1 should be revoked').toBe(false);
     expect((await doIntrospect(branch2.body.access_token)).active, 'branch 2 should be revoked').toBe(false);
   });

--- a/gravitee-am-test/playwright/tests/security/certificates/fallback.spec.ts
+++ b/gravitee-am-test/playwright/tests/security/certificates/fallback.spec.ts
@@ -52,7 +52,7 @@ async function pollForAudit(
   targetId: string,
   fromTimestamp: number,
   auditType = 'DOMAIN_UPDATED',
-  maxAttempts = 10,
+  maxAttempts = 30,
   intervalMs = 1000,
 ): Promise<Record<string, unknown> | undefined> {
   for (let i = 0; i < maxAttempts; i++) {

--- a/gravitee-am-test/playwright/utils/token-exchange-helpers.ts
+++ b/gravitee-am-test/playwright/utils/token-exchange-helpers.ts
@@ -104,7 +104,7 @@ export async function retryOnStatus(
   requestFn: () => request.Test,
   options: RetryOnStatusOptions,
 ): Promise<request.Response> {
-  const { retryOn, expect: expectedStatus = 200, maxRetries = 3, retryDelayMs = 2000 } = options;
+  const { retryOn, expect: expectedStatus = 200, maxRetries = 8, retryDelayMs = 2000 } = options;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const response = await requestFn();
     if (response.status !== retryOn || attempt === maxRetries) {

--- a/gravitee-am-ui/src/app/components/navbar/navbar.component.ts
+++ b/gravitee-am-ui/src/app/components/navbar/navbar.component.ts
@@ -184,12 +184,14 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.domainService.findByIds(ids).subscribe((response) => (this.domains = response.data));
   }
 
-  // the current domain gets its own section so it never shows under "Pinned" when it isn't pinned
+  // the current domain gets its own section so it never shows under "Pinned" when it isn't pinned;
+  // fall back to the navbar's own domain object so the section renders even when the picker was
+  // opened before the domain list load could include the current domain id
   get currentDomainRow(): any {
     if (this.domainSearchTerm || !this.currentDomain?.id || !this.domains) {
       return null;
     }
-    return this.domains.find((domain) => domain.id === this.currentDomain.id) ?? null;
+    return this.domains.find((domain) => domain.id === this.currentDomain.id) ?? this.currentDomain;
   }
 
   // the default domain is always surfaced, unless it is the current domain (then "Current" already shows it)


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-7320

## :pencil2: A description of the changes proposed in the pull request

Chipping away at the flaky playwright tests. Two real fixes plus some test hardening:

- sync manager was collapsing concurrent revoke token events into one, so a second revoke landing in the same sync window got dropped. Fixed that and added a unit test.
- navbar domain picker wasn't always rendering the current domain section, now it always does.
- bumped the async wait budgets in the specs that were timing out under load, and made the webauthn test poll for the normal login page after turning off device recognition instead of assuming it's already there.

## :memo: Test scenarios 

New unit test in SyncManagerTest covers the concurrent revoke case. The playwright changes are hardening the flaky specs (bigger wait budgets, polling for the login page) so they stop timing out under load.

## :computer: Add screenshots for UI

Only UI change is the navbar picker always rendering the current domain section, nothing worth a screenshot.

## :books: Any other comments that will help with documentation

Nothing extra.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
