### PR TITLE
feat: send managed cloud access point templates to Cockpit on hello

### DIFF
--- a/docker/local-stack/dev/docker-compose.cloud.yml
+++ b/docker/local-stack/dev/docker-compose.cloud.yml
@@ -36,6 +36,7 @@ services:
       - GRAVITEE_CLOUD_ENABLED=true
       - GRAVITEE_INSTALLATION_TYPE=managed
       - GRAVITEE_CLOUD_CONNECTOR_WS_ENDPOINTS_0=http://cockpit-mock:8085
+      - gravitee_installation_managed_accessPoints_environment_gateway_host={environment}.{organization}.{account}.example.com
     depends_on:
       cockpit-mock:
         condition: service_healthy

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/CockpitAccessService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/CockpitAccessService.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.management.service;
+
+import io.gravitee.am.management.service.model.AccessPointTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Eric Leleu (eric.leleu@graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface CockpitAccessService {
+    Map<AccessPointTemplate.Type, List<AccessPointTemplate>> getAccessPointsTemplate();
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/CockpitAccessServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/CockpitAccessServiceImpl.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.management.service.impl;
+
+import com.google.common.base.Strings;
+import com.google.common.net.InternetDomainName;
+import io.gravitee.am.common.env.CloudProperties;
+import io.gravitee.am.management.service.CockpitAccessService;
+import io.gravitee.am.management.service.model.AccessPointTemplate;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+@CustomLog
+public class CockpitAccessServiceImpl implements CockpitAccessService {
+
+    private static final String MANAGED_ACCESS_POINT_PROPERTY =
+            "installation." + CloudProperties.INSTALLATION_TYPE_MANAGED + ".accessPoints";
+
+    private final ConfigurableEnvironment environment;
+
+    private final Map<AccessPointTemplate.Type, List<AccessPointTemplate>> accessPointsTemplate = new EnumMap<>(
+            AccessPointTemplate.Type.class
+    );
+
+    @PostConstruct
+    public void afterPropertiesSet() {
+        if (CloudProperties.isManagedCloudEnabled(environment)) {
+
+            for (AccessPointTemplate.Type type : AccessPointTemplate.Type.values()) {
+                List<AccessPointTemplate> accessPoints = new ArrayList<>();
+                for (AccessPointTemplate.Target target : AccessPointTemplate.Target.values()) {
+                    String host = environment.getProperty(
+                            MANAGED_ACCESS_POINT_PROPERTY + "." + type.getLabel() + "." + target.getLabel() + ".host"
+                    );
+                    if (host != null) {
+                        validateHost(host);
+                        Boolean secured = environment.getProperty(
+                                MANAGED_ACCESS_POINT_PROPERTY + "." + type.getLabel() + "." + target.getLabel() + ".secured",
+                                Boolean.class,
+                                true
+                        );
+                        accessPoints.add(AccessPointTemplate.builder().target(target).host(host).secured(secured).build());
+                    }
+                }
+                if (!accessPoints.isEmpty()) {
+                    accessPointsTemplate.put(type, accessPoints);
+                }
+            }
+
+            if (accessPointsTemplate.isEmpty()) {
+                throw new InvalidAccessPointException("Installation is managed but doesn't configure any access points.");
+            }
+        }
+    }
+
+    private void validateHost(String value) {
+        String toValidate = value.replaceAll("[{}]", "").replaceAll(":\\d*", "");
+        if (!isValidDomainName(toValidate)) {
+            throw new InvalidAccessPointException("Installation access point '%s' is malformed.".formatted(value));
+        }
+    }
+
+    private boolean isValidDomainName(String domain) {
+        if (Strings.isNullOrEmpty(domain)) {
+            return false;
+        }
+        return InternetDomainName.isValid(domain);
+    }
+
+    @Override
+    public Map<AccessPointTemplate.Type, List<AccessPointTemplate>> getAccessPointsTemplate() {
+        return accessPointsTemplate;
+    }
+
+    static class InvalidAccessPointException extends RuntimeException {
+        public InvalidAccessPointException(String message) {
+            super(message);
+        }
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/adapter/HelloCommandAdapter.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/adapter/HelloCommandAdapter.java
@@ -16,9 +16,12 @@
 package io.gravitee.am.management.service.impl.adapter;
 
 import com.google.common.base.Strings;
+import io.gravitee.am.common.env.CloudProperties;
+import io.gravitee.am.management.service.CockpitAccessService;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.service.InstallationService;
+import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
 import io.gravitee.cockpit.api.command.v1.hello.HelloCommand;
 import io.gravitee.cockpit.api.command.v1.hello.HelloCommandPayload;
@@ -32,7 +35,9 @@ import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -55,6 +60,8 @@ public class HelloCommandAdapter implements CommandAdapter<io.gravitee.exchange.
 
     private final Node node;
     private final InstallationService installationService;
+    private final CockpitAccessService cockpitAccessService;
+    private final org.springframework.core.env.Environment environment;
 
     @Override
     public String supportType() {
@@ -63,10 +70,12 @@ public class HelloCommandAdapter implements CommandAdapter<io.gravitee.exchange.
 
     @Override
     public Single<HelloCommand> adapt(final String targetId, final io.gravitee.exchange.api.command.hello.HelloCommand command) {
+        final var isManaged = CloudProperties.isManagedCloudEnabled(environment);
         return installationService.getOrInitialize()
                 .map(installation -> {
                     HelloCommandPayload.HelloCommandPayloadBuilder<?, ?> payloadBuilder = HelloCommandPayload
                             .builder()
+                            .installationType(isManaged ? CloudProperties.INSTALLATION_TYPE_MANAGED : CloudProperties.INSTALLATION_TYPE_STANDALONE)
                             .node(
                                     io.gravitee.cockpit.api.command.model.Node
                                             .builder()
@@ -81,6 +90,29 @@ public class HelloCommandAdapter implements CommandAdapter<io.gravitee.exchange.
                     Map<String, String> additionalInformation = new HashMap<>(installation.getAdditionalInformation());
                     additionalInformation.put(API_URL, sanitizeUrl(apiURL));
                     additionalInformation.put(UI_URL, sanitizeUrl(uiURL));
+
+                    if (isManaged) {
+                        Map<AccessPoint.Type, List<AccessPoint>> accessPointTemplates = new EnumMap<>(AccessPoint.Type.class);
+                        cockpitAccessService
+                                .getAccessPointsTemplate()
+                                .forEach((type, accessPoints) ->
+                                        accessPointTemplates.put(
+                                                AccessPoint.Type.valueOf(type.name()),
+                                                accessPoints
+                                                        .stream()
+                                                        .map(accessPoint ->
+                                                                AccessPoint.builder()
+                                                                        .host(accessPoint.getHost())
+                                                                        .secured(accessPoint.isSecured())
+                                                                        .target(AccessPoint.Target.valueOf(accessPoint.getTarget().name()))
+                                                                        .build()
+                                                        )
+                                                        .toList()
+                                        )
+                                );
+                        payloadBuilder.accessPointsTemplate(accessPointTemplates);
+                    }
+
                     payloadBuilder.additionalInformation(additionalInformation);
                     return new HelloCommand(payloadBuilder.build());
                 });

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/model/AccessPointTemplate.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/model/AccessPointTemplate.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.am.management.service.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Eric Leleu (eric.leleu@graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class AccessPointTemplate {
+
+    private Target target;
+    private String host;
+    private boolean secured;
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum Type {
+        ENVIRONMENT("environment");
+
+        private final String label;
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum Target {
+        GATEWAY("gateway");
+
+        private final String label;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/CockpitAccessServiceImplTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/CockpitAccessServiceImplTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl;
+
+import io.gravitee.am.management.service.model.AccessPointTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Eric Leleu (eric.leleu@graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class CockpitAccessServiceImplTest {
+
+    private static final String ENV_HOST = "{organizationId}.env.gravitee.io";
+
+    @Mock
+    private ConfigurableEnvironment environment;
+
+    private CockpitAccessServiceImpl cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new CockpitAccessServiceImpl(environment);
+    }
+
+    @Test
+    void should_not_populate_templates_when_not_managed_cloud() {
+        when(environment.getProperty("cloud.enabled", Boolean.class)).thenReturn(false);
+
+        cut.afterPropertiesSet();
+
+        assertTrue(cut.getAccessPointsTemplate().isEmpty());
+    }
+
+    @Test
+    void should_populate_templates_when_managed_cloud_with_valid_hosts() {
+        mockManagedCloud();
+        when(
+                environment.getProperty(
+                        "installation.managed.accessPoints.environment.gateway.host"
+                )
+        ).thenReturn(ENV_HOST);
+        when(
+                environment.getProperty(
+                        "installation.managed.accessPoints.environment.gateway.secured",
+                        Boolean.class,
+                        true
+                )
+        ).thenReturn(false);
+
+        cut.afterPropertiesSet();
+
+        Map<AccessPointTemplate.Type, List<AccessPointTemplate>> templates = cut.getAccessPointsTemplate();
+        assertEquals(1, templates.size());
+
+        AccessPointTemplate envTemplate = templates.get(AccessPointTemplate.Type.ENVIRONMENT).get(0);
+        assertEquals(AccessPointTemplate.Target.GATEWAY, envTemplate.getTarget());
+        assertEquals(ENV_HOST, envTemplate.getHost());
+        assertTrue(!envTemplate.isSecured());
+    }
+
+    @Test
+    void should_throw_when_managed_cloud_without_any_access_point_configured() {
+        mockManagedCloud();
+
+        assertThrows(RuntimeException.class, () -> cut.afterPropertiesSet());
+    }
+
+    @Test
+    void should_throw_when_host_is_malformed() {
+        mockManagedCloud();
+        when(
+                environment.getProperty(
+                        "installation.managed.accessPoints.environment.gateway.host"
+                )
+        ).thenReturn("not a valid host!!");
+
+        assertThrows(RuntimeException.class, () -> cut.afterPropertiesSet());
+    }
+
+    private void mockManagedCloud() {
+        when(environment.getProperty("cloud.enabled", Boolean.class)).thenReturn(true);
+        when(environment.getProperty("installation.type", "standalone")).thenReturn("managed");
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/adapter/HelloCommandAdapterTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/adapter/HelloCommandAdapterTest.java
@@ -16,11 +16,14 @@
 package io.gravitee.am.management.service.impl.adapter;
 
 
+import io.gravitee.am.management.service.CockpitAccessService;
+import io.gravitee.am.management.service.model.AccessPointTemplate;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Installation;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.service.InstallationService;
+import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
 import io.gravitee.cockpit.api.command.v1.hello.HelloCommand;
 import io.gravitee.cockpit.api.command.v1.hello.HelloCommandPayload;
@@ -33,10 +36,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /**
@@ -57,11 +65,18 @@ class HelloCommandAdapterTest {
     @Mock
     private Node node;
 
+    @Mock
+    private CockpitAccessService cockpitAccessService;
+
+    @Mock
+    private org.springframework.core.env.Environment environment;
+
     private HelloCommandAdapter cut;
 
     @BeforeEach
     public void beforeEach() {
-        cut = new HelloCommandAdapter(node, installationService);
+        cut = new HelloCommandAdapter(node, installationService, cockpitAccessService, environment);
+        lenient().when(environment.getProperty("cloud.enabled", Boolean.class)).thenReturn(false);
     }
 
     @Test
@@ -105,6 +120,59 @@ class HelloCommandAdapterTest {
                 .adapt(INSTALLATION_ID, new io.gravitee.exchange.api.command.hello.HelloCommand(new HelloCommandPayload()))
                 .test()
                 .assertError(TechnicalException.class);
+    }
+
+    @Test
+    void adaptWithoutManagedCloud_doesNotSetAccessPointsTemplate() {
+        final Installation installation = new Installation();
+        installation.setId(INSTALLATION_ID);
+
+        when(node.hostname()).thenReturn(HOSTNAME);
+        when(installationService.getOrInitialize()).thenReturn(Single.just(installation));
+
+        final TestObserver<HelloCommand> obs = cut
+                .adapt(INSTALLATION_ID, new io.gravitee.exchange.api.command.hello.HelloCommand(new HelloCommandPayload()))
+                .test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(helloCommand -> {
+            assertTrue(helloCommand.getPayload().getAccessPointsTemplate() == null || helloCommand.getPayload().getAccessPointsTemplate().isEmpty());
+            return true;
+        });
+    }
+
+    @Test
+    void adaptWithManagedCloud_setsAccessPointsTemplate() {
+        when(environment.getProperty("cloud.enabled", Boolean.class)).thenReturn(true);
+        when(environment.getProperty("installation.type", "standalone")).thenReturn("managed");
+
+        final Installation installation = new Installation();
+        installation.setId(INSTALLATION_ID);
+
+        when(node.hostname()).thenReturn(HOSTNAME);
+        when(installationService.getOrInitialize()).thenReturn(Single.just(installation));
+
+        final Map<AccessPointTemplate.Type, List<AccessPointTemplate>> templates = new EnumMap<>(AccessPointTemplate.Type.class);
+        templates.put(
+                AccessPointTemplate.Type.ENVIRONMENT,
+                List.of(AccessPointTemplate.builder().target(AccessPointTemplate.Target.GATEWAY).host("env.gravitee.io").secured(true).build())
+        );
+        when(cockpitAccessService.getAccessPointsTemplate()).thenReturn(templates);
+
+        final TestObserver<HelloCommand> obs = cut
+                .adapt(INSTALLATION_ID, new io.gravitee.exchange.api.command.hello.HelloCommand(new HelloCommandPayload()))
+                .test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(helloCommand -> {
+            final Map<AccessPoint.Type, List<AccessPoint>> accessPointsTemplate = helloCommand.getPayload().getAccessPointsTemplate();
+            assertTrue(accessPointsTemplate.containsKey(AccessPoint.Type.ENVIRONMENT));
+            final AccessPoint accessPoint = accessPointsTemplate.get(AccessPoint.Type.ENVIRONMENT).get(0);
+            assertEquals("env.gravitee.io", accessPoint.getHost());
+            assertTrue(accessPoint.isSecured());
+            assertEquals(AccessPoint.Target.GATEWAY, accessPoint.getTarget());
+            return true;
+        });
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -29,7 +29,19 @@
 
 ## Installation type of this node: "standalone" (default) or "managed".
 #installation:
+#  # Installation type standalone (default) or managed
+#  # * standalone: AM installation deployed on-premise with manual connection to cockpit
+#  # * managed: AM installation managed by Gravitee Cloud
 #  type: standalone
+#  managed:
+#    # Specify the access points of your installation, mandatory if you want to connect it to Cockpit
+#    # with a managed installation (a.k.a Cloud deployment)
+#    # You can use template variable such as {account}, {organization} or {environment}
+#    accessPoints:
+#      environment:
+#        gateway:
+#          host: '{environment}.{organization}.{account}.example.com'
+#          secured: true
 
 # Secret managers config in order to use secret
 #secrets:


### PR DESCRIPTION
## Summary
- Expose environment/organization gateway access point templates configured under `installation.managed.accessPoints` through a new `CockpitAccessService`
- Include the access point templates in the `HelloCommand` payload sent to Cockpit when running as a managed cloud installation
- Document the new configuration under `installation.managed` in `gravitee.yml`

## Test plan
- [x] Added `CockpitAccessServiceImplTest` covering non-managed cloud, valid managed-cloud config, malformed host, and missing access points
- [x] Updated `HelloCommandAdapterTest` for the new constructor dependencies and added coverage for the managed/non-managed access-point-template branches
- [x] `mvn -pl gravitee-am-management-api/gravitee-am-management-api-service test` passes (10/10)

related-to AM-7326