### PR TITLE
fix: reduce redundant iterations when computing login page authorize URLs

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginAuthenticationHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginAuthenticationHandler.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -89,6 +90,7 @@ public class LoginAuthenticationHandler implements Handler<RoutingContext> {
     }
 
     public static final String SOCIAL_AUTHORIZE_URL_CONTEXT_KEY = "authorizeUrls";
+    public static final String SOCIAL_PROVIDER_MAP_CONTEXT_KEY = "socialProvidersById";
     private static final String OAUTH2_PROVIDER_CONTEXT_KEY = "oauth2Providers";
 
     private final IdentityProviderManager identityProviderManager;
@@ -146,14 +148,24 @@ public class LoginAuthenticationHandler implements Handler<RoutingContext> {
                 // put social providers in context data
                 final var socialProviderData = resultHandler.result();
                 if (socialProviderData != null) {
-                    final var filteredSocialProviderData = socialProviderData.stream().filter(providerData -> providerData.getIdentityProvider() != null && providerData.getAuthorizeUrl() != null).collect(Collectors.toList());
-                    final var providers = filteredSocialProviderData.stream().map(SocialProviderData::getIdentityProvider).map(IdentityProvider::asSafeIdentityProvider).collect(Collectors.toList());
-                    Map<String, String> authorizeUrls = filteredSocialProviderData.stream().collect(Collectors.toMap(o -> o.getIdentityProvider().getId(), SocialProviderData::getAuthorizeUrl));
+                    final List<IdentityProvider> providers = new ArrayList<>(socialProviderData.size());
+                    final Map<String, String> authorizeUrls = new HashMap<>();
+                    final Map<String, IdentityProvider> providersById = new HashMap<>();
+                    for (SocialProviderData providerData : socialProviderData) {
+                        final IdentityProvider identityProvider = providerData.getIdentityProvider();
+                        if (identityProvider != null && providerData.getAuthorizeUrl() != null) {
+                            final IdentityProvider safeIdentityProvider = identityProvider.asSafeIdentityProvider();
+                            providers.add(safeIdentityProvider);
+                            authorizeUrls.put(identityProvider.getId(), providerData.getAuthorizeUrl());
+                            providersById.put(safeIdentityProvider.getId(), safeIdentityProvider);
+                        }
+                    }
 
                     // backwards compatibility
                     routingContext.put(OAUTH2_PROVIDER_CONTEXT_KEY, providers);
                     routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, providers);
                     routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, authorizeUrls);
+                    routingContext.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, providersById);
                 }
 
                 // continue

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandler.java
@@ -29,13 +29,12 @@ import io.vertx.rxjava3.ext.web.RoutingContext;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static io.gravitee.am.common.utils.ConstantKeys.REMEMBER_ME_PARAM_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY;
 import static io.gravitee.am.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
 import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginAuthenticationHandler.SOCIAL_PROVIDER_MAP_CONTEXT_KEY;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -59,9 +58,7 @@ public class LoginSelectionRuleHandler extends LoginAbstractHandler  {
         if ((socialProviders != null && !socialProviders.isEmpty())
                 && (client.getIdentityProviders() != null && !client.getIdentityProviders().isEmpty())) {
 
-        var socialProviderMap = socialProviders.stream().collect(Collectors.toMap(
-                    IdentityProvider::getId, Function.identity()
-            ));
+            Map<String, IdentityProvider> socialProviderMap = routingContext.get(SOCIAL_PROVIDER_MAP_CONTEXT_KEY);
 
             var context = new SimpleAuthenticationContext(new VertxHttpServerRequest(routingContext.request().getDelegate()), routingContext.data());
             context.setDomain(domain);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/identifierfirst/IdentifierFirstLoginEndpointTest.java
@@ -54,6 +54,7 @@ import static io.gravitee.am.common.utils.ConstantKeys.SOCIAL_PROVIDER_CONTEXT_K
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.resolveProxyRequest;
 import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginAuthenticationHandler.SOCIAL_PROVIDER_MAP_CONTEXT_KEY;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
@@ -137,6 +138,7 @@ public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
                     final IdentityProvider idp = new IdentityProvider();
                     idp.setId("provider-id");
                     routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+                    routingContext.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, Map.of(idp.getId(), idp));
                     routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
 
                     var identityProviders = new TreeSet<ApplicationIdentityProvider>();
@@ -171,6 +173,7 @@ public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
                     final IdentityProvider idp = new IdentityProvider();
                     idp.setId("provider-id");
                     routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+                    routingContext.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, Map.of(idp.getId(), idp));
                     routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
 
                     var identityProviders = new TreeSet<ApplicationIdentityProvider>();
@@ -204,6 +207,7 @@ public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
                     final IdentityProvider idp = new IdentityProvider();
                     idp.setId("provider-id");
                     routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+                    routingContext.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, Map.of(idp.getId(), idp));
                     routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
 
                     var identityProviders = new TreeSet<ApplicationIdentityProvider>();
@@ -254,6 +258,7 @@ public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
                     final IdentityProvider idp = new IdentityProvider();
                     idp.setId("provider-id");
                     routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+                    routingContext.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, Map.of(idp.getId(), idp));
                     routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "/some/provider/oauth/authorize"));
 
                     routingContext.next();
@@ -280,6 +285,7 @@ public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
                     final IdentityProvider idp = new IdentityProvider();
                     idp.setId("provider-id");
                     routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+                    routingContext.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, Map.of(idp.getId(), idp));
                     routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "https://host/some/provider/oauth/authorize"));
 
                     var identityProviders = new TreeSet<ApplicationIdentityProvider>();
@@ -315,6 +321,7 @@ public class IdentifierFirstLoginEndpointTest extends RxWebTestBase {
                     idp.setId("provider-id");
                     idp.setType("google");
                     routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
+                    routingContext.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, Map.of(idp.getId(), idp));
                     routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "https://host/some/provider/oauth/authorize"));
 
                     var identityProviders = new TreeSet<ApplicationIdentityProvider>();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpointHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/endpoint/login/LoginEndpointHandlerTest.java
@@ -57,6 +57,7 @@ import static io.gravitee.am.common.utils.ConstantKeys.USERNAME_PARAM_KEY;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.resolveProxyRequest;
 import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginAuthenticationHandler.SOCIAL_PROVIDER_MAP_CONTEXT_KEY;
 import static java.lang.Boolean.TRUE;
 import static java.time.temporal.ChronoUnit.DECADES;
 import static org.mockito.Mockito.any;
@@ -185,6 +186,7 @@ public class LoginEndpointHandlerTest extends RxWebTestBase {
                     idp.setId("provider-id");
                     routingContext.put(SOCIAL_PROVIDER_CONTEXT_KEY, List.of(idp));
                     routingContext.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, Map.of(idp.getId(), "https://somewhere/some/provider/oauth/authorize"));
+                    routingContext.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, Map.of(idp.getId(), idp));
                     routingContext.next();
                 })
                 .handler(new LoginHideFormHandler(domain))

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginAuthenticationHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginAuthenticationHandlerTest.java
@@ -38,6 +38,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -139,6 +140,61 @@ public class LoginAuthenticationHandlerTest extends RxWebTestBase {
             Assertions.assertThat(idp).hasSize(1);
             Assertions.assertThat(idp.get(0).getConfiguration()).isNull();
             Assertions.assertThat(rc.data()).doesNotContainKeys(ConstantKeys.INTERNAL_PROVIDER_CONTEXT_KEY);
+
+            Assertions.assertThat(rc.data()).containsKey(LoginAuthenticationHandler.SOCIAL_PROVIDER_MAP_CONTEXT_KEY);
+            Map<String, IdentityProvider> providersById = rc.get(LoginAuthenticationHandler.SOCIAL_PROVIDER_MAP_CONTEXT_KEY);
+            Assertions.assertThat(providersById).hasSize(1).containsKey(identityProvider.getId());
+
+            Assertions.assertThat(rc.data()).containsKey(LoginAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY);
+            Map<String, String> authorizeUrls = rc.get(LoginAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY);
+            Assertions.assertThat(authorizeUrls).hasSize(1).containsKey(identityProvider.getId());
+        });
+
+        testRequest(HttpMethod.GET, RootProvider.PATH_LOGIN, 200, "OK", "completed");
+    }
+
+    @Test
+    public void should_filter_out_social_idp_without_authorize_url_from_all_context_collections() throws Exception {
+        var applicationIdentityProviderWithUrl = new ApplicationIdentityProvider();
+        applicationIdentityProviderWithUrl.setIdentity("idpWithUrl");
+        var identityProviderWithUrl = new IdentityProvider();
+        identityProviderWithUrl.setId(applicationIdentityProviderWithUrl.getIdentity());
+        identityProviderWithUrl.setExternal(true);
+        identityProviderWithUrl.setConfiguration(UUID.randomUUID().toString());
+
+        var applicationIdentityProviderNoUrl = new ApplicationIdentityProvider();
+        applicationIdentityProviderNoUrl.setIdentity("idpNoUrl");
+        var identityProviderNoUrl = new IdentityProvider();
+        identityProviderNoUrl.setId(applicationIdentityProviderNoUrl.getIdentity());
+        identityProviderNoUrl.setExternal(true);
+        identityProviderNoUrl.setConfiguration(UUID.randomUUID().toString());
+
+        when(client.getIdentityProviders()).thenReturn(new TreeSet<>(Set.of(applicationIdentityProviderWithUrl, applicationIdentityProviderNoUrl)));
+        when(identityProviderManager.getIdentityProvider(identityProviderWithUrl.getId())).thenReturn(identityProviderWithUrl);
+        when(identityProviderManager.getIdentityProvider(identityProviderNoUrl.getId())).thenReturn(identityProviderNoUrl);
+
+        final var authProviderWithUrl = Mockito.mock(SocialAuthenticationProvider.class);
+        final var request = new Request();
+        request.setUri(UUID.randomUUID().toString());
+        request.setMethod(io.gravitee.common.http.HttpMethod.GET);
+        when(authProviderWithUrl.asyncSignInUrl(any(), any(), any())).thenReturn(Maybe.just(request));
+        when(identityProviderManager.get(eq(identityProviderWithUrl.getId()))).thenReturn(Maybe.just(authProviderWithUrl));
+
+        final var authProviderNoUrl = Mockito.mock(SocialAuthenticationProvider.class);
+        when(authProviderNoUrl.asyncSignInUrl(any(), any(), any())).thenReturn(Maybe.empty());
+        when(identityProviderManager.get(eq(identityProviderNoUrl.getId()))).thenReturn(Maybe.just(authProviderNoUrl));
+
+        router.route(HttpMethod.GET, RootProvider.PATH_LOGIN);
+
+        assertAfterRequest(rc -> {
+            List<IdentityProvider> idp = rc.get(ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY);
+            Assertions.assertThat(idp).extracting(IdentityProvider::getId).containsExactly(identityProviderWithUrl.getId());
+
+            Map<String, String> authorizeUrls = rc.get(LoginAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY);
+            Assertions.assertThat(authorizeUrls).containsOnlyKeys(identityProviderWithUrl.getId());
+
+            Map<String, IdentityProvider> providersById = rc.get(LoginAuthenticationHandler.SOCIAL_PROVIDER_MAP_CONTEXT_KEY);
+            Assertions.assertThat(providersById).containsOnlyKeys(identityProviderWithUrl.getId());
         });
 
         testRequest(HttpMethod.GET, RootProvider.PATH_LOGIN, 200, "OK", "completed");

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandlerTest.java
@@ -34,6 +34,9 @@ import java.util.TreeSet;
 
 import static io.gravitee.am.common.utils.ConstantKeys.SOCIAL_PROVIDER_CONTEXT_KEY;
 import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginAuthenticationHandler.SOCIAL_AUTHORIZE_URL_CONTEXT_KEY;
+import static io.gravitee.am.gateway.handler.root.resources.handler.login.LoginAuthenticationHandler.SOCIAL_PROVIDER_MAP_CONTEXT_KEY;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -82,6 +85,7 @@ public class LoginSelectionRuleHandlerTest extends RxWebTestBase {
                     rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
                     rc.put(SOCIAL_PROVIDER_CONTEXT_KEY, socialProviders);
                     rc.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, urls);
+                    rc.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY, socialProviders.stream().collect(toMap(IdentityProvider::getId, identity())));
                     rc.next();
                 });
 


### PR DESCRIPTION
## Summary
- On GET `/login`, `LoginAuthenticationHandler` iterated 3 times over the social identity providers (filter + 2 separate map/collect passes) to build the safe provider list and the authorize URL map. This is now a single pass.
- `LoginAuthenticationHandler` now also builds an id -> `IdentityProvider` map in that same pass and stores it in the `RoutingContext` (new local constant `SOCIAL_PROVIDER_MAP_CONTEXT_KEY`), so `LoginSelectionRuleHandler` no longer has to rebuild it via a fresh stream over the social providers list.
- Verified both the normal login (`GET /login`) and identifier-first login (`POST /login/identifier`) handler chains populate/consume the new context key correctly, since `LoginAuthenticationHandler` always runs upstream of `LoginSelectionRuleHandler` on both routes.

Fixes AM-7367.

## Test plan
- [x] Updated/added unit tests in `LoginAuthenticationHandlerTest` (including a new regression test for the provider-without-authorize-url filtering case)
- [x] Updated `LoginSelectionRuleHandlerTest`, `IdentifierFirstLoginEndpointTest`, `LoginEndpointHandlerTest` to seed the new context key
- [x] `mvn test -pl gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core` — 521 tests, 0 failures, 0 errors