### PR TITLE
fix: AM-7343 prevent permanent unlicensed plugin states

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImpl.java
@@ -197,6 +197,7 @@ public class IdentityProviderManagerImpl extends AbstractService implements Iden
     private Single<IdentityProvider> forceUpdateAuthenticationProvider(IdentityProvider identityProvider) {
         String identityProviderId = identityProvider.getId();
         try {
+            domainReadinessService.initPluginSync(domain.getId(), identityProviderId, Type.IDENTITY_PROVIDER.name());
             if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_IDENTITY_PROVIDER, identityProvider.getType(), identityProviderId)) {
                 if (hasExistingProvider(identityProviderId)) {
                     clearProvider(identityProviderId, false);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/flow/impl/FlowManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/flow/impl/FlowManagerImpl.java
@@ -293,16 +293,19 @@ public class FlowManagerImpl extends AbstractService implements FlowManager, Ini
     }
 
     private Policy createPolicy(Step step) {
+        domainReadinessService.initPluginSync(domain.getId(), step.getPolicy(), io.gravitee.am.common.event.Type.POLICY.name());
+        if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_POLICY, step.getPolicy(), step.getPolicy())) {
+            return null;
+        }
         try {
-            if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_POLICY, step.getPolicy(), step.getPolicy())) {
-                return null;
-            }
             log.info("\tInitializing policy: {} [{}]", step.getName(), step.getPolicy());
             Policy policy = policyPluginManager.create(step.getPolicy(), step.getCondition(), step.getConfiguration());
             log.info("\tPolicy : {} [{}] has been loaded", step.getName(), step.getPolicy());
             policy.activate();
+             domainReadinessService.pluginUnloaded(domain.getId(), step.getPolicy());
             return policy;
         } catch (Exception ex) {
+            domainReadinessService.pluginFailed(domain.getId(), step.getPolicy(), ex.getMessage());
             return null;
         }
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/idp/impl/IdentityProviderManagerImplTest.java
@@ -92,6 +92,8 @@ public class IdentityProviderManagerImplTest {
 
         verifyNoInteractions(identityProviderPluginManager);
         verify(domainReadinessService, never()).pluginFailed(any(), any(), any());
+        // the provider is registered with its type before the gate check, so the unlicensed entry is not type-less
+        verify(domainReadinessService).initPluginSync("domain-id", "ee-idp", "IDENTITY_PROVIDER");
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/flow/FlowManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/flow/FlowManagerTest.java
@@ -202,6 +202,10 @@ public class FlowManagerTest {
             return true;
         });
         verify(policyPluginManager, never()).create(anyString(), any(), anyString());
+        // the policy is registered with its type before the gate check, so an unlicensed entry is not type-less
+        verify(domainReadinessService).initPluginSync("domain-id", "ee-policy", io.gravitee.am.common.event.Type.POLICY.name());
+        // an unlicensed policy must not be cleared (the gate records it as unlicensed)
+        verify(domainReadinessService, never()).pluginUnloaded(anyString(), anyString());
     }
 
     @Test
@@ -231,6 +235,38 @@ public class FlowManagerTest {
             return true;
         });
         verify(policyPluginManager, times(1)).create(anyString(), anyString(), anyString());
+        // registered with its type, then removed on success so a licensed policy is not listed individually
+        verify(domainReadinessService).initPluginSync("domain-id", "step-policy", io.gravitee.am.common.event.Type.POLICY.name());
+        verify(domainReadinessService).pluginUnloaded("domain-id", "step-policy");
+    }
+
+    @Test
+    public void shouldRecordFailedPolicyAsFailed() {
+        Step step = mock(Step.class);
+        when(step.isEnabled()).thenReturn(true);
+        when(step.getPolicy()).thenReturn("step-policy");
+        when(step.getConfiguration()).thenReturn("step-configuration");
+        when(step.getCondition()).thenReturn("step-condition");
+
+        Flow flow = mock(Flow.class);
+        when(flow.getId()).thenReturn("flow-id");
+        when(flow.getType()).thenReturn(Type.CONSENT);
+        when(flow.isEnabled()).thenReturn(true);
+        when(flow.getPre()).thenReturn(Collections.singletonList(step));
+
+        when(domain.getId()).thenReturn("domain-id");
+        when(policyPluginManager.create(step.getPolicy(), step.getCondition(), step.getConfiguration()))
+                .thenThrow(new RuntimeException("boom"));
+        when(flowService.findAll(ReferenceType.DOMAIN, domain.getId())).thenReturn(Flowable.just(flow));
+        flowManager.afterPropertiesSet();
+        TestObserver<List<Policy>> obs = flowManager.findByExtensionPoint(ExtensionPoint.PRE_CONSENT, null, null).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(policies -> {
+            Assert.assertTrue(policies.isEmpty());
+            return true;
+        });
+        verify(domainReadinessService).pluginFailed("domain-id", "step-policy", "boom");
+        verify(domainReadinessService, never()).pluginUnloaded("domain-id", "step-policy");
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/resource/impl/ResourceManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/manager/resource/impl/ResourceManagerImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.manager.resource.impl;
 
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.event.ResourceEvent;
+import io.gravitee.am.common.event.Type;
 import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.manager.resource.ResourceManager;
 import io.gravitee.am.model.Domain;
@@ -27,6 +28,7 @@ import io.gravitee.am.plugins.handlers.api.provider.ProviderConfiguration;
 import io.gravitee.am.plugins.resource.core.ResourcePluginManager;
 import io.gravitee.am.resource.api.ResourceProvider;
 import io.gravitee.am.service.PluginLicenseGate;
+import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.service.ServiceResourceService;
 import io.gravitee.am.service.exception.ResourceNotFoundException;
 import io.gravitee.common.event.Event;
@@ -66,6 +68,9 @@ public class ResourceManagerImpl extends AbstractService implements ResourceMana
     @Autowired
     private DomainPluginLicenseGate domainPluginLicenseGate;
 
+    @Autowired
+    private DomainReadinessService domainReadinessService;
+
     private final Map<String, ResourceProvider> resourceProviders = new ConcurrentHashMap<>();
     private final Map<String, ServiceResource> resources = new ConcurrentHashMap<>();
 
@@ -95,6 +100,7 @@ public class ResourceManagerImpl extends AbstractService implements ResourceMana
                 .subscribeOn(Schedulers.io())
                 .subscribe(
                         res -> {
+                            domainReadinessService.initPluginSync(domain.getId(), res.getId(), Type.RESOURCE.name());
                             if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_RESOURCE, res.getType(), res.getId())) {
                                 return;
                             }
@@ -104,8 +110,10 @@ public class ResourceManagerImpl extends AbstractService implements ResourceMana
                                 resourceProviders.put(res.getId(), provider);
                                 resources.put(res.getId(), res);
                                 log.info("Resource {} loaded for domain {}", res.getName(), domain.getName());
+                                domainReadinessService.pluginLoaded(domain.getId(), res.getId());
                             } catch (Exception e) {
                                 log.error("Resource {} not loaded for domain {} due to: {}", res.getName(), domain.getName(), e.getMessage());
+                                domainReadinessService.pluginFailed(domain.getId(), res.getId(), e.getMessage());
                             }
                         },
                         error -> log.error("Unable to initialize resources for domain {}", domain.getName(), error)
@@ -137,13 +145,20 @@ public class ResourceManagerImpl extends AbstractService implements ResourceMana
                 .map(res -> {
                     if (needDeployment(res)) {
                         unloadResource(res.getId());
+                        domainReadinessService.initPluginSync(domain.getId(), res.getId(), Type.RESOURCE.name());
                         if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_RESOURCE, res.getType(), res.getId())) {
                             return res;
                         }
-                        var provider = resourcePluginManager.create(new ProviderConfiguration(res.getType(), res.getConfiguration()));
-                        provider.start();
-                        this.resources.put(res.getId(), res);
-                        this.resourceProviders.put(resourceId, provider);
+                        try {
+                            var provider = resourcePluginManager.create(new ProviderConfiguration(res.getType(), res.getConfiguration()));
+                            provider.start();
+                            this.resources.put(res.getId(), res);
+                            this.resourceProviders.put(resourceId, provider);
+                            domainReadinessService.pluginLoaded(domain.getId(), res.getId());
+                        } catch (Exception e) {
+                            domainReadinessService.pluginFailed(domain.getId(), res.getId(), e.getMessage());
+                            throw e;
+                        }
                     }
                     return res;
                 })

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandler.java
@@ -42,6 +42,7 @@ import io.gravitee.am.gateway.handler.manager.resource.ResourceManager;
 import io.gravitee.am.gateway.handler.manager.theme.ThemeManager;
 import io.gravitee.am.gateway.handler.root.RootProvider;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.plugins.authenticator.core.AuthenticatorPluginManager;
 import io.gravitee.am.plugins.protocol.core.ProtocolPluginManager;
 import io.gravitee.am.plugins.protocol.core.ProtocolProviderConfiguration;
@@ -89,6 +90,9 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
 
     @Autowired
     private DomainPluginLicenseGate domainPluginLicenseGate;
+
+    @Autowired
+    private DomainReadinessService domainReadinessService;
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -175,6 +179,7 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
         log.info("Start security domain protocols");
 
         PROTOCOLS.forEach(protocol -> {
+            domainReadinessService.initPluginSync(domain.getId(), protocol, "PROTOCOL");
             try {
                 if (!domainPluginLicenseGate.check(PluginLicenseGate.TYPE_PROTOCOL, protocol, protocol)) {
                     return;
@@ -185,9 +190,13 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
                     protocolProvider.start();
                     protocolProviders.add(protocolProvider);
                     log.info("\t Protocol {} loaded", protocol);
+                    domainReadinessService.pluginLoaded(domain.getId(), protocol);
+                } else {
+                    domainReadinessService.pluginUnloaded(domain.getId(), protocol);
                 }
             } catch (Exception e) {
                 log.error("\t An error occurs while loading {} protocol", protocol, e);
+                domainReadinessService.pluginFailed(domain.getId(), protocol, e.getMessage());
             }
         });
     }
@@ -195,7 +204,7 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
     private void startSecurityDomainAuthenticators() {
         log.info("Start security domain authenticators");
         List<AuthenticatorProvider> providers = authenticatorPluginManager.createAll(applicationContext,
-                pluginId -> domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHENTICATOR, pluginId, pluginId));
+                this::isAuthenticatorLicensed);
         providers.forEach(provider -> {
             try {
                 provider.start();
@@ -205,6 +214,15 @@ public class VertxSecurityDomainHandler extends AbstractService<VertxSecurityDom
                 log.error("\t An error occurs while loading {} authenticator", provider.name(), e);
             }
         });
+    }
+
+    private boolean isAuthenticatorLicensed(String pluginId) {
+        domainReadinessService.initPluginSync(domain.getId(), pluginId, "AUTHENTICATOR");
+        boolean allowed = domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHENTICATOR, pluginId, pluginId);
+        if (allowed) {
+            domainReadinessService.pluginLoaded(domain.getId(), pluginId);
+        }
+        return allowed;
     }
 
     private void stopProtocols() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/resource/impl/ResourceManagerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/manager/resource/impl/ResourceManagerImplTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.manager.resource.impl;
+
+import io.gravitee.am.common.event.Action;
+import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.event.ResourceEvent;
+import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.model.resource.ServiceResource;
+import io.gravitee.am.plugins.resource.core.ResourcePluginManager;
+import io.gravitee.am.resource.api.ResourceProvider;
+import io.gravitee.am.service.PluginLicenseGate;
+import io.gravitee.am.service.ServiceResourceService;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.gravitee.am.monitoring.DomainReadinessService;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class ResourceManagerImplTest {
+
+    private static final String DOMAIN_ID = "domain-id";
+    private static final String RESOURCE_ID = "res-1";
+    private static final String RESOURCE_TYPE = "ee-resource";
+
+    @Mock
+    private ResourcePluginManager resourcePluginManager;
+
+    @Mock
+    private Domain domain;
+
+    @Mock
+    private EventManager eventManager;
+
+    @Mock
+    private ServiceResourceService resourceService;
+
+    @Mock
+    private DomainPluginLicenseGate domainPluginLicenseGate;
+
+    @Mock
+    private DomainReadinessService domainReadinessService;
+
+    @InjectMocks
+    private ResourceManagerImpl resourceManager;
+
+    @Before
+    public void setUp() {
+        when(domain.getId()).thenReturn(DOMAIN_ID);
+    }
+
+    private ServiceResource resource() {
+        ServiceResource res = new ServiceResource();
+        res.setId(RESOURCE_ID);
+        res.setType(RESOURCE_TYPE);
+        res.setConfiguration("{}");
+        return res;
+    }
+
+    @Test
+    public void shouldClearReadinessForLicensedResourceOnInit() throws Exception {
+        when(resourceService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.just(resource()));
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_RESOURCE, RESOURCE_TYPE, RESOURCE_ID)).thenReturn(true);
+        when(resourcePluginManager.create(any())).thenReturn(mock(ResourceProvider.class));
+
+        resourceManager.afterPropertiesSet();
+
+        // a licensed resource that loads clears any stale "unlicensed" readiness recorded by the gate
+        verify(domainReadinessService, timeout(2000)).pluginLoaded(DOMAIN_ID, RESOURCE_ID);
+        // and is registered with its type so the readiness entry is not left type-less
+        verify(domainReadinessService).initPluginSync(DOMAIN_ID, RESOURCE_ID, "RESOURCE");
+    }
+
+    @Test
+    public void shouldNotLoadOrClearReadinessForUnlicensedResourceOnInit() throws Exception {
+        when(resourceService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.just(resource()));
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_RESOURCE, RESOURCE_TYPE, RESOURCE_ID)).thenReturn(false);
+
+        resourceManager.afterPropertiesSet();
+
+        // wait for the async chain to reach the gate, then assert the plugin was neither created nor cleared
+        verify(domainPluginLicenseGate, timeout(2000)).check(PluginLicenseGate.TYPE_RESOURCE, RESOURCE_TYPE, RESOURCE_ID);
+        verify(resourcePluginManager, never()).create(any());
+        verify(domainReadinessService, never()).pluginLoaded(anyString(), anyString());
+    }
+
+    @Test
+    public void shouldClearReadinessForLicensedResourceOnReload() throws Exception {
+        when(resourceService.findById(RESOURCE_ID)).thenReturn(Maybe.just(resource()));
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_RESOURCE, RESOURCE_TYPE, RESOURCE_ID)).thenReturn(true);
+        when(resourcePluginManager.create(any())).thenReturn(mock(ResourceProvider.class));
+
+        resourceManager.onEvent(new SimpleEvent<>(ResourceEvent.UPDATE,
+                new Payload(RESOURCE_ID, ReferenceType.DOMAIN, DOMAIN_ID, Action.UPDATE)));
+
+        verify(domainReadinessService, timeout(2000)).pluginLoaded(DOMAIN_ID, RESOURCE_ID);
+        verify(domainReadinessService).initPluginSync(DOMAIN_ID, RESOURCE_ID, "RESOURCE");
+    }
+
+    @Test
+    public void shouldRecordFailedResourceOnReload() throws Exception {
+        when(resourceService.findById(RESOURCE_ID)).thenReturn(Maybe.just(resource()));
+        when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_RESOURCE, RESOURCE_TYPE, RESOURCE_ID)).thenReturn(true);
+        ResourceProvider provider = mock(ResourceProvider.class);
+        doThrow(new RuntimeException("boom")).when(provider).start();
+        when(resourcePluginManager.create(any())).thenReturn(provider);
+
+        resourceManager.onEvent(new SimpleEvent<>(ResourceEvent.UPDATE,
+                new Payload(RESOURCE_ID, ReferenceType.DOMAIN, DOMAIN_ID, Action.UPDATE)));
+
+        verify(domainReadinessService, timeout(2000)).pluginFailed(DOMAIN_ID, RESOURCE_ID, "boom");
+        verify(domainReadinessService, never()).pluginLoaded(DOMAIN_ID, RESOURCE_ID);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/vertx/VertxSecurityDomainHandlerTest.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.am.gateway.handler.vertx;
 
+import io.gravitee.am.gateway.handler.api.ProtocolProvider;
 import io.gravitee.am.gateway.handler.common.license.DomainPluginLicenseGate;
 import io.gravitee.am.gateway.handler.root.RootProvider;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.monitoring.DomainReadinessService;
 import io.gravitee.am.plugins.authenticator.core.AuthenticatorPluginManager;
 import io.gravitee.am.plugins.protocol.core.ProtocolPluginManager;
 import io.gravitee.am.plugins.protocol.core.ProtocolProviderConfiguration;
@@ -41,9 +43,13 @@ import java.util.function.Predicate;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -64,6 +70,9 @@ public class VertxSecurityDomainHandlerTest {
 
     @Mock
     private DomainPluginLicenseGate domainPluginLicenseGate;
+
+    @Mock
+    private DomainReadinessService domainReadinessService;
 
     @Mock
     private ApplicationContext applicationContext;
@@ -119,5 +128,47 @@ public class VertxSecurityDomainHandlerTest {
         when(domainPluginLicenseGate.check(PluginLicenseGate.TYPE_AUTHENTICATOR, "ee-authenticator", "ee-authenticator")).thenReturn(false);
         assertFalse(filter.test("ee-authenticator"));
         assertTrue(filter.test("oss-authenticator"));
+
+        // both are registered with their type so the readiness entry is not left type-less
+        verify(domainReadinessService).initPluginSync(domain.getId(), "oss-authenticator", "AUTHENTICATOR");
+        verify(domainReadinessService).initPluginSync(domain.getId(), "ee-authenticator", "AUTHENTICATOR");
+        // a licensed authenticator must clear any stale "unlicensed" readiness; an unlicensed one must not
+        verify(domainReadinessService).pluginLoaded(domain.getId(), "oss-authenticator");
+        verify(domainReadinessService, never()).pluginLoaded(domain.getId(), "ee-authenticator");
+    }
+
+    @Test
+    public void shouldRegisterAndClearReadinessForLicensedProtocol() throws Exception {
+        when(protocolPluginManager.create(any())).thenReturn(mock(ProtocolProvider.class));
+
+        handler.doStart();
+
+        // every protocol is registered with its type, and a loaded one clears its readiness entry
+        verify(domainReadinessService).initPluginSync(domain.getId(), "openid-connect", "PROTOCOL");
+        verify(domainReadinessService).pluginLoaded(domain.getId(), "openid-connect");
+    }
+
+    @Test
+    public void shouldDropReadinessForProtocolWithoutProvider() throws Exception {
+        // create returns null (protocol not installed on this node): the seeded entry must be removed
+        when(protocolPluginManager.create(any())).thenReturn(null);
+
+        handler.doStart();
+
+        verify(domainReadinessService).initPluginSync(domain.getId(), "openid-connect", "PROTOCOL");
+        verify(domainReadinessService).pluginUnloaded(domain.getId(), "openid-connect");
+        verify(domainReadinessService, never()).pluginLoaded(domain.getId(), "openid-connect");
+    }
+
+    @Test
+    public void shouldRecordFailedProtocolAsFailed() throws Exception {
+        ProtocolProvider provider = mock(ProtocolProvider.class);
+        doThrow(new RuntimeException("boom")).when(provider).start();
+        when(protocolPluginManager.create(any())).thenReturn(provider);
+
+        handler.doStart();
+
+        verify(domainReadinessService, atLeastOnce()).pluginFailed(eq(domain.getId()), anyString(), eq("boom"));
+        verify(domainReadinessService, never()).pluginLoaded(eq(domain.getId()), anyString());
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7343](https://gravitee.atlassian.net/browse/AM-7343)

## :pencil2: A description of the changes proposed in the pull request
Fully initialise plugins for the domain readiness endpoint and set terminal states to avoid sticky unlicensed messages.

- Unlicensed warning entries for **Protocol**, **Authenticator**, **Resource** and **Policy** types are reset when a license change grants them.
- Plugin states for **Protocol**/**Resource**/**Authenticator** are initialised so they are included in domain readiness responses and entries in domain readiness responses always have `type`.
- **Identity providers** are also initialised during redeployment so entries in domain readiness responses always have `type`.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7343]: https://gravitee.atlassian.net/browse/AM-7343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ