### PR TITLE
fix: AM-7238 eliminate deadlock by preloading organization reference

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/license/DomainPluginLicenseGate.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/license/DomainPluginLicenseGate.java
@@ -16,10 +16,13 @@
 package io.gravitee.am.gateway.handler.common.license;
 
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.service.EnvironmentService;
 import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.service.exception.LicenseFeatureRequiredException;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import lombok.CustomLog;
 
@@ -31,14 +34,13 @@ import lombok.CustomLog;
  * and recorded in the domain state as unlicensed (readiness stays healthy). Outside managed cloud
  * mode the underlying {@link PluginLicenseGate} is a no-op and every plugin loads.
  * <p>
- * Blocking is acceptable here: checks run during domain (re)deployment on deployment threads,
- * and the gate is in-memory except the first domain-to-organization resolution, which is cached.
+ * The domain's organization is resolved <strong>once</strong>, when this bean initializes during the
+ * domain's deployment (on the sync deployment pool), and held as an organization {@link Reference}.
  *
  * @author GraviteeSource Team
  */
 @CustomLog
-public class DomainPluginLicenseGate {
-
+public class DomainPluginLicenseGate implements InitializingBean {
 
     @Autowired
     private Domain domain;
@@ -48,6 +50,29 @@ public class DomainPluginLicenseGate {
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Autowired
+    private EnvironmentService environmentService;
+
+    private volatile Reference licenseReference;
+
+    @Override
+    public void afterPropertiesSet() {
+        // Resolve domain -> environment -> organization exactly once. This runs during the domain's
+        // Spring context refresh, on the sync deployment pool.
+        try {
+            final String organizationId = environmentService.findById(domain.getReferenceId())
+                    .map(Environment::getOrganizationId)
+                    .blockingGet();
+            if (organizationId != null && !organizationId.isBlank()) {
+                this.licenseReference = Reference.organization(organizationId);
+            } else {
+                log.warn("No organization resolved for domain {}; license checks will fail open", domain.getId());
+            }
+        } catch (Exception e) {
+            log.warn("Cannot resolve the organization of domain {}; license checks will fail open", domain.getId(), e);
+        }
+    }
 
     /**
      * Checks that an instance of the given plugin may be loaded for the current domain.
@@ -61,8 +86,12 @@ public class DomainPluginLicenseGate {
      * @return {@code true} when the plugin may be loaded, {@code false} when it is not licensed
      */
     public boolean check(String pluginType, String pluginId, String instanceId) {
+        if (licenseReference == null) {
+            return true;
+        }
         try {
-            pluginLicenseGate.check(Reference.domain(domain.getId()), pluginType, pluginId).blockingAwait();
+            // the underlying check resolves synchronously because the reference is already resolved to an organization
+            pluginLicenseGate.check(licenseReference, pluginType, pluginId).blockingAwait();
             return true;
         } catch (LicenseFeatureRequiredException e) {
             log.warn("Skipping {} '{}' [{}] for domain {}: {}", pluginType, instanceId, pluginId, domain.getId(), e.getMessage());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/license/DomainPluginLicenseGateTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/license/DomainPluginLicenseGateTest.java
@@ -16,11 +16,14 @@
 package io.gravitee.am.gateway.handler.common.license;
 
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.service.EnvironmentService;
 import io.gravitee.am.service.PluginLicenseGate;
 import io.gravitee.am.service.exception.LicenseFeatureRequiredException;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,8 +33,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -43,6 +48,8 @@ import static org.mockito.Mockito.when;
 public class DomainPluginLicenseGateTest {
 
     private static final String DOMAIN_ID = "domain#1";
+    private static final String ENVIRONMENT_ID = "env#1";
+    private static final String ORGANIZATION_ID = "org#1";
 
     @Mock
     private Domain domain;
@@ -53,17 +60,31 @@ public class DomainPluginLicenseGateTest {
     @Mock
     private DomainReadinessService domainReadinessService;
 
+    @Mock
+    private EnvironmentService environmentService;
+
     @InjectMocks
     private DomainPluginLicenseGate domainPluginLicenseGate;
 
     @Before
     public void setUp() {
-        when(domain.getId()).thenReturn(DOMAIN_ID);
+        // used only by the paths that log / record readiness against the domain
+        lenient().when(domain.getId()).thenReturn(DOMAIN_ID);
+    }
+
+    private void initWithResolvedOrganization() {
+        Environment environment = new Environment();
+        environment.setId(ENVIRONMENT_ID);
+        environment.setOrganizationId(ORGANIZATION_ID);
+        when(domain.getReferenceId()).thenReturn(ENVIRONMENT_ID);
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(environment));
+        domainPluginLicenseGate.afterPropertiesSet();
     }
 
     @Test
     public void shouldAllowLicensedPlugin() {
-        when(pluginLicenseGate.check(Reference.domain(DOMAIN_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
+        initWithResolvedOrganization();
+        when(pluginLicenseGate.check(Reference.organization(ORGANIZATION_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
                 .thenReturn(Completable.complete());
 
         assertTrue(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_FACTOR, "otp-sender", "factor-instance-1"));
@@ -73,7 +94,8 @@ public class DomainPluginLicenseGateTest {
 
     @Test
     public void shouldSkipAndRecordUnlicensedPlugin() {
-        when(pluginLicenseGate.check(Reference.domain(DOMAIN_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
+        initWithResolvedOrganization();
+        when(pluginLicenseGate.check(Reference.organization(ORGANIZATION_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
                 .thenReturn(Completable.error(new LicenseFeatureRequiredException("am-factor-otp-sender", "otp-sender")));
 
         assertFalse(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_FACTOR, "otp-sender", "factor-instance-1"));
@@ -83,11 +105,25 @@ public class DomainPluginLicenseGateTest {
 
     @Test
     public void shouldFailOpenOnUnexpectedErrors() {
-        when(pluginLicenseGate.check(Reference.domain(DOMAIN_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
-                .thenReturn(Completable.error(new IllegalStateException("cannot resolve organization")));
+        initWithResolvedOrganization();
+        when(pluginLicenseGate.check(Reference.organization(ORGANIZATION_ID), PluginLicenseGate.TYPE_FACTOR, "otp-sender"))
+                .thenReturn(Completable.error(new IllegalStateException("boom")));
 
         assertTrue(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_FACTOR, "otp-sender", "factor-instance-1"));
 
+        verifyNoInteractions(domainReadinessService);
+    }
+
+    @Test
+    public void shouldFailOpenAndNotBlockWhenOrganizationUnresolved() {
+        // organization resolution fails at init: the gate must never fall back to a blocking lazy lookup
+        when(domain.getReferenceId()).thenReturn(ENVIRONMENT_ID);
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.error(new IllegalStateException("db down")));
+        domainPluginLicenseGate.afterPropertiesSet();
+
+        assertTrue(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_FACTOR, "otp-sender", "factor-instance-1"));
+
+        verify(pluginLicenseGate, org.mockito.Mockito.never()).check(any(), anyString(), anyString());
         verifyNoInteractions(domainReadinessService);
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7238](https://gravitee.atlassian.net/browse/AM-7238)

## :pencil2: A description of the changes proposed in the pull request
Avoid license checking deadlock during domain redeployment: resolve the domain's org once at init, hold it as an `ORGANIZATION` reference, and feed that to the unchanged underlying gate. Every `check()` then resolves synchronously (`Single.just(org)` → in-memory `getOrganizationLicense`) with no cache and no cross-pool hop.

## :memo: Test scenarios 
1. Enable managed cloud mode
2. Start gateway with valid EE license
3. Restart nodes or amend existing domains to trigger redeployment

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7238]: https://gravitee.atlassian.net/browse/AM-7238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ