### PR TITLE
feat: scope webauthn to the environment entrypoint in managed cloud

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
@@ -375,6 +375,26 @@ public class UriBuilder {
         return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
     }
 
+    public static String toOrigin(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        final URI uri;
+        try {
+            uri = URI.create(url.trim());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        if (uri.getScheme() == null || uri.getHost() == null) {
+            return null;
+        }
+        StringBuilder origin = new StringBuilder(uri.getScheme().toLowerCase(Locale.ROOT)).append("://").append(uri.getHost());
+        if (uri.getPort() >= 0) {
+            origin.append(':').append(uri.getPort());
+        }
+        return origin.toString();
+    }
+
     public static String buildErrorRedirect(String baseRedirectUri, ErrorInfo error, boolean fragment, Map<String, String> extraParams) throws URISyntaxException {
         final URI redirectUri = UriBuilder.fromURIString(baseRedirectUri).build();
 

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
@@ -18,6 +18,7 @@ package io.gravitee.am.common.web;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.common.utils.ConstantKeys;
 
+import java.net.IDN;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -378,21 +379,17 @@ public class UriBuilder {
 
     /**
      * The url's origin, serialized the way a browser serializes {@code window.location.origin}: scheme and
-     * host lowercased, and the port present only when it is not the scheme's default. WebAuthn compares the
-     * ceremony origin against {@code clientDataJSON.origin} by exact string equality, so an origin that
-     * keeps {@code :443} or the stored host's casing fails verification against the very host it matched.
+     * host lowercased, a unicode host in its punycode form, and the port present only when it is not the
+     * scheme's default. WebAuthn compares the ceremony origin against {@code clientDataJSON.origin} by
+     * exact string equality, so an origin that keeps {@code :443} or the stored host's casing fails
+     * verification against the very host it matched.
      */
     public static String toOrigin(String url) {
         if (url == null || url.isBlank()) {
             return null;
         }
-        final URI uri;
-        try {
-            uri = URI.create(url.trim());
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
-        if (uri.getScheme() == null || uri.getHost() == null) {
+        final URI uri = toAsciiUri(url.trim());
+        if (uri == null || uri.getScheme() == null || uri.getHost() == null) {
             return null;
         }
         StringBuilder origin = new StringBuilder(uri.getScheme().toLowerCase(Locale.ROOT))
@@ -402,6 +399,39 @@ public class UriBuilder {
             origin.append(':').append(uri.getPort());
         }
         return origin.toString();
+    }
+
+    /**
+     * The url parsed with an ascii host, whatever it was written with. {@link URI} only recognises a host
+     * spelled in ascii, so {@code https://bücher.example} parses as a registry-based authority with no
+     * host at all. The browser puts the punycode form in {@code clientDataJSON.origin}, so that is the
+     * form a stored url has to be compared in, and converting after the parse is too late.
+     */
+    private static URI toAsciiUri(String url) {
+        final URI uri;
+        try {
+            uri = URI.create(url);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        if (uri.getHost() != null || uri.getAuthority() == null) {
+            return uri;
+        }
+        try {
+            return new URI(uri.getScheme(), toAsciiAuthority(uri.getAuthority()), uri.getPath(), uri.getQuery(), uri.getFragment());
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            // Not a host we can make sense of, so there is no origin to take.
+            return null;
+        }
+    }
+
+    private static String toAsciiAuthority(String authority) {
+        int hostStart = authority.lastIndexOf('@') + 1;
+        int portStart = authority.indexOf(':', hostStart);
+        String host = portStart >= 0 ? authority.substring(hostStart, portStart) : authority.substring(hostStart);
+        return authority.substring(0, hostStart)
+                + IDN.toASCII(host)
+                + (portStart >= 0 ? authority.substring(portStart) : "");
     }
 
     public static String buildErrorRedirect(String baseRedirectUri, ErrorInfo error, boolean fragment, Map<String, String> extraParams) throws URISyntaxException {

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/web/UriBuilder.java
@@ -369,12 +369,19 @@ public class UriBuilder {
     }
 
     private static int effectivePort(URI uri) {
-        if (uri.getPort() >= 0) {
-            return uri.getPort();
-        }
+        return uri.getPort() >= 0 ? uri.getPort() : defaultPort(uri);
+    }
+
+    private static int defaultPort(URI uri) {
         return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
     }
 
+    /**
+     * The url's origin, serialized the way a browser serializes {@code window.location.origin}: scheme and
+     * host lowercased, and the port present only when it is not the scheme's default. WebAuthn compares the
+     * ceremony origin against {@code clientDataJSON.origin} by exact string equality, so an origin that
+     * keeps {@code :443} or the stored host's casing fails verification against the very host it matched.
+     */
     public static String toOrigin(String url) {
         if (url == null || url.isBlank()) {
             return null;
@@ -388,8 +395,10 @@ public class UriBuilder {
         if (uri.getScheme() == null || uri.getHost() == null) {
             return null;
         }
-        StringBuilder origin = new StringBuilder(uri.getScheme().toLowerCase(Locale.ROOT)).append("://").append(uri.getHost());
-        if (uri.getPort() >= 0) {
+        StringBuilder origin = new StringBuilder(uri.getScheme().toLowerCase(Locale.ROOT))
+                .append("://")
+                .append(uri.getHost().toLowerCase(Locale.ROOT));
+        if (uri.getPort() >= 0 && uri.getPort() != defaultPort(uri)) {
             origin.append(':').append(uri.getPort());
         }
         return origin.toString();

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/web/UriBuilderTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/web/UriBuilderTest.java
@@ -130,5 +130,24 @@ public class UriBuilderTest {
         return URLEncoder.encode(s, StandardCharsets.UTF_8);
     }
 
+    @Test
+    public void toOriginDropsPathQueryAndTrailingSlash() {
+        assertEquals("https://auth.example.com", UriBuilder.toOrigin("https://auth.example.com/"));
+        assertEquals("https://auth.example.com", UriBuilder.toOrigin("https://auth.example.com/some/path?a=b"));
+        assertEquals("https://auth.example.com:8443", UriBuilder.toOrigin("https://auth.example.com:8443/path"));
+    }
+
+    @Test
+    public void toOriginLowercasesTheSchemeAndKeepsAnExplicitDefaultPort() {
+        assertEquals("https://auth.example.com:443", UriBuilder.toOrigin("HTTPS://auth.example.com:443"));
+    }
+
+    @Test
+    public void toOriginIsNullWhenThereIsNoOriginToTake() {
+        Assertions.assertNull(UriBuilder.toOrigin(null));
+        Assertions.assertNull(UriBuilder.toOrigin("   "));
+        Assertions.assertNull(UriBuilder.toOrigin("auth.example.com"));
+        Assertions.assertNull(UriBuilder.toOrigin("https://not a host"));
+    }
 
 }

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/web/UriBuilderTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/web/UriBuilderTest.java
@@ -152,6 +152,14 @@ public class UriBuilderTest {
     }
 
     @Test
+    public void toOriginPunycodesAUnicodeHost() {
+        // Whatever the entrypoint was written with, the browser puts the ascii form in clientDataJSON.origin.
+        assertEquals("https://xn--bcher-kva.example", UriBuilder.toOrigin("https://bücher.example"));
+        assertEquals("https://xn--bcher-kva.example", UriBuilder.toOrigin("https://BÜCHER.example:443/path"));
+        assertEquals("https://xn--bcher-kva.example:8443", UriBuilder.toOrigin("https://bücher.example:8443"));
+    }
+
+    @Test
     public void toOriginIsNullWhenThereIsNoOriginToTake() {
         Assertions.assertNull(UriBuilder.toOrigin(null));
         Assertions.assertNull(UriBuilder.toOrigin("   "));

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/web/UriBuilderTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/web/UriBuilderTest.java
@@ -138,8 +138,17 @@ public class UriBuilderTest {
     }
 
     @Test
-    public void toOriginLowercasesTheSchemeAndKeepsAnExplicitDefaultPort() {
-        assertEquals("https://auth.example.com:443", UriBuilder.toOrigin("HTTPS://auth.example.com:443"));
+    public void toOriginLowercasesTheSchemeAndHost() {
+        assertEquals("https://auth.example.com", UriBuilder.toOrigin("HTTPS://Auth.Example.COM"));
+        assertEquals("https://auth.example.com:8443", UriBuilder.toOrigin("https://AUTH.example.com:8443"));
+    }
+
+    @Test
+    public void toOriginDropsAnExplicitDefaultPort() {
+        // The browser omits it from clientDataJSON.origin, and WebAuthn compares the two with string equality.
+        assertEquals("https://auth.example.com", UriBuilder.toOrigin("https://auth.example.com:443"));
+        assertEquals("http://auth.example.com", UriBuilder.toOrigin("http://auth.example.com:80"));
+        assertEquals("https://auth.example.com:80", UriBuilder.toOrigin("https://auth.example.com:80"));
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/CommonConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.common.spring;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.gateway.handler.common.alert.AlertEventProcessor;
@@ -131,6 +132,7 @@ import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.repository.gateway.api.AuthenticationFlowContextRepository;
 import io.gravitee.am.repository.oauth2.api.BackwardCompatibleTokenRepository;
 import io.gravitee.am.service.DomainDataPlane;
+import io.gravitee.am.service.EntryPointManager;
 import io.gravitee.am.service.ScopeService;
 import io.gravitee.am.service.dataplane.user.activity.configuration.UserActivityConfiguration;
 import io.gravitee.am.service.http.PoolOptionsBuilder;
@@ -566,9 +568,9 @@ public class CommonConfiguration {
     }
 
     @Bean
-    public DomainDataPlane domainDataPlane(Domain domain, DataPlaneRegistry dataPlaneRegistry) {
+    public DomainDataPlane domainDataPlane(Domain domain, DataPlaneRegistry dataPlaneRegistry, EntryPointManager entryPointManager) {
         DataPlaneDescription description = dataPlaneRegistry.getDescription(domain);
-        return new DomainDataPlane(domain, description);
+        return new DomainDataPlane(domain, description, entryPointManager, CloudProperties.isManagedCloudEnabled(environment));
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/RootProvider.java
@@ -671,7 +671,7 @@ public class RootProvider extends AbstractProtocolProvider {
         rootRouter.route(PATH_WEBAUTHN_LOGIN_CREDENTIALS)
                 .handler(clientRequestParseHandler)
                 .handler(webAuthnAccessHandler)
-                .handler(new WebAuthnLoginCredentialsEndpoint(webAuthn));
+                .handler(new WebAuthnLoginCredentialsEndpoint(domainDataPlane, webAuthn));
         rootRouter.post(PATH_WEBAUTHN_RESPONSE)
                 .handler(clientRequestParseHandler)
                 .handler(webAuthnAccessHandler)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengePostEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/mfa/MFAChallengePostEndpoint.java
@@ -28,6 +28,7 @@ import io.gravitee.am.gateway.handler.common.service.DeviceGatewayService;
 import io.gravitee.am.gateway.handler.common.service.mfa.RateLimiterService;
 import io.gravitee.am.gateway.handler.common.service.mfa.VerifyAttemptService;
 import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
+import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.manager.deviceidentifiers.DeviceIdentifierManager;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.identityprovider.api.DefaultUser;
@@ -174,7 +175,7 @@ public class MFAChallengePostEndpoint extends MFAChallengeEndpoint {
         if (factor.is(FIDO2)) {
             factorCtx.registerData(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY, routingContext.session().get(PASSWORDLESS_CHALLENGE_KEY));
             factorCtx.registerData(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY, routingContext.session().get(PASSWORDLESS_CHALLENGE_USERNAME_KEY));
-            factorCtx.registerData(ConstantKeys.PASSWORDLESS_ORIGIN, domainDataPlane.getWebAuthnOrigin());
+            factorCtx.registerData(ConstantKeys.PASSWORDLESS_ORIGIN, domainDataPlane.getWebAuthnOrigin(UriBuilderRequest.resolveOrigin(routingContext.request())));
         }
 
         verifyAttemptService.checkVerifyAttempt(endUser, factorId, client, domainDataPlane.getDomain())

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginCredentialsEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnLoginCredentialsEndpoint.java
@@ -17,6 +17,7 @@ package io.gravitee.am.gateway.handler.root.resources.endpoint.webauthn;
 
 import io.gravitee.am.common.utils.ConstantKeys;
 import io.gravitee.am.gateway.handler.root.resources.handler.webauthn.WebAuthnHandler;
+import io.gravitee.am.service.DomainDataPlane;
 import io.gravitee.am.service.exception.NotImplementedException;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.json.Json;
@@ -44,7 +45,8 @@ public class WebAuthnLoginCredentialsEndpoint extends WebAuthnHandler {
 
     private final WebAuthn webAuthn;
 
-    public WebAuthnLoginCredentialsEndpoint(WebAuthn webAuthn) {
+    public WebAuthnLoginCredentialsEndpoint(DomainDataPlane domainDataPlane, WebAuthn webAuthn) {
+        setDomainDataplane(domainDataPlane);
         this.webAuthn = webAuthn;
     }
 
@@ -86,6 +88,7 @@ public class WebAuthnLoginCredentialsEndpoint extends WebAuthnHandler {
             Single.fromCompletionStage(webAuthn.getCredentialsOptions(username).toCompletionStage())
                     .subscribe(
                             entries -> {
+                                applyRelyingPartyId(ctx, entries);
                                 session
                                         .put(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY, entries.getString("challenge"))
                                         .put(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY, username);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterCredentialsEndpoint.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/endpoint/webauthn/WebAuthnRegisterCredentialsEndpoint.java
@@ -92,6 +92,8 @@ public class WebAuthnRegisterCredentialsEndpoint extends WebAuthnHandler {
             Single.fromCompletionStage(webAuthn.createCredentialsOptions(webauthnRegister).toCompletionStage())
                     .subscribe(
                             entries -> {
+                                applyRelyingPartyId(ctx, entries);
+
                                 // force user id with our own user id
                                 entries.getJsonObject("user").put("id", user.getId());
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
@@ -126,14 +126,16 @@ public abstract class WebAuthnHandler extends AbstractEndpoint implements Handle
      * cloud. Rewriting the emitted options is safe because we never set {@code WebAuthnCredentials.domain},
      * so Vert.x skips its {@code rpIdHash} check and the id is purely what we advertise to the browser.
      * <p>
-     * Registration carries it as {@code rp.id}, assertion as a top-level {@code rpId}. Outside managed
-     * cloud the options are left exactly as the factory built them.
+     * Registration carries it as {@code rp.id}, assertion as a top-level {@code rpId}. Only an origin that
+     * came from an entrypoint is used: with no entrypoint to go on the factory's value already honours
+     * whatever relying party id the domain configured, and deriving one from the fallback origin would
+     * overwrite it with the origin's host.
      */
     protected void applyRelyingPartyId(RoutingContext ctx, JsonObject options) {
-        if (!domainDataPlane.isManagedCloud()) {
-            return;
-        }
-        String relyingPartyId = RequestUtils.getDomain(webAuthnOrigin(ctx));
+        String relyingPartyId = domainDataPlane
+                .getWebAuthnEntrypointOrigin(UriBuilderRequest.resolveOrigin(ctx.request()))
+                .map(RequestUtils::getDomain)
+                .orElse(null);
         if (relyingPartyId == null) {
             return;
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
@@ -25,6 +25,7 @@ import io.gravitee.am.gateway.handler.common.auth.user.UserAuthenticationManager
 import io.gravitee.am.gateway.handler.common.factor.FactorManager;
 import io.gravitee.am.gateway.handler.common.service.CredentialGatewayService;
 import io.gravitee.am.gateway.handler.common.vertx.core.http.VertxHttpServerRequest;
+import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.gateway.handler.root.resources.endpoint.AbstractEndpoint;
 import io.gravitee.am.gateway.handler.root.service.user.UserService;
 import io.gravitee.am.identityprovider.api.AuthenticationContext;
@@ -106,6 +107,42 @@ public abstract class WebAuthnHandler extends AbstractEndpoint implements Handle
 
     public void setDomainDataplane(DomainDataPlane domainDataPlane) {
         this.domainDataPlane = domainDataPlane;
+    }
+
+    /**
+     * The origin this request's ceremony is verified against. Resolved per request rather than once at
+     * deploy time, so an environment with several entrypoints answers on the host the browser is on.
+     */
+    protected String webAuthnOrigin(RoutingContext ctx) {
+        return domainDataPlane.getWebAuthnOrigin(UriBuilderRequest.resolveOrigin(ctx.request()));
+    }
+
+    /**
+     * Point the generated options at the relying party for this request's origin.
+     * <p>
+     * {@link io.gravitee.am.gateway.handler.vertx.auth.webauthn.WebAuthnFactory} builds the {@code WebAuthn}
+     * bean once per domain, so its relying party id cannot follow the request. It also has no view of the
+     * environment entrypoint and falls back to {@code localhost}, which the browser rejects outright in
+     * cloud. Rewriting the emitted options is safe because we never set {@code WebAuthnCredentials.domain},
+     * so Vert.x skips its {@code rpIdHash} check and the id is purely what we advertise to the browser.
+     * <p>
+     * Registration carries it as {@code rp.id}, assertion as a top-level {@code rpId}. Outside managed
+     * cloud the options are left exactly as the factory built them.
+     */
+    protected void applyRelyingPartyId(RoutingContext ctx, JsonObject options) {
+        if (!domainDataPlane.isManagedCloud()) {
+            return;
+        }
+        String relyingPartyId = RequestUtils.getDomain(webAuthnOrigin(ctx));
+        if (relyingPartyId == null) {
+            return;
+        }
+        if (options.containsKey("rp")) {
+            options.getJsonObject("rp").put("id", relyingPartyId);
+        }
+        if (options.containsKey("rpId")) {
+            options.put("rpId", relyingPartyId);
+        }
     }
 
     protected static boolean isEmptyString(JsonObject json, String key) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
@@ -118,18 +118,14 @@ public abstract class WebAuthnHandler extends AbstractEndpoint implements Handle
     }
 
     /**
-     * Point the generated options at the relying party for this request's origin.
+     * Point the generated options at the relying party for this request's origin: {@code rp.id} on
+     * registration, top-level {@code rpId} on assertion.
      * <p>
      * {@link io.gravitee.am.gateway.handler.vertx.auth.webauthn.WebAuthnFactory} builds the {@code WebAuthn}
-     * bean once per domain, so its relying party id cannot follow the request. It also has no view of the
-     * environment entrypoint and falls back to {@code localhost}, which the browser rejects outright in
-     * cloud. Rewriting the emitted options is safe because we never set {@code WebAuthnCredentials.domain},
-     * so Vert.x skips its {@code rpIdHash} check and the id is purely what we advertise to the browser.
-     * <p>
-     * Registration carries it as {@code rp.id}, assertion as a top-level {@code rpId}. Only an origin that
-     * came from an entrypoint is used: with no entrypoint to go on the factory's value already honours
-     * whatever relying party id the domain configured, and deriving one from the fallback origin would
-     * overwrite it with the origin's host.
+     * bean once per domain and falls back to {@code localhost}, so its id cannot follow the request.
+     * Rewriting is safe because we never set {@code WebAuthnCredentials.domain}, so Vert.x skips its
+     * {@code rpIdHash} check. Only entrypoint-derived origins are used: otherwise the factory's value
+     * already honours the relying party id the domain configured.
      */
     protected void applyRelyingPartyId(RoutingContext ctx, JsonObject options) {
         String relyingPartyId = domainDataPlane

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
@@ -132,8 +132,7 @@ public abstract class WebAuthnHandler extends AbstractEndpoint implements Handle
      * covers several subdomains — would stop every existing authenticator offering it.
      */
     protected void applyRelyingPartyId(RoutingContext ctx, JsonObject options) {
-        WebAuthnSettings webAuthnSettings = domainDataPlane.getDomain().getWebAuthnSettings();
-        if (webAuthnSettings != null && webAuthnSettings.getRelyingPartyId() != null) {
+        if (saysMoreThanTheOrigin(domainDataPlane.getDomain().getWebAuthnSettings())) {
             return;
         }
         String relyingPartyId = domainDataPlane
@@ -149,6 +148,22 @@ public abstract class WebAuthnHandler extends AbstractEndpoint implements Handle
         if (options.containsKey("rpId")) {
             options.put("rpId", relyingPartyId);
         }
+    }
+
+    /**
+     * Whether the configured relying party id carries an intent the origin does not already imply.
+     * <p>
+     * A non-null id is not by itself a deliberate one: the console prefills the field with the configured
+     * origin's host, so most domains carry a value nobody chose. Such an id is worth no more than the
+     * origin it was taken from — the same origin the entrypoint is replacing — and keeping it would hand
+     * the browser a relying party id for one host while the ceremony runs on another, which it refuses.
+     * An id that differs is a decision, most often a parent domain, and only that is left alone.
+     */
+    private static boolean saysMoreThanTheOrigin(WebAuthnSettings webAuthnSettings) {
+        if (webAuthnSettings == null || webAuthnSettings.getRelyingPartyId() == null) {
+            return false;
+        }
+        return !webAuthnSettings.getRelyingPartyId().equals(RequestUtils.getDomain(webAuthnSettings.getOrigin()));
     }
 
     protected static boolean isEmptyString(JsonObject json, String key) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandler.java
@@ -126,8 +126,16 @@ public abstract class WebAuthnHandler extends AbstractEndpoint implements Handle
      * Rewriting is safe because we never set {@code WebAuthnCredentials.domain}, so Vert.x skips its
      * {@code rpIdHash} check. Only entrypoint-derived origins are used: otherwise the factory's value
      * already honours the relying party id the domain configured.
+     * <p>
+     * A relying party id the domain set explicitly is left alone. Credentials are bound to the id they
+     * were registered under, so replacing a deliberate one — often a parent domain, so a single credential
+     * covers several subdomains — would stop every existing authenticator offering it.
      */
     protected void applyRelyingPartyId(RoutingContext ctx, JsonObject options) {
+        WebAuthnSettings webAuthnSettings = domainDataPlane.getDomain().getWebAuthnSettings();
+        if (webAuthnSettings != null && webAuthnSettings.getRelyingPartyId() != null) {
+            return;
+        }
         String relyingPartyId = domainDataPlane
                 .getWebAuthnEntrypointOrigin(UriBuilderRequest.resolveOrigin(ctx.request()))
                 .map(RequestUtils::getDomain)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnLoginHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnLoginHandler.java
@@ -61,7 +61,6 @@ import lombok.CustomLog;
 public class WebAuthnLoginHandler extends WebAuthnHandler {
 
     private final WebAuthn webAuthn;
-    private final String origin;
 
     public WebAuthnLoginHandler(UserService userService,
                                 FactorManager factorManager,
@@ -75,7 +74,6 @@ public class WebAuthnLoginHandler extends WebAuthnHandler {
         setUserAuthenticationManager(userAuthenticationManager);
         setDomainDataplane(domainDataPlane);
         this.webAuthn = webAuthn;
-        this.origin = domainDataPlane.getWebAuthnOrigin();
     }
 
     @Override
@@ -127,6 +125,7 @@ public class WebAuthnLoginHandler extends WebAuthnHandler {
         Single.fromCompletionStage(webAuthn.getCredentialsOptions(username).toCompletionStage())
                 .subscribe(
                         entries -> {
+                            applyRelyingPartyId(ctx, entries);
                             session
                                     .put(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY, entries.getString("challenge"))
                                     .put(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY, username);
@@ -178,7 +177,7 @@ public class WebAuthnLoginHandler extends WebAuthnHandler {
         Single.fromCompletionStage(webAuthn.authenticate(
                         // authInfo
                         new WebAuthnCredentials()
-                                .setOrigin(origin)
+                                .setOrigin(webAuthnOrigin(ctx))
                                 .setChallenge(session.get(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY))
                                 .setUsername(session.get(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY))
                                 .setWebauthn(webauthnResp)).toCompletionStage()).onErrorResumeNext(throwable -> {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnRegisterHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnRegisterHandler.java
@@ -49,7 +49,6 @@ import lombok.CustomLog;
 public class WebAuthnRegisterHandler extends WebAuthnHandler {
 
     private final WebAuthn webAuthn;
-    private final String origin;
 
     public WebAuthnRegisterHandler(UserService userService,
                                    FactorManager factorManager,
@@ -61,7 +60,6 @@ public class WebAuthnRegisterHandler extends WebAuthnHandler {
         setCredentialService(credentialService);
         setDomainDataplane(domainDataplane);
         this.webAuthn = webAuthn;
-        this.origin = domainDataplane.getWebAuthnOrigin();
     }
 
     @Override
@@ -120,6 +118,8 @@ public class WebAuthnRegisterHandler extends WebAuthnHandler {
         Single.fromCompletionStage(webAuthn.createCredentialsOptions(webauthnRegister).toCompletionStage())
                 .subscribe(
                         entries -> {
+                            applyRelyingPartyId(ctx, entries);
+
                             // force user id with our own user id
                             entries.getJsonObject("user").put("id", user.getId());
 
@@ -183,7 +183,7 @@ public class WebAuthnRegisterHandler extends WebAuthnHandler {
         Single.fromCompletionStage(webAuthn.authenticate(
                 // authInfo
                 new WebAuthnCredentials()
-                        .setOrigin(origin)
+                        .setOrigin(webAuthnOrigin(ctx))
                         .setChallenge(session.get(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY))
                         .setUsername(session.get(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY))
                         .setWebauthn(webauthnResp)).toCompletionStage())

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnResponseHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnResponseHandler.java
@@ -49,7 +49,6 @@ import lombok.CustomLog;
 public class WebAuthnResponseHandler extends WebAuthnHandler {
 
     private final WebAuthn webAuthn;
-    private final String origin;
 
     public WebAuthnResponseHandler(UserService userService,
                                    FactorManager factorManager,
@@ -63,7 +62,6 @@ public class WebAuthnResponseHandler extends WebAuthnHandler {
         setUserAuthenticationManager(userAuthenticationManager);
         setDomainDataplane(domainDataPlane);
         this.webAuthn = webAuthn;
-        this.origin = domainDataPlane.getWebAuthnOrigin();
     }
 
     @Override
@@ -98,7 +96,7 @@ public class WebAuthnResponseHandler extends WebAuthnHandler {
             Single.fromCompletionStage(webAuthn.authenticate(
                     // authInfo
                     new WebAuthnCredentials()
-                            .setOrigin(origin)
+                            .setOrigin(webAuthnOrigin(ctx))
                             .setChallenge(session.get(ConstantKeys.PASSWORDLESS_CHALLENGE_KEY))
                             .setUsername(session.get(ConstantKeys.PASSWORDLESS_CHALLENGE_USERNAME_KEY))
                             .setWebauthn(webauthnResp)).toCompletionStage())

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandlerRelyingPartyTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandlerRelyingPartyTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.root.resources.handler.webauthn;
+
+import io.gravitee.am.service.DomainDataPlane;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The relying party id the browser is handed has to follow the origin the ceremony is verified
+ * against, otherwise it refuses the ceremony outright.
+ *
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebAuthnHandlerRelyingPartyTest {
+
+    @Mock
+    private DomainDataPlane domainDataPlane;
+
+    private final RoutingContext ctx = mock(RoutingContext.class);
+    private WebAuthnHandler cut;
+
+    @Before
+    public void before() {
+        when(ctx.request()).thenReturn(mock(HttpServerRequest.class));
+        cut = new WebAuthnHandler() {
+            @Override
+            public void handle(RoutingContext event) {
+                // nothing to route, only the shared helpers are under test
+            }
+        };
+        cut.setDomainDataplane(domainDataPlane);
+    }
+
+    @Test
+    public void shouldRewriteTheRegistrationRelyingPartyId() {
+        inManagedCloudOn("https://auth.acme.com");
+        JsonObject options = new JsonObject().put("rp", new JsonObject().put("id", "localhost").put("name", "Gravitee"));
+
+        cut.applyRelyingPartyId(ctx, options);
+
+        assertEquals("auth.acme.com", options.getJsonObject("rp").getString("id"));
+        assertEquals("Gravitee", options.getJsonObject("rp").getString("name"));
+    }
+
+    @Test
+    public void shouldRewriteTheAssertionRelyingPartyId() {
+        inManagedCloudOn("https://auth.acme.com:8443");
+        JsonObject options = new JsonObject().put("rpId", "localhost");
+
+        cut.applyRelyingPartyId(ctx, options);
+
+        // The port is part of the origin but never part of the relying party id.
+        assertEquals("auth.acme.com", options.getString("rpId"));
+    }
+
+    @Test
+    public void shouldLeaveTheOptionsAloneOutsideManagedCloud() {
+        when(domainDataPlane.isManagedCloud()).thenReturn(false);
+        JsonObject options = new JsonObject().put("rpId", "configured.acme.com");
+
+        cut.applyRelyingPartyId(ctx, options);
+
+        assertEquals("configured.acme.com", options.getString("rpId"));
+    }
+
+    @Test
+    public void shouldLeaveTheOptionsAloneWhenTheOriginCarriesNoHost() {
+        inManagedCloudOn("not-a-url");
+        JsonObject options = new JsonObject().put("rpId", "configured.acme.com");
+
+        cut.applyRelyingPartyId(ctx, options);
+
+        assertEquals("configured.acme.com", options.getString("rpId"));
+    }
+
+    private void inManagedCloudOn(String origin) {
+        when(domainDataPlane.isManagedCloud()).thenReturn(true);
+        when(domainDataPlane.getWebAuthnOrigin(any())).thenReturn(origin);
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandlerRelyingPartyTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandlerRelyingPartyTest.java
@@ -54,7 +54,7 @@ public class WebAuthnHandlerRelyingPartyTest {
     @Before
     public void before() {
         when(ctx.request()).thenReturn(mock(HttpServerRequest.class));
-        when(domainDataPlane.getDomain()).thenReturn(domainWithRelyingPartyId(null));
+        when(domainDataPlane.getDomain()).thenReturn(domainWith(null, null));
         cut = new WebAuthnHandler() {
             @Override
             public void handle(RoutingContext event) {
@@ -64,9 +64,10 @@ public class WebAuthnHandlerRelyingPartyTest {
         cut.setDomainDataplane(domainDataPlane);
     }
 
-    private Domain domainWithRelyingPartyId(String relyingPartyId) {
+    private Domain domainWith(String relyingPartyId, String origin) {
         WebAuthnSettings settings = new WebAuthnSettings();
         settings.setRelyingPartyId(relyingPartyId);
+        settings.setOrigin(origin);
         Domain domain = new Domain();
         domain.setWebAuthnSettings(settings);
         return domain;
@@ -121,13 +122,38 @@ public class WebAuthnHandlerRelyingPartyTest {
     public void shouldLeaveAConfiguredRelyingPartyIdAlone() {
         // Credentials are bound to the id they were registered under, so a domain that deliberately scoped
         // itself to a parent domain keeps it even though an entrypoint resolves.
-        when(domainDataPlane.getDomain()).thenReturn(domainWithRelyingPartyId("acme.com"));
+        when(domainDataPlane.getDomain()).thenReturn(domainWith("acme.com", "https://auth.acme.com"));
         JsonObject options = new JsonObject().put("rpId", "acme.com");
 
         cut.applyRelyingPartyId(ctx, options);
 
         assertEquals("acme.com", options.getString("rpId"));
         verify(domainDataPlane, never()).getWebAuthnEntrypointOrigin(any());
+    }
+
+    @Test
+    public void shouldLeaveARelyingPartyIdConfiguredWithoutAnOriginAlone() {
+        when(domainDataPlane.getDomain()).thenReturn(domainWith("acme.com", null));
+        JsonObject options = new JsonObject().put("rpId", "acme.com");
+
+        cut.applyRelyingPartyId(ctx, options);
+
+        assertEquals("acme.com", options.getString("rpId"));
+        verify(domainDataPlane, never()).getWebAuthnEntrypointOrigin(any());
+    }
+
+    @Test
+    public void shouldRewriteARelyingPartyIdThatOnlyMirrorsTheConfiguredOrigin() {
+        // The console prefills the field with the origin's host, so this id was never a choice. The origin
+        // it mirrors is the one the entrypoint replaces, and keeping it would scope the ceremony to a host
+        // the browser is not on.
+        when(domainDataPlane.getDomain()).thenReturn(domainWith("auth.acme.com", "https://auth.acme.com"));
+        resolvedEntrypoint("https://tenant.eu.gravitee.io");
+        JsonObject options = new JsonObject().put("rpId", "auth.acme.com");
+
+        cut.applyRelyingPartyId(ctx, options);
+
+        assertEquals("tenant.eu.gravitee.io", options.getString("rpId"));
     }
 
     private void resolvedEntrypoint(String origin) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandlerRelyingPartyTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandlerRelyingPartyTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.gateway.handler.root.resources.handler.webauthn;
 
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.login.WebAuthnSettings;
 import io.gravitee.am.service.DomainDataPlane;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
@@ -30,6 +32,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -50,6 +54,7 @@ public class WebAuthnHandlerRelyingPartyTest {
     @Before
     public void before() {
         when(ctx.request()).thenReturn(mock(HttpServerRequest.class));
+        when(domainDataPlane.getDomain()).thenReturn(domainWithRelyingPartyId(null));
         cut = new WebAuthnHandler() {
             @Override
             public void handle(RoutingContext event) {
@@ -57,6 +62,14 @@ public class WebAuthnHandlerRelyingPartyTest {
             }
         };
         cut.setDomainDataplane(domainDataPlane);
+    }
+
+    private Domain domainWithRelyingPartyId(String relyingPartyId) {
+        WebAuthnSettings settings = new WebAuthnSettings();
+        settings.setRelyingPartyId(relyingPartyId);
+        Domain domain = new Domain();
+        domain.setWebAuthnSettings(settings);
+        return domain;
     }
 
     @Test
@@ -102,6 +115,19 @@ public class WebAuthnHandlerRelyingPartyTest {
         cut.applyRelyingPartyId(ctx, options);
 
         assertEquals("configured.acme.com", options.getString("rpId"));
+    }
+
+    @Test
+    public void shouldLeaveAConfiguredRelyingPartyIdAlone() {
+        // Credentials are bound to the id they were registered under, so a domain that deliberately scoped
+        // itself to a parent domain keeps it even though an entrypoint resolves.
+        when(domainDataPlane.getDomain()).thenReturn(domainWithRelyingPartyId("acme.com"));
+        JsonObject options = new JsonObject().put("rpId", "acme.com");
+
+        cut.applyRelyingPartyId(ctx, options);
+
+        assertEquals("acme.com", options.getString("rpId"));
+        verify(domainDataPlane, never()).getWebAuthnEntrypointOrigin(any());
     }
 
     private void resolvedEntrypoint(String origin) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandlerRelyingPartyTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/webauthn/WebAuthnHandlerRelyingPartyTest.java
@@ -19,6 +19,8 @@ import io.gravitee.am.service.DomainDataPlane;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.ext.web.RoutingContext;
+
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,7 +61,7 @@ public class WebAuthnHandlerRelyingPartyTest {
 
     @Test
     public void shouldRewriteTheRegistrationRelyingPartyId() {
-        inManagedCloudOn("https://auth.acme.com");
+        resolvedEntrypoint("https://auth.acme.com");
         JsonObject options = new JsonObject().put("rp", new JsonObject().put("id", "localhost").put("name", "Gravitee"));
 
         cut.applyRelyingPartyId(ctx, options);
@@ -70,7 +72,7 @@ public class WebAuthnHandlerRelyingPartyTest {
 
     @Test
     public void shouldRewriteTheAssertionRelyingPartyId() {
-        inManagedCloudOn("https://auth.acme.com:8443");
+        resolvedEntrypoint("https://auth.acme.com:8443");
         JsonObject options = new JsonObject().put("rpId", "localhost");
 
         cut.applyRelyingPartyId(ctx, options);
@@ -80,8 +82,11 @@ public class WebAuthnHandlerRelyingPartyTest {
     }
 
     @Test
-    public void shouldLeaveTheOptionsAloneOutsideManagedCloud() {
-        when(domainDataPlane.isManagedCloud()).thenReturn(false);
+    public void shouldLeaveTheOptionsAloneWithoutAnEntrypoint() {
+        // No entrypoint means the origin fell back to the domain's own settings or the gateway url, and
+        // the factory has already applied whatever relying party id the domain configured. Deriving one
+        // from the fallback origin would replace a deliberate parent-domain id with the origin's host.
+        when(domainDataPlane.getWebAuthnEntrypointOrigin(any())).thenReturn(Optional.empty());
         JsonObject options = new JsonObject().put("rpId", "configured.acme.com");
 
         cut.applyRelyingPartyId(ctx, options);
@@ -90,8 +95,8 @@ public class WebAuthnHandlerRelyingPartyTest {
     }
 
     @Test
-    public void shouldLeaveTheOptionsAloneWhenTheOriginCarriesNoHost() {
-        inManagedCloudOn("not-a-url");
+    public void shouldLeaveTheOptionsAloneWhenTheEntrypointCarriesNoHost() {
+        resolvedEntrypoint("not-a-url");
         JsonObject options = new JsonObject().put("rpId", "configured.acme.com");
 
         cut.applyRelyingPartyId(ctx, options);
@@ -99,8 +104,7 @@ public class WebAuthnHandlerRelyingPartyTest {
         assertEquals("configured.acme.com", options.getString("rpId"));
     }
 
-    private void inManagedCloudOn(String origin) {
-        when(domainDataPlane.isManagedCloud()).thenReturn(true);
-        when(domainDataPlane.getWebAuthnOrigin(any())).thenReturn(origin);
+    private void resolvedEntrypoint(String origin) {
+        when(domainDataPlane.getWebAuthnEntrypointOrigin(any())).thenReturn(Optional.of(origin));
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainDataPlane.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainDataPlane.java
@@ -55,6 +55,10 @@ public class DomainDataPlane {
      * Empty unless the origin came from an environment entrypoint. Callers that derive the relying party
      * id need to tell that apart from the fallbacks: a domain that configured its own relying party id
      * keeps it, and deriving one from the fallback origin would silently replace it.
+     * <p>
+     * Present does not mean the entrypoint matched {@code requestOrigin} — the environment's primary
+     * entrypoint stands in when nothing matches, so an unrecognised host resolves to a host the browser
+     * is not on and fails the ceremony rather than being trusted.
      */
     public Optional<String> getWebAuthnEntrypointOrigin(@Nullable String requestOrigin) {
         if (!managedCloud || domain.getReferenceId() == null) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainDataPlane.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainDataPlane.java
@@ -39,7 +39,7 @@ public class DomainDataPlane {
     private final boolean managedCloud;
 
     public String getWebAuthnOrigin(@Nullable String requestOrigin) {
-        Optional<String> entrypointOrigin = entrypointOrigin(requestOrigin);
+        Optional<String> entrypointOrigin = getWebAuthnEntrypointOrigin(requestOrigin);
         if (entrypointOrigin.isPresent()) {
             return entrypointOrigin.get();
         }
@@ -51,7 +51,12 @@ public class DomainDataPlane {
         }
     }
 
-    private Optional<String> entrypointOrigin(@Nullable String requestOrigin) {
+    /**
+     * Empty unless the origin came from an environment entrypoint. Callers that derive the relying party
+     * id need to tell that apart from the fallbacks: a domain that configured its own relying party id
+     * keeps it, and deriving one from the fallback origin would silently replace it.
+     */
+    public Optional<String> getWebAuthnEntrypointOrigin(@Nullable String requestOrigin) {
         if (!managedCloud || domain.getReferenceId() == null) {
             return Optional.empty();
         }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainDataPlane.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DomainDataPlane.java
@@ -15,12 +15,17 @@
  */
 package io.gravitee.am.service;
 
+import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.login.WebAuthnSettings;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Getter
@@ -29,13 +34,29 @@ public class DomainDataPlane {
     private final Domain domain;
     @NonNull
     private final DataPlaneDescription dataPlaneDescription;
+    @NonNull
+    private final EntryPointManager entryPointManager;
+    private final boolean managedCloud;
 
-    public String getWebAuthnOrigin() {
+    public String getWebAuthnOrigin(@Nullable String requestOrigin) {
+        Optional<String> entrypointOrigin = entrypointOrigin(requestOrigin);
+        if (entrypointOrigin.isPresent()) {
+            return entrypointOrigin.get();
+        }
         WebAuthnSettings webAuthnSettings = domain.getWebAuthnSettings();
         if (webAuthnSettings != null && webAuthnSettings.getOrigin() != null) {
             return webAuthnSettings.getOrigin();
         } else {
             return dataPlaneDescription.gatewayUrl();
         }
+    }
+
+    private Optional<String> entrypointOrigin(@Nullable String requestOrigin) {
+        if (!managedCloud || domain.getReferenceId() == null) {
+            return Optional.empty();
+        }
+        return entryPointManager.resolveForRequest(domain.getReferenceId(), requestOrigin)
+                .map(Entrypoint::getUrl)
+                .map(UriBuilder::toOrigin);
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
@@ -40,8 +40,6 @@ import java.util.Optional;
  */
 public interface EntryPointManager extends Service<EntryPointManager> {
 
-    Logger LOG = NodeLoggerFactory.getLogger(EntryPointManager.class);
-
     List<Entrypoint> findByOrganizationId(String organizationId);
 
     List<Entrypoint> findAllByEnvironmentId(String environmentId);
@@ -92,10 +90,11 @@ public interface EntryPointManager extends Service<EntryPointManager> {
                 .filter(entrypoint -> sameOrigin(entrypoint.getUrl(), requestOrigin))
                 .min(Comparator.comparing(Entrypoint::getUrl));
         if (matched.isEmpty()) {
-            // Either a forged host or an entrypoint the environment never synced, and the two look the
-            // same from here. Worth saying out loud, because the fallback silently differs from the host
-            // the user is on.
-            LOG.warn("Environment {} has no entrypoint matching the request origin, falling back to its primary entrypoint", environmentId);
+            // Either a forged host or an entrypoint the environment never synced, and the two look the same
+            // from here. Debug rather than warn: this also runs per webauthn request, so an environment
+            // whose entrypoints never synced would warn at request rate.
+            Logger logger = NodeLoggerFactory.getLogger(this.getClass());
+            logger.debug("Environment {} has no entrypoint matching the request origin, falling back to its primary entrypoint", environmentId);
         }
         return matched;
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
@@ -15,9 +15,15 @@
  */
 package io.gravitee.am.service;
 
+import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.model.Entrypoint;
 import io.gravitee.common.service.Service;
+import io.gravitee.node.logging.NodeLoggerFactory;
+import jakarta.annotation.Nullable;
+import org.slf4j.Logger;
 
+import java.net.URI;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +39,8 @@ import java.util.Optional;
  * @author GraviteeSource Team
  */
 public interface EntryPointManager extends Service<EntryPointManager> {
+
+    Logger LOG = NodeLoggerFactory.getLogger(EntryPointManager.class);
 
     List<Entrypoint> findByOrganizationId(String organizationId);
 
@@ -59,4 +67,45 @@ public interface EntryPointManager extends Service<EntryPointManager> {
      * emails for one environment could carry different hosts.
      */
     Optional<Entrypoint> findPrimaryByEnvironmentId(String environmentId);
+
+    /**
+     * The entrypoint an environment should be addressed by for a caller arriving on {@code requestOrigin},
+     * so an environment with several hosts answers on the one in the address bar rather than an arbitrary
+     * pick. Falls back to {@link #findPrimaryByEnvironmentId(String)} when there is no request to go on or
+     * nothing matches.
+     * <p>
+     * Only ever returns a stored entrypoint, never the caller's string: an unrecognised origin is a forged
+     * {@code Host} header away from trusting somebody else's domain.
+     */
+    default Optional<Entrypoint> resolveForRequest(String environmentId, @Nullable String requestOrigin) {
+        return matchingEntrypoint(environmentId, requestOrigin).or(() -> findPrimaryByEnvironmentId(environmentId));
+    }
+
+    private Optional<Entrypoint> matchingEntrypoint(String environmentId, @Nullable String requestOrigin) {
+        if (requestOrigin == null || requestOrigin.isBlank()) {
+            return Optional.empty();
+        }
+        // The lowest url wins rather than the first, for the same reason findPrimaryByEnvironmentId picks
+        // that way: cache iteration order is unspecified, so two entrypoints sharing an origin would
+        // otherwise resolve differently between planes.
+        Optional<Entrypoint> matched = findAllByEnvironmentId(environmentId).stream()
+                .filter(entrypoint -> sameOrigin(entrypoint.getUrl(), requestOrigin))
+                .min(Comparator.comparing(Entrypoint::getUrl));
+        if (matched.isEmpty()) {
+            // Either a forged host or an entrypoint the environment never synced, and the two look the
+            // same from here. Worth saying out loud, because the fallback silently differs from the host
+            // the user is on.
+            LOG.warn("Environment {} has no entrypoint matching the request origin, falling back to its primary entrypoint", environmentId);
+        }
+        return matched;
+    }
+
+    private static boolean sameOrigin(String entrypointUrl, String requestOrigin) {
+        String entrypointOrigin = UriBuilder.toOrigin(entrypointUrl);
+        String callerOrigin = UriBuilder.toOrigin(requestOrigin);
+        if (entrypointOrigin == null || callerOrigin == null) {
+            return false;
+        }
+        return UriBuilder.sameOriginAuthority(URI.create(entrypointOrigin), URI.create(callerOrigin));
+    }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/application/DomainReadServiceImpl.java
@@ -36,8 +36,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
-import java.net.URI;
-import java.util.Comparator;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -130,64 +128,13 @@ public class DomainReadServiceImpl implements DomainReadService {
     // and until Cockpit has synced one, the data plane url stands.
     private String resolveEntryPoint(Domain domain, @Nullable String requestOrigin) {
         if (CloudProperties.isManagedCloudEnabled(springEnvironment)) {
-            Optional<String> entrypointUrl = matchingEntrypoint(domain, requestOrigin)
-                    .or(() -> entryPointManager.findPrimaryByEnvironmentId(domain.getReferenceId()))
+            Optional<String> entrypointUrl = entryPointManager.resolveForRequest(domain.getReferenceId(), requestOrigin)
                     .map(Entrypoint::getUrl);
             if (entrypointUrl.isPresent()) {
                 return entrypointUrl.get();
             }
         }
         return ofNullable(dataPlaneRegistry.getDescription(domain).gatewayUrl()).orElse(gatewayUrl);
-    }
-
-    /**
-     * The environment entrypoint the user actually reached us on, so an environment with several hosts
-     * mails links back to the one in the address bar rather than an arbitrary pick.
-     * <p>
-     * Only ever returns a stored entrypoint, never the caller's string: an unrecognised origin is a
-     * forged {@code Host} header away from mailing a password-reset token to somebody else's domain.
-     */
-    private Optional<Entrypoint> matchingEntrypoint(Domain domain, @Nullable String requestOrigin) {
-        if (requestOrigin == null || requestOrigin.isBlank()) {
-            return Optional.empty();
-        }
-        // The lowest url wins rather than the first, for the same reason findPrimaryByEnvironmentId picks
-        // that way: cache iteration order is unspecified, so two entrypoints sharing an origin would
-        // otherwise mail different hosts from one environment.
-        Optional<Entrypoint> matched = entryPointManager.findAllByEnvironmentId(domain.getReferenceId()).stream()
-                .filter(entrypoint -> sameOrigin(entrypoint.getUrl(), requestOrigin))
-                .min(Comparator.comparing(Entrypoint::getUrl));
-        if (matched.isEmpty()) {
-            // Either a forged host or an entrypoint the environment never synced, and the two look the
-            // same from here. Worth saying out loud, because the fallback link silently differs from
-            // the host the user is on.
-            log.warn("Environment {} has no entrypoint matching the request origin, building URLs from the configured entrypoint instead", domain.getReferenceId());
-        }
-        return matched;
-    }
-
-    private static boolean sameOrigin(String entrypointUrl, String requestOrigin) {
-        if (entrypointUrl == null) {
-            return false;
-        }
-        URI entrypointUri = toUri(stripTrailingSlash(entrypointUrl));
-        URI requestUri = toUri(stripTrailingSlash(requestOrigin));
-        if (entrypointUri == null || requestUri == null) {
-            return false;
-        }
-        return UriBuilder.sameOriginAuthority(entrypointUri, requestUri);
-    }
-
-    private static URI toUri(String url) {
-        try {
-            return URI.create(url);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
-    }
-
-    private static String stripTrailingSlash(String url) {
-        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainDataPlaneTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainDataPlaneTest.java
@@ -15,39 +15,130 @@
  */
 package io.gravitee.am.service;
 
-import io.gravitee.am.dataplane.api.DataPlane;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.login.WebAuthnSettings;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import javax.xml.crypto.Data;
+import java.util.List;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-public class DomainDataPlaneTest {
+class DomainDataPlaneTest {
+    private static final String ENVIRONMENT_ID = "env#1";
+    private static final DataPlaneDescription DESCRIPTION = new DataPlaneDescription("id", "name", "jdbc", "base", "http://gravitee.io");
+
+    private final EntryPointManager entryPointManager = mock();
+
+    @BeforeEach
+    public void init() {
+        when(entryPointManager.resolveForRequest(any(), any())).thenCallRealMethod();
+    }
 
     @Test
     public void if_webauthn_settings_is_empty_should_return_gateway_url_from_dataplane() {
-        Domain domain = new Domain();
-        DataPlaneDescription desc = new DataPlaneDescription("id", "name", "jdbc", "base", "http://gravitee.io");
-        DomainDataPlane domainDataPlane = new DomainDataPlane(domain, desc);
-        String webAuthnOrigin = domainDataPlane.getWebAuthnOrigin();
+        DomainDataPlane domainDataPlane = standalone(new Domain());
 
-        assertEquals("http://gravitee.io", webAuthnOrigin);
+        assertEquals("http://gravitee.io", domainDataPlane.getWebAuthnOrigin(null));
     }
 
     @Test
     public void should_return_webauthn_origin_if_its_present() {
-        Domain domain = new Domain();
-        WebAuthnSettings webAuthnSettings = new WebAuthnSettings();
-        webAuthnSettings.setOrigin("http://gravitee2.io");
-        domain.setWebAuthnSettings(webAuthnSettings);
-        DataPlaneDescription desc = new DataPlaneDescription("id", "name", "jdbc", "base", "http://gravitee.io");
-        DomainDataPlane domainDataPlane = new DomainDataPlane(domain, desc);
-        String webAuthnOrigin = domainDataPlane.getWebAuthnOrigin();
+        DomainDataPlane domainDataPlane = standalone(withConfiguredOrigin(new Domain(), "http://gravitee2.io"));
 
-        assertEquals("http://gravitee2.io", webAuthnOrigin);
+        assertEquals("http://gravitee2.io", domainDataPlane.getWebAuthnOrigin(null));
     }
 
+    @Test
+    public void should_ignore_the_entrypoints_outside_managed_cloud() {
+        DomainDataPlane domainDataPlane = standalone(cloudDomain());
+
+        assertEquals("http://gravitee.io", domainDataPlane.getWebAuthnOrigin("https://custom.acme.com"));
+        verifyNoInteractions(entryPointManager);
+    }
+
+    @Test
+    public void should_return_the_primary_entrypoint_in_managed_cloud() {
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
+
+        assertEquals("https://auth.acme.com", managedCloud(cloudDomain()).getWebAuthnOrigin(null));
+    }
+
+    @Test
+    public void should_prefer_the_entrypoint_the_request_came_in_on() {
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(List.of(entrypoint("https://auth.acme.com"), entrypoint("https://custom.acme.com")));
+
+        assertEquals("https://custom.acme.com", managedCloud(cloudDomain()).getWebAuthnOrigin("https://custom.acme.com"));
+    }
+
+    @Test
+    public void should_fall_back_to_the_primary_entrypoint_when_the_request_origin_is_unknown() {
+        when(entryPointManager.findAllByEnvironmentId(ENVIRONMENT_ID)).thenReturn(List.of(entrypoint("https://auth.acme.com")));
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
+
+        assertEquals("https://auth.acme.com", managedCloud(cloudDomain()).getWebAuthnOrigin("https://evil.example"));
+    }
+
+    @Test
+    public void the_entrypoint_beats_a_configured_origin_in_managed_cloud() {
+        Domain domain = withConfiguredOrigin(cloudDomain(), "https://stale.acme.com");
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
+
+        assertEquals("https://auth.acme.com", managedCloud(domain).getWebAuthnOrigin(null));
+    }
+
+    @Test
+    public void should_cut_the_entrypoint_back_to_an_origin() {
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com:8443/some/path/")));
+
+        assertEquals("https://auth.acme.com:8443", managedCloud(cloudDomain()).getWebAuthnOrigin(null));
+    }
+
+    @Test
+    public void should_fall_back_to_the_gateway_url_when_the_environment_has_no_entrypoint() {
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
+
+        assertEquals("http://gravitee.io", managedCloud(cloudDomain()).getWebAuthnOrigin(null));
+    }
+
+    @Test
+    public void should_fall_back_to_the_gateway_url_when_the_domain_has_no_environment() {
+        assertEquals("http://gravitee.io", managedCloud(new Domain()).getWebAuthnOrigin(null));
+        verifyNoInteractions(entryPointManager);
+    }
+
+    private DomainDataPlane standalone(Domain domain) {
+        return new DomainDataPlane(domain, DESCRIPTION, entryPointManager, false);
+    }
+
+    private DomainDataPlane managedCloud(Domain domain) {
+        return new DomainDataPlane(domain, DESCRIPTION, entryPointManager, true);
+    }
+
+    private static Domain cloudDomain() {
+        Domain domain = new Domain();
+        domain.setReferenceId(ENVIRONMENT_ID);
+        return domain;
+    }
+
+    private static Domain withConfiguredOrigin(Domain domain, String origin) {
+        WebAuthnSettings webAuthnSettings = new WebAuthnSettings();
+        webAuthnSettings.setOrigin(origin);
+        domain.setWebAuthnSettings(webAuthnSettings);
+        return domain;
+    }
+
+    private static Entrypoint entrypoint(String url) {
+        Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setUrl(url);
+        return entrypoint;
+    }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainDataPlaneTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainDataPlaneTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -113,6 +114,24 @@ class DomainDataPlaneTest {
     public void should_fall_back_to_the_gateway_url_when_the_domain_has_no_environment() {
         assertEquals("http://gravitee.io", managedCloud(new Domain()).getWebAuthnOrigin(null));
         verifyNoInteractions(entryPointManager);
+    }
+
+    @Test
+    public void the_entrypoint_origin_is_empty_whenever_the_origin_did_not_come_from_one() {
+        // Callers deriving a relying party id key off this: a fallback origin must not produce one, or a
+        // domain that configured its own relying party id would have it replaced by the origin's host.
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
+
+        assertTrue(standalone(cloudDomain()).getWebAuthnEntrypointOrigin(null).isEmpty());
+        assertTrue(managedCloud(new Domain()).getWebAuthnEntrypointOrigin(null).isEmpty());
+        assertTrue(managedCloud(cloudDomain()).getWebAuthnEntrypointOrigin(null).isEmpty());
+    }
+
+    @Test
+    public void the_entrypoint_origin_is_present_when_the_environment_resolves_one() {
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://auth.acme.com")));
+
+        assertEquals(Optional.of("https://auth.acme.com"), managedCloud(cloudDomain()).getWebAuthnEntrypointOrigin(null));
     }
 
     private DomainDataPlane standalone(Domain domain) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainDataPlaneTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DomainDataPlaneTest.java
@@ -104,6 +104,15 @@ class DomainDataPlaneTest {
     }
 
     @Test
+    public void should_serialize_the_entrypoint_origin_the_way_the_browser_does() {
+        // Vert.x compares this against clientDataJSON.origin by string equality, and the browser sends
+        // neither the scheme's default port nor the casing the entrypoint was stored with.
+        when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.of(entrypoint("https://Auth.Acme.com:443/")));
+
+        assertEquals("https://auth.acme.com", managedCloud(cloudDomain()).getWebAuthnOrigin(null));
+    }
+
+    @Test
     public void should_fall_back_to_the_gateway_url_when_the_environment_has_no_entrypoint() {
         when(entryPointManager.findPrimaryByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Optional.empty());
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
@@ -335,4 +335,64 @@ public class AbstractEntryPointManagerTest {
 
         assertEquals("https://a.gravitee.io", cut.findPrimaryByEnvironmentId("env#1").orElseThrow().getUrl());
     }
+
+    @Test
+    public void shouldResolveForRequestFromTheEntrypointTheCallerArrivedOn() throws Exception {
+        cache(generatedEntrypoint("generated", "env#1", "https://generated.gravitee.io"),
+                overridingEntrypoint("overriding", "env#1", "https://custom.acme.com"));
+
+        assertEquals("generated", cut.resolveForRequest("env#1", "https://generated.gravitee.io").orElseThrow().getId());
+    }
+
+    @Test
+    public void shouldResolveForRequestIgnoringCaseTrailingSlashAndDefaultPort() throws Exception {
+        // The match has to be the entrypoint the primary would not have picked, otherwise the assertion
+        // passes on the fallback.
+        cache(generatedEntrypoint("generated", "env#1", "https://Custom.Acme.com:443/"),
+                overridingEntrypoint("overriding", "env#1", "https://other.acme.com"));
+
+        assertEquals("generated", cut.resolveForRequest("env#1", "https://custom.acme.com").orElseThrow().getId());
+    }
+
+    @Test
+    public void shouldResolveForRequestFromTheLowestUrlWhenSeveralEntrypointsShareAnOrigin() throws Exception {
+        cache(generatedEntrypoint("generated-z", "env#1", "https://custom.acme.com/z"),
+                generatedEntrypoint("generated-a", "env#1", "https://custom.acme.com/a"),
+                overridingEntrypoint("overriding", "env#1", "https://other.acme.com"));
+
+        assertEquals("generated-a", cut.resolveForRequest("env#1", "https://custom.acme.com").orElseThrow().getId());
+    }
+
+    @Test
+    public void shouldResolveForRequestFallingBackToPrimaryWhenTheOriginIsUnknown() throws Exception {
+        cache(overridingEntrypoint("overriding", "env#1", "https://custom.acme.com"),
+                generatedEntrypoint("generated", "env#1", "https://generated.gravitee.io"));
+
+        assertEquals("overriding", cut.resolveForRequest("env#1", "https://evil.example").orElseThrow().getId());
+    }
+
+    @Test
+    public void shouldResolveForRequestFallingBackToPrimaryWithoutARequestOrigin() throws Exception {
+        cache(overridingEntrypoint("overriding", "env#1", "https://custom.acme.com"),
+                generatedEntrypoint("generated", "env#1", "https://generated.gravitee.io"));
+
+        assertEquals("overriding", cut.resolveForRequest("env#1", null).orElseThrow().getId());
+        assertEquals("overriding", cut.resolveForRequest("env#1", "   ").orElseThrow().getId());
+    }
+
+    @Test
+    public void shouldResolveForRequestRejectingAnOriginOnADifferentSchemeOrPort() throws Exception {
+        cache(generatedEntrypoint("generated", "env#1", "https://custom.acme.com:8443"),
+                overridingEntrypoint("overriding", "env#1", "https://other.acme.com"));
+
+        assertEquals("overriding", cut.resolveForRequest("env#1", "http://custom.acme.com:8443").orElseThrow().getId());
+        assertEquals("overriding", cut.resolveForRequest("env#1", "https://custom.acme.com").orElseThrow().getId());
+    }
+
+    @Test
+    public void shouldResolveNothingForRequestWhenEnvironmentHasNoEntrypoint() throws Exception {
+        cache(generatedEntrypoint("other-env-generated", "env#other", "https://other.gravitee.io"));
+
+        assertTrue(cut.resolveForRequest("env#1", "https://other.gravitee.io").isEmpty());
+    }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/application/DomainReadServiceImplTest.java
@@ -56,6 +56,9 @@ class DomainReadServiceImplTest {
     @BeforeEach
     public void init() {
         when(dataPlaneRegistry.getDescription(any())).thenReturn(new DataPlaneDescription("default", "Legcay DataPlane", "mongo", "baseProp", "http://localhost:8092"));
+        // resolveForRequest is a default method carrying the origin matching itself, so the cases below
+        // exercise it for real off the findAll/findPrimary stubs rather than a canned Optional.
+        when(entryPointManager.resolveForRequest(any(), any())).thenCallRealMethod();
     }
 
     @Test

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-webauthn-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-webauthn-fixture.ts
@@ -24,6 +24,8 @@ import { uniqueName } from '@utils-commands/misc';
 const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
 const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 const REDIRECT_URI = 'https://callback.example.com';
+const PATH_LOGIN_CREDENTIALS = '/webauthn/login/credentials';
+const CONFIGURED_RELYING_PARTY_ID = 'configured.example.com';
 
 const urlFor = (host: string) => `https://${host}`;
 
@@ -37,24 +39,29 @@ export interface CloudWebAuthnFixture {
   overridingHost: string;
   /** A globally-unique gateway host, safe to reuse across parallel runs. */
   uniqueHost: () => string;
+  /** The relying party id the second domain configured for itself. */
+  configuredRelyingPartyId: string;
   /**
    * Assertion options from POST /webauthn/login/credentials, optionally as seen from a given host.
    * The registration endpoint carries the same relying party id but demands an authenticated session,
    * so it is left to the unit tests.
    */
   assertionOptions: (forwardedHost?: string) => Promise<any>;
+  /** As {@link assertionOptions}, for the domain that configured its own relying party id. */
+  configuredAssertionOptions: (forwardedHost?: string) => Promise<any>;
   /** Re-issue the ENVIRONMENT command with a new set of gateway access points. */
   resyncAccessPoints: (hosts: { generated: string; overriding: string }) => Promise<void>;
   cleanup: () => Promise<void>;
 }
 
 /**
- * A managed-cloud environment with two gateway access points and a passwordless domain deployed in it,
+ * A managed-cloud environment with two gateway access points and two passwordless domains deployed in it,
  * so the relying party the gateway advertises can be observed per request.
  * <p>
- * The domain's own WebAuthn settings are deliberately seeded with the wrong host: in cloud the
- * environment entrypoint has to win over them, and a domain with nothing configured would pass the
- * assertions for the wrong reason.
+ * Both domains seed a deliberately wrong origin, so the environment entrypoint has to be what wins and a
+ * domain with nothing configured cannot pass the assertions for the wrong reason. They differ in the one
+ * thing under test: the first leaves the relying party id unset for the entrypoint to supply, the second
+ * sets its own and must keep it.
  *
  * Managed-cloud stack only (local-stack.sh --cloud).
  */
@@ -93,71 +100,90 @@ export const setupCloudWebAuthnFixture = async (accessToken: string): Promise<Cl
 
   await resyncAccessPoints({ generated: generatedHost, overriding: overridingHost });
 
+  const domainApi = getDomainApi(accessToken);
+  const gatewayUrl = process.env.AM_GATEWAY_URL;
+
   // Passwordless and the WebAuthn settings go on before the domain starts, so the initial sync picks
   // everything up in one pass and no patch lands on a running domain.
-  const domainApi = getDomainApi(accessToken);
-  const domain = await domainApi.createDomain({
-    organizationId,
-    environmentId,
-    newDomain: { name: uniqueName('wa-entrypoint-domain', true), dataPlaneId: DATA_PLANE_ID },
-  });
-  await domainApi.patchDomain({
-    organizationId,
-    environmentId,
-    domain: domain.id,
-    patchDomain: {
-      loginSettings: { inherited: false, passwordlessEnabled: true },
-      webAuthnSettings: { origin: 'http://localhost:8092', relyingPartyId: 'localhost', relyingPartyName: 'AM7231' },
-    },
-  });
+  const passwordlessDomain = async (namePrefix: string, webAuthnSettings: Record<string, string>) => {
+    const domain = await domainApi.createDomain({
+      organizationId,
+      environmentId,
+      newDomain: { name: uniqueName(namePrefix, true), dataPlaneId: DATA_PLANE_ID },
+    });
+    await domainApi.patchDomain({
+      organizationId,
+      environmentId,
+      domain: domain.id,
+      patchDomain: { loginSettings: { inherited: false, passwordlessEnabled: true }, webAuthnSettings },
+    });
 
-  // Through the API directly rather than createTestApp: that helper hardcodes the default
-  // organization/environment, and this domain lives in the environment Cockpit just provisioned.
-  const clientId = uniqueName('wa-entrypoint-app', true);
-  const application = await getApplicationApi(accessToken).createApplication({
-    organizationId,
-    environmentId,
-    domain: domain.id,
-    newApplication: { name: clientId, type: 'WEB', clientId, redirectUris: [REDIRECT_URI] },
-  });
+    // Through the API directly rather than createTestApp: that helper hardcodes the default
+    // organization/environment, and this domain lives in the environment Cockpit just provisioned.
+    const clientId = uniqueName(`${namePrefix}-app`, true);
+    const application = await getApplicationApi(accessToken).createApplication({
+      organizationId,
+      environmentId,
+      domain: domain.id,
+      newApplication: { name: clientId, type: 'WEB', clientId, redirectUris: [REDIRECT_URI] },
+    });
 
-  await domainApi.patchDomain({ organizationId, environmentId, domain: domain.id, patchDomain: { enabled: true } });
-  // waitForDomainStart, not waitForDomainReady: the latter only reports sync, and the gateway rebuilds its
-  // routes asynchronously after that, so the first request can land in a 404 window.
-  await waitForDomainStart(domain);
+    await domainApi.patchDomain({ organizationId, environmentId, domain: domain.id, patchDomain: { enabled: true } });
+    // waitForDomainStart, not waitForDomainReady: the latter only reports sync, and the gateway rebuilds its
+    // routes asynchronously after that, so the first request can land in a 404 window.
+    await waitForDomainStart(domain);
 
-  const gatewayUrl = process.env.AM_GATEWAY_URL;
-  const options = async (path: string, body: any, forwardedHost?: string) => {
-    // X-Forwarded-Host rather than Host: supertest owns the Host header, and the gateway resolves the
-    // public origin from the forwarding headers first anyway.
-    const headers = {
-      'Content-Type': 'application/json',
-      ...(forwardedHost ? { 'X-Forwarded-Host': forwardedHost, 'X-Forwarded-Proto': 'https' } : {}),
+    const assertionOptions = async (forwardedHost?: string) => {
+      // X-Forwarded-Host rather than Host: supertest owns the Host header, and the gateway resolves the
+      // public origin from the forwarding headers first anyway.
+      const headers = {
+        'Content-Type': 'application/json',
+        ...(forwardedHost ? { 'X-Forwarded-Host': forwardedHost, 'X-Forwarded-Proto': 'https' } : {}),
+      };
+      const response = await performPost(
+        gatewayUrl,
+        `/${domain.hrid}${PATH_LOGIN_CREDENTIALS}?client_id=${application.settings.oauth.clientId}`,
+        { name: uniqueName('wa-user', true) },
+        headers,
+      );
+      if (response.status !== 200) {
+        throw new Error(`${PATH_LOGIN_CREDENTIALS} returned ${response.status}: ${response.text}`);
+      }
+      return JSON.parse(response.text);
     };
-    const response = await performPost(
-      gatewayUrl,
-      `/${domain.hrid}${path}?client_id=${application.settings.oauth.clientId}`,
-      body,
-      headers,
-    );
-    if (response.status !== 200) {
-      throw new Error(`${path} returned ${response.status}: ${response.text}`);
-    }
-    return JSON.parse(response.text);
+
+    return { domain, assertionOptions };
   };
+
+  // Origin deliberately wrong and no relying party id at all, so the entrypoint is the only thing that can
+  // supply one and a passing assertion cannot mean "it was already right".
+  const derived = await passwordlessDomain('wa-entrypoint-domain', {
+    origin: 'http://localhost:8092',
+    relyingPartyName: 'AM7231',
+  });
+
+  // A relying party id the domain set deliberately. Credentials are bound to it, so the entrypoint must
+  // leave it alone or every already-registered authenticator stops offering them.
+  const configured = await passwordlessDomain('wa-configured-domain', {
+    origin: 'http://localhost:8092',
+    relyingPartyId: CONFIGURED_RELYING_PARTY_ID,
+    relyingPartyName: 'AM7231',
+  });
 
   // The entrypoints this fixture provisions are deliberately left behind: AM-7228 makes them read-only
   // in a managed installation, so deleting them can only ever return 400. The hosts are unique per run.
   const cleanup = async () => {
-    await domainApi
-      .deleteDomain({ organizationId, environmentId, domain: domain.id })
-      .catch((e) => console.warn(`cleanup: failed to delete domain ${domain.id}: ${e.message}`));
+    for (const { domain } of [derived, configured]) {
+      await domainApi
+        .deleteDomain({ organizationId, environmentId, domain: domain.id })
+        .catch((e) => console.warn(`cleanup: failed to delete domain ${domain.id}: ${e.message}`));
+    }
   };
 
   return {
     organizationId,
     environmentId,
-    domainId: domain.id,
+    domainId: derived.domain.id,
     get generatedHost() {
       return generatedHost;
     },
@@ -165,8 +191,9 @@ export const setupCloudWebAuthnFixture = async (accessToken: string): Promise<Cl
       return overridingHost;
     },
     uniqueHost,
-    assertionOptions: (forwardedHost?: string) =>
-      options('/webauthn/login/credentials', { name: uniqueName('wa-user', true) }, forwardedHost),
+    configuredRelyingPartyId: CONFIGURED_RELYING_PARTY_ID,
+    assertionOptions: derived.assertionOptions,
+    configuredAssertionOptions: configured.assertionOptions,
     resyncAccessPoints,
     cleanup,
   };

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-webauthn-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-webauthn-fixture.ts
@@ -15,7 +15,7 @@
  */
 
 import { getApplicationApi, getDomainApi, getEntrypointsApi } from '@management-commands/service/utils';
-import { waitForDomainReady } from '@gateway-commands/monitoring-commands';
+import { waitForDomainStart } from '@management-commands/domain-management-commands';
 import { performPost } from '@gateway-commands/oauth-oidc-commands';
 import { sendCockpitCommand } from '@cloud-commands/cockpit-commands';
 import { retryUntil } from '@utils-commands/retry';
@@ -61,7 +61,9 @@ export interface CloudWebAuthnFixture {
 export const setupCloudWebAuthnFixture = async (accessToken: string): Promise<CloudWebAuthnFixture> => {
   const organizationId = process.env.AM_DEF_ORG_ID;
   const environmentId = uniqueName('env-wa', true);
-  const uniqueHost = () => `${uniqueName('gw', true)}.example.com`;
+  // Lowercased: uniqueName capitalises a word, and a host is case-insensitive, so the browser lowercases
+  // it when it parses the origin. The relying party id has to match that, not the stored spelling.
+  const uniqueHost = () => `${uniqueName('gw', true)}.example.com`.toLowerCase();
 
   let generatedHost = uniqueHost();
   let overridingHost = uniqueHost();
@@ -120,7 +122,9 @@ export const setupCloudWebAuthnFixture = async (accessToken: string): Promise<Cl
   });
 
   await domainApi.patchDomain({ organizationId, environmentId, domain: domain.id, patchDomain: { enabled: true } });
-  await waitForDomainReady(domain.id);
+  // waitForDomainStart, not waitForDomainReady: the latter only reports sync, and the gateway rebuilds its
+  // routes asynchronously after that, so the first request can land in a 404 window.
+  await waitForDomainStart(domain);
 
   const gatewayUrl = process.env.AM_GATEWAY_URL;
   const options = async (path: string, body: any, forwardedHost?: string) => {

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-webauthn-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-webauthn-fixture.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getApplicationApi, getDomainApi, getEntrypointsApi } from '@management-commands/service/utils';
+import { waitForDomainReady } from '@gateway-commands/monitoring-commands';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { sendCockpitCommand } from '@cloud-commands/cockpit-commands';
+import { retryUntil } from '@utils-commands/retry';
+import { uniqueName } from '@utils-commands/misc';
+
+const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
+const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
+const REDIRECT_URI = 'https://callback.example.com';
+
+const urlFor = (host: string) => `https://${host}`;
+
+export interface CloudWebAuthnFixture {
+  organizationId: string;
+  environmentId: string;
+  domainId: string;
+  /** Cockpit's own access point for this environment. */
+  generatedHost: string;
+  /** The customer's overriding access point, which entrypoint resolution prefers. */
+  overridingHost: string;
+  /** A globally-unique gateway host, safe to reuse across parallel runs. */
+  uniqueHost: () => string;
+  /**
+   * Assertion options from POST /webauthn/login/credentials, optionally as seen from a given host.
+   * The registration endpoint carries the same relying party id but demands an authenticated session,
+   * so it is left to the unit tests.
+   */
+  assertionOptions: (forwardedHost?: string) => Promise<any>;
+  /** Re-issue the ENVIRONMENT command with a new set of gateway access points. */
+  resyncAccessPoints: (hosts: { generated: string; overriding: string }) => Promise<void>;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * A managed-cloud environment with two gateway access points and a passwordless domain deployed in it,
+ * so the relying party the gateway advertises can be observed per request.
+ * <p>
+ * The domain's own WebAuthn settings are deliberately seeded with the wrong host: in cloud the
+ * environment entrypoint has to win over them, and a domain with nothing configured would pass the
+ * assertions for the wrong reason.
+ *
+ * Managed-cloud stack only (local-stack.sh --cloud).
+ */
+export const setupCloudWebAuthnFixture = async (accessToken: string): Promise<CloudWebAuthnFixture> => {
+  const organizationId = process.env.AM_DEF_ORG_ID;
+  const environmentId = uniqueName('env-wa', true);
+  const uniqueHost = () => `${uniqueName('gw', true)}.example.com`;
+
+  let generatedHost = uniqueHost();
+  let overridingHost = uniqueHost();
+
+  const resyncAccessPoints = async (hosts: { generated: string; overriding: string }): Promise<void> => {
+    generatedHost = hosts.generated;
+    overridingHost = hosts.overriding;
+    await sendCockpitCommand({
+      type: 'ENVIRONMENT',
+      payload: {
+        id: environmentId,
+        organizationId,
+        hrids: [environmentId],
+        name: 'AM7231 cloud webauthn env',
+        accessPoints: [
+          { target: 'GATEWAY', host: generatedHost, overriding: false },
+          { target: 'GATEWAY', host: overridingHost, overriding: true },
+        ],
+      },
+    });
+    await retryUntil(
+      () => getEntrypointsApi(accessToken).listEntrypoints({ organizationId }),
+      (entrypoints: any[]) => [generatedHost, overridingHost].every((host) => entrypoints.some((e) => e.url === urlFor(host))),
+      POLL,
+    );
+  };
+
+  await resyncAccessPoints({ generated: generatedHost, overriding: overridingHost });
+
+  // Passwordless and the WebAuthn settings go on before the domain starts, so the initial sync picks
+  // everything up in one pass and no patch lands on a running domain.
+  const domainApi = getDomainApi(accessToken);
+  const domain = await domainApi.createDomain({
+    organizationId,
+    environmentId,
+    newDomain: { name: uniqueName('wa-entrypoint-domain', true), dataPlaneId: DATA_PLANE_ID },
+  });
+  await domainApi.patchDomain({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    patchDomain: {
+      loginSettings: { inherited: false, passwordlessEnabled: true },
+      webAuthnSettings: { origin: 'http://localhost:8092', relyingPartyId: 'localhost', relyingPartyName: 'AM7231' },
+    },
+  });
+
+  // Through the API directly rather than createTestApp: that helper hardcodes the default
+  // organization/environment, and this domain lives in the environment Cockpit just provisioned.
+  const clientId = uniqueName('wa-entrypoint-app', true);
+  const application = await getApplicationApi(accessToken).createApplication({
+    organizationId,
+    environmentId,
+    domain: domain.id,
+    newApplication: { name: clientId, type: 'WEB', clientId, redirectUris: [REDIRECT_URI] },
+  });
+
+  await domainApi.patchDomain({ organizationId, environmentId, domain: domain.id, patchDomain: { enabled: true } });
+  await waitForDomainReady(domain.id);
+
+  const gatewayUrl = process.env.AM_GATEWAY_URL;
+  const options = async (path: string, body: any, forwardedHost?: string) => {
+    // X-Forwarded-Host rather than Host: supertest owns the Host header, and the gateway resolves the
+    // public origin from the forwarding headers first anyway.
+    const headers = {
+      'Content-Type': 'application/json',
+      ...(forwardedHost ? { 'X-Forwarded-Host': forwardedHost, 'X-Forwarded-Proto': 'https' } : {}),
+    };
+    const response = await performPost(
+      gatewayUrl,
+      `/${domain.hrid}${path}?client_id=${application.settings.oauth.clientId}`,
+      body,
+      headers,
+    );
+    if (response.status !== 200) {
+      throw new Error(`${path} returned ${response.status}: ${response.text}`);
+    }
+    return JSON.parse(response.text);
+  };
+
+  // The entrypoints this fixture provisions are deliberately left behind: AM-7228 makes them read-only
+  // in a managed installation, so deleting them can only ever return 400. The hosts are unique per run.
+  const cleanup = async () => {
+    await domainApi
+      .deleteDomain({ organizationId, environmentId, domain: domain.id })
+      .catch((e) => console.warn(`cleanup: failed to delete domain ${domain.id}: ${e.message}`));
+  };
+
+  return {
+    organizationId,
+    environmentId,
+    domainId: domain.id,
+    get generatedHost() {
+      return generatedHost;
+    },
+    get overridingHost() {
+      return overridingHost;
+    },
+    uniqueHost,
+    assertionOptions: (forwardedHost?: string) =>
+      options('/webauthn/login/credentials', { name: uniqueName('wa-user', true) }, forwardedHost),
+    resyncAccessPoints,
+    cleanup,
+  };
+};

--- a/gravitee-am-test/specs/cloud/webauthn-entrypoint-origin.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/webauthn-entrypoint-origin.jest.spec.ts
@@ -29,8 +29,9 @@ setup(200000);
  * origin is only compared server-side during verification and needs a real authenticator, so these
  * assert on the relying party id the gateway hands the browser, which travels with it.
  *
- * The fixture's domain deliberately has origin/relyingPartyId set to localhost, so a passing assertion
- * can only mean the entrypoint overrode them.
+ * The fixture's domains deliberately point their origin at localhost, so a passing assertion can only
+ * mean the entrypoint overrode it. A relying party id the domain set for itself is the exception: that
+ * one has to survive, because existing credentials are bound to it.
  */
 describe('AM - Cloud - webauthn relying party from the environment entrypoint', () => {
   let accessToken: string;
@@ -64,6 +65,15 @@ describe('AM - Cloud - webauthn relying party from the environment entrypoint', 
     const options = await fixture.assertionOptions('forged.example.com');
 
     expect(options.rpId).toEqual(fixture.overridingHost);
+  });
+
+  it('leaves a relying party id the domain configured for itself alone', async () => {
+    // Credentials are bound to the relying party id they were registered under, so overriding a
+    // deliberate one — typically a parent domain covering several subdomains — would orphan every
+    // credential a customer already has.
+    const options = await fixture.configuredAssertionOptions();
+
+    expect(options.rpId).toEqual(fixture.configuredRelyingPartyId);
   });
 
   it('picks up re-synced access points without redeploying the domain', async () => {

--- a/gravitee-am-test/specs/cloud/webauthn-entrypoint-origin.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/webauthn-entrypoint-origin.jest.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { waitForCockpitConnection } from '@cloud-commands/cockpit-commands';
+import { retryUntil } from '@utils-commands/retry';
+import { setup } from '../test-fixture';
+import { CloudWebAuthnFixture, setupCloudWebAuthnFixture } from './fixtures/cloud-webauthn-fixture';
+
+setup(200000);
+
+/**
+ * In managed cloud the browser reaches the gateway on the environment's entrypoint, so that host, not
+ * gateway.url and not the domain's own WebAuthn settings, is what the ceremony has to be scoped to. The
+ * origin is only compared server-side during verification and needs a real authenticator, so these
+ * assert on the relying party id the gateway hands the browser, which travels with it.
+ *
+ * The fixture's domain deliberately has origin/relyingPartyId set to localhost, so a passing assertion
+ * can only mean the entrypoint overrode them.
+ */
+describe('AM - Cloud - webauthn relying party from the environment entrypoint', () => {
+  let accessToken: string;
+  let fixture: CloudWebAuthnFixture;
+
+  beforeAll(async () => {
+    accessToken = await requestAdminAccessToken();
+    await waitForCockpitConnection();
+    fixture = await setupCloudWebAuthnFixture(accessToken);
+  });
+
+  afterAll(async () => {
+    await fixture?.cleanup();
+  });
+
+  it('scopes the ceremony to the environment entrypoint rather than the configured localhost', async () => {
+    const options = await fixture.assertionOptions();
+
+    expect(options.rpId).toEqual(fixture.overridingHost);
+  });
+
+  it('follows the entrypoint the request actually came in on', async () => {
+    const options = await fixture.assertionOptions(fixture.generatedHost);
+
+    // The overriding access point is the environment's primary, so answering with the generated one
+    // proves the request host won rather than the fallback.
+    expect(options.rpId).toEqual(fixture.generatedHost);
+  });
+
+  it('falls back to the primary entrypoint for a host the environment never synced', async () => {
+    const options = await fixture.assertionOptions('forged.example.com');
+
+    expect(options.rpId).toEqual(fixture.overridingHost);
+  });
+
+  it('picks up re-synced access points without redeploying the domain', async () => {
+    const generated = fixture.uniqueHost();
+    const overriding = fixture.uniqueHost();
+
+    await fixture.resyncAccessPoints({ generated, overriding });
+
+    // No domain restart in between: the origin is resolved per request, so the gateway's entrypoint
+    // cache update is enough. retryUntil covers the gap between the management API persisting the new
+    // entrypoints and the gateway's cache catching the events.
+    const options = await retryUntil(
+      () => fixture.assertionOptions(),
+      (resolved: any) => resolved.rpId === overriding,
+      { timeoutMillis: 30000, intervalMillis: 1000 },
+    );
+    expect(options.rpId).toEqual(overriding);
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7231

## :pencil2: A description of the changes proposed in the pull request

In managed cloud the browser reaches the gateway on the environment's Cockpit access point, so that's the host a WebAuthn ceremony has to be scoped to. We were using `gateway.url` (or whatever the domain had configured), which is the wrong host, and the relying party id was falling back to `localhost` so the browser rejected the ceremony outright.

Origin and relying party id now both come from the environment entrypoint. Two things worth flagging for review:

It resolves per request rather than once when the domain deploys. A Cockpit ENVIRONMENT resync swaps an environment's entrypoints without redeploying its domains, so anything captured at startup goes stale and stays stale. Same reason the three handlers stopped caching the origin in a constructor field.

An environment with several entrypoints matches the host the request actually came in on, falling back to the primary. WebAuthn compares the origin by exact string against `window.location.origin`, so a fixed pick breaks anyone sitting on the other host. That matching already existed for the AM-7230 email links, so I moved it onto `EntryPointManager` rather than writing a second copy of the "never trust the Host header" bit.

A relying party id the domain set for itself is never overridden. The entrypoint only supplies one when `relyingPartyId` is unset. Credentials are bound to the id they were registered under, so replacing a deliberate one (commonly a parent domain, so a single credential covers several subdomains) would stop every authenticator a customer already has from offering it. See the release note below.

The origin is serialized the way a browser serializes `window.location.origin`, meaning lowercased host and no port when it's the scheme default. Vert.x compares it to `clientDataJSON.origin` with `.equals()`, so an entrypoint stored as `https://Auth.Acme.com` or `https://auth.acme.com:443` would match during entrypoint resolution and then fail verification against the very host it matched.

## :memo: Test scenarios

Unit: `DomainDataPlaneTest` for the resolution order and the browser-style origin serialization, `AbstractEntryPointManagerTest` for the request matching, `UriBuilderTest` for `toOrigin`, `WebAuthnHandlerRelyingPartyTest` for the rpId rewrite including the configured-id guard. `DomainReadServiceImplTest` passes unchanged, which is the net for AM-7230 after the extraction. Email links still carry the entrypoint url verbatim, port and casing included, so nothing there moves.

Jest: new `specs/cloud/webauthn-entrypoint-origin.jest.spec.ts` covers all five behaviours against a real managed cloud gateway, including a resync being picked up with no domain restart and a domain whose configured `relyingPartyId` has to survive. Whole `specs/cloud` suite is green.

Manual: walked it end to end on a `--cloud` stack, which is how I found the rpId bug. Playwright webauthn suite is 18 passed, the 2 failures in `webauthn-mfa-remember-device.spec.ts` are `mock-am-factor not deployed` and fail the same way on master unless you build with `-P ee-bundle,addons-bundle`.

One thing I could not cover automatically: the origin itself is only compared server side during verification so it needs a real authenticator. The rpId travels with it and is observable over HTTP, so that's what the assertions read.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

Not a breaking change for existing credentials, but it is worth a release note because an earlier revision of this PR was.

Domains that set `relyingPartyId` themselves keep it, so their credentials keep working. That guard is the point of the fourth commit and it's what makes this safe to ship.

Domains that never set one were advertising `localhost` in cloud. A browser refuses a ceremony whose rpId isn't a registrable suffix of the page origin, so no credential could ever have been registered there. There's nothing to orphan and those users go from broken to working.

The one case that does change: a domain that left `relyingPartyId` unset but set a custom `origin` whose host isn't the environment entrypoint. That combination was working, and the rpId now moves to the entrypoint host, so those credentials would need registering again. Anyone in that position can pin the old behaviour by setting `relyingPartyId` explicitly to the host they were using before upgrading.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
