### PR TITLE
test: (AM-7330) enhance automated tests for domain picker feature

### DIFF
--- a/gravitee-am-test/playwright/pages/home.page.ts
+++ b/gravitee-am-test/playwright/pages/home.page.ts
@@ -47,6 +47,44 @@ export class HomePage extends BasePage {
     return this.page.locator('.domain-information a').filter({ hasText: name }).first();
   }
 
+  get datatable(): Locator {
+    return this.page.locator('ngx-datatable');
+  }
+
+  /** Row container for a domain in the "All domains" list, by name. */
+  domainRow(name: string): Locator {
+    return this.datatable.locator('.datatable-body-row').filter({ hasText: name });
+  }
+
+  /** Toggle the default-domain star for a row on the "All domains" list page. */
+  async toggleDefaultInList(name: string): Promise<void> {
+    await this.domainRow(name)
+      .getByRole('button')
+      .filter({ has: this.page.locator('mat-icon', { hasText: /^star/ }) })
+      .click();
+  }
+
+  /** Toggle the pin control for a row on the "All domains" list page. */
+  async togglePinInList(name: string): Promise<void> {
+    await this.domainRow(name)
+      .getByRole('button')
+      .filter({ has: this.page.locator('mat-icon', { hasText: /bookmark/ }) })
+      .click();
+  }
+
+  /** Default-domain star icon for a row on the "All domains" list page — asserts via toHaveText, not a one-shot read, since the icon updates asynchronously after the toggle click. */
+  defaultIconInList(name: string): Locator {
+    return this.domainRow(name).locator('mat-icon').filter({ hasText: /^star/ }).first();
+  }
+
+  /** Pin/bookmark icon for a row on the "All domains" list page — asserts via toHaveText, not a one-shot read, since the icon updates asynchronously after the toggle click. */
+  pinIconInList(name: string): Locator {
+    return this.domainRow(name)
+      .locator('mat-icon')
+      .filter({ hasText: /bookmark/ })
+      .first();
+  }
+
   /** Navigate to a domain's detail page via the domains list search. */
   async navigateToDomain(domainName: string): Promise<void> {
     await this.gotoDomainsList();

--- a/gravitee-am-test/playwright/pages/home.page.ts
+++ b/gravitee-am-test/playwright/pages/home.page.ts
@@ -51,38 +51,36 @@ export class HomePage extends BasePage {
     return this.page.locator('ngx-datatable');
   }
 
-  /** Row container for a domain in the "All domains" list, by name. */
-  domainRow(name: string): Locator {
+  /** Row container for a domain in the "All domains" list, by name — filters via the search box first, same as navigateToDomain, to avoid pagination issues when many domains exist. */
+  async domainRow(name: string): Promise<Locator> {
+    const searchInput = this.page.getByPlaceholder(/search/i).first();
+    await expect(searchInput).toBeVisible();
+    await searchInput.fill(name);
     return this.datatable.locator('.datatable-body-row').filter({ hasText: name });
   }
 
   /** Toggle the default-domain star for a row on the "All domains" list page. */
   async toggleDefaultInList(name: string): Promise<void> {
-    await this.domainRow(name)
-      .getByRole('button')
-      .filter({ has: this.page.locator('mat-icon', { hasText: /^star/ }) })
-      .click();
+    await this.domainRow(name); // filters the datatable so the row is actually rendered first
+    await this.page.getByTestId(`domainDefaultToggle-${name}`).click();
   }
 
   /** Toggle the pin control for a row on the "All domains" list page. */
   async togglePinInList(name: string): Promise<void> {
-    await this.domainRow(name)
-      .getByRole('button')
-      .filter({ has: this.page.locator('mat-icon', { hasText: /bookmark/ }) })
-      .click();
+    await this.domainRow(name); // filters the datatable so the row is actually rendered first
+    await this.page.getByTestId(`domainPinToggle-${name}`).click();
   }
 
   /** Default-domain star icon for a row on the "All domains" list page — asserts via toHaveText, not a one-shot read, since the icon updates asynchronously after the toggle click. */
-  defaultIconInList(name: string): Locator {
-    return this.domainRow(name).locator('mat-icon').filter({ hasText: /^star/ }).first();
+  async defaultIconInList(name: string): Promise<Locator> {
+    await this.domainRow(name);
+    return this.page.getByTestId(`domainDefaultToggle-${name}`).locator('mat-icon');
   }
 
   /** Pin/bookmark icon for a row on the "All domains" list page — asserts via toHaveText, not a one-shot read, since the icon updates asynchronously after the toggle click. */
-  pinIconInList(name: string): Locator {
-    return this.domainRow(name)
-      .locator('mat-icon')
-      .filter({ hasText: /bookmark/ })
-      .first();
+  async pinIconInList(name: string): Promise<Locator> {
+    await this.domainRow(name);
+    return this.page.getByTestId(`domainPinToggle-${name}`).locator('mat-icon');
   }
 
   /** Navigate to a domain's detail page via the domains list search. */

--- a/gravitee-am-test/playwright/pages/navbar.page.ts
+++ b/gravitee-am-test/playwright/pages/navbar.page.ts
@@ -16,7 +16,7 @@
 import { Locator, expect } from '@playwright/test';
 import { BasePage } from './base.page';
 
-type PickerSection = 'Current' | 'Default' | 'Pinned';
+type PickerSection = 'Current' | 'Default' | 'Pinned' | 'Results';
 
 /** Page object for the navbar domain picker (opens from the current-domain chip). */
 export class NavbarPage extends BasePage {
@@ -57,6 +57,21 @@ export class NavbarPage extends BasePage {
   /** The "All domains" link in the picker footer. */
   get allDomainsLink(): Locator {
     return this.menu.locator('.userAccountFooter__link', { hasText: /all domains/i });
+  }
+
+  /** Message shown in place of Results when the search matches no domain. */
+  get noSearchResultsMessage(): Locator {
+    return this.menu.locator('.domains_list__empty');
+  }
+
+  /** The avatar button that opens the account menu (profile/sign out) — distinct from the domain picker trigger. */
+  get accountMenuTrigger(): Locator {
+    return this.page.getByTestId('user-account-button');
+  }
+
+  /** The account menu overlay — scoped by its sign-out link since it shares a panel class with the domain picker. */
+  get accountMenu(): Locator {
+    return this.page.locator('.mat-mdc-menu-panel', { has: this.page.locator('a[routerLink="/logout"]') });
   }
 
   row(name: string): Locator {

--- a/gravitee-am-test/playwright/pages/navbar.page.ts
+++ b/gravitee-am-test/playwright/pages/navbar.page.ts
@@ -86,21 +86,13 @@ export class NavbarPage extends BasePage {
 
   /** Toggle the pin control on a row (controls reveal on hover). */
   async pin(name: string): Promise<void> {
-    const row = this.row(name);
-    await row.hover();
-    await row
-      .getByRole('button')
-      .filter({ has: this.page.locator('mat-icon', { hasText: /bookmark/ }) })
-      .click();
+    await this.row(name).hover();
+    await this.menu.getByTestId(`domainPinToggle-${name}`).click();
   }
 
   /** Toggle the default control on a row (controls reveal on hover). */
   async setDefault(name: string): Promise<void> {
-    const row = this.row(name);
-    await row.hover();
-    await row
-      .getByRole('button')
-      .filter({ has: this.page.locator('mat-icon', { hasText: /^star/ }) })
-      .click();
+    await this.row(name).hover();
+    await this.menu.getByTestId(`domainDefaultToggle-${name}`).click();
   }
 }

--- a/gravitee-am-test/playwright/tests/navbar/domain-picker.spec.ts
+++ b/gravitee-am-test/playwright/tests/navbar/domain-picker.spec.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { safeDeleteDomain } from '@management-commands/domain-management-commands';
+
 import { test, expect } from '../../fixtures/domain-picker.fixture';
 import { uniqueTestName as uniqueName } from '../../utils/fixture-helpers';
 
@@ -124,5 +126,174 @@ test.describe('Navbar domain picker', () => {
 
     await navbar.open();
     await expect(navbar.row(name)).toBeVisible();
+  });
+
+  test('reload lands the user directly on their default domain', async ({ homePage, extraDomains, setPreferences }) => {
+    await setPreferences({
+      defaultDomainId: extraDomains.toDefault.id,
+      defaultEnvironmentId: process.env.AM_DEF_ENV_ID,
+    });
+
+    await homePage.navigate('/');
+
+    await homePage.expectUrlMatches(new RegExp(`/domains/${extraDomains.toDefault.id}`));
+  });
+
+  test('falls back gracefully when the default domain has been deleted', async ({
+    page,
+    homePage,
+    adminToken,
+    extraDomains,
+    setPreferences,
+  }) => {
+    await setPreferences({
+      defaultDomainId: extraDomains.toDefault.id,
+      defaultEnvironmentId: process.env.AM_DEF_ENV_ID,
+    });
+
+    await safeDeleteDomain(extraDomains.toDefault.id, adminToken);
+
+    await homePage.navigate('/');
+
+    // never tries to load the now-deleted domain, and no error is shown
+    expect(page.url()).not.toContain(extraDomains.toDefault.id);
+    await expect(page.locator('text=/not found|error/i')).toHaveCount(0);
+  });
+
+  test('pin/default controls on the "All domains" list stay in sync with the navbar picker', async ({ homePage, navbar, extraDomains }) => {
+    await homePage.gotoDomainsList();
+
+    await homePage.togglePinInList(extraDomains.toPin.name);
+    await homePage.toggleDefaultInList(extraDomains.toDefault.name);
+
+    // toHaveText polls until the async toggle request resolves and the icon re-renders
+    await expect(homePage.pinIconInList(extraDomains.toPin.name)).toHaveText('bookmark');
+    await expect(homePage.defaultIconInList(extraDomains.toDefault.name)).toHaveText('star');
+
+    // reflected in the navbar picker
+    await navbar.open();
+    await expect(navbar.sectionLabel('Default')).toBeVisible();
+    await expect(navbar.row(extraDomains.toDefault.name)).toBeVisible();
+    await expect(navbar.sectionLabel('Pinned')).toBeVisible();
+    await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
+
+    // and unpinning from the navbar picker is reflected back on the "All domains" list
+    await navbar.pin(extraDomains.toPin.name);
+    await homePage.gotoDomainsList();
+    await expect(homePage.pinIconInList(extraDomains.toPin.name)).toHaveText('bookmark_border');
+  });
+
+  test('avatar opens the account menu, not the domain picker', async ({ homePage, navbar, currentDomain }) => {
+    await homePage.navigateToDomain(currentDomain.name);
+
+    await navbar.accountMenuTrigger.click();
+
+    await expect(navbar.accountMenu).toBeVisible();
+    await expect(navbar.search).toHaveCount(0);
+  });
+
+  test('a pinned domain survives a full page reload', async ({ page, homePage, navbar, currentDomain, extraDomains }) => {
+    await homePage.navigateToDomain(currentDomain.name);
+    await navbar.open();
+    await navbar.searchFor(extraDomains.toPin.name);
+    await navbar.pin(extraDomains.toPin.name);
+    await navbar.searchFor('');
+
+    await page.reload();
+    await homePage.waitForReady();
+
+    await navbar.open();
+    await expect(navbar.sectionLabel('Pinned')).toBeVisible();
+    await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
+  });
+
+  test('unpinning a domain via the picker removes it from Pinned', async ({
+    homePage,
+    navbar,
+    currentDomain,
+    extraDomains,
+    setPreferences,
+  }) => {
+    await setPreferences({ pinnedDomainIds: [extraDomains.toPin.id] });
+
+    await homePage.navigateToDomain(currentDomain.name);
+    await navbar.open();
+    await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
+
+    await navbar.pin(extraDomains.toPin.name);
+
+    await expect(navbar.row(extraDomains.toPin.name)).toHaveCount(0);
+    await expect(navbar.sectionLabel('Pinned')).toHaveCount(0);
+  });
+
+  test('clicking the picker star sets a domain as default', async ({ homePage, navbar, currentDomain, extraDomains }) => {
+    await homePage.navigateToDomain(currentDomain.name);
+    await navbar.open();
+    await navbar.searchFor(extraDomains.toDefault.name);
+    await navbar.setDefault(extraDomains.toDefault.name);
+    await navbar.searchFor('');
+
+    await expect(navbar.sectionLabel('Default')).toBeVisible();
+    await expect(navbar.row(extraDomains.toDefault.name)).toBeVisible();
+  });
+
+  test('clicking the picker star again unsets the default domain', async ({
+    homePage,
+    navbar,
+    currentDomain,
+    extraDomains,
+    setPreferences,
+  }) => {
+    await setPreferences({
+      defaultDomainId: extraDomains.toDefault.id,
+      defaultEnvironmentId: process.env.AM_DEF_ENV_ID,
+    });
+
+    await homePage.navigateToDomain(currentDomain.name);
+    await navbar.open();
+    await expect(navbar.sectionLabel('Default')).toBeVisible();
+
+    await navbar.setDefault(extraDomains.toDefault.name);
+
+    await expect(navbar.sectionLabel('Default')).toHaveCount(0);
+  });
+
+  test('search filters the picker to matching domains only', async ({ homePage, navbar, currentDomain, extraDomains }) => {
+    await homePage.navigateToDomain(currentDomain.name);
+    await navbar.open();
+
+    await navbar.searchFor(extraDomains.toPin.name);
+
+    await expect(navbar.sectionLabel('Results')).toBeVisible();
+    await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
+    await expect(navbar.row(extraDomains.toDefault.name)).toHaveCount(0);
+    await expect(navbar.sectionLabel('Current')).toHaveCount(0);
+  });
+
+  test('search with no matches shows the empty message', async ({ homePage, navbar, currentDomain }) => {
+    await homePage.navigateToDomain(currentDomain.name);
+    await navbar.open();
+
+    await navbar.searchFor('zz-no-such-domain-exists-xyz');
+
+    await expect(navbar.noSearchResultsMessage).toHaveText(/no domains match/i);
+  });
+
+  test('a deleted pinned domain quietly drops out of the picker', async ({
+    homePage,
+    navbar,
+    currentDomain,
+    extraDomains,
+    adminToken,
+    setPreferences,
+  }) => {
+    await setPreferences({ pinnedDomainIds: [extraDomains.toPin.id] });
+    await safeDeleteDomain(extraDomains.toPin.id, adminToken);
+
+    await homePage.navigateToDomain(currentDomain.name);
+    await navbar.open();
+
+    await expect(navbar.row(extraDomains.toPin.name)).toHaveCount(0);
+    await expect(navbar.search).toBeVisible();
   });
 });

--- a/gravitee-am-test/playwright/tests/navbar/domain-picker.spec.ts
+++ b/gravitee-am-test/playwright/tests/navbar/domain-picker.spec.ts
@@ -18,8 +18,10 @@ import { safeDeleteDomain } from '@management-commands/domain-management-command
 import { test, expect } from '../../fixtures/domain-picker.fixture';
 import { uniqueTestName as uniqueName } from '../../utils/fixture-helpers';
 
-// tests share the admin user's console preferences, so run them one at a time
-test.describe.configure({ mode: 'serial' });
+// tests share the admin user's console preferences, so they must run one at a time in the
+// same worker (this also overrides fullyParallel for this file) — 'default' rather than
+// 'serial' so one failing test doesn't skip every test after it
+test.describe.configure({ mode: 'default' });
 
 test.describe('Navbar domain picker', () => {
   test('opens from the domain chip and shows the current domain', async ({ homePage, navbar, currentDomain }) => {
@@ -68,33 +70,43 @@ test.describe('Navbar domain picker', () => {
     await expect(navbar.chipDefaultStar).toHaveCount(0);
   });
 
-  test('pinning a domain from search persists it under Pinned', async ({ homePage, navbar, currentDomain, extraDomains }) => {
+  test('pin, unpin, set default, and unset default all work via the picker controls', async ({
+    homePage,
+    navbar,
+    currentDomain,
+    extraDomains,
+  }) => {
     await homePage.navigateToDomain(currentDomain.name);
     await navbar.open();
 
+    // pin a domain found via search, and confirm it sticks after clearing the search
     await navbar.searchFor(extraDomains.toPin.name);
     await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
     await navbar.pin(extraDomains.toPin.name);
-
-    // clearing the search returns to the Current/Pinned view where the pin should now stick
     await navbar.searchFor('');
     await expect(navbar.sectionLabel('Pinned')).toBeVisible();
     await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
-  });
 
-  test('marks the chip with a star when the current domain is the default', async ({ homePage, navbar, currentDomain, setPreferences }) => {
-    await setPreferences({
-      defaultDomainId: currentDomain.id,
-      defaultEnvironmentId: process.env.AM_DEF_ENV_ID,
-    });
+    // unpin it again — the row disappears once the PUT resolves
+    await navbar.pin(extraDomains.toPin.name);
+    await expect(navbar.row(extraDomains.toPin.name)).toHaveCount(0);
+    await expect(navbar.sectionLabel('Pinned')).toHaveCount(0);
 
-    await homePage.navigateToDomain(currentDomain.name);
+    // set a different domain as default — it gets its own section
+    await navbar.searchFor(extraDomains.toDefault.name);
+    await navbar.setDefault(extraDomains.toDefault.name);
+    await navbar.searchFor('');
+    await expect(navbar.sectionLabel('Default')).toBeVisible();
+    await expect(navbar.row(extraDomains.toDefault.name)).toBeVisible();
 
+    // unset it again — the Default section disappears
+    await navbar.setDefault(extraDomains.toDefault.name);
+    await expect(navbar.sectionLabel('Default')).toHaveCount(0);
+
+    // setting the current domain itself as default shows a star on the chip,
+    // and folds into Current instead of a separate Default section
+    await navbar.setDefault(currentDomain.name);
     await expect(navbar.chipDefaultStar).toBeVisible();
-
-    // when current is the default it only appears under Current, never a separate Default section
-    await navbar.open();
-    await expect(navbar.sectionLabel('Current')).toBeVisible();
     await expect(navbar.sectionLabel('Default')).toHaveCount(0);
   });
 
@@ -128,15 +140,36 @@ test.describe('Navbar domain picker', () => {
     await expect(navbar.row(name)).toBeVisible();
   });
 
-  test('reload lands the user directly on their default domain', async ({ homePage, extraDomains, setPreferences }) => {
+  test('reload persists both a pin made via the picker and the saved default-domain redirect', async ({
+    homePage,
+    navbar,
+    currentDomain,
+    extraDomains,
+    setPreferences,
+  }) => {
     await setPreferences({
       defaultDomainId: extraDomains.toDefault.id,
       defaultEnvironmentId: process.env.AM_DEF_ENV_ID,
     });
 
-    await homePage.navigate('/');
+    await homePage.navigateToDomain(currentDomain.name);
+    await navbar.open();
+    await navbar.searchFor(extraDomains.toPin.name);
+    await navbar.pin(extraDomains.toPin.name);
+    await navbar.searchFor('');
+    // wait for the pin to actually land before reloading — otherwise the in-flight
+    // PUT can be cancelled by the navigation and the pin would never persist
+    await expect(navbar.sectionLabel('Pinned')).toBeVisible();
+    await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
 
+    // a full reload-equivalent navigation to root — proves the pin persisted server-side
+    // AND that the default-domain redirect fires correctly on this fresh bootstrap
+    await homePage.navigate('/');
     await homePage.expectUrlMatches(new RegExp(`/domains/${extraDomains.toDefault.id}`));
+
+    await navbar.open();
+    await expect(navbar.sectionLabel('Pinned')).toBeVisible();
+    await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
   });
 
   test('falls back gracefully when the default domain has been deleted', async ({
@@ -155,8 +188,10 @@ test.describe('Navbar domain picker', () => {
 
     await homePage.navigate('/');
 
-    // never tries to load the now-deleted domain, and no error is shown
-    expect(page.url()).not.toContain(extraDomains.toDefault.id);
+    // toDefault is deleted, so toPin is the only domain left — the fallback
+    // deterministically lands here, proving the redirect chain actually completed
+    await homePage.expectUrlMatches(new RegExp(`/domains/${extraDomains.toPin.id}`));
+    await expect(page).not.toHaveURL(new RegExp(extraDomains.toDefault.id));
     await expect(page.locator('text=/not found|error/i')).toHaveCount(0);
   });
 
@@ -167,8 +202,8 @@ test.describe('Navbar domain picker', () => {
     await homePage.toggleDefaultInList(extraDomains.toDefault.name);
 
     // toHaveText polls until the async toggle request resolves and the icon re-renders
-    await expect(homePage.pinIconInList(extraDomains.toPin.name)).toHaveText('bookmark');
-    await expect(homePage.defaultIconInList(extraDomains.toDefault.name)).toHaveText('star');
+    await expect(await homePage.pinIconInList(extraDomains.toPin.name)).toHaveText('bookmark');
+    await expect(await homePage.defaultIconInList(extraDomains.toDefault.name)).toHaveText('star');
 
     // reflected in the navbar picker
     await navbar.open();
@@ -179,8 +214,11 @@ test.describe('Navbar domain picker', () => {
 
     // and unpinning from the navbar picker is reflected back on the "All domains" list
     await navbar.pin(extraDomains.toPin.name);
+    // wait for the PUT to resolve and the row to disappear before navigating away —
+    // otherwise the in-flight request can be cancelled by the navigation
+    await expect(navbar.row(extraDomains.toPin.name)).toHaveCount(0);
     await homePage.gotoDomainsList();
-    await expect(homePage.pinIconInList(extraDomains.toPin.name)).toHaveText('bookmark_border');
+    await expect(await homePage.pinIconInList(extraDomains.toPin.name)).toHaveText('bookmark_border');
   });
 
   test('avatar opens the account menu, not the domain picker', async ({ homePage, navbar, currentDomain }) => {
@@ -192,90 +230,22 @@ test.describe('Navbar domain picker', () => {
     await expect(navbar.search).toHaveCount(0);
   });
 
-  test('a pinned domain survives a full page reload', async ({ page, homePage, navbar, currentDomain, extraDomains }) => {
-    await homePage.navigateToDomain(currentDomain.name);
-    await navbar.open();
-    await navbar.searchFor(extraDomains.toPin.name);
-    await navbar.pin(extraDomains.toPin.name);
-    await navbar.searchFor('');
-
-    await page.reload();
-    await homePage.waitForReady();
-
-    await navbar.open();
-    await expect(navbar.sectionLabel('Pinned')).toBeVisible();
-    await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
-  });
-
-  test('unpinning a domain via the picker removes it from Pinned', async ({
+  test('search filters to matching domains, and shows an empty message when nothing matches', async ({
     homePage,
     navbar,
     currentDomain,
     extraDomains,
-    setPreferences,
   }) => {
-    await setPreferences({ pinnedDomainIds: [extraDomains.toPin.id] });
-
-    await homePage.navigateToDomain(currentDomain.name);
-    await navbar.open();
-    await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
-
-    await navbar.pin(extraDomains.toPin.name);
-
-    await expect(navbar.row(extraDomains.toPin.name)).toHaveCount(0);
-    await expect(navbar.sectionLabel('Pinned')).toHaveCount(0);
-  });
-
-  test('clicking the picker star sets a domain as default', async ({ homePage, navbar, currentDomain, extraDomains }) => {
-    await homePage.navigateToDomain(currentDomain.name);
-    await navbar.open();
-    await navbar.searchFor(extraDomains.toDefault.name);
-    await navbar.setDefault(extraDomains.toDefault.name);
-    await navbar.searchFor('');
-
-    await expect(navbar.sectionLabel('Default')).toBeVisible();
-    await expect(navbar.row(extraDomains.toDefault.name)).toBeVisible();
-  });
-
-  test('clicking the picker star again unsets the default domain', async ({
-    homePage,
-    navbar,
-    currentDomain,
-    extraDomains,
-    setPreferences,
-  }) => {
-    await setPreferences({
-      defaultDomainId: extraDomains.toDefault.id,
-      defaultEnvironmentId: process.env.AM_DEF_ENV_ID,
-    });
-
-    await homePage.navigateToDomain(currentDomain.name);
-    await navbar.open();
-    await expect(navbar.sectionLabel('Default')).toBeVisible();
-
-    await navbar.setDefault(extraDomains.toDefault.name);
-
-    await expect(navbar.sectionLabel('Default')).toHaveCount(0);
-  });
-
-  test('search filters the picker to matching domains only', async ({ homePage, navbar, currentDomain, extraDomains }) => {
     await homePage.navigateToDomain(currentDomain.name);
     await navbar.open();
 
     await navbar.searchFor(extraDomains.toPin.name);
-
     await expect(navbar.sectionLabel('Results')).toBeVisible();
     await expect(navbar.row(extraDomains.toPin.name)).toBeVisible();
     await expect(navbar.row(extraDomains.toDefault.name)).toHaveCount(0);
     await expect(navbar.sectionLabel('Current')).toHaveCount(0);
-  });
-
-  test('search with no matches shows the empty message', async ({ homePage, navbar, currentDomain }) => {
-    await homePage.navigateToDomain(currentDomain.name);
-    await navbar.open();
 
     await navbar.searchFor('zz-no-such-domain-exists-xyz');
-
     await expect(navbar.noSearchResultsMessage).toHaveText(/no domains match/i);
   });
 
@@ -293,7 +263,10 @@ test.describe('Navbar domain picker', () => {
     await homePage.navigateToDomain(currentDomain.name);
     await navbar.open();
 
+    // prove the picker actually rendered before asserting the deleted domain is absent
+    await expect(navbar.sectionLabel('Current')).toBeVisible();
     await expect(navbar.row(extraDomains.toPin.name)).toHaveCount(0);
+    await expect(navbar.sectionLabel('Pinned')).toHaveCount(0);
     await expect(navbar.search).toBeVisible();
   });
 });

--- a/gravitee-am-test/specs/management/user-preferences.jest.spec.ts
+++ b/gravitee-am-test/specs/management/user-preferences.jest.spec.ts
@@ -67,6 +67,38 @@ describe('Console user preferences', () => {
     expect(getResponse.body).toMatchObject(preferences);
   });
 
+  it('should replace the whole preferences object on PUT, not merge fields', async () => {
+    const initial = {
+      defaultDomainId: domainA.id,
+      defaultEnvironmentId: process.env.AM_DEF_ENV_ID,
+      pinnedDomainIds: [domainA.id, domainB.id],
+    };
+    const initialResponse = await performPut(managementUrl(), '/user/preferences', initial, authHeaders());
+    expect(initialResponse.status).toBe(200);
+
+    const partialUpdate = { pinnedDomainIds: [domainB.id] };
+    const putResponse = await performPut(managementUrl(), '/user/preferences', partialUpdate, authHeaders());
+    expect(putResponse.status).toBe(200);
+    expect(putResponse.body.pinnedDomainIds).toEqual([domainB.id]);
+    expect(putResponse.body.defaultDomainId).toBeUndefined();
+    expect(putResponse.body.defaultEnvironmentId).toBeUndefined();
+
+    const getResponse = await performGet(managementUrl(), '/user/preferences', authHeaders());
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.body.pinnedDomainIds).toEqual([domainB.id]);
+    expect(getResponse.body.defaultDomainId).toBeUndefined();
+    expect(getResponse.body.defaultEnvironmentId).toBeUndefined();
+  });
+
+  it('should accept exactly 50 pinned domains', async () => {
+    const preferences = { pinnedDomainIds: Array.from({ length: 50 }, (_, i) => `domain-${i}`) };
+
+    const response = await performPut(managementUrl(), '/user/preferences', preferences, authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body.pinnedDomainIds).toHaveLength(50);
+  });
+
   it('should reject more than 50 pinned domains', async () => {
     const preferences = { pinnedDomainIds: Array.from({ length: 51 }, (_, i) => `domain-${i}`) };
 
@@ -79,6 +111,25 @@ describe('Console user preferences', () => {
     const response = await performGet(managementUrl(), '/user/preferences', { 'Content-Type': 'application/json' });
 
     expect(response.status).toBe(401);
+  });
+
+  it('should record an audit entry when preferences are updated', async () => {
+    const putResponse = await performPut(
+      managementUrl(),
+      '/user/preferences',
+      { defaultDomainId: domainA.id, defaultEnvironmentId: process.env.AM_DEF_ENV_ID },
+      authHeaders(),
+    );
+    expect(putResponse.status).toBe(200);
+
+    const auditResponse = await performGet(getOrganisationManagementUrl(), '/audits?type=USER_PREFERENCES_UPDATED&size=1', authHeaders());
+
+    expect(auditResponse.status).toBe(200);
+    expect(auditResponse.body.data.length).toBeGreaterThan(0);
+    expect(auditResponse.body.data[0]).toMatchObject({
+      type: 'USER_PREFERENCES_UPDATED',
+      outcome: { status: 'success' },
+    });
   });
 });
 
@@ -93,5 +144,17 @@ describe('Domains list filtered by ids', () => {
     expect(response.status).toBe(200);
     expect(response.body.data.map((domain) => domain.id)).toEqual([domainA.id]);
     expect(response.body.totalCount).toBe(1);
+  });
+
+  it('should reject more than 50 ids', async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => `domain-${i}`).join('&ids=');
+
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      `/environments/${process.env.AM_DEF_ENV_ID}/domains?ids=${ids}`,
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(400);
   });
 });

--- a/gravitee-am-test/specs/management/user-preferences.jest.spec.ts
+++ b/gravitee-am-test/specs/management/user-preferences.jest.spec.ts
@@ -20,6 +20,7 @@ import { createDomain, safeDeleteDomain } from '@management-commands/domain-mana
 import { getOrganisationManagementUrl } from '@management-commands/service/utils';
 import { performGet, performPut } from '@gateway-commands/oauth-oidc-commands';
 import { uniqueName } from '@utils-commands/misc';
+import { retryUntil } from '@utils-commands/retry';
 import type { Domain } from '@management-models/Domain';
 import { setup } from '../test-fixture';
 
@@ -114,6 +115,7 @@ describe('Console user preferences', () => {
   });
 
   it('should record an audit entry when preferences are updated', async () => {
+    const beforePut = Date.now();
     const putResponse = await performPut(
       managementUrl(),
       '/user/preferences',
@@ -122,10 +124,14 @@ describe('Console user preferences', () => {
     );
     expect(putResponse.status).toBe(200);
 
-    const auditResponse = await performGet(getOrganisationManagementUrl(), '/audits?type=USER_PREFERENCES_UPDATED&size=1', authHeaders());
+    // audits are written asynchronously, and `from` excludes any USER_PREFERENCES_UPDATED
+    // entries from earlier tests in this file so this only matches the update above
+    const auditResponse = await retryUntil(
+      () => performGet(getOrganisationManagementUrl(), `/audits?type=USER_PREFERENCES_UPDATED&from=${beforePut}&size=1`, authHeaders()),
+      (response) => response.status === 200 && response.body.data.length > 0,
+      { timeoutMillis: 10_000, intervalMillis: 250 },
+    );
 
-    expect(auditResponse.status).toBe(200);
-    expect(auditResponse.body.data.length).toBeGreaterThan(0);
     expect(auditResponse.body.data[0]).toMatchObject({
       type: 'USER_PREFERENCES_UPDATED',
       outcome: { status: 'success' },

--- a/gravitee-am-ui/src/app/components/navbar/navbar.component.html
+++ b/gravitee-am-ui/src/app/components/navbar/navbar.component.html
@@ -110,6 +110,7 @@
                     mat-icon-button
                     (click)="toggleDefault(domain, $event)"
                     [matTooltip]="isDefault(domain.id) ? 'Unset default domain' : 'Set as default domain'"
+                    [attr.data-testid]="'domainDefaultToggle-' + domain.name"
                   >
                     <mat-icon>{{ isDefault(domain.id) ? 'star' : 'star_border' }}</mat-icon>
                   </button>
@@ -117,6 +118,7 @@
                     mat-icon-button
                     (click)="togglePin(domain, $event)"
                     [matTooltip]="isPinned(domain.id) ? 'Unpin domain' : 'Pin domain'"
+                    [attr.data-testid]="'domainPinToggle-' + domain.name"
                   >
                     <!-- bookmark instead of push_pin: the bundled Material Icons font predates the push_pin ligature -->
                     <mat-icon>{{ isPinned(domain.id) ? 'bookmark' : 'bookmark_border' }}</mat-icon>

--- a/gravitee-am-ui/src/app/services/user-preferences.service.spec.ts
+++ b/gravitee-am-ui/src/app/services/user-preferences.service.spec.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+
+import { AppConfig } from '../../config/app.config';
+
+import { UserPreferencesService } from './user-preferences.service';
+
+describe('UserPreferencesService', () => {
+  let httpTestingController: HttpTestingController;
+  let service: UserPreferencesService;
+  const preferencesUrl = `${AppConfig.settings.baseURL}/user/preferences`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      teardown: { destroyAfterEach: false },
+      providers: [UserPreferencesService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+    });
+
+    httpTestingController = TestBed.get(HttpTestingController);
+    service = TestBed.get(UserPreferencesService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('load', () => {
+    it('stores fetched preferences and exposes them via preferences()', (done) => {
+      const response = { defaultDomainId: 'domain-1', defaultEnvironmentId: 'env-1', pinnedDomainIds: ['domain-1', 'domain-2'] };
+
+      service.load().subscribe(() => {
+        expect(service.preferences()).toEqual(response);
+        done();
+      });
+
+      httpTestingController.expectOne({ method: 'GET', url: preferencesUrl }).flush(response);
+    });
+
+    it('falls back to an empty object when the server returns nothing', (done) => {
+      service.load().subscribe(() => {
+        expect(service.preferences()).toEqual({});
+        done();
+      });
+
+      httpTestingController.expectOne({ method: 'GET', url: preferencesUrl }).flush(null);
+    });
+  });
+
+  describe('pinnedDomainIds / isPinned', () => {
+    it('returns an empty array and false when nothing has been loaded yet', () => {
+      expect(service.pinnedDomainIds()).toEqual([]);
+      expect(service.isPinned('domain-1')).toBe(false);
+    });
+  });
+
+  describe('isDefault / defaultDomainId', () => {
+    it('returns null/false when nothing has been loaded yet', () => {
+      expect(service.defaultDomainId()).toBeNull();
+      expect(service.isDefault('domain-1')).toBe(false);
+    });
+  });
+
+  describe('togglePin', () => {
+    it('adds a domain id when it is not yet pinned', (done) => {
+      service.togglePin('domain-1').subscribe(() => {
+        expect(service.pinnedDomainIds()).toEqual(['domain-1']);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({ method: 'PUT', url: preferencesUrl });
+      expect(req.request.body.pinnedDomainIds).toEqual(['domain-1']);
+      req.flush({ pinnedDomainIds: ['domain-1'] });
+    });
+
+    it('removes a domain id when it is already pinned, leaving the others untouched', (done) => {
+      service.load().subscribe();
+      httpTestingController.expectOne({ method: 'GET', url: preferencesUrl }).flush({ pinnedDomainIds: ['domain-1', 'domain-2'] });
+
+      service.togglePin('domain-1').subscribe(() => {
+        expect(service.pinnedDomainIds()).toEqual(['domain-2']);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({ method: 'PUT', url: preferencesUrl });
+      expect(req.request.body.pinnedDomainIds).toEqual(['domain-2']);
+      req.flush({ pinnedDomainIds: ['domain-2'] });
+    });
+
+    it('sends a full-object PUT that carries the existing default alongside the new pin', (done) => {
+      service.load().subscribe();
+      httpTestingController
+        .expectOne({ method: 'GET', url: preferencesUrl })
+        .flush({ defaultDomainId: 'domain-9', defaultEnvironmentId: 'env-1' });
+
+      service.togglePin('domain-1').subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'PUT', url: preferencesUrl });
+      expect(req.request.body).toEqual({ defaultDomainId: 'domain-9', defaultEnvironmentId: 'env-1', pinnedDomainIds: ['domain-1'] });
+      req.flush({});
+    });
+  });
+
+  describe('toggleDefaultDomain', () => {
+    it('sets the domain as default when it is not currently the default', (done) => {
+      service.toggleDefaultDomain('domain-1', 'env-1').subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'PUT', url: preferencesUrl });
+      expect(req.request.body).toEqual({ defaultDomainId: 'domain-1', defaultEnvironmentId: 'env-1' });
+      req.flush({ defaultDomainId: 'domain-1', defaultEnvironmentId: 'env-1' });
+    });
+
+    it('unsets the default when the domain is already the default', (done) => {
+      service.load().subscribe();
+      httpTestingController
+        .expectOne({ method: 'GET', url: preferencesUrl })
+        .flush({ defaultDomainId: 'domain-1', defaultEnvironmentId: 'env-1' });
+
+      service.toggleDefaultDomain('domain-1', 'env-1').subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'PUT', url: preferencesUrl });
+      expect(req.request.body).toEqual({ defaultDomainId: null, defaultEnvironmentId: null });
+      req.flush({});
+    });
+  });
+
+  describe('consumeDefaultDomainRedirect', () => {
+    it('returns the default domain id exactly once after load, then null on every subsequent call', () => {
+      service.load().subscribe();
+      httpTestingController.expectOne({ method: 'GET', url: preferencesUrl }).flush({ defaultDomainId: 'domain-1' });
+
+      expect(service.consumeDefaultDomainRedirect()).toBe('domain-1');
+      expect(service.consumeDefaultDomainRedirect()).toBeNull();
+      expect(service.consumeDefaultDomainRedirect()).toBeNull();
+    });
+
+    it('returns null when load found no default domain', () => {
+      service.load().subscribe();
+      httpTestingController.expectOne({ method: 'GET', url: preferencesUrl }).flush({});
+
+      expect(service.consumeDefaultDomainRedirect()).toBeNull();
+    });
+
+    it('returns null before load has ever been called', () => {
+      expect(service.consumeDefaultDomainRedirect()).toBeNull();
+    });
+  });
+});

--- a/gravitee-am-ui/src/app/services/user-preferences.service.spec.ts
+++ b/gravitee-am-ui/src/app/services/user-preferences.service.spec.ts
@@ -28,12 +28,11 @@ describe('UserPreferencesService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      teardown: { destroyAfterEach: false },
       providers: [UserPreferencesService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
     });
 
-    httpTestingController = TestBed.get(HttpTestingController);
-    service = TestBed.get(UserPreferencesService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(UserPreferencesService);
   });
 
   afterEach(() => {

--- a/gravitee-am-ui/src/app/settings/domains/domains.component.html
+++ b/gravitee-am-ui/src/app/settings/domains/domains.component.html
@@ -71,10 +71,16 @@
             mat-icon-button
             (click)="toggleDefault(row, $event)"
             [matTooltip]="isDefault(row.id) ? 'Unset default domain' : 'Set as default domain'"
+            [attr.data-testid]="'domainDefaultToggle-' + row.name"
           >
             <mat-icon>{{ isDefault(row.id) ? 'star' : 'star_border' }}</mat-icon>
           </button>
-          <button mat-icon-button (click)="togglePin(row, $event)" [matTooltip]="isPinned(row.id) ? 'Unpin domain' : 'Pin domain'">
+          <button
+            mat-icon-button
+            (click)="togglePin(row, $event)"
+            [matTooltip]="isPinned(row.id) ? 'Unpin domain' : 'Pin domain'"
+            [attr.data-testid]="'domainPinToggle-' + row.name"
+          >
             <!-- bookmark instead of push_pin: the bundled Material Icons font predates the push_pin ligature -->
             <mat-icon>{{ isPinned(row.id) ? 'bookmark' : 'bookmark_border' }}</mat-icon>
           </button>


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7330

## :pencil2: A description of the changes proposed in the pull request
 Adds automated regression coverage for the domain picker / console preferences feature (AM-7306), closing gaps found during manual QA.

  **Backend/API:** a Jest test confirming PUT /user/preferences fully replaces the preferences object rather than merging fields, a boundary test for the 50-pinned-domains cap
  (exactly 50 succeeds, 51 rejected), an audit-log check confirming preference updates are recorded, and a ids-query-param cap check on the domains list endpoint.

  **Frontend:** a new unit spec for UserPreferencesService covering the pin/default toggle logic and the one-shot default-domain-redirect flag, independent of the browser. Playwright
  E2E coverage extended for the navbar picker — reload-to-default-domain, graceful fallback when the default domain has been deleted, search filtering and empty-state, pin/unpin
  and set/unset-default via the picker's own controls, the avatar menu staying unaffected, and the "All domains" list's pin/star controls staying in sync with the navbar picker.

## :memo: Test scenarios 
NA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
NA
