### PR TITLE
chore: gravitee-node bump-up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <gravitee-bom.version>8.3.65</gravitee-bom.version>
         <gravitee-common.version>4.2.0</gravitee-common.version>
         <gravitee-plugin.version>4.6.0</gravitee-plugin.version>
-        <gravitee-node.version>7.1.0</gravitee-node.version>
+        <gravitee-node.version>7.28.0</gravitee-node.version>
         <gravitee-reporter.version>1.17.1</gravitee-reporter.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>


### PR DESCRIPTION
contains new License feature entry for OCI Certificate

Ill ammend mergify PRs if 8.x or 9.x gravitee-node is requried.