### PR TITLE
fix: expose a map of Ttusted issuers in the token exchange settings

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidator.java
@@ -155,9 +155,6 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
     }
 
     private static TrustedIssuer findTrustedIssuer(TokenExchangeSettings settings, String issuer) {
-        return settings.getTrustedIssuers().stream()
-                .filter(ti -> issuer.equals(ti.getIssuer()))
-                .findFirst()
-                .orElse(null);
+        return settings.getMapOfTrustedIssuers().get(issuer);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidatorTest.java
@@ -211,6 +211,7 @@ public class TrustedIssuerTokenValidatorTest {
     public void testTrustedIssuer_success() throws Exception {
         TrustedIssuer ti = createTrustedIssuer();
         when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -251,6 +252,7 @@ public class TrustedIssuerTokenValidatorTest {
     public void testTrustedIssuer_signatureVerificationFails() throws Exception {
         TrustedIssuer ti = createTrustedIssuer();
         when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -277,6 +279,7 @@ public class TrustedIssuerTokenValidatorTest {
         TrustedIssuer ti = createTrustedIssuer();
         ti.setScopeMappings(Map.of("ext:read", "domain:read", "ext:write", "domain:write"));
         when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -313,6 +316,7 @@ public class TrustedIssuerTokenValidatorTest {
     public void testTrustedIssuer_noScopeMapping_passThrough() throws Exception {
         TrustedIssuer ti = createTrustedIssuer();
         when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -347,6 +351,7 @@ public class TrustedIssuerTokenValidatorTest {
     public void testTrustedIssuer_allFieldsCopied() throws Exception {
         TrustedIssuer ti = createTrustedIssuer();
         when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -398,6 +403,7 @@ public class TrustedIssuerTokenValidatorTest {
     public void testTrustedIssuer_expiredToken() throws Exception {
         TrustedIssuer ti = createTrustedIssuer();
         when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -429,6 +435,7 @@ public class TrustedIssuerTokenValidatorTest {
     public void testTrustedIssuer_nullTimestamps() throws Exception {
         TrustedIssuer ti = createTrustedIssuer();
         when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/TokenExchangeSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/TokenExchangeSettings.java
@@ -15,12 +15,20 @@
  */
 package io.gravitee.am.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.am.model.application.TokenExchangeOAuthSettings;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.util.StringUtils;
 
+import java.beans.Transient;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static io.gravitee.am.common.oauth2.TokenType.ACCESS_TOKEN;
 import static io.gravitee.am.common.oauth2.TokenType.ID_TOKEN;
@@ -107,6 +115,13 @@ public class TokenExchangeSettings {
     private List<TrustedIssuer> trustedIssuers;
 
     /**
+     * Map representation of the TrustedIssuer list to each the lookup
+     */
+    @Setter(AccessLevel.NONE)
+    @JsonIgnore
+    private Map<String, TrustedIssuer> mapOfTrustedIssuers = Map.of();
+
+    /**
      * Domain-level default token exchange OAuth settings (e.g. scope handling).
      * Applications can inherit these or override them per-application.
      * Null means use system defaults (DOWNSCOPING).
@@ -140,4 +155,16 @@ public class TokenExchangeSettings {
         this.maxDelegationDepth = Math.max(MIN_MAX_DELEGATION_DEPTH, Math.min(MAX_MAX_DELEGATION_DEPTH, maxDelegationDepth));
     }
 
+    public void setTrustedIssuers(List<TrustedIssuer> trustedIssuers) {
+        this.trustedIssuers = trustedIssuers;
+        if (trustedIssuers != null) {
+            this.mapOfTrustedIssuers = trustedIssuers.stream()
+                    // make sure the issuer has value to avoid "null" in the map
+                    .filter(ti -> StringUtils.hasText(ti.getIssuer()))
+                    // in case of two issuer definitions keep the first one.
+                    .collect(Collectors.toMap(TrustedIssuer::getIssuer, Function.identity(), (issuer1, issuer2) -> issuer1));
+        } else {
+            this.mapOfTrustedIssuers = Map.of();
+        }
+    }
 }


### PR DESCRIPTION
this change is an optimization to allow quick lookup during the token exchange

persistence layer doesn't change, we only compute the map when the object is initialized

fixes AM-7358

