### PR TITLE
feat: build email links from the environment entrypoint in managed cloud

### DIFF
--- a/docker/local-stack/dev/docker-compose.cloud.yml
+++ b/docker/local-stack/dev/docker-compose.cloud.yml
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cloud/console overlay: puts the management API into managed-cloud mode and
-# starts the cockpit mock it dials out to. Layer this on top of the base +
+# Cloud/console overlay: puts both planes into managed-cloud mode and starts the
+# cockpit mock the management API dials out to. Layer this on top of the base +
 # dev/ci overlays to exercise the console/cloud command path (e.g. Cockpit
 # ENVIRONMENT commands whose gateway access points become entrypoints).
 # It is absent by default, so the standalone suites are unaffected.
@@ -40,3 +40,11 @@ services:
     depends_on:
       cockpit-mock:
         condition: service_healthy
+
+  # The gateway never talks to Cockpit, so it needs no connector endpoint — but it does resolve the
+  # environment's entrypoint when building links in the emails it sends, and that is gated on managed
+  # cloud. Without these it silently falls back to the data plane gateway url.
+  gateway:
+    environment:
+      - GRAVITEE_CLOUD_ENABLED=true
+      - GRAVITEE_INSTALLATION_TYPE=managed

--- a/docker/local-stack/dev/docker-compose.cloud.yml
+++ b/docker/local-stack/dev/docker-compose.cloud.yml
@@ -41,7 +41,7 @@ services:
       cockpit-mock:
         condition: service_healthy
 
-  # The gateway never talks to Cockpit, so it needs no connector endpoint — but it does resolve the
+  # The gateway never talks to Cockpit, so it needs no connector endpoint, but it does resolve the
   # environment's entrypoint when building links in the emails it sends, and that is gated on managed
   # cloud. Without these it silently falls back to the data plane gateway url.
   gateway:

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -823,12 +823,11 @@ public class DomainServiceImpl implements DomainService {
     }
 
     /**
-     * The environment has no entrypoint yet — Cockpit has not synced it. Fall back to the organization's
-     * own default entrypoint carrying the data-plane gateway url, as the organization resolution does.
+     * Fallback for an environment Cockpit has not synced an entrypoint for yet: the organization's own
+     * default entrypoint, carrying the data-plane gateway url.
      * <p>
-     * Deliberately does not call {@link #listOrganizationEntryPoint}: that one reads every entrypoint in
-     * the organization, environment-scoped rows included, and those are flagged default too — so its
-     * "drop the defaults once something else matched" step could filter the whole list away.
+     * Not {@link #listOrganizationEntryPoint}, which also reads environment-scoped rows; those are
+     * flagged default too, so its "drop the defaults once something else matched" step can empty the list.
      */
     private Maybe<Entrypoint> getOrganizationDefaultEntrypoint(Domain domain, String organizationId) {
         return entrypointService.findAll(organizationId)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
@@ -121,7 +121,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
 
         // Counter-intuitive but avoids introducing a field: the access point Cockpit generates itself is
         // the environment's *default* entrypoint, and the customer's overriding one is not. Resolution
-        // then drops the default whenever an override exists — see EntryPointManager#findByEnvironmentId.
+        // then drops the default whenever an override exists, see EntryPointManager#findByEnvironmentId.
         return entrypointService.create(organizationId, newEntrypoint, !accessPoint.isOverriding(), null).ignoreElement();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -1972,7 +1972,7 @@ public class DomainServiceTest {
 
         final var subscriber = domainService.listEntryPoint(mockDomain, ORGANIZATION_ID).test();
         // createDefaults gives every organization a default entrypoint and the last-default guard stops
-        // it being removed, so this should be unreachable — it just must not blow up if it ever is.
+        // it being removed, so this should be unreachable, it just must not blow up if it ever is.
         subscriber.assertNoErrors();
         subscriber.assertValue(List::isEmpty);
     }
@@ -1991,7 +1991,7 @@ public class DomainServiceTest {
         second.setEnvironmentId(ENVIRONMENT_ID);
         second.setUrl("https://second.gravitee.io");
 
-        // Whatever the environment resolves to is returned as-is — no collapsing to a single entrypoint.
+        // Whatever the environment resolves to is returned as-is, no collapsing to a single entrypoint.
         when(entryPointManager.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(first, second));
 
         final var subscriber = domainService.listEntryPoint(cloudDomain(), ORGANIZATION_ID).test();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/EmailServiceImplTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/EmailServiceImplTest.java
@@ -55,6 +55,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.util.StringUtils;
 
@@ -146,7 +147,7 @@ public class EmailServiceImplTest {
                 freemarkerConfiguration,
                 auditService,
                 jwtBuilder,
-                new DomainReadServiceImpl(mock(), dataPlaneRegistry, "http://localhost:1234/unittest"),
+                new DomainReadServiceImpl(mock(), dataPlaneRegistry, mock(), new MockEnvironment(), "http://localhost:1234/unittest"),
                 i18nDictionaryService,
                 environment
         );
@@ -210,7 +211,7 @@ public class EmailServiceImplTest {
                 freemarkerConfiguration,
                 auditService,
                 jwtBuilder,
-                new DomainReadServiceImpl(mock(), dataPlaneRegistry, "http://localhost:1234/default/unittest"),
+                new DomainReadServiceImpl(mock(), dataPlaneRegistry, mock(), new MockEnvironment(), "http://localhost:1234/default/unittest"),
                 i18nDictionaryService,
                 environment
         );

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
@@ -41,15 +41,9 @@ public interface EntryPointManager extends Service<EntryPointManager> {
     /**
      * The entrypoints user-facing URLs should be built from for the given environment.
      * <p>
-     * Cockpit provisions one entrypoint per gateway access point; the access point it generates itself
-     * is flagged {@code defaultEntrypoint} and the customer's overriding one is not (see
-     * {@code EnvironmentCommandHandler}). So whenever an environment resolves to more than its default,
-     * the customer has an override and it wins.
-     * <p>
-     * Never narrows a non-empty environment down to nothing: when no entrypoint survives the filter —
-     * every one of them is flagged default, which is what an access point payload carrying no
-     * {@code overriding} field produces — the full list is returned instead. Callers dereference the
-     * URL of whatever comes back, so an empty result would break them.
+     * Cockpit's own access point is flagged {@code defaultEntrypoint} and the customer's overriding one
+     * is not, so the override wins whenever both are present. Falls back to the full list when every
+     * entrypoint is flagged default: callers dereference a URL, so an empty result would break them.
      */
     default List<Entrypoint> findByEnvironmentId(String environmentId) {
         List<Entrypoint> all = findAllByEnvironmentId(environmentId);
@@ -60,11 +54,9 @@ public interface EntryPointManager extends Service<EntryPointManager> {
     /**
      * The single entrypoint a user-facing URL should be built from for the given environment.
      * <p>
-     * {@link #findByEnvironmentId(String)} can return several, since an environment may have more than
-     * one overriding access point, but a link needs exactly one. The lowest URL wins rather than the first
-     * in the list: the cache is a {@link java.util.concurrent.ConcurrentHashMap} whose iteration order is
-     * unspecified and varies with how many entrypoints a node holds, so "the first" would differ between
-     * the management API and a gateway and two emails for one environment could carry different hosts.
+     * The lowest URL wins rather than the first in the list. Cache iteration order is unspecified and the
+     * management API and gateway hold separate caches, so "the first" could differ between planes and two
+     * emails for one environment could carry different hosts.
      */
     Optional<Entrypoint> resolvePrimaryByEnvironmentId(String environmentId);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
@@ -19,6 +19,7 @@ import io.gravitee.am.model.Entrypoint;
 import io.gravitee.common.service.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * In-memory cache of entrypoints, loaded on startup and kept current through entrypoint events, so
@@ -55,4 +56,15 @@ public interface EntryPointManager extends Service<EntryPointManager> {
         List<Entrypoint> overriding = all.stream().filter(entrypoint -> !entrypoint.isDefaultEntrypoint()).toList();
         return overriding.isEmpty() ? all : overriding;
     }
+
+    /**
+     * The single entrypoint a user-facing URL should be built from for the given environment.
+     * <p>
+     * {@link #findByEnvironmentId(String)} can return several, since an environment may have more than
+     * one overriding access point, but a link needs exactly one. The lowest URL wins rather than the first
+     * in the list: the cache is a {@link java.util.concurrent.ConcurrentHashMap} whose iteration order is
+     * unspecified and varies with how many entrypoints a node holds, so "the first" would differ between
+     * the management API and a gateway and two emails for one environment could carry different hosts.
+     */
+    Optional<Entrypoint> resolvePrimaryByEnvironmentId(String environmentId);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
@@ -58,5 +58,5 @@ public interface EntryPointManager extends Service<EntryPointManager> {
      * management API and gateway hold separate caches, so "the first" could differ between planes and two
      * emails for one environment could carry different hosts.
      */
-    Optional<Entrypoint> resolvePrimaryByEnvironmentId(String environmentId);
+    Optional<Entrypoint> findPrimaryByEnvironmentId(String environmentId);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractEntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractEntryPointManager.java
@@ -113,7 +113,7 @@ public abstract class AbstractEntryPointManager extends AbstractService<EntryPoi
     }
 
     @Override
-    public Optional<Entrypoint> resolvePrimaryByEnvironmentId(String environmentId) {
+    public Optional<Entrypoint> findPrimaryByEnvironmentId(String environmentId) {
         List<Entrypoint> resolved = findByEnvironmentId(environmentId);
         if (resolved.size() > 1) {
             log.warn("Environment {} resolves to {} entrypoints, building URLs from the first in URL order", environmentId, resolved.size());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractEntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractEntryPointManager.java
@@ -31,8 +31,10 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -108,6 +110,15 @@ public abstract class AbstractEntryPointManager extends AbstractService<EntryPoi
         return entrypoints.values().stream()
                 .filter(entrypoint -> environmentId != null && environmentId.equals(entrypoint.getEnvironmentId()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Entrypoint> resolvePrimaryByEnvironmentId(String environmentId) {
+        List<Entrypoint> resolved = findByEnvironmentId(environmentId);
+        if (resolved.size() > 1) {
+            log.warn("Environment {} resolves to {} entrypoints, building URLs from the first in URL order", environmentId, resolved.size());
+        }
+        return resolved.stream().min(Comparator.comparing(Entrypoint::getUrl));
     }
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
@@ -15,13 +15,16 @@
  */
 package io.gravitee.am.service.impl.application;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.common.utils.PathUtils;
 import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.repository.management.api.DomainRepository;
 import io.gravitee.am.service.DomainReadService;
+import io.gravitee.am.service.EntryPointManager;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -29,8 +32,10 @@ import io.vertx.core.MultiMap;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,10 +49,18 @@ public class DomainReadServiceImpl implements DomainReadService {
     private final String gatewayUrl;
     private final DomainRepository domainRepository;
     private final DataPlaneRegistry dataPlaneRegistry;
+    private final EntryPointManager entryPointManager;
+    private final Environment springEnvironment;
 
-    public DomainReadServiceImpl(@Lazy DomainRepository domainRepository, @Lazy DataPlaneRegistry dataPlaneRegistry, @Value("${gateway.url:http://localhost:8092}") String gatewayUrl) {
+    public DomainReadServiceImpl(@Lazy DomainRepository domainRepository,
+                                 @Lazy DataPlaneRegistry dataPlaneRegistry,
+                                 @Lazy EntryPointManager entryPointManager,
+                                 Environment springEnvironment,
+                                 @Value("${gateway.url:http://localhost:8092}") String gatewayUrl) {
         this.dataPlaneRegistry = dataPlaneRegistry;
         this.domainRepository = domainRepository;
+        this.entryPointManager = entryPointManager;
+        this.springEnvironment = springEnvironment;
         this.gatewayUrl = gatewayUrl;
     }
 
@@ -75,8 +88,7 @@ public class DomainReadServiceImpl implements DomainReadService {
 
     @Override
     public String buildUrl(Domain domain, String path, MultiMap queryParams) {
-        final var dataPlaneDesc = dataPlaneRegistry.getDescription(domain);
-        String entryPoint = ofNullable(dataPlaneDesc.gatewayUrl()).orElse(gatewayUrl);
+        String entryPoint = resolveEntryPoint(domain);
 
         if (entryPoint != null && entryPoint.endsWith("/")) {
             entryPoint = entryPoint.substring(0, entryPoint.length() - 1);
@@ -109,6 +121,19 @@ public class DomainReadServiceImpl implements DomainReadService {
         }
 
         return uri;
+    }
+
+    // In managed cloud the environment's entrypoint is this domain's gateway hostname; everywhere else,
+    // and until Cockpit has synced one, the data plane url stands.
+    private String resolveEntryPoint(Domain domain) {
+        if (CloudProperties.isManagedCloudEnabled(springEnvironment)) {
+            Optional<String> entrypointUrl = entryPointManager.resolvePrimaryByEnvironmentId(domain.getReferenceId())
+                    .map(Entrypoint::getUrl);
+            if (entrypointUrl.isPresent()) {
+                return entrypointUrl.get();
+            }
+        }
+        return ofNullable(dataPlaneRegistry.getDescription(domain).gatewayUrl()).orElse(gatewayUrl);
     }
 
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
@@ -127,7 +127,7 @@ public class DomainReadServiceImpl implements DomainReadService {
     // and until Cockpit has synced one, the data plane url stands.
     private String resolveEntryPoint(Domain domain) {
         if (CloudProperties.isManagedCloudEnabled(springEnvironment)) {
-            Optional<String> entrypointUrl = entryPointManager.resolvePrimaryByEnvironmentId(domain.getReferenceId())
+            Optional<String> entrypointUrl = entryPointManager.findPrimaryByEnvironmentId(domain.getReferenceId())
                     .map(Entrypoint::getUrl);
             if (entrypointUrl.isPresent()) {
                 return entrypointUrl.get();

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
@@ -114,6 +114,18 @@ public class AbstractEntryPointManagerTest {
         return entrypoint;
     }
 
+    private static Entrypoint generatedEntrypoint(String id, String environmentId, String url) {
+        Entrypoint entrypoint = generatedEntrypoint(id, environmentId);
+        entrypoint.setUrl(url);
+        return entrypoint;
+    }
+
+    private static Entrypoint overridingEntrypoint(String id, String environmentId, String url) {
+        Entrypoint entrypoint = entrypoint(id, "org#1", environmentId);
+        entrypoint.setUrl(url);
+        return entrypoint;
+    }
+
     private static SimpleEvent<EntrypointEvent, Payload> event(EntrypointEvent type, String id) {
         return new SimpleEvent<>(type, new Payload(id, ReferenceType.ENVIRONMENT, "env#1", Action.CREATE));
     }
@@ -283,5 +295,47 @@ public class AbstractEntryPointManagerTest {
         cache(generatedEntrypoint("generated-1", "env#1"), generatedEntrypoint("generated-2", "env#1"));
 
         assertEquals(Set.of("generated-1", "generated-2"), idsOf(cut.findByEnvironmentId("env#1")));
+    }
+
+    @Test
+    public void shouldResolveNoPrimaryWhenEnvironmentHasNoEntrypoint() throws Exception {
+        cache(generatedEntrypoint("other-env-generated", "env#other", "https://other.gravitee.io"));
+
+        assertTrue(cut.resolvePrimaryByEnvironmentId("env#1").isEmpty());
+    }
+
+    @Test
+    public void shouldResolvePrimaryAsTheOnlyEntrypoint() throws Exception {
+        cache(generatedEntrypoint("generated", "env#1", "https://generated.gravitee.io"));
+
+        assertEquals("https://generated.gravitee.io", cut.resolvePrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
+    }
+
+    @Test
+    public void shouldResolvePrimaryAsTheOverridingEntrypoint() throws Exception {
+        // The generated URL sorts first, so this fails if the default is not dropped before the tiebreak.
+        cache(generatedEntrypoint("generated", "env#1", "https://aaa-generated.gravitee.io"),
+                overridingEntrypoint("overriding", "env#1", "https://zzz.acme.com"));
+
+        assertEquals("overriding", cut.resolvePrimaryByEnvironmentId("env#1").orElseThrow().getId());
+    }
+
+    @Test
+    public void shouldResolvePrimaryFromTheLowestUrlWhenSeveralOverridingExist() throws Exception {
+        // Seeded highest URL first, so an implementation taking whatever the cache yields first would
+        // have to get lucky to pass.
+        cache(overridingEntrypoint("overriding-z", "env#1", "https://z.acme.com"),
+                overridingEntrypoint("overriding-a", "env#1", "https://a.acme.com"),
+                generatedEntrypoint("generated", "env#1", "https://generated.gravitee.io"));
+
+        assertEquals("https://a.acme.com", cut.resolvePrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
+    }
+
+    @Test
+    public void shouldResolvePrimaryFromTheLowestUrlWhenEveryEntrypointIsFlaggedDefault() throws Exception {
+        cache(generatedEntrypoint("generated-2", "env#1", "https://b.gravitee.io"),
+                generatedEntrypoint("generated-1", "env#1", "https://a.gravitee.io"));
+
+        assertEquals("https://a.gravitee.io", cut.resolvePrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
@@ -313,7 +313,6 @@ public class AbstractEntryPointManagerTest {
 
     @Test
     public void shouldResolvePrimaryAsTheOverridingEntrypoint() throws Exception {
-        // The generated URL sorts first, so this fails if the default is not dropped before the tiebreak.
         cache(generatedEntrypoint("generated", "env#1", "https://aaa-generated.gravitee.io"),
                 overridingEntrypoint("overriding", "env#1", "https://zzz.acme.com"));
 
@@ -322,8 +321,6 @@ public class AbstractEntryPointManagerTest {
 
     @Test
     public void shouldResolvePrimaryFromTheLowestUrlWhenSeveralOverridingExist() throws Exception {
-        // Seeded highest URL first, so an implementation taking whatever the cache yields first would
-        // have to get lucky to pass.
         cache(overridingEntrypoint("overriding-z", "env#1", "https://z.acme.com"),
                 overridingEntrypoint("overriding-a", "env#1", "https://a.acme.com"),
                 generatedEntrypoint("generated", "env#1", "https://generated.gravitee.io"));

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
@@ -301,14 +301,14 @@ public class AbstractEntryPointManagerTest {
     public void shouldResolveNoPrimaryWhenEnvironmentHasNoEntrypoint() throws Exception {
         cache(generatedEntrypoint("other-env-generated", "env#other", "https://other.gravitee.io"));
 
-        assertTrue(cut.resolvePrimaryByEnvironmentId("env#1").isEmpty());
+        assertTrue(cut.findPrimaryByEnvironmentId("env#1").isEmpty());
     }
 
     @Test
     public void shouldResolvePrimaryAsTheOnlyEntrypoint() throws Exception {
         cache(generatedEntrypoint("generated", "env#1", "https://generated.gravitee.io"));
 
-        assertEquals("https://generated.gravitee.io", cut.resolvePrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
+        assertEquals("https://generated.gravitee.io", cut.findPrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
     }
 
     @Test
@@ -316,7 +316,7 @@ public class AbstractEntryPointManagerTest {
         cache(generatedEntrypoint("generated", "env#1", "https://aaa-generated.gravitee.io"),
                 overridingEntrypoint("overriding", "env#1", "https://zzz.acme.com"));
 
-        assertEquals("overriding", cut.resolvePrimaryByEnvironmentId("env#1").orElseThrow().getId());
+        assertEquals("overriding", cut.findPrimaryByEnvironmentId("env#1").orElseThrow().getId());
     }
 
     @Test
@@ -325,7 +325,7 @@ public class AbstractEntryPointManagerTest {
                 overridingEntrypoint("overriding-a", "env#1", "https://a.acme.com"),
                 generatedEntrypoint("generated", "env#1", "https://generated.gravitee.io"));
 
-        assertEquals("https://a.acme.com", cut.resolvePrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
+        assertEquals("https://a.acme.com", cut.findPrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
     }
 
     @Test
@@ -333,6 +333,6 @@ public class AbstractEntryPointManagerTest {
         cache(generatedEntrypoint("generated-2", "env#1", "https://b.gravitee.io"),
                 generatedEntrypoint("generated-1", "env#1", "https://a.gravitee.io"));
 
-        assertEquals("https://a.gravitee.io", cut.resolvePrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
+        assertEquals("https://a.gravitee.io", cut.findPrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
@@ -17,31 +17,41 @@ package io.gravitee.am.service.impl.application;
 
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Entrypoint;
+import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.repository.management.api.DomainRepository;
 import io.gravitee.am.service.DomainReadService;
+import io.gravitee.am.service.EntryPointManager;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class DomainReadServiceImplTest {
+    private static final String ENVIRONMENT_ID = "env#1";
+
     private final DomainRepository domainRepository = mock();
     private final DataPlaneRegistry dataPlaneRegistry = mock();
-    private final DomainReadService underTest = new DomainReadServiceImpl(domainRepository, dataPlaneRegistry, "http://default:8092");
+    private final EntryPointManager entryPointManager = mock();
+    private final MockEnvironment springEnvironment = new MockEnvironment();
+    private final DomainReadService underTest = new DomainReadServiceImpl(domainRepository, dataPlaneRegistry, entryPointManager, springEnvironment, "http://default:8092");
 
     @BeforeEach
     public void init() {
@@ -147,7 +157,7 @@ class DomainReadServiceImplTest {
     @Test
     void shouldBuildUrl_vhostModeAndHttps() {
 
-        var underTest = new DomainReadServiceImpl(mock(), dataPlaneRegistry, "http://localhost:8092");
+        var underTest = new DomainReadServiceImpl(mock(), dataPlaneRegistry, entryPointManager, springEnvironment, "http://localhost:8092");
         when(dataPlaneRegistry.getDescription(any())).thenReturn(new DataPlaneDescription("default", "Legcay DataPlane", "mongo", "baseProp", "https://localhost:8092"));
 
 
@@ -169,6 +179,96 @@ class DomainReadServiceImplTest {
         String url = underTest.buildUrl(domain, "/mySubPath?myParam=param1");
 
         assertEquals("https://test2.gravitee.io/test2/mySubPath?myParam=param1", url);
+    }
+
+    @Test
+    void shouldBuildUrl_nonCloud_neverConsultsTheEntrypointManager() {
+        Domain domain = cloudDomain();
+
+        underTest.buildUrl(domain, "/mySubPath");
+
+        verifyNoInteractions(entryPointManager);
+    }
+
+    @Test
+    void shouldBuildUrl_cloud_usesEnvironmentEntrypoint() {
+        enableCloudMode();
+        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath?myParam=param1");
+
+        assertEquals("https://auth.acme.com/testPath/mySubPath?myParam=param1", url);
+    }
+
+    @Test
+    void shouldBuildUrl_cloud_stripsTrailingSlashFromEntrypoint() {
+        enableCloudMode();
+        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com/")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath");
+
+        assertEquals("https://auth.acme.com/testPath/mySubPath", url);
+    }
+
+    @Test
+    void shouldBuildUrl_cloud_noEntrypoint_fallsBackToDataPlaneUrl() {
+        enableCloudMode();
+        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath?myParam=param1");
+
+        assertEquals("http://localhost:8092/testPath/mySubPath?myParam=param1", url);
+    }
+
+    @Test
+    void shouldBuildUrl_cloud_noEntrypoint_nullDataPlaneUrl_fallsBackToConfiguredGatewayUrl() {
+        enableCloudMode();
+        when(dataPlaneRegistry.getDescription(any())).thenReturn(new DataPlaneDescription("default", "Legcay DataPlane", "mongo", "baseProp", null));
+        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath?myParam=param1");
+
+        assertEquals("http://default:8092/testPath/mySubPath?myParam=param1", url);
+    }
+
+    @Test
+    void shouldBuildUrl_cloud_vhostModeStillWins() {
+        // Unreachable in production: EnvironmentCommandHandler leaves domainRestrictions unset in managed
+        // cloud, so setDeployMode never turns vhost mode on, and AM-7228 blocks enabling it afterwards.
+        enableCloudMode();
+        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
+
+        Domain domain = cloudDomain();
+        domain.setVhostMode(true);
+        VirtualHost vhost = new VirtualHost();
+        vhost.setHost("legacy.gravitee.io");
+        vhost.setPath("/legacy");
+        vhost.setOverrideEntrypoint(true);
+        domain.setVhosts(new ArrayList<>(List.of(vhost)));
+
+        String url = underTest.buildUrl(domain, "/mySubPath");
+
+        assertEquals("https://legacy.gravitee.io/legacy/mySubPath", url);
+    }
+
+    private void enableCloudMode() {
+        springEnvironment.setProperty("cloud.enabled", "true");
+        springEnvironment.setProperty("installation.type", "managed");
+    }
+
+    private static Domain cloudDomain() {
+        Domain domain = new Domain();
+        domain.setPath("/testPath");
+        domain.setVhostMode(false);
+        domain.setReferenceType(ReferenceType.ENVIRONMENT);
+        domain.setReferenceId(ENVIRONMENT_ID);
+        return domain;
+    }
+
+    private static Entrypoint entrypoint(String url) {
+        Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setUrl(url);
+        return entrypoint;
     }
 
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
@@ -233,8 +233,8 @@ class DomainReadServiceImplTest {
 
     @Test
     void shouldBuildUrl_cloud_vhostModeStillWins() {
-        // Unreachable in production: EnvironmentCommandHandler leaves domainRestrictions unset in managed
-        // cloud, so setDeployMode never turns vhost mode on, and AM-7228 blocks enabling it afterwards.
+        // Unreachable in production: managed cloud leaves domainRestrictions unset, so vhost mode never
+        // turns on. Pinned so the precedence is defined if that ever changes.
         enableCloudMode();
         when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
@@ -193,7 +193,7 @@ class DomainReadServiceImplTest {
     @Test
     void shouldBuildUrl_cloud_usesEnvironmentEntrypoint() {
         enableCloudMode();
-        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
 
         String url = underTest.buildUrl(cloudDomain(), "/mySubPath?myParam=param1");
 
@@ -203,7 +203,7 @@ class DomainReadServiceImplTest {
     @Test
     void shouldBuildUrl_cloud_stripsTrailingSlashFromEntrypoint() {
         enableCloudMode();
-        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com/")));
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com/")));
 
         String url = underTest.buildUrl(cloudDomain(), "/mySubPath");
 
@@ -213,7 +213,7 @@ class DomainReadServiceImplTest {
     @Test
     void shouldBuildUrl_cloud_noEntrypoint_fallsBackToDataPlaneUrl() {
         enableCloudMode();
-        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
 
         String url = underTest.buildUrl(cloudDomain(), "/mySubPath?myParam=param1");
 
@@ -224,7 +224,7 @@ class DomainReadServiceImplTest {
     void shouldBuildUrl_cloud_noEntrypoint_nullDataPlaneUrl_fallsBackToConfiguredGatewayUrl() {
         enableCloudMode();
         when(dataPlaneRegistry.getDescription(any())).thenReturn(new DataPlaneDescription("default", "Legcay DataPlane", "mongo", "baseProp", null));
-        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
 
         String url = underTest.buildUrl(cloudDomain(), "/mySubPath?myParam=param1");
 
@@ -236,7 +236,7 @@ class DomainReadServiceImplTest {
         // Unreachable in production: managed cloud leaves domainRestrictions unset, so vhost mode never
         // turns on. Pinned so the precedence is defined if that ever changes.
         enableCloudMode();
-        when(entryPointManager.resolvePrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
 
         Domain domain = cloudDomain();
         domain.setVhostMode(true);

--- a/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
@@ -55,9 +55,6 @@ const domainEntrypointUrls = async (): Promise<string[]> => {
 // not the internal data-plane gateway URL. retryUntil covers the management API sync-tick cache latency.
 describe('Cloud domain entrypoint URL (management API)', () => {
   it('resolves every access point when none of them is the customer override', async () => {
-    // The fixture provisions two GATEWAY access points with no `overriding` flag, so both are stored
-    // as the environment's default entrypoint. Nothing can be dropped without emptying the list, so
-    // the endpoint returns them both — never nothing.
     const urls = await retryUntil(
       () => domainEntrypointUrls(),
       (resolved) => resolved.length === fixture.expectedUrls.length,
@@ -75,8 +72,6 @@ describe('Cloud domain entrypoint URL (management API)', () => {
       { host: overridingHost, overriding: true },
     ]);
 
-    // This is the whole point of the flag: Cockpit's `overriding` bit has to survive the wire into
-    // AM, or the generated host would be resolved instead.
     const urls = await retryUntil(
       () => domainEntrypointUrls(),
       (resolved) => resolved.length === 1 && resolved[0] === `https://${overridingHost}`,
@@ -95,7 +90,6 @@ describe('Cloud domain entrypoint URL (management API)', () => {
       { host: second, overriding: true },
     ]);
 
-    // Nothing is the generated default here, so there is nothing to drop and both are returned.
     const expected = [`https://${first}`, `https://${second}`].sort();
     const urls = await retryUntil(() => domainEntrypointUrls(), (resolved) => resolved.length === 2, POLL);
 

--- a/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { clearEmails, getLastEmail } from '@utils-commands/email-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { CloudEmailFixture, setupCloudEmailFixture } from './fixtures/cloud-email-fixture';
+import { setup } from '../test-fixture';
+
+setup(200000);
+
+/**
+ * AM-7229 — in managed cloud, links in emails are built from the environment's entrypoint rather than
+ * from the data plane's gateway url.
+ *
+ * These are the request-less flows: nothing in them carries an end-user request AM could take a
+ * hostname from, so the entrypoint is the only thing that can produce a correct link.
+ *
+ * The entrypoint host is synthetic and does not resolve, so every assertion is on the link string.
+ * Never follow it.
+ */
+describe('AM - Cloud - entrypoint url in email links', () => {
+  let fixture: CloudEmailFixture;
+  let expectedOrigin: string;
+
+  beforeAll(async () => {
+    const accessToken = await requestAdminAccessToken();
+    fixture = await setupCloudEmailFixture(accessToken);
+    // Through URL rather than string concatenation: uniqueName produces mixed case and hostnames are
+    // case-insensitive, so both sides have to be normalised the same way.
+    expectedOrigin = new URL(`https://${fixture.entrypointHost}`).origin;
+  });
+
+  afterAll(async () => {
+    if (fixture) await fixture.cleanup();
+  });
+
+  const emailAddress = () => `${uniqueName('am7229', true)}@acme.fr`;
+
+  it('builds the pre-registration link from the environment entrypoint', async () => {
+    const email = emailAddress();
+    await clearEmails(email);
+
+    await fixture.createPreRegisteredUser(email);
+
+    const link = (await getLastEmail(5000, email)).extractLink();
+    expect(new URL(link).origin).toEqual(expectedOrigin);
+    await clearEmails(email);
+  });
+
+  it('builds the re-sent registration confirmation link from the environment entrypoint', async () => {
+    const email = emailAddress();
+    await clearEmails(email);
+
+    const user = await fixture.createPreRegisteredUser(email);
+    // Drop the email the creation itself sent, so the assertion cannot pass on the wrong one.
+    await getLastEmail(5000, email);
+    await clearEmails(email);
+
+    await fixture.resendRegistrationConfirmation(user.id);
+
+    const link = (await getLastEmail(5000, email)).extractLink();
+    expect(new URL(link).origin).toEqual(expectedOrigin);
+    await clearEmails(email);
+  });
+
+  it('builds the SCIM-provisioned registration link from the environment entrypoint', async () => {
+    // The gateway's own email path. SCIM has no end-user request, so it keeps resolving from the
+    // entrypoint even once AM-7230 makes request-bearing flows use the request hostname.
+    const email = emailAddress();
+    await clearEmails(email);
+
+    await fixture.createScimUser(email);
+
+    const link = (await getLastEmail(5000, email)).extractLink();
+    expect(new URL(link).origin).toEqual(expectedOrigin);
+    await clearEmails(email);
+  });
+});

--- a/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
@@ -23,14 +23,11 @@ import { setup } from '../test-fixture';
 setup(200000);
 
 /**
- * AM-7229 — in managed cloud, links in emails are built from the environment's entrypoint rather than
- * from the data plane's gateway url.
+ * In managed cloud, email links are built from the environment's entrypoint rather than the data
+ * plane's gateway url. These are the request-less flows, with no end-user request to take a hostname
+ * from, so the entrypoint is the only thing that can produce a correct link.
  *
- * These are the request-less flows: nothing in them carries an end-user request AM could take a
- * hostname from, so the entrypoint is the only thing that can produce a correct link.
- *
- * The entrypoint host is synthetic and does not resolve, so every assertion is on the link string.
- * Never follow it.
+ * The entrypoint host is synthetic and never resolves: assert on the link string, never follow it.
  */
 describe('AM - Cloud - entrypoint url in email links', () => {
   let fixture: CloudEmailFixture;
@@ -78,8 +75,7 @@ describe('AM - Cloud - entrypoint url in email links', () => {
   });
 
   it('builds the SCIM-provisioned registration link from the environment entrypoint', async () => {
-    // The gateway's own email path. SCIM has no end-user request, so it keeps resolving from the
-    // entrypoint even once AM-7230 makes request-bearing flows use the request hostname.
+    // The gateway's own email path, and the one flow with no end-user request to fall back on.
     const email = emailAddress();
     await clearEmails(email);
 

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
@@ -160,7 +160,7 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
   };
 
   // preRegistration is only honoured when the payload deserializes into a GraviteeUser, which needs the
-  // custom schema URI both in `schemas` and as the key of the extension object (UserMapper:203).
+  // custom schema URI both in `schemas` and as the key of the extension object (see UserMapper).
   const createScimUser = async (email: string) => {
     const username = uniqueName('scimuser', true);
     const response = await performPost(
@@ -181,8 +181,8 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     return response.body;
   };
 
-  // Only the domain. The environment's entrypoints are Cockpit-owned and AM-7228 rejects deleting them
-  // in a managed installation, so attempting it only ever produces a 400 and a misleading warning.
+  // Only the domain. Entrypoints are Cockpit-owned and a managed installation rejects deleting them,
+  // so attempting it only ever produces a 400 and a misleading warning.
   const cleanup = async () => {
     await domainApi
       .deleteDomain({ organizationId, environmentId, domain: domain.id })

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getApplicationApi, getDomainApi, getEntrypointsApi, getUserApi } from '@management-commands/service/utils';
+import { waitForOidcReady } from '@management-commands/domain-management-commands';
+import { getDomainState, waitForDomainReady } from '@gateway-commands/monitoring-commands';
+import { sendCockpitCommand } from '@cloud-commands/cockpit-commands';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { applicationBase64Token } from '@gateway-commands/utils';
+import { retryUntil, withRetry } from '@utils-commands/retry';
+import { uniqueName } from '@utils-commands/misc';
+import { expect } from '@jest/globals';
+
+const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
+const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
+const SCIM_CUSTOM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:extension:custom:2.0:User';
+
+export interface CloudEmailFixture {
+  organizationId: string;
+  environmentId: string;
+  domainId: string;
+  /** The single GATEWAY access point Cockpit provisioned for this environment, e.g. `gw-abc.example.com`. */
+  entrypointHost: string;
+  /** Create a pre-registered user through the management API; MAPI emails the confirmation link. */
+  createPreRegisteredUser: (email: string) => Promise<any>;
+  /** Re-send the registration confirmation for an existing pre-registered user. */
+  resendRegistrationConfirmation: (userId: string) => Promise<void>;
+  /** Provision a pre-registered user through SCIM; the gateway emails the confirmation link. */
+  createScimUser: (email: string) => Promise<any>;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * A managed-cloud environment holding exactly one GATEWAY access point, plus a domain in it wired for
+ * both management-API and SCIM user provisioning. One access point rather than several because these
+ * specs assert the host of an emailed link, and the entrypoint tiebreak is covered by unit tests.
+ *
+ * Managed-cloud stack only (local-stack.sh --cloud).
+ */
+export const setupCloudEmailFixture = async (accessToken: string): Promise<CloudEmailFixture> => {
+  const organizationId = process.env.AM_DEF_ORG_ID;
+  const environmentId = uniqueName('env-email', true);
+  const entrypointHost = `${uniqueName('gw', true)}.example.com`;
+  const entrypointUrl = `https://${entrypointHost}`;
+
+  // 1. Cockpit provisions the environment; its GATEWAY access point becomes the environment entrypoint.
+  await sendCockpitCommand({
+    type: 'ENVIRONMENT',
+    payload: {
+      id: environmentId,
+      organizationId,
+      hrids: [environmentId],
+      name: 'AM7229 cloud email env',
+      accessPoints: [{ target: 'GATEWAY', host: entrypointHost }],
+    },
+  });
+
+  await retryUntil(
+    () => getEntrypointsApi(accessToken).listEntrypoints({ organizationId }),
+    (entrypoints: any[]) => entrypoints.some((e) => e.url === entrypointUrl),
+    POLL,
+  );
+
+  // 2. A domain in that environment, with SCIM on and a service app able to call it. Configure before
+  //    enabling the domain so the initial sync picks everything up.
+  const domainApi = getDomainApi(accessToken);
+  const domain = await domainApi.createDomain({
+    organizationId,
+    environmentId,
+    newDomain: { name: uniqueName('email-entrypoint-domain', true), dataPlaneId: DATA_PLANE_ID },
+  });
+
+  await domainApi.patchDomain({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    patchDomain: { scim: { enabled: true, idpSelectionEnabled: false } },
+  });
+
+  const applicationApi = getApplicationApi(accessToken);
+  const scimApp = await applicationApi.createApplication({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    newApplication: { name: uniqueName('scim-app', true), type: 'SERVICE' },
+  });
+  await applicationApi.updateApplication({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    application: scimApp.id,
+    patchApplication: {
+      settings: {
+        oauth: {
+          grantTypes: ['client_credentials'],
+          scopeSettings: [{ scope: 'scim', defaultScope: true }],
+        },
+      },
+    },
+  });
+
+  await domainApi.patchDomain({ organizationId, environmentId, domain: domain.id, patchDomain: { enabled: true } });
+  await waitForDomainReady(domain.id);
+  const oidcConfig = (await waitForOidcReady(domain.hrid)).body;
+
+  // The entrypoint row is in the database by now, but neither plane reads it from there: each resolves
+  // from its own in-memory cache, warmed a moment later by the entrypoint event. Gate on both caches or
+  // the first test races them and sees the data plane fallback.
+  await retryUntil(
+    () => domainApi.getDomainEntrypoints({ organizationId, environmentId, domain: domain.id }),
+    (entrypoints: any[]) => entrypoints.some((e) => e.url === entrypointUrl),
+    POLL,
+  );
+  await retryUntil(
+    () => getDomainState(domain.id),
+    (state: any) => (state.entrypoints ?? []).some((e: any) => e.url === entrypointUrl),
+    POLL,
+  );
+
+  // The service app lags the OIDC endpoint under load, so retry rather than return a token that 401s.
+  const scimAccessToken = await withRetry(
+    async () => {
+      const response = await performPost(oidcConfig.token_endpoint, '', 'grant_type=client_credentials', {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: 'Basic ' + applicationBase64Token(scimApp),
+      }).expect(200);
+      expect(response.body.access_token).toBeDefined();
+      return response.body.access_token;
+    },
+    60,
+    500,
+  );
+
+  const userApi = getUserApi(accessToken);
+
+  const createPreRegisteredUser = (email: string) => {
+    const username = uniqueName('prereg', true);
+    return userApi.createUser({
+      organizationId,
+      environmentId,
+      domain: domain.id,
+      newUser: { username, firstName: 'Pre', lastName: 'Registered', email, preRegistration: true },
+    });
+  };
+
+  const resendRegistrationConfirmation = async (userId: string) => {
+    await userApi.sendRegistrationConfirmation({ organizationId, environmentId, domain: domain.id, user: userId });
+  };
+
+  // preRegistration is only honoured when the payload deserializes into a GraviteeUser, which needs the
+  // custom schema URI both in `schemas` and as the key of the extension object (UserMapper:203).
+  const createScimUser = async (email: string) => {
+    const username = uniqueName('scimuser', true);
+    const response = await performPost(
+      `${process.env.AM_GATEWAY_URL}/${domain.hrid}/scim`,
+      '/Users',
+      JSON.stringify({
+        schemas: [SCIM_CUSTOM_USER_SCHEMA, 'urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: username,
+        password: null,
+        name: { givenName: 'Scim', familyName: 'Provisioned' },
+        emails: [{ value: email, primary: true }],
+        active: true,
+        [SCIM_CUSTOM_USER_SCHEMA]: { preRegistration: true },
+      }),
+      { Authorization: `Bearer ${scimAccessToken}`, 'Content-Type': 'application/json' },
+    );
+    expect(response.status).toEqual(201);
+    return response.body;
+  };
+
+  // Only the domain. The environment's entrypoints are Cockpit-owned and AM-7228 rejects deleting them
+  // in a managed installation, so attempting it only ever produces a 400 and a misleading warning.
+  const cleanup = async () => {
+    await domainApi
+      .deleteDomain({ organizationId, environmentId, domain: domain.id })
+      .catch((e) => console.warn(`cleanup: failed to delete domain ${domain.id}: ${e.message}`));
+  };
+
+  return {
+    organizationId,
+    environmentId,
+    domainId: domain.id,
+    entrypointHost,
+    createPreRegisteredUser,
+    resendRegistrationConfirmation,
+    createScimUser,
+    cleanup,
+  };
+};


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7229

## :pencil2: A description of the changes proposed in the pull request

Targets AM-7298 rather than master, so the diff stays to just this change.

In cloud mode, emails were still built from the data plane gateway url, so a customer got links pointing at the wrong hostname for their environment. `DomainReadServiceImpl.buildUrl` now resolves the environment's entrypoint first and falls back to the data plane url as before. Everything after that in the method is untouched, vhosts still win, the domain path composes the same way.

Which entrypoint is `resolveByEnvironmentId` from AM-7298, narrowed to one by `resolvePrimaryByEnvironmentId`. The list can hold more than one and an email link needs exactly one, so it takes the lowest url. That matters more than it sounds, the cache is a ConcurrentHashMap so "the first one" is not the same on the management api and the gateway, and you would get two emails for one environment with different hosts.

Worth calling out, there is only one `buildUrl` and both planes inject it, so this changes gateway emails too. That is deliberate. It absorbs the entrypoint half of AM-7230 and leaves 7230 with the request object logic and SCIM.

Two things I found on the way that are worth a look, both are in the thread with Eric:

Cockpit only sends the overriding access points once a custom domain exists (`CommandFactory.environmentCommand`), so AM never holds a generated and a custom entrypoint at the same time. That means "always use the default entrypoint" cannot be honoured today, whatever rule AM implements.

The local stack only put the management api into managed cloud. That was fine until now because nothing in the gateway used cloud mode. I have added it to the gateway in the cloud overlay, but it opens the question of whether the production cloud gateways carry `installation.type=managed`. If they do not, the gateway half of this does nothing there and 7230 hits the same wall.

## :memo: Test scenarios

Unit, `AbstractEntryPointManagerTest` covers the selection rule, empty, single, generated plus overriding, several overriding, all flagged default. The generated url deliberately sorts first in one case so it fails if the default is not dropped before the tiebreak.

`DomainReadServiceImplTest` covers the url matrix, non cloud never touches the entrypoint manager, cloud with an entrypoint, trailing slash, no entrypoint falling back to the data plane url, null gateway url falling back to `gateway.url`, and vhost mode still winning. The four existing tests are unchanged apart from the constructor.

Jest, three new specs in `specs/cloud/email-entrypoint-url.jest.spec.ts` for the three request-less flows, pre registration, resend confirmation, and SCIM provisioning. SCIM rather than forgot password on purpose, forgot password has a request so 7230 will change where its host comes from and the assertion would need inverting.

All green against a `--cloud` stack, and the full `ci:cloud` suite still passes with the gateway in cloud mode, 4 suites, 13 tests.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

The vhost branch is unreachable in cloud, `EnvironmentCommandHandler` leaves domainRestrictions unset in managed cloud so `setDeployMode` never turns vhost mode on, and AM-7228 blocks enabling it after. I kept the precedence anyway rather than restructure a branch I cannot test. The one gap is the Automation API, `AutomationDomainMapper.applyTo` sets vhostMode straight from the request body with no cloud guard, that probably wants a ticket against 7228.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
