### PR TITLE
feat: AM-7238 enforce org license on domain redeploy and gateway restart only

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/license/GatewayOrganizationLicenseManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/license/GatewayOrganizationLicenseManager.java
@@ -17,11 +17,8 @@ package io.gravitee.am.gateway.license;
 
 import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.common.event.LicenseEvent;
-import io.gravitee.am.gateway.reactor.SecurityDomainManager;
-import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Payload;
-import io.gravitee.am.service.EnvironmentService;
 import io.gravitee.am.service.LicenseService;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
@@ -30,21 +27,15 @@ import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.license.License;
 import io.gravitee.node.api.license.LicenseFactory;
 import io.gravitee.node.api.license.LicenseManager;
-import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Scheduler;
-import io.reactivex.rxjava3.schedulers.Schedulers;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import lombok.CustomLog;
 
 /**
  * Feeds the node {@link LicenseManager} with the organization licenses persisted by the cockpit/cloud
  * command flow, so runtime license gating can resolve an organization's license on the gateway.
  * <p>
- * In managed cloud mode, a license change or expiry triggers a redeployment of the affected
- * organization's domains so their managers re-evaluate plugin gating against the new license.
+ * In managed cloud mode, feature gating is enforced when a domain redeploys: its plugin managers
+ * consult the in-memory license through {@code io.gravitee.am.service.PluginLicenseGate}. This manager
+ * only keeps that in-memory view current.
  *
  * @author GraviteeSource Team
  */
@@ -56,26 +47,17 @@ public class GatewayOrganizationLicenseManager extends AbstractService<GatewayOr
     private final LicenseFactory licenseFactory;
     private final LicenseManager licenseManager;
     private final EventManager eventManager;
-    private final SecurityDomainManager securityDomainManager;
-    private final EnvironmentService environmentService;
     private final boolean managedCloudEnabled;
-
-    private ExecutorService redeployExecutor;
-    private Scheduler redeployScheduler;
 
     public GatewayOrganizationLicenseManager(LicenseService licenseService,
                                              LicenseFactory licenseFactory,
                                              LicenseManager licenseManager,
                                              EventManager eventManager,
-                                             SecurityDomainManager securityDomainManager,
-                                             EnvironmentService environmentService,
                                              org.springframework.core.env.Environment environment) {
         this.licenseService = licenseService;
         this.licenseFactory = licenseFactory;
         this.licenseManager = licenseManager;
         this.eventManager = eventManager;
-        this.securityDomainManager = securityDomainManager;
-        this.environmentService = environmentService;
         this.managedCloudEnabled = CloudProperties.isManagedCloudEnabled(environment);
     }
 
@@ -91,16 +73,6 @@ public class GatewayOrganizationLicenseManager extends AbstractService<GatewayOr
         log.info("Register event listener for license events for the gateway");
         eventManager.subscribeForEvents(this, LicenseEvent.class);
 
-        // set up a single thread for redeploying domains
-        final ClassLoader deploymentClassLoader = SecurityDomainManager.class.getClassLoader();
-        redeployExecutor = Executors.newSingleThreadExecutor(r -> {
-            Thread t = new Thread(r, "gio.license-redeployer");
-            t.setDaemon(true);
-            t.setContextClassLoader(deploymentClassLoader);
-            return t;
-        });
-        redeployScheduler = Schedulers.from(redeployExecutor);
-
         // block here since licenses must be registered before the Reactor starts and the first domain deploys
         try {
             licenseService.findAll()
@@ -112,10 +84,10 @@ public class GatewayOrganizationLicenseManager extends AbstractService<GatewayOr
             log.error("An error occurred while loading organization licenses", e);
         }
 
+        // Log expiries for observability only. Enforcement is deferred to the next domain redeployment.
         licenseManager.onLicenseExpires(license -> {
             if (License.REFERENCE_TYPE_ORGANIZATION.equals(license.getReferenceType())) {
-                log.info("License of organization={} has expired", license.getReferenceId());
-                redeployOrganizationDomains(license.getReferenceId());
+                log.info("License of organization={} has expired; restrictions will take effect on the next domain update or restart", license.getReferenceId());
             }
         });
     }
@@ -123,9 +95,6 @@ public class GatewayOrganizationLicenseManager extends AbstractService<GatewayOr
     @Override
     protected void doStop() throws Exception {
         eventManager.unsubscribeForEvents(this, LicenseEvent.class);
-        if (redeployExecutor != null) {
-            redeployExecutor.shutdown();
-        }
         super.doStop();
     }
 
@@ -142,17 +111,13 @@ public class GatewayOrganizationLicenseManager extends AbstractService<GatewayOr
 
     private void deploy(String organizationId) {
         licenseService.findByReference(ReferenceType.ORGANIZATION, organizationId)
-                .subscribe(license -> {
-                            register(organizationId, license.getLicense());
-                            redeployOrganizationDomains(organizationId);
-                        },
+                .subscribe(license -> register(organizationId, license.getLicense()),
                         ex -> log.error("An error occurred while loading license for organization={}", organizationId, ex),
                         () -> undeploy(organizationId));
     }
 
     private void undeploy(String organizationId) {
         licenseManager.registerOrganizationLicense(organizationId, null);
-        redeployOrganizationDomains(organizationId);
     }
 
     private void register(String organizationId, String rawLicense) {
@@ -164,26 +129,5 @@ public class GatewayOrganizationLicenseManager extends AbstractService<GatewayOr
         } catch (Exception e) {
             log.warn("License cannot be registered for organization={}", organizationId, e);
         }
-    }
-
-    private void redeployOrganizationDomains(String organizationId) {
-        log.info("Redeploying domains of organization={} following a license change", organizationId);
-        Flowable.fromIterable(securityDomainManager.domains())
-                .flatMapMaybe(domain -> environmentService.findById(domain.getReferenceId())
-                        .map(Environment::getOrganizationId)
-                        .filter(organizationId::equals)
-                        .map(orgId -> domain)
-                        .onErrorResumeNext(ex -> {
-                            log.warn("Cannot resolve the organization of domain={}, skipping its redeployment", domain.getId(), ex);
-                            return Maybe.empty();
-                        }))
-                .observeOn(redeployScheduler)
-                // A concurrent sync cycle may update the same domain; worst case is a redundant rebuild.
-                .concatMapCompletable(domain -> securityDomainManager.updateReactive(domain)
-                        .doOnError(ex -> log.error("Unable to redeploy domain={} following a license change", domain.getId(), ex))
-                        .onErrorComplete())
-                .subscribe(
-                        () -> log.debug("Domains of organization={} redeployed", organizationId),
-                        ex -> log.error("An error occurred while redeploying domains of organization={}", organizationId, ex));
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/spring/StandaloneConfiguration.java
@@ -32,7 +32,6 @@ import io.gravitee.am.gateway.event.EventManagerImpl;
 import io.gravitee.am.gateway.license.GatewayOrganizationLicenseManager;
 import io.gravitee.am.gateway.node.GatewayNode;
 import io.gravitee.am.gateway.node.GatewayNodeMetadataResolver;
-import io.gravitee.am.gateway.reactor.SecurityDomainManager;
 import io.gravitee.am.gateway.reactor.spring.ReactorConfiguration;
 import io.gravitee.am.gateway.vertx.VertxServerConfiguration;
 import io.gravitee.am.password.dictionary.spring.PasswordDictionaryConfiguration;
@@ -66,7 +65,6 @@ import io.gravitee.am.repository.management.api.OrganizationRepository;
 import io.gravitee.am.gateway.entrypoint.GatewayEntryPointManager;
 import io.gravitee.am.service.EntryPointManager;
 import org.springframework.context.annotation.Lazy;
-import io.gravitee.am.service.EnvironmentService;
 import io.gravitee.am.service.LicenseService;
 import io.gravitee.am.service.secrets.SecretsConfiguration;
 import io.gravitee.am.service.spring.ServiceConfiguration;
@@ -258,10 +256,8 @@ public class StandaloneConfiguration {
                                                                                LicenseFactory licenseFactory,
                                                                                LicenseManager licenseManager,
                                                                                EventManager eventManager,
-                                                                               SecurityDomainManager securityDomainManager,
-                                                                               EnvironmentService environmentService,
                                                                                Environment environment) {
         return new GatewayOrganizationLicenseManager(licenseService, licenseFactory, licenseManager,
-                eventManager, securityDomainManager, environmentService, environment);
+                eventManager, environment);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/test/java/io/gravitee/am/gateway/license/GatewayOrganizationLicenseManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/test/java/io/gravitee/am/gateway/license/GatewayOrganizationLicenseManagerTest.java
@@ -17,21 +17,16 @@ package io.gravitee.am.gateway.license;
 
 import io.gravitee.am.common.event.Action;
 import io.gravitee.am.common.event.LicenseEvent;
-import io.gravitee.am.gateway.reactor.SecurityDomainManager;
-import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.License;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Payload;
-import io.gravitee.am.service.EnvironmentService;
 import io.gravitee.am.service.LicenseService;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.event.impl.SimpleEvent;
 import io.gravitee.node.api.license.LicenseFactory;
 import io.gravitee.node.api.license.LicenseManager;
-import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Single;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,14 +37,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.Environment;
 
-import java.util.List;
 import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -61,9 +54,6 @@ import static org.mockito.Mockito.when;
 public class GatewayOrganizationLicenseManagerTest {
 
     private static final String ORGANIZATION_ID = "orga#1";
-    private static final String OTHER_ORGANIZATION_ID = "orga#2";
-    private static final String ENVIRONMENT_ID = "env#1";
-    private static final String OTHER_ENVIRONMENT_ID = "env#2";
 
     @Mock
     private LicenseService licenseService;
@@ -78,12 +68,6 @@ public class GatewayOrganizationLicenseManagerTest {
     private EventManager eventManager;
 
     @Mock
-    private SecurityDomainManager securityDomainManager;
-
-    @Mock
-    private EnvironmentService environmentService;
-
-    @Mock
     private Environment environment;
 
     @Mock
@@ -96,8 +80,7 @@ public class GatewayOrganizationLicenseManagerTest {
 
     @Before
     public void setUp() {
-        when(licenseService.findAll()).thenReturn(Flowable.empty());
-        when(securityDomainManager.domains()).thenReturn(List.of());
+        lenient().when(licenseService.findAll()).thenReturn(Flowable.empty());
     }
 
     @After
@@ -115,7 +98,7 @@ public class GatewayOrganizationLicenseManagerTest {
         lenient().when(environment.getProperty("cloud.enabled", Boolean.class)).thenReturn(managedCloud);
         lenient().when(environment.getProperty("installation.type", "standalone")).thenReturn(managedCloud ? "managed" : "standalone");
         manager = new GatewayOrganizationLicenseManager(licenseService, licenseFactory, licenseManager,
-                eventManager, securityDomainManager, environmentService, environment);
+                eventManager, environment);
         return manager;
     }
 
@@ -168,8 +151,7 @@ public class GatewayOrganizationLicenseManagerTest {
     }
 
     @Test
-    public void shouldRegisterLicenseAndRedeployAffectedDomainsOnDeployEvent() throws Exception {
-        givenDeployedDomains();
+    public void shouldRegisterLicenseOnDeployEvent() throws Exception {
         when(licenseService.findByReference(ReferenceType.ORGANIZATION, ORGANIZATION_ID))
                 .thenReturn(Maybe.just(license(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "license-1")));
         when(licenseFactory.create(ReferenceType.ORGANIZATION.name(), ORGANIZATION_ID, "license-1")).thenReturn(parsedLicense);
@@ -178,19 +160,14 @@ public class GatewayOrganizationLicenseManagerTest {
         manager.onEvent(new SimpleEvent<>(LicenseEvent.DEPLOY, payload(Action.CREATE)));
 
         verify(licenseManager).registerOrganizationLicense(ORGANIZATION_ID, parsedLicense);
-        verify(securityDomainManager, timeout(2000)).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#1")));
-        verify(securityDomainManager, never()).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#2")));
     }
 
     @Test
-    public void shouldDeregisterLicenseAndRedeployOnUndeployEvent() throws Exception {
-        givenDeployedDomains();
-
+    public void shouldDeregisterLicenseOnUndeployEvent() throws Exception {
         manager(true).doStart();
         manager.onEvent(new SimpleEvent<>(LicenseEvent.UNDEPLOY, payload(Action.DELETE)));
 
         verify(licenseManager).registerOrganizationLicense(ORGANIZATION_ID, null);
-        verify(securityDomainManager, timeout(2000)).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#1")));
     }
 
     @Test
@@ -213,18 +190,17 @@ public class GatewayOrganizationLicenseManagerTest {
     }
 
     @Test
-    public void shouldRedeployAffectedDomainsOnLicenseExpiry() throws Exception {
-        givenDeployedDomains();
-
+    public void shouldRegisterExpiryListenerForObservabilityOnly() throws Exception {
         manager(true).doStart();
 
         verify(licenseManager).onLicenseExpires(expirationListenerCaptor.capture());
         when(parsedLicense.getReferenceType()).thenReturn(io.gravitee.node.api.license.License.REFERENCE_TYPE_ORGANIZATION);
         when(parsedLicense.getReferenceId()).thenReturn(ORGANIZATION_ID);
+
         expirationListenerCaptor.getValue().accept(parsedLicense);
 
-        verify(securityDomainManager, timeout(2000)).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#1")));
-        verify(securityDomainManager, never()).updateReactive(org.mockito.ArgumentMatchers.argThat(d -> d.getId().equals("domain#2")));
+        verify(licenseService, never()).findByReference(any(), anyString());
+        verify(licenseManager, never()).registerOrganizationLicense(anyString(), any());
     }
 
     @Test
@@ -232,30 +208,6 @@ public class GatewayOrganizationLicenseManagerTest {
         manager(false).doStart();
 
         verifyNoInteractions(eventManager, licenseService, licenseManager);
-    }
-
-    private void givenDeployedDomains() {
-        Domain affectedDomain = domain("domain#1", ENVIRONMENT_ID);
-        Domain otherDomain = domain("domain#2", OTHER_ENVIRONMENT_ID);
-        when(securityDomainManager.domains()).thenReturn(List.of(affectedDomain, otherDomain));
-        when(securityDomainManager.updateReactive(any())).thenReturn(Completable.complete());
-        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(environment(ENVIRONMENT_ID, ORGANIZATION_ID)));
-        when(environmentService.findById(OTHER_ENVIRONMENT_ID)).thenReturn(Single.just(environment(OTHER_ENVIRONMENT_ID, OTHER_ORGANIZATION_ID)));
-    }
-
-    private static Domain domain(String id, String environmentId) {
-        Domain domain = new Domain();
-        domain.setId(id);
-        domain.setReferenceType(ReferenceType.ENVIRONMENT);
-        domain.setReferenceId(environmentId);
-        return domain;
-    }
-
-    private static io.gravitee.am.model.Environment environment(String id, String organizationId) {
-        io.gravitee.am.model.Environment env = new io.gravitee.am.model.Environment();
-        env.setId(id);
-        env.setOrganizationId(organizationId);
-        return env;
     }
 
     private static License license(ReferenceType referenceType, String referenceId, String rawLicense) {


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7238](https://gravitee.atlassian.net/browse/AM-7238)

## :pencil2: A description of the changes proposed in the pull request
Simplify gateway responsiveness to organization license changes in managed cloud mode: only enforce license checks of plugins at domain redeployment and gateway restarts.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7238]: https://gravitee.atlassian.net/browse/AM-7238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ