### PR TITLE
feat: prefer the overriding access point when resolving an environment entrypoint

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/api/DomainReadinessEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/api/DomainReadinessEndpoint.java
@@ -120,6 +120,11 @@ public class DomainReadinessEndpoint implements ManagementEndpoint, Probe {
      * Attach the entrypoints the gateway has cached for this domain's environment. Entrypoints are
      * environment-scoped rather than per-domain, so we resolve the domain's environment from the
      * deployed domain registry and read that environment's entrypoints from the in-memory cache.
+     * <p>
+     * Deliberately reports the raw cache rather than
+     * {@link io.gravitee.am.service.EntryPointManager#resolveByEnvironmentId(String)}: this is a
+     * diagnostic surface, so it should show everything the gateway actually holds, not the subset
+     * user-facing URLs are built from.
      */
     private void enrichWithEntrypoints(String domainId, DomainState details) {
         Domain domain = securityDomainManager.get(domainId);

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/api/DomainReadinessEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/api/DomainReadinessEndpoint.java
@@ -120,18 +120,13 @@ public class DomainReadinessEndpoint implements ManagementEndpoint, Probe {
      * Attach the entrypoints the gateway has cached for this domain's environment. Entrypoints are
      * environment-scoped rather than per-domain, so we resolve the domain's environment from the
      * deployed domain registry and read that environment's entrypoints from the in-memory cache.
-     * <p>
-     * Deliberately reports the raw cache rather than
-     * {@link io.gravitee.am.service.EntryPointManager#resolveByEnvironmentId(String)}: this is a
-     * diagnostic surface, so it should show everything the gateway actually holds, not the subset
-     * user-facing URLs are built from.
      */
     private void enrichWithEntrypoints(String domainId, DomainState details) {
         Domain domain = securityDomainManager.get(domainId);
         if (domain == null || domain.getReferenceType() != ReferenceType.ENVIRONMENT) {
             return;
         }
-        details.setEntrypoints(entryPointManager.findByEnvironmentId(domain.getReferenceId()).stream()
+        details.setEntrypoints(entryPointManager.findAllByEnvironmentId(domain.getReferenceId()).stream()
                 .map(entrypoint -> DomainState.EntrypointRef.builder()
                         .id(entrypoint.getId())
                         .name(entrypoint.getName())

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -812,27 +812,35 @@ public class DomainServiceImpl implements DomainService {
 
     private Single<List<Entrypoint>> listEnvironmentEntryPoint(Domain domain, String organizationId) {
         return Single.defer(() -> {
-            List<Entrypoint> environmentEntrypoints = entryPointManager.findByEnvironmentId(domain.getReferenceId());
+            List<Entrypoint> environmentEntrypoints = entryPointManager.resolveByEnvironmentId(domain.getReferenceId());
             if (environmentEntrypoints.isEmpty()) {
-                // No environment entrypoint synced yet: degrade to the organization resolution, whose
-                // default entrypoint always carries a url (the UI builds links from it, never null).
-                return listOrganizationEntryPoint(domain, organizationId);
+                return organizationDefaultEntryPoint(domain, organizationId);
             }
-
-            // Cockpit recreates every environment entrypoint on each environment command, so createdAt/id
-            // churn and are not stable to order on. Prefer the one flagged default (the overridden access
-            // point), otherwise take the first in the list received from the command.
-            Entrypoint selected = environmentEntrypoints.stream()
-                    .filter(Entrypoint::isDefaultEntrypoint)
-                    .findFirst()
-                    .orElseGet(() -> {
-                        if (environmentEntrypoints.size() > 1) {
-                            log.warn("Environment {} resolves to {} entrypoints and none is flagged default; using the first", domain.getReferenceId(), environmentEntrypoints.size());
-                        }
-                        return environmentEntrypoints.get(0);
-                    });
-            return Single.just(List.of(selected));
+            return Single.just(environmentEntrypoints);
         });
+    }
+
+    /**
+     * The environment has no entrypoint yet — Cockpit has not synced it. Fall back to the organization's
+     * own default entrypoint carrying the data-plane gateway url, as the organization resolution does.
+     * <p>
+     * Deliberately does not call {@link #listOrganizationEntryPoint}: that one reads every entrypoint in
+     * the organization, environment-scoped rows included, and those are flagged default too — so its
+     * "drop the defaults once something else matched" step could filter the whole list away.
+     */
+    private Single<List<Entrypoint>> organizationDefaultEntryPoint(Domain domain, String organizationId) {
+        return entrypointService.findAll(organizationId)
+                .filter(entrypoint -> entrypoint.getEnvironmentId() == null && entrypoint.isDefaultEntrypoint())
+                .firstElement()
+                .map(entrypoint -> {
+                    ofNullable(this.dataPlaneRegistry.getDescription(domain).gatewayUrl())
+                            .ifPresent(entrypoint::setUrl);
+                    return List.of(entrypoint);
+                })
+                .switchIfEmpty(Single.fromCallable(() -> {
+                    log.warn("Organization {} has no default entrypoint; domain {} resolves to no entrypoint at all", organizationId, domain.getId());
+                    return List.<Entrypoint>of();
+                }));
     }
 
     private Single<Domain> createSystemScopes(Domain domain) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -812,9 +812,11 @@ public class DomainServiceImpl implements DomainService {
 
     private Single<List<Entrypoint>> listEnvironmentEntryPoint(Domain domain, String organizationId) {
         return Single.defer(() -> {
-            List<Entrypoint> environmentEntrypoints = entryPointManager.resolveByEnvironmentId(domain.getReferenceId());
+            List<Entrypoint> environmentEntrypoints = entryPointManager.findByEnvironmentId(domain.getReferenceId());
             if (environmentEntrypoints.isEmpty()) {
-                return organizationDefaultEntryPoint(domain, organizationId);
+                return getOrganizationDefaultEntrypoint(domain, organizationId)
+                        .<List<Entrypoint>>map(List::of)
+                        .defaultIfEmpty(List.of());
             }
             return Single.just(environmentEntrypoints);
         });
@@ -828,19 +830,16 @@ public class DomainServiceImpl implements DomainService {
      * the organization, environment-scoped rows included, and those are flagged default too — so its
      * "drop the defaults once something else matched" step could filter the whole list away.
      */
-    private Single<List<Entrypoint>> organizationDefaultEntryPoint(Domain domain, String organizationId) {
+    private Maybe<Entrypoint> getOrganizationDefaultEntrypoint(Domain domain, String organizationId) {
         return entrypointService.findAll(organizationId)
                 .filter(entrypoint -> entrypoint.getEnvironmentId() == null && entrypoint.isDefaultEntrypoint())
                 .firstElement()
                 .map(entrypoint -> {
                     ofNullable(this.dataPlaneRegistry.getDescription(domain).gatewayUrl())
                             .ifPresent(entrypoint::setUrl);
-                    return List.of(entrypoint);
+                    return entrypoint;
                 })
-                .switchIfEmpty(Single.fromCallable(() -> {
-                    log.warn("Organization {} has no default entrypoint; domain {} resolves to no entrypoint at all", organizationId, domain.getId());
-                    return List.<Entrypoint>of();
-                }));
+                .doOnComplete(() -> log.warn("Organization {} has no default entrypoint; domain {} resolves to no entrypoint at all", organizationId, domain.getId()));
     }
 
     private Single<Domain> createSystemScopes(Domain domain) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
@@ -121,7 +121,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
 
         // Counter-intuitive but avoids introducing a field: the access point Cockpit generates itself is
         // the environment's *default* entrypoint, and the customer's overriding one is not. Resolution
-        // then drops the default whenever an override exists — see EntryPointManager#resolveByEnvironmentId.
+        // then drops the default whenever an override exists — see EntryPointManager#findByEnvironmentId.
         return entrypointService.create(organizationId, newEntrypoint, !accessPoint.isOverriding(), null).ignoreElement();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
@@ -119,6 +119,9 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         newEntrypoint.setName(accessPoint.getHost());
         newEntrypoint.setEnvironmentId(environmentId);
 
-        return entrypointService.create(organizationId, newEntrypoint, null).ignoreElement();
+        // Counter-intuitive but avoids introducing a field: the access point Cockpit generates itself is
+        // the environment's *default* entrypoint, and the customer's overriding one is not. Resolution
+        // then drops the default whenever an override exists — see EntryPointManager#resolveByEnvironmentId.
+        return entrypointService.create(organizationId, newEntrypoint, !accessPoint.isOverriding(), null).ignoreElement();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -1878,7 +1878,7 @@ public class DomainServiceTest {
         envEntrypoint.setEnvironmentId(ENVIRONMENT_ID);
         envEntrypoint.setUrl("https://acme.gravitee.io");
 
-        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(envEntrypoint));
+        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(envEntrypoint));
 
         final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
         subscriber.assertValue(entrypoints -> entrypoints.size() == 1
@@ -1892,7 +1892,7 @@ public class DomainServiceTest {
         enableCloudMode();
 
         final Domain mockDomain = cloudDomain();
-        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
         when(dataPlaneRegistry.getDescription(mockDomain))
                 .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", "http://gateway:8092"));
 
@@ -1910,26 +1910,34 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldGetEntrypoint_cloud_multipleEntrypoints_picksDefaultFlagged() {
+    public void shouldGetEntrypoint_cloud_noEnvironmentEntrypoint_fallbackIgnoresEnvironmentScopedEntrypoints() {
         enableCloudMode();
 
-        final Entrypoint first = new Entrypoint();
-        first.setId("first-entrypoint");
-        first.setEnvironmentId(ENVIRONMENT_ID);
-        first.setUrl("https://first.gravitee.io");
+        final Domain mockDomain = cloudDomain();
+        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(dataPlaneRegistry.getDescription(mockDomain))
+                .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", null));
 
-        final Entrypoint flagged = new Entrypoint();
-        flagged.setId("flagged-entrypoint");
-        flagged.setEnvironmentId(ENVIRONMENT_ID);
-        flagged.setUrl("https://flagged.gravitee.io");
-        flagged.setDefaultEntrypoint(true);
+        // Another environment's generated entrypoint: organization-wide, flagged default, and must not
+        // be mistaken for this organization's own default.
+        final Entrypoint otherEnvironmentEntrypoint = new Entrypoint();
+        otherEnvironmentEntrypoint.setId("other-env-generated");
+        otherEnvironmentEntrypoint.setEnvironmentId("env#other");
+        otherEnvironmentEntrypoint.setDefaultEntrypoint(true);
+        otherEnvironmentEntrypoint.setUrl("https://other-env.gravitee.io");
+        otherEnvironmentEntrypoint.setOrganizationId(ORGANIZATION_ID);
 
-        // The default-flagged entrypoint wins even when it is not first in the list.
-        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(first, flagged));
+        final Entrypoint defaultEntrypoint = new Entrypoint();
+        defaultEntrypoint.setId(ENTRYPOINT_ID_DEFAULT);
+        defaultEntrypoint.setDefaultEntrypoint(true);
+        defaultEntrypoint.setUrl("https://default.gravitee.io");
+        defaultEntrypoint.setOrganizationId(ORGANIZATION_ID);
 
-        final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
+        doReturn(Flowable.just(otherEnvironmentEntrypoint, defaultEntrypoint)).when(entrypointService).findAll(ORGANIZATION_ID);
+
+        final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
         subscriber.assertValue(entrypoints -> entrypoints.size() == 1
-                && entrypoints.get(0).getId().equals("flagged-entrypoint"));
+                && entrypoints.get(0).getId().equals(ENTRYPOINT_ID_DEFAULT));
     }
 
     @Test
@@ -1937,7 +1945,7 @@ public class DomainServiceTest {
         enableCloudMode();
 
         final Domain mockDomain = cloudDomain();
-        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
         when(dataPlaneRegistry.getDescription(mockDomain))
                 .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", null));
 
@@ -1955,7 +1963,7 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldGetEntrypoint_cloud_multipleEntrypoints_noneDefault_picksFirstInList() {
+    public void shouldGetEntrypoint_cloud_severalEnvironmentEntrypoints_returnsThemAll() {
         enableCloudMode();
 
         final Entrypoint first = new Entrypoint();
@@ -1968,12 +1976,14 @@ public class DomainServiceTest {
         second.setEnvironmentId(ENVIRONMENT_ID);
         second.setUrl("https://second.gravitee.io");
 
-        // None flagged default: fall back to the first in the list received from the command.
-        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(first, second));
+        // Whatever the environment resolves to is returned as-is — no collapsing to a single entrypoint.
+        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(first, second));
 
         final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
-        subscriber.assertValue(entrypoints -> entrypoints.size() == 1
-                && entrypoints.get(0).getId().equals("first-entrypoint"));
+        subscriber.assertValue(entrypoints -> entrypoints.size() == 2
+                && entrypoints.stream().anyMatch(e -> e.getId().equals("first-entrypoint"))
+                && entrypoints.stream().anyMatch(e -> e.getId().equals("second-entrypoint")));
+        verify(entrypointService, never()).findAll(anyString());
     }
 
     @Test
@@ -1999,7 +2009,7 @@ public class DomainServiceTest {
         final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
         subscriber.assertValue(entrypoints -> entrypoints.size() == 1
                 && entrypoints.get(0).getId().equals(ENTRYPOINT_ID1));
-        verify(entryPointManager, never()).findByEnvironmentId(anyString());
+        verify(entryPointManager, never()).resolveByEnvironmentId(anyString());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -1878,7 +1878,7 @@ public class DomainServiceTest {
         envEntrypoint.setEnvironmentId(ENVIRONMENT_ID);
         envEntrypoint.setUrl("https://acme.gravitee.io");
 
-        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(envEntrypoint));
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(envEntrypoint));
 
         final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
         subscriber.assertValue(entrypoints -> entrypoints.size() == 1
@@ -1892,7 +1892,7 @@ public class DomainServiceTest {
         enableCloudMode();
 
         final Domain mockDomain = cloudDomain();
-        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
         when(dataPlaneRegistry.getDescription(mockDomain))
                 .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", "http://gateway:8092"));
 
@@ -1914,7 +1914,7 @@ public class DomainServiceTest {
         enableCloudMode();
 
         final Domain mockDomain = cloudDomain();
-        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
         when(dataPlaneRegistry.getDescription(mockDomain))
                 .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", null));
 
@@ -1945,7 +1945,7 @@ public class DomainServiceTest {
         enableCloudMode();
 
         final Domain mockDomain = cloudDomain();
-        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
         when(dataPlaneRegistry.getDescription(mockDomain))
                 .thenReturn(new DataPlaneDescription("dp1", "legacy", "mongodb", "baseProp", null));
 
@@ -1967,7 +1967,7 @@ public class DomainServiceTest {
         enableCloudMode();
 
         final Domain mockDomain = cloudDomain();
-        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
         doReturn(Flowable.empty()).when(entrypointService).findAll(ORGANIZATION_ID);
 
         final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
@@ -1992,7 +1992,7 @@ public class DomainServiceTest {
         second.setUrl("https://second.gravitee.io");
 
         // Whatever the environment resolves to is returned as-is — no collapsing to a single entrypoint.
-        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(first, second));
+        when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(first, second));
 
         final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();
         subscriber.assertValue(entrypoints -> entrypoints.size() == 2
@@ -2024,7 +2024,7 @@ public class DomainServiceTest {
         final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
         subscriber.assertValue(entrypoints -> entrypoints.size() == 1
                 && entrypoints.get(0).getId().equals(ENTRYPOINT_ID1));
-        verify(entryPointManager, never()).resolveByEnvironmentId(anyString());
+        verify(entryPointManager, never()).findByEnvironmentId(anyString());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -1963,6 +1963,21 @@ public class DomainServiceTest {
     }
 
     @Test
+    public void shouldGetEntrypoint_cloud_noEnvironmentEntrypoint_noOrganizationDefault_returnsEmptyWithoutError() {
+        enableCloudMode();
+
+        final Domain mockDomain = cloudDomain();
+        when(entryPointManager.resolveByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of());
+        doReturn(Flowable.empty()).when(entrypointService).findAll(ORGANIZATION_ID);
+
+        final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
+        // createDefaults gives every organization a default entrypoint and the last-default guard stops
+        // it being removed, so this should be unreachable — it just must not blow up if it ever is.
+        subscriber.assertNoErrors();
+        subscriber.assertValue(List::isEmpty);
+    }
+
+    @Test
     public void shouldGetEntrypoint_cloud_severalEnvironmentEntrypoints_returnsThemAll() {
         enableCloudMode();
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/ManagementEntryPointManagerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/ManagementEntryPointManagerTest.java
@@ -98,10 +98,10 @@ public class ManagementEntryPointManagerTest {
                 .thenReturn(Single.just(entrypoint), Single.error(new EntrypointNotFoundException("e1")));
 
         cut.onEvent(event(EntrypointEvent.DEPLOY));
-        assertEquals(List.of(entrypoint), cut.findByEnvironmentId("env#1"));
+        assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
 
         cut.onEvent(event(EntrypointEvent.UPDATE));
-        assertTrue(cut.findByEnvironmentId("env#1").isEmpty());
+        assertTrue(cut.findAllByEnvironmentId("env#1").isEmpty());
     }
 
     @Test
@@ -111,9 +111,9 @@ public class ManagementEntryPointManagerTest {
         when(entrypointService.findById("e1", "org#1")).thenReturn(Single.just(entrypoint));
 
         cut.onEvent(event(EntrypointEvent.DEPLOY));
-        assertEquals(List.of(entrypoint), cut.findByEnvironmentId("env#1"));
+        assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
 
         cut.onEvent(event(EntrypointEvent.UPDATE));
-        assertTrue(cut.findByEnvironmentId("env#1").isEmpty());
+        assertTrue(cut.findAllByEnvironmentId("env#1").isEmpty());
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -208,7 +209,7 @@ class EnvironmentCommandHandlerTest {
         when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.just(existing1, existing2));
         when(entrypointService.delete(eq("entrypoint#1"), eq("orga#1"), isNull())).thenReturn(Completable.complete());
         when(entrypointService.delete(eq("entrypoint#2"), eq("orga#1"), isNull())).thenReturn(Completable.complete());
-        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
+        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
 
         TestObserver<EnvironmentReply> obs = cut.handle(command).test();
 
@@ -220,13 +221,13 @@ class EnvironmentCommandHandlerTest {
         verify(entrypointService, times(1)).create(eq("orga#1"), argThat(newEntrypoint ->
                 newEntrypoint.getUrl().equals("https://domain.restriction1.io")
                         && newEntrypoint.getName().equals("domain.restriction1.io")
-                        && "env#1".equals(newEntrypoint.getEnvironmentId())), isNull());
+                        && "env#1".equals(newEntrypoint.getEnvironmentId())), eq(true), isNull());
         verify(entrypointService, times(1)).create(eq("orga#1"), argThat(newEntrypoint ->
                 newEntrypoint.getUrl().equals("https://domain.restriction2.io")
                         && newEntrypoint.getName().equals("domain.restriction2.io")
-                        && "env#1".equals(newEntrypoint.getEnvironmentId())), isNull());
+                        && "env#1".equals(newEntrypoint.getEnvironmentId())), eq(true), isNull());
         // CONSOLE access point must not generate an entrypoint
-        verify(entrypointService, times(2)).create(eq("orga#1"), any(NewEntrypoint.class), isNull());
+        verify(entrypointService, times(2)).create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull());
     }
 
     @Test
@@ -245,7 +246,7 @@ class EnvironmentCommandHandlerTest {
 
         when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
         when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.empty());
-        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
+        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
 
         TestObserver<EnvironmentReply> obs = cut.handle(command).test();
 
@@ -253,7 +254,7 @@ class EnvironmentCommandHandlerTest {
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
 
         verify(entrypointService, never()).delete(any(), any(), any());
-        verify(entrypointService, times(1)).create(eq("orga#1"), any(NewEntrypoint.class), isNull());
+        verify(entrypointService, times(1)).create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull());
     }
 
     @Test
@@ -277,6 +278,65 @@ class EnvironmentCommandHandlerTest {
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
 
         verifyNoInteractions(entrypointService);
+    }
+
+    /**
+     * The access point Cockpit generates itself becomes the environment's default entrypoint; the
+     * customer's overriding one does not. Resolution later drops the default whenever an override
+     * exists, so getting this inversion right is what makes the override win.
+     */
+    private void assertPersistedDefaultFlag(AccessPoint accessPoint, boolean expectedDefaultFlag) {
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
+                .organizationId("orga#1")
+                .name("Environment name")
+                .accessPoints(List.of(accessPoint))
+                .build();
+
+        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
+        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.empty());
+        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
+
+        TestObserver<EnvironmentReply> obs = cut.handle(new EnvironmentCommand(environmentPayload)).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+        verify(entrypointService, times(1)).create(eq("orga#1"), any(NewEntrypoint.class), eq(expectedDefaultFlag), isNull());
+    }
+
+    @Test
+    void handleCloudMode_overridingAccessPoint_isNotTheDefaultEntrypoint() {
+        enableCloudMode();
+
+        assertPersistedDefaultFlag(AccessPoint.builder()
+                .target(AccessPoint.Target.GATEWAY)
+                .host("auth.acme.com")
+                .overriding(true)
+                .build(), false);
+    }
+
+    @Test
+    void handleCloudMode_nonOverridingAccessPoint_becomesTheDefaultEntrypoint() {
+        enableCloudMode();
+
+        assertPersistedDefaultFlag(AccessPoint.builder()
+                .target(AccessPoint.Target.GATEWAY)
+                .host("env-acme.gravitee.io")
+                .overriding(false)
+                .build(), true);
+    }
+
+    @Test
+    void handleCloudMode_accessPointWithoutOverridingFlag_becomesTheDefaultEntrypoint() {
+        enableCloudMode();
+
+        // `overriding` is a primitive boolean, so a payload omitting it deserializes to false and every
+        // entrypoint ends up flagged default. Resolution copes by returning them all rather than none.
+        assertPersistedDefaultFlag(AccessPoint.builder()
+                .target(AccessPoint.Target.GATEWAY)
+                .host("env-acme.gravitee.io")
+                .build(), true);
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
@@ -36,4 +36,23 @@ public interface EntryPointManager extends Service<EntryPointManager> {
     List<Entrypoint> findByOrganizationId(String organizationId);
 
     List<Entrypoint> findByEnvironmentId(String environmentId);
+
+    /**
+     * The entrypoints user-facing URLs should be built from for the given environment.
+     * <p>
+     * Cockpit provisions one entrypoint per gateway access point; the access point it generates itself
+     * is flagged {@code defaultEntrypoint} and the customer's overriding one is not (see
+     * {@code EnvironmentCommandHandler}). So whenever an environment resolves to more than its default,
+     * the customer has an override and it wins.
+     * <p>
+     * Never narrows a non-empty environment down to nothing: when no entrypoint survives the filter —
+     * every one of them is flagged default, which is what an access point payload carrying no
+     * {@code overriding} field produces — the full list is returned instead. Callers dereference the
+     * URL of whatever comes back, so an empty result would break them.
+     */
+    default List<Entrypoint> resolveByEnvironmentId(String environmentId) {
+        List<Entrypoint> all = findByEnvironmentId(environmentId);
+        List<Entrypoint> overriding = all.stream().filter(entrypoint -> !entrypoint.isDefaultEntrypoint()).toList();
+        return overriding.isEmpty() ? all : overriding;
+    }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
@@ -26,7 +26,7 @@ import java.util.List;
  * management API and the gateway.
  * <p>
  * The cache only holds entrypoints within the node's configured organization/environment scope
- * (node metadata; unscoped nodes cache everything), and {@link #findByEnvironmentId(String)} only
+ * (node metadata; unscoped nodes cache everything), and {@link #findAllByEnvironmentId(String)} only
  * returns environment-scoped entrypoints — organization-level ones are not matched by it.
  *
  * @author GraviteeSource Team
@@ -35,7 +35,7 @@ public interface EntryPointManager extends Service<EntryPointManager> {
 
     List<Entrypoint> findByOrganizationId(String organizationId);
 
-    List<Entrypoint> findByEnvironmentId(String environmentId);
+    List<Entrypoint> findAllByEnvironmentId(String environmentId);
 
     /**
      * The entrypoints user-facing URLs should be built from for the given environment.
@@ -50,8 +50,8 @@ public interface EntryPointManager extends Service<EntryPointManager> {
      * {@code overriding} field produces — the full list is returned instead. Callers dereference the
      * URL of whatever comes back, so an empty result would break them.
      */
-    default List<Entrypoint> resolveByEnvironmentId(String environmentId) {
-        List<Entrypoint> all = findByEnvironmentId(environmentId);
+    default List<Entrypoint> findByEnvironmentId(String environmentId) {
+        List<Entrypoint> all = findAllByEnvironmentId(environmentId);
         List<Entrypoint> overriding = all.stream().filter(entrypoint -> !entrypoint.isDefaultEntrypoint()).toList();
         return overriding.isEmpty() ? all : overriding;
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntrypointService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntrypointService.java
@@ -40,12 +40,6 @@ public interface EntrypointService {
         return create(organizationId, entrypoint, false, principal);
     }
 
-    /**
-     * The {@code defaultEntrypoint} flag is deliberately kept off {@link NewEntrypoint}: that DTO is the
-     * public REST body, and letting an API caller raise the flag would allow a second default entrypoint
-     * per organization, which the organization-wide resolution and the last-default deletion guard both
-     * assume cannot happen. Only the Cockpit environment sync passes {@code true}.
-     */
     Single<Entrypoint> create(String organizationId, NewEntrypoint entrypoint, boolean defaultEntrypoint, User principal);
 
     Flowable<Entrypoint> createDefaults(Organization organization);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntrypointService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntrypointService.java
@@ -36,7 +36,17 @@ public interface EntrypointService {
 
     Flowable<Entrypoint> findByEnvironment(String organizationId, String environmentId);
 
-    Single<Entrypoint> create(String organizationId, NewEntrypoint entrypoint, User principal);
+    default Single<Entrypoint> create(String organizationId, NewEntrypoint entrypoint, User principal) {
+        return create(organizationId, entrypoint, false, principal);
+    }
+
+    /**
+     * The {@code defaultEntrypoint} flag is deliberately kept off {@link NewEntrypoint}: that DTO is the
+     * public REST body, and letting an API caller raise the flag would allow a second default entrypoint
+     * per organization, which the organization-wide resolution and the last-default deletion guard both
+     * assume cannot happen. Only the Cockpit environment sync passes {@code true}.
+     */
+    Single<Entrypoint> create(String organizationId, NewEntrypoint entrypoint, boolean defaultEntrypoint, User principal);
 
     Flowable<Entrypoint> createDefaults(Organization organization);
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractEntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractEntryPointManager.java
@@ -104,7 +104,7 @@ public abstract class AbstractEntryPointManager extends AbstractService<EntryPoi
     }
 
     @Override
-    public List<Entrypoint> findByEnvironmentId(String environmentId) {
+    public List<Entrypoint> findAllByEnvironmentId(String environmentId) {
         return entrypoints.values().stream()
                 .filter(entrypoint -> environmentId != null && environmentId.equals(entrypoint.getEnvironmentId()))
                 .collect(Collectors.toList());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
@@ -111,12 +111,13 @@ public class EntrypointServiceImpl implements EntrypointService {
     }
 
     @Override
-    public Single<Entrypoint> create(String organizationId, NewEntrypoint newEntrypoint, User principal) {
+    public Single<Entrypoint> create(String organizationId, NewEntrypoint newEntrypoint, boolean defaultEntrypoint, User principal) {
 
         log.debug("Create a new entrypoint {} for organization {}", newEntrypoint, organizationId);
 
         Entrypoint toCreate = new Entrypoint();
         toCreate.setOrganizationId(organizationId);
+        toCreate.setDefaultEntrypoint(defaultEntrypoint);
         toCreate.setEnvironmentId(newEntrypoint.getEnvironmentId());
         toCreate.setName(newEntrypoint.getName());
         toCreate.setDescription(newEntrypoint.getDescription());

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
@@ -180,6 +180,72 @@ public class EntrypointServiceTest {
         }));
     }
 
+    private NewEntrypoint newEntrypointFor(String host) {
+        NewEntrypoint newEntrypoint = new NewEntrypoint();
+        newEntrypoint.setName(host);
+        newEntrypoint.setTags(Collections.emptyList());
+        newEntrypoint.setUrl("https://" + host);
+        newEntrypoint.setEnvironmentId("env#1");
+
+        Organization organization = new Organization();
+        organization.setId(ORGANIZATION_ID);
+        when(organizationService.findById(ORGANIZATION_ID)).thenReturn(Single.just(organization));
+        when(entrypointRepository.create(any(Entrypoint.class))).thenAnswer(i -> Single.just(i.getArgument(0)));
+        doReturn(true).when(virtualHostValidator).isValidDomainOrSubDomain(host, null);
+
+        return newEntrypoint;
+    }
+
+    @Test
+    public void shouldCreateDefaultEntrypointWhenFlagged() {
+
+        NewEntrypoint newEntrypoint = newEntrypointFor("env-acme.gravitee.io");
+
+        TestObserver<Entrypoint> obs = cut.create(ORGANIZATION_ID, newEntrypoint, true, null).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(Entrypoint::isDefaultEntrypoint);
+    }
+
+    @Test
+    public void shouldNotCreateDefaultEntrypointWhenCallerOmitsTheFlag() {
+        // The three-arg form is what the public REST resource calls; it must never raise the flag.
+        NewEntrypoint newEntrypoint = newEntrypointFor("auth.acme.com");
+
+        TestObserver<Entrypoint> obs = cut.create(ORGANIZATION_ID, newEntrypoint, null).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(entrypoint -> !entrypoint.isDefaultEntrypoint());
+    }
+
+    @Test
+    public void shouldDeleteDefaultFlaggedEnvironmentEntrypoint() {
+        // Cockpit's generated access point is now stored as a default entrypoint, and every ENVIRONMENT
+        // command deletes the environment's entrypoints before recreating them. That delete goes through
+        // the last-default guard, which passes because the organization keeps its own default entrypoint.
+        Entrypoint environmentEntrypoint = new Entrypoint();
+        environmentEntrypoint.setId(ENTRYPOINT_ID);
+        environmentEntrypoint.setOrganizationId(ORGANIZATION_ID);
+        environmentEntrypoint.setEnvironmentId("env#1");
+        environmentEntrypoint.setDefaultEntrypoint(true);
+
+        Entrypoint organizationDefault = new Entrypoint();
+        organizationDefault.setId("org-default");
+        organizationDefault.setOrganizationId(ORGANIZATION_ID);
+        organizationDefault.setDefaultEntrypoint(true);
+
+        when(entrypointRepository.findById(ENTRYPOINT_ID, ORGANIZATION_ID)).thenReturn(Maybe.just(environmentEntrypoint));
+        when(entrypointRepository.findAll(ORGANIZATION_ID)).thenReturn(Flowable.just(environmentEntrypoint, organizationDefault));
+        when(entrypointRepository.delete(ENTRYPOINT_ID)).thenReturn(Completable.complete());
+
+        TestObserver<Void> obs = cut.delete(ENTRYPOINT_ID, ORGANIZATION_ID, null).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertComplete();
+
+        verify(entrypointRepository, times(1)).delete(ENTRYPOINT_ID);
+    }
+
     @Test
     public void shouldDeleteWithNullPrincipal() {
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
@@ -39,6 +39,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -107,8 +108,24 @@ public class AbstractEntryPointManagerTest {
         return entrypoint;
     }
 
+    private static Entrypoint generatedEntrypoint(String id, String environmentId) {
+        Entrypoint entrypoint = entrypoint(id, "org#1", environmentId);
+        entrypoint.setDefaultEntrypoint(true);
+        return entrypoint;
+    }
+
     private static SimpleEvent<EntrypointEvent, Payload> event(EntrypointEvent type, String id) {
         return new SimpleEvent<>(type, new Payload(id, ReferenceType.ENVIRONMENT, "env#1", Action.CREATE));
+    }
+
+    /** Seeds the cache with the given entrypoints, all owned by org#1. */
+    private void cache(Entrypoint... entrypoints) throws Exception {
+        when(node.metadata()).thenReturn(Map.of());
+        Organization organization = new Organization();
+        organization.setId("org#1");
+        when(organizationRepository.findAll()).thenReturn(Flowable.just(organization));
+        when(entrypointRepository.findAll("org#1")).thenReturn(Flowable.fromArray(entrypoints));
+        cut.doStart();
     }
 
     @Test
@@ -223,5 +240,48 @@ public class AbstractEntryPointManagerTest {
         cut.onEvent(event(EntrypointEvent.DEPLOY, "e2"));
 
         assertTrue(cut.findByEnvironmentId("env#9").isEmpty());
+    }
+
+    private static Set<String> idsOf(List<Entrypoint> entrypoints) {
+        return entrypoints.stream().map(Entrypoint::getId).collect(Collectors.toSet());
+    }
+
+    @Test
+    public void shouldResolveNothingWhenEnvironmentHasNoEntrypoint() throws Exception {
+        cache(generatedEntrypoint("other-env-generated", "env#other"));
+
+        assertTrue(cut.resolveByEnvironmentId("env#1").isEmpty());
+    }
+
+    @Test
+    public void shouldResolveTheGeneratedEntrypointWhenItIsTheOnlyOne() throws Exception {
+        cache(generatedEntrypoint("generated", "env#1"));
+
+        assertEquals(Set.of("generated"), idsOf(cut.resolveByEnvironmentId("env#1")));
+    }
+
+    @Test
+    public void shouldResolveTheOverridingEntrypointAndDropTheGeneratedOne() throws Exception {
+        cache(generatedEntrypoint("generated", "env#1"), entrypoint("overriding", "org#1", "env#1"));
+
+        assertEquals(Set.of("overriding"), idsOf(cut.resolveByEnvironmentId("env#1")));
+    }
+
+    @Test
+    public void shouldResolveEveryOverridingEntrypointWhenSeveralExist() throws Exception {
+        cache(generatedEntrypoint("generated", "env#1"),
+                entrypoint("overriding-1", "org#1", "env#1"),
+                entrypoint("overriding-2", "org#1", "env#1"));
+
+        assertEquals(Set.of("overriding-1", "overriding-2"), idsOf(cut.resolveByEnvironmentId("env#1")));
+    }
+
+    @Test
+    public void shouldResolveEveryEntrypointWhenTheyAreAllFlaggedDefault() throws Exception {
+        // What an access point payload carrying no `overriding` field produces: everything flagged
+        // default. Filtering them all away would leave callers with no URL at all.
+        cache(generatedEntrypoint("generated-1", "env#1"), generatedEntrypoint("generated-2", "env#1"));
+
+        assertEquals(Set.of("generated-1", "generated-2"), idsOf(cut.resolveByEnvironmentId("env#1")));
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
@@ -161,8 +161,8 @@ public class AbstractEntryPointManagerTest {
         cut.doStart();
 
         assertEquals(List.of(orgEntrypoint), cut.findByOrganizationId("org#1"));
-        assertEquals(List.of(envEntrypoint), cut.findByEnvironmentId("env#1"));
-        assertTrue(cut.findByEnvironmentId("env#other").isEmpty());
+        assertEquals(List.of(envEntrypoint), cut.findAllByEnvironmentId("env#1"));
+        assertTrue(cut.findAllByEnvironmentId("env#other").isEmpty());
     }
 
     @Test
@@ -173,7 +173,7 @@ public class AbstractEntryPointManagerTest {
 
         cut.onEvent(event(EntrypointEvent.DEPLOY, "e1"));
 
-        assertEquals(List.of(entrypoint), cut.findByEnvironmentId("env#1"));
+        assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class AbstractEntryPointManagerTest {
         cut.onEvent(event(EntrypointEvent.DEPLOY, "e1"));
         cut.onEvent(event(EntrypointEvent.UPDATE, "e1"));
 
-        List<Entrypoint> result = cut.findByEnvironmentId("env#1");
+        List<Entrypoint> result = cut.findAllByEnvironmentId("env#1");
         assertEquals(1, result.size());
         assertEquals("https://after.example.com", result.get(0).getUrl());
     }
@@ -213,10 +213,10 @@ public class AbstractEntryPointManagerTest {
         when(entrypointRepository.findById("e1")).thenReturn(Maybe.just(entrypoint), Maybe.empty());
 
         cut.onEvent(event(EntrypointEvent.DEPLOY, "e1"));
-        assertEquals(1, cut.findByEnvironmentId("env#1").size());
+        assertEquals(1, cut.findAllByEnvironmentId("env#1").size());
 
         cut.onEvent(event(EntrypointEvent.UPDATE, "e1"));
-        assertTrue(cut.findByEnvironmentId("env#1").isEmpty());
+        assertTrue(cut.findAllByEnvironmentId("env#1").isEmpty());
     }
 
     @Test
@@ -228,7 +228,7 @@ public class AbstractEntryPointManagerTest {
         cut.onEvent(event(EntrypointEvent.DEPLOY, "e1"));
         cut.onEvent(event(EntrypointEvent.UPDATE, "e1"));
 
-        assertEquals(List.of(entrypoint), cut.findByEnvironmentId("env#1"));
+        assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
     }
 
     @Test
@@ -239,7 +239,7 @@ public class AbstractEntryPointManagerTest {
 
         cut.onEvent(event(EntrypointEvent.DEPLOY, "e2"));
 
-        assertTrue(cut.findByEnvironmentId("env#9").isEmpty());
+        assertTrue(cut.findAllByEnvironmentId("env#9").isEmpty());
     }
 
     private static Set<String> idsOf(List<Entrypoint> entrypoints) {
@@ -250,21 +250,21 @@ public class AbstractEntryPointManagerTest {
     public void shouldResolveNothingWhenEnvironmentHasNoEntrypoint() throws Exception {
         cache(generatedEntrypoint("other-env-generated", "env#other"));
 
-        assertTrue(cut.resolveByEnvironmentId("env#1").isEmpty());
+        assertTrue(cut.findByEnvironmentId("env#1").isEmpty());
     }
 
     @Test
     public void shouldResolveTheGeneratedEntrypointWhenItIsTheOnlyOne() throws Exception {
         cache(generatedEntrypoint("generated", "env#1"));
 
-        assertEquals(Set.of("generated"), idsOf(cut.resolveByEnvironmentId("env#1")));
+        assertEquals(Set.of("generated"), idsOf(cut.findByEnvironmentId("env#1")));
     }
 
     @Test
     public void shouldResolveTheOverridingEntrypointAndDropTheGeneratedOne() throws Exception {
         cache(generatedEntrypoint("generated", "env#1"), entrypoint("overriding", "org#1", "env#1"));
 
-        assertEquals(Set.of("overriding"), idsOf(cut.resolveByEnvironmentId("env#1")));
+        assertEquals(Set.of("overriding"), idsOf(cut.findByEnvironmentId("env#1")));
     }
 
     @Test
@@ -273,7 +273,7 @@ public class AbstractEntryPointManagerTest {
                 entrypoint("overriding-1", "org#1", "env#1"),
                 entrypoint("overriding-2", "org#1", "env#1"));
 
-        assertEquals(Set.of("overriding-1", "overriding-2"), idsOf(cut.resolveByEnvironmentId("env#1")));
+        assertEquals(Set.of("overriding-1", "overriding-2"), idsOf(cut.findByEnvironmentId("env#1")));
     }
 
     @Test
@@ -282,6 +282,6 @@ public class AbstractEntryPointManagerTest {
         // default. Filtering them all away would leave callers with no URL at all.
         cache(generatedEntrypoint("generated-1", "env#1"), generatedEntrypoint("generated-2", "env#1"));
 
-        assertEquals(Set.of("generated-1", "generated-2"), idsOf(cut.resolveByEnvironmentId("env#1")));
+        assertEquals(Set.of("generated-1", "generated-2"), idsOf(cut.findByEnvironmentId("env#1")));
     }
 }

--- a/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
@@ -54,18 +54,37 @@ const domainEntrypointUrls = async (): Promise<string[]> => {
 // first, then re-synced to a single one. In cloud mode the endpoint resolves the environment entrypoint,
 // not the internal data-plane gateway URL. retryUntil covers the management API sync-tick cache latency.
 describe('Cloud domain entrypoint URL (management API)', () => {
-  it('resolves a single environment access-point URL when the environment has several access points', async () => {
-    // The fixture provisions two GATEWAY access points; cloud mode returns exactly one (the
-    // default-flagged access point if any, otherwise the first), always one of the environment
-    // URLs (never the gateway fallback).
+  it('resolves every access point when none of them is the customer override', async () => {
+    // The fixture provisions two GATEWAY access points with no `overriding` flag, so both are stored
+    // as the environment's default entrypoint. Nothing can be dropped without emptying the list, so
+    // the endpoint returns them both — never nothing.
     const urls = await retryUntil(
       () => domainEntrypointUrls(),
-      (resolved) => resolved.length === 1 && fixture.expectedUrls.includes(resolved[0]),
+      (resolved) => resolved.length === fixture.expectedUrls.length,
       POLL,
     );
 
-    expect(urls).toHaveLength(1);
-    expect(fixture.expectedUrls).toContain(urls[0]);
+    expect([...urls].sort()).toEqual([...fixture.expectedUrls].sort());
+  });
+
+  it("resolves the customer's overriding access point and drops the one Cockpit generated", async () => {
+    const generatedHost = fixture.uniqueHost();
+    const overridingHost = fixture.uniqueHost();
+    await fixture.resyncAccessPoints([
+      { host: generatedHost, overriding: false },
+      { host: overridingHost, overriding: true },
+    ]);
+
+    // This is the whole point of the flag: Cockpit's `overriding` bit has to survive the wire into
+    // AM, or the generated host would be resolved instead.
+    const urls = await retryUntil(
+      () => domainEntrypointUrls(),
+      (resolved) => resolved.length === 1 && resolved[0] === `https://${overridingHost}`,
+      POLL,
+    );
+
+    expect(urls).toEqual([`https://${overridingHost}`]);
+    expect(urls).not.toContain(`https://${generatedHost}`);
   });
 
   it('resolves the environment access-point URL when the environment has a single access point', async () => {

--- a/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
@@ -87,6 +87,21 @@ describe('Cloud domain entrypoint URL (management API)', () => {
     expect(urls).not.toContain(`https://${generatedHost}`);
   });
 
+  it('resolves every overriding access point when the customer has several custom domains', async () => {
+    const first = fixture.uniqueHost();
+    const second = fixture.uniqueHost();
+    await fixture.resyncAccessPoints([
+      { host: first, overriding: true },
+      { host: second, overriding: true },
+    ]);
+
+    // Nothing is the generated default here, so there is nothing to drop and both are returned.
+    const expected = [`https://${first}`, `https://${second}`].sort();
+    const urls = await retryUntil(() => domainEntrypointUrls(), (resolved) => resolved.length === 2, POLL);
+
+    expect([...urls].sort()).toEqual(expected);
+  });
+
   it('resolves the environment access-point URL when the environment has a single access point', async () => {
     const [expectedUrl] = await fixture.resyncAccessPoints([fixture.uniqueHost()]);
 

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-entrypoint-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-entrypoint-fixture.ts
@@ -25,6 +25,18 @@ const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 
 const urlFor = (host: string) => `https://${host}`;
 
+/**
+ * A gateway access point to provision. A bare host is the access point Cockpit generates itself
+ * (`overriding` absent, exactly as older Cockpit versions send it); the object form sets the flag
+ * explicitly so specs can provision a customer's overriding access point.
+ */
+export type AccessPointSpec = string | { host: string; overriding: boolean };
+
+const hostOf = (spec: AccessPointSpec): string => (typeof spec === 'string' ? spec : spec.host);
+
+const accessPointPayload = (spec: AccessPointSpec) =>
+  typeof spec === 'string' ? { target: 'GATEWAY', host: spec } : { target: 'GATEWAY', host: spec.host, overriding: spec.overriding };
+
 export interface CloudEntrypointFixture {
   organizationId: string;
   environmentId: string;
@@ -33,8 +45,8 @@ export interface CloudEntrypointFixture {
   expectedUrls: string[];
   /** A globally-unique gateway host, safe to reuse across parallel runs. */
   uniqueHost: () => string;
-  /** Re-issue the ENVIRONMENT command with a new set of gateway hosts; returns the expected https URLs. */
-  resyncAccessPoints: (hosts: string[]) => Promise<string[]>;
+  /** Re-issue the ENVIRONMENT command with a new set of gateway access points; returns the expected https URLs. */
+  resyncAccessPoints: (accessPoints: AccessPointSpec[]) => Promise<string[]>;
   /** The entrypoint URLs the gateway currently has cached for this domain's environment, sorted. */
   cachedEntrypointUrls: () => Promise<string[]>;
   cleanup: () => Promise<void>;
@@ -55,7 +67,8 @@ export const setupCloudEntrypointFixture = async (accessToken: string): Promise<
   // Track every host we ever provision so cleanup removes all of them, not just the current set
   // (each ENVIRONMENT command deletes-and-recreates the environment's entrypoints).
   const provisionedHosts = new Set<string>();
-  const resyncAccessPoints = async (hosts: string[]): Promise<string[]> => {
+  const resyncAccessPoints = async (accessPoints: AccessPointSpec[]): Promise<string[]> => {
+    const hosts = accessPoints.map(hostOf);
     hosts.forEach((host) => provisionedHosts.add(host));
     await sendCockpitCommand({
       type: 'ENVIRONMENT',
@@ -64,7 +77,7 @@ export const setupCloudEntrypointFixture = async (accessToken: string): Promise<
         organizationId,
         hrids: [environmentId],
         name: 'AM7226 cloud entrypoint env',
-        accessPoints: hosts.map((host) => ({ target: 'GATEWAY', host })),
+        accessPoints: accessPoints.map(accessPointPayload),
       },
     });
     return hosts.map(urlFor);

--- a/gravitee-am-ui/src/app/services/domain.service.ts
+++ b/gravitee-am-ui/src/app/services/domain.service.ts
@@ -76,7 +76,10 @@ export class DomainService {
         if (entrypoints.length === 1) {
           entrypoint = entrypoints[0];
         } else {
-          entrypoint = entrypoints.filter((e) => !e.defaultEntrypoint)[0];
+          // In cloud mode an environment whose access points all arrive without Cockpit's `overriding`
+          // flag resolves to several entrypoints that are every one of them flagged default, so the
+          // filter can come back empty. Fall back rather than hand callers an undefined entrypoint.
+          entrypoint = entrypoints.filter((e) => !e.defaultEntrypoint)[0] ?? entrypoints[0];
         }
 
         return entrypoint;


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7298

## :pencil2: A description of the changes proposed in the pull request

Cockpit tells us which of an environment's gateway access points is the customer's override, via `AccessPoint.isOverriding()`. We were dropping it, so `listEnvironmentEntryPoint` had to guess which entrypoint to build URLs from.

I carry the bit on the existing `defaultEntrypoint` field, inverted. The access point Cockpit generates itself becomes the environment's default entrypoint, the customer's override does not. Counter intuitive, but it avoids a new field, a migration across six DB dialects and an API contract change. Resolution then drops the default whenever an override exists, which mirrors what the organization path has always done.

The rule sits on `EntryPointManager` in `gravitee-am-service` rather than in the management API, so the gateway can reach it too. That's the "apply this logic everywhere in MAPI/GW" part of the ticket, and it means AM-7229 and AM-7230 become call sites instead of two independent reimplementations.

### Worth knowing before you review

Cockpit already does this selection upstream, so the drop-the-default branch will not fire in practice. `CommandFactory.environmentCommand` groups access points by target and sends either only the overriding ones or the whole group:

```java
var hasOverride = group.stream().anyMatch(AccessPoint::isOverriding);
return hasOverride
    ? group.stream().filter(AccessPoint::isOverriding)
    : group.stream();
```

So AM never receives a generated plus custom mix for GATEWAY, it gets all-overriding or all-generated. Either way the rule returns everything it was given. I have kept it as defence in depth rather than relying on a filter in another repo staying put, and because the flag is still worth persisting as information, but it is not load bearing and I would rather you knew that going in than found it in review.

What that leaves genuinely doing work is the never-empty guard and the console fix. An environment with no custom domain and more than one generated gateway access point comes back all flagged default, which is the normal case rather than an edge case, and the console used to resolve that to undefined.

### Two other decisions worth a look

The cloud branch no longer falls through to `listOrganizationEntryPoint`. `findAll(organizationId)` is organization wide and returns environment scoped rows, so once those are default flagged that path would collect every other environment's default, trip its `size > 1` branch and filter the whole list away. Cutting the delegation means `listOrganizationEntryPoint` is untouched and only reachable in non cloud mode, where environment entrypoints cannot exist.

`overriding` is a primitive boolean, so a payload that omits it deserializes to false and flags everything default. Resolution returns all of them rather than none in that case.

## :memo: Test scenarios

Unit, four seams. `AbstractEntryPointManagerTest` covers the rule itself (none, only generated, generated plus override, several overrides, all flagged default). `EntrypointServiceTest` covers the flag plumbing and deleting a default flagged environment entrypoint, which now goes through the last default guard. `EnvironmentCommandHandlerTest` covers `overriding` true, false and absent. `DomainServiceTest` covers the read path, including a case proving the organization fallback ignores other environments' rows.

Two existing tests encoded the assumption this inverts and are rewritten rather than extended, `shouldGetEntrypoint_cloud_multipleEntrypoints_picksDefaultFlagged` and `..._noneDefault_picksFirstInList`. The five non cloud tests pass untouched as the regression guard.

Jest, `specs/cloud/domain-entrypoint-url.jest.spec.ts` provisions a generated plus an overriding access point and asserts the management API returns the override host.

Run against a managed cloud stack: all 3 `specs/cloud` suites pass (9 tests), plus `applications` (26), `application-endpoints` (9) and `automation/domains` (14). `domain/vhost-mode` fails on a cloud stack but that is AM-7228's vhost ban rejecting with a different message, nothing to do with this branch. 2726 and 642 Java tests green across the two modules, 128 UI tests green, lint and prettier clean.

I also drove the cockpit mock directly. Flags land as expected, `overriding:false` gives `defaultEntrypoint=true`, `overriding:true` gives false, omitted gives true. Resolution returns the override only for a mixed pair, both for two non overriding, the single one when there is one, both for two overrides, and the org default carrying the data plane URL when the environment has none.

## :computer: Add screenshots for UI

No visible UI changes. The one frontend change is a one line fallback in `DomainService.getEntrypoint` so it cannot hand callers an undefined entrypoint.

## :books: Any other comments that will help with documentation

Some pre existing residue I noticed but deliberately left alone, none of it introduced here. `createEntrypoint` hardcodes `https://` and ignores `AccessPoint.secured`, both from AM-7226. And environment entrypoint deletes now take the last default guard branch instead of short circuiting, so there is an extra organization wide query per entrypoint on each ENVIRONMENT command. It always passes because the organization keeps its own default, and I covered it with a test rather than adding a guard for a case that cannot happen.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
