### PR TITLE
fix: resolve IdP user id via findByUsername before UserProvider update/delete

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/services/impl/AccountServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/main/java/io/gravitee/am/gateway/handler/account/services/impl/AccountServiceImpl.java
@@ -176,7 +176,9 @@ public class AccountServiceImpl implements AccountService, InitializingBean {
                     if (user.getExternalId() == null) {
                         return Single.error(new InvalidRequestException("User does not exist in upstream IDP"));
                     } else {
-                        return userProvider.update(user.getExternalId(), convert(user));
+                        return userProvider.findByUsername(user.getUsername())
+                                .switchIfEmpty(Single.error(() -> new UserNotFoundException(user.getUsername())))
+                                .flatMap(idpUser -> userProvider.update(idpUser.getId(), convert(user)));
                     }
                 })
                 .flatMap(idpUser -> userRepository.update(user))

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/test/java/io/gravitee/am/gateway/handler/account/services/AccountServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-account/src/test/java/io/gravitee/am/gateway/handler/account/services/AccountServiceTest.java
@@ -42,6 +42,7 @@ import io.gravitee.am.service.PasswordService;
 import io.gravitee.am.service.exception.CredentialNotFoundException;
 import io.gravitee.am.service.exception.InvalidPasswordException;
 import io.gravitee.am.service.exception.InvalidUserException;
+import io.gravitee.am.service.exception.UserNotFoundException;
 import io.gravitee.am.service.validators.user.UserValidator;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -347,9 +348,13 @@ public class AccountServiceTest {
         userUpdate.setWebsite("https://crazyhost/user-id");
 
         final UserProvider userProvider = mock(UserProvider.class);
+        final DefaultUser idpUser = new DefaultUser(userUpdate.getUsername());
+        // the id resolved from the IdP is different from the (potentially stale) AM external id
+        idpUser.setId("idp-resolved-id");
 
         when(userValidator.validate(userUpdate)).thenReturn(Completable.complete());
         when(identityProviderManager.getUserProvider(userUpdate.getSource())).thenReturn(Maybe.just(userProvider));
+        when(userProvider.findByUsername(userUpdate.getUsername())).thenReturn(Maybe.just(idpUser));
         when(userProvider.update(any(), any())).thenReturn(Single.just(new DefaultUser()));
         when(userRepository.update(any())).thenReturn(Single.just(userUpdate));
 
@@ -358,19 +363,49 @@ public class AccountServiceTest {
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
-        verify(userProvider).update(any(), argThat(idpUser ->
-                userUpdate.getFirstName().equals(idpUser.getFirstName()) &&
-                        userUpdate.getLastName().equals(idpUser.getLastName()) &&
-                        userUpdate.getNickName().equals(idpUser.getAdditionalInformation().get(StandardClaims.NICKNAME)) &&
-                        userUpdate.getMiddleName().equals(idpUser.getAdditionalInformation().get(StandardClaims.MIDDLE_NAME)) &&
-                        userUpdate.getBirthdate().equals(idpUser.getAdditionalInformation().get(StandardClaims.BIRTHDATE)) &&
-                        userUpdate.getPicture().equals(idpUser.getAdditionalInformation().get(StandardClaims.PICTURE)) &&
-                        userUpdate.getProfile().equals(idpUser.getAdditionalInformation().get(StandardClaims.PROFILE)) &&
-                        userUpdate.getWebsite().equals(idpUser.getAdditionalInformation().get(StandardClaims.WEBSITE)) &&
-                        userUpdate.getEmail().equals(idpUser.getEmail())&&
-                        userUpdate.getPhoneNumber().equals(idpUser.getAdditionalInformation().get(StandardClaims.PHONE_NUMBER))
+        verify(userProvider).findByUsername(userUpdate.getUsername());
+        // update must be called with the id resolved through findByUsername, not the stored external id
+        verify(userProvider).update(argThat(id -> id.equals(idpUser.getId()) && !id.equals(userUpdate.getExternalId())), argThat(convertedUser ->
+                userUpdate.getFirstName().equals(convertedUser.getFirstName()) &&
+                        userUpdate.getLastName().equals(convertedUser.getLastName()) &&
+                        userUpdate.getNickName().equals(convertedUser.getAdditionalInformation().get(StandardClaims.NICKNAME)) &&
+                        userUpdate.getMiddleName().equals(convertedUser.getAdditionalInformation().get(StandardClaims.MIDDLE_NAME)) &&
+                        userUpdate.getBirthdate().equals(convertedUser.getAdditionalInformation().get(StandardClaims.BIRTHDATE)) &&
+                        userUpdate.getPicture().equals(convertedUser.getAdditionalInformation().get(StandardClaims.PICTURE)) &&
+                        userUpdate.getProfile().equals(convertedUser.getAdditionalInformation().get(StandardClaims.PROFILE)) &&
+                        userUpdate.getWebsite().equals(convertedUser.getAdditionalInformation().get(StandardClaims.WEBSITE)) &&
+                        userUpdate.getEmail().equals(convertedUser.getEmail())&&
+                        userUpdate.getPhoneNumber().equals(convertedUser.getAdditionalInformation().get(StandardClaims.PHONE_NUMBER))
         ));
         verify(userRepository).update(any());
+    }
+
+    @Test
+    public void shouldUpdateUser_idpUserNotFound_fallbackToAmUserOnly() {
+        final String userId = "user-id";
+        final io.gravitee.am.model.User userUpdate = new io.gravitee.am.model.User();
+        userUpdate.setSource("source");
+        userUpdate.setId(userId);
+        userUpdate.setExternalId("ext-" + userId);
+        userUpdate.setUsername("john.doe");
+        userUpdate.setPassword("secret");
+
+        final UserProvider userProvider = mock(UserProvider.class);
+
+        when(userValidator.validate(userUpdate)).thenReturn(Completable.complete());
+        when(identityProviderManager.getUserProvider(userUpdate.getSource())).thenReturn(Maybe.just(userProvider));
+        when(userProvider.findByUsername(userUpdate.getUsername())).thenReturn(Maybe.empty());
+        when(userRepository.update(any())).thenReturn(Single.just(userUpdate));
+
+        TestObserver testObserver = accountService.update(userUpdate).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(userProvider).findByUsername(userUpdate.getUsername());
+        // the idp user could not be resolved so update must never be invoked
+        verify(userProvider, never()).update(any(), any());
+        verify(userRepository).update(argThat(u -> u.getPassword() == null));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/ProvisioningUserServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/service/impl/ProvisioningUserServiceImpl.java
@@ -449,7 +449,9 @@ public class ProvisioningUserServiceImpl implements ProvisioningUserService, Ini
                                                                 } else {
                                                                     return createPasswordHistory(domain, userToUpdate, rawPassword, principal, client)
                                                                             .switchIfEmpty(Single.just(new PasswordHistory()))
-                                                                            .flatMap(ph -> userProvider.update(userToUpdate.getExternalId(), UserMapper.convert(userToUpdate)));
+                                                                            .flatMap(ph -> userProvider.findByUsername(userToUpdate.getUsername())
+                                                                                    .switchIfEmpty(Single.error(() -> new UserNotFoundException(userToUpdate.getUsername())))
+                                                                                    .flatMap(idpUser -> userProvider.update(idpUser.getId(), UserMapper.convert(userToUpdate))));
                                                                 }
                                                             });
                                                 })
@@ -569,7 +571,9 @@ public class ProvisioningUserServiceImpl implements ProvisioningUserService, Ini
                 .switchIfEmpty(Maybe.error(() -> new UserNotFoundException(userId)))
                 .flatMapCompletable(user -> identityProviderManager.getUserProvider(user.getSource())
                         .switchIfEmpty(Maybe.error(() -> new UserProviderNotFoundException(user.getSource())))
-                        .flatMapCompletable(userProvider -> userProvider.delete(user.getExternalId()))
+                        .flatMapCompletable(userProvider -> userProvider.findByUsername(user.getUsername())
+                                .switchIfEmpty(Maybe.error(() -> new UserNotFoundException(user.getUsername())))
+                                .flatMapCompletable(idpUser -> userProvider.delete(idpUser.getId())))
                         .onErrorResumeNext(ex -> {
                             if (ex instanceof UserNotFoundException || ex instanceof UserProviderNotFoundException) {
                                 // idp user does not exist, only remove AM user

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -602,8 +602,11 @@ public class ProvisioningUserServiceTest {
         when(scimUser.isActive()).thenReturn(true);
 
         io.gravitee.am.identityprovider.api.User idpUser = mock(io.gravitee.am.identityprovider.api.User.class);
+        // the id resolved from the IdP is different from the (potentially stale) AM external id
+        when(idpUser.getId()).thenReturn("idp-resolved-id");
 
         UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(existingUser.getUsername())).thenReturn(Maybe.just(idpUser));
         when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
 
         when(userRepository.findById(existingUser.getId())).thenReturn(Maybe.just(existingUser));
@@ -621,7 +624,9 @@ public class ProvisioningUserServiceTest {
 
         verify(userRepository, times(1)).update(userCaptor.capture(), any());
         verify(userProvider, never()).create(any());
-        verify(userProvider).update(anyString(), any());
+        verify(userProvider).findByUsername(existingUser.getUsername());
+        // update must be called with the id resolved through findByUsername, not the stored external id
+        verify(userProvider).update(argThat(id -> id.equals(idpUser.getId()) && !id.equals(existingUser.getExternalId())), any());
         verify(userProvider, never()).updatePassword(any(), eq(PASSWORD));
         verify(eventService).create(any(), any());
         assertTrue(userCaptor.getValue().isEnabled());
@@ -642,8 +647,11 @@ public class ProvisioningUserServiceTest {
         when(scimUser.isActive()).thenReturn(true);
 
         io.gravitee.am.identityprovider.api.User idpUser = mock(io.gravitee.am.identityprovider.api.User.class);
+        // the id resolved from the IdP is different from the (potentially stale) AM external id
+        when(idpUser.getId()).thenReturn("idp-resolved-id");
 
         UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(existingUser.getUsername())).thenReturn(Maybe.just(idpUser));
         when(userProvider.update(anyString(), any())).thenReturn(Single.just(idpUser));
 
         when(userRepository.findById(existingUser.getId())).thenReturn(Maybe.just(existingUser));
@@ -660,10 +668,47 @@ public class ProvisioningUserServiceTest {
 
         verify(userRepository, times(1)).update(userCaptor.capture(), any());
         verify(userProvider, never()).create(any());
-        verify(userProvider).update(anyString(), any());
+        verify(userProvider).findByUsername(existingUser.getUsername());
+        // update must be called with the id resolved through findByUsername, not the stored external id
+        verify(userProvider).update(argThat(id -> id.equals(idpUser.getId()) && !id.equals(existingUser.getExternalId())), any());
         verify(userProvider, never()).updatePassword(any(), eq(PASSWORD));
         verify(eventService).create(any(), any());
         assertTrue(userCaptor.getValue().isEnabled());
+    }
+
+    @Test
+    public void shouldNotUpdateUser_idpUserNotFound() {
+        io.gravitee.am.model.User existingUser = mock(io.gravitee.am.model.User.class);
+        when(existingUser.getId()).thenReturn("user-id");
+        when(existingUser.getSource()).thenReturn("user-idp");
+        when(existingUser.getExternalId()).thenReturn("user-extid");
+        when(existingUser.getUsername()).thenReturn("username");
+        when(existingUser.getReferenceId()).thenReturn(DOMAIN_ID);
+        when(existingUser.getReferenceType()).thenReturn(ReferenceType.DOMAIN);
+
+        User scimUser = mock(User.class);
+        when(scimUser.isActive()).thenReturn(true);
+
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(existingUser.getUsername())).thenReturn(Maybe.empty());
+
+        when(userRepository.findById(existingUser.getId())).thenReturn(Maybe.just(existingUser));
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        ArgumentCaptor<io.gravitee.am.model.User> userCaptor = ArgumentCaptor.forClass(io.gravitee.am.model.User.class);
+        when(userRepository.update(any(), any())).thenReturn(Single.just(existingUser));
+        when(groupService.findByMember(existingUser.getId())).thenReturn(Flowable.empty());
+        when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
+
+        // the idp user could not be resolved, so update must never be invoked; only the AM user is updated
+        TestObserver<User> testObserver = userService.update(existingUser.getId(), scimUser, null, "/", null, null).test();
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+
+        verify(userRepository, times(1)).update(userCaptor.capture(), any());
+        verify(userProvider).findByUsername(existingUser.getUsername());
+        verify(userProvider, never()).update(anyString(), any());
+        assertNull(userCaptor.getValue().getPassword());
     }
 
     @Test
@@ -844,11 +889,17 @@ public class ProvisioningUserServiceTest {
         io.gravitee.am.model.User endUser = mock(io.gravitee.am.model.User.class);
         when(endUser.getId()).thenReturn(userId);
         when(endUser.getExternalId()).thenReturn("user-external-id");
+        when(endUser.getUsername()).thenReturn("username");
         when(endUser.getSource()).thenReturn("user-idp");
         when(endUser.getReferenceId()).thenReturn(DOMAIN_ID);
         when(endUser.getReferenceType()).thenReturn(ReferenceType.DOMAIN);
 
+        io.gravitee.am.identityprovider.api.User idpUser = mock(io.gravitee.am.identityprovider.api.User.class);
+        // the id resolved from the IdP is different from the (potentially stale) AM external id
+        when(idpUser.getId()).thenReturn("idp-resolved-id");
+
         UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(endUser.getUsername())).thenReturn(Maybe.just(idpUser));
         when(userProvider.delete(any())).thenReturn(complete());
 
         when(userRepository.findById(userId)).thenReturn(Maybe.just(endUser));
@@ -866,7 +917,42 @@ public class ProvisioningUserServiceTest {
         testObserver.assertComplete();
         verify(userRepository, times(1)).delete(userId);
         verify(identityProviderManager, times(1)).getUserProvider(anyString());
-        verify(userProvider, times(1)).delete(anyString());
+        verify(userProvider, times(1)).findByUsername(endUser.getUsername());
+        // delete must be called with the id resolved through findByUsername, not the stored external id
+        verify(userProvider, times(1)).delete(argThat(id -> id.equals(idpUser.getId()) && !id.equals(endUser.getExternalId())));
+    }
+
+    @Test
+    public void shouldDeleteUser_idpUserNotFound() {
+        final String userId = "userId";
+
+        io.gravitee.am.model.User endUser = mock(io.gravitee.am.model.User.class);
+        when(endUser.getId()).thenReturn(userId);
+        when(endUser.getExternalId()).thenReturn("user-external-id");
+        when(endUser.getUsername()).thenReturn("username");
+        when(endUser.getSource()).thenReturn("user-idp");
+        when(endUser.getReferenceId()).thenReturn(DOMAIN_ID);
+        when(endUser.getReferenceType()).thenReturn(ReferenceType.DOMAIN);
+
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(endUser.getUsername())).thenReturn(Maybe.empty());
+
+        when(userRepository.findById(userId)).thenReturn(Maybe.just(endUser));
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+        when(userRepository.delete(userId)).thenReturn(complete());
+        when(userActivityService.deleteByDomainAndUser(domain, userId)).thenReturn(complete());
+        when(rateLimiterService.deleteByUser(any())).thenReturn(complete());
+        when(passwordHistoryService.deleteByUser(any(), eq(userId))).thenReturn(complete());
+        when(verifyAttemptService.deleteByUser(any())).thenReturn(complete());
+        when(credentialService.deleteByUserId(any(), eq(userId))).thenReturn(complete());
+
+        // even though the idp user cannot be resolved, the AM user deletion must still proceed
+        var testObserver = userService.delete(userId, null).test();
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+        verify(userRepository, times(1)).delete(userId);
+        verify(userProvider, times(1)).findByUsername(endUser.getUsername());
+        verify(userProvider, never()).delete(any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementUserServiceImpl.java
@@ -789,7 +789,9 @@ public class ManagementUserServiceImpl implements ManagementUserService {
                             if (user.getExternalId() == null || user.getExternalId().isEmpty()) {
                                 return Completable.complete();
                             }
-                            return optUserProvider.get().delete(user.getExternalId())
+                            return optUserProvider.get().findByUsername(user.getUsername())
+                                    .switchIfEmpty(Maybe.error(() -> new UserNotFoundException(user.getUsername())))
+                                    .flatMapCompletable(idpUser -> optUserProvider.get().delete(idpUser.getId()))
                                     .onErrorResumeNext(ex -> {
                                         if (ex instanceof UserNotFoundException) {
                                             // idp user does not exist, continue

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/OrganizationUserServiceImpl.java
@@ -305,7 +305,9 @@ public class OrganizationUserServiceImpl implements OrganizationUserService {
                             if (user.getExternalId() == null || user.getExternalId().isEmpty()) {
                                 return Completable.complete();
                             }
-                            return optUserProvider.get().delete(user.getExternalId())
+                            return optUserProvider.get().findByUsername(user.getUsername())
+                                    .switchIfEmpty(Maybe.error(() -> new UserNotFoundException(user.getUsername())))
+                                    .flatMapCompletable(idpUser -> optUserProvider.get().delete(idpUser.getId()))
                                     .onErrorResumeNext(ex -> {
                                         if (ex instanceof UserNotFoundException) {
                                             // idp user does not exist, continue

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/ManagementUserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/ManagementUserServiceTest.java
@@ -561,13 +561,19 @@ public class ManagementUserServiceTest {
         User user = new User();
         user.setId("user-id");
         user.setExternalId("ext-user-id");
+        user.setUsername("john.doe");
         user.setSource("idp-id");
         user.setReferenceId("domain");
         user.setReferenceType(ReferenceType.DOMAIN);
 
         when(userRepository.findById(any(Reference.class), any(UserId.class))).thenReturn(Maybe.just(user));
 
+        io.gravitee.am.identityprovider.api.User idpUser = mock(io.gravitee.am.identityprovider.api.DefaultUser.class);
+        // the id resolved from the IdP is different from the (potentially stale) AM external id
+        when(idpUser.getId()).thenReturn("idp-resolved-id");
+
         UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
         when(userProvider.delete(any())).thenReturn(Completable.complete());
         when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
         when(userActivityManagementService.deleteByDomainAndUser(any(), any())).thenReturn(Completable.complete());
@@ -586,9 +592,49 @@ public class ManagementUserServiceTest {
         // Verify that WebAuthn credentials are deleted
         verify(credentialService, times(1)).deleteByUserId(domain, user.getId());
 
+        verify(userProvider).findByUsername(user.getUsername());
+        // delete must be called with the id resolved through findByUsername, not the stored external id
+        verify(userProvider).delete(argThat(id -> id.equals(idpUser.getId()) && !id.equals(user.getExternalId())));
         verify(tokenService).deleteByUser(any(), any());
         verify(auditService).report(argThat(auditBuilder -> auditBuilder.build(new ObjectMapper()).getOutcome().getStatus() == Status.SUCCESS));
         verify(eventService).create(argThat(arg -> arg.getType() == Type.USER && arg.getPayload().getId().equals(user.getId())));
+    }
+
+    @Test
+    void should_delete_user_when_idp_user_not_found() {
+        Domain domain = new Domain();
+        domain.setId("domain");
+
+        User user = new User();
+        user.setId("user-id");
+        user.setExternalId("ext-user-id");
+        user.setUsername("john.doe");
+        user.setSource("idp-id");
+        user.setReferenceId("domain");
+        user.setReferenceType(ReferenceType.DOMAIN);
+
+        when(userRepository.findById(any(Reference.class), any(UserId.class))).thenReturn(Maybe.just(user));
+
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.empty());
+        when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
+        when(userActivityManagementService.deleteByDomainAndUser(any(), any())).thenReturn(Completable.complete());
+        when(userRepository.delete(anyString())).thenReturn(Completable.complete());
+        when(passwordHistoryService.deleteByUser(any(), anyString())).thenReturn(Completable.complete());
+        when(credentialService.deleteByUserId(any(), anyString())).thenReturn(Completable.complete());
+
+        when(eventService.create(any())).thenAnswer(invocation -> Single.just(invocation.getArguments()[0]));
+        when(tokenService.deleteByUser(any(), any())).thenReturn(Completable.complete());
+
+        // even though the idp user cannot be resolved, the AM user deletion must still proceed
+        userService.delete(domain, user.getId(), null)
+                .test()
+                .assertComplete()
+                .assertNoErrors();
+
+        verify(userProvider).findByUsername(user.getUsername());
+        verify(userProvider, never()).delete(any());
+        verify(userRepository).delete(user.getId());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/OrganizationUserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/OrganizationUserServiceTest.java
@@ -160,6 +160,75 @@ public class OrganizationUserServiceTest {
         verify(membershipService, times(3)).delete(any(), anyString());
     }
 
+    @Test
+    public void shouldDeleteUser_resolveIdpUserIdViaFindByUsername() {
+        String organization = "DEFAULT";
+        String userId = "user-id";
+        User user = new User();
+        user.setId(userId);
+        user.setExternalId("ext-user-id");
+        user.setUsername("john.doe");
+        user.setSource("source-idp");
+        user.setReferenceId("ud");
+        user.setReferenceType(ReferenceType.ORGANIZATION);
+
+        io.gravitee.am.identityprovider.api.User idpUser = mock(io.gravitee.am.identityprovider.api.DefaultUser.class);
+        // the id resolved from the IdP is different from the (potentially stale) AM external id
+        when(idpUser.getId()).thenReturn("idp-resolved-id");
+
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.just(idpUser));
+        when(userProvider.delete(any())).thenReturn(Completable.complete());
+
+        when(commonUserService.findById(any(), any(), any())).thenReturn(Single.just(user));
+        when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
+        when(commonUserService.delete(anyString())).thenReturn(Single.just(user));
+        when(commonUserService.revokeUserAccessTokens(any(), any(), any())).thenReturn(Completable.complete());
+        when(membershipService.findByMember(any(), any())).thenReturn(Flowable.empty());
+
+        organizationUserService.delete(ReferenceType.ORGANIZATION, organization, userId)
+                .test()
+                .assertComplete()
+                .assertNoErrors();
+
+        verify(userProvider).findByUsername(user.getUsername());
+        // delete must be called with the id resolved through findByUsername, not the stored external id
+        verify(userProvider).delete(argThat(id -> id.equals(idpUser.getId()) && !id.equals(user.getExternalId())));
+        verify(commonUserService, times(1)).delete(any());
+    }
+
+    @Test
+    public void shouldDeleteUser_whenIdpUserNotFound() {
+        String organization = "DEFAULT";
+        String userId = "user-id";
+        User user = new User();
+        user.setId(userId);
+        user.setExternalId("ext-user-id");
+        user.setUsername("john.doe");
+        user.setSource("source-idp");
+        user.setReferenceId("ud");
+        user.setReferenceType(ReferenceType.ORGANIZATION);
+
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.findByUsername(user.getUsername())).thenReturn(Maybe.empty());
+
+        when(commonUserService.findById(any(), any(), any())).thenReturn(Single.just(user));
+        when(identityProviderManager.getUserProvider(user.getSource())).thenReturn(Maybe.just(userProvider));
+        when(commonUserService.delete(anyString())).thenReturn(Single.just(user));
+        when(commonUserService.revokeUserAccessTokens(any(), any(), any())).thenReturn(Completable.complete());
+        when(membershipService.findByMember(any(), any())).thenReturn(Flowable.empty());
+
+        // even though the idp user cannot be resolved, the AM user deletion must still proceed
+        organizationUserService.delete(ReferenceType.ORGANIZATION, organization, userId)
+                .test()
+                .assertComplete()
+                .assertNoErrors();
+
+        verify(userProvider).findByUsername(user.getUsername());
+        verify(userProvider, never()).delete(any());
+        verify(commonUserService, times(1)).delete(any());
+    }
+
     private NewOrganizationUser newOrganizationUser() {
         NewOrganizationUser newUser = new NewOrganizationUser();
         newUser.setUsername("userid");


### PR DESCRIPTION
## Summary
- The `externalId` stored on an AM user can diverge from the identity provider's actual user id, causing `UserProvider.update`/`UserProvider.delete` calls to target the wrong (or a non-existent) user upstream.
- Resolve the id through `UserProvider.findByUsername` right before calling `update`/`delete` in:
  - `AccountServiceImpl` (gateway account service)
  - `ProvisioningUserServiceImpl` (SCIM)
  - `ManagementUserServiceImpl`
  - `OrganizationUserServiceImpl`
- This mirrors the pattern already used elsewhere in the codebase (e.g. `UserServiceImpl.confirmRegistration`, `updateWithUserProvider`) and its documented rationale (gravitee-io/issues#8407).

## Test plan
- [x] Added/updated unit tests for each of the four call sites, covering both the nominal case (verifying `update`/`delete` is invoked with the id resolved via `findByUsername`, not the stale `externalId`) and the "IdP user not found" fallback case.
- [ ] CI build/test run (local `mvn test-compile` currently fails in this workspace due to a pre-existing, unrelated Lombok annotation-processing issue present even on the unmodified branch)

fix AM-7346