### PR TITLE
chore: add postman collection for the cockpit mock control api

### DIFF
--- a/gravitee-am-cockpit-mock/README.md
+++ b/gravitee-am-cockpit-mock/README.md
@@ -196,6 +196,17 @@ status/queue inspection, every supported command type with valid example payload
 templates for AM-initiated commands, and management API calls to verify the results.
 Command ids are chained between requests automatically via collection variables.
 
+`Commands → AM > License changes (AM-7237)` walks an organization license through
+create / no-op / update / delete — the only write path, since the management API exposes
+the license read-only. Set `{{licenseB64}}` to `base64 -i <your>.key | tr -d '\n'` first,
+then read the result with `List organization license audits`, which asserts the audits
+exist and that the raw license appears nowhere in them.
+
+Run it against DEFAULT (the `{{orgId}}` default). A cockpit-created org has no audit
+reporter, so its audits go to an event-bus address with no consumer and are dropped —
+the log lines still appear, but nothing lands in the store and the admin gets 403 reading
+that org's audits anyway.
+
 ## Notes
 
 - **Single active connection.** One AM at a time; a reconnect (AM restart) takes over

--- a/gravitee-am-cockpit-mock/README.md
+++ b/gravitee-am-cockpit-mock/README.md
@@ -164,6 +164,24 @@ curl -i localhost:8085/_control/queue
 
 Returns the full queue as an array, non-destructively.
 
+### Read AM's HELLO — `GET /_control/hello`
+
+The handshake is answered automatically and never reaches the queue, so this is the only way to see
+what AM announced itself with. **204** until AM connects; overwritten on each reconnect.
+
+```bash
+curl -s localhost:8085/_control/hello
+# { "commandId": "...", "receivedAt": "2026-07-30T...",
+#   "payload": { "installationType": "managed", "node": { ... },
+#                "accessPointsTemplate": { "ENVIRONMENT": [ { "host": "{environment}.{organization}...",
+#                                                             "target": "GATEWAY", "secured": true } ] },
+#                "additionalInformation": { "API_URL": "...", "UI_URL": "..." } } }
+```
+
+`accessPointsTemplate` is only populated by a managed installation; a standalone one still sends the
+field, as an empty object. Note this `installationType` is AM's own (command direction) — not the same
+field as the `--installation-type` flag, which rides on the reply and is inert.
+
 ### Connection status — `GET /_control/status`
 
 ```bash

--- a/gravitee-am-cockpit-mock/README.md
+++ b/gravitee-am-cockpit-mock/README.md
@@ -171,6 +171,13 @@ curl -s localhost:8085/_control/status
 # { "connected": true, "installation": { ... }, "queueSize": 0 }
 ```
 
+## Postman collection
+
+Import `postman/gravitee-am-cockpit-mock.postman_collection.json` for ready-made requests:
+status/queue inspection, every supported command type with valid example payloads, REPLY
+templates for AM-initiated commands, and management API calls to verify the results.
+Command ids are chained between requests automatically via collection variables.
+
 ## Notes
 
 - **Single active connection.** One AM at a time; a reconnect (AM restart) takes over

--- a/gravitee-am-cockpit-mock/postman/gravitee-am-cockpit-mock.postman_collection.json
+++ b/gravitee-am-cockpit-mock/postman/gravitee-am-cockpit-mock.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Gravitee AM Cockpit Mock",
-    "description": "Common requests against the cockpit mock (gravitee-am-cockpit-mock) control API, plus a few management API calls to verify the results in AM.\n\nPrerequisites: stack up in managed-cloud mode (`./local-stack.sh up --cloud` or `--full`), or the mock running standalone (`npm start` in gravitee-am-cockpit-mock). The mock itself has NO auth. `POST /_control/send` returns 409 while no AM instance is connected — check `Connection status` first.\n\nFlow: send a command, note the returned `id` (auto-saved to `{{commandId}}`), then pop the queue until AM's REPLY with that `commandId` appears.",
+    "description": "Common requests against the cockpit mock (gravitee-am-cockpit-mock) control API, plus a few management API calls to verify the results in AM.\n\nPrerequisites: stack up in managed-cloud mode (`./local-stack.sh up --cloud`, or `--with cloud`; note `--full` does NOT include the cloud overlay), or the mock running standalone (`npm start` in gravitee-am-cockpit-mock). The mock itself has NO auth. `POST /_control/send` returns 409 while no AM instance is connected — check `Connection status` first.\n\nFlow: send a command, note the returned `id` (auto-saved to `{{commandId}}`), then pop the queue until AM's REPLY with that `commandId` appears.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -12,7 +12,10 @@
     { "key": "envId", "value": "postman-cloud-env" },
     { "key": "commandId", "value": "" },
     { "key": "amCommandId", "value": "" },
-    { "key": "token", "value": "" }
+    { "key": "token", "value": "" },
+    { "key": "orgId", "value": "DEFAULT" },
+    { "key": "licenseB64", "value": "" },
+    { "key": "licenseB64Alt", "value": "bm90LWEtcmVhbC1saWNlbnNl" }
   ],
   "item": [
     {
@@ -121,7 +124,7 @@
               "raw": "{\n  \"type\": \"ORGANIZATION\",\n  \"payload\": {\n    \"id\": \"DEFAULT\",\n    \"name\": \"Acme (via cockpit mock)\",\n    \"hrids\": [\"default\"],\n    \"description\": \"Updated by the cockpit mock Postman collection\"\n  }\n}",
               "options": { "raw": { "language": "json" } }
             },
-            "description": "createOrUpdate on the organization. Required: `id`, `name`, `hrids`. With `id: DEFAULT` this renames the default org."
+            "description": "createOrUpdate on the organization. Required: `id`, `name`, `hrids`. With `id: DEFAULT` this renames the default org. An optional `license` field (base64 of a signed key, see `{{licenseB64}}`) attaches an organization license — `License changes (AM-7237)` below drives that through create/update/delete."
           }
         },
         {
@@ -231,6 +234,102 @@
             },
             "description": "Missing required fields — AM rejects it and the queue receives a REPLY with `commandStatus: ERROR` and an errorDetails message listing the missing fields."
           }
+        },
+        {
+          "name": "License changes (AM-7237)",
+          "description": "Drives the organization license through create / no-op / update / delete — the only write path there is, since the management API exposes the license read-only.\n\nSet `{{licenseB64}}` first: `base64 -i <your>.key | tr -d '\\n'`. Without it step 1 attaches an OSS license and the whole run still works, just with `tier: oss` everywhere.\n\n`{{orgId}}` defaults to DEFAULT on purpose. A cockpit-created org has no audit reporter, so its audits are published to an event-bus address with no consumer and silently dropped — the log lines appear but `List organization license audits` stays empty, and the admin gets 403 on that org anyway. Run 1 → 4 in order; the org is left with no license, which is the state it started in (AM falls back to the platform license).",
+          "item": [
+            {
+              "name": "1. Set license (create)",
+              "request": {
+                "method": "POST",
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "url": {
+                  "raw": "{{cockpitMockUrl}}/_control/send",
+                  "host": ["{{cockpitMockUrl}}"],
+                  "path": ["_control", "send"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"type\": \"ORGANIZATION\",\n  \"payload\": {\n    \"id\": \"{{orgId}}\",\n    \"name\": \"AM-7237 license traceability\",\n    \"hrids\": [\"{{orgId}}\"],\n    \"license\": \"{{licenseB64}}\"\n  }\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "description": "Creates the org and attaches the license. Produces an `ORGANIZATION_LICENSE_CREATED` audit whose newValue is the decoded tier/packs/features/expiry, `License created for referenceType=ORGANIZATION...` in the management API log, and `License registered for organization={{orgId}}` in both planes once the LICENSE event propagates."
+              }
+            },
+            {
+              "name": "2. Resend same license (no-op)",
+              "request": {
+                "method": "POST",
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "url": {
+                  "raw": "{{cockpitMockUrl}}/_control/send",
+                  "host": ["{{cockpitMockUrl}}"],
+                  "path": ["_control", "send"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"type\": \"ORGANIZATION\",\n  \"payload\": {\n    \"id\": \"{{orgId}}\",\n    \"name\": \"AM-7237 license traceability\",\n    \"hrids\": [\"{{orgId}}\"],\n    \"license\": \"{{licenseB64}}\"\n  }\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "description": "Identical license — the write is skipped. Expect SUCCEEDED, no new audit, no new event, and `License unchanged ... skipping` at debug level."
+              }
+            },
+            {
+              "name": "3. Change license (update)",
+              "request": {
+                "method": "POST",
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "url": {
+                  "raw": "{{cockpitMockUrl}}/_control/send",
+                  "host": ["{{cockpitMockUrl}}"],
+                  "path": ["_control", "send"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"type\": \"ORGANIZATION\",\n  \"payload\": {\n    \"id\": \"{{orgId}}\",\n    \"name\": \"AM-7237 license traceability\",\n    \"hrids\": [\"{{orgId}}\"],\n    \"license\": \"{{licenseB64Alt}}\"\n  }\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "description": "Produces `ORGANIZATION_LICENSE_UPDATED`, whose message is a JSON patch from the old decoded license to the new one. The default `{{licenseB64Alt}}` is valid base64 but not a signed license — the license factory does not reject it, it hands back an OSS license, so expect `tier: universe -> oss` and the org silently downgraded until step 4. Swap in a second real key for a tier-to-tier diff."
+              }
+            },
+            {
+              "name": "4. Remove license (delete)",
+              "request": {
+                "method": "POST",
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "url": {
+                  "raw": "{{cockpitMockUrl}}/_control/send",
+                  "host": ["{{cockpitMockUrl}}"],
+                  "path": ["_control", "send"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"type\": \"ORGANIZATION\",\n  \"payload\": {\n    \"id\": \"{{orgId}}\",\n    \"name\": \"AM-7237 license traceability\",\n    \"hrids\": [\"{{orgId}}\"]\n  }\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "description": "Omitting `license` deletes it. Produces `ORGANIZATION_LICENSE_DELETED` carrying the previous decoded license in `outcome.message` rather than a diff, plus `License deregistered for organization={{orgId}}` in both planes."
+              }
+            },
+            {
+              "name": "5. Invalid license (rejected, no audit)",
+              "request": {
+                "method": "POST",
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "url": {
+                  "raw": "{{cockpitMockUrl}}/_control/send",
+                  "host": ["{{cockpitMockUrl}}"],
+                  "path": ["_control", "send"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"type\": \"ORGANIZATION\",\n  \"payload\": {\n    \"id\": \"{{orgId}}\",\n    \"name\": \"AM-7237 license traceability\",\n    \"hrids\": [\"{{orgId}}\"],\n    \"license\": \"not base64 !!\"\n  }\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "description": "Documents a known gap: OrganizationServiceImpl validates the license before LicenseService is reached, so the command replies ERROR and no license audit is written at all. The failure audits in LicenseServiceImpl only fire on repository failures, which cannot be triggered from outside."
+              }
+            }
+          ]
         }
       ]
     },
@@ -349,6 +448,102 @@
               "path": ["management", "organizations", "DEFAULT", "environments"]
             },
             "description": "Shows environments including those created by ENVIRONMENT commands."
+          }
+        },
+        {
+          "name": "List organization license audits",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const audits = (pm.response.json().data || []).filter((a) => a.type && a.type.startsWith('ORGANIZATION_LICENSE_'));",
+                  "",
+                  "pm.test('at least one license audit', () => {",
+                  "    // audits are reported asynchronously - re-send this request if the list comes back empty",
+                  "    pm.expect(audits.length).to.be.above(0);",
+                  "});",
+                  "",
+                  "pm.test('raw license never leaves the database', () => {",
+                  "    const raw = pm.response.text();",
+                  "    ['licenseB64', 'licenseB64Alt'].forEach((key) => {",
+                  "        const value = pm.collectionVariables.get(key);",
+                  "        if (value && value.length > 32) {",
+                  "            pm.expect(raw).to.not.include(value.substring(0, 32));",
+                  "        }",
+                  "    });",
+                  "});",
+                  "",
+                  "audits.forEach((a) =>",
+                  "    console.log(a.timestamp + ' ' + a.type + ' ' + a.outcome.status + ' ' + (a.outcome.message || '(no detail - license could not be decoded)')),",
+                  ");"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }]
+            },
+            "url": {
+              "raw": "{{managementUrl}}/management/organizations/{{orgId}}/audits?size=20",
+              "host": ["{{managementUrl}}"],
+              "path": ["management", "organizations", "{{orgId}}", "audits"],
+              "query": [{ "key": "size", "value": "20" }]
+            },
+            "description": "The traceability this ticket is about. Asserts the license audits exist and that the raw base64 license appears nowhere in them — only the decoded metadata is audited. Append `&type=ORGANIZATION_LICENSE_UPDATED` to filter to one event. There is no organization-level audit screen in the Console, so this endpoint is the only way to read them."
+          }
+        },
+        {
+          "name": "Get organization license (decoded)",
+          "request": {
+            "method": "GET",
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }]
+            },
+            "url": {
+              "raw": "{{managementUrl}}/management/organizations/{{orgId}}/license",
+              "host": ["{{managementUrl}}"],
+              "path": ["management", "organizations", "{{orgId}}", "license"]
+            },
+            "description": "The license AM is actually applying for the org. Falls back to the platform license when the org has none, so after `4. Remove license` this returns the platform license rather than a 404."
+          }
+        },
+        {
+          "name": "List audit event types",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('license event types are registered', () => {",
+                  "    pm.expect(pm.response.json()).to.include.members([",
+                  "        'ORGANIZATION_LICENSE_CREATED',",
+                  "        'ORGANIZATION_LICENSE_UPDATED',",
+                  "        'ORGANIZATION_LICENSE_DELETED',",
+                  "    ]);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }]
+            },
+            "url": {
+              "raw": "{{managementUrl}}/management/platform/audits/events",
+              "host": ["{{managementUrl}}"],
+              "path": ["management", "platform", "audits", "events"]
+            },
+            "description": "The list backing the Console audit filter. Confirms the three ORGANIZATION_LICENSE_* types are registered in EventType.types()."
           }
         }
       ]

--- a/gravitee-am-cockpit-mock/postman/gravitee-am-cockpit-mock.postman_collection.json
+++ b/gravitee-am-cockpit-mock/postman/gravitee-am-cockpit-mock.postman_collection.json
@@ -1,0 +1,345 @@
+{
+  "info": {
+    "name": "Gravitee AM Cockpit Mock",
+    "description": "Common requests against the cockpit mock (gravitee-am-cockpit-mock) control API, plus a few management API calls to verify the results in AM.\n\nPrerequisites: stack up in managed-cloud mode (`./local-stack.sh up --cloud` or `--full`), or the mock running standalone (`npm start` in gravitee-am-cockpit-mock). The mock itself has NO auth. `POST /_control/send` returns 409 while no AM instance is connected — check `Connection status` first.\n\nFlow: send a command, note the returned `id` (auto-saved to `{{commandId}}`), then pop the queue until AM's REPLY with that `commandId` appears.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "cockpitMockUrl", "value": "http://localhost:8085" },
+    { "key": "managementUrl", "value": "http://localhost:8093" },
+    { "key": "adminUsername", "value": "admin" },
+    { "key": "adminPassword", "value": "adminadmin" },
+    { "key": "envId", "value": "postman-cloud-env" },
+    { "key": "commandId", "value": "" },
+    { "key": "amCommandId", "value": "" },
+    { "key": "token", "value": "" }
+  ],
+  "item": [
+    {
+      "name": "Status & Queue",
+      "item": [
+        {
+          "name": "Connection status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/status",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "status"]
+            },
+            "description": "Returns `{ connected, installation, queueSize }`. `connected: true` means AM's WebSocket is up and `/_control/send` will work."
+          }
+        },
+        {
+          "name": "Pop next message (FIFO)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const entry = pm.response.json();",
+                  "    if (entry.protocolType === 'COMMAND' && entry.commandId) {",
+                  "        pm.collectionVariables.set('amCommandId', entry.commandId);",
+                  "        console.log('AM-initiated COMMAND, saved amCommandId=' + entry.commandId);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/queue",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "queue"]
+            },
+            "description": "Removes and returns the queue head; 204 when empty. REPLY entries carry the `commandId` of the command they answer plus `commandStatus` (SUCCEEDED/ERROR). If the entry is an AM-initiated COMMAND, its `commandId` is auto-saved to `{{amCommandId}}` for the reply requests."
+          }
+        },
+        {
+          "name": "Peek queue (non-destructive)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/queue/peek",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "queue", "peek"]
+            },
+            "description": "Returns the whole queue as an array without consuming anything."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Commands → AM",
+      "description": "Each request POSTs a cockpit command at AM and auto-saves the returned command `id` to `{{commandId}}`. AM's REPLY (matching that `commandId`) lands on the queue — pop it to see SUCCEEDED/ERROR.",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "if (pm.response.code === 200) {",
+              "    const json = pm.response.json();",
+              "    if (json.id) {",
+              "        pm.collectionVariables.set('commandId', json.id);",
+              "        console.log('sent command, saved commandId=' + json.id);",
+              "    }",
+              "}"
+            ]
+          }
+        }
+      ],
+      "item": [
+        {
+          "name": "ORGANIZATION - create/update org",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"ORGANIZATION\",\n  \"payload\": {\n    \"id\": \"DEFAULT\",\n    \"name\": \"Acme (via cockpit mock)\",\n    \"hrids\": [\"default\"],\n    \"description\": \"Updated by the cockpit mock Postman collection\"\n  }\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "createOrUpdate on the organization. Required: `id`, `name`, `hrids`. With `id: DEFAULT` this renames the default org."
+          }
+        },
+        {
+          "name": "ENVIRONMENT - create env with GATEWAY access points",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"ENVIRONMENT\",\n  \"payload\": {\n    \"id\": \"{{envId}}\",\n    \"organizationId\": \"DEFAULT\",\n    \"hrids\": [\"{{envId}}\"],\n    \"name\": \"Postman cloud environment\",\n    \"description\": \"Created via cockpit mock\",\n    \"accessPoints\": [\n      { \"target\": \"GATEWAY\", \"host\": \"gw-{{envId}}.example.com\" },\n      { \"target\": \"GATEWAY\", \"host\": \"custom-{{envId}}.example.com\", \"overriding\": true }\n    ]\n  }\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "createOrUpdate on the environment. Required: `organizationId`, `id`, `name`, `hrids`. In managed-cloud mode the GATEWAY access points are synced to organization entrypoints: `overriding: true` marks the customer's custom host, the other becomes `defaultEntrypoint: true`. The only way to create environments/entrypoints locally — the Console cannot.\n\nGotchas: entrypoints are cockpit-owned (deleting them via the console returns 400) and both planes warm their caches async, so poll before relying on them. Verify with `List organization entrypoints`."
+          }
+        },
+        {
+          "name": "USER - create/update org user",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"USER\",\n  \"payload\": {\n    \"id\": \"cockpit-user-1\",\n    \"organizationId\": \"DEFAULT\",\n    \"username\": \"cockpit.user\",\n    \"firstName\": \"Cockpit\",\n    \"lastName\": \"User\",\n    \"email\": \"cockpit.user@example.com\",\n    \"picture\": \"https://example.com/avatar.png\"\n  }\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "createOrUpdate on an organization user with source `cockpit`. Required: `id`, `username`, `organizationId`. The payload `id` becomes the user's externalId — MEMBERSHIP commands reference it via `userId`."
+          }
+        },
+        {
+          "name": "MEMBERSHIP - assign role",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"MEMBERSHIP\",\n  \"payload\": {\n    \"organizationId\": \"DEFAULT\",\n    \"referenceType\": \"ENVIRONMENT\",\n    \"referenceId\": \"{{envId}}\",\n    \"userId\": \"cockpit-user-1\",\n    \"role\": \"ENVIRONMENT_PRIMARY_OWNER\"\n  }\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "Assigns a role to a cockpit-sourced user. All fields required. `userId` is the USER command's payload `id` (externalId) — the user must exist first. `referenceType` is ENVIRONMENT or ORGANIZATION; `role` is a system role name (e.g. ENVIRONMENT_PRIMARY_OWNER, ORGANIZATION_PRIMARY_OWNER) or default role name (e.g. ENVIRONMENT_OWNER, ORGANIZATION_USER)."
+          }
+        },
+        {
+          "name": "INSTALLATION - update status",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"INSTALLATION\",\n  \"payload\": {\n    \"status\": \"ACCEPTED\"\n  }\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "Sets the installation's cockpit status (`COCKPIT_INSTALLATION_STATUS` in the installation's additionalInformation). Required: `status`."
+          }
+        },
+        {
+          "name": "GOODBYE - decommission installation (careful)",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"GOODBYE\",\n  \"payload\": {}\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "Marks the installation's cockpit status DELETED — AM considers itself unlinked from cockpit. Only send when testing the decommission path; recover by restarting the stack (or sending INSTALLATION with status ACCEPTED)."
+          }
+        },
+        {
+          "name": "Invalid payload - exercise ERROR reply",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"ORGANIZATION\",\n  \"payload\": {}\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "Missing required fields — AM rejects it and the queue receives a REPLY with `commandStatus: ERROR` and an errorDetails message listing the missing fields."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Replies → AM",
+      "description": "When AM initiates a command toward cockpit it shows up on the queue as a COMMAND entry (popping it auto-saves `{{amCommandId}}`). Answer it with one of these.",
+      "item": [
+        {
+          "name": "Reply SUCCEEDED",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"protocolType\": \"REPLY\",\n  \"type\": \"<type-from-queue-entry>\",\n  \"commandId\": \"{{amCommandId}}\",\n  \"commandStatus\": \"SUCCEEDED\",\n  \"payload\": {}\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "Set `type` to the queue entry's `type`. `commandStatus` defaults to SUCCEEDED if omitted."
+          }
+        },
+        {
+          "name": "Reply ERROR",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/send",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "send"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"protocolType\": \"REPLY\",\n  \"type\": \"<type-from-queue-entry>\",\n  \"commandId\": \"{{amCommandId}}\",\n  \"commandStatus\": \"ERROR\",\n  \"errorDetails\": \"simulated cockpit failure\",\n  \"payload\": {}\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "Exercises AM's failure handling for its own outbound commands."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Verify in AM (Management API)",
+      "description": "Companion requests against the management API (port 8093) to check what the cockpit commands actually produced. Run `Get admin token` first — it saves `{{token}}` for the others.",
+      "item": [
+        {
+          "name": "Get admin token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    pm.collectionVariables.set('token', pm.response.json().access_token);",
+                  "    console.log('saved management API token');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "auth": {
+              "type": "basic",
+              "basic": [
+                { "key": "username", "value": "{{adminUsername}}", "type": "string" },
+                { "key": "password", "value": "{{adminPassword}}", "type": "string" }
+              ]
+            },
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "url": {
+              "raw": "{{managementUrl}}/management/auth/token",
+              "host": ["{{managementUrl}}"],
+              "path": ["management", "auth", "token"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"grant_type\": \"password\",\n  \"username\": \"{{adminUsername}}\",\n  \"password\": \"{{adminPassword}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "description": "Saves `access_token` to `{{token}}` for the other requests in this folder."
+          }
+        },
+        {
+          "name": "List organization entrypoints",
+          "request": {
+            "method": "GET",
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }]
+            },
+            "url": {
+              "raw": "{{managementUrl}}/management/organizations/DEFAULT/entrypoints",
+              "host": ["{{managementUrl}}"],
+              "path": ["management", "organizations", "DEFAULT", "entrypoints"]
+            },
+            "description": "Shows the entrypoints created from the ENVIRONMENT command's GATEWAY access points. Caches warm async — retry if a just-sent command's entrypoints aren't visible yet."
+          }
+        },
+        {
+          "name": "List environments",
+          "request": {
+            "method": "GET",
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }]
+            },
+            "url": {
+              "raw": "{{managementUrl}}/management/organizations/DEFAULT/environments",
+              "host": ["{{managementUrl}}"],
+              "path": ["management", "organizations", "DEFAULT", "environments"]
+            },
+            "description": "Shows environments including those created by ENVIRONMENT commands."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gravitee-am-cockpit-mock/postman/gravitee-am-cockpit-mock.postman_collection.json
+++ b/gravitee-am-cockpit-mock/postman/gravitee-am-cockpit-mock.postman_collection.json
@@ -70,6 +70,18 @@
             },
             "description": "Returns the whole queue as an array without consuming anything."
           }
+        },
+        {
+          "name": "Read AM's HELLO",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{cockpitMockUrl}}/_control/hello",
+              "host": ["{{cockpitMockUrl}}"],
+              "path": ["_control", "hello"]
+            },
+            "description": "The HELLO command AM sent on connect. HELLO only ever flows AM -> cockpit (AM is the WebSocket client and opens with it), the mock answers it automatically, and it never reaches the queue — so there is no HELLO to *send*, and this is the only way to see what AM announced itself with. 204 until AM connects; overwritten on each reconnect.\n\nUseful fields in `payload`: `installationType` (managed/standalone), `accessPointsTemplate` (the host template per type/target — only populated by a managed installation, a standalone one sends it as `{}`), `node`, and `additionalInformation` (API_URL/UI_URL).\n\nWatch out: this `installationType` is AM's own, on the command. It is a different field from the mock's `--installation-type` flag, which rides on the reply and is inert (AM ignores it)."
+          }
         }
       ]
     },

--- a/gravitee-am-cockpit-mock/src/server.ts
+++ b/gravitee-am-cockpit-mock/src/server.ts
@@ -24,6 +24,7 @@
  *   POST /_control/send        send a COMMAND (default) or REPLY toward AM
  *   GET  /_control/queue       pop the FIFO head of AM's messages (204 when empty)
  *   GET  /_control/queue/peek  non-destructive snapshot of the queue
+ *   GET  /_control/hello       the HELLO AM sent on connect (204 before it arrives)
  *   GET  /_control/status      connection + installation + queue summary
  */
 
@@ -33,6 +34,13 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { decodeFrame, encodeFrame, ProtocolType } from './protocol';
 import { loadInstallationState, InstallationState } from './state';
 import { ReplyQueue, QueueEntry } from './queue';
+
+/** AM's HELLO command, retained so its payload can be read back over HTTP. */
+interface HelloCapture {
+  commandId?: string;
+  payload?: unknown;
+  receivedAt: string;
+}
 
 interface Config {
   port: number;
@@ -128,6 +136,9 @@ function main(): void {
   /** The single active AM connection (last-writer-wins on reconnect). */
   let activeSocket: WebSocket | null = null;
 
+  /** AM's latest HELLO, kept because the handshake never reaches the queue. */
+  let lastHello: HelloCapture | null = null;
+
   const httpServer = createServer((req, res) => handleHttp(req, res));
   const wss = new WebSocketServer({ noServer: true });
 
@@ -161,8 +172,14 @@ function main(): void {
     const frame = decodeFrame(raw);
     const exchangeType = frame.exchangeType ?? frame.exchange?.type;
 
-    // Auto-handle the HELLO handshake so the link comes up; keep it off the queue.
+    // Auto-handle the HELLO handshake so the link comes up; keep it off the queue, but retain it —
+    // its payload carries AM's installationType and access point templates, and nothing else exposes them.
     if (frame.protocolType === 'COMMAND' && exchangeType === 'HELLO') {
+      lastHello = {
+        commandId: frame.exchange?.id,
+        payload: frame.exchange?.payload,
+        receivedAt: new Date().toISOString(),
+      };
       replyToHello(frame.exchange?.id);
       return;
     }
@@ -237,6 +254,14 @@ function main(): void {
     if (req.method === 'GET' && path === `${cfg.controlPrefix}/queue/peek`) {
       return sendJson(res, 200, queue.peek());
     }
+    if (req.method === 'GET' && path === `${cfg.controlPrefix}/hello`) {
+      if (!lastHello) {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+      return sendJson(res, 200, lastHello);
+    }
     if (req.method === 'GET' && path === `${cfg.controlPrefix}/status`) {
       return sendJson(res, 200, {
         connected: !!activeSocket && activeSocket.readyState === WebSocket.OPEN,
@@ -299,7 +324,7 @@ function main(): void {
   httpServer.listen(cfg.port, () => {
     log('boot', `listening on http://localhost:${cfg.port}`);
     log('boot', `  WebSocket : ws://localhost:${cfg.port}${cfg.wsPath}`);
-    log('boot', `  control   : ${cfg.controlPrefix}/send | /queue | /queue/peek | /status`);
+    log('boot', `  control   : ${cfg.controlPrefix}/send | /queue | /queue/peek | /hello | /status`);
     log('boot', `  installation: id=${installation.installationId} status=${installation.installationStatus}${installation.installationType ? ` type=${installation.installationType}` : ''}`);
     if (cfg.stateFile) log('boot', `  state file: ${cfg.stateFile}`);
     log('boot', `Point AM at it: cloud.connector.ws.endpoints=http://localhost:${cfg.port} + cloud.enabled=true`);


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7353

## :pencil2: A description of the changes proposed in the pull request

Adds a Postman collection for the cockpit mock's control API, so poking at the cloud command path locally doesn't mean hand rolling curl every time.

Four folders: status/queue inspection, one request per cockpit command type AM actually handles (ORGANIZATION, ENVIRONMENT, USER, MEMBERSHIP, INSTALLATION, GOODBYE) with valid example payloads, REPLY templates for the commands AM initiates, and a few management API calls to check what the commands produced. Command ids chain between requests automatically via collection variables, so you send a command and the next queue pop already knows what to match on.

The example payloads come from each handler's required field validation, and the descriptions carry the gotchas I kept relearning: the mock has no auth, /_control/send returns 409 until AM's websocket is up, entrypoints are cockpit owned so you can't delete them, and both planes warm their entrypoint caches async so verification may need a retry. Also added a short pointer to it in the mock's README.

Second commit is a small addition to the mock itself. Writing the collection turned up the fact that you cannot see AM's HELLO at all: it only flows AM to cockpit, the mock auto answers the handshake and deliberately keeps it off the queue, and the log line only prints what the mock sent back. That made AM-7326 (installation type plus the access point hostname template in HELLO) untestable outside unit tests. So the mock now retains the last HELLO and serves it on GET /_control/hello, 200 with the payload or 204 before AM connects, and the collection gets a matching request. I kept it off the FIFO queue on purpose, that's what waitForCockpitReply pops through and a HELLO landing there on every connect and reconnect would just be noise the specs have to discard.

## :memo: Test scenarios

No automated tests, it's a JSON collection, a README section and a read only endpoint on a dev only tool. Verified by hand against a local --cloud stack.

Collection: sent the INSTALLATION command through the mock and got the SUCCEEDED reply back on the queue with the matching commandId, and confirmed the management API token request shape works. Didn't run the ENVIRONMENT example since the entrypoints it creates can't be deleted afterwards.

New endpoint: in managed mode GET /_control/hello returns installationType "managed" and the accessPointsTemplate matching the configured template (ENVIRONMENT -> GATEWAY, host {environment}.{organization}.{account}.example.com, secured true), plus node, default org/env ids and additionalInformation. Flipped GRAVITEE_INSTALLATION_TYPE to standalone and restarted the management API, it comes back as "standalone" with the template unpopulated, so the managed gating holds in both directions. That's AM-7326 verified end to end, details are on that ticket.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

The collection descriptions are the documentation, they're written to be read in Postman rather than skimmed here. Two things worth knowing.

While testing AM-7225: there's no cockpit command that deletes an environment (AM registers no DELETE_ENVIRONMENT handler and EnvironmentService has no delete), so the way to test entrypoint removal is to resend the ENVIRONMENT command with an empty accessPoints list, which makes the handler wipe and recreate. AM-7354 is the follow up for rejecting that case in cloud mode.

On the HELLO payload: in standalone the accessPointsTemplate field is still sent, just empty, it's not absent. And there are two installationType fields facing opposite ways, the one on the command AM sends and the one on the reply cockpit sends, which AM ignores. Both are called out in the request description so nobody checks the wrong one.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
