### PR TITLE
chore(ci): bump aikido orb in v1.0.3

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -7,7 +7,7 @@ orbs:
   aws-cli: circleci/aws-cli@5.4.2
   aws-s3: circleci/aws-s3@4.1.3
   helm: circleci/helm@2.0.1
-  aikido: gravitee-io/aikido@1.0.1
+  aikido: gravitee-io/aikido@1.0.3
 
 executors:
   ubuntu:


### PR DESCRIPTION
this upgrade allowes to see all tags on aikido dashboard instead of the latest scan
