### PR TITLE
fix: create the WWW_TARGET before copying the ui files

### DIFF
--- a/docker/management-ui/Dockerfile
+++ b/docker/management-ui/Dockerfile
@@ -34,6 +34,7 @@ RUN apk update \
   && wget https://download.gravitee.io/graviteeio-am/components/gravitee-am-webui/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip -P /tmp \
   && unzip /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip -d /tmp/ \
   && apk del unzip netcat-openbsd wget \
+  && mkdir -p ${WWW_TARGET} \
   && cp -fr /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}/* ${WWW_TARGET} \
   && rm -rf /tmp/*
 

--- a/docker/management-ui/Dockerfile-dev
+++ b/docker/management-ui/Dockerfile-dev
@@ -30,7 +30,7 @@ RUN apk add --update unzip && \
     unzip /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip -d /tmp/ && \
     apk del unzip
 
-RUN mv /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}/* ${WWW_TARGET}
+RUN mkdir -p ${WWW_TARGET} && mv /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}/* ${WWW_TARGET}
 
 ADD config/constants.json /usr/share/nginx/html/constants.json
 ADD config/default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
seems the latest version of Nginx is not providing it anymore
