### PR TITLE
feat: AM-7240 lock unlicensed features in UI

### DIFF
--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -261,6 +261,7 @@ import { EntrypointsResolver } from './resolvers/entrypoints.resolver';
 import { EntrypointResolver } from './resolvers/entrypoint.resolver';
 import { EntrypointService } from './services/entrypoint.service';
 import { CloudModeService } from './services/cloud-mode.service';
+import { PluginFeatureService } from './services/plugin-feature.service';
 import { EntrypointsComponent } from './settings/management/entrypoints/entrypoints.component';
 import { EntrypointCreationComponent } from './settings/management/entrypoints/creation/entrypoint-creation.component';
 import { EntrypointComponent } from './settings/management/entrypoints/entrypoint/entrypoint.component';
@@ -316,6 +317,7 @@ import { DomainPermissionsResolver } from './resolvers/domain-permissions.resolv
 import { AuthGuard } from './guards/auth-guard.service';
 import { HasPermissionDirective } from './directives/has-permission.directive';
 import { HasAnyPermissionDirective } from './directives/has-any-permission.directive';
+import { LicenseGuardDirective } from './directives/license-guard.directive';
 import { AnalyticsService } from './services/analytics.service';
 import { DashboardComponent } from './domain/components/dashboard/dashboard.component';
 import { WidgetComponent } from './components/widget/widget.component';
@@ -724,6 +726,7 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     MembershipsDialogComponent,
     HasPermissionDirective,
     HasAnyPermissionDirective,
+    LicenseGuardDirective,
     IdenticonHashDirective,
     InfoBannerComponent,
     DashboardComponent,
@@ -948,6 +951,7 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     TagResolver,
     EntrypointService,
     CloudModeService,
+    PluginFeatureService,
     EntrypointsResolver,
     EntrypointResolver,
     PolicyService,

--- a/gravitee-am-ui/src/app/components/gio-license/gio-license-data.ts
+++ b/gravitee-am-ui/src/app/components/gio-license/gio-license-data.ts
@@ -37,6 +37,11 @@ export enum AmFeature {
   AM_GRAVITEE_RISK_ASSESSMENT = 'gravitee-risk-assessment',
   AM_IDP_SAML2 = 'am-idp-saml2',
   ALERT_ENGINE = 'alert-engine',
+  /**
+   * Generic fallback used to render the upgrade dialog for an Enterprise plugin whose own feature
+   * has no dedicated entry.
+   */
+  AM_ENTERPRISE = 'am-enterprise',
 }
 
 export const FeatureInfoData: Record<AmFeature, FeatureInfo> = {
@@ -147,6 +152,11 @@ export const FeatureInfoData: Record<AmFeature, FeatureInfo> = {
     image: 'assets/gio-license/alert-engine.svg',
     description:
       'Alert Engine allows you to isolate, understand and remediate for API performance and security risks before they cause a problem for your customers.',
+  },
+  [AmFeature.AM_ENTERPRISE]: {
+    image: 'assets/gio-license/gravitee-ee-upgrade.svg',
+    title: 'Gravitee Enterprise',
+    description: 'This is part of Gravitee Enterprise. Upgrade your license to enable it.',
   },
 };
 

--- a/gravitee-am-ui/src/app/directives/license-guard.directive.spec.ts
+++ b/gravitee-am-ui/src/app/directives/license-guard.directive.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElementRef } from '@angular/core';
+import { of } from 'rxjs';
+import { GioLicenseService } from '@gravitee/ui-particles-angular';
+
+import { AmFeature } from '../components/gio-license/gio-license-data';
+
+import { LicenseGuardDirective } from './license-guard.directive';
+
+describe('LicenseGuardDirective', () => {
+  let element: HTMLButtonElement;
+  let openDialog: jest.Mock;
+  let isMissingFeature$: jest.Mock;
+  let directive: LicenseGuardDirective;
+
+  const setup = (missing: boolean) => {
+    element = document.createElement('button');
+    document.body.appendChild(element);
+    openDialog = jest.fn();
+    isMissingFeature$ = jest.fn().mockReturnValue(of(missing));
+    const licenseService = { isMissingFeature$, openDialog } as unknown as GioLicenseService;
+    directive = new LicenseGuardDirective(licenseService, { nativeElement: element } as ElementRef);
+    directive.licenseOptions = { feature: 'am-mfa-sms' };
+    directive.ngOnInit();
+    directive.ngOnChanges();
+  };
+
+  afterEach(() => {
+    directive.ngOnDestroy();
+    element.remove();
+  });
+
+  it('opens the upgrade dialog and blocks the host click when the feature is missing', () => {
+    setup(true);
+    const hostClick = jest.fn();
+    element.addEventListener('click', hostClick);
+    element.click();
+    expect(openDialog).toHaveBeenCalledWith({ feature: 'am-mfa-sms' }, expect.anything());
+    expect(hostClick).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a generic upsell dialog when the feature has no FeatureInfoData entry', () => {
+    setup(true);
+    openDialog.mockImplementationOnce(() => {
+      throw new Error('Unknown Feature value');
+    });
+    const hostClick = jest.fn();
+    element.addEventListener('click', hostClick);
+    element.click();
+    expect(openDialog).toHaveBeenCalledTimes(2);
+    expect(openDialog).toHaveBeenLastCalledWith({ feature: AmFeature.AM_ENTERPRISE }, expect.anything());
+    expect(hostClick).not.toHaveBeenCalled(); // still blocked
+  });
+
+  it('lets the host click through when the feature is granted', () => {
+    setup(false);
+    const hostClick = jest.fn();
+    element.addEventListener('click', hostClick);
+    element.click();
+    expect(openDialog).not.toHaveBeenCalled();
+    expect(hostClick).toHaveBeenCalled();
+  });
+
+  it('re-evaluates when the license options resolve asynchronously', () => {
+    setup(false); // initially not missing (e.g. before the feature is resolved)
+    isMissingFeature$.mockReturnValue(of(true));
+    directive.licenseOptions = { feature: 'am-mfa-call' };
+    directive.ngOnChanges();
+
+    const hostClick = jest.fn();
+    element.addEventListener('click', hostClick);
+    element.click();
+    expect(openDialog).toHaveBeenCalled();
+    expect(hostClick).not.toHaveBeenCalled();
+  });
+});

--- a/gravitee-am-ui/src/app/directives/license-guard.directive.ts
+++ b/gravitee-am-ui/src/app/directives/license-guard.directive.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive, ElementRef, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { GioLicenseService, LicenseOptions } from '@gravitee/ui-particles-angular';
+
+import { AmFeature } from '../components/gio-license/gio-license-data';
+
+/**
+ * Reactive licensing guard for an action control (e.g. a SAVE button or a plugin creation card).
+ *
+ * When the bound feature is not granted by the effective license, a capture-phase click handler
+ * swallows the click and opens the Gravitee upgrade dialog instead of letting the component's own
+ * handler run (which would hit the backend and 403). When the feature is granted — or no feature is
+ * required — the control behaves normally.
+ *
+ * Improvements over the library's {@code gioLicense} directive:
+ * - it re-evaluates on input changes, so it works when the {@link LicenseOptions} are resolved
+ *   asynchronously (the common case here — the feature is looked up from the plugin catalog after
+ *   the view has initialised);
+ * - it tolerates a feature with no dedicated {@code FeatureInfoData} entry (e.g. a newer/third-party
+ *   plugin): {@code gioLicense}/{@code getFeatureInfo} throw in that case, which silently breaks the
+ *   interception; here we fall back to a generic upgrade dialog instead.
+ */
+@Directive({
+  selector: '[licenseGuard]',
+  standalone: false,
+})
+export class LicenseGuardDirective implements OnInit, OnChanges, OnDestroy {
+  @Input('licenseGuard') licenseOptions?: LicenseOptions;
+
+  private missingFeature = false;
+  private subscription?: Subscription;
+  private readonly onClick = (event: Event): void => {
+    if (!this.missingFeature) {
+      return;
+    }
+    // Block the host's own (click) handler (which would hit the backend and 403) and upsell instead.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    try {
+      this.licenseService.openDialog(this.licenseOptions, event);
+    } catch {
+      // getFeatureInfo throws when the plugin's feature has no dedicated FeatureInfoData entry;
+      // fall back to a generic Enterprise upgrade dialog so the upsell still shows.
+      this.licenseService.openDialog({ feature: AmFeature.AM_ENTERPRISE }, event);
+    }
+  };
+
+  constructor(
+    private readonly licenseService: GioLicenseService,
+    private readonly elementRef: ElementRef,
+  ) {}
+
+  ngOnInit(): void {
+    // Capture phase so we intercept before the host's own (click) handler.
+    this.elementRef.nativeElement.addEventListener('click', this.onClick, true);
+  }
+
+  ngOnChanges(): void {
+    this.subscription?.unsubscribe();
+    this.subscription = this.licenseService
+      .isMissingFeature$(this.licenseOptions?.feature)
+      .subscribe((missingFeature) => (this.missingFeature = missingFeature));
+  }
+
+  ngOnDestroy(): void {
+    this.elementRef.nativeElement.removeEventListener('click', this.onClick, true);
+    this.subscription?.unsubscribe();
+  }
+}

--- a/gravitee-am-ui/src/app/domain/alerts/notifiers/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/alerts/notifiers/creation/steps/step1/step1.component.html
@@ -18,24 +18,27 @@
 <div fxLayout="column">
   <p class="gv-plugin-creation-description">Choose how your alerts will be emitted. It could be any of the following supported channels</p>
 
-  <div *ngIf="notifiers.length > 0" fxLayout="row wrap" fxFlex fxLayoutGap="10px" fxLayoutAlign="center">
+  <div *ngIf="notifiers.length > 0" class="plugin-type-grid" fxLayout="row wrap" fxFlex fxLayoutAlign="center">
     <mat-card
       appearance="outlined"
+      class="plugin-type-card"
       *ngFor="let n of notifiers"
       fxFlex="30"
       [class.selected]="alertNotifier.type === n.id"
       (click)="selectNotifier(n)"
       (keyup.enter)="selectNotifier(n)"
       tabIndex="0"
+      [licenseGuard]="n.licenseOptions"
     >
       <mat-card-content>
+        <mat-icon *ngIf="n.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         <div class="identity-provider__icon" [innerHTML]="getNotifierIcon(n) | safe: 'html'"></div>
         {{ n.name }}
       </mat-card-content>
     </mat-card>
   </div>
 
-  <div *ngIf="notifiers.length === 0" fxLayout="row wrap" fxFlex fxLayoutGap="10px" fxLayoutAlign="center">
+  <div *ngIf="notifiers.length === 0" class="plugin-type-grid" fxLayout="row wrap" fxFlex fxLayoutAlign="center">
     <p>No plugin notifier installed</p>
   </div>
 </div>

--- a/gravitee-am-ui/src/app/domain/alerts/notifiers/creation/steps/step1/step1.component.scss
+++ b/gravitee-am-ui/src/app/domain/alerts/notifiers/creation/steps/step1/step1.component.scss
@@ -5,7 +5,6 @@ mat-card {
 
   display: flex;
   box-sizing: border-box;
-  margin-top: 10px;
   place-content: center center;
 }
 

--- a/gravitee-am-ui/src/app/domain/alerts/notifiers/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/alerts/notifiers/creation/steps/step1/step1.component.ts
@@ -16,6 +16,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../services/plugin-feature.service';
+
 @Component({
   selector: 'alert-notifier-creation-step1',
   templateUrl: './step1.component.html',
@@ -23,13 +25,18 @@ import { ActivatedRoute } from '@angular/router';
   standalone: false,
 })
 export class DomainAlertNotifierCreationStep1Component implements OnInit {
-  notifiers: any[];
+  notifiers: (any & LicensedPlugin)[];
   @Input() alertNotifier;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(
+    private route: ActivatedRoute,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit() {
-    this.notifiers = this.route.snapshot.data['notifiers'];
+    this.pluginFeatureService
+      .decorateCatalog$(this.route.snapshot.data['notifiers'])
+      .subscribe((notifiers) => (this.notifiers = notifiers));
   }
 
   selectNotifier(notifier) {

--- a/gravitee-am-ui/src/app/domain/alerts/notifiers/notifier/notifier.component.html
+++ b/gravitee-am-ui/src/app/domain/alerts/notifiers/notifier/notifier.component.html
@@ -51,9 +51,11 @@
             <div *hasPermission="['domain_alert_notifier_update']" fxLayout="row">
               <button
                 mat-raised-button
+                [licenseGuard]="licenseOptions"
                 [disabled]="(!alertNotifierForm.valid || alertNotifierForm.pristine) && (!configurationIsValid || configurationPristine)"
                 (click)="update()"
               >
+                <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
                 SAVE
               </button>
             </div>

--- a/gravitee-am-ui/src/app/domain/alerts/notifiers/notifier/notifier.component.ts
+++ b/gravitee-am-ui/src/app/domain/alerts/notifiers/notifier/notifier.component.ts
@@ -15,12 +15,15 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { AlertService } from '../../../../services/alert.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { DialogService } from '../../../../services/dialog.service';
 import { OrganizationService } from '../../../../services/organization.service';
+import { PluginFeatureService } from '../../../../services/plugin-feature.service';
 
 @Component({
   templateUrl: './notifier.component.html',
@@ -37,6 +40,8 @@ export class DomainAlertNotifierComponent implements OnInit {
   alertNotifierConfiguration: any;
   updateAlertNotifierConfiguration: any;
   redirectUri: string;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
 
   constructor(
     private alertService: AlertService,
@@ -45,6 +50,7 @@ export class DomainAlertNotifierComponent implements OnInit {
     private router: Router,
     private dialogService: DialogService,
     private organizationService: OrganizationService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -52,6 +58,10 @@ export class DomainAlertNotifierComponent implements OnInit {
     this.domain = this.route.snapshot.data['domain'];
     this.alertNotifierConfiguration = JSON.parse(this.alertNotifier.configuration);
     this.updateAlertNotifierConfiguration = this.alertNotifierConfiguration;
+    this.pluginFeatureService.getFeature$('notifier', this.alertNotifier.type).subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('notifier', this.alertNotifier.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
     this.organizationService.notifierSchema(this.alertNotifier.type).subscribe((data) => {
       this.notifierSchema = data;

--- a/gravitee-am-ui/src/app/domain/authorization-engines/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/authorization-engines/creation/steps/step1/step1.component.html
@@ -38,9 +38,10 @@
     </mat-card>
   </div>
 
-  <div *ngIf="hasAvailablePlugins" fxLayout="row wrap" fxFlex fxLayoutGap="10px" fxLayoutAlign="center">
+  <div *ngIf="hasAvailablePlugins" class="plugin-type-grid" fxLayout="row wrap" fxFlex fxLayoutAlign="center">
     <mat-card
       appearance="outlined"
+      class="plugin-type-card"
       *ngFor="let plugin of filteredPlugins"
       fxFlex="30"
       [class.selected]="authorizationEngine.type === plugin.id"
@@ -48,9 +49,10 @@
       (click)="selectEngineType(plugin)"
       (keyup.enter)="selectEngineType(plugin)"
       tabIndex="0"
-      [gioLicense]="plugin"
+      [licenseGuard]="plugin.licenseOptions"
     >
       <mat-card-content>
+        <mat-icon *ngIf="plugin.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         <div class="authorization-engine-plugin__icon" [innerHTML]="getIcon(plugin) | safe: 'html'"></div>
         {{ displayName(plugin) }}
         <div *ngIf="isTypeInUse(plugin.id)" class="already-in-use-badge">

--- a/gravitee-am-ui/src/app/domain/authorization-engines/creation/steps/step1/step1.component.scss
+++ b/gravitee-am-ui/src/app/domain/authorization-engines/creation/steps/step1/step1.component.scss
@@ -5,7 +5,6 @@ mat-card {
 
   display: flex;
   box-sizing: border-box;
-  margin-top: 10px;
   place-content: center center;
 }
 

--- a/gravitee-am-ui/src/app/domain/authorization-engines/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/authorization-engines/creation/steps/step1/step1.component.ts
@@ -16,6 +16,8 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
+import { PluginFeatureService } from '../../../../../services/plugin-feature.service';
+
 @Component({
   selector: 'authorization-engine-creation-step1',
   templateUrl: './step1.component.html',
@@ -30,13 +32,18 @@ export class AuthorizationEngineCreationStep1Component implements OnInit {
   filteredPlugins: any[];
   hasAvailablePlugins: boolean;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(
+    private route: ActivatedRoute,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit() {
     this.filter = '';
-    this.authorizationEnginePlugins = this.route.snapshot.data['authorizationEnginePlugins'];
     this.existingEngines = this.route.snapshot.data['authorizationEngines'] || [];
-    this.filteredPlugins = this.getFilteredPlugins();
+    this.pluginFeatureService.decorateCatalog$(this.route.snapshot.data['authorizationEnginePlugins']).subscribe((plugins) => {
+      this.authorizationEnginePlugins = plugins;
+      this.filteredPlugins = this.getFilteredPlugins();
+    });
   }
 
   selectEngineType(plugin: any) {

--- a/gravitee-am-ui/src/app/domain/authorization-engines/openfga/openfga.component.html
+++ b/gravitee-am-ui/src/app/domain/authorization-engines/openfga/openfga.component.html
@@ -364,10 +364,12 @@ type document
             <button
               mat-raised-button
               color="primary"
+              [licenseGuard]="licenseOptions$ | async"
               (click)="saveConfiguration()"
               [disabled]="!isConfigurationDirty() || !configurationIsValid || isSaving"
             >
               <span class="gv-button-content">
+                <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
                 <mat-progress-spinner *ngIf="isSaving" [diameter]="16" [strokeWidth]="2" mode="indeterminate"></mat-progress-spinner>
                 <span>{{ isSaving ? 'Saving...' : 'SAVE' }}</span>
               </span>

--- a/gravitee-am-ui/src/app/domain/authorization-engines/openfga/openfga.component.ts
+++ b/gravitee-am-ui/src/app/domain/authorization-engines/openfga/openfga.component.ts
@@ -18,12 +18,13 @@ import { ActivatedRoute } from '@angular/router';
 import { FormControl, Validators } from '@angular/forms';
 import { transformer } from '@openfga/syntax-transformer';
 import { graphBuilder } from '@openfga/frontend-utils';
-import { Subscription } from 'rxjs';
-import { filter, finalize, switchMap, tap } from 'rxjs/operators';
+import { Observable, Subscription } from 'rxjs';
+import { filter, finalize, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { Network } from 'vis-network';
 import { decodeTime } from 'ulid';
 import './openfga-mode';
 import { HttpErrorResponse } from '@angular/common/http';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { OpenFGAService } from '../../../services/openfga.service';
 import { AuthorizationEngineService } from '../../../services/authorization-engine.service';
@@ -31,6 +32,7 @@ import { SnackbarService } from '../../../services/snackbar.service';
 import { OrganizationService } from '../../../services/organization.service';
 import { DialogService } from '../../../services/dialog.service';
 import { PaginationService } from '../../../services/pagination.service';
+import { PluginFeatureService } from '../../../services/plugin-feature.service';
 
 interface AuthorizationEngine {
   id?: string;
@@ -79,6 +81,8 @@ export class OpenFGAComponent implements OnInit, OnDestroy {
   engineId: string;
   authorizationEngine: AuthorizationEngine = { name: '', type: '', configuration: '' };
   plugin: Plugin | null = null;
+  licenseOptions$: Observable<LicenseOptions>;
+  isMissingFeature$: Observable<boolean>;
   storeId: string;
   authorizationModelId: string;
   storeInfo: StoreInfo | null = null;
@@ -162,6 +166,7 @@ export class OpenFGAComponent implements OnInit, OnDestroy {
     private snackbarService: SnackbarService,
     private organizationService: OrganizationService,
     private dialogService: DialogService,
+    private pluginFeatureService: PluginFeatureService,
   ) {
     this.tuplePagination = new PaginationService<Tuple>();
     this.modelPagination = new PaginationService<AuthorizationModel>();
@@ -188,6 +193,12 @@ export class OpenFGAComponent implements OnInit, OnDestroy {
         next: (engine) => {
           this.authorizationEngine = engine;
           this.plugin = this.authorizationEnginePlugins?.[engine.type];
+          this.licenseOptions$ = this.pluginFeatureService
+            .getFeature$('authorization_engine', engine.type)
+            .pipe(map((feature) => ({ feature })));
+          this.isMissingFeature$ = this.pluginFeatureService
+            .isMissingFeatureForType$('authorization_engine', engine.type)
+            .pipe(shareReplay({ bufferSize: 1, refCount: true }));
           const config = JSON.parse(engine.configuration || '{}');
           this.storeId = config.storeId;
           this.authorizationModelId = config.authorizationModelId;

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.html
@@ -75,7 +75,10 @@
         </div>
       </div>
       <div fxLayout="row">
-        <button mat-raised-button [disabled]="!readyToSave()" (click)="save()">SAVE</button>
+        <button mat-raised-button [licenseGuard]="licenseOptions" [disabled]="!readyToSave()" (click)="save()">
+          <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
+          SAVE
+        </button>
       </div>
       <ng-template [ngIf]="!createMode">
         <!-- use ng-template otherwise *ngIf can't be used into the div -->

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.ts
@@ -15,12 +15,15 @@
  */
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { DialogService } from '../../../../../services/dialog.service';
 import { OrganizationService } from '../../../../../services/organization.service';
 import { ReporterService } from '../../../../../services/reporter.service';
 import { SnackbarService } from '../../../../../services/snackbar.service';
+import { PluginFeatureService } from '../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'app-reporter',
@@ -43,6 +46,8 @@ export class ReporterComponent implements OnInit {
   updateReporterConfiguration: any;
   formChanged = false;
   hasName = false;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
 
   constructor(
     private route: ActivatedRoute,
@@ -51,6 +56,7 @@ export class ReporterComponent implements OnInit {
     private reporterService: ReporterService,
     private snackbarService: SnackbarService,
     private dialogService: DialogService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -84,6 +90,14 @@ export class ReporterComponent implements OnInit {
     }
     this.validateName();
     this.getSchemaFor(this.reporter.type);
+    this.updateLicenseOptions(this.reporter.type);
+  }
+
+  private updateLicenseOptions(type) {
+    this.pluginFeatureService.getFeature$('reporter', type).subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('reporter', type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
   }
 
   getSchemaFor(type) {
@@ -105,6 +119,7 @@ export class ReporterComponent implements OnInit {
 
   onReporterTypeChanged(event) {
     this.getSchemaFor(event.value);
+    this.updateLicenseOptions(event.value);
   }
 
   labelFor(pluginId) {

--- a/gravitee-am-ui/src/app/domain/settings/botdetections/bot-detection/bot-detection.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/botdetections/bot-detection/bot-detection.component.html
@@ -60,11 +60,13 @@
         <div fxLayout="row" *ngIf="editMode">
           <button
             mat-raised-button
+            [licenseGuard]="licenseOptions"
             [disabled]="
               (!botDetectionForm.valid || botDetectionForm.pristine) && (!configurationIsValid || configurationPristine) && !formChanged
             "
             (click)="update()"
           >
+            <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
             SAVE
           </button>
         </div>

--- a/gravitee-am-ui/src/app/domain/settings/botdetections/bot-detection/bot-detection.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/botdetections/bot-detection/bot-detection.component.ts
@@ -15,13 +15,16 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { BotDetectionService } from '../../../../services/bot-detection.service';
 import { OrganizationService } from '../../../../services/organization.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { DialogService } from '../../../../services/dialog.service';
 import { AuthService } from '../../../../services/auth.service';
+import { PluginFeatureService } from '../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'app-bot-detection',
@@ -39,6 +42,8 @@ export class BotDetectionComponent implements OnInit {
   botDetectionConfiguration: any;
   updatebotDetectionConfiguration: any;
   editMode: boolean;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
 
   constructor(
     private route: ActivatedRoute,
@@ -48,6 +53,7 @@ export class BotDetectionComponent implements OnInit {
     private snackbarService: SnackbarService,
     private dialogService: DialogService,
     private authService: AuthService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -56,6 +62,12 @@ export class BotDetectionComponent implements OnInit {
     this.botDetectionConfiguration = JSON.parse(this.botDetection.configuration);
     this.updatebotDetectionConfiguration = this.botDetectionConfiguration;
     this.editMode = this.authService.hasPermissions(['domain_bot_detection_update']);
+    this.pluginFeatureService
+      .getFeature$('bot_detection', this.botDetection.type)
+      .subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('bot_detection', this.botDetection.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
     this.organizationService.botDetectionsSchema(this.botDetection.type).subscribe((data) => {
       this.botDetectionSchema = data;

--- a/gravitee-am-ui/src/app/domain/settings/botdetections/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/botdetections/creation/steps/step1/step1.component.html
@@ -18,13 +18,20 @@
 <div fxLayout="column">
   <p class="gv-plugin-creation-description">Choose bot detection mechanism.</p>
   <div fxLayout="row wrap" fxLayoutGap="10px">
-    <mat-card appearance="outlined" *ngFor="let botDetection of botDetections" fxFlex="30">
+    <mat-card
+      appearance="outlined"
+      class="plugin-type-card"
+      *ngFor="let botDetection of botDetections"
+      fxFlex="30"
+      [licenseGuard]="botDetection.licenseOptions"
+    >
       <mat-card-header fxLayoutAlign="end end" fxLayout="row">
         <mat-radio-group [(ngModel)]="selectedBotDetectionTypeId" (ngModelChange)="selectBotDetectionType()">
-          <mat-radio-button [value]="botDetection.id"></mat-radio-button>
+          <mat-radio-button [value]="botDetection.id" [class.plugin-type-radio-locked]="botDetection.isMissing$ | async"></mat-radio-button>
         </mat-radio-group>
       </mat-card-header>
       <mat-card-content>
+        <mat-icon *ngIf="botDetection.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         {{ displayName(botDetection) }}
       </mat-card-content>
     </mat-card>

--- a/gravitee-am-ui/src/app/domain/settings/botdetections/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/botdetections/creation/steps/step1/step1.component.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 import { Component, OnInit, Input } from '@angular/core';
+import { switchMap } from 'rxjs/operators';
 
 import { OrganizationService } from '../../../../../../services/organization.service';
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'bot-detection-creation-step1',
@@ -28,13 +30,19 @@ export class BotDetectionCreationStep1Component implements OnInit {
     'google-recaptcha-v3-am-bot-detection': 'Google reCAPTHCA v3',
   };
   @Input() botDetection: any;
-  botDetections: any[];
+  botDetections: (any & LicensedPlugin)[];
   selectedBotDetectionTypeId: string;
 
-  constructor(private organizationService: OrganizationService) {}
+  constructor(
+    private organizationService: OrganizationService,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit() {
-    this.organizationService.botDetections().subscribe((data) => (this.botDetections = data));
+    this.organizationService
+      .botDetections()
+      .pipe(switchMap((data) => this.pluginFeatureService.decorateCatalog$(data)))
+      .subscribe((botDetections) => (this.botDetections = botDetections));
   }
 
   selectBotDetectionType() {

--- a/gravitee-am-ui/src/app/domain/settings/certificates/certificate/certificate.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/certificates/certificate/certificate.component.html
@@ -49,12 +49,14 @@
           <button
             mat-raised-button
             color="primary"
+            [licenseGuard]="licenseOptions"
             [disabled]="
               ((!certificateForm.valid || certificateForm.pristine) && (!configurationIsValid || configurationPristine)) ||
               submissionPending
             "
             (click)="update()"
           >
+            <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
             SAVE
           </button>
         </div>

--- a/gravitee-am-ui/src/app/domain/settings/certificates/certificate/certificate.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/certificates/certificate/certificate.component.ts
@@ -15,13 +15,15 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
-import { finalize } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { finalize, Observable } from 'rxjs';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { OrganizationService } from '../../../../services/organization.service';
 import { CertificateService } from '../../../../services/certificate.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { DialogService } from '../../../../services/dialog.service';
+import { PluginFeatureService } from '../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'app-certificate',
@@ -38,6 +40,8 @@ export class CertificateComponent implements OnInit {
   certificateConfiguration: any;
   updateCertificateConfiguration: any;
   submissionPending = false;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
 
   constructor(
     private route: ActivatedRoute,
@@ -46,6 +50,7 @@ export class CertificateComponent implements OnInit {
     private snackbarService: SnackbarService,
     private router: Router,
     private dialogService: DialogService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -53,6 +58,10 @@ export class CertificateComponent implements OnInit {
     this.certificate = this.route.snapshot.data['certificate'];
     this.certificateConfiguration = JSON.parse(this.certificate.configuration);
     this.updateCertificateConfiguration = this.certificateConfiguration;
+    this.pluginFeatureService.getFeature$('certificate', this.certificate.type).subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('certificate', this.certificate.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
     this.organizationService.certificateSchema(this.certificate.type).subscribe((data) => (this.certificateSchema = data));
   }
 

--- a/gravitee-am-ui/src/app/domain/settings/certificates/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/certificates/creation/steps/step1/step1.component.html
@@ -19,13 +19,20 @@
   <p class="gv-plugin-creation-description">Choose your cryptographic algorithms to sign the data (JWT tokens).</p>
 
   <div fxLayout="row wrap" fxLayoutGap="10px">
-    <mat-card appearance="outlined" *ngFor="let certificate of certificates" fxFlex="30">
+    <mat-card
+      appearance="outlined"
+      class="plugin-type-card"
+      *ngFor="let certificate of certificates"
+      fxFlex="30"
+      [licenseGuard]="certificate.licenseOptions"
+    >
       <mat-card-header fxLayoutAlign="end end" fxLayout="row">
         <mat-radio-group [(ngModel)]="selectedCertificateTypeId" (ngModelChange)="selectCertificateType()">
-          <mat-radio-button [value]="certificate.id"></mat-radio-button>
+          <mat-radio-button [value]="certificate.id" [class.plugin-type-radio-locked]="certificate.isMissing$ | async"></mat-radio-button>
         </mat-radio-group>
       </mat-card-header>
       <mat-card-content>
+        <mat-icon *ngIf="certificate.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         {{ displayName(certificate) }}
       </mat-card-content>
     </mat-card>

--- a/gravitee-am-ui/src/app/domain/settings/certificates/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/certificates/creation/steps/step1/step1.component.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 import { Component, OnInit, Input } from '@angular/core';
+import { switchMap } from 'rxjs/operators';
 
 import { OrganizationService } from '../../../../../../services/organization.service';
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'certificate-creation-step1',
@@ -30,13 +32,19 @@ export class CertificateCreationStep1Component implements OnInit {
     'aws-am-certificate': 'AWS Secret Manager',
   };
   @Input() certificate: any;
-  certificates: any[];
+  certificates: (any & LicensedPlugin)[];
   selectedCertificateTypeId: string;
 
-  constructor(private organizationService: OrganizationService) {}
+  constructor(
+    private organizationService: OrganizationService,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit(): void {
-    this.organizationService.certificates().subscribe((data) => (this.certificates = data));
+    this.organizationService
+      .certificates()
+      .pipe(switchMap((data) => this.pluginFeatureService.decorateCatalog$(data)))
+      .subscribe((certificates) => (this.certificates = certificates));
   }
 
   selectCertificateType(): void {

--- a/gravitee-am-ui/src/app/domain/settings/deviceidentifiers/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/deviceidentifiers/creation/steps/step1/step1.component.html
@@ -18,13 +18,23 @@
 <div fxLayout="column">
   <p class="gv-plugin-creation-description">Choose device identifier mechanism.</p>
   <div fxLayout="row wrap" fxLayoutGap="10px">
-    <mat-card appearance="outlined" *ngFor="let deviceIdentifier of deviceIdentifiers" fxFlex="30">
+    <mat-card
+      appearance="outlined"
+      class="plugin-type-card"
+      *ngFor="let deviceIdentifier of deviceIdentifiers"
+      fxFlex="30"
+      [licenseGuard]="deviceIdentifier.licenseOptions"
+    >
       <mat-card-header fxLayoutAlign="end end" fxLayout="row">
         <mat-radio-group [(ngModel)]="selectedDeviceIdentifierTypeId" (ngModelChange)="selectType()">
-          <mat-radio-button [value]="deviceIdentifier.id"></mat-radio-button>
+          <mat-radio-button
+            [value]="deviceIdentifier.id"
+            [class.plugin-type-radio-locked]="deviceIdentifier.isMissing$ | async"
+          ></mat-radio-button>
         </mat-radio-group>
       </mat-card-header>
       <mat-card-content>
+        <mat-icon *ngIf="deviceIdentifier.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         {{ displayName(deviceIdentifier) }}
       </mat-card-content>
     </mat-card>

--- a/gravitee-am-ui/src/app/domain/settings/deviceidentifiers/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/deviceidentifiers/creation/steps/step1/step1.component.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 import { Component, OnInit, Input } from '@angular/core';
+import { switchMap } from 'rxjs/operators';
 
 import { OrganizationService } from '../../../../../../services/organization.service';
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'device-identifier-creation-step1',
@@ -29,13 +31,19 @@ export class DeviceIdentifierCreationStep1Component implements OnInit {
     'fingerprintjs-v3-pro-device-identifier': 'FingerprintJS v3 Pro',
   };
   @Input() deviceIdentifier: any;
-  deviceIdentifiers: any[];
+  deviceIdentifiers: (any & LicensedPlugin)[];
   selectedDeviceIdentifierTypeId: string;
 
-  constructor(private organizationService: OrganizationService) {}
+  constructor(
+    private organizationService: OrganizationService,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit() {
-    this.organizationService.deviceIdentifiers().subscribe((data) => (this.deviceIdentifiers = data));
+    this.organizationService
+      .deviceIdentifiers()
+      .pipe(switchMap((data) => this.pluginFeatureService.decorateCatalog$(data)))
+      .subscribe((deviceIdentifiers) => (this.deviceIdentifiers = deviceIdentifiers));
   }
 
   selectType() {

--- a/gravitee-am-ui/src/app/domain/settings/deviceidentifiers/device-identifier/device-identifier.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/deviceidentifiers/device-identifier/device-identifier.component.html
@@ -60,6 +60,7 @@
         <div fxLayout="row" *ngIf="editMode">
           <button
             mat-raised-button
+            [licenseGuard]="licenseOptions"
             [disabled]="
               (!deviceIdentifierForm.valid || deviceIdentifierForm.pristine) &&
               (!configurationIsValid || configurationPristine) &&
@@ -67,6 +68,7 @@
             "
             (click)="update()"
           >
+            <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
             SAVE
           </button>
         </div>

--- a/gravitee-am-ui/src/app/domain/settings/deviceidentifiers/device-identifier/device-identifier.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/deviceidentifiers/device-identifier/device-identifier.component.ts
@@ -15,13 +15,16 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { OrganizationService } from '../../../../services/organization.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { DialogService } from '../../../../services/dialog.service';
 import { AuthService } from '../../../../services/auth.service';
 import { DeviceIdentifierService } from '../../../../services/device-identifier.service';
+import { PluginFeatureService } from '../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'app-device-identifier',
@@ -39,6 +42,8 @@ export class DeviceIdentifierComponent implements OnInit {
   deviceIdentifierConfiguration: any;
   updateDeviceIdentifierConfiguration: any;
   editMode: boolean;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
 
   private deviceIdentifierTypes: any = {
     'fingerprintjs-v3-community-device-identifier': 'FingerprintJS v3 community',
@@ -53,6 +58,7 @@ export class DeviceIdentifierComponent implements OnInit {
     private snackbarService: SnackbarService,
     private dialogService: DialogService,
     private authService: AuthService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -61,6 +67,12 @@ export class DeviceIdentifierComponent implements OnInit {
     this.deviceIdentifierConfiguration = JSON.parse(this.deviceIdentifier.configuration);
     this.updateDeviceIdentifierConfiguration = this.deviceIdentifierConfiguration;
     this.editMode = this.authService.hasPermissions(['domain_device_identifier_update']);
+    this.pluginFeatureService
+      .getFeature$('device_identifier', this.deviceIdentifier.type)
+      .subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('device_identifier', this.deviceIdentifier.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
     this.organizationService.deviceIdentifiersSchema(this.deviceIdentifier.type).subscribe((data) => {
       this.deviceIdentifierSchema = data;

--- a/gravitee-am-ui/src/app/domain/settings/extension-grants/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/extension-grants/creation/steps/step1/step1.component.html
@@ -18,13 +18,23 @@
 <div fxLayout="column">
   <p class="gv-plugin-creation-description">Choose grant type flow to request OAuth 2.0 tokens.</p>
   <div fxLayout="row wrap" fxLayoutGap="10px">
-    <mat-card appearance="outlined" *ngFor="let extensionGrant of extensionGrants" fxFlex="30">
+    <mat-card
+      appearance="outlined"
+      class="plugin-type-card"
+      *ngFor="let extensionGrant of extensionGrants"
+      fxFlex="30"
+      [licenseGuard]="extensionGrant.licenseOptions"
+    >
       <mat-card-header fxLayoutAlign="end end" fxLayout="row">
         <mat-radio-group [(ngModel)]="selectedExtensionGrantTypeId" (ngModelChange)="selectExtensionGrantType()">
-          <mat-radio-button [value]="extensionGrant.id"></mat-radio-button>
+          <mat-radio-button
+            [value]="extensionGrant.id"
+            [class.plugin-type-radio-locked]="extensionGrant.isMissing$ | async"
+          ></mat-radio-button>
         </mat-radio-group>
       </mat-card-header>
       <mat-card-content>
+        <mat-icon *ngIf="extensionGrant.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         {{ displayName(extensionGrant) }}
       </mat-card-content>
     </mat-card>

--- a/gravitee-am-ui/src/app/domain/settings/extension-grants/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/extension-grants/creation/steps/step1/step1.component.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 import { Component, OnInit, Input } from '@angular/core';
+import { switchMap } from 'rxjs/operators';
 
 import { OrganizationService } from '../../../../../../services/organization.service';
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'extension-grant-creation-step1',
@@ -28,13 +30,19 @@ export class ExtensionGrantCreationStep1Component implements OnInit {
     'jwtbearer-am-extension-grant': 'Extension Grant JWT Bearer',
   };
   @Input() extensionGrant: any;
-  extensionGrants: any[];
+  extensionGrants: (any & LicensedPlugin)[];
   selectedExtensionGrantTypeId: string;
 
-  constructor(private organizationService: OrganizationService) {}
+  constructor(
+    private organizationService: OrganizationService,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit() {
-    this.organizationService.extensionGrants().subscribe((data) => (this.extensionGrants = data));
+    this.organizationService
+      .extensionGrants()
+      .pipe(switchMap((data) => this.pluginFeatureService.decorateCatalog$(data)))
+      .subscribe((extensionGrants) => (this.extensionGrants = extensionGrants));
   }
 
   selectExtensionGrantType() {

--- a/gravitee-am-ui/src/app/domain/settings/extension-grants/extension-grant/extension-grant.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/extension-grants/extension-grant/extension-grant.component.html
@@ -115,11 +115,13 @@
         <div fxLayout="row" *ngIf="editMode">
           <button
             mat-raised-button
+            [licenseGuard]="licenseOptions"
             [disabled]="
               (!tokenGranterForm.valid || tokenGranterForm.pristine) && (!configurationIsValid || configurationPristine) && !formChanged
             "
             (click)="update()"
           >
+            <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
             SAVE
           </button>
         </div>

--- a/gravitee-am-ui/src/app/domain/settings/extension-grants/extension-grant/extension-grant.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/extension-grants/extension-grant/extension-grant.component.ts
@@ -15,13 +15,16 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { OrganizationService } from '../../../../services/organization.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { ExtensionGrantService } from '../../../../services/extension-grant.service';
 import { DialogService } from '../../../../services/dialog.service';
 import { AuthService } from '../../../../services/auth.service';
+import { PluginFeatureService } from '../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'app-extension-grant',
@@ -44,6 +47,8 @@ export class ExtensionGrantComponent implements OnInit {
     // eslint-disable-next-line
     /^[A-Za-z][A-Za-z0-9+\-.]*:(?:\/\/(?:(?:[A-Za-z0-9\-._~!$&'()*+,;=:]|%[0-9A-Fa-f]{2})*@)?(?:\[(?:(?:(?:(?:[0-9A-Fa-f]{1,4}:){6}|::(?:[0-9A-Fa-f]{1,4}:){5}|(?:[0-9A-Fa-f]{1,4})?::(?:[0-9A-Fa-f]{1,4}:){4}|(?:(?:[0-9A-Fa-f]{1,4}:){0,1}[0-9A-Fa-f]{1,4})?::(?:[0-9A-Fa-f]{1,4}:){3}|(?:(?:[0-9A-Fa-f]{1,4}:){0,2}[0-9A-Fa-f]{1,4})?::(?:[0-9A-Fa-f]{1,4}:){2}|(?:(?:[0-9A-Fa-f]{1,4}:){0,3}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}:|(?:(?:[0-9A-Fa-f]{1,4}:){0,4}[0-9A-Fa-f]{1,4})?::)(?:[0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))|(?:(?:[0-9A-Fa-f]{1,4}:){0,5}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}|(?:(?:[0-9A-Fa-f]{1,4}:){0,6}[0-9A-Fa-f]{1,4})?::)|[Vv][0-9A-Fa-f]+\.[A-Za-z0-9\-._~!$&'()*+,;=:]+)\]|(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|(?:[A-Za-z0-9\-._~!$&'()*+,;=]|%[0-9A-Fa-f]{2})*)(?::[0-9]*)?(?:\/(?:[A-Za-z0-9\-._~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2})*)*|\/(?:(?:[A-Za-z0-9\-._~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2})+(?:\/(?:[A-Za-z0-9\-._~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2})*)*)?|(?:[A-Za-z0-9\-._~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2})+(?:\/(?:[A-Za-z0-9\-._~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2})*)*|)(?:\?(?:[A-Za-z0-9\-._~!$&'()*+,;=:@\/?]|%[0-9A-Fa-f]{2})*)?$/;
   editMode: boolean;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
 
   constructor(
     private route: ActivatedRoute,
@@ -53,6 +58,7 @@ export class ExtensionGrantComponent implements OnInit {
     private snackbarService: SnackbarService,
     private dialogService: DialogService,
     private authService: AuthService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -62,6 +68,12 @@ export class ExtensionGrantComponent implements OnInit {
     this.extensionGrantConfiguration = JSON.parse(this.extensionGrant.configuration);
     this.updateTokenGranterConfiguration = this.extensionGrantConfiguration;
     this.editMode = this.authService.hasPermissions(['domain_extension_grant_update']);
+    this.pluginFeatureService
+      .getFeature$('extension_grant', this.extensionGrant.type)
+      .subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('extension_grant', this.extensionGrant.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
     this.organizationService.extensionGrantSchema(this.extensionGrant.type).subscribe((data) => {
       this.extensionGrantSchema = data;
       // set the grant_type value

--- a/gravitee-am-ui/src/app/domain/settings/factors/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/factors/creation/steps/step1/step1.component.html
@@ -20,18 +20,19 @@
   <div fxLayout="row wrap" fxLayoutGap="10px">
     <mat-card
       appearance="outlined"
+      class="plugin-type-card"
       *ngFor="let factor of factors"
       fxFlex="30"
-      [gioLicense]="factor"
+      [licenseGuard]="factor.licenseOptions"
       [attr.data-testid]="'factorType-' + factor.id"
     >
       <mat-card-header fxLayoutAlign="end end" fxLayout="row">
-        <mat-radio-group [(ngModel)]="selectedFactorTypeId" *ngIf="factor.deployed" (ngModelChange)="selectFactorType()">
-          <mat-radio-button [value]="factor.id"></mat-radio-button>
+        <mat-radio-group [(ngModel)]="selectedFactorTypeId" (ngModelChange)="selectFactorType()">
+          <mat-radio-button [value]="factor.id" [class.plugin-type-radio-locked]="factor.isMissing$ | async"></mat-radio-button>
         </mat-radio-group>
-        <mat-icon *ngIf="!factor.deployed" svgIcon="gio:lock"></mat-icon>
       </mat-card-header>
       <mat-card-content>
+        <mat-icon *ngIf="factor.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         {{ displayName(factor) }}
       </mat-card-content>
     </mat-card>

--- a/gravitee-am-ui/src/app/domain/settings/factors/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/factors/creation/steps/step1/step1.component.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import { Component, OnInit, Input, OnDestroy } from '@angular/core';
-import { takeUntil, tap } from 'rxjs/operators';
+import { switchMap, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
 import { OrganizationService } from '../../../../../../services/organization.service';
 import { Plugin } from '../../../../../../entities/plugins/Plugin';
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'factor-creation-step1',
@@ -38,22 +39,23 @@ export class FactorCreationStep1Component implements OnInit, OnDestroy {
     'mock-am-factor': 'MOCK Factor',
   };
   @Input() factor: any;
-  factors: Plugin[];
+  factors: (Plugin & LicensedPlugin)[];
   selectedFactorTypeId: string;
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
-  constructor(private organizationService: OrganizationService) {}
+  constructor(
+    private organizationService: OrganizationService,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit() {
     this.organizationService
       .factors()
       .pipe(
-        tap((factors) => {
-          this.factors = factors;
-        }),
+        switchMap((factors) => this.pluginFeatureService.decorateCatalog$(factors)),
         takeUntil(this.unsubscribe$),
       )
-      .subscribe();
+      .subscribe((factors) => (this.factors = factors));
   }
 
   ngOnDestroy(): void {

--- a/gravitee-am-ui/src/app/domain/settings/factors/factor/factor.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/factors/factor/factor.component.html
@@ -78,9 +78,11 @@
           <button
             mat-raised-button
             color="primary"
+            [licenseGuard]="licenseOptions"
             [disabled]="(!factorForm.valid || factorForm.pristine) && (!configurationIsValid || configurationPristine) && !formChanged"
             (click)="update()"
           >
+            <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
             SAVE
           </button>
         </div>

--- a/gravitee-am-ui/src/app/domain/settings/factors/factor/factor.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/factors/factor/factor.component.ts
@@ -15,13 +15,16 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { OrganizationService } from '../../../../services/organization.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { DialogService } from '../../../../services/dialog.service';
 import { AuthService } from '../../../../services/auth.service';
 import { FactorService } from '../../../../services/factor.service';
+import { PluginFeatureService } from '../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'app-factor',
@@ -39,6 +42,8 @@ export class FactorComponent implements OnInit {
   factorConfiguration: any;
   updateFactorConfiguration: any;
   editMode: boolean;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
   private factorPlugins: any[];
   private resourcePlugins: any[];
   private resources: any[];
@@ -51,6 +56,7 @@ export class FactorComponent implements OnInit {
     private snackbarService: SnackbarService,
     private dialogService: DialogService,
     private authService: AuthService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -59,6 +65,10 @@ export class FactorComponent implements OnInit {
     this.factorConfiguration = JSON.parse(this.factor.configuration);
     this.updateFactorConfiguration = this.factorConfiguration;
     this.editMode = this.authService.hasPermissions(['domain_factor_update']);
+    this.pluginFeatureService.getFeature$('factor', this.factor.type).subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('factor', this.factor.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
     this.factorPlugins = this.route.snapshot.data['factorPlugins'];
     this.resourcePlugins = this.route.snapshot.data['resourcePlugins'];
     this.resources = this.route.snapshot.data['resources'];

--- a/gravitee-am-ui/src/app/domain/settings/openid/ciba/device-notifiers/create/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/ciba/device-notifiers/create/steps/step1/step1.component.html
@@ -18,13 +18,23 @@
 <div fxLayout="column">
   <p class="gv-plugin-creation-description">Choose authentication device notifier to interact with the user.</p>
   <div fxLayout="row wrap" fxLayoutGap="10px">
-    <mat-card appearance="outlined" *ngFor="let deviceNotifier of deviceNotifiers" fxFlex="30">
+    <mat-card
+      appearance="outlined"
+      class="plugin-type-card"
+      *ngFor="let deviceNotifier of deviceNotifiers"
+      fxFlex="30"
+      [licenseGuard]="deviceNotifier.licenseOptions"
+    >
       <mat-card-header fxLayoutAlign="end end" fxLayout="row">
         <mat-radio-group [(ngModel)]="selectedNotifierTypeId" (ngModelChange)="selectNotifierType()">
-          <mat-radio-button [value]="deviceNotifier.id"></mat-radio-button>
+          <mat-radio-button
+            [value]="deviceNotifier.id"
+            [class.plugin-type-radio-locked]="deviceNotifier.isMissing$ | async"
+          ></mat-radio-button>
         </mat-radio-group>
       </mat-card-header>
       <mat-card-content>
+        <mat-icon *ngIf="deviceNotifier.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         <div [innerHTML]="getIcon(deviceNotifier) | safe: 'html'"></div>
         {{ displayName(deviceNotifier) }}
       </mat-card-content>

--- a/gravitee-am-ui/src/app/domain/settings/openid/ciba/device-notifiers/create/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/ciba/device-notifiers/create/steps/step1/step1.component.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 import { Component, OnInit, Input } from '@angular/core';
+import { switchMap } from 'rxjs/operators';
 
 import { OrganizationService } from '../../../../../../../../services/organization.service';
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'device-notifier-creation-step1',
@@ -28,15 +30,19 @@ export class DeviceNotifierCreationStep1Component implements OnInit {
     'http-am-authdevice-notifier': 'External HTTP Service',
   };
   @Input() deviceNotifier: any;
-  deviceNotifiers: any[];
+  deviceNotifiers: (any & LicensedPlugin)[];
   selectedNotifierTypeId: string;
 
-  constructor(private organizationService: OrganizationService) {}
+  constructor(
+    private organizationService: OrganizationService,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit() {
-    this.organizationService.deviceNotifiers(true).subscribe((data) => {
-      this.deviceNotifiers = data;
-    });
+    this.organizationService
+      .deviceNotifiers(true)
+      .pipe(switchMap((data) => this.pluginFeatureService.decorateCatalog$(data)))
+      .subscribe((deviceNotifiers) => (this.deviceNotifiers = deviceNotifiers));
   }
 
   selectNotifierType() {

--- a/gravitee-am-ui/src/app/domain/settings/openid/ciba/device-notifiers/device-notifier/device-notifier.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/ciba/device-notifiers/device-notifier/device-notifier.component.html
@@ -49,11 +49,13 @@
           <button
             mat-raised-button
             color="primary"
+            [licenseGuard]="licenseOptions"
             [disabled]="
               (!deviceNotifierForm.valid || deviceNotifierForm.pristine) && (!configurationIsValid || configurationPristine) && !formChanged
             "
             (click)="update()"
           >
+            <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
             SAVE
           </button>
         </div>

--- a/gravitee-am-ui/src/app/domain/settings/openid/ciba/device-notifiers/device-notifier/device-notifier.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/ciba/device-notifiers/device-notifier/device-notifier.component.ts
@@ -15,7 +15,9 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { AuthService } from '../../../../../../services/auth.service';
 import { DeviceNotifiersService } from '../../../../../../services/device-notifiers.service';
@@ -23,6 +25,7 @@ import { DialogService } from '../../../../../../services/dialog.service';
 import { OrganizationService } from '../../../../../../services/organization.service';
 import { ProviderService } from '../../../../../../services/provider.service';
 import { SnackbarService } from '../../../../../../services/snackbar.service';
+import { PluginFeatureService } from '../../../../../../services/plugin-feature.service';
 import { DynamicSourceMap } from '../dynamic-sources';
 
 @Component({
@@ -41,6 +44,8 @@ export class DeviceNotifierComponent implements OnInit {
   deviceNotifierConfiguration: any;
   updateDeviceNotifierConfiguration: any;
   editMode: boolean;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
   /** Populated on init; passed to the form so AJSF can render dynamic dropdowns. */
   dynamicSources: DynamicSourceMap = {};
 
@@ -53,6 +58,7 @@ export class DeviceNotifierComponent implements OnInit {
     private snackbarService: SnackbarService,
     private dialogService: DialogService,
     private authService: AuthService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -61,6 +67,12 @@ export class DeviceNotifierComponent implements OnInit {
     this.deviceNotifierConfiguration = JSON.parse(this.deviceNotifier.configuration);
     this.updateDeviceNotifierConfiguration = this.deviceNotifierConfiguration;
     this.editMode = this.authService.hasPermissions(['domain_authdevice_notifier_update']);
+    this.pluginFeatureService
+      .getFeature$('authdevice_notifier', this.deviceNotifier.type)
+      .subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('authdevice_notifier', this.deviceNotifier.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
     // Fetch identity providers so the form can render a populated dropdown for
     // any schema property whose widget is 'graviteeIdentityProvider'.

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.html
@@ -28,18 +28,20 @@
     </mat-form-field>
   </div>
 
-  <div fxLayout="row wrap" fxFlex fxLayoutGap="10px" fxLayoutAlign="center">
+  <div class="plugin-type-grid" fxLayout="row wrap" fxFlex fxLayoutAlign="center">
     <mat-card
       appearance="outlined"
+      class="plugin-type-card"
       *ngFor="let idp of filteredIdentities"
       fxFlex="30"
       [class.selected]="provider.type === idp.id"
       (click)="selectProviderType(idp)"
       (keyup.enter)="selectProviderType(idp)"
       tabIndex="0"
-      [gioLicense]="idp"
+      [licenseGuard]="idp.licenseOptions"
     >
       <mat-card-content>
+        <mat-icon *ngIf="idp.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         <div class="identity-provider__icon" [innerHTML]="getIcon(idp) | safe: 'html'"></div>
         {{ displayName(idp) }}
       </mat-card-content>

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.scss
@@ -5,7 +5,6 @@ mat-card {
 
   display: flex;
   box-sizing: border-box;
-  margin-top: 10px;
   place-content: center center;
 }
 

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.ts
@@ -18,6 +18,7 @@ import { ActivatedRoute } from '@angular/router';
 
 import { OrganizationService } from '../../../../../../services/organization.service';
 import { IdentityProvider } from '../../../../../../entities/identity-providers/IdentityProvider';
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'provider-creation-step1',
@@ -26,20 +27,25 @@ import { IdentityProvider } from '../../../../../../entities/identity-providers/
   standalone: false,
 })
 export class ProviderCreationStep1Component implements OnInit {
-  identities: IdentityProvider[];
+  identities: (IdentityProvider & LicensedPlugin)[];
   @Input() provider;
   filter: string;
-  filteredIdentities: IdentityProvider[];
+  filteredIdentities: (IdentityProvider & LicensedPlugin)[];
 
   constructor(
     private organizationService: OrganizationService,
     private route: ActivatedRoute,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
     this.filter = '';
-    this.identities = this.route.snapshot.data['identities'];
-    this.filteredIdentities = this.getFilteredIdentities();
+    this.pluginFeatureService
+      .decorateCatalog$<IdentityProvider>(Object.values(this.route.snapshot.data['identities'] ?? {}))
+      .subscribe((identities) => {
+        this.identities = identities;
+        this.filteredIdentities = this.getFilteredIdentities();
+      });
   }
 
   private initDomainWhitelist(idpType: string) {

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
@@ -79,9 +79,11 @@
           <button
             mat-raised-button
             color="primary"
+            [licenseGuard]="licenseOptions"
             [disabled]="(!providerForm.valid || providerForm.pristine) && (!configurationIsValid || configurationPristine)"
             (click)="update($event)"
           >
+            <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
             SAVE
           </button>
         </div>

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
@@ -16,9 +16,12 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { filter, map, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, map, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { ProviderService } from '../../../../../services/provider.service';
+import { PluginFeatureService } from '../../../../../services/plugin-feature.service';
 import { SnackbarService } from '../../../../../services/snackbar.service';
 import { OrganizationService } from '../../../../../services/organization.service';
 import { DomainService } from '../../../../../services/domain.service';
@@ -50,6 +53,8 @@ export class ProviderSettingsComponent implements OnInit {
   customCode: string;
   domainWhitelistPattern: string;
   certificates: any[];
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
   private datasources: any[];
 
   constructor(
@@ -62,12 +67,19 @@ export class ProviderSettingsComponent implements OnInit {
     private dialogService: DialogService,
     private entrypointService: EntrypointService,
     private dataSourcesService: DataSourcesService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
     this.certificates = this.route.snapshot.data['certificates'];
     this.datasources = this.route.snapshot.data['datasources'];
     this.provider = this.route.snapshot.data['provider'];
+    this.pluginFeatureService
+      .getFeature$('identity_provider', this.provider.type)
+      .subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('identity_provider', this.provider.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
     if (this.provider.system) {
       // settings tab is useless for system providers
       // define the mappers as default landing page in this case

--- a/gravitee-am-ui/src/app/domain/settings/resources/creation/steps/step1/step1.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/resources/creation/steps/step1/step1.component.html
@@ -17,23 +17,20 @@
 -->
 <div fxLayout="column">
   <p class="gv-plugin-creation-description">Choose resource to create.</p>
-  <div fxLayout="row wrap" fxLayoutGap="10px" fxLayoutAlign="center">
+  <div class="plugin-type-grid" fxLayout="row wrap" fxLayoutAlign="center">
     <mat-card
       appearance="outlined"
+      class="plugin-type-card"
       *ngFor="let res of resources"
       fxFlex="30"
       [class.selected]="resource.type === res.id"
       (click)="selectResourceType(res.id)"
       (keyup.enter)="selectResourceType(res.id)"
       tabIndex="0"
-      [gioLicense]="res"
+      [licenseGuard]="res.licenseOptions"
     >
       <mat-card-content>
-        <mat-icon
-          *ngIf="res.deployed === false"
-          svgIcon="gio:lock"
-          class="settings-resources-creation-steps__card__content__featureIcon"
-        ></mat-icon>
+        <mat-icon *ngIf="res.isMissing$ | async" svgIcon="gio:lock" class="plugin-license-lock"></mat-icon>
         <div class="identity-provider__icon" [innerHTML]="getIcon(res) | safe: 'html'"></div>
         {{ displayName(res) }}
       </mat-card-content>

--- a/gravitee-am-ui/src/app/domain/settings/resources/creation/steps/step1/step1.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/resources/creation/steps/step1/step1.component.scss
@@ -5,7 +5,6 @@ mat-card {
 
   display: flex;
   box-sizing: border-box;
-  margin-top: 10px;
   place-content: center center;
 }
 
@@ -29,16 +28,4 @@ mat-card-content {
 
 :host ::ng-deep mat-card-content img {
   height: 6rem;
-}
-
-.settings-resources-creation-steps {
-  &__card {
-    &__content {
-      &__featureIcon {
-        position: absolute;
-        top: 5px;
-        right: 5px;
-      }
-    }
-  }
 }

--- a/gravitee-am-ui/src/app/domain/settings/resources/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/resources/creation/steps/step1/step1.component.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import { Component, OnInit, Input, OnDestroy } from '@angular/core';
-import { takeUntil, tap } from 'rxjs/operators';
+import { switchMap, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
 import { Plugin } from '../../../../../../entities/plugins/Plugin';
 import { OrganizationService } from '../../../../../../services/organization.service';
+import { LicensedPlugin, PluginFeatureService } from '../../../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'resource-creation-step1',
@@ -34,21 +35,22 @@ export class ResourceCreationStep1Component implements OnInit, OnDestroy {
     'http-factor-am-resource': 'HTTP Factor',
   };
   @Input() resource: any;
-  resources: Plugin[];
+  resources: (Plugin & LicensedPlugin)[];
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
-  constructor(private organizationService: OrganizationService) {}
+  constructor(
+    private organizationService: OrganizationService,
+    private pluginFeatureService: PluginFeatureService,
+  ) {}
 
   ngOnInit() {
     this.organizationService
       .resources(true)
       .pipe(
-        tap((resources) => {
-          this.resources = resources;
-        }),
+        switchMap((resources) => this.pluginFeatureService.decorateCatalog$(resources)),
         takeUntil(this.unsubscribe$),
       )
-      .subscribe();
+      .subscribe((resources) => (this.resources = resources));
   }
 
   ngOnDestroy(): void {

--- a/gravitee-am-ui/src/app/domain/settings/resources/resource/resource.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/resources/resource/resource.component.html
@@ -48,9 +48,11 @@
           <button
             mat-raised-button
             color="primary"
+            [licenseGuard]="licenseOptions"
             [disabled]="(!resourceForm.valid || resourceForm.pristine) && (!configurationIsValid || configurationPristine) && !formChanged"
             (click)="update()"
           >
+            <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
             SAVE
           </button>
         </div>

--- a/gravitee-am-ui/src/app/domain/settings/resources/resource/resource.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/resources/resource/resource.component.ts
@@ -15,13 +15,16 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { catchError, filter, switchMap, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { catchError, filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { LicenseOptions } from '@gravitee/ui-particles-angular';
 
 import { OrganizationService } from '../../../../services/organization.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { DialogService } from '../../../../services/dialog.service';
 import { AuthService } from '../../../../services/auth.service';
 import { ResourceService } from '../../../../services/resource.service';
+import { PluginFeatureService } from '../../../../services/plugin-feature.service';
 
 @Component({
   selector: 'app-resource',
@@ -39,6 +42,8 @@ export class ResourceComponent implements OnInit {
   resourceConfiguration: any;
   updateResourceConfiguration: any;
   editMode: boolean;
+  licenseOptions: LicenseOptions = {};
+  isMissingFeature$: Observable<boolean>;
 
   constructor(
     private route: ActivatedRoute,
@@ -48,6 +53,7 @@ export class ResourceComponent implements OnInit {
     private snackbarService: SnackbarService,
     private dialogService: DialogService,
     private authService: AuthService,
+    private pluginFeatureService: PluginFeatureService,
   ) {}
 
   ngOnInit() {
@@ -56,6 +62,10 @@ export class ResourceComponent implements OnInit {
     this.resourceConfiguration = JSON.parse(this.resource.configuration);
     this.updateResourceConfiguration = this.resourceConfiguration;
     this.editMode = this.authService.hasPermissions(['domain_resource_update']);
+    this.pluginFeatureService.getFeature$('resource', this.resource.type).subscribe((feature) => (this.licenseOptions = { feature }));
+    this.isMissingFeature$ = this.pluginFeatureService
+      .isMissingFeatureForType$('resource', this.resource.type)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
     this.organizationService.resourceSchema(this.resource.type).subscribe((data) => {
       this.resourceSchema = data;
     });

--- a/gravitee-am-ui/src/app/services/plugin-feature.service.spec.ts
+++ b/gravitee-am-ui/src/app/services/plugin-feature.service.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { firstValueFrom, of } from 'rxjs';
+import { GioLicenseService } from '@gravitee/ui-particles-angular';
+
+import { OrganizationService } from './organization.service';
+import { PluginFeatureService } from './plugin-feature.service';
+
+type Factor = { id: string; feature?: string; deployed?: boolean };
+
+describe('PluginFeatureService', () => {
+  const factors: Factor[] = [
+    { id: 'sms-am-factor', feature: 'am-mfa-sms', deployed: true },
+    { id: 'otp-am-factor', feature: '', deployed: true },
+    { id: 'legacy-am-factor', deployed: false },
+  ];
+
+  let factorsSpy: jest.Mock;
+  let isMissingFeature$: jest.Mock;
+  let service: PluginFeatureService;
+
+  beforeEach(() => {
+    factorsSpy = jest.fn().mockReturnValue(of(factors));
+    // Mirrors GioLicenseService: only 'am-mfa-sms' is missing from the effective license.
+    isMissingFeature$ = jest.fn().mockImplementation((feature?: string) => of(feature === 'am-mfa-sms'));
+    const organizationService = { factors: factorsSpy } as unknown as OrganizationService;
+    const licenseService = { isMissingFeature$ } as unknown as GioLicenseService;
+    service = new PluginFeatureService(organizationService, licenseService);
+  });
+
+  describe('getFeature$', () => {
+    it('resolves the plugin feature for a known type', async () => {
+      expect(await firstValueFrom(service.getFeature$('factor', 'sms-am-factor'))).toBe('am-mfa-sms');
+    });
+
+    it('treats a blank feature as OSS (undefined)', async () => {
+      expect(await firstValueFrom(service.getFeature$('factor', 'otp-am-factor'))).toBeUndefined();
+    });
+
+    it('resolves undefined for an unknown or empty type', async () => {
+      expect(await firstValueFrom(service.getFeature$('factor', 'does-not-exist'))).toBeUndefined();
+      expect(await firstValueFrom(service.getFeature$('factor', ''))).toBeUndefined();
+    });
+
+    it('caches the catalog across calls (fetched once)', async () => {
+      await firstValueFrom(service.getFeature$('factor', 'sms-am-factor'));
+      await firstValueFrom(service.getFeature$('factor', 'otp-am-factor'));
+      expect(factorsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves social/enterprise IdPs by merging the built-in and social catalogs', async () => {
+      const identities = jest.fn().mockReturnValue(of([{ id: 'ldap-am-idp', feature: 'am-idp-ldap' }]));
+      const socialIdentities = jest.fn().mockReturnValue(of([{ id: 'azure-ad-am-idp', feature: 'am-idp-azure-ad' }]));
+      const organizationService = { identities, socialIdentities } as unknown as OrganizationService;
+      const idpService = new PluginFeatureService(organizationService, { isMissingFeature$ } as unknown as GioLicenseService);
+
+      expect(await firstValueFrom(idpService.getFeature$('identity_provider', 'azure-ad-am-idp'))).toBe('am-idp-azure-ad');
+      expect(await firstValueFrom(idpService.getFeature$('identity_provider', 'ldap-am-idp'))).toBe('am-idp-ldap');
+    });
+  });
+
+  describe('isMissingFeatureForType$', () => {
+    it('reports the missing feature via the license', async () => {
+      expect(await firstValueFrom(service.isMissingFeatureForType$('factor', 'sms-am-factor'))).toBe(true);
+      expect(isMissingFeature$).toHaveBeenCalledWith('am-mfa-sms');
+    });
+
+    it('is false for an OSS plugin (no feature required)', async () => {
+      expect(await firstValueFrom(service.isMissingFeatureForType$('factor', 'otp-am-factor'))).toBe(false);
+    });
+  });
+
+  describe('decorateCatalog$', () => {
+    it('gates each item on its declared feature via the license', async () => {
+      const decorated = await firstValueFrom(service.decorateCatalog$(factors));
+      expect(decorated[0].licenseOptions).toEqual({ feature: 'am-mfa-sms' });
+      expect(await firstValueFrom(decorated[0].isMissing$)).toBe(true);
+      expect(await firstValueFrom(decorated[1].isMissing$)).toBe(false); // blank feature normalised to OSS
+      expect(await firstValueFrom(decorated[2].isMissing$)).toBe(false); // no feature
+    });
+  });
+});

--- a/gravitee-am-ui/src/app/services/plugin-feature.service.ts
+++ b/gravitee-am-ui/src/app/services/plugin-feature.service.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { forkJoin, Observable, of } from 'rxjs';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
+import { GioLicenseService, LicenseOptions } from '@gravitee/ui-particles-angular';
+
+import { OrganizationService } from './organization.service';
+
+/** A blank/whitespace manifest feature means "OSS plugin" — treat it as no feature. */
+const normalizeFeature = (feature?: string): string | undefined => (feature && feature.trim().length > 0 ? feature : undefined);
+
+/** A plugin catalog item decorated with the license state the creation cards bind to. */
+export interface LicensedPlugin {
+  /** Feature-only license options for the guard/upgrade dialog (undefined feature ⇒ ungated). */
+  licenseOptions?: LicenseOptions;
+  /** Whether the card should render locked (upsell) rather than selectable. */
+  isMissing$: Observable<boolean>;
+}
+
+/**
+ * Plugin categories that the backend license gate can restrict for write operations.
+ */
+export type PluginCategory =
+  | 'identity_provider'
+  | 'certificate'
+  | 'factor'
+  | 'resource'
+  | 'extension_grant'
+  | 'bot_detection'
+  | 'device_identifier'
+  | 'authdevice_notifier'
+  | 'reporter'
+  | 'authorization_engine'
+  | 'notifier';
+
+/**
+ * Resolves, for a given plugin instance type, whether the effective license grants its declared
+ * feature — mirroring the backend {@code PluginLicenseGate}.
+ */
+@Injectable()
+export class PluginFeatureService {
+  private readonly catalogCache = new Map<PluginCategory, Observable<any[]>>();
+
+  constructor(
+    private readonly organizationService: OrganizationService,
+    private readonly licenseService: GioLicenseService,
+  ) {}
+
+  /**
+   * Resolves the license feature declared by the plugin of the given type, or undefined when the
+   * type is unknown or the plugin is OSS (no feature).
+   */
+  getFeature$(category: PluginCategory, type: string): Observable<string | undefined> {
+    if (!type) {
+      return of(undefined);
+    }
+    return this.catalog$(category).pipe(map((plugins) => normalizeFeature(plugins?.find((plugin) => plugin.id === type)?.feature)));
+  }
+
+  /**
+   * Whether the license effective for this node does not grant the feature required to write an
+   * instance of the given plugin type. False for OSS plugins.
+   */
+  isMissingFeatureForType$(category: PluginCategory, type: string): Observable<boolean> {
+    return this.getFeature$(category, type).pipe(switchMap((feature) => this.licenseService.isMissingFeature$(feature)));
+  }
+
+  /**
+   * Decorates a plugin catalog (as consumed by the creation cards) with the license state to bind:
+   * each item is gated on its declared feature.
+   */
+  decorateCatalog$<T extends { feature?: string }>(plugins: T[]): Observable<(T & LicensedPlugin)[]> {
+    return of(
+      plugins.map((plugin) => {
+        const feature = normalizeFeature(plugin.feature);
+        return { ...plugin, licenseOptions: { feature }, isMissing$: this.licenseService.isMissingFeature$(feature) };
+      }),
+    );
+  }
+
+  private catalog$(category: PluginCategory): Observable<any[]> {
+    let cached = this.catalogCache.get(category);
+    if (!cached) {
+      cached = this.fetchCatalog(category).pipe(shareReplay({ bufferSize: 1, refCount: false }));
+      this.catalogCache.set(category, cached);
+    }
+    return cached;
+  }
+
+  private fetchCatalog(category: PluginCategory): Observable<any[]> {
+    switch (category) {
+      case 'identity_provider':
+        // merge built-in and social/enterprise IdPs, which are served by separate endpoints
+        return forkJoin([this.organizationService.identities(), this.organizationService.socialIdentities()]).pipe(
+          map(([builtIn, social]) => [...(builtIn ?? []), ...(social ?? [])]),
+        );
+      case 'certificate':
+        return this.organizationService.certificates();
+      case 'factor':
+        return this.organizationService.factors();
+      case 'resource':
+        return this.organizationService.resources();
+      case 'extension_grant':
+        return this.organizationService.extensionGrants();
+      case 'bot_detection':
+        return this.organizationService.botDetections();
+      case 'device_identifier':
+        return this.organizationService.deviceIdentifiers();
+      case 'authdevice_notifier':
+        return this.organizationService.deviceNotifiers();
+      case 'reporter':
+        return this.organizationService.reporterPlugins();
+      case 'authorization_engine':
+        return this.organizationService.authorizationEngines(false);
+      case 'notifier':
+        return this.organizationService.notifiers();
+    }
+  }
+}

--- a/gravitee-am-ui/src/styles.scss
+++ b/gravitee-am-ui/src/styles.scss
@@ -352,6 +352,23 @@ p.gv-plugin-creation-description {
   text-align: center;
 }
 
+.plugin-type-grid {
+  margin-top: 10px;
+  gap: 10px;
+}
+
+.plugin-license-lock {
+  position: absolute;
+  z-index: 1;
+  top: 16px;
+  left: 16px;
+}
+
+.plugin-type-radio-locked {
+  opacity: 0.38;
+  pointer-events: none;
+}
+
 .no-padding-dialog-container .mat-mdc-dialog-container {
   padding: 0;
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7240](https://gravitee.atlassian.net/browse/AM-7240)

## :pencil2: A description of the changes proposed in the pull request
Apply lock icon convention to plugin types that are deployed but unlicensed (managed cloud mode) and redirect to the upsell dialog when selected.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
<img width="1915" height="928" alt="image" src="https://github.com/user-attachments/assets/70bd4270-d3ca-4f35-b32a-5829a5654fed" />

<img width="1053" height="720" alt="image" src="https://github.com/user-attachments/assets/b3424be1-85f4-4227-94c5-b527b08b26e8" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-7240]: https://gravitee.atlassian.net/browse/AM-7240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ