### PR TITLE
feat: build email links from the request host in managed cloud

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
@@ -354,6 +354,27 @@ public class UriBuilder {
         return host.matches("[0-9]+(?:\\.[0-9]+){1,3}") || host.contains(":");
     }
 
+    /**
+     * True when the two URIs share an origin: scheme and host compared case-insensitively, ports by
+     * what they resolve to, so a spelled-out default port still matches an implicit one.
+     */
+    public static boolean sameOriginAuthority(URI left, URI right) {
+        return equalsIgnoreCase(left.getScheme(), right.getScheme())
+                && equalsIgnoreCase(left.getHost(), right.getHost())
+                && effectivePort(left) == effectivePort(right);
+    }
+
+    private static boolean equalsIgnoreCase(String left, String right) {
+        return left != null && left.equalsIgnoreCase(right);
+    }
+
+    private static int effectivePort(URI uri) {
+        if (uri.getPort() >= 0) {
+            return uri.getPort();
+        }
+        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+    }
+
     public static String buildErrorRedirect(String baseRedirectUri, ErrorInfo error, boolean fragment, Map<String, String> extraParams) throws URISyntaxException {
         final URI redirectUri = UriBuilder.fromURIString(baseRedirectUri).build();
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/UserAuthenticationService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/UserAuthenticationService.java
@@ -81,7 +81,7 @@ public interface UserAuthenticationService {
      * @param user End-User to lock
      * @param requestOrigin the origin the failed login came in on, or null when there is no request to
      *                      take one from. The blocked account email carries a reset password link, so it
-     *                      resolves its url the same way the reset password flow does. See AM-7230.
+     *                      resolves its url the same way the reset password flow does.
      * @return
      */
     Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user, @Nullable String requestOrigin);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/UserAuthenticationService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/UserAuthenticationService.java
@@ -21,6 +21,7 @@ import io.gravitee.am.model.User;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.gateway.api.Request;
+import jakarta.annotation.Nullable;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -83,7 +84,7 @@ public interface UserAuthenticationService {
      *                      resolves its url the same way the reset password flow does. See AM-7230.
      * @return
      */
-    Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user, String requestOrigin);
+    Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user, @Nullable String requestOrigin);
 
     default Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user) {
         return lockAccount(criteria, accountSettings, client, user, null);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/UserAuthenticationService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/UserAuthenticationService.java
@@ -78,9 +78,16 @@ public interface UserAuthenticationService {
      * @param accountSettings account settings
      * @param client oauth2 client
      * @param user End-User to lock
+     * @param requestOrigin the origin the failed login came in on, or null when there is no request to
+     *                      take one from. The blocked account email carries a reset password link, so it
+     *                      resolves its url the same way the reset password flow does. See AM-7230.
      * @return
      */
-    Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user);
+    Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user, String requestOrigin);
+
+    default Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user) {
+        return lockAccount(criteria, accountSettings, client, user, null);
+    }
 
     default Single<User> connect(io.gravitee.am.identityprovider.api.User principal, boolean afterAuthentication) {
         return connect(principal, null, null, afterAuthentication);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationManagerImpl.java
@@ -35,7 +35,9 @@ import io.gravitee.am.gateway.handler.common.auth.user.UserAuthenticationService
 import io.gravitee.am.gateway.handler.common.password.PasswordPolicyManager;
 import io.gravitee.am.gateway.handler.common.service.LoginAttemptGatewayService;
 import io.gravitee.am.gateway.handler.common.user.UserGatewayService;
+import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.identityprovider.api.Authentication;
+import io.gravitee.am.identityprovider.api.AuthenticationContext;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.PasswordPolicy;
@@ -238,10 +240,15 @@ public class UserAuthenticationManagerImpl implements UserAuthenticationManager 
         String username = ofNullable(authentication.getContext())
                 .map(ctx -> (String) ctx.get(ACTUAL_USERNAME))
                 .orElse(authentication.getPrincipal().toString());
-        return postAuthentication(client, username, source, userAuthentication);
+        // Carried down for the blocked account email, which links back to reset password.
+        String requestOrigin = ofNullable(authentication.getContext())
+                .map(AuthenticationContext::request)
+                .map(UriBuilderRequest::resolveOrigin)
+                .orElse(null);
+        return postAuthentication(client, username, source, userAuthentication, requestOrigin);
     }
 
-    private Completable postAuthentication(Client client, String username, String source, UserAuthentication userAuthentication) {
+    private Completable postAuthentication(Client client, String username, String source, UserAuthentication userAuthentication, String requestOrigin) {
         final AccountSettings accountSettings = AccountSettings.getInstance(domain, client);
 
         // if brute force detection feature disabled, continue
@@ -281,7 +288,7 @@ public class UserAuthenticationManagerImpl implements UserAuthenticationManager 
                                 .flatMapCompletable(user -> loginAttemptService.loginFailed(domain, criteria, accountSettings)
                                         .flatMapCompletable(loginAttempt -> {
                                             if (loginAttempt.isAccountLocked(accountSettings.getMaxLoginAttempts())) {
-                                                return userAuthenticationService.lockAccount(criteria, accountSettings, client, user);
+                                                return userAuthenticationService.lockAccount(criteria, accountSettings, client, user, requestOrigin);
                                             }
                                             return Completable.complete();
                                         })

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationManagerImpl.java
@@ -240,11 +240,12 @@ public class UserAuthenticationManagerImpl implements UserAuthenticationManager 
         String username = ofNullable(authentication.getContext())
                 .map(ctx -> (String) ctx.get(ACTUAL_USERNAME))
                 .orElse(authentication.getPrincipal().toString());
-        // Carried down for the blocked account email, which links back to reset password.
+
         String requestOrigin = ofNullable(authentication.getContext())
                 .map(AuthenticationContext::request)
                 .map(UriBuilderRequest::resolveOrigin)
                 .orElse(null);
+
         return postAuthentication(client, username, source, userAuthentication, requestOrigin);
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/auth/user/impl/UserAuthenticationServiceImpl.java
@@ -53,6 +53,7 @@ import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.management.UserAuditBuilder;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
+import io.vertx.core.MultiMap;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -216,7 +217,7 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
     }
 
     @Override
-    public Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user) {
+    public Completable lockAccount(LoginAttemptCriteria criteria, AccountSettings accountSettings, Client client, User user, String requestOrigin) {
         if (user == null) {
             return Completable.complete();
         }
@@ -230,7 +231,7 @@ public class UserAuthenticationServiceImpl implements UserAuthenticationService 
                 .flatMap(user1 -> {
                     // send an email if option is enabled
                     if (user1.getEmail() != null && accountSettings.isSendRecoverAccountEmail()) {
-                        new Thread(() -> emailService.send(Template.BLOCKED_ACCOUNT, user1, client)).start();
+                        new Thread(() -> emailService.send(Template.BLOCKED_ACCOUNT, user1, client, MultiMap.caseInsensitiveMultiMap(), requestOrigin)).start();
                     }
                     return Single.just(user);
                 })

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/EmailService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/EmailService.java
@@ -22,6 +22,7 @@ import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
 
 import io.vertx.core.MultiMap;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
@@ -41,7 +42,7 @@ public interface EmailService {
         this.send(template, user, client, queryParams, null);
     }
 
-    void send(Template template, User user, Client client, MultiMap queryParams, String requestOrigin);
+    void send(Template template, User user, Client client, MultiMap queryParams, @Nullable String requestOrigin);
 
     void asyncSend(Template template, User user, Client client, MultiMap queryParams);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/EmailService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/EmailService.java
@@ -37,7 +37,15 @@ public interface EmailService {
         this.send(template, user, client, MultiMap.caseInsensitiveMultiMap());
     }
 
-    void send(Template template, User user, Client client, MultiMap queryParams);
+    default void send(Template template, User user, Client client, MultiMap queryParams) {
+        this.send(template, user, client, queryParams, null);
+    }
+
+    /**
+     * @param requestOrigin the origin the end user reached the gateway on, or null when the flow has no
+     *                      end-user request to take one from. See AM-7230.
+     */
+    void send(Template template, User user, Client client, MultiMap queryParams, String requestOrigin);
 
     void asyncSend(Template template, User user, Client client, MultiMap queryParams);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/EmailService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/EmailService.java
@@ -41,10 +41,6 @@ public interface EmailService {
         this.send(template, user, client, queryParams, null);
     }
 
-    /**
-     * @param requestOrigin the origin the end user reached the gateway on, or null when the flow has no
-     *                      end-user request to take one from. See AM-7230.
-     */
     void send(Template template, User user, Client client, MultiMap queryParams, String requestOrigin);
 
     void asyncSend(Template template, User user, Client client, MultiMap queryParams);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
@@ -168,12 +168,12 @@ public class EmailServiceImpl implements EmailService, InitializingBean, Disposa
     }
 
     @Override
-    public void send(io.gravitee.am.model.Template template, User user, Client client, MultiMap queryParams) {
+    public void send(io.gravitee.am.model.Template template, User user, Client client, MultiMap queryParams, String requestOrigin) {
         if (enabled) {
             // get raw email template
             io.gravitee.am.model.Email emailTemplate = getEmailTemplate(template, client);
             // prepare email
-            Email email = prepareEmail(template, emailTemplate, user, client, queryParams);
+            Email email = prepareEmail(template, emailTemplate, user, client, queryParams, requestOrigin);
             // send email
             sendEmail(email, user, client);
         }
@@ -198,7 +198,8 @@ public class EmailServiceImpl implements EmailService, InitializingBean, Disposa
                     // get raw email template
                     io.gravitee.am.model.Email emailTemplate = getEmailTemplate(template, container.client());
                     // prepare email
-                    email = prepareEmail(template, emailTemplate, container.user(), container.client(), MultiMap.caseInsensitiveMultiMap());
+                    // Staged emails are sent well after the request that queued them, so there is no origin.
+                    email = prepareEmail(template, emailTemplate, container.user(), container.client(), MultiMap.caseInsensitiveMultiMap(), null);
 
                     return container.with(prepareEmailToSend(email, container.user()));
                 } catch (Exception ex) {
@@ -371,8 +372,8 @@ public class EmailServiceImpl implements EmailService, InitializingBean, Disposa
                 .user(user));
     }
 
-    private Email prepareEmail(io.gravitee.am.model.Template template, io.gravitee.am.model.Email emailTemplate, User user, Client client, MultiMap queryParams) {
-        Map<String, Object> params = prepareEmailParams(user, client, emailTemplate.getExpiresAfter(), template, queryParams);
+    private Email prepareEmail(io.gravitee.am.model.Template template, io.gravitee.am.model.Email emailTemplate, User user, Client client, MultiMap queryParams, String requestOrigin) {
+        Map<String, Object> params = prepareEmailParams(user, client, emailTemplate.getExpiresAfter(), template, queryParams, requestOrigin);
         return new EmailBuilder()
                 .to(user.getEmail())
                 .from(emailTemplate.getFrom())
@@ -383,7 +384,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean, Disposa
                 .build();
     }
 
-    private Map<String, Object> prepareEmailParams(User user, Client client, Integer expiresAfter, io.gravitee.am.model.Template template, MultiMap queryParams) {
+    private Map<String, Object> prepareEmailParams(User user, Client client, Integer expiresAfter, io.gravitee.am.model.Template template, MultiMap queryParams, String requestOrigin) {
         // generate a JWT to store user's information and for security purpose
         final Map<String, Object> claims = new HashMap<>();
         Instant now = Instant.now();
@@ -418,7 +419,7 @@ public class EmailServiceImpl implements EmailService, InitializingBean, Disposa
             params.put("client", new ClientProperties(client));
         }
 
-        params.put("url", domainService.buildUrl(domain, template.redirectUri(), queryParams));
+        params.put("url", domainService.buildUrl(domain, template.redirectUri(), queryParams, requestOrigin));
 
         return params;
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
@@ -198,7 +198,6 @@ public class EmailServiceImpl implements EmailService, InitializingBean, Disposa
                     // get raw email template
                     io.gravitee.am.model.Email emailTemplate = getEmailTemplate(template, container.client());
                     // prepare email
-                    // Staged emails are sent well after the request that queued them, so there is no origin.
                     email = prepareEmail(template, emailTemplate, container.user(), container.client(), MultiMap.caseInsensitiveMultiMap(), null);
 
                     return container.with(prepareEmailToSend(email, container.user()));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -222,9 +222,8 @@ public class UriBuilderRequest {
     /**
      * This request's public origin as {@code scheme://host[:port]}, using the same {@code X-Forwarded-*}
      * resolution as {@link #resolveProxyRequest(HttpServerRequest, String, MultiMap, boolean)}.
-     * <p>
-     * Carries no path: callers compare it against configured entrypoints and vhosts, which are hosts
-     * rather than URLs, so neither the request path nor {@code X-Forwarded-Prefix} belongs in it.
+     * Carries no path and ignores {@code X-Forwarded-Prefix}; null when the forwarding headers do not
+     * form a parseable origin.
      */
     public static @Nullable String resolveOrigin(HttpServerRequest request) {
         final URI baseUri;
@@ -232,7 +231,7 @@ public class UriBuilderRequest {
             baseUri = URI.create(resolveProxyRequest(request, "/", (MultiMap) null, false));
         } catch (IllegalArgumentException e) {
             // The forwarding headers are caller-controlled and go into the url unencoded, so they can
-            // fail to parse. Callers read null as "no origin" and resolve the url the usual way.
+            // fail to parse.
             LOGGER.warn("Unable to resolve the request origin from the forwarding headers");
             return null;
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -219,6 +219,22 @@ public class UriBuilderRequest {
     }
 
     /**
+     * This request's public origin as {@code scheme://host[:port]}, using the same {@code X-Forwarded-*}
+     * resolution as {@link #resolveProxyRequest(HttpServerRequest, String, MultiMap, boolean)}.
+     * <p>
+     * Carries no path: callers compare it against configured entrypoints and vhosts, which are hosts
+     * rather than URLs, so neither the request path nor {@code X-Forwarded-Prefix} belongs in it.
+     */
+    public static String resolveOrigin(HttpServerRequest request) {
+        final URI baseUri = URI.create(resolveProxyRequest(request, "/", (MultiMap) null, false));
+        StringBuilder origin = new StringBuilder().append(baseUri.getScheme()).append("://").append(baseUri.getHost());
+        if (baseUri.getPort() >= 0) {
+            origin.append(':').append(baseUri.getPort());
+        }
+        return origin.toString();
+    }
+
+    /**
      * True when {@code Origin} matches this request's public origin (scheme, host, port), using the same
      * {@code X-Forwarded-*} resolution as {@link #resolveProxyRequest(HttpServerRequest, String, MultiMap, boolean)}.
      * Rejects missing, literal {@code null}, opaque, or non-http(s) origins.

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -246,6 +246,17 @@ public class UriBuilderRequest {
     }
 
     /**
+     * As {@link #resolveOrigin(HttpServerRequest)}, for the flows that carry the gateway request rather
+     * than the Vert.x one. Null request means no origin, same as a request we cannot parse.
+     */
+    public static String resolveOrigin(Request request) {
+        if (request == null) {
+            return null;
+        }
+        return resolveOrigin(new HttpServerRequest(new GraviteeVertxHttpServerRequest(request)));
+    }
+
+    /**
      * True when {@code Origin} matches this request's public origin (scheme, host, port), using the same
      * {@code X-Forwarded-*} resolution as {@link #resolveProxyRequest(HttpServerRequest, String, MultiMap, boolean)}.
      * Rejects missing, literal {@code null}, opaque, or non-http(s) origins.

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -226,7 +226,18 @@ public class UriBuilderRequest {
      * rather than URLs, so neither the request path nor {@code X-Forwarded-Prefix} belongs in it.
      */
     public static String resolveOrigin(HttpServerRequest request) {
-        final URI baseUri = URI.create(resolveProxyRequest(request, "/", (MultiMap) null, false));
+        final URI baseUri;
+        try {
+            baseUri = URI.create(resolveProxyRequest(request, "/", (MultiMap) null, false));
+        } catch (IllegalArgumentException e) {
+            // The forwarding headers are caller-controlled and go into the url unencoded, so they can
+            // fail to parse. Callers read null as "no origin" and resolve the url the usual way.
+            LOGGER.warn("Unable to resolve the request origin from the forwarding headers");
+            return null;
+        }
+        if (baseUri.getScheme() == null || baseUri.getHost() == null) {
+            return null;
+        }
         StringBuilder origin = new StringBuilder().append(baseUri.getScheme()).append("://").append(baseUri.getHost());
         if (baseUri.getPort() >= 0) {
             origin.append(':').append(baseUri.getPort());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -298,28 +298,6 @@ public class UriBuilderRequest {
         if (baseUri.getScheme() == null || baseUri.getHost() == null) {
             return false;
         }
-        return sameOriginAuthority(baseUri, originUri);
-    }
-
-    private static boolean sameOriginAuthority(URI expected, URI origin) {
-        if (!expected.getScheme().equalsIgnoreCase(origin.getScheme())) {
-            return false;
-        }
-        if (!expected.getHost().equalsIgnoreCase(origin.getHost())) {
-            return false;
-        }
-        return effectivePort(expected) == effectivePort(origin);
-    }
-
-    private static int effectivePort(URI uri) {
-        int port = uri.getPort();
-        if (port >= 0) {
-            return port;
-        }
-        String scheme = uri.getScheme();
-        if (scheme != null && "https".equalsIgnoreCase(scheme)) {
-            return 443;
-        }
-        return 80;
+        return UriBuilder.sameOriginAuthority(baseUri, originUri);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -235,13 +235,16 @@ public class UriBuilderRequest {
             LOGGER.warn("Unable to resolve the request origin from the forwarding headers");
             return null;
         }
+
         if (baseUri.getScheme() == null || baseUri.getHost() == null) {
             return null;
         }
+
         StringBuilder origin = new StringBuilder().append(baseUri.getScheme()).append("://").append(baseUri.getHost());
         if (baseUri.getPort() >= 0) {
             origin.append(':').append(baseUri.getPort());
         }
+
         return origin.toString();
     }
 
@@ -253,6 +256,7 @@ public class UriBuilderRequest {
         if (request == null) {
             return null;
         }
+
         return resolveOrigin(new HttpServerRequest(new GraviteeVertxHttpServerRequest(request)));
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequest.java
@@ -21,6 +21,7 @@ import io.gravitee.am.gateway.handler.common.utils.StaticEnvironmentProvider;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.Request;
 import io.vertx.core.MultiMap;
+import jakarta.annotation.Nullable;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 import org.slf4j.Logger;
@@ -225,7 +226,7 @@ public class UriBuilderRequest {
      * Carries no path: callers compare it against configured entrypoints and vhosts, which are hosts
      * rather than URLs, so neither the request path nor {@code X-Forwarded-Prefix} belongs in it.
      */
-    public static String resolveOrigin(HttpServerRequest request) {
+    public static @Nullable String resolveOrigin(HttpServerRequest request) {
         final URI baseUri;
         try {
             baseUri = URI.create(resolveProxyRequest(request, "/", (MultiMap) null, false));
@@ -252,7 +253,7 @@ public class UriBuilderRequest {
      * As {@link #resolveOrigin(HttpServerRequest)}, for the flows that carry the gateway request rather
      * than the Vert.x one. Null request means no origin, same as a request we cannot parse.
      */
-    public static String resolveOrigin(Request request) {
+    public static @Nullable String resolveOrigin(Request request) {
         if (request == null) {
             return null;
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationManagerTest.java
@@ -766,7 +766,7 @@ public class UserAuthenticationManagerTest {
         observer.assertError(BadCredentialsException.class);
         verify(userService, never()).findByUsernameAndSource(anyString(), anyString());
         verify(loginAttemptService, never()).loginFailed(any(), any(), any());
-        verify(userAuthenticationService, never()).lockAccount(any(), any(), any(), any());
+        verify(userAuthenticationService, never()).lockAccount(any(), any(), any(), any(), any());
         verify(eventManager, times(1)).publishEvent(eq(AuthenticationEvent.FAILURE), any());
     }
 
@@ -820,7 +820,7 @@ public class UserAuthenticationManagerTest {
         observer.assertError(BadCredentialsException.class);
         verify(userService, times(1)).findByUsernameAndSource(anyString(), anyString(), anyBoolean());
         verify(loginAttemptService, never()).loginFailed(any(), any(), any());
-        verify(userAuthenticationService, never()).lockAccount(any(), any(), any(), any());
+        verify(userAuthenticationService, never()).lockAccount(any(), any(), any(), any(), any());
         verify(eventManager, times(1)).publishEvent(eq(AuthenticationEvent.FAILURE), any());
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
@@ -1235,7 +1235,6 @@ public class UserAuthenticationServiceTest {
         verify(userService).update(argThat(updatedUser -> !updatedUser.isAccountNonLocked()
                 && updatedUser.getAccountLockedAt() != null
                 && updatedUser.getAccountLockedUntil() != null));
-        // The email goes out on its own thread, so this is what proves the origin survived the hop.
         verify(emailService, timeout(1000)).send(eq(Template.BLOCKED_ACCOUNT), eq(user), eq(client), any(), eq("https://auth.acme.com"));
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/auth/UserAuthenticationServiceTest.java
@@ -1226,7 +1226,7 @@ public class UserAuthenticationServiceTest {
 
         when(userService.update(any())).thenReturn(Single.just(user));
 
-        TestObserver<Void> testObserver = userAuthenticationService.lockAccount(criteria, accountSettings, client, user).test();
+        TestObserver<Void> testObserver = userAuthenticationService.lockAccount(criteria, accountSettings, client, user, "https://auth.acme.com").test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
 
         testObserver.assertComplete();
@@ -1235,7 +1235,8 @@ public class UserAuthenticationServiceTest {
         verify(userService).update(argThat(updatedUser -> !updatedUser.isAccountNonLocked()
                 && updatedUser.getAccountLockedAt() != null
                 && updatedUser.getAccountLockedUntil() != null));
-        verify(emailService, timeout(1000)).send(eq(Template.BLOCKED_ACCOUNT), eq(user), eq(client));
+        // The email goes out on its own thread, so this is what proves the origin survived the hop.
+        verify(emailService, timeout(1000)).send(eq(Template.BLOCKED_ACCOUNT), eq(user), eq(client), any(), eq("https://auth.acme.com"));
     }
 
     @Test
@@ -1269,7 +1270,7 @@ public class UserAuthenticationServiceTest {
         verify(userService).update(argThat(updatedUser -> !updatedUser.isAccountNonLocked()
                 && updatedUser.getAccountLockedAt() != null
                 && updatedUser.getAccountLockedUntil() != null));
-        verify(emailService, never()).send(eq(Template.BLOCKED_ACCOUNT), eq(user), eq(client));
+        verify(emailService, never()).send(eq(Template.BLOCKED_ACCOUNT), eq(user), eq(client), any(), any());
     }
 
     private Client initClient() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequestTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequestTest.java
@@ -697,4 +697,46 @@ public class UriBuilderRequestTest {
         assertFalse(UriBuilderRequest.isRequestOriginAllowed(request, "null"));
     }
 
+    @Test
+    public void shouldResolveOrigin_fromForwardedHeaders() {
+        setupMockEnvironment(false, true);
+        when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PROTO))).thenReturn("https");
+        when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("gw.example.com");
+        when(request.getHeader(eq(HttpHeaders.X_FORWARDED_PORT))).thenReturn("8443");
+        when(request.scheme()).thenReturn("http");
+        when(request.authority()).thenReturn(HostAndPort.create("internal", 8080));
+
+        assertEquals("https://gw.example.com:8443", UriBuilderRequest.resolveOrigin(request));
+    }
+
+    @Test
+    public void shouldResolveOrigin_fromHostHeaderWhenNotForwarded() {
+        setupMockEnvironment(false, true);
+        when(request.getHeader(eq(HttpHeaders.HOST))).thenReturn("auth.acme.com");
+        when(request.scheme()).thenReturn("https");
+
+        assertEquals("https://auth.acme.com", UriBuilderRequest.resolveOrigin(request));
+    }
+
+    @Test
+    public void shouldResolveOrigin_omitsDefaultPort() {
+        setupMockEnvironment(false, true);
+        when(request.getHeader(eq(HttpHeaders.HOST))).thenReturn("auth.acme.com:443");
+        when(request.scheme()).thenReturn("https");
+
+        assertEquals("https://auth.acme.com", UriBuilderRequest.resolveOrigin(request));
+    }
+
+    @Test
+    public void shouldResolveOrigin_withoutPathOrForwardedPrefix() {
+        // The origin is compared against configured entrypoints and vhosts, which carry no path, so the
+        // request path and X-Forwarded-Prefix must not leak into it.
+        setupMockEnvironment(false, true);
+        when(request.getHeader(eq(HttpHeaders.HOST))).thenReturn("auth.acme.com");
+        when(request.getHeader(eq("X-Forwarded-Prefix"))).thenReturn("/auth");
+        when(request.scheme()).thenReturn("https");
+
+        assertEquals("https://auth.acme.com", UriBuilderRequest.resolveOrigin(request));
+    }
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequestTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/utils/UriBuilderRequestTest.java
@@ -27,6 +27,7 @@ import org.springframework.core.env.Environment;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -725,6 +726,17 @@ public class UriBuilderRequestTest {
         when(request.scheme()).thenReturn("https");
 
         assertEquals("https://auth.acme.com", UriBuilderRequest.resolveOrigin(request));
+    }
+
+    @Test
+    public void shouldResolveOrigin_returnsNullWhenTheHeadersDoNotFormAUri() {
+        // X-Forwarded-Host is attacker controlled and UriBuilder appends it raw, so a hostile value can
+        // make the resolved url unparseable. Callers treat null as "no origin" and fall back.
+        setupMockEnvironment(false, true);
+        when(request.getHeader(eq(HttpHeaders.X_FORWARDED_HOST))).thenReturn("bad host|value");
+        when(request.scheme()).thenReturn("https");
+
+        assertNull(UriBuilderRequest.resolveOrigin(request));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordSubmissionEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/password/ForgotPasswordSubmissionEndpoint.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.user.password;
 import io.gravitee.am.common.exception.authentication.AccountStatusException;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.root.resources.handler.user.UserRequestHandler;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.gateway.handler.root.service.user.model.ForgotPasswordParameters;
@@ -62,7 +63,8 @@ public class ForgotPasswordSubmissionEndpoint extends UserRequestHandler {
 
         AccountSettings settings = AccountSettings.getInstance(domain, client);
 
-        final ForgotPasswordParameters parameters = new ForgotPasswordParameters(email, username, settings != null && settings.isResetPasswordCustomForm(), settings != null && settings.isResetPasswordConfirmIdentity());
+        final ForgotPasswordParameters parameters = new ForgotPasswordParameters(email, username, settings != null && settings.isResetPasswordCustomForm(), settings != null && settings.isResetPasswordConfirmIdentity())
+                .withRequestOrigin(UriBuilderRequest.resolveOrigin(context.request()));
         userService.forgotPassword(parameters, client, getAuthenticatedUser(context))
                 .subscribe(
                         () -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterProcessHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterProcessHandler.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.root.resources.handler.user.register;
 
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.root.resources.handler.user.UserRequestHandler;
 import io.gravitee.am.gateway.handler.root.service.response.RegistrationResponse;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
@@ -62,7 +63,7 @@ public class RegisterProcessHandler extends UserRequestHandler {
         User user = convert(params, client);
         MultiMap queryParams = RequestUtils.getCleanedQueryParams(context.request());
         // register the user
-        register(client, user, getAuthenticatedUser(context), queryParams, h -> {
+        register(client, user, getAuthenticatedUser(context), queryParams, UriBuilderRequest.resolveOrigin(context.request()), h -> {
             // if failure, return to the register page with an error
             if (h.failed()) {
                 context.fail(h.cause());
@@ -81,8 +82,8 @@ public class RegisterProcessHandler extends UserRequestHandler {
         });
     }
 
-    private void register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams, Handler<AsyncResult<RegistrationResponse>> handler) {
-        userService.register(client, user, principal, queryParams).subscribe(
+    private void register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams, String requestOrigin, Handler<AsyncResult<RegistrationResponse>> handler) {
+        userService.register(client, user, principal, queryParams, requestOrigin).subscribe(
                 response -> handler.handle(Future.succeededFuture(response)),
                 error -> handler.handle(Future.failedFuture(error))
         );

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserService.java
@@ -26,6 +26,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.MultiMap;
+import jakarta.annotation.Nullable;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -50,7 +51,7 @@ public interface UserService {
         return register(client, user, principal, queryParams, null);
     }
 
-    Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams, String requestOrigin);
+    Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams, @Nullable String requestOrigin);
 
     Single<RegistrationResponse> confirmRegistration(Client client, User user, io.gravitee.am.identityprovider.api.User principal);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserService.java
@@ -50,10 +50,6 @@ public interface UserService {
         return register(client, user, principal, queryParams, null);
     }
 
-    /**
-     * @param requestOrigin the origin the end user registered on, or null when the flow has no end-user
-     *                      request to take one from. See AM-7230.
-     */
     Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams, String requestOrigin);
 
     Single<RegistrationResponse> confirmRegistration(Client client, User user, io.gravitee.am.identityprovider.api.User principal);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/UserService.java
@@ -46,7 +46,15 @@ public interface UserService {
 
     Maybe<UserToken> confirmVerifyRegistration(String token);
 
-    Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams);
+    default Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams) {
+        return register(client, user, principal, queryParams, null);
+    }
+
+    /**
+     * @param requestOrigin the origin the end user registered on, or null when the flow has no end-user
+     *                      request to take one from. See AM-7230.
+     */
+    Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams, String requestOrigin);
 
     Single<RegistrationResponse> confirmRegistration(Client client, User user, io.gravitee.am.identityprovider.api.User principal);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
@@ -585,7 +585,7 @@ public class UserServiceImpl implements UserService {
                             })
                             .onErrorResumeNext(exception -> Single.error(new UserNotFoundException(email != null ? email : params.getUsername())));
                 })
-                .doOnSuccess(user -> new Thread(() -> emailService.send(RESET_PASSWORD, user, client)).start())
+                .doOnSuccess(user -> new Thread(() -> emailService.send(RESET_PASSWORD, user, client, MultiMap.caseInsensitiveMultiMap(), params.getRequestOrigin())).start())
                 .doOnSuccess(user1 -> {
                     // reload principal
                     io.gravitee.am.identityprovider.api.User principal1 = reloadPrincipal(principal, user1);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/impl/UserServiceImpl.java
@@ -230,7 +230,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams) {
+    public Single<RegistrationResponse> register(Client client, User user, io.gravitee.am.identityprovider.api.User principal, MultiMap queryParams, String requestOrigin) {
         // set user idp source
         var accountSettings = AccountSettings.getInstance(client, domain);
         final String source = UserRegistrationIdpResolver.getRegistrationIdpForUser(domain, client, user);
@@ -241,8 +241,8 @@ public class UserServiceImpl implements UserService {
                         .flatMapMaybe(checkUserPresence(user, source))
                         .switchIfEmpty(Single.error(() -> new UserProviderNotFoundException(source)))
                         .flatMap(userProvider -> userProvider.create(convert(user)))
-                        .flatMap(idpUser -> registerUser(user, accountSettings, source, idpUser, queryParams))
-                        .flatMap(amUser -> sendVerifyAccountEmail(client, amUser, accountSettings, queryParams))
+                        .flatMap(idpUser -> registerUser(user, accountSettings, source, idpUser, queryParams, requestOrigin))
+                        .flatMap(amUser -> sendVerifyAccountEmail(client, amUser, accountSettings, queryParams, requestOrigin))
                         .flatMap(amUser -> createPasswordHistory(amUser, rawPassword, principal))
                         .flatMap(userService::enhance)
                         .map(enhancedUser -> buildRegistrationResponse(accountSettings, enhancedUser))
@@ -267,7 +267,7 @@ public class UserServiceImpl implements UserService {
         return new RegistrationResponse(user, redirectUri, isAutoLogin);
     }
 
-    private Single<User> registerUser(User user, Optional<AccountSettings> accountSettings, String source, io.gravitee.am.identityprovider.api.User idpUser, MultiMap queryParams) {
+    private Single<User> registerUser(User user, Optional<AccountSettings> accountSettings, String source, io.gravitee.am.identityprovider.api.User idpUser, MultiMap queryParams, String requestOrigin) {
         // AM 'users' collection is not made for authentication (but only management stuff)
         var now = new Date();
         // clear password
@@ -295,7 +295,7 @@ public class UserServiceImpl implements UserService {
                 user.setPreRegistration(true);
                 user.setRegistrationCompleted(false);
                 user.setEnabled(false);
-                user.setRegistrationUserUri(domainService.buildUrl(domain, REGISTRATION_VERIFY.redirectUri(), queryParams));
+                user.setRegistrationUserUri(domainService.buildUrl(domain, REGISTRATION_VERIFY.redirectUri(), queryParams, requestOrigin));
             }
         });
         user.setLastPasswordReset(now);
@@ -313,9 +313,9 @@ public class UserServiceImpl implements UserService {
         };
     }
 
-    private @NonNull Single<User> sendVerifyAccountEmail(Client client, User amUser, Optional<AccountSettings> accountSettings, MultiMap queryParams) {
+    private @NonNull Single<User> sendVerifyAccountEmail(Client client, User amUser, Optional<AccountSettings> accountSettings, MultiMap queryParams, String requestOrigin) {
         accountSettings.filter(AccountSettings::isSendVerifyRegistrationAccountEmail).ifPresent(sendEmail ->
-                fromRunnable(() -> emailService.send(REGISTRATION_VERIFY, amUser, client, queryParams)).subscribe()
+                fromRunnable(() -> emailService.send(REGISTRATION_VERIFY, amUser, client, queryParams, requestOrigin)).subscribe()
         );
         return Single.just(amUser);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/model/ForgotPasswordParameters.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/model/ForgotPasswordParameters.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.root.service.user.model;
 
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
+import jakarta.annotation.Nullable;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
@@ -56,11 +57,11 @@ public class ForgotPasswordParameters {
         this.requestOrigin = requestOrigin;
     }
 
-    public ForgotPasswordParameters withRequestOrigin(String requestOrigin) {
+    public ForgotPasswordParameters withRequestOrigin(@Nullable String requestOrigin) {
         return new ForgotPasswordParameters(email, username, customFormEnabled, confirmIdentityEnabled, requestOrigin);
     }
 
-    public String getRequestOrigin() {
+    public @Nullable String getRequestOrigin() {
         return requestOrigin;
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/model/ForgotPasswordParameters.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/model/ForgotPasswordParameters.java
@@ -56,10 +56,6 @@ public class ForgotPasswordParameters {
         this.requestOrigin = requestOrigin;
     }
 
-    /**
-     * The origin the user submitted the form on, carried through to the reset email because the send
-     * happens on its own thread with no request in scope. See AM-7230.
-     */
     public ForgotPasswordParameters withRequestOrigin(String requestOrigin) {
         return new ForgotPasswordParameters(email, username, customFormEnabled, confirmIdentityEnabled, requestOrigin);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/model/ForgotPasswordParameters.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/service/user/model/ForgotPasswordParameters.java
@@ -29,24 +29,43 @@ public class ForgotPasswordParameters {
     final String username;
     final boolean customFormEnabled;
     final boolean confirmIdentityEnabled;
+    final String requestOrigin;
 
     public ForgotPasswordParameters(String email,
                                     String username,
                                     boolean customFormEnabled,
                                     boolean confirmIdentityEnabled) {
-        this.email = email;
-        this.username = username;
-        this.customFormEnabled = customFormEnabled;
-        this.confirmIdentityEnabled = confirmIdentityEnabled;
+        this(email, username, customFormEnabled, confirmIdentityEnabled, null);
     }
 
     public ForgotPasswordParameters(String email,
                                     boolean customFormEnabled,
                                     boolean confirmIdentityEnabled) {
+        this(email, null, customFormEnabled, confirmIdentityEnabled, null);
+    }
+
+    private ForgotPasswordParameters(String email,
+                                     String username,
+                                     boolean customFormEnabled,
+                                     boolean confirmIdentityEnabled,
+                                     String requestOrigin) {
         this.email = email;
-        this.username = null;
+        this.username = username;
         this.customFormEnabled = customFormEnabled;
         this.confirmIdentityEnabled = confirmIdentityEnabled;
+        this.requestOrigin = requestOrigin;
+    }
+
+    /**
+     * The origin the user submitted the form on, carried through to the reset email because the send
+     * happens on its own thread with no request in scope. See AM-7230.
+     */
+    public ForgotPasswordParameters withRequestOrigin(String requestOrigin) {
+        return new ForgotPasswordParameters(email, username, customFormEnabled, confirmIdentityEnabled, requestOrigin);
+    }
+
+    public String getRequestOrigin() {
+        return requestOrigin;
     }
 
     public String getEmail() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/user/register/RegisterSubmissionEndpointTest.java
@@ -80,7 +80,7 @@ public class RegisterSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.register(eq(client), any(), any(), any())).thenReturn(Single.just(new RegistrationResponse()));
+        when(userService.register(eq(client), any(), any(), any(), any())).thenReturn(Single.just(new RegistrationResponse()));
 
         testRequest(
                 HttpMethod.POST, "/register?client_id=client-id",
@@ -109,7 +109,7 @@ public class RegisterSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.register(eq(client), any(), any(), any())).thenReturn(Single.just(registrationResponse));
+        when(userService.register(eq(client), any(), any(), any(), any())).thenReturn(Single.just(registrationResponse));
 
         testRequest(
                 HttpMethod.POST, "/register?client_id=client-id",
@@ -134,7 +134,7 @@ public class RegisterSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.register(eq(client), any(), any(), any())).thenReturn(Single.error(new UserAlreadyExistsException("test")));
+        when(userService.register(eq(client), any(), any(), any(), any())).thenReturn(Single.error(new UserAlreadyExistsException("test")));
 
         testRequest(
                 HttpMethod.POST, "/register?client_id=client-id",
@@ -159,7 +159,7 @@ public class RegisterSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.register(eq(client), any(), any(), any())).thenReturn(Single.error(new InvalidUserException("Username invalid")));
+        when(userService.register(eq(client), any(), any(), any(), any())).thenReturn(Single.error(new InvalidUserException("Username invalid")));
 
         testRequest(
                 HttpMethod.POST, "/register?client_id=client-id",
@@ -184,7 +184,7 @@ public class RegisterSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.register(eq(client), any(), any(), any())).thenReturn(Single.error(new EmailFormatInvalidException("test")));
+        when(userService.register(eq(client), any(), any(), any(), any())).thenReturn(Single.error(new EmailFormatInvalidException("test")));
 
         testRequest(
                 HttpMethod.POST, "/register?client_id=client-id",
@@ -214,7 +214,7 @@ public class RegisterSubmissionEndpointTest extends RxWebTestBase {
             routingContext.next();
         });
 
-        when(userService.register(eq(client), any(), any(), any())).thenReturn(Single.just(registrationResponse));
+        when(userService.register(eq(client), any(), any(), any(), any())).thenReturn(Single.just(registrationResponse));
 
         testRequest(
                 HttpMethod.POST, "/register?client_id=client-id&some-param=some-value",

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterProcessHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterProcessHandlerTest.java
@@ -73,11 +73,11 @@ public class RegisterProcessHandlerTest {
 
         RegistrationResponse registrationResponse = new RegistrationResponse();
         registrationResponse.setUser(new User());
-        when(userService.register(any(), any(), any(), any())).thenReturn(Single.just(registrationResponse));
+        when(userService.register(any(), any(), any(), any(), any())).thenReturn(Single.just(registrationResponse));
 
         registerProcessHandler.handle(context);
 
-        verify(userService).register(any(), argThat(user -> client.getId().equals(user.getClient())), any(), any());
+        verify(userService).register(any(), argThat(user -> client.getId().equals(user.getClient())), any(), any(), any());
         context.verifyNext(1);
         assertNotNull(context.get(REGISTRATION_RESPONSE_KEY));
         assertNotNull(context.get(USER_CONTEXT_KEY));
@@ -89,11 +89,11 @@ public class RegisterProcessHandlerTest {
 
         RegistrationResponse registrationResponse = new RegistrationResponse();
         registrationResponse.setUser(new User());
-        when(userService.register(any(), any(), any(), any())).thenReturn(Single.just(registrationResponse));
+        when(userService.register(any(), any(), any(), any(), any())).thenReturn(Single.just(registrationResponse));
 
         registerProcessHandler.handle(context);
 
-        verify(userService).register(any(), argThat(user -> user.getClient() == null), any(), any());
+        verify(userService).register(any(), argThat(user -> user.getClient() == null), any(), any(), any());
         context.verifyNext(1);
         assertNotNull(context.get(REGISTRATION_RESPONSE_KEY));
         assertNotNull(context.get(USER_CONTEXT_KEY));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterProcessHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/user/register/RegisterProcessHandlerTest.java
@@ -21,6 +21,7 @@ import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.common.http.HttpHeaders;
 import io.reactivex.rxjava3.core.Single;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -39,6 +40,7 @@ import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderReques
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,6 +57,8 @@ public class RegisterProcessHandlerTest {
     @Mock
     private Domain domain;
 
+    private static final String REQUEST_ORIGIN = "https://auth.acme.com";
+
     private SpyRoutingContext context;
     private RegisterProcessHandler registerProcessHandler;
 
@@ -63,6 +67,11 @@ public class RegisterProcessHandlerTest {
         registerProcessHandler = new RegisterProcessHandler(userService, domain);
         context = new SpyRoutingContext("/register");
         context.put(CONTEXT_PATH, "");
+        // The registration email links back to the host the user reached us on, so the handler has to
+        // take the origin off this request rather than leave it to the configured entrypoint.
+        context.request().headers()
+                .set(HttpHeaders.X_FORWARDED_PROTO, "https")
+                .set(HttpHeaders.X_FORWARDED_HOST, "auth.acme.com");
     }
 
     @Test
@@ -77,7 +86,7 @@ public class RegisterProcessHandlerTest {
 
         registerProcessHandler.handle(context);
 
-        verify(userService).register(any(), argThat(user -> client.getId().equals(user.getClient())), any(), any(), any());
+        verify(userService).register(any(), argThat(user -> client.getId().equals(user.getClient())), any(), any(), eq(REQUEST_ORIGIN));
         context.verifyNext(1);
         assertNotNull(context.get(REGISTRATION_RESPONSE_KEY));
         assertNotNull(context.get(USER_CONTEXT_KEY));
@@ -93,7 +102,7 @@ public class RegisterProcessHandlerTest {
 
         registerProcessHandler.handle(context);
 
-        verify(userService).register(any(), argThat(user -> user.getClient() == null), any(), any(), any());
+        verify(userService).register(any(), argThat(user -> user.getClient() == null), any(), any(), eq(REQUEST_ORIGIN));
         context.verifyNext(1);
         assertNotNull(context.get(REGISTRATION_RESPONSE_KEY));
         assertNotNull(context.get(USER_CONTEXT_KEY));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
@@ -748,7 +748,7 @@ public class UserServiceTest {
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertNoErrors();
         verify(tokenService, never()).deleteByUser(any());
-        verify(emailService, timeout(2000)).send(any(), any(), any());
+        verify(emailService, timeout(2000)).send(any(), any(), any(), any(), any());
         verify(auditService).report(argThat(builder -> {
             final Audit audit = builder.build(new ObjectMapper());
             return audit.getType().equals(EventType.FORGOT_PASSWORD_REQUESTED) && audit.getOutcome().getStatus().equals(Status.SUCCESS);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
@@ -741,14 +741,15 @@ public class UserServiceTest {
         when(commonUserService.update(any())).thenReturn(Single.just(user));
 
         TestObserver testObserver = userService.forgotPassword(
-                new ForgotPasswordParameters(user.getEmail(), true, true),
+                new ForgotPasswordParameters(user.getEmail(), true, true).withRequestOrigin("https://auth.acme.com"),
                 client,
                 mock(io.gravitee.am.identityprovider.api.User.class)).test();
 
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertNoErrors();
         verify(tokenService, never()).deleteByUser(any());
-        verify(emailService, timeout(2000)).send(any(), any(), any(), any(), any());
+        // The email goes out on its own thread, so this is what proves the origin survived the hop.
+        verify(emailService, timeout(2000)).send(any(), any(), any(), any(), eq("https://auth.acme.com"));
         verify(auditService).report(argThat(builder -> {
             final Audit audit = builder.build(new ObjectMapper());
             return audit.getType().equals(EventType.FORGOT_PASSWORD_REQUESTED) && audit.getOutcome().getStatus().equals(Status.SUCCESS);
@@ -1536,14 +1537,14 @@ public class UserServiceTest {
         final Client client = new Client();
         client.setId("clientId");
 
-        var testObserver = userService.register(client, user).test();
+        var testObserver = userService.register(client, user, null, io.vertx.core.MultiMap.caseInsensitiveMultiMap(), "https://auth.acme.com").test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertComplete();
         testObserver.assertValue(registrationResponse -> {
             return !registrationResponse.isAutoLogin() && registrationResponse.getUser().equals(user) && !registrationResponse.getUser().isEnabled();
         });
 
-        verify(emailService, times(1)).send(any(), any(), any(), any(), any());
+        verify(emailService, times(1)).send(any(), any(), any(), any(), eq("https://auth.acme.com"));
         verify(auditService, times(1)).report(any());
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
@@ -748,7 +748,6 @@ public class UserServiceTest {
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertNoErrors();
         verify(tokenService, never()).deleteByUser(any());
-        // The email goes out on its own thread, so this is what proves the origin survived the hop.
         verify(emailService, timeout(2000)).send(any(), any(), any(), any(), eq("https://auth.acme.com"));
         verify(auditService).report(argThat(builder -> {
             final Audit audit = builder.build(new ObjectMapper());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/service/user/UserServiceTest.java
@@ -1543,7 +1543,7 @@ public class UserServiceTest {
             return !registrationResponse.isAutoLogin() && registrationResponse.getUser().equals(user) && !registrationResponse.getUser().isEnabled();
         });
 
-        verify(emailService, times(1)).send(any(), any(), any(), any());
+        verify(emailService, times(1)).send(any(), any(), any(), any(), any());
         verify(auditService, times(1)).report(any());
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -778,8 +778,8 @@ public class DomainServiceImpl implements DomainService {
     }
 
     @Override
-    public String buildUrl(Domain domain, String path, MultiMap queryParams) {
-        return domainReadService.buildUrl(domain, path, queryParams);
+    public String buildUrl(Domain domain, String path, MultiMap queryParams, String requestOrigin) {
+        return domainReadService.buildUrl(domain, path, queryParams, requestOrigin);
     }
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -385,8 +385,10 @@ public class DomainServiceTest {
 
     @Test
     public void shouldDelegateBuildUrl() {
-        domainService.buildUrl(any(), any(), any());
-        verify(domainReadService).buildUrl(any(), any(), any());
+        // The management API has no end-user request, so it must always delegate without an origin.
+        Domain domain = new Domain();
+        domainService.buildUrl(domain, "/path", null);
+        verify(domainReadService).buildUrl(domain, "/path", null, null);
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainReadService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainReadService.java
@@ -27,8 +27,9 @@ public interface DomainReadService {
     Maybe<Domain> findById(String id);
     /**
      * @param requestOrigin the {@code scheme://host[:port]} the end user reached the gateway on, or null
-     *                      for flows with no end-user request (SCIM, management API). Not consulted yet,
-     *                      see AM-7230.
+     *                      or blank for flows with no end-user request (SCIM, management API). Honoured
+     *                      only in managed cloud, and only when it matches one of the environment's
+     *                      entrypoints; anything else falls back to the configured resolution.
      */
     String buildUrl(Domain domain, String path, MultiMap queryParams, String requestOrigin);
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainReadService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainReadService.java
@@ -20,6 +20,7 @@ import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.MultiMap;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 
@@ -31,7 +32,7 @@ public interface DomainReadService {
      *                      only in managed cloud, and only when it matches one of the environment's
      *                      entrypoints; anything else falls back to the configured resolution.
      */
-    String buildUrl(Domain domain, String path, MultiMap queryParams, String requestOrigin);
+    String buildUrl(Domain domain, String path, MultiMap queryParams, @Nullable String requestOrigin);
 
     default String buildUrl(Domain domain, String path, MultiMap queryParams) {
         return buildUrl(domain, path, queryParams, null);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainReadService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainReadService.java
@@ -25,7 +25,16 @@ import java.util.List;
 
 public interface DomainReadService {
     Maybe<Domain> findById(String id);
-    String buildUrl(Domain domain, String path, MultiMap queryParams);
+    /**
+     * @param requestOrigin the {@code scheme://host[:port]} the end user reached the gateway on, or null
+     *                      for flows with no end-user request (SCIM, management API). Not consulted yet,
+     *                      see AM-7230.
+     */
+    String buildUrl(Domain domain, String path, MultiMap queryParams, String requestOrigin);
+
+    default String buildUrl(Domain domain, String path, MultiMap queryParams) {
+        return buildUrl(domain, path, queryParams, null);
+    }
 
     default String buildUrl(Domain domain, String path) {
         return buildUrl(domain, path, MultiMap.caseInsensitiveMultiMap());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
@@ -125,18 +125,40 @@ public class DomainReadServiceImpl implements DomainReadService {
 
     // In managed cloud the environment's entrypoint is this domain's gateway hostname; everywhere else,
     // and until Cockpit has synced one, the data plane url stands.
-    // requestOrigin is carried here for AM-7230 but not consulted yet: it may only be honoured once it is
-    // checked against the hosts already known for the domain, otherwise a forged Host header would steer
-    // password-reset links at an attacker.
     private String resolveEntryPoint(Domain domain, String requestOrigin) {
         if (CloudProperties.isManagedCloudEnabled(springEnvironment)) {
-            Optional<String> entrypointUrl = entryPointManager.findPrimaryByEnvironmentId(domain.getReferenceId())
+            Optional<String> entrypointUrl = matchingEntrypoint(domain, requestOrigin)
+                    .or(() -> entryPointManager.findPrimaryByEnvironmentId(domain.getReferenceId()))
                     .map(Entrypoint::getUrl);
             if (entrypointUrl.isPresent()) {
                 return entrypointUrl.get();
             }
         }
         return ofNullable(dataPlaneRegistry.getDescription(domain).gatewayUrl()).orElse(gatewayUrl);
+    }
+
+    /**
+     * The environment entrypoint the user actually reached us on, so an environment with several hosts
+     * mails links back to the one in the address bar rather than an arbitrary pick.
+     * <p>
+     * Only ever returns a stored entrypoint, never the caller's string: an unrecognised origin is a
+     * forged {@code Host} header away from mailing a password-reset token to somebody else's domain.
+     */
+    private Optional<Entrypoint> matchingEntrypoint(Domain domain, String requestOrigin) {
+        if (requestOrigin == null || requestOrigin.isBlank()) {
+            return Optional.empty();
+        }
+        return entryPointManager.findAllByEnvironmentId(domain.getReferenceId()).stream()
+                .filter(entrypoint -> sameOrigin(entrypoint.getUrl(), requestOrigin))
+                .findFirst();
+    }
+
+    private static boolean sameOrigin(String entrypointUrl, String requestOrigin) {
+        return entrypointUrl != null && stripTrailingSlash(entrypointUrl).equalsIgnoreCase(stripTrailingSlash(requestOrigin));
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
@@ -87,8 +87,8 @@ public class DomainReadServiceImpl implements DomainReadService {
     }
 
     @Override
-    public String buildUrl(Domain domain, String path, MultiMap queryParams) {
-        String entryPoint = resolveEntryPoint(domain);
+    public String buildUrl(Domain domain, String path, MultiMap queryParams, String requestOrigin) {
+        String entryPoint = resolveEntryPoint(domain, requestOrigin);
 
         if (entryPoint != null && entryPoint.endsWith("/")) {
             entryPoint = entryPoint.substring(0, entryPoint.length() - 1);
@@ -125,7 +125,10 @@ public class DomainReadServiceImpl implements DomainReadService {
 
     // In managed cloud the environment's entrypoint is this domain's gateway hostname; everywhere else,
     // and until Cockpit has synced one, the data plane url stands.
-    private String resolveEntryPoint(Domain domain) {
+    // requestOrigin is carried here for AM-7230 but not consulted yet: it may only be honoured once it is
+    // checked against the hosts already known for the domain, otherwise a forged Host header would steer
+    // password-reset links at an attacker.
+    private String resolveEntryPoint(Domain domain, String requestOrigin) {
         if (CloudProperties.isManagedCloudEnabled(springEnvironment)) {
             Optional<String> entrypointUrl = entryPointManager.findPrimaryByEnvironmentId(domain.getReferenceId())
                     .map(Entrypoint::getUrl);

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
@@ -175,22 +175,7 @@ public class DomainReadServiceImpl implements DomainReadService {
         if (entrypointUri == null || requestUri == null) {
             return false;
         }
-        return equalsIgnoringCase(entrypointUri.getScheme(), requestUri.getScheme())
-                && equalsIgnoringCase(entrypointUri.getHost(), requestUri.getHost())
-                && effectivePort(entrypointUri) == effectivePort(requestUri);
-    }
-
-    private static boolean equalsIgnoringCase(String left, String right) {
-        return left != null && left.equalsIgnoreCase(right);
-    }
-
-    // An entrypoint may spell out the default port where the request origin never does, so compare what
-    // the two actually resolve to rather than the text.
-    private static int effectivePort(URI uri) {
-        if (uri.getPort() >= 0) {
-            return uri.getPort();
-        }
-        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+        return UriBuilder.sameOriginAuthority(entrypointUri, requestUri);
     }
 
     private static URI toUri(String url) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
+import java.net.URI;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -148,13 +149,51 @@ public class DomainReadServiceImpl implements DomainReadService {
         if (requestOrigin == null || requestOrigin.isBlank()) {
             return Optional.empty();
         }
-        return entryPointManager.findAllByEnvironmentId(domain.getReferenceId()).stream()
+        Optional<Entrypoint> matched = entryPointManager.findAllByEnvironmentId(domain.getReferenceId()).stream()
                 .filter(entrypoint -> sameOrigin(entrypoint.getUrl(), requestOrigin))
                 .findFirst();
+        if (matched.isEmpty()) {
+            // Either a forged host or an entrypoint the environment never synced, and the two look the
+            // same from here. Worth saying out loud, because the fallback link silently differs from
+            // the host the user is on.
+            log.warn("Environment {} has no entrypoint matching the request origin, building URLs from the configured entrypoint instead", domain.getReferenceId());
+        }
+        return matched;
     }
 
     private static boolean sameOrigin(String entrypointUrl, String requestOrigin) {
-        return entrypointUrl != null && stripTrailingSlash(entrypointUrl).equalsIgnoreCase(stripTrailingSlash(requestOrigin));
+        if (entrypointUrl == null) {
+            return false;
+        }
+        URI entrypointUri = toUri(stripTrailingSlash(entrypointUrl));
+        URI requestUri = toUri(stripTrailingSlash(requestOrigin));
+        if (entrypointUri == null || requestUri == null) {
+            return false;
+        }
+        return equalsIgnoringCase(entrypointUri.getScheme(), requestUri.getScheme())
+                && equalsIgnoringCase(entrypointUri.getHost(), requestUri.getHost())
+                && effectivePort(entrypointUri) == effectivePort(requestUri);
+    }
+
+    private static boolean equalsIgnoringCase(String left, String right) {
+        return left != null && left.equalsIgnoreCase(right);
+    }
+
+    // An entrypoint may spell out the default port where the request origin never does, so compare what
+    // the two actually resolve to rather than the text.
+    private static int effectivePort(URI uri) {
+        if (uri.getPort() >= 0) {
+            return uri.getPort();
+        }
+        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+    }
+
+    private static URI toUri(String url) {
+        try {
+            return URI.create(url);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private static String stripTrailingSlash(String url) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
@@ -29,6 +29,7 @@ import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.vertx.core.MultiMap;
+import jakarta.annotation.Nullable;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
@@ -36,6 +37,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -88,7 +90,7 @@ public class DomainReadServiceImpl implements DomainReadService {
     }
 
     @Override
-    public String buildUrl(Domain domain, String path, MultiMap queryParams, String requestOrigin) {
+    public String buildUrl(Domain domain, String path, MultiMap queryParams, @Nullable String requestOrigin) {
         String entryPoint = resolveEntryPoint(domain, requestOrigin);
 
         if (entryPoint != null && entryPoint.endsWith("/")) {
@@ -126,7 +128,7 @@ public class DomainReadServiceImpl implements DomainReadService {
 
     // In managed cloud the environment's entrypoint is this domain's gateway hostname; everywhere else,
     // and until Cockpit has synced one, the data plane url stands.
-    private String resolveEntryPoint(Domain domain, String requestOrigin) {
+    private String resolveEntryPoint(Domain domain, @Nullable String requestOrigin) {
         if (CloudProperties.isManagedCloudEnabled(springEnvironment)) {
             Optional<String> entrypointUrl = matchingEntrypoint(domain, requestOrigin)
                     .or(() -> entryPointManager.findPrimaryByEnvironmentId(domain.getReferenceId()))
@@ -145,13 +147,16 @@ public class DomainReadServiceImpl implements DomainReadService {
      * Only ever returns a stored entrypoint, never the caller's string: an unrecognised origin is a
      * forged {@code Host} header away from mailing a password-reset token to somebody else's domain.
      */
-    private Optional<Entrypoint> matchingEntrypoint(Domain domain, String requestOrigin) {
+    private Optional<Entrypoint> matchingEntrypoint(Domain domain, @Nullable String requestOrigin) {
         if (requestOrigin == null || requestOrigin.isBlank()) {
             return Optional.empty();
         }
+        // The lowest url wins rather than the first, for the same reason findPrimaryByEnvironmentId picks
+        // that way: cache iteration order is unspecified, so two entrypoints sharing an origin would
+        // otherwise mail different hosts from one environment.
         Optional<Entrypoint> matched = entryPointManager.findAllByEnvironmentId(domain.getReferenceId()).stream()
                 .filter(entrypoint -> sameOrigin(entrypoint.getUrl(), requestOrigin))
-                .findFirst();
+                .min(Comparator.comparing(Entrypoint::getUrl));
         if (matched.isEmpty()) {
             // Either a forged host or an entrypoint the environment never synced, and the two look the
             // same from here. Worth saying out loud, because the fallback link silently differs from

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
@@ -281,6 +281,28 @@ class DomainReadServiceImplTest {
     }
 
     @Test
+    public void shouldBuildUrl_cloud_requestOriginMatchesEntrypointCarryingAnExplicitDefaultPort() {
+        // resolveOrigin drops :443, so a stored entrypoint that spells it out has to compare equal or
+        // the request would be ignored on a host the user legitimately reached us on.
+        enableCloudMode();
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(entrypoint("https://custom.acme.com:443")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, "https://custom.acme.com");
+
+        assertEquals("https://custom.acme.com:443/testPath/mySubPath", url);
+    }
+
+    @Test
+    public void shouldBuildUrl_cloud_blankRequestOriginFallsBack() {
+        enableCloudMode();
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://custom.acme.com")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, "   ");
+
+        assertEquals("https://custom.acme.com/testPath/mySubPath", url);
+    }
+
+    @Test
     public void shouldBuildUrl_cloud_unknownRequestOriginIsRejected() {
         // The whole point of the check: a forged Host must never steer the link.
         enableCloudMode();

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
@@ -251,6 +251,24 @@ class DomainReadServiceImplTest {
         assertEquals("https://legacy.gravitee.io/legacy/mySubPath", url);
     }
 
+    @Test
+    public void shouldBuildUrl_threeArgFormPassesNoRequestOrigin() {
+        when(dataPlaneRegistry.getDescription(any())).thenReturn(new DataPlaneDescription(null, null, null, null, "https://gw.gravitee.io"));
+        Domain domain = cloudDomain();
+
+        assertEquals(underTest.buildUrl(domain, "/mySubPath", null, null), underTest.buildUrl(domain, "/mySubPath", null));
+    }
+
+    @Test
+    public void shouldBuildUrl_requestOriginNotYetConsulted() {
+        // Plumbing only: the origin is carried to resolveEntryPoint but nothing reads it until the
+        // AM-7230 precedence is agreed. Pinned so wiring it up is a deliberate change, not a surprise.
+        when(dataPlaneRegistry.getDescription(any())).thenReturn(new DataPlaneDescription(null, null, null, null, "https://gw.gravitee.io"));
+        Domain domain = cloudDomain();
+
+        assertEquals("https://gw.gravitee.io/testPath/mySubPath", underTest.buildUrl(domain, "/mySubPath", null, "https://request.acme.com"));
+    }
+
     private void enableCloudMode() {
         springEnvironment.setProperty("cloud.enabled", "true");
         springEnvironment.setProperty("installation.type", "managed");

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
@@ -315,6 +315,32 @@ class DomainReadServiceImplTest {
     }
 
     @Test
+    public void shouldBuildUrl_cloud_requestOriginOnADifferentSchemeIsRejected() {
+        // Same host over plain http is a different origin, so it must not unlock the entrypoint. The
+        // primary is a different host on purpose: it is what tells a rejection apart from a match.
+        enableCloudMode();
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(entrypoint("https://custom.acme.com")));
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://primary.acme.com")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, "http://custom.acme.com");
+
+        assertEquals("https://primary.acme.com/testPath/mySubPath", url);
+    }
+
+    @Test
+    public void shouldBuildUrl_cloud_requestOriginOnADifferentPortIsRejected() {
+        // The default-port normalisation must not collapse into "ports do not matter": an entrypoint on
+        // 8443 is not the origin of a request that resolved to 443.
+        enableCloudMode();
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(entrypoint("https://custom.acme.com:8443")));
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://primary.acme.com")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, "https://custom.acme.com");
+
+        assertEquals("https://primary.acme.com/testPath/mySubPath", url);
+    }
+
+    @Test
     public void shouldBuildUrl_cloud_noMatchingEntrypointFallsBackToTheFirstCustomHost() {
         enableCloudMode();
         when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(entrypoint("https://custom.acme.com")));

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
@@ -260,13 +260,58 @@ class DomainReadServiceImplTest {
     }
 
     @Test
-    public void shouldBuildUrl_requestOriginNotYetConsulted() {
-        // Plumbing only: the origin is carried to resolveEntryPoint but nothing reads it until the
-        // AM-7230 precedence is agreed. Pinned so wiring it up is a deliberate change, not a surprise.
-        when(dataPlaneRegistry.getDescription(any())).thenReturn(new DataPlaneDescription(null, null, null, null, "https://gw.gravitee.io"));
-        Domain domain = cloudDomain();
+    public void shouldBuildUrl_cloud_requestOriginWinsWhenItIsAnEnvironmentEntrypoint() {
+        enableCloudMode();
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(List.of(entrypoint("https://generated.gravitee.io"), entrypoint("https://custom.acme.com")));
 
-        assertEquals("https://gw.gravitee.io/testPath/mySubPath", underTest.buildUrl(domain, "/mySubPath", null, "https://request.acme.com"));
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, "https://custom.acme.com");
+
+        assertEquals("https://custom.acme.com/testPath/mySubPath", url);
+    }
+
+    @Test
+    public void shouldBuildUrl_cloud_requestOriginMatchIsCaseInsensitiveAndIgnoresTrailingSlash() {
+        enableCloudMode();
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(entrypoint("https://Custom.Acme.com/")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, "https://custom.acme.com");
+
+        assertEquals("https://Custom.Acme.com/testPath/mySubPath", url);
+    }
+
+    @Test
+    public void shouldBuildUrl_cloud_unknownRequestOriginIsRejected() {
+        // The whole point of the check: a forged Host must never steer the link.
+        enableCloudMode();
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(entrypoint("https://custom.acme.com")));
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://custom.acme.com")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, "https://evil.example");
+
+        assertEquals("https://custom.acme.com/testPath/mySubPath", url);
+    }
+
+    @Test
+    public void shouldBuildUrl_cloud_noMatchingEntrypointFallsBackToTheFirstCustomHost() {
+        enableCloudMode();
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(entrypoint("https://custom.acme.com")));
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://custom.acme.com")));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, null);
+
+        assertEquals("https://custom.acme.com/testPath/mySubPath", url);
+    }
+
+    @Test
+    public void shouldBuildUrl_nonCloud_ignoresRequestOrigin() {
+        // Agreed 29 Jul: the change is limited to managed cloud, self-hosted behaviour must not move.
+        when(dataPlaneRegistry.getDescription(any())).thenReturn(new DataPlaneDescription(null, null, null, null, "https://gw.gravitee.io"));
+
+        String url = underTest.buildUrl(cloudDomain(), "/mySubPath", null, "https://custom.acme.com");
+
+        assertEquals("https://gw.gravitee.io/testPath/mySubPath", url);
+        verifyNoInteractions(entryPointManager);
     }
 
     private void enableCloudMode() {

--- a/gravitee-am-test/api/config/dev.setup.js
+++ b/gravitee-am-test/api/config/dev.setup.js
@@ -19,7 +19,6 @@ process.env.AM_GATEWAY_URL = 'http://localhost:8092';
 process.env.AM_DOMAIN_DATA_PLANE_ID = 'default';
 process.env.AM_INTERNAL_GATEWAY_URL = 'http://localhost:8092';
 process.env.AM_MONGODB_URI = 'mongodb://localhost:27017';
-// Handed to identity providers the gateway resolves from inside docker, so it cannot be localhost.
 process.env.AM_INTERNAL_MONGODB_URI = 'mongodb://mongodb:27017';
 process.env.AM_POSTGRES_HOST = 'localhost';
 process.env.AM_GATEWAY_NODE_MONITORING_URL = 'http://localhost:18092/_node';

--- a/gravitee-am-test/api/config/dev.setup.js
+++ b/gravitee-am-test/api/config/dev.setup.js
@@ -19,6 +19,8 @@ process.env.AM_GATEWAY_URL = 'http://localhost:8092';
 process.env.AM_DOMAIN_DATA_PLANE_ID = 'default';
 process.env.AM_INTERNAL_GATEWAY_URL = 'http://localhost:8092';
 process.env.AM_MONGODB_URI = 'mongodb://localhost:27017';
+// Handed to identity providers the gateway resolves from inside docker, so it cannot be localhost.
+process.env.AM_INTERNAL_MONGODB_URI = 'mongodb://mongodb:27017';
 process.env.AM_POSTGRES_HOST = 'localhost';
 process.env.AM_GATEWAY_NODE_MONITORING_URL = 'http://localhost:18092/_node';
 process.env.AM_COCKPIT_MOCK_URL = 'http://localhost:8085';

--- a/gravitee-am-test/api/config/dev.setup.js
+++ b/gravitee-am-test/api/config/dev.setup.js
@@ -19,7 +19,6 @@ process.env.AM_GATEWAY_URL = 'http://localhost:8092';
 process.env.AM_DOMAIN_DATA_PLANE_ID = 'default';
 process.env.AM_INTERNAL_GATEWAY_URL = 'http://localhost:8092';
 process.env.AM_MONGODB_URI = 'mongodb://localhost:27017';
-process.env.AM_INTERNAL_MONGODB_URI = 'mongodb://mongodb:27017';
 process.env.AM_POSTGRES_HOST = 'localhost';
 process.env.AM_GATEWAY_NODE_MONITORING_URL = 'http://localhost:18092/_node';
 process.env.AM_COCKPIT_MOCK_URL = 'http://localhost:8085';

--- a/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
@@ -111,4 +111,34 @@ describe('AM - Cloud - entrypoint url in email links', () => {
     expect(link).not.toContain('evil.example.com');
     await clearEmails(fixture.resetPasswordUserEmail);
   });
+
+  // The blocked-account mail links to /resetPassword too, so its host matters for the same reason.
+  // It travels a different route to get there: the origin comes off the authentication context
+  // rather than the routing context, and survives a detached thread.
+  it('builds the blocked account link from the host the user reached the gateway on', async () => {
+    const user = await fixture.createLoginUser();
+    await clearEmails(user.email);
+
+    await fixture.failLogin(user.username, fixture.entrypointHost);
+
+    const email = await getLastEmail(5000, user.email);
+    const link = email.extractLink();
+    expect(new URL(link).origin).toEqual(generatedOrigin);
+    expect(new URL(link).pathname).toContain('/resetPassword');
+    await clearEmails(user.email);
+  });
+
+  it('ignores a forged request host on the blocked account link', async () => {
+    // A fresh user: the previous lockout is sticky for accountBlockedDuration, so re-using one
+    // never sends a second mail.
+    const user = await fixture.createLoginUser();
+    await clearEmails(user.email);
+
+    await fixture.failLogin(user.username, 'evil.example.com');
+
+    const link = (await getLastEmail(5000, user.email)).extractLink();
+    expect(new URL(link).origin).toEqual(expectedOrigin);
+    expect(link).not.toContain('evil.example.com');
+    await clearEmails(user.email);
+  });
 });

--- a/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
@@ -32,13 +32,15 @@ setup(200000);
 describe('AM - Cloud - entrypoint url in email links', () => {
   let fixture: CloudEmailFixture;
   let expectedOrigin: string;
+  let generatedOrigin: string;
 
   beforeAll(async () => {
     const accessToken = await requestAdminAccessToken();
     fixture = await setupCloudEmailFixture(accessToken);
     // Through URL rather than string concatenation: uniqueName produces mixed case and hostnames are
     // case-insensitive, so both sides have to be normalised the same way.
-    expectedOrigin = new URL(`https://${fixture.entrypointHost}`).origin;
+    expectedOrigin = new URL(`https://${fixture.overridingHost}`).origin;
+    generatedOrigin = new URL(`https://${fixture.entrypointHost}`).origin;
   });
 
   afterAll(async () => {
@@ -84,5 +86,29 @@ describe('AM - Cloud - entrypoint url in email links', () => {
     const link = (await getLastEmail(5000, email)).extractLink();
     expect(new URL(link).origin).toEqual(expectedOrigin);
     await clearEmails(email);
+  });
+
+  it('builds the reset password link from the host the user reached the gateway on', async () => {
+    // The generated access point is a real host for this environment but not the one the request-less
+    // flows above resolve to, so seeing it here is only possible if the request decided it.
+    await clearEmails(fixture.resetPasswordUserEmail);
+
+    await fixture.requestForgotPassword(fixture.entrypointHost);
+
+    const link = (await getLastEmail(5000, fixture.resetPasswordUserEmail)).extractLink();
+    expect(new URL(link).origin).toEqual(generatedOrigin);
+    await clearEmails(fixture.resetPasswordUserEmail);
+  });
+
+  it('ignores a request host that is not one of the environment entrypoints', async () => {
+    // A forged Host must not steer the link, the reset token travels in its query string.
+    await clearEmails(fixture.resetPasswordUserEmail);
+
+    await fixture.requestForgotPassword('evil.example.com');
+
+    const link = (await getLastEmail(5000, fixture.resetPasswordUserEmail)).extractLink();
+    expect(new URL(link).origin).toEqual(expectedOrigin);
+    expect(link).not.toContain('evil.example.com');
+    await clearEmails(fixture.resetPasswordUserEmail);
   });
 });

--- a/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { clearEmails, getLastEmail } from '@utils-commands/email-commands';
 import { uniqueName } from '@utils-commands/misc';
@@ -47,22 +47,30 @@ describe('AM - Cloud - entrypoint url in email links', () => {
     if (fixture) await fixture.cleanup();
   });
 
-  const emailAddress = () => `${uniqueName('am7229', true)}@acme.fr`;
+  // Cleared per address rather than a blanket delete: the fake SMTP inbox is shared with whatever
+  // suites run in parallel.
+  const usedEmails: string[] = [];
+  const track = (email: string) => {
+    usedEmails.push(email);
+    return email;
+  };
+  const emailAddress = () => track(`${uniqueName('am7229', true)}@acme.fr`);
+
+  afterEach(async () => {
+    await Promise.all(usedEmails.splice(0).map((email) => clearEmails(email)));
+  });
 
   it('builds the pre-registration link from the environment entrypoint', async () => {
     const email = emailAddress();
-    await clearEmails(email);
 
     await fixture.createPreRegisteredUser(email);
 
     const link = (await getLastEmail(5000, email)).extractLink();
     expect(new URL(link).origin).toEqual(expectedOrigin);
-    await clearEmails(email);
   });
 
   it('builds the re-sent registration confirmation link from the environment entrypoint', async () => {
     const email = emailAddress();
-    await clearEmails(email);
 
     const user = await fixture.createPreRegisteredUser(email);
     // Drop the email the creation itself sent, so the assertion cannot pass on the wrong one.
@@ -73,43 +81,38 @@ describe('AM - Cloud - entrypoint url in email links', () => {
 
     const link = (await getLastEmail(5000, email)).extractLink();
     expect(new URL(link).origin).toEqual(expectedOrigin);
-    await clearEmails(email);
   });
 
   it('builds the SCIM-provisioned registration link from the environment entrypoint', async () => {
     // The gateway's own email path, and the one flow with no end-user request to fall back on.
     const email = emailAddress();
-    await clearEmails(email);
 
     await fixture.createScimUser(email);
 
     const link = (await getLastEmail(5000, email)).extractLink();
     expect(new URL(link).origin).toEqual(expectedOrigin);
-    await clearEmails(email);
   });
 
   it('builds the reset password link from the host the user reached the gateway on', async () => {
     // The generated access point is a real host for this environment but not the one the request-less
     // flows above resolve to, so seeing it here is only possible if the request decided it.
-    await clearEmails(fixture.resetPasswordUserEmail);
+    await clearEmails(track(fixture.resetPasswordUserEmail));
 
     await fixture.requestForgotPassword(fixture.entrypointHost);
 
     const link = (await getLastEmail(5000, fixture.resetPasswordUserEmail)).extractLink();
     expect(new URL(link).origin).toEqual(generatedOrigin);
-    await clearEmails(fixture.resetPasswordUserEmail);
   });
 
   it('ignores a request host that is not one of the environment entrypoints', async () => {
     // A forged Host must not steer the link, the reset token travels in its query string.
-    await clearEmails(fixture.resetPasswordUserEmail);
+    await clearEmails(track(fixture.resetPasswordUserEmail));
 
     await fixture.requestForgotPassword('evil.example.com');
 
     const link = (await getLastEmail(5000, fixture.resetPasswordUserEmail)).extractLink();
     expect(new URL(link).origin).toEqual(expectedOrigin);
     expect(link).not.toContain('evil.example.com');
-    await clearEmails(fixture.resetPasswordUserEmail);
   });
 
   // The blocked-account mail links to /resetPassword too, so its host matters for the same reason.
@@ -117,7 +120,7 @@ describe('AM - Cloud - entrypoint url in email links', () => {
   // rather than the routing context, and survives a detached thread.
   it('builds the blocked account link from the host the user reached the gateway on', async () => {
     const user = await fixture.createLoginUser();
-    await clearEmails(user.email);
+    await clearEmails(track(user.email));
 
     await fixture.failLogin(user.username, fixture.entrypointHost);
 
@@ -125,21 +128,19 @@ describe('AM - Cloud - entrypoint url in email links', () => {
     const link = email.extractLink();
     expect(new URL(link).origin).toEqual(generatedOrigin);
     expect(new URL(link).pathname).toContain('/resetPassword');
-    await clearEmails(user.email);
   });
 
   it('ignores a forged request host on the blocked account link', async () => {
     // A fresh user: the previous lockout is sticky for accountBlockedDuration, so re-using one
     // never sends a second mail.
     const user = await fixture.createLoginUser();
-    await clearEmails(user.email);
+    await clearEmails(track(user.email));
 
     await fixture.failLogin(user.username, 'evil.example.com');
 
     const link = (await getLastEmail(5000, user.email)).extractLink();
     expect(new URL(link).origin).toEqual(expectedOrigin);
     expect(link).not.toContain('evil.example.com');
-    await clearEmails(user.email);
   });
 
   // Self-service registration is the third request-bearing flow, and the only registration one. Its
@@ -147,24 +148,20 @@ describe('AM - Cloud - entrypoint url in email links', () => {
   // yet another route than the two above.
   it('builds the self-service registration link from the host the user reached the gateway on', async () => {
     const email = emailAddress();
-    await clearEmails(email);
 
     await fixture.selfServiceRegister(email, fixture.entrypointHost);
 
     const link = (await getLastEmail(5000, email)).extractLink();
     expect(new URL(link).origin).toEqual(generatedOrigin);
-    await clearEmails(email);
   });
 
   it('ignores a forged request host on the self-service registration link', async () => {
     const email = emailAddress();
-    await clearEmails(email);
 
     await fixture.selfServiceRegister(email, 'evil.example.com');
 
     const link = (await getLastEmail(5000, email)).extractLink();
     expect(new URL(link).origin).toEqual(expectedOrigin);
     expect(link).not.toContain('evil.example.com');
-    await clearEmails(email);
   });
 });

--- a/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
@@ -141,4 +141,30 @@ describe('AM - Cloud - entrypoint url in email links', () => {
     expect(link).not.toContain('evil.example.com');
     await clearEmails(user.email);
   });
+
+  // Self-service registration is the third request-bearing flow, and the only registration one. Its
+  // origin comes off the routing context in RegisterProcessHandler, so it reaches the url builder by
+  // yet another route than the two above.
+  it('builds the self-service registration link from the host the user reached the gateway on', async () => {
+    const email = emailAddress();
+    await clearEmails(email);
+
+    await fixture.selfServiceRegister(email, fixture.entrypointHost);
+
+    const link = (await getLastEmail(5000, email)).extractLink();
+    expect(new URL(link).origin).toEqual(generatedOrigin);
+    await clearEmails(email);
+  });
+
+  it('ignores a forged request host on the self-service registration link', async () => {
+    const email = emailAddress();
+    await clearEmails(email);
+
+    await fixture.selfServiceRegister(email, 'evil.example.com');
+
+    const link = (await getLastEmail(5000, email)).extractLink();
+    expect(new URL(link).origin).toEqual(expectedOrigin);
+    expect(link).not.toContain('evil.example.com');
+    await clearEmails(email);
+  });
 });

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
@@ -17,7 +17,7 @@ import { getApplicationApi, getDomainApi, getEntrypointsApi, getUserApi } from '
 import { waitForOidcReady } from '@management-commands/domain-management-commands';
 import { getDomainState, waitForDomainReady } from '@gateway-commands/monitoring-commands';
 import { sendCockpitCommand } from '@cloud-commands/cockpit-commands';
-import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { extractXsrfTokenAndActionResponse, performFormPost, performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
 import { applicationBase64Token } from '@gateway-commands/utils';
 import { retryUntil, withRetry } from '@utils-commands/retry';
 import { uniqueName } from '@utils-commands/misc';
@@ -26,26 +26,34 @@ import { expect } from '@jest/globals';
 const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
 const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 const SCIM_CUSTOM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:extension:custom:2.0:User';
+const RESET_REDIRECT_URI = 'http://localhost:4000';
 
 export interface CloudEmailFixture {
   organizationId: string;
   environmentId: string;
   domainId: string;
-  /** The single GATEWAY access point Cockpit provisioned for this environment, e.g. `gw-abc.example.com`. */
+  /** The access point Cockpit generated. Reachable, but not what request-less flows resolve to. */
   entrypointHost: string;
+  /** The customer's overriding access point, so what request-less flows resolve to. */
+  overridingHost: string;
   /** Create a pre-registered user through the management API; MAPI emails the confirmation link. */
   createPreRegisteredUser: (email: string) => Promise<any>;
   /** Re-send the registration confirmation for an existing pre-registered user. */
   resendRegistrationConfirmation: (userId: string) => Promise<void>;
   /** Provision a pre-registered user through SCIM; the gateway emails the confirmation link. */
   createScimUser: (email: string) => Promise<any>;
+  /** The address of the user the forgot-password flow is driven for. */
+  resetPasswordUserEmail: string;
+  /** Ask the gateway to email a reset link, as if the user reached it on `forwardedHost`. */
+  requestForgotPassword: (forwardedHost: string) => Promise<void>;
   cleanup: () => Promise<void>;
 }
 
 /**
- * A managed-cloud environment holding exactly one GATEWAY access point, plus a domain in it wired for
- * both management-API and SCIM user provisioning. One access point rather than several because these
- * specs assert the host of an emailed link, and the entrypoint tiebreak is covered by unit tests.
+ * A managed-cloud environment with two GATEWAY access points: the one Cockpit generated, and the
+ * customer's overriding one. Two rather than one so the specs can tell the two resolutions apart,
+ * request-less flows resolve to the overriding host while a request-bearing flow follows the host the
+ * user actually reached us on.
  *
  * Managed-cloud stack only (local-stack.sh --cloud).
  */
@@ -53,9 +61,12 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
   const organizationId = process.env.AM_DEF_ORG_ID;
   const environmentId = uniqueName('env-email', true);
   const entrypointHost = `${uniqueName('gw', true)}.example.com`;
+  const overridingHost = `${uniqueName('custom', true)}.example.com`;
   const entrypointUrl = `https://${entrypointHost}`;
+  const overridingUrl = `https://${overridingHost}`;
 
-  // 1. Cockpit provisions the environment; its GATEWAY access point becomes the environment entrypoint.
+  // 1. Cockpit provisions the environment. The access point it generates itself is the environment's
+  //    default entrypoint; the customer's overriding one is what resolution prefers.
   await sendCockpitCommand({
     type: 'ENVIRONMENT',
     payload: {
@@ -63,13 +74,16 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
       organizationId,
       hrids: [environmentId],
       name: 'AM7229 cloud email env',
-      accessPoints: [{ target: 'GATEWAY', host: entrypointHost }],
+      accessPoints: [
+        { target: 'GATEWAY', host: entrypointHost },
+        { target: 'GATEWAY', host: overridingHost, overriding: true },
+      ],
     },
   });
 
   await retryUntil(
     () => getEntrypointsApi(accessToken).listEntrypoints({ organizationId }),
-    (entrypoints: any[]) => entrypoints.some((e) => e.url === entrypointUrl),
+    (entrypoints: any[]) => entrypoints.some((e) => e.url === entrypointUrl) && entrypoints.some((e) => e.url === overridingUrl),
     POLL,
   );
 
@@ -86,7 +100,18 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     organizationId,
     environmentId,
     domain: domain.id,
-    patchDomain: { scim: { enabled: true, idpSelectionEnabled: false } },
+    patchDomain: {
+      scim: { enabled: true, idpSelectionEnabled: false },
+      loginSettings: { forgotPasswordEnabled: true },
+      // The reset app redirects to localhost, which the domain rejects by default.
+      oidc: {
+        clientRegistrationSettings: {
+          allowLocalhostRedirectUri: true,
+          allowHttpSchemeRedirectUri: true,
+          allowWildCardRedirectUri: true,
+        },
+      },
+    },
   });
 
   const applicationApi = getApplicationApi(accessToken);
@@ -111,6 +136,52 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     },
   });
 
+  // A web app and a real user, so the forgot-password form can be driven end to end.
+  const webApp = await applicationApi.createApplication({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    newApplication: {
+      name: uniqueName('reset-app', true),
+      type: 'WEB',
+      clientId: uniqueName('reset-app', true),
+      redirectUris: [RESET_REDIRECT_URI],
+    },
+  });
+  await applicationApi.updateApplication({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    application: webApp.id,
+    patchApplication: {
+      settings: {
+        oauth: {
+          redirectUris: [RESET_REDIRECT_URI],
+          grantTypes: ['implicit', 'authorization_code', 'password', 'refresh_token'],
+          scopeSettings: [{ scope: 'openid', defaultScope: true }],
+        },
+      },
+      identityProviders: new Set([{ identity: `default-idp-${domain.id}`, priority: 0 }]),
+    },
+  });
+  const resetClientId = webApp.settings.oauth.clientId;
+
+  // Created before the domain starts, so the initial sync picks it up with no extra wait.
+  const resetPasswordUserEmail = `reset-${uniqueName('user', true)}@acme.fr`;
+  await getUserApi(accessToken).createUser({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    newUser: {
+      username: uniqueName('resetuser', true),
+      firstName: 'Reset',
+      lastName: 'Me',
+      email: resetPasswordUserEmail,
+      password: 'Password123!',
+      preRegistration: false,
+    },
+  });
+
   await domainApi.patchDomain({ organizationId, environmentId, domain: domain.id, patchDomain: { enabled: true } });
   await waitForDomainReady(domain.id);
   const oidcConfig = (await waitForOidcReady(domain.hrid)).body;
@@ -120,12 +191,16 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
   // the first test races them and sees the data plane fallback.
   await retryUntil(
     () => domainApi.getDomainEntrypoints({ organizationId, environmentId, domain: domain.id }),
-    (entrypoints: any[]) => entrypoints.some((e) => e.url === entrypointUrl),
+    (entrypoints: any[]) => entrypoints.some((e) => e.url === overridingUrl),
     POLL,
   );
+  // The gateway endpoint reports the raw cache, so both access points show up here.
   await retryUntil(
     () => getDomainState(domain.id),
-    (state: any) => (state.entrypoints ?? []).some((e: any) => e.url === entrypointUrl),
+    (state: any) => {
+      const urls = (state.entrypoints ?? []).map((e: any) => e.url);
+      return urls.includes(entrypointUrl) && urls.includes(overridingUrl);
+    },
     POLL,
   );
 
@@ -181,6 +256,30 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     return response.body;
   };
 
+  // X-Forwarded-Host is how the gateway learns the public host behind a proxy, so it is what decides
+  // the origin here. The request itself still goes to the local gateway.
+  const requestForgotPassword = async (forwardedHost: string) => {
+    const authParams = `?response_type=token&client_id=${resetClientId}&redirect_uri=${RESET_REDIRECT_URI}`;
+    const authResponse = await performGet(oidcConfig.authorization_endpoint, authParams).expect(302);
+    const { headers, token } = await extractXsrfTokenAndActionResponse(authResponse);
+
+    await performFormPost(
+      process.env.AM_GATEWAY_URL,
+      `/${domain.hrid}/forgotPassword${authParams}`,
+      {
+        'X-XSRF-TOKEN': token,
+        email: resetPasswordUserEmail,
+        client_id: resetClientId,
+      },
+      {
+        Cookie: headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+        'X-Forwarded-Host': forwardedHost,
+        'X-Forwarded-Proto': 'https',
+      },
+    ).expect(302);
+  };
+
   // Only the domain. Entrypoints are Cockpit-owned and a managed installation rejects deleting them,
   // so attempting it only ever produces a 400 and a misleading warning.
   const cleanup = async () => {
@@ -194,9 +293,12 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     environmentId,
     domainId: domain.id,
     entrypointHost,
+    overridingHost,
     createPreRegisteredUser,
     resendRegistrationConfirmation,
     createScimUser,
+    resetPasswordUserEmail,
+    requestForgotPassword,
     cleanup,
   };
 };

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
@@ -17,7 +17,7 @@ import { getApplicationApi, getDomainApi, getEntrypointsApi, getUserApi } from '
 import { waitForOidcReady } from '@management-commands/domain-management-commands';
 import { getDomainState, waitForDomainReady } from '@gateway-commands/monitoring-commands';
 import { sendCockpitCommand } from '@cloud-commands/cockpit-commands';
-import { extractXsrfTokenAndActionResponse, performFormPost, performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { extractXsrfToken, extractXsrfTokenAndActionResponse, performFormPost, performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
 import { applicationBase64Token } from '@gateway-commands/utils';
 import { retryUntil, withRetry } from '@utils-commands/retry';
 import { uniqueName } from '@utils-commands/misc';
@@ -43,6 +43,8 @@ export interface CloudEmailFixture {
   resendRegistrationConfirmation: (userId: string) => Promise<void>;
   /** Provision a pre-registered user through SCIM; the gateway emails the confirmation link. */
   createScimUser: (email: string) => Promise<any>;
+  /** Register through the gateway's own form, as if the user reached it on `forwardedHost`. */
+  selfServiceRegister: (email: string, forwardedHost: string) => Promise<void>;
   /** The address of the user the forgot-password flow is driven for. */
   resetPasswordUserEmail: string;
   /** Ask the gateway to email a reset link, as if the user reached it on `forwardedHost`. */
@@ -181,6 +183,39 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
   });
   const resetClientId = webApp.settings.oauth.clientId;
 
+  // Self-service registration, the one registration flow that carries an end-user request.
+  // sendVerifyRegistrationAccountEmail is what makes it mail a link at all.
+  const registerApp = await applicationApi.createApplication({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    newApplication: {
+      name: uniqueName('register-app', true),
+      type: 'WEB',
+      clientId: uniqueName('register-app', true),
+      redirectUris: [RESET_REDIRECT_URI],
+    },
+  });
+  await applicationApi.updateApplication({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    application: registerApp.id,
+    patchApplication: {
+      settings: {
+        oauth: {
+          redirectUris: [RESET_REDIRECT_URI],
+          grantTypes: ['authorization_code'],
+          scopeSettings: [{ scope: 'openid', defaultScope: true }],
+        },
+        login: { inherited: false, registerEnabled: true },
+        account: { inherited: false, sendVerifyRegistrationAccountEmail: true },
+      },
+      identityProviders: new Set([{ identity: `default-idp-${domain.id}`, priority: 0 }]),
+    },
+  });
+  const registerClientId = registerApp.settings.oauth.clientId;
+
   // Created before the domain starts, so the initial sync picks it up with no extra wait.
   const resetPasswordUserEmail = `reset-${uniqueName('user', true)}@acme.fr`;
   await getUserApi(accessToken).createUser({
@@ -269,6 +304,31 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     );
     expect(response.status).toEqual(201);
     return response.body;
+  };
+
+  const selfServiceRegister = async (email: string, forwardedHost: string) => {
+    const uri = `/${domain.hrid}/register?client_id=${registerClientId}`;
+    const { headers, token } = await extractXsrfToken(process.env.AM_GATEWAY_URL, uri);
+
+    await performFormPost(
+      process.env.AM_GATEWAY_URL,
+      uri,
+      {
+        'X-XSRF-TOKEN': token,
+        firstName: 'Self',
+        lastName: 'Registered',
+        username: uniqueName('selfreg', true),
+        email,
+        password: LOGIN_PASSWORD,
+        client_id: registerClientId,
+      },
+      {
+        Cookie: headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+        'X-Forwarded-Host': forwardedHost,
+        'X-Forwarded-Proto': 'https',
+      },
+    ).expect(302);
   };
 
   // X-Forwarded-Host is how the gateway learns the public host behind a proxy, so it is what decides
@@ -361,6 +421,7 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     createPreRegisteredUser,
     resendRegistrationConfirmation,
     createScimUser,
+    selfServiceRegister,
     resetPasswordUserEmail,
     requestForgotPassword,
     createLoginUser,

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
@@ -27,6 +27,7 @@ const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
 const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 const SCIM_CUSTOM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:extension:custom:2.0:User';
 const RESET_REDIRECT_URI = 'http://localhost:4000';
+const LOGIN_PASSWORD = 'Password123!';
 
 export interface CloudEmailFixture {
   organizationId: string;
@@ -46,6 +47,10 @@ export interface CloudEmailFixture {
   resetPasswordUserEmail: string;
   /** Ask the gateway to email a reset link, as if the user reached it on `forwardedHost`. */
   requestForgotPassword: (forwardedHost: string) => Promise<void>;
+  /** A user with a password, for the login flows. One per lockout case: the lock is sticky. */
+  createLoginUser: () => Promise<{ username: string; email: string }>;
+  /** Fail one login, as if the user reached the gateway on `forwardedHost`. Trips the lockout. */
+  failLogin: (username: string, forwardedHost: string) => Promise<void>;
   cleanup: () => Promise<void>;
 }
 
@@ -103,6 +108,16 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     patchDomain: {
       scim: { enabled: true, idpSelectionEnabled: false },
       loginSettings: { forgotPasswordEnabled: true },
+      // One failed login locks the account and sends the blocked-account mail. The durations only
+      // have to outlast the run: nothing here unlocks a user, each case brings its own.
+      accountSettings: {
+        inherited: false,
+        loginAttemptsDetectionEnabled: true,
+        maxLoginAttempts: 1,
+        loginAttemptsResetTime: 60,
+        accountBlockedDuration: 120,
+        sendRecoverAccountEmail: true,
+      },
       // The reset app redirects to localhost, which the domain rejects by default.
       oidc: {
         clientRegistrationSettings: {
@@ -177,7 +192,7 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
       firstName: 'Reset',
       lastName: 'Me',
       email: resetPasswordUserEmail,
-      password: 'Password123!',
+      password: LOGIN_PASSWORD,
       preRegistration: false,
     },
   });
@@ -280,6 +295,55 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     ).expect(302);
   };
 
+  // Users are not part of domain sync, the gateway reads them straight from the data plane, so one
+  // created here is immediately usable without waiting. `source` has to be the idp the application
+  // authenticates against: without it the provider raises UsernameNotFoundException, which the
+  // brute-force path deliberately ignores, so the login fails without ever counting as an attempt.
+  const createLoginUser = async () => {
+    // Lower-cased: the brute-force lookup does not find a mixed-case username, so the lockout never
+    // fires and no mail is sent. uniqueName mixes case, hence the fold.
+    const username = uniqueName('lockout', true).toLowerCase();
+    const email = `${username}@acme.fr`;
+    await userApi.createUser({
+      organizationId,
+      environmentId,
+      domain: domain.id,
+      newUser: {
+        username,
+        firstName: 'Lock',
+        lastName: 'Me',
+        email,
+        password: LOGIN_PASSWORD,
+        source: `default-idp-${domain.id}`,
+        preRegistration: false,
+      },
+    });
+    return { username, email };
+  };
+
+  const failLogin = async (username: string, forwardedHost: string) => {
+    const authParams = `?response_type=token&client_id=${resetClientId}&redirect_uri=${RESET_REDIRECT_URI}`;
+    const authResponse = await performGet(oidcConfig.authorization_endpoint, authParams).expect(302);
+    const { headers, token, action } = await extractXsrfTokenAndActionResponse(authResponse);
+
+    await performFormPost(
+      action,
+      '',
+      {
+        'X-XSRF-TOKEN': token,
+        username,
+        password: 'DefinitelyNotThePassword1!',
+        client_id: resetClientId,
+      },
+      {
+        Cookie: headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+        'X-Forwarded-Host': forwardedHost,
+        'X-Forwarded-Proto': 'https',
+      },
+    ).expect(302);
+  };
+
   // Only the domain. Entrypoints are Cockpit-owned and a managed installation rejects deleting them,
   // so attempting it only ever produces a 400 and a misleading warning.
   const cleanup = async () => {
@@ -299,6 +363,8 @@ export const setupCloudEmailFixture = async (accessToken: string): Promise<Cloud
     createScimUser,
     resetPasswordUserEmail,
     requestForgotPassword,
+    createLoginUser,
+    failLogin,
     cleanup,
   };
 };


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7230

## :pencil2: A description of the changes proposed in the pull request

In managed cloud, reset password, registration and blocked account emails now build their links from the host the user actually arrived on, as long as that host is one of the environment's entrypoints. If it isn't one, or there's no request to take a host from (SCIM, management API), we fall back to the AM-7229 resolution.

Blocked account is in there because that email carries a reset password link too. It fires on a failed login, so the host comes off the same request the login did, and it goes through the same entrypoint check as everything else. Worst case is a link to another host the environment already trusts.

Only a stored entrypoint is ever used to build the url, never the string off the request. So a forged Host header can't point a reset link at someone else's domain, which was the main thing we sorted out in Slack with Eric and William.

Limited to cloud mode as agreed, self hosted behaviour doesn't move.

## :memo: Test scenarios

Unit tests in `DomainReadServiceImplTest` cover the new precedence: request host wins when it matches an entrypoint, matching is case and trailing slash tolerant, an unknown origin is rejected and falls back, the same host on a different scheme or a different port is rejected too, a null origin falls back, and non cloud ignores it completely.

`UriBuilderRequestTest` covers the new `resolveOrigin` helper, including the X-Forwarded handling it inherits and that it carries no path or forwarded prefix.

`UserAuthenticationServiceTest` covers the blocked account side, that the origin survives the hop onto the email thread when the recovery email is on, and that nothing is sent when it's off.

`specs/cloud/email-entrypoint-url.jest.spec.ts` drives the forgot password form end to end against an environment with two entrypoints, once on a host that belongs to the environment and once on a forged one, and asserts the emailed link follows the first and ignores the second.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

Worth knowing the request only ever picks between hosts we already trust, it can't introduce a new one. So behaviour only changes when an environment has more than one host, otherwise it resolves to the same place it did before.

The self hosted `setDeployMode` pick of `vhosts.get(0)` is still arbitrary and has the same underlying problem, we deliberately left it out of scope here. Probably worth its own ticket.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am


