### PR TITLE
ci: run jdbc testcontainer tests sequentially instead of under -T 1C

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -926,10 +926,18 @@ jobs:
       - restore-maven-job-cache:
           jobName: run_testcontainer_tests_jdbc
       - run:
-          name: Build
+          name: Build (parallel compile, no tests)
           command: |
-            # -T 1C runs one build thread per core across the reactor; safe here because -DskipTests means no fixed-port test collisions.
-            mvn install -T 1C -pl \!gravitee-am-ui -P gio-artifactory-snapshot -Pcicd-jdbc -P << parameters.jdbcType >> -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
+            # -T 1C parallelises the reactor compile. cicd-jdbc is intentionally left off here so the JDBC
+            # integration tests do NOT run under parallel load - they self-manage DB containers and flaked
+            # (async bulk-flush read 0) when 130+ other modules compiled on the other cores. See AM-7327.
+            mvn install -T 1C -pl \!gravitee-am-ui -P gio-artifactory-snapshot -P << parameters.jdbcType >> -DskipTests -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
+      - run:
+          name: Run JDBC testcontainer tests (sequential)
+          command: |
+            # Run only the cicd-jdbc test modules, sequentially (no -T 1C), against the << parameters.jdbcType >> container.
+            # Keep this list in sync with the modules that declare the cicd-jdbc profile.
+            mvn test -pl :gravitee-am-repository-jdbc,:gravitee-am-reporter-jdbc,:gravitee-am-dataplane-jdbc -P gio-artifactory-snapshot,cicd-jdbc -P << parameters.jdbcType >> -Dmaven.javadoc.skip=true -s /tmp/.gravitee.settings.xml
       - save-maven-job-cache:
           jobName: run_testcontainer_tests_jdbc
 


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7327

## :pencil2: A description of the changes proposed in the pull request

The JDBC testcontainer jobs run `mvn install -T 1C ... -Pcicd-jdbc -DskipTests`. Turns out cicd-jdbc forces the repository/reporter JDBC integration tests to run anyway, it hardcodes skipTests=false in surefire which overrides the -DskipTests flag. So those tests were executing under the parallel reactor, and JdbcAuditReporterTest.testReporter_aggregationCount_accessPointId flaked, the async bulk processor hadn't flushed before the count assertion while 130+ other modules were compiling on the other cores and it read {data=0}.

This splits the step. Keep -T 1C for the compile (build only, cicd-jdbc dropped so no tests run there), then run just the three cicd-jdbc modules sequentially without -T 1C. Also fixed the comment that wrongly claimed -DskipTests meant no tests ran.

Mongo and redis testcontainer jobs keep -T 1C, they aren't flaky.

## :memo: Test scenarios

CI-only change, no product code. Validated with `circleci config validate` and confirmed the three `-pl` selectors resolve to the right modules (repository-jdbc, reporter-jdbc, dataplane-jdbc). The real check is the JDBC testcontainer jobs going green on this PR without the reporter flake.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

Those three modules are the only ones declaring the cicd-jdbc profile today, so the sequential -pl list is complete. If a new module adds cicd-jdbc it needs adding there too, there's a comment in the config saying so. This is the CI half of AM-7327, the OAuth2GenericAuthenticationProviderTest junit flake still needs the test hardening (dynamic wiremock port + a less strict retry assertion) which I'll do separately.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
