### PR TITLE
feat: load and register provisioned data planes in the management api

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpoint.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpoint.java
@@ -31,9 +31,6 @@ import lombok.CustomLog;
  * Provisions a data plane definition: {@code POST /_node/dataplanes}. Responds with the
  * credential-free summary.
  *
- * Registering the definition is a separate step from persisting it, because the service deliberately
- * keeps the raw configuration to itself: the loader reads the definition back out of the repository.
- *
  * @author GraviteeSource Team
  */
 @CustomLog

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpoint.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpoint.java
@@ -19,9 +19,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.model.NewDataPlaneDefinition;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Single;
 import io.vertx.ext.web.RoutingContext;
 import lombok.CustomLog;
 
@@ -29,16 +31,23 @@ import lombok.CustomLog;
  * Provisions a data plane definition: {@code POST /_node/dataplanes}. Responds with the
  * credential-free summary.
  *
+ * Registering the definition is a separate step from persisting it, because the service deliberately
+ * keeps the raw configuration to itself: the loader reads the definition back out of the repository.
+ *
  * @author GraviteeSource Team
  */
 @CustomLog
 public class CreateDataPlaneEndpoint extends AbstractInternalApiEndpoint {
 
     private final DataPlaneDefinitionService dataPlaneDefinitionService;
+    private final ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
 
-    public CreateDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService, ObjectMapper objectMapper) {
+    public CreateDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService,
+                                   ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+                                   ObjectMapper objectMapper) {
         super(objectMapper);
         this.dataPlaneDefinitionService = dataPlaneDefinitionService;
+        this.provisionedDataPlaneLoader = provisionedDataPlaneLoader;
     }
 
     @Override
@@ -68,6 +77,7 @@ public class CreateDataPlaneEndpoint extends AbstractInternalApiEndpoint {
         }
 
         dataPlaneDefinitionService.create(payload)
+                .flatMap(summary -> provisionedDataPlaneLoader.register(summary.id()).andThen(Single.just(summary)))
                 .subscribe(
                         summary -> respond(context, HttpStatusCode.CREATED_201, summary),
                         throwable -> respondFailure(context, throwable, "Unable to create the data plane definition"));

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/spring/InternalApiConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/spring/InternalApiConfiguration.java
@@ -22,6 +22,7 @@ import io.gravitee.am.management.handlers.internalapi.endpoints.GetDataPlaneEndp
 import io.gravitee.am.management.handlers.internalapi.InternalApiService;
 import io.gravitee.am.management.handlers.internalapi.endpoints.ListDataPlanesEndpoint;
 import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -35,8 +36,10 @@ import org.springframework.context.annotation.Configuration;
 public class InternalApiConfiguration {
 
     @Bean
-    public CreateDataPlaneEndpoint createDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService, ObjectMapper objectMapper) {
-        return new CreateDataPlaneEndpoint(dataPlaneDefinitionService, objectMapper);
+    public CreateDataPlaneEndpoint createDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService,
+                                                           ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+                                                           ObjectMapper objectMapper) {
+        return new CreateDataPlaneEndpoint(dataPlaneDefinitionService, provisionedDataPlaneLoader, objectMapper);
     }
 
     @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpointTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpointTest.java
@@ -18,11 +18,13 @@ package io.gravitee.am.management.handlers.internalapi.endpoints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.management.handlers.internalapi.endpoints.CreateDataPlaneEndpoint;
 import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.exception.DataPlaneDefinitionAlreadyExistsException;
 import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.model.NewDataPlaneDefinition;
 import io.gravitee.common.http.HttpMethod;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RequestBody;
@@ -75,6 +77,9 @@ class CreateDataPlaneEndpointTest {
     private DataPlaneDefinitionService dataPlaneDefinitionService;
 
     @Mock
+    private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+
+    @Mock
     private RoutingContext routingContext;
 
     @Mock
@@ -89,7 +94,8 @@ class CreateDataPlaneEndpointTest {
         response = mock(HttpServerResponse.class, RETURNS_SELF);
         when(routingContext.body()).thenReturn(requestBody);
         when(routingContext.response()).thenReturn(response);
-        endpoint = new CreateDataPlaneEndpoint(dataPlaneDefinitionService, new ObjectMapper());
+        when(provisionedDataPlaneLoader.register(any())).thenReturn(Completable.complete());
+        endpoint = new CreateDataPlaneEndpoint(dataPlaneDefinitionService, provisionedDataPlaneLoader, new ObjectMapper());
     }
 
     @Test
@@ -138,6 +144,28 @@ class CreateDataPlaneEndpointTest {
         assertThat(payload.getType()).isEqualTo("mongodb");
         assertThat(payload.getGatewayUrl()).isEqualTo("https://gw-acme.cloud.gravitee.io");
         assertThat(payload.getConfiguration().at("/mongodb/dbname").asText()).isEqualTo("gravitee-am-acme");
+    }
+
+    @Test
+    void shouldRegisterTheProvisionedDataPlaneSoItIsUsableWithoutARestart() {
+        when(requestBody.asString()).thenReturn(PAYLOAD);
+        when(dataPlaneDefinitionService.create(any())).thenReturn(Single.just(summary()));
+
+        endpoint.handle(routingContext);
+
+        verify(provisionedDataPlaneLoader).register("dp-acme");
+        verify(response).setStatusCode(201);
+    }
+
+    @Test
+    void shouldNotRegisterADefinitionThatWasNotPersisted() {
+        when(requestBody.asString()).thenReturn(PAYLOAD);
+        when(dataPlaneDefinitionService.create(any()))
+                .thenReturn(Single.error(new DataPlaneDefinitionAlreadyExistsException("dp-acme")));
+
+        endpoint.handle(routingContext);
+
+        verify(provisionedDataPlaneLoader, never()).register(any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/spring/StandaloneConfiguration.java
@@ -47,6 +47,8 @@ import io.gravitee.am.plugins.policy.spring.PolicySpringConfiguration;
 import io.gravitee.am.plugins.reporter.spring.ReporterSpringConfiguration;
 import io.gravitee.am.plugins.resource.spring.ResourceSpringConfiguration;
 import io.gravitee.am.repository.ManagementRepositoryScopeProvider;
+import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.secrets.SecretsConfiguration;
 import io.gravitee.am.service.spring.ServiceConfiguration;
 import io.gravitee.common.event.EventManager;
@@ -67,7 +69,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 
 import java.util.List;
@@ -165,7 +169,14 @@ public class StandaloneConfiguration {
     }
 
     @Bean
-    public DataPlaneRegistry dataPlaneRegistry(MultiDataPlaneLoader loader, DataPlanePluginManager manager) {
+    public ProvisionedDataPlaneLoader provisionedDataPlaneLoader(MultiDataPlaneLoader configurationLoader,
+                                                                @Lazy DataPlaneDefinitionRepository dataPlaneDefinitionRepository,
+                                                                ConfigurableEnvironment environment) {
+        return new ProvisionedDataPlaneLoader(configurationLoader, dataPlaneDefinitionRepository, environment);
+    }
+
+    @Bean
+    public DataPlaneRegistry dataPlaneRegistry(ProvisionedDataPlaneLoader loader, DataPlanePluginManager manager) {
         return new DataPlaneRegistryImpl(loader, manager);
     }
 

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImpl.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImpl.java
@@ -192,7 +192,11 @@ public class DataPlaneRegistryImpl extends AbstractService<DataPlaneRegistryImpl
         if (this.dataPlanProviders.containsKey(description.id())) {
             throw new IllegalStateException("Invalid data plan definition, id must be unique");
         }
-        dataPlanePluginManager.create(description).ifPresent(provider -> this.dataPlanProviders.put(description.id(), provider));
+        // publishing a description without a provider lets a domain bind to a data plane nothing can
+        // serve, and the domain cannot then be deleted: getProviderById is on the deletion path too
+        var provider = dataPlanePluginManager.create(description)
+                .orElseThrow(() -> new IllegalStateException("No data plane provider could be built for id " + description.id()));
+        dataPlanProviders.put(description.id(), provider);
         dataPlanDescriptions.put(description.id(), description);
     }
 }

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/MultiDataPlaneLoader.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/MultiDataPlaneLoader.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -47,20 +46,36 @@ public class MultiDataPlaneLoader implements DataPlaneLoader {
         }
     }
 
+    /**
+     * Whether the configuration declares a data plane under this id. Only the ids are read: a
+     * declaration too broken to describe is the node's problem at startup, not the caller's.
+     */
+    public boolean isDeclared(String id) {
+        for (int i = 0; configuration.containsProperty(propertyBase(i) + ".id"); i++) {
+            if (id.equals(configuration.getProperty(propertyBase(i) + ".id", String.class))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private List<DataPlaneDescription> readList() {
-        Function<Integer, String> propertyResolver = (idx) -> DATA_PLANES_KEY + "[" + idx + "]";
         List<DataPlaneDescription> result = new ArrayList<>();
 
         int i = 0;
-        String base = propertyResolver.apply(i);
+        String base = propertyBase(i);
         while (configuration.containsProperty(base + ".id")) {
             result.add(readSingle(base));
-            base = propertyResolver.apply(++i);
+            base = propertyBase(++i);
         }
         if (result.stream().noneMatch(DataPlaneDescription::isDefault)) {
             throw new IllegalStateException("Default dataPlane is missing");
         }
         return result;
+    }
+
+    private static String propertyBase(int index) {
+        return DATA_PLANES_KEY + "[" + index + "]";
     }
 
     private DataPlaneDescription readSingle(String base) {

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/test/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImplTest.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/test/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImplTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.plugins.dataplane.core;
+
+import io.gravitee.am.dataplane.api.DataPlaneDescription;
+import io.gravitee.am.dataplane.api.DataPlaneProvider;
+import io.gravitee.am.dataplane.exceptions.IllegalDataPlaneIdException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class DataPlaneRegistryImplTest {
+
+    private static final DataPlaneDescription DESCRIPTION =
+            new DataPlaneDescription("dp-1", "name", "jdbc", "dataPlanes.provisioned.dp-1", "https://gw");
+
+    @Mock
+    private DataPlanePluginManager dataPlanePluginManager;
+
+    @Mock
+    private DataPlaneProvider provider;
+
+    private DataPlaneRegistryImpl registry() {
+        return new DataPlaneRegistryImpl(storage -> {}, dataPlanePluginManager);
+    }
+
+    @Test
+    void should_register_a_description_whose_provider_was_built() {
+        when(dataPlanePluginManager.create(DESCRIPTION)).thenReturn(Optional.of(provider));
+        DataPlaneRegistryImpl registry = registry();
+
+        registry.register(DESCRIPTION);
+
+        assertThat(registry.getDataPlanes()).containsExactly(DESCRIPTION);
+        assertThat(registry.getProviderById("dp-1")).isSameAs(provider);
+    }
+
+    @Test
+    void should_not_register_a_description_whose_provider_could_not_be_built() {
+        // otherwise a domain can bind to a data plane nothing can serve, and cannot then be deleted
+        when(dataPlanePluginManager.create(DESCRIPTION)).thenReturn(Optional.empty());
+        DataPlaneRegistryImpl registry = registry();
+
+        assertThatThrownBy(() -> registry.register(DESCRIPTION))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("dp-1");
+
+        assertThat(registry.getDataPlanes()).isEmpty();
+        assertThatThrownBy(() -> registry.getProviderById("dp-1"))
+                .isInstanceOf(IllegalDataPlaneIdException.class);
+    }
+
+    @Test
+    void should_reject_a_second_definition_claiming_a_registered_id() {
+        when(dataPlanePluginManager.create(DESCRIPTION)).thenReturn(Optional.of(provider));
+        DataPlaneRegistryImpl registry = registry();
+        registry.register(DESCRIPTION);
+
+        assertThatThrownBy(() -> registry.register(DESCRIPTION))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_reject_a_definition_with_no_id() {
+        DataPlaneRegistryImpl registry = registry();
+
+        assertThatThrownBy(() -> registry.register(new DataPlaneDescription("", "name", "jdbc", "base", "gw")))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_leave_a_failed_id_free_for_a_later_definition() {
+        when(dataPlanePluginManager.create(DESCRIPTION)).thenReturn(Optional.empty(), Optional.of(provider));
+        DataPlaneRegistryImpl registry = registry();
+        assertThatThrownBy(() -> registry.register(DESCRIPTION)).isInstanceOf(IllegalStateException.class);
+
+        assertThatCode(() -> registry.register(DESCRIPTION)).doesNotThrowAnyException();
+        assertThat(registry.getProviderById("dp-1")).isSameAs(provider);
+    }
+}

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/test/java/io/gravitee/am/plugins/dataplane/core/MultiDataPlaneLoaderTest.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/test/java/io/gravitee/am/plugins/dataplane/core/MultiDataPlaneLoaderTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.plugins.dataplane.core;
+
+import io.gravitee.node.api.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author GraviteeSource Team
+ */
+class MultiDataPlaneLoaderTest {
+
+    private final Configuration configuration = Mockito.mock(Configuration.class);
+
+    private MultiDataPlaneLoader loader(String... ids) {
+        for (int i = 0; i < ids.length; i++) {
+            Mockito.when(configuration.containsProperty("dataPlanes[" + i + "].id")).thenReturn(true);
+            Mockito.when(configuration.getProperty("dataPlanes[" + i + "].id", String.class)).thenReturn(ids[i]);
+        }
+        MultiDataPlaneLoader loader = new MultiDataPlaneLoader();
+        loader.configuration = configuration;
+        return loader;
+    }
+
+    @Test
+    void should_recognise_a_declared_id() {
+        assertThat(loader("default", "dp-yml").isDeclared("dp-yml")).isTrue();
+    }
+
+    @Test
+    void should_not_recognise_an_id_beyond_the_declared_ones() {
+        assertThat(loader("default", "dp-yml").isDeclared("dp-provisioned")).isFalse();
+    }
+
+    @Test
+    void should_not_recognise_anything_when_nothing_is_declared() {
+        assertThat(loader().isDeclared("default")).isFalse();
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -23,17 +23,20 @@ import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.model.DataPlaneDefinition;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneLoader;
 import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
+import io.reactivex.rxjava3.core.Completable;
 import lombok.CustomLog;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 /**
  * Loads the data planes declared in the gravitee.yml, then the ones provisioned through the internal
- * API (AM-7259) and stored in the management repository.
+ * API (AM-7259) and stored in the management repository. {@link #register(String)} adds a definition
+ * provisioned since startup, so a new data plane can be served without restarting the node.
  *
  * A provider never receives its configuration: {@link DataPlaneDescription#propertiesBase()} hands it a
  * property prefix and the plugin resolves the settings out of the Spring environment itself. A stored
@@ -65,6 +68,8 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
             .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
             .build();
     private final Map<String, Object> properties = new ConcurrentHashMap<>();
+    private final Set<String> registered = ConcurrentHashMap.newKeySet();
+    private volatile Consumer<DataPlaneDescription> storage;
 
     public ProvisionedDataPlaneLoader(DataPlaneLoader configurationLoader,
                                       DataPlaneDefinitionRepository dataPlaneDefinitionRepository,
@@ -77,9 +82,32 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
     @Override
     public void load(Consumer<DataPlaneDescription> storage) {
+        // kept so a definition provisioned later reaches the same registry this one is filling
+        this.storage = storage;
         configurationLoader.load(storage);
         dataPlaneDefinitionRepository.findAll()
                 .blockingForEach(definition -> load(definition, storage));
+    }
+
+    /**
+     * Registers a definition provisioned since startup so domains bound to it can be served straight away,
+     * rather than from the next restart.
+     *
+     * Best effort on purpose: the definition is persisted before this runs, so failing here only costs the
+     * node the live registration — the startup load will pick it up next time — and it must not turn a
+     * successful provisioning call into an error.
+     */
+    public Completable register(String dataPlaneId) {
+        var storage = this.storage;
+        // nothing registered yet means no registry to add to; its own load() will read this definition
+        if (storage == null || !registered.add(dataPlaneId)) {
+            return Completable.complete();
+        }
+        return dataPlaneDefinitionRepository.findById(dataPlaneId)
+                .doOnSuccess(definition -> load(definition, storage))
+                .ignoreElement()
+                .doOnError(e -> log.error("Data plane [{}] could not be read back after being provisioned and will be unavailable until restart", dataPlaneId, e))
+                .onErrorComplete();
     }
 
     /**
@@ -91,6 +119,7 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
     private void load(DataPlaneDefinition definition, Consumer<DataPlaneDescription> storage) {
         try {
             storage.accept(publish(definition));
+            registered.add(definition.getId());
             log.info("Data plane [{}] of type [{}] loaded from the management repository", definition.getId(), definition.getType());
         } catch (Exception e) {
             log.error("Data plane [{}] of type [{}] could not be loaded and will be unavailable; domains bound to it cannot be served",

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -51,6 +51,7 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
     private final DataPlaneLoader configurationLoader;
     private final DataPlaneDefinitionRepository dataPlaneDefinitionRepository;
+    private final ConfigurableEnvironment environment;
 
     private final ObjectMapper objectMapper = JsonMapper.builder()
             .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
@@ -58,33 +59,36 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
     private final Map<String, Object> properties = new ConcurrentHashMap<>();
     private final Set<String> registered = ConcurrentHashMap.newKeySet();
-    private final AtomicReference<Consumer<DataPlaneDescription>> storage = new AtomicReference<>();
+    private final AtomicReference<Consumer<DataPlaneDescription>> storageRef = new AtomicReference<>();
 
     public ProvisionedDataPlaneLoader(DataPlaneLoader configurationLoader,
                                       DataPlaneDefinitionRepository dataPlaneDefinitionRepository,
                                       ConfigurableEnvironment environment) {
         this.configurationLoader = configurationLoader;
         this.dataPlaneDefinitionRepository = dataPlaneDefinitionRepository;
-        environment.getPropertySources().addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+        this.environment = environment;
     }
 
     @Override
     public void load(Consumer<DataPlaneDescription> storage) {
-        this.storage.set(storage);
+        environment.getPropertySources().addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+        storageRef.set(storage);
         configurationLoader.load(storage);
         dataPlaneDefinitionRepository.findAll()
-                .blockingForEach(definition -> load(definition, storage));
+                .blockingForEach(definition -> activate(definition, storage));
     }
 
     public Completable register(String dataPlaneId) {
-        var storage = this.storage.get();
+        var storage = storageRef.get();
 
+        // nothing is lost when the registry has not started yet: load publishes its consumer before
+        // reading the repository, so the definition just persisted is picked up by that read
         if (storage == null || registered.contains(dataPlaneId)) {
             return Completable.complete();
         }
 
         return dataPlaneDefinitionRepository.findById(dataPlaneId)
-                .doOnSuccess(definition -> load(definition, storage))
+                .doOnSuccess(definition -> activate(definition, storage))
                 // fires only when findById completes empty
                 .doOnComplete(() -> log.warn("Data plane [{}] was not found when read back after being provisioned and will be unavailable until restart", dataPlaneId))
                 .ignoreElement()
@@ -92,7 +96,7 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
                 .onErrorComplete();
     }
 
-    private void load(DataPlaneDefinition definition, Consumer<DataPlaneDescription> storage) {
+    private void activate(DataPlaneDefinition definition, Consumer<DataPlaneDescription> storage) {
         try {
             storage.accept(publish(definition));
             registered.add(definition.getId());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -31,6 +31,7 @@ import org.springframework.core.env.MapPropertySource;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /**
@@ -42,6 +43,8 @@ import java.util.function.Consumer;
 @CustomLog
 public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
+    // must not be "graviteeYamlConfiguration": gravitee-node's /_node/configuration endpoint dumps that
+    // source key by key, and these definitions carry credentials
     static final String PROPERTY_SOURCE_NAME = "provisionedDataPlanes";
 
     static final String PROPERTIES_BASE = "dataPlanes.provisioned";
@@ -55,7 +58,7 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
     private final Map<String, Object> properties = new ConcurrentHashMap<>();
     private final Set<String> registered = ConcurrentHashMap.newKeySet();
-    private volatile Consumer<DataPlaneDescription> storage;
+    private final AtomicReference<Consumer<DataPlaneDescription>> storage = new AtomicReference<>();
 
     public ProvisionedDataPlaneLoader(DataPlaneLoader configurationLoader,
                                       DataPlaneDefinitionRepository dataPlaneDefinitionRepository,
@@ -67,14 +70,14 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
     @Override
     public void load(Consumer<DataPlaneDescription> storage) {
-        this.storage = storage;
+        this.storage.set(storage);
         configurationLoader.load(storage);
         dataPlaneDefinitionRepository.findAll()
                 .blockingForEach(definition -> load(definition, storage));
     }
 
     public Completable register(String dataPlaneId) {
-        var storage = this.storage;
+        var storage = this.storage.get();
 
         if (storage == null || registered.contains(dataPlaneId)) {
             return Completable.complete();
@@ -82,6 +85,8 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
         return dataPlaneDefinitionRepository.findById(dataPlaneId)
                 .doOnSuccess(definition -> load(definition, storage))
+                // fires only when findById completes empty
+                .doOnComplete(() -> log.warn("Data plane [{}] was not found when read back after being provisioned and will be unavailable until restart", dataPlaneId))
                 .ignoreElement()
                 .doOnError(e -> log.error("Data plane [{}] could not be read back after being provisioned and will be unavailable until restart", dataPlaneId, e))
                 .onErrorComplete();
@@ -100,6 +105,8 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
     private DataPlaneDescription publish(DataPlaneDefinition definition) throws Exception {
         var propertiesBase = PROPERTIES_BASE + "." + definition.getId();
+        // a failed registration leaves its keys published; drop them so a corrected definition cannot resolve stale values
+        properties.keySet().removeIf(key -> key.startsWith(propertiesBase + "."));
         flatten(propertiesBase, objectMapper.readTree(definition.getConfiguration()), properties);
         return new DataPlaneDescription(
                 definition.getId(),

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.dataplane;
+
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.gravitee.am.dataplane.api.DataPlaneDescription;
+import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneLoader;
+import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
+import lombok.CustomLog;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Loads the data planes declared in the gravitee.yml, then the ones provisioned through the internal
+ * API (AM-7259) and stored in the management repository.
+ *
+ * A provider never receives its configuration: {@link DataPlaneDescription#propertiesBase()} hands it a
+ * property prefix and the plugin resolves the settings out of the Spring environment itself. A stored
+ * definition only holds a JSON blob, so its settings are flattened onto dotted keys under
+ * {@code dataPlanes.provisioned.<id>} and published as a property source before the description is
+ * handed over. Every existing read site — both plugins, both connection providers, liquibase — resolves
+ * through that same environment, so none of them need to know where a definition came from.
+ *
+ * Reads {@link DataPlaneDefinitionRepository} rather than {@code DataPlaneDefinitionService} on purpose:
+ * the service deliberately has no route out for the raw configuration.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
+
+    /**
+     * Must not be {@code graviteeYamlConfiguration}: gravitee-node's {@code /_node/configuration}
+     * endpoint enumerates that one source key by key, and these definitions carry credentials.
+     */
+    static final String PROPERTY_SOURCE_NAME = "provisionedDataPlanes";
+
+    static final String PROPERTIES_BASE = "dataPlanes.provisioned";
+
+    private final DataPlaneLoader configurationLoader;
+    private final DataPlaneDefinitionRepository dataPlaneDefinitionRepository;
+    // a parse failure is logged, and Jackson quotes the source it choked on unless told not to
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+            .build();
+    private final Map<String, Object> properties = new ConcurrentHashMap<>();
+
+    public ProvisionedDataPlaneLoader(DataPlaneLoader configurationLoader,
+                                      DataPlaneDefinitionRepository dataPlaneDefinitionRepository,
+                                      ConfigurableEnvironment environment) {
+        this.configurationLoader = configurationLoader;
+        this.dataPlaneDefinitionRepository = dataPlaneDefinitionRepository;
+        // the source stays backed by the live map, so definitions published later are visible too
+        environment.getPropertySources().addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+    }
+
+    @Override
+    public void load(Consumer<DataPlaneDescription> storage) {
+        configurationLoader.load(storage);
+        dataPlaneDefinitionRepository.findAll()
+                .blockingForEach(definition -> load(definition, storage));
+    }
+
+    /**
+     * A stored definition outlives the deployment that created it, so by the time it is read its type's
+     * plugin may be gone, its id may collide with a gravitee.yml one, or its configuration may no longer
+     * parse. None of that is worth refusing to start the node over: skip the definition and leave the
+     * rest of the installation running.
+     */
+    private void load(DataPlaneDefinition definition, Consumer<DataPlaneDescription> storage) {
+        try {
+            storage.accept(publish(definition));
+            log.info("Data plane [{}] of type [{}] loaded from the management repository", definition.getId(), definition.getType());
+        } catch (Exception e) {
+            log.error("Data plane [{}] of type [{}] could not be loaded and will be unavailable; domains bound to it cannot be served",
+                    definition.getId(), definition.getType(), e);
+        }
+    }
+
+    private DataPlaneDescription publish(DataPlaneDefinition definition) throws Exception {
+        var propertiesBase = PROPERTIES_BASE + "." + definition.getId();
+        flatten(propertiesBase, objectMapper.readTree(definition.getConfiguration()), properties);
+        return new DataPlaneDescription(
+                definition.getId(),
+                definition.getName(),
+                definition.getType(),
+                propertiesBase,
+                definition.getGatewayUrl());
+    }
+
+    /**
+     * Mirrors how the gravitee.yml maps onto the environment: nested objects become dotted keys and
+     * list entries keep their index, so {@code {"mongodb":{"servers":[{"host":"h"}]}}} publishes
+     * {@code <base>.mongodb.servers[0].host}, which is the key {@code MongoFactoryImpl} looks for.
+     */
+    private static void flatten(String prefix, JsonNode node, Map<String, Object> properties) {
+        if (node.isObject()) {
+            node.properties().forEach(property -> flatten(prefix + "." + property.getKey(), property.getValue(), properties));
+        } else if (node.isArray()) {
+            for (int i = 0; i < node.size(); i++) {
+                flatten(prefix + "[" + i + "]", node.get(i), properties);
+            }
+        } else if (!node.isNull()) {
+            properties.put(prefix, node.asText());
+        }
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -34,39 +34,25 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 /**
- * Loads the data planes declared in the gravitee.yml, then the ones provisioned through the internal
- * API (AM-7259) and stored in the management repository. {@link #register(String)} adds a definition
- * provisioned since startup, so a new data plane can be served without restarting the node.
- *
- * A provider never receives its configuration: {@link DataPlaneDescription#propertiesBase()} hands it a
- * property prefix and the plugin resolves the settings out of the Spring environment itself. A stored
- * definition only holds a JSON blob, so its settings are flattened onto dotted keys under
- * {@code dataPlanes.provisioned.<id>} and published as a property source before the description is
- * handed over. Every existing read site — both plugins, both connection providers, liquibase — resolves
- * through that same environment, so none of them need to know where a definition came from.
- *
- * Reads {@link DataPlaneDefinitionRepository} rather than {@code DataPlaneDefinitionService} on purpose:
- * the service deliberately has no route out for the raw configuration.
+ * Loads the data planes declared in the gravitee.yml, then the provisioned ones stored in the
+ * management repository.
  *
  * @author GraviteeSource Team
  */
 @CustomLog
 public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
-    /**
-     * Must not be {@code graviteeYamlConfiguration}: gravitee-node's {@code /_node/configuration}
-     * endpoint enumerates that one source key by key, and these definitions carry credentials.
-     */
     static final String PROPERTY_SOURCE_NAME = "provisionedDataPlanes";
 
     static final String PROPERTIES_BASE = "dataPlanes.provisioned";
 
     private final DataPlaneLoader configurationLoader;
     private final DataPlaneDefinitionRepository dataPlaneDefinitionRepository;
-    // a parse failure is logged, and Jackson quotes the source it choked on unless told not to
+
     private final ObjectMapper objectMapper = JsonMapper.builder()
             .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
             .build();
+
     private final Map<String, Object> properties = new ConcurrentHashMap<>();
     private final Set<String> registered = ConcurrentHashMap.newKeySet();
     private volatile Consumer<DataPlaneDescription> storage;
@@ -76,35 +62,24 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
                                       ConfigurableEnvironment environment) {
         this.configurationLoader = configurationLoader;
         this.dataPlaneDefinitionRepository = dataPlaneDefinitionRepository;
-        // the source stays backed by the live map, so definitions published later are visible too
         environment.getPropertySources().addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
     }
 
     @Override
     public void load(Consumer<DataPlaneDescription> storage) {
-        // kept so a definition provisioned later reaches the same registry this one is filling
         this.storage = storage;
         configurationLoader.load(storage);
         dataPlaneDefinitionRepository.findAll()
                 .blockingForEach(definition -> load(definition, storage));
     }
 
-    /**
-     * Registers a definition provisioned since startup so domains bound to it can be served straight away,
-     * rather than from the next restart.
-     *
-     * Best effort on purpose: the definition is persisted before this runs, so failing here only costs the
-     * node the live registration — the startup load will pick it up next time — and it must not turn a
-     * successful provisioning call into an error.
-     */
     public Completable register(String dataPlaneId) {
         var storage = this.storage;
-        // nothing registered yet means no registry to add to; its own load() will read this definition.
-        // only a definition that actually registered is remembered, so an id whose provider could not be
-        // built stays free for the corrected definition that replaces it
+
         if (storage == null || registered.contains(dataPlaneId)) {
             return Completable.complete();
         }
+
         return dataPlaneDefinitionRepository.findById(dataPlaneId)
                 .doOnSuccess(definition -> load(definition, storage))
                 .ignoreElement()
@@ -112,12 +87,6 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
                 .onErrorComplete();
     }
 
-    /**
-     * A stored definition outlives the deployment that created it, so by the time it is read its type's
-     * plugin may be gone, its id may collide with a gravitee.yml one, or its configuration may no longer
-     * parse. None of that is worth refusing to start the node over: skip the definition and leave the
-     * rest of the installation running.
-     */
     private void load(DataPlaneDefinition definition, Consumer<DataPlaneDescription> storage) {
         try {
             storage.accept(publish(definition));
@@ -140,11 +109,6 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
                 definition.getGatewayUrl());
     }
 
-    /**
-     * Mirrors how the gravitee.yml maps onto the environment: nested objects become dotted keys and
-     * list entries keep their index, so {@code {"mongodb":{"servers":[{"host":"h"}]}}} publishes
-     * {@code <base>.mongodb.servers[0].host}, which is the key {@code MongoFactoryImpl} looks for.
-     */
     private static void flatten(String prefix, JsonNode node, Map<String, Object> properties) {
         if (node.isObject()) {
             node.properties().forEach(property -> flatten(prefix + "." + property.getKey(), property.getValue(), properties));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -99,8 +99,10 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
      */
     public Completable register(String dataPlaneId) {
         var storage = this.storage;
-        // nothing registered yet means no registry to add to; its own load() will read this definition
-        if (storage == null || !registered.add(dataPlaneId)) {
+        // nothing registered yet means no registry to add to; its own load() will read this definition.
+        // only a definition that actually registered is remembered, so an id whose provider could not be
+        // built stays free for the corrected definition that replaces it
+        if (storage == null || registered.contains(dataPlaneId)) {
             return Completable.complete();
         }
         return dataPlaneDefinitionRepository.findById(dataPlaneId)

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
@@ -42,6 +42,7 @@ import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.model.NewDataPlaneDefinition;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.management.DataPlaneDefinitionAuditBuilder;
+import io.gravitee.node.api.configuration.Configuration;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
@@ -76,6 +77,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
     private final PluginConfigurationValidatorsRegistry pluginValidatorsRegistry;
     private final List<DataPlaneConfigHandler> configHandlers;
     private final AuditService auditService;
+    private final Configuration configuration;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -86,7 +88,8 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                                           DataPlanePluginManager dataPlanePluginManager,
                                           PluginConfigurationValidatorsRegistry pluginValidatorsRegistry,
                                           List<DataPlaneConfigHandler> configHandlers,
-                                          AuditService auditService) {
+                                          AuditService auditService,
+                                          Configuration configuration) {
         this.dataPlaneDefinitionRepository = dataPlaneDefinitionRepository;
         this.domainRepository = domainRepository;
         this.organizationService = organizationService;
@@ -95,6 +98,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
         this.pluginValidatorsRegistry = pluginValidatorsRegistry;
         this.configHandlers = configHandlers;
         this.auditService = auditService;
+        this.configuration = configuration;
     }
 
     @Override
@@ -242,8 +246,8 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
         if (!hasText(payload.getId())) {
             throw new InvalidParameterException("'id' is required");
         }
-        if (DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(payload.getId())) {
-            throw new InvalidParameterException("'" + DataPlaneDescription.DEFAULT_DATA_PLANE_ID + "' is reserved for the data plane declared in the gravitee.yml");
+        if (DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(payload.getId()) || isDeclaredInConfiguration(payload.getId())) {
+            throw new InvalidParameterException("'" + payload.getId() + "' is reserved for a data plane declared in the gravitee.yml");
         }
         if (!hasText(payload.getName())) {
             throw new InvalidParameterException("'name' is required");
@@ -266,6 +270,17 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
         definition.setEnvironmentId(hasText(payload.getEnvironmentId()) ? payload.getEnvironmentId() : Environment.DEFAULT);
         definition.setConfiguration(payload.getConfiguration().toString());
         return definition;
+    }
+
+    // an id colliding with a gravitee.yml plane would persist but never register: the registry keeps
+    // serving the yml plane, and domains binding to the id would silently land on the wrong store
+    private boolean isDeclaredInConfiguration(String id) {
+        for (int i = 0; configuration.containsProperty("dataPlanes[" + i + "].id"); i++) {
+            if (id.equals(configuration.getProperty("dataPlanes[" + i + "].id", String.class))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void validateConfiguration(String type, JsonNode configuration) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.am.model.DataPlaneDefinition;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.plugins.dataplane.core.DataPlanePluginManager;
+import io.gravitee.am.plugins.dataplane.core.MultiDataPlaneLoader;
 import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidatorsRegistry;
 import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
 import io.gravitee.am.repository.management.api.DomainRepository;
@@ -42,7 +43,6 @@ import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.model.NewDataPlaneDefinition;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.management.DataPlaneDefinitionAuditBuilder;
-import io.gravitee.node.api.configuration.Configuration;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
@@ -77,7 +77,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
     private final PluginConfigurationValidatorsRegistry pluginValidatorsRegistry;
     private final List<DataPlaneConfigHandler> configHandlers;
     private final AuditService auditService;
-    private final Configuration configuration;
+    private final MultiDataPlaneLoader configurationLoader;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -89,7 +89,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                                           PluginConfigurationValidatorsRegistry pluginValidatorsRegistry,
                                           List<DataPlaneConfigHandler> configHandlers,
                                           AuditService auditService,
-                                          Configuration configuration) {
+                                          MultiDataPlaneLoader configurationLoader) {
         this.dataPlaneDefinitionRepository = dataPlaneDefinitionRepository;
         this.domainRepository = domainRepository;
         this.organizationService = organizationService;
@@ -98,7 +98,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
         this.pluginValidatorsRegistry = pluginValidatorsRegistry;
         this.configHandlers = configHandlers;
         this.auditService = auditService;
-        this.configuration = configuration;
+        this.configurationLoader = configurationLoader;
     }
 
     @Override
@@ -246,7 +246,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
         if (!hasText(payload.getId())) {
             throw new InvalidParameterException("'id' is required");
         }
-        if (DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(payload.getId()) || isDeclaredInConfiguration(payload.getId())) {
+        if (isReservedByConfiguration(payload.getId())) {
             throw new InvalidParameterException("'" + payload.getId() + "' is reserved for a data plane declared in the gravitee.yml");
         }
         if (!hasText(payload.getName())) {
@@ -273,14 +273,10 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
     }
 
     // an id colliding with a gravitee.yml plane would persist but never register: the registry keeps
-    // serving the yml plane, and domains binding to the id would silently land on the wrong store
-    private boolean isDeclaredInConfiguration(String id) {
-        for (int i = 0; configuration.containsProperty("dataPlanes[" + i + "].id"); i++) {
-            if (id.equals(configuration.getProperty("dataPlanes[" + i + "].id", String.class))) {
-                return true;
-            }
-        }
-        return false;
+    // serving the yml plane, and domains binding to the id would silently land on the wrong store.
+    // "default" is spelled out because it is the id the registry falls back to for an unbound domain
+    private boolean isReservedByConfiguration(String id) {
+        return DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(id) || configurationLoader.isDeclared(id);
     }
 
     private void validateConfiguration(String type, JsonNode configuration) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
@@ -100,6 +100,9 @@ class DataPlaneDefinitionServiceTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private io.gravitee.node.api.configuration.Configuration configuration;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final PluginConfigurationValidatorsRegistry validatorsRegistry = new PluginConfigurationValidatorsRegistry();
@@ -116,7 +119,8 @@ class DataPlaneDefinitionServiceTest {
                 dataPlanePluginManager,
                 validatorsRegistry,
                 List.of(new MongoDataPlaneConfigHandler(), new JdbcDataPlaneConfigHandler()),
-                auditService);
+                auditService,
+                configuration);
 
         when(dataPlanePluginManager.get("dataplane-am-mongodb")).thenReturn(mock(DataPlane.class));
         when(dataPlanePluginManager.get("dataplane-am-jdbc")).thenReturn(mock(DataPlane.class));
@@ -260,6 +264,19 @@ class DataPlaneDefinitionServiceTest {
         payload.setId("default");
 
         assertRejected(payload, InvalidParameterException.class, "reserved");
+    }
+
+    @Test
+    void shouldRejectAnIdDeclaredInTheGraviteeYml() {
+        when(configuration.containsProperty("dataPlanes[0].id")).thenReturn(true);
+        when(configuration.getProperty("dataPlanes[0].id", String.class)).thenReturn("default");
+        when(configuration.containsProperty("dataPlanes[1].id")).thenReturn(true);
+        when(configuration.getProperty("dataPlanes[1].id", String.class)).thenReturn("dp-yml");
+
+        NewDataPlaneDefinition payload = payload();
+        payload.setId("dp-yml");
+
+        assertRejected(payload, InvalidParameterException.class, "reserved for a data plane declared in the gravitee.yml");
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
@@ -29,6 +29,7 @@ import io.gravitee.am.model.DataPlaneDefinition;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.plugins.dataplane.core.DataPlanePluginManager;
+import io.gravitee.am.plugins.dataplane.core.MultiDataPlaneLoader;
 import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidator;
 import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidatorsRegistry;
 import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
@@ -101,7 +102,7 @@ class DataPlaneDefinitionServiceTest {
     private AuditService auditService;
 
     @Mock
-    private io.gravitee.node.api.configuration.Configuration configuration;
+    private MultiDataPlaneLoader configurationLoader;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -120,7 +121,7 @@ class DataPlaneDefinitionServiceTest {
                 validatorsRegistry,
                 List.of(new MongoDataPlaneConfigHandler(), new JdbcDataPlaneConfigHandler()),
                 auditService,
-                configuration);
+                configurationLoader);
 
         when(dataPlanePluginManager.get("dataplane-am-mongodb")).thenReturn(mock(DataPlane.class));
         when(dataPlanePluginManager.get("dataplane-am-jdbc")).thenReturn(mock(DataPlane.class));
@@ -268,10 +269,7 @@ class DataPlaneDefinitionServiceTest {
 
     @Test
     void shouldRejectAnIdDeclaredInTheGraviteeYml() {
-        when(configuration.containsProperty("dataPlanes[0].id")).thenReturn(true);
-        when(configuration.getProperty("dataPlanes[0].id", String.class)).thenReturn("default");
-        when(configuration.containsProperty("dataPlanes[1].id")).thenReturn(true);
-        when(configuration.getProperty("dataPlanes[1].id", String.class)).thenReturn("dp-yml");
+        when(configurationLoader.isDeclared("dp-yml")).thenReturn(true);
 
         NewDataPlaneDefinition payload = payload();
         payload.setId("dp-yml");

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.dataplane;
+
+import io.gravitee.am.dataplane.api.DataPlaneDescription;
+import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneLoader;
+import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
+import io.reactivex.rxjava3.core.Flowable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class ProvisionedDataPlaneLoaderTest {
+
+    @Mock
+    private DataPlaneDefinitionRepository dataPlaneDefinitionRepository;
+
+    private ConfigurableEnvironment environment;
+    private List<DataPlaneDescription> loaded;
+    private List<DataPlaneDescription> fromConfiguration;
+
+    @BeforeEach
+    void setUp() {
+        environment = new StandardEnvironment();
+        loaded = new ArrayList<>();
+        fromConfiguration = new ArrayList<>();
+    }
+
+    private ProvisionedDataPlaneLoader loader() {
+        DataPlaneLoader configurationLoader = storage -> fromConfiguration.forEach(storage);
+        return new ProvisionedDataPlaneLoader(configurationLoader, dataPlaneDefinitionRepository, environment);
+    }
+
+    private static DataPlaneDefinition definition(String id, String type, String configuration) {
+        var definition = new DataPlaneDefinition();
+        definition.setId(id);
+        definition.setName(id + "-name");
+        definition.setType(type);
+        definition.setGatewayUrl("https://gw.example.com");
+        definition.setOrganizationId("DEFAULT");
+        definition.setEnvironmentId("DEFAULT");
+        definition.setConfiguration(configuration);
+        return definition;
+    }
+
+    @Test
+    void should_emit_the_configured_data_planes_before_the_stored_ones() {
+        fromConfiguration.add(new DataPlaneDescription("default", "Default", "mongodb", "dataPlanes[0]", null));
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}")));
+
+        loader().load(loaded::add);
+
+        assertThat(loaded).extracting(DataPlaneDescription::id).containsExactly("default", "dp-1");
+    }
+
+    @Test
+    void should_describe_a_stored_definition_against_its_own_properties_base() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}")));
+
+        loader().load(loaded::add);
+
+        assertThat(loaded).singleElement().isEqualTo(new DataPlaneDescription(
+                "dp-1", "dp-1-name", "mongodb", "dataPlanes.provisioned.dp-1", "https://gw.example.com"));
+    }
+
+    @Test
+    void should_publish_the_stored_configuration_onto_the_environment() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb",
+                        "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\",\"sslEnabled\":true,\"maxSize\":50}}")));
+
+        loader().load(loaded::add);
+
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.uri")).isEqualTo("mongodb://h:27017/db");
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.sslEnabled", Boolean.class)).isTrue();
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.maxSize", Integer.class)).isEqualTo(50);
+    }
+
+    @Test
+    void should_index_list_entries_the_way_the_connection_providers_read_them() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb",
+                        "{\"mongodb\":{\"dbname\":\"db\",\"servers\":[{\"host\":\"h1\",\"port\":27017},{\"host\":\"h2\",\"port\":27018}]}}")));
+
+        loader().load(loaded::add);
+
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.servers[0].host")).isEqualTo("h1");
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.servers[0].port", Integer.class)).isEqualTo(27017);
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.servers[1].host")).isEqualTo("h2");
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.servers[2].host")).isNull();
+    }
+
+    @Test
+    void should_keep_each_definition_under_its_own_prefix() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(
+                definition("dp-1", "mongodb", "{\"mongodb\":{\"dbname\":\"one\",\"host\":\"h1\"}}"),
+                definition("dp-2", "jdbc", "{\"jdbc\":{\"database\":\"two\",\"host\":\"h2\"}}")));
+
+        loader().load(loaded::add);
+
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.dbname")).isEqualTo("one");
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-2.jdbc.database")).isEqualTo("two");
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.jdbc.database")).isNull();
+    }
+
+    @Test
+    void should_publish_the_configuration_before_the_description_is_handed_over() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}")));
+
+        List<String> resolvedAtRegistration = new ArrayList<>();
+        // the registry builds the provider inside this callback, and the provider resolves its own settings
+        loader().load(description -> resolvedAtRegistration.add(environment.getProperty(description.propertiesBase() + ".mongodb.uri")));
+
+        assertThat(resolvedAtRegistration).containsExactly("mongodb://h:27017/db");
+    }
+
+    @Test
+    void should_not_expose_the_configuration_through_the_source_the_node_configuration_endpoint_dumps() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"password\":\"s3cret\"}}")));
+
+        loader().load(loaded::add);
+
+        assertThat(environment.getPropertySources().get("graviteeYamlConfiguration")).isNull();
+        assertThat(environment.getPropertySources().get(ProvisionedDataPlaneLoader.PROPERTY_SOURCE_NAME)).isNotNull();
+    }
+
+    @Test
+    void should_skip_a_definition_whose_configuration_cannot_be_read() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(
+                definition("dp-broken", "mongodb", "not json"),
+                definition("dp-2", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}")));
+
+        loader().load(loaded::add);
+
+        assertThat(loaded).extracting(DataPlaneDescription::id).containsExactly("dp-2");
+    }
+
+    @Test
+    void should_skip_a_definition_the_registry_refuses() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(
+                definition("dp-rejected", "gone", "{\"gone\":{\"host\":\"h\"}}"),
+                definition("dp-2", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}")));
+
+        // stands in for the registry failing to build a provider, e.g. the type's plugin is not deployed
+        loader().load(description -> {
+            if ("gone".equals(description.type())) {
+                throw new IllegalStateException("No data plan provider is registered for type gone");
+            }
+            loaded.add(description);
+        });
+
+        assertThat(loaded).extracting(DataPlaneDescription::id).containsExactly("dp-2");
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -223,6 +223,29 @@ class ProvisionedDataPlaneLoaderTest {
     }
 
     @Test
+    void should_retry_an_id_whose_provider_could_not_be_built() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
+        var loader = loader();
+        var refused = new ArrayList<String>();
+        // stands in for the registry refusing the first definition, e.g. its store was unreachable
+        loader.load(description -> {
+            if (refused.isEmpty()) {
+                refused.add(description.id());
+                throw new IllegalStateException("No data plane provider could be built for id " + description.id());
+            }
+            loaded.add(description);
+        });
+        when(dataPlaneDefinitionRepository.findById("dp-1"))
+                .thenReturn(Maybe.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}")));
+
+        loader.register("dp-1").test().assertComplete();
+        loader.register("dp-1").test().assertComplete();
+
+        assertThat(refused).containsExactly("dp-1");
+        assertThat(loaded).extracting(DataPlaneDescription::id).containsExactly("dp-1");
+    }
+
+    @Test
     void should_not_fail_the_caller_when_the_definition_cannot_be_read_back() {
         when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
         var loader = loader();

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -246,6 +246,41 @@ class ProvisionedDataPlaneLoaderTest {
     }
 
     @Test
+    void should_not_leave_stale_properties_behind_when_a_corrected_definition_replaces_a_failed_one() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
+        var loader = loader();
+        var refused = new ArrayList<String>();
+        loader.load(description -> {
+            if (refused.isEmpty()) {
+                refused.add(description.id());
+                throw new IllegalStateException("No data plane provider could be built for id " + description.id());
+            }
+            loaded.add(description);
+        });
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(
+                Maybe.just(definition("dp-1", "jdbc", "{\"jdbc\":{\"host\":\"h1\",\"collation\":\"latin1\"}}")),
+                Maybe.just(definition("dp-1", "jdbc", "{\"jdbc\":{\"host\":\"h2\"}}")));
+
+        loader.register("dp-1").test().assertComplete();
+        loader.register("dp-1").test().assertComplete();
+
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.jdbc.host")).isEqualTo("h2");
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.jdbc.collation")).isNull();
+    }
+
+    @Test
+    void should_complete_quietly_when_the_definition_is_missing_at_registration_time() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
+        var loader = loader();
+        loader.load(loaded::add);
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.empty());
+
+        loader.register("dp-1").test().assertComplete();
+
+        assertThat(loaded).isEmpty();
+    }
+
+    @Test
     void should_not_fail_the_caller_when_the_definition_cannot_be_read_back() {
         when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
         var loader = loader();

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -150,6 +150,13 @@ class ProvisionedDataPlaneLoaderTest {
     }
 
     @Test
+    void should_leave_the_environment_alone_until_it_is_loaded() {
+        loader();
+
+        assertThat(environment.getPropertySources().get(ProvisionedDataPlaneLoader.PROPERTY_SOURCE_NAME)).isNull();
+    }
+
+    @Test
     void should_not_expose_the_configuration_through_the_source_the_node_configuration_endpoint_dumps() {
         when(dataPlaneDefinitionRepository.findAll())
                 .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"password\":\"s3cret\"}}")));

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -20,6 +20,7 @@ import io.gravitee.am.model.DataPlaneDefinition;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneLoader;
 import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -182,5 +186,51 @@ class ProvisionedDataPlaneLoaderTest {
         });
 
         assertThat(loaded).extracting(DataPlaneDescription::id).containsExactly("dp-2");
+    }
+
+    @Test
+    void should_register_a_definition_provisioned_after_startup() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
+        var loader = loader();
+        loader.load(loaded::add);
+        when(dataPlaneDefinitionRepository.findById("dp-1"))
+                .thenReturn(Maybe.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}")));
+
+        loader.register("dp-1").test().assertComplete();
+
+        assertThat(loaded).extracting(DataPlaneDescription::id).containsExactly("dp-1");
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.uri")).isEqualTo("mongodb://h:27017/db");
+    }
+
+    @Test
+    void should_not_register_a_definition_the_startup_load_already_picked_up() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}")));
+        var loader = loader();
+        loader.load(loaded::add);
+
+        loader.register("dp-1").test().assertComplete();
+
+        assertThat(loaded).extracting(DataPlaneDescription::id).containsExactly("dp-1");
+        verify(dataPlaneDefinitionRepository, never()).findById(any());
+    }
+
+    @Test
+    void should_ignore_a_registration_that_arrives_before_the_registry_has_started() {
+        loader().register("dp-1").test().assertComplete();
+
+        verify(dataPlaneDefinitionRepository, never()).findById(any());
+    }
+
+    @Test
+    void should_not_fail_the_caller_when_the_definition_cannot_be_read_back() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
+        var loader = loader();
+        loader.load(loaded::add);
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.error(new RuntimeException("connection lost")));
+
+        loader.register("dp-1").test().assertComplete();
+
+        assertThat(loaded).isEmpty();
     }
 }

--- a/gravitee-am-test/api/commands/management/domain-management-commands.ts
+++ b/gravitee-am-test/api/commands/management/domain-management-commands.ts
@@ -65,14 +65,14 @@ export const setupDomainForTest = async (
  */
 const getDomainDataPlaneId = (): string => process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 
-export const createDomain = (accessToken, name, description): Promise<Domain> =>
+export const createDomain = (accessToken, name, description, dataPlaneId?: string): Promise<Domain> =>
   getDomainApi(accessToken).createDomain({
     organizationId: process.env.AM_DEF_ORG_ID,
     environmentId: process.env.AM_DEF_ENV_ID,
     newDomain: {
       name: name,
       description: description,
-      dataPlaneId: getDomainDataPlaneId(),
+      dataPlaneId: dataPlaneId ?? getDomainDataPlaneId(),
     },
   });
 

--- a/gravitee-am-test/specs/management/internal-api/dataplane-provisioning.jest.spec.ts
+++ b/gravitee-am-test/specs/management/internal-api/dataplane-provisioning.jest.spec.ts
@@ -43,6 +43,7 @@ import {
   uriFormPayload,
 } from './fixtures/dataplane-provisioning-fixture';
 import { setup } from '../../test-fixture';
+import { uniqueName } from '@utils-commands/misc';
 
 setup(60000);
 
@@ -303,7 +304,9 @@ describe('Data plane provisioning (management technical API)', () => {
     });
 
     it('refuses to delete a data plane a domain still uses, and allows it once the domain is gone', async () => {
-      const provisioned = await provisionConnectableDataPlane(PROVISIONED_ID);
+      // unique per attempt: a leaked bound domain wedges its data plane id (the delete guard blocks
+      // cleanup), so reusing a shared id would fail every later test and retry with "already exists"
+      const provisioned = await provisionConnectableDataPlane(uniqueName('dp-e2e-guarded', true));
       let bound: BoundDomain | undefined;
 
       try {
@@ -324,7 +327,7 @@ describe('Data plane provisioning (management technical API)', () => {
 
   describe('runtime registration', () => {
     it('accepts a domain on a data plane provisioned since the node started', async () => {
-      const provisioned = await provisionConnectableDataPlane(PROVISIONED_ID);
+      const provisioned = await provisionConnectableDataPlane(uniqueName('dp-e2e-live', true));
       let bound: BoundDomain | undefined;
 
       try {

--- a/gravitee-am-test/specs/management/internal-api/dataplane-provisioning.jest.spec.ts
+++ b/gravitee-am-test/specs/management/internal-api/dataplane-provisioning.jest.spec.ts
@@ -27,13 +27,17 @@ import {
 } from '@management-commands/dataplane-provisioning-commands';
 import {
   ALLOWED_SUMMARY_FIELDS,
+  BoundDomain,
+  createDomainOnDataPlane,
   DATABASE_NAME,
   dataPlanePayload,
   deleteProvisionedDataPlanes,
   JDBC_SUMMARY,
   jdbcPayload,
   MONGO_SUMMARY,
+  provisionConnectableDataPlane,
   provisionDataPlane,
+  releaseBoundDomain,
   SECRET_PASSWORD,
   SECRET_USERNAME,
   uriFormPayload,
@@ -296,6 +300,42 @@ describe('Data plane provisioning (management technical API)', () => {
 
       const recreated = await createDataPlane(dataPlanePayload(PROVISIONED_ID));
       expect(recreated.status).toBe(201);
+    });
+
+    it('refuses to delete a data plane a domain still uses, and allows it once the domain is gone', async () => {
+      const provisioned = await provisionConnectableDataPlane(PROVISIONED_ID);
+      let bound: BoundDomain | undefined;
+
+      try {
+        bound = await createDomainOnDataPlane(provisioned.id);
+
+        const refused = await deleteDataPlane(provisioned.id);
+        expect(refused.status).toBe(409);
+        expect(refused.raw).toContain(provisioned.id);
+      } finally {
+        // before the outer afterEach, which deletes the data plane and would hit the same guard
+        await releaseBoundDomain(bound);
+      }
+
+      const deleted = await deleteDataPlane(provisioned.id);
+      expect(deleted.status).toBe(204);
+    });
+  });
+
+  describe('runtime registration', () => {
+    it('accepts a domain on a data plane provisioned since the node started', async () => {
+      const provisioned = await provisionConnectableDataPlane(PROVISIONED_ID);
+      let bound: BoundDomain | undefined;
+
+      try {
+        // domain creation validates the id against the registry, so this fails unless the definition
+        // was registered when it was provisioned rather than at the next restart
+        bound = await createDomainOnDataPlane(provisioned.id);
+
+        expect(bound.dataPlaneId).toEqual(provisioned.id);
+      } finally {
+        await releaseBoundDomain(bound);
+      }
     });
   });
 

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -21,6 +21,9 @@ import {
   listDataPlanes,
   NewDataPlane,
 } from '@management-commands/dataplane-provisioning-commands';
+import { createDomain, safeDeleteDomain } from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { uniqueName } from '@utils-commands/misc';
 
 export const SECRET_PASSWORD = 'sup3r-s3cret-e2e';
 export const SECRET_USERNAME = 'am-e2e-user';
@@ -86,6 +89,46 @@ export function jdbcPayload(id: string): NewDataPlane {
   };
 }
 
+/**
+ * A data plane the running stack can genuinely connect to, mirroring its own `dataPlanes[0]`.
+ *
+ * The payloads above are never dialled, because nothing connects at provisioning time. Registering one
+ * does build a provider though, and that needs both a reachable store and the matching
+ * ConnectionProvider bean, which only exists for the repository type the stack was started with.
+ */
+export function connectablePayload(id: string): NewDataPlane {
+  return process.env.REPOSITORY_TYPE === 'jdbc'
+    ? {
+        id,
+        name: 'E2E connectable data plane',
+        type: 'jdbc',
+        configuration: {
+          jdbc: {
+            driver: 'postgresql',
+            host: 'postgres',
+            port: 5432,
+            database: 'postgres',
+            username: 'postgres',
+            password: 'postgres',
+          },
+        },
+      }
+    : {
+        id,
+        name: 'E2E connectable data plane',
+        type: 'mongodb',
+        configuration: { mongodb: { dbname: 'gravitee-am', host: 'mongodb', port: 27017 } },
+      };
+}
+
+export async function provisionConnectableDataPlane(id: string): Promise<DataPlaneSummary> {
+  const created = await createDataPlane(connectablePayload(id));
+  if (created.status !== 201) {
+    throw new Error(`Unable to provision a connectable data plane: status=${created.status} body=${created.raw}`);
+  }
+  return created.body;
+}
+
 export async function deleteProvisionedDataPlanes(): Promise<void> {
   const listed = await listDataPlanes();
   const provisioned = listed.body?.filter((dataPlane) => dataPlane.environmentId === ENVIRONMENT_ID) ?? [];
@@ -100,6 +143,29 @@ export async function provisionDataPlane(id: string): Promise<DataPlaneSummary> 
     throw new Error(`Unable to provision a data plane: status=${created.status} body=${created.raw}`);
   }
   return created.body;
+}
+
+export interface BoundDomain {
+  domainId: string;
+  dataPlaneId: string;
+  accessToken: string;
+}
+
+/**
+ * Creates a domain against a data plane provisioned since the node started. Domain creation checks the
+ * id against the data plane registry, so this only succeeds once the definition has been registered
+ * at runtime rather than at the next restart (AM-7260).
+ */
+export async function createDomainOnDataPlane(dataPlaneId: string): Promise<BoundDomain> {
+  const accessToken = await requestAdminAccessToken();
+  const domain = await createDomain(accessToken, uniqueName('dp-e2e-bound', true), 'Bound to a provisioned data plane', dataPlaneId);
+  return { domainId: domain.id, dataPlaneId: domain.dataPlaneId, accessToken };
+}
+
+export async function releaseBoundDomain(bound: BoundDomain | undefined): Promise<void> {
+  if (bound) {
+    await safeDeleteDomain(bound.domainId, bound.accessToken);
+  }
 }
 
 export const ALLOWED_SUMMARY_FIELDS = [

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -131,9 +131,16 @@ export async function provisionConnectableDataPlane(id: string): Promise<DataPla
 
 export async function deleteProvisionedDataPlanes(): Promise<void> {
   const listed = await listDataPlanes();
-  const provisioned = listed.body?.filter((dataPlane) => dataPlane.environmentId === ENVIRONMENT_ID) ?? [];
+  if (listed.status !== 200) {
+    console.warn(`⚠️  Could not list data planes for cleanup: status=${listed.status}`);
+    return;
+  }
+  const provisioned = listed.body.filter((dataPlane) => dataPlane.environmentId === ENVIRONMENT_ID);
   for (const dataPlane of provisioned) {
-    await deleteDataPlane(dataPlane.id);
+    const deleted = await deleteDataPlane(dataPlane.id);
+    if (deleted.status !== 204) {
+      console.warn(`⚠️  Could not clean up data plane [${dataPlane.id}]: status=${deleted.status} body=${deleted.raw}`);
+    }
   }
 }
 


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7260

## :pencil2: A description of the changes proposed in the pull request

Loads the data plane definitions AM-7259 stores, so domains can be served from a provisioned data plane.

At startup the loader reads the definitions out of the management repository and hands them to the registry alongside the gravitee.yml ones. When one is provisioned over the internal API it registers straight away, so you don't have to restart the node to use it.

The provider never sees its configuration. The stored JSON gets flattened onto dotted keys under dataPlanes.provisioned.<id> and published as a property source, and the plugin resolves its own settings out of the environment exactly like it already does for the yaml ones. Nothing downstream needs to know where a definition came from.

Registering is best effort. The definition is already saved by the time it runs, so a failure gets logged and the plane waits for the next restart rather than failing a provisioning call that actually succeeded.

Also in here:

- DataPlaneRegistryImpl.register throws when no provider could be built, instead of storing a description that a domain can bind to but nothing can serve.
- An id whose registration failed stays free, so a corrected definition can reuse it without a restart.
- Provisioning an id the gravitee.yml already declares is rejected, not just default.

The register call sits in the endpoint rather than the service. ServiceConfiguration component scans io.gravitee.am.service and the gateway imports it, so DataPlaneDefinitionServiceImpl is a bean in the gateway too, and injecting the management API only loader into it would break gateway startup.

## :memo: Test scenarios

Unit and e2e coverage in the branch, all green. Manual test steps with curl commands are in the Jira ticket.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

The runtime registration is idempotent on purpose. AM-7261 adds the sync event that tells the other management API instances about a new data plane, and when that lands it can just call register(id) without worrying about double registering on the node that created it.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
