### PR TITLE
build: bump gravitee-parent to 25.1.0 and drop archunit override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>25.0.0</version>
+        <version>25.1.0</version>
         <relativePath/>
     </parent>
 
@@ -239,7 +239,6 @@
 
         <kryo.version>5.6.2</kryo.version>
         <testcontainers.version>2.0.3</testcontainers.version>
-        <gravitee.archrules.skip>false</gravitee.archrules.skip>
     </properties>
 
     <dependencyManagement>
@@ -879,8 +878,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Parent pins archrules 1.0.0 (ArchUnit 1.2.1) whose ASM can't read Java 25 (class major version 69);
-                 override with a Java 25-capable ArchUnit so the rules actually analyse our bytecode -->
             <plugin>
                 <groupId>io.gravitee.maven</groupId>
                 <artifactId>gravitee-archrules-maven-plugin</artifactId>
@@ -891,15 +888,6 @@
                         <ignoreExecutionContextClass>io.gravitee.am.gateway.handler.context.ExecutionContextFactory</ignoreExecutionContextClass>
                     </ignoreExecutionContextClasses>
                 </configuration>
-                <dependencies>
-                    <!-- TODO(AM-7328): drop this override once gravitee-parent bumps
-                         gravitee-archrules-maven-plugin to a Java 25-capable ArchUnit -->
-                    <dependency>
-                        <groupId>com.tngtech.archunit</groupId>
-                        <artifactId>archunit</artifactId>
-                        <version>1.4.1</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7328

## :pencil2: A description of the changes proposed in the pull request

Bumps gravitee-parent to 25.1.0 and drops the local ArchUnit workaround we added back when the arch rules couldn't read Java 25 bytecode.

Parent 25.1.0 ships gravitee-archrules-maven-plugin 2.0.0, which bundles an ArchUnit that handles class major version 69, so pinning archunit 1.4.1 on the plugin ourselves is redundant now. The `gravitee.archrules.skip=false` property goes too, 2.0.0 defaults skip to false so the rules run without us forcing them on.

## :memo: Test scenarios

Full `mvn install` is green across all 138 modules with the override gone.

I also ran a negative test, because "all rules passed" on its own doesn't prove much here. The checks also run on packaging only modules where there are no classes to analyse, so a silent pass would look identical to a real one. Swapped a `@CustomLog` class in gravitee-am-common for a direct slf4j `LoggerFactory` and the build failed on the global logging rule, naming the right class and source line. That confirms the rules are genuinely reading our Java 25 bytecode rather than importing nothing. Reverted that afterwards.

Also checked separately that both checks still execute with the skip property removed.

No new automated tests, it's a build config change.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

Worth flagging that archrules 2.0.0 defaults skip to false, so the logging arch rules now run by default instead of being opt in. Anyone who wasn't already setting `gravitee.archrules.skip=false` will start seeing these checks, and a violation fails the build.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
