### PR TITLE
feat: notify other management api instances when a data plane changes

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/event/DataPlaneEvent.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/event/DataPlaneEvent.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.event;
+
+/**
+ * @author GraviteeSource Team
+ */
+public enum DataPlaneEvent {
+
+    DEPLOY,
+    UPDATE,
+    UNDEPLOY;
+
+    public static DataPlaneEvent actionOf(Action action) {
+        return switch (action) {
+            case CREATE -> DataPlaneEvent.DEPLOY;
+            case UPDATE -> DataPlaneEvent.UPDATE;
+            case DELETE -> DataPlaneEvent.UNDEPLOY;
+            default -> null;
+        };
+    }
+}

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/event/Event.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/event/Event.java
@@ -61,6 +61,7 @@ public abstract class Event {
             case CIMD_METADATA -> CimdMetadataEvent.actionOf(action);
             case LICENSE -> LicenseEvent.actionOf(action);
             case ENTRYPOINT -> EntrypointEvent.actionOf(action);
+            case DATA_PLANE -> DataPlaneEvent.actionOf(action);
             default -> null;
         };
     }

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/event/Type.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/event/Type.java
@@ -56,5 +56,6 @@ public enum Type {
     CIMD_METADATA,
     TRUST_DOMAIN,
     LICENSE,
-    ENTRYPOINT
+    ENTRYPOINT,
+    DATA_PLANE
 }

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/event/DataPlaneEventTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/event/DataPlaneEventTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author GraviteeSource Team
+ */
+class DataPlaneEventTest {
+
+    @Test
+    void actionOf_mapsTheLifecycleActions() {
+        assertEquals(DataPlaneEvent.DEPLOY, DataPlaneEvent.actionOf(Action.CREATE));
+        assertEquals(DataPlaneEvent.UPDATE, DataPlaneEvent.actionOf(Action.UPDATE));
+        assertEquals(DataPlaneEvent.UNDEPLOY, DataPlaneEvent.actionOf(Action.DELETE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Action.class, names = {"BULK_CREATE", "BULK_UPDATE", "BULK_DELETE"})
+    void actionOf_ignoresBulkActions(Action action) {
+        assertNull(DataPlaneEvent.actionOf(action));
+    }
+
+    /**
+     * A missing case here does not fail loudly: the sync manager logs "Cannot publish event as type
+     * is null" at debug and drops the event, so provisioned data planes would silently never reach
+     * the other management API instances.
+     */
+    @Test
+    void valueOf_resolvesDataPlaneEvents() {
+        assertEquals(DataPlaneEvent.DEPLOY, Event.valueOf(Type.DATA_PLANE, Action.CREATE));
+        assertEquals(DataPlaneEvent.UPDATE, Event.valueOf(Type.DATA_PLANE, Action.UPDATE));
+        assertEquals(DataPlaneEvent.UNDEPLOY, Event.valueOf(Type.DATA_PLANE, Action.DELETE));
+    }
+}

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/event/DataPlaneEventTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/event/DataPlaneEventTest.java
@@ -40,11 +40,6 @@ class DataPlaneEventTest {
         assertNull(DataPlaneEvent.actionOf(action));
     }
 
-    /**
-     * A missing case here does not fail loudly: the sync manager logs "Cannot publish event as type
-     * is null" at debug and drops the event, so provisioned data planes would silently never reach
-     * the other management API instances.
-     */
     @Test
     void valueOf_resolvesDataPlaneEvents() {
         assertEquals(DataPlaneEvent.DEPLOY, Event.valueOf(Type.DATA_PLANE, Action.CREATE));

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpoint.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpoint.java
@@ -24,9 +24,6 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.vertx.ext.web.RoutingContext;
 
 /**
- * Removes a provisioned data plane: {@code DELETE /_node/dataplanes/:id}. Refused with a 409 while
- * a domain still points at it.
- *
  * @author GraviteeSource Team
  */
 public class DeleteDataPlaneEndpoint extends AbstractInternalApiEndpoint {
@@ -64,10 +61,11 @@ public class DeleteDataPlaneEndpoint extends AbstractInternalApiEndpoint {
         dataPlaneDefinitionService.delete(id)
                 .subscribe(
                         () -> {
-                            // this node stops serving it now; the others follow on the sync event
                             dataPlaneRegistry.unregister(id);
                             provisionedDataPlaneLoader.forget(id);
-                            context.response().setStatusCode(HttpStatusCode.NO_CONTENT_204).end();
+                            context.response()
+                                    .setStatusCode(HttpStatusCode.NO_CONTENT_204)
+                                    .end();
                         },
                         throwable -> respondFailure(context, throwable, "Unable to delete the data plane definition"));
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpoint.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpoint.java
@@ -16,7 +16,9 @@
 package io.gravitee.am.management.handlers.internalapi.endpoints;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.vertx.ext.web.RoutingContext;
@@ -32,10 +34,17 @@ public class DeleteDataPlaneEndpoint extends AbstractInternalApiEndpoint {
     static final String PARAM_ID = "id";
 
     private final DataPlaneDefinitionService dataPlaneDefinitionService;
+    private final DataPlaneRegistry dataPlaneRegistry;
+    private final ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
 
-    public DeleteDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService, ObjectMapper objectMapper) {
+    public DeleteDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService,
+                                   DataPlaneRegistry dataPlaneRegistry,
+                                   ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+                                   ObjectMapper objectMapper) {
         super(objectMapper);
         this.dataPlaneDefinitionService = dataPlaneDefinitionService;
+        this.dataPlaneRegistry = dataPlaneRegistry;
+        this.provisionedDataPlaneLoader = provisionedDataPlaneLoader;
     }
 
     @Override
@@ -54,7 +63,12 @@ public class DeleteDataPlaneEndpoint extends AbstractInternalApiEndpoint {
 
         dataPlaneDefinitionService.delete(id)
                 .subscribe(
-                        () -> context.response().setStatusCode(HttpStatusCode.NO_CONTENT_204).end(),
+                        () -> {
+                            // this node stops serving it now; the others follow on the sync event
+                            dataPlaneRegistry.unregister(id);
+                            provisionedDataPlaneLoader.forget(id);
+                            context.response().setStatusCode(HttpStatusCode.NO_CONTENT_204).end();
+                        },
                         throwable -> respondFailure(context, throwable, "Unable to delete the data plane definition"));
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/spring/InternalApiConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/spring/InternalApiConfiguration.java
@@ -21,6 +21,7 @@ import io.gravitee.am.management.handlers.internalapi.endpoints.DeleteDataPlaneE
 import io.gravitee.am.management.handlers.internalapi.endpoints.GetDataPlaneEndpoint;
 import io.gravitee.am.management.handlers.internalapi.InternalApiService;
 import io.gravitee.am.management.handlers.internalapi.endpoints.ListDataPlanesEndpoint;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import org.springframework.context.annotation.Bean;
@@ -53,8 +54,11 @@ public class InternalApiConfiguration {
     }
 
     @Bean
-    public DeleteDataPlaneEndpoint deleteDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService, ObjectMapper objectMapper) {
-        return new DeleteDataPlaneEndpoint(dataPlaneDefinitionService, objectMapper);
+    public DeleteDataPlaneEndpoint deleteDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService,
+                                                           DataPlaneRegistry dataPlaneRegistry,
+                                                           ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+                                                           ObjectMapper objectMapper) {
+        return new DeleteDataPlaneEndpoint(dataPlaneDefinitionService, dataPlaneRegistry, provisionedDataPlaneLoader, objectMapper);
     }
 
     @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpointTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpointTest.java
@@ -16,7 +16,9 @@
 package io.gravitee.am.management.handlers.internalapi.endpoints;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.exception.DataPlaneDefinitionNotFoundException;
 import io.gravitee.am.service.exception.DataPlaneInUseByDomainsException;
 import io.gravitee.common.http.HttpMethod;
@@ -33,8 +35,10 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +53,12 @@ class DeleteDataPlaneEndpointTest {
     private DataPlaneDefinitionService dataPlaneDefinitionService;
 
     @Mock
+    private DataPlaneRegistry dataPlaneRegistry;
+
+    @Mock
+    private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+
+    @Mock
     private RoutingContext routingContext;
 
     private HttpServerResponse response;
@@ -59,7 +69,7 @@ class DeleteDataPlaneEndpointTest {
     void setUp() {
         response = mock(HttpServerResponse.class, RETURNS_SELF);
         when(routingContext.response()).thenReturn(response);
-        endpoint = new DeleteDataPlaneEndpoint(dataPlaneDefinitionService, new ObjectMapper());
+        endpoint = new DeleteDataPlaneEndpoint(dataPlaneDefinitionService, dataPlaneRegistry, provisionedDataPlaneLoader, new ObjectMapper());
     }
 
     @Test
@@ -77,6 +87,29 @@ class DeleteDataPlaneEndpointTest {
 
         verify(response).setStatusCode(204);
         verify(response).end();
+    }
+
+    @Test
+    void shouldStopServingTheDataPlaneOnThisNode() {
+        when(routingContext.pathParam(DeleteDataPlaneEndpoint.PARAM_ID)).thenReturn("dp-acme");
+        when(dataPlaneDefinitionService.delete("dp-acme")).thenReturn(Completable.complete());
+
+        endpoint.handle(routingContext);
+
+        verify(dataPlaneRegistry).unregister("dp-acme");
+        verify(provisionedDataPlaneLoader).forget("dp-acme");
+    }
+
+    @Test
+    void shouldKeepServingTheDataPlaneWhenTheDeletionIsRefused() {
+        when(routingContext.pathParam(DeleteDataPlaneEndpoint.PARAM_ID)).thenReturn("dp-acme");
+        when(dataPlaneDefinitionService.delete("dp-acme"))
+                .thenReturn(Completable.error(new DataPlaneInUseByDomainsException("dp-acme")));
+
+        endpoint.handle(routingContext);
+
+        verify(dataPlaneRegistry, never()).unregister(any());
+        verify(provisionedDataPlaneLoader, never()).forget(any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManager.java
@@ -82,9 +82,15 @@ public class ProvisionedDataPlaneManager extends AbstractService<ProvisionedData
     }
 
     private void register(DataPlaneDefinition definition) {
+        // the node that served the provisioning request reads its own event back
+        if (provisionedDataPlaneLoader.isServing(definition)) {
+            log.debug("Data plane [{}] is already served at this version, ignoring the event", definition.getId());
+            return;
+        }
         try {
             dataPlaneRegistry.unregister(definition.getId());
             dataPlaneRegistry.register(provisionedDataPlaneLoader.publish(definition));
+            provisionedDataPlaneLoader.markServing(definition);
             log.info("Data plane [{}] of type [{}] registered from a sync event", definition.getId(), definition.getType());
         } catch (Exception e) {
             log.error("Data plane [{}] could not be registered and will be unavailable; domains bound to it cannot be served",

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManager.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl;
+
+import io.gravitee.am.common.event.DataPlaneEvent;
+import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.service.AbstractService;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Applies data plane definitions provisioned on another management API instance. The node serving
+ * the provisioning request registers the definition itself; every other node only ever learns about
+ * it here.
+ * <p>
+ * There is no initial load to do: {@code DataPlaneRegistryImpl} reads the stored definitions when it
+ * starts, and it is listed before this component in the node's components.
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+@CustomLog
+public class ProvisionedDataPlaneManager extends AbstractService<ProvisionedDataPlaneManager> implements EventListener<DataPlaneEvent, Payload> {
+
+    private final DataPlaneRegistry dataPlaneRegistry;
+    private final ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+    private final DataPlaneDefinitionRepository dataPlaneDefinitionRepository;
+    private final EventManager eventManager;
+
+    public ProvisionedDataPlaneManager(DataPlaneRegistry dataPlaneRegistry,
+                                       ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+                                       @Lazy DataPlaneDefinitionRepository dataPlaneDefinitionRepository,
+                                       EventManager eventManager) {
+        this.dataPlaneRegistry = dataPlaneRegistry;
+        this.provisionedDataPlaneLoader = provisionedDataPlaneLoader;
+        this.dataPlaneDefinitionRepository = dataPlaneDefinitionRepository;
+        this.eventManager = eventManager;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        log.info("Register event listener for data plane events for the management API");
+        eventManager.subscribeForEvents(this, DataPlaneEvent.class);
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        eventManager.unsubscribeForEvents(this, DataPlaneEvent.class);
+    }
+
+    @Override
+    public void onEvent(Event<DataPlaneEvent, Payload> event) {
+        String dataPlaneId = event.content().getId();
+        switch (event.type()) {
+            case DEPLOY, UPDATE -> reload(dataPlaneId);
+            case UNDEPLOY -> undeploy(dataPlaneId);
+        }
+    }
+
+    private void reload(String dataPlaneId) {
+        dataPlaneDefinitionRepository.findById(dataPlaneId)
+                .subscribe(
+                        this::register,
+                        error -> log.error("Data plane [{}] could not be read and will be unavailable until restart", dataPlaneId, error),
+                        // the definition was deleted between the event being written and read back
+                        () -> undeploy(dataPlaneId));
+    }
+
+    private void register(DataPlaneDefinition definition) {
+        try {
+            // rebuild rather than skip an id already held: a delete and a re-create of one id can
+            // reach this node collapsed into a single deploy, and the provider held is then the
+            // one belonging to the definition that has gone
+            dataPlaneRegistry.unregister(definition.getId());
+            dataPlaneRegistry.register(provisionedDataPlaneLoader.publish(definition));
+            log.info("Data plane [{}] of type [{}] registered from a sync event", definition.getId(), definition.getType());
+        } catch (Exception e) {
+            log.error("Data plane [{}] could not be registered and will be unavailable; domains bound to it cannot be served",
+                    definition.getId(), e);
+        }
+    }
+
+    private void undeploy(String dataPlaneId) {
+        dataPlaneRegistry.unregister(dataPlaneId);
+        provisionedDataPlaneLoader.forget(dataPlaneId);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManager.java
@@ -30,13 +30,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /**
- * Applies data plane definitions provisioned on another management API instance. The node serving
- * the provisioning request registers the definition itself; every other node only ever learns about
- * it here.
- * <p>
- * There is no initial load to do: {@code DataPlaneRegistryImpl} reads the stored definitions when it
- * starts, and it is listed before this component in the node's components.
- *
  * @author GraviteeSource Team
  */
 @Component
@@ -85,15 +78,11 @@ public class ProvisionedDataPlaneManager extends AbstractService<ProvisionedData
                 .subscribe(
                         this::register,
                         error -> log.error("Data plane [{}] could not be read and will be unavailable until restart", dataPlaneId, error),
-                        // the definition was deleted between the event being written and read back
                         () -> undeploy(dataPlaneId));
     }
 
     private void register(DataPlaneDefinition definition) {
         try {
-            // rebuild rather than skip an id already held: a delete and a re-create of one id can
-            // reach this node collapsed into a single deploy, and the provider held is then the
-            // one belonging to the definition that has gone
             dataPlaneRegistry.unregister(definition.getId());
             dataPlaneRegistry.register(provisionedDataPlaneLoader.publish(definition));
             log.info("Data plane [{}] of type [{}] registered from a sync event", definition.getId(), definition.getType());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManagerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManagerTest.java
@@ -101,11 +101,11 @@ class ProvisionedDataPlaneManagerTest {
 
     /**
      * The sync poll keeps only the latest event per type and id, so a delete and a re-create of one
-     * id inside the poll window arrive as a lone deploy. Skipping an id already held would leave
-     * this node serving the definition that was deleted.
+     * id inside the poll window arrive as a lone deploy. Registering without dropping the id first
+     * would be refused by the registry, which rejects a duplicate id.
      */
     @Test
-    void shouldReplaceAnIdItAlreadyHoldsOnDeploy() throws Exception {
+    void shouldUnregisterBeforeRegisteringOnDeploy() throws Exception {
         when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(definition()));
 
         manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
@@ -113,6 +113,45 @@ class ProvisionedDataPlaneManagerTest {
         InOrder inOrder = inOrder(dataPlaneRegistry);
         inOrder.verify(dataPlaneRegistry).unregister("dp-1");
         inOrder.verify(dataPlaneRegistry).register(DESCRIPTION);
+    }
+
+    /**
+     * The management sync is not filtered by origin, so the node that served the provisioning request
+     * reads its own deploy back. It already holds the provider, and rebuilding would close the pool
+     * under any domain already using it.
+     */
+    @Test
+    void shouldIgnoreADeployForTheVersionItAlreadyServes() throws Exception {
+        DataPlaneDefinition definition = definition();
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(definition));
+        when(provisionedDataPlaneLoader.isServing(definition)).thenReturn(true);
+
+        manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
+
+        verify(dataPlaneRegistry, never()).unregister(any());
+        verify(dataPlaneRegistry, never()).register(any());
+        verify(provisionedDataPlaneLoader, never()).publish(any());
+    }
+
+    @Test
+    void shouldRecordTheVersionItServesOnceRegistered() throws Exception {
+        DataPlaneDefinition definition = definition();
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(definition));
+
+        manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
+
+        verify(provisionedDataPlaneLoader).markServing(definition);
+    }
+
+    @Test
+    void shouldNotRecordTheVersionWhenTheProviderCannotBeBuilt() throws Exception {
+        DataPlaneDefinition definition = definition();
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(definition));
+        doThrow(new IllegalStateException("no provider for type mongodb")).when(dataPlaneRegistry).register(DESCRIPTION);
+
+        manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
+
+        verify(provisionedDataPlaneLoader, never()).markServing(any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManagerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManagerTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl;
+
+import io.gravitee.am.common.event.Action;
+import io.gravitee.am.common.event.DataPlaneEvent;
+import io.gravitee.am.dataplane.api.DataPlaneDescription;
+import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.reactivex.rxjava3.core.Maybe;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProvisionedDataPlaneManagerTest {
+
+    private static final DataPlaneDescription DESCRIPTION =
+            new DataPlaneDescription("dp-1", "name", "mongodb", "dataPlanes.provisioned.dp-1", "https://gw");
+
+    @Mock
+    private DataPlaneRegistry dataPlaneRegistry;
+
+    @Mock
+    private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+
+    @Mock
+    private DataPlaneDefinitionRepository dataPlaneDefinitionRepository;
+
+    @Mock
+    private EventManager eventManager;
+
+    private ProvisionedDataPlaneManager manager;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        manager = new ProvisionedDataPlaneManager(dataPlaneRegistry, provisionedDataPlaneLoader, dataPlaneDefinitionRepository, eventManager);
+        when(provisionedDataPlaneLoader.publish(any())).thenReturn(DESCRIPTION);
+    }
+
+    @Test
+    void shouldSubscribeToDataPlaneEventsOnStart() throws Exception {
+        manager.doStart();
+
+        verify(eventManager).subscribeForEvents(manager, DataPlaneEvent.class);
+    }
+
+    @Test
+    void shouldUnsubscribeOnStop() throws Exception {
+        manager.doStart();
+        manager.doStop();
+
+        verify(eventManager).unsubscribeForEvents(manager, DataPlaneEvent.class);
+    }
+
+    @Test
+    void shouldRegisterTheDefinitionOnDeploy() throws Exception {
+        DataPlaneDefinition definition = definition();
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(definition));
+
+        manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
+
+        verify(provisionedDataPlaneLoader).publish(definition);
+        verify(dataPlaneRegistry).register(DESCRIPTION);
+    }
+
+    /**
+     * The sync poll keeps only the latest event per type and id, so a delete and a re-create of one
+     * id inside the poll window arrive as a lone deploy. Skipping an id already held would leave
+     * this node serving the definition that was deleted.
+     */
+    @Test
+    void shouldReplaceAnIdItAlreadyHoldsOnDeploy() throws Exception {
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(definition()));
+
+        manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
+
+        InOrder inOrder = inOrder(dataPlaneRegistry);
+        inOrder.verify(dataPlaneRegistry).unregister("dp-1");
+        inOrder.verify(dataPlaneRegistry).register(DESCRIPTION);
+    }
+
+    @Test
+    void shouldRegisterTheDefinitionOnUpdate() {
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(definition()));
+
+        manager.onEvent(event(DataPlaneEvent.UPDATE, "dp-1"));
+
+        verify(dataPlaneRegistry).register(DESCRIPTION);
+    }
+
+    @Test
+    void shouldStopServingTheDataPlaneOnUndeploy() {
+        manager.onEvent(event(DataPlaneEvent.UNDEPLOY, "dp-1"));
+
+        verify(dataPlaneRegistry).unregister("dp-1");
+        verify(provisionedDataPlaneLoader).forget("dp-1");
+        verify(dataPlaneDefinitionRepository, never()).findById(any());
+    }
+
+    @Test
+    void shouldStopServingTheDataPlaneWhenTheDefinitionHasGoneByTheTimeTheDeployIsRead() {
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.empty());
+
+        manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
+
+        verify(dataPlaneRegistry).unregister("dp-1");
+        verify(provisionedDataPlaneLoader).forget("dp-1");
+        verify(dataPlaneRegistry, never()).register(any());
+    }
+
+    @Test
+    void shouldNotFailWhenTheDefinitionCannotBeRead() {
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.error(new RuntimeException("connection lost")));
+
+        manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
+
+        verify(dataPlaneRegistry, never()).register(any());
+    }
+
+    @Test
+    void shouldNotFailWhenTheProviderCannotBeBuilt() {
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(definition()));
+        doThrow(new IllegalStateException("no provider for type mongodb")).when(dataPlaneRegistry).register(DESCRIPTION);
+
+        manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
+
+        verify(dataPlaneRegistry).register(DESCRIPTION);
+    }
+
+    private static SimpleEvent<DataPlaneEvent, Payload> event(DataPlaneEvent type, String dataPlaneId) {
+        Action action = switch (type) {
+            case DEPLOY -> Action.CREATE;
+            case UPDATE -> Action.UPDATE;
+            case UNDEPLOY -> Action.DELETE;
+        };
+        return new SimpleEvent<>(type, new Payload(dataPlaneId, ReferenceType.ENVIRONMENT, "DEFAULT", action));
+    }
+
+    private static DataPlaneDefinition definition() {
+        var definition = new DataPlaneDefinition();
+        definition.setId("dp-1");
+        definition.setName("Data plane 1");
+        definition.setType("mongodb");
+        definition.setOrganizationId("DEFAULT");
+        definition.setEnvironmentId("DEFAULT");
+        definition.setConfiguration("{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}");
+        return definition;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/node/ManagementNode.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/node/ManagementNode.java
@@ -24,6 +24,7 @@ import io.gravitee.am.management.service.IdentityProviderManager;
 import io.gravitee.am.management.service.impl.ClientSecretManager;
 import io.gravitee.am.management.service.impl.OrganizationLicenseManager;
 import io.gravitee.am.management.service.impl.ProtectedResourceSecretManager;
+import io.gravitee.am.management.service.impl.ProvisionedDataPlaneManager;
 import io.gravitee.am.management.service.spring.ManagementUpgraderConfiguration;
 import io.gravitee.am.management.service.tasks.TasksLoader;
 import io.gravitee.am.management.handlers.internalapi.InternalApiService;
@@ -75,6 +76,8 @@ public class ManagementNode extends JettyNode {
     public List<Class<? extends LifecycleComponent>> components() {
         List<Class<? extends LifecycleComponent>> components = super.components();
         components.add(DataPlaneRegistryImpl.class);
+        // after the registry: it loads the stored definitions on start, this only reacts to changes
+        components.add(ProvisionedDataPlaneManager.class);
         components.addAll(ManagementUpgraderConfiguration.getComponents());
         components.add(PluginEventListener.class);
         components.add(AuditReporterManager.class);

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/node/ManagementNode.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/node/ManagementNode.java
@@ -76,7 +76,6 @@ public class ManagementNode extends JettyNode {
     public List<Class<? extends LifecycleComponent>> components() {
         List<Class<? extends LifecycleComponent>> components = super.components();
         components.add(DataPlaneRegistryImpl.class);
-        // after the registry: it loads the stored definitions on start, this only reacts to changes
         components.add(ProvisionedDataPlaneManager.class);
         components.addAll(ManagementUpgraderConfiguration.getComponents());
         components.add(PluginEventListener.class);

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistry.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistry.java
@@ -45,15 +45,8 @@ import java.util.List;
 public interface DataPlaneRegistry {
     List<DataPlaneDescription> getDataPlanes();
 
-    /**
-     * Builds the provider for this description and makes it available. Throws if the id is already
-     * registered, so a caller replacing a definition must {@link #unregister(String)} first.
-     */
     void register(DataPlaneDescription description);
 
-    /**
-     * Stops the provider registered under this id and drops it. Does nothing when the id is unknown.
-     */
     void unregister(String dataPlaneId);
 
     List<DataPlaneProvider> getAllProviders();

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistry.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistry.java
@@ -45,6 +45,17 @@ import java.util.List;
 public interface DataPlaneRegistry {
     List<DataPlaneDescription> getDataPlanes();
 
+    /**
+     * Builds the provider for this description and makes it available. Throws if the id is already
+     * registered, so a caller replacing a definition must {@link #unregister(String)} first.
+     */
+    void register(DataPlaneDescription description);
+
+    /**
+     * Stops the provider registered under this id and drops it. Does nothing when the id is unknown.
+     */
+    void unregister(String dataPlaneId);
+
     List<DataPlaneProvider> getAllProviders();
 
     DataPlaneProvider getProvider(Domain domain);

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImpl.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImpl.java
@@ -190,11 +190,11 @@ public class DataPlaneRegistryImpl extends AbstractService<DataPlaneRegistryImpl
         if (!hasText(description.id())) {
             throw new IllegalStateException("Invalid data plan definition, id must be specified");
         }
+
         if (this.dataPlanProviders.containsKey(description.id())) {
             throw new IllegalStateException("Invalid data plan definition, id must be unique");
         }
-        // publishing a description without a provider lets a domain bind to a data plane nothing can
-        // serve, and the domain cannot then be deleted: getProviderById is on the deletion path too
+
         var provider = dataPlanePluginManager.create(description)
                 .orElseThrow(() -> new IllegalStateException("No data plane provider could be built for id " + description.id()));
         dataPlanProviders.put(description.id(), provider);
@@ -208,13 +208,13 @@ public class DataPlaneRegistryImpl extends AbstractService<DataPlaneRegistryImpl
         if (provider == null) {
             return;
         }
+
         try {
             provider.stop();
         } catch (Exception e) {
-            // the id is already free either way, so a provider that will not close must not block a
-            // replacement definition from registering
             log.error("Data plane [{}] could not be stopped cleanly", dataPlaneId, e);
         }
+
         log.info("Data plane [{}] unregistered", dataPlaneId);
     }
 }

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImpl.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImpl.java
@@ -185,7 +185,8 @@ public class DataPlaneRegistryImpl extends AbstractService<DataPlaneRegistryImpl
         }
     }
 
-    void register(DataPlaneDescription description){
+    @Override
+    public void register(DataPlaneDescription description){
         if (!hasText(description.id())) {
             throw new IllegalStateException("Invalid data plan definition, id must be specified");
         }
@@ -198,5 +199,22 @@ public class DataPlaneRegistryImpl extends AbstractService<DataPlaneRegistryImpl
                 .orElseThrow(() -> new IllegalStateException("No data plane provider could be built for id " + description.id()));
         dataPlanProviders.put(description.id(), provider);
         dataPlanDescriptions.put(description.id(), description);
+    }
+
+    @Override
+    public void unregister(String dataPlaneId) {
+        dataPlanDescriptions.remove(dataPlaneId);
+        var provider = dataPlanProviders.remove(dataPlaneId);
+        if (provider == null) {
+            return;
+        }
+        try {
+            provider.stop();
+        } catch (Exception e) {
+            // the id is already free either way, so a provider that will not close must not block a
+            // replacement definition from registering
+            log.error("Data plane [{}] could not be stopped cleanly", dataPlaneId, e);
+        }
+        log.info("Data plane [{}] unregistered", dataPlaneId);
     }
 }

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/test/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImplTest.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/test/java/io/gravitee/am/plugins/dataplane/core/DataPlaneRegistryImplTest.java
@@ -28,6 +28,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -101,5 +104,48 @@ class DataPlaneRegistryImplTest {
 
         assertThatCode(() -> registry.register(DESCRIPTION)).doesNotThrowAnyException();
         assertThat(registry.getProviderById("dp-1")).isSameAs(provider);
+    }
+
+    @Test
+    void should_stop_and_drop_an_unregistered_provider() {
+        when(dataPlanePluginManager.create(DESCRIPTION)).thenReturn(Optional.of(provider));
+        DataPlaneRegistryImpl registry = registry();
+        registry.register(DESCRIPTION);
+
+        registry.unregister("dp-1");
+
+        verify(provider).stop();
+        assertThat(registry.getDataPlanes()).isEmpty();
+        assertThatThrownBy(() -> registry.getProviderById("dp-1")).isInstanceOf(IllegalDataPlaneIdException.class);
+    }
+
+    @Test
+    void should_let_an_unregistered_id_be_claimed_again() {
+        // a deleted definition and a new one under the same id must not resolve to the old provider
+        DataPlaneProvider replacement = mock(DataPlaneProvider.class);
+        when(dataPlanePluginManager.create(DESCRIPTION)).thenReturn(Optional.of(provider), Optional.of(replacement));
+        DataPlaneRegistryImpl registry = registry();
+        registry.register(DESCRIPTION);
+
+        registry.unregister("dp-1");
+        registry.register(DESCRIPTION);
+
+        assertThat(registry.getProviderById("dp-1")).isSameAs(replacement);
+    }
+
+    @Test
+    void should_ignore_unregistering_an_unknown_id() {
+        assertThatCode(() -> registry().unregister("never-registered")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_free_the_id_even_when_the_provider_will_not_stop() {
+        when(dataPlanePluginManager.create(DESCRIPTION)).thenReturn(Optional.of(provider), Optional.of(provider));
+        doThrow(new IllegalStateException("connection pool is wedged")).when(provider).stop();
+        DataPlaneRegistryImpl registry = registry();
+        registry.register(DESCRIPTION);
+
+        assertThatCode(() -> registry.unregister("dp-1")).doesNotThrowAnyException();
+        assertThatCode(() -> registry.register(DESCRIPTION)).doesNotThrowAnyException();
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -107,7 +107,21 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
         }
     }
 
-    private DataPlaneDescription publish(DataPlaneDefinition definition) throws Exception {
+    /**
+     * Drops what {@link #publish} put in the environment, so a later definition reusing this id
+     * cannot resolve the settings of the one that has gone.
+     */
+    public void forget(String dataPlaneId) {
+        registered.remove(dataPlaneId);
+        properties.keySet().removeIf(key -> key.startsWith(PROPERTIES_BASE + "." + dataPlaneId + "."));
+    }
+
+    /**
+     * Publishes a definition's connection settings under a prefix of its own and describes it in the
+     * terms the plugins expect: they resolve their configuration from the environment rather than
+     * being handed it.
+     */
+    public DataPlaneDescription publish(DataPlaneDefinition definition) throws Exception {
         var propertiesBase = PROPERTIES_BASE + "." + definition.getId();
         // a failed registration leaves its keys published; drop them so a corrected definition cannot resolve stale values
         properties.keySet().removeIf(key -> key.startsWith(propertiesBase + "."));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -43,10 +43,7 @@ import java.util.function.Consumer;
 @CustomLog
 public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
-    // must not be "graviteeYamlConfiguration": gravitee-node's /_node/configuration endpoint dumps that
-    // source key by key, and these definitions carry credentials
     static final String PROPERTY_SOURCE_NAME = "provisionedDataPlanes";
-
     static final String PROPERTIES_BASE = "dataPlanes.provisioned";
 
     private final DataPlaneLoader configurationLoader;
@@ -107,25 +104,17 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
         }
     }
 
-    /**
-     * Drops what {@link #publish} put in the environment, so a later definition reusing this id
-     * cannot resolve the settings of the one that has gone.
-     */
     public void forget(String dataPlaneId) {
         registered.remove(dataPlaneId);
         properties.keySet().removeIf(key -> key.startsWith(PROPERTIES_BASE + "." + dataPlaneId + "."));
     }
 
-    /**
-     * Publishes a definition's connection settings under a prefix of its own and describes it in the
-     * terms the plugins expect: they resolve their configuration from the environment rather than
-     * being handed it.
-     */
     public DataPlaneDescription publish(DataPlaneDefinition definition) throws Exception {
         var propertiesBase = PROPERTIES_BASE + "." + definition.getId();
-        // a failed registration leaves its keys published; drop them so a corrected definition cannot resolve stale values
+
         properties.keySet().removeIf(key -> key.startsWith(propertiesBase + "."));
         flatten(propertiesBase, objectMapper.readTree(definition.getConfiguration()), properties);
+
         return new DataPlaneDescription(
                 definition.getId(),
                 definition.getName(),

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -29,7 +29,6 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -43,7 +42,10 @@ import java.util.function.Consumer;
 @CustomLog
 public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
+    // must not be "graviteeYamlConfiguration": gravitee-node's /_node/configuration endpoint dumps that
+    // source key by key, and these definitions carry credentials
     static final String PROPERTY_SOURCE_NAME = "provisionedDataPlanes";
+
     static final String PROPERTIES_BASE = "dataPlanes.provisioned";
 
     private final DataPlaneLoader configurationLoader;
@@ -55,7 +57,8 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
             .build();
 
     private final Map<String, Object> properties = new ConcurrentHashMap<>();
-    private final Set<String> registered = ConcurrentHashMap.newKeySet();
+    // id -> the version of the definition this node serves, so a deploy can be told from a replay
+    private final Map<String, String> registered = new ConcurrentHashMap<>();
     private final AtomicReference<Consumer<DataPlaneDescription>> storageRef = new AtomicReference<>();
 
     public ProvisionedDataPlaneLoader(DataPlaneLoader configurationLoader,
@@ -80,7 +83,7 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
 
         // nothing is lost when the registry has not started yet: load publishes its consumer before
         // reading the repository, so the definition just persisted is picked up by that read
-        if (storage == null || registered.contains(dataPlaneId)) {
+        if (storage == null || registered.containsKey(dataPlaneId)) {
             return Completable.complete();
         }
 
@@ -96,7 +99,7 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
     private void activate(DataPlaneDefinition definition, Consumer<DataPlaneDescription> storage) {
         try {
             storage.accept(publish(definition));
-            registered.add(definition.getId());
+            markServing(definition);
             log.info("Data plane [{}] of type [{}] loaded from the management repository", definition.getId(), definition.getType());
         } catch (Exception e) {
             log.error("Data plane [{}] of type [{}] could not be loaded and will be unavailable; domains bound to it cannot be served",
@@ -107,6 +110,29 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
     public void forget(String dataPlaneId) {
         registered.remove(dataPlaneId);
         properties.keySet().removeIf(key -> key.startsWith(PROPERTIES_BASE + "." + dataPlaneId + "."));
+    }
+
+    /**
+     * Whether this node already serves this exact definition. The node handling a provisioning request
+     * registers it directly and then reads its own event back, since the sync poll is not filtered by
+     * origin. Rebuilding on that event would stop a provider that is already current and close its
+     * connection pool under whatever is using it.
+     */
+    public boolean isServing(DataPlaneDefinition definition) {
+        return versionOf(definition).equals(registered.get(definition.getId()));
+    }
+
+    public void markServing(DataPlaneDefinition definition) {
+        registered.put(definition.getId(), versionOf(definition));
+    }
+
+    /**
+     * A delete and a re-create of one id can reach a node collapsed into a single deploy, and that pair
+     * moves the timestamp, so the replacement is still rebuilt.
+     */
+    private static String versionOf(DataPlaneDefinition definition) {
+        var updatedAt = definition.getUpdatedAt();
+        return updatedAt == null ? "" : Long.toString(updatedAt.getTime());
     }
 
     public DataPlaneDescription publish(DataPlaneDefinition definition) throws Exception {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
@@ -18,10 +18,15 @@ package io.gravitee.am.service.impl;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.common.audit.EventType;
+import io.gravitee.am.common.event.Action;
+import io.gravitee.am.common.event.Type;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.model.DataPlaneDefinition;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Organization;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Event;
+import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.plugins.dataplane.core.DataPlanePluginManager;
 import io.gravitee.am.plugins.dataplane.core.MultiDataPlaneLoader;
 import io.gravitee.am.plugins.handlers.api.core.PluginConfigurationValidatorsRegistry;
@@ -30,6 +35,7 @@ import io.gravitee.am.repository.management.api.DomainRepository;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.EnvironmentService;
+import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.OrganizationService;
 import io.gravitee.am.service.dataplane.config.DataPlaneConfigHandler;
 import io.gravitee.am.service.dataplane.config.DataPlaneConnectionSummary;
@@ -60,8 +66,9 @@ import static io.gravitee.am.plugins.dataplane.core.DataPlanePluginManager.PLUGI
 import static org.springframework.util.StringUtils.hasText;
 
 /**
- * Persists a data plane definition. Persisting is all it does: registering the definition so that
- * domains can be served from it is the loader's job, and nothing here emits a sync event.
+ * Persists a data plane definition and emits the sync event that tells the other management API
+ * instances about it. Registering the definition so that domains can be served from it is the
+ * loader's job on the node handling the request, and the manager's job everywhere else.
  *
  * @author GraviteeSource Team
  */
@@ -77,6 +84,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
     private final PluginConfigurationValidatorsRegistry pluginValidatorsRegistry;
     private final List<DataPlaneConfigHandler> configHandlers;
     private final AuditService auditService;
+    private final EventService eventService;
     private final MultiDataPlaneLoader configurationLoader;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -89,6 +97,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                                           PluginConfigurationValidatorsRegistry pluginValidatorsRegistry,
                                           List<DataPlaneConfigHandler> configHandlers,
                                           AuditService auditService,
+                                          EventService eventService,
                                           MultiDataPlaneLoader configurationLoader) {
         this.dataPlaneDefinitionRepository = dataPlaneDefinitionRepository;
         this.domainRepository = domainRepository;
@@ -98,6 +107,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
         this.pluginValidatorsRegistry = pluginValidatorsRegistry;
         this.configHandlers = configHandlers;
         this.auditService = auditService;
+        this.eventService = eventService;
         this.configurationLoader = configurationLoader;
     }
 
@@ -117,7 +127,21 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                                 }))
                                 .map(this::toSummary))
                         .doOnError(throwable -> reportCreated(toSummary(definition), throwable)))
-                .doOnSuccess(summary -> reportCreated(summary, null));
+                .doOnSuccess(summary -> reportCreated(summary, null))
+                // after the audit: a failed event must not report the creation itself as failed
+                .flatMap(summary -> publishEvent(summary, Action.CREATE).toSingleDefault(summary));
+    }
+
+    /**
+     * Tells the other management API instances to load, or drop, this definition. The node handling
+     * the request registers it itself and does not wait for this.
+     */
+    private Completable publishEvent(DataPlaneDefinitionSummary summary, Action action) {
+        // deferred: chained after andThen, an eager call would emit even when the delete was refused
+        return Completable.defer(() -> {
+            Event event = new Event(Type.DATA_PLANE, new Payload(summary.id(), ReferenceType.ENVIRONMENT, summary.environmentId(), action));
+            return eventService.create(event).ignoreElement();
+        });
     }
 
     private void reportCreated(DataPlaneDefinitionSummary summary, Throwable throwable) {
@@ -150,7 +174,8 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                 .flatMapCompletable(summary -> checkNoDomainUsesIt(id)
                         .andThen(Completable.defer(() -> dataPlaneDefinitionRepository.delete(id)))
                         .doOnComplete(() -> reportDeleted(summary, null))
-                        .doOnError(throwable -> reportDeleted(summary, throwable)));
+                        .doOnError(throwable -> reportDeleted(summary, throwable))
+                        .andThen(publishEvent(summary, Action.DELETE)));
     }
 
     private Completable checkNoDomainUsesIt(String dataPlaneId) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
@@ -66,10 +66,6 @@ import static io.gravitee.am.plugins.dataplane.core.DataPlanePluginManager.PLUGI
 import static org.springframework.util.StringUtils.hasText;
 
 /**
- * Persists a data plane definition and emits the sync event that tells the other management API
- * instances about it. Registering the definition so that domains can be served from it is the
- * loader's job on the node handling the request, and the manager's job everywhere else.
- *
  * @author GraviteeSource Team
  */
 @Component
@@ -132,12 +128,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                 .flatMap(summary -> publishEvent(summary, Action.CREATE).toSingleDefault(summary));
     }
 
-    /**
-     * Tells the other management API instances to load, or drop, this definition. The node handling
-     * the request registers it itself and does not wait for this.
-     */
     private Completable publishEvent(DataPlaneDefinitionSummary summary, Action action) {
-        // deferred: chained after andThen, an eager call would emit even when the delete was refused
         return Completable.defer(() -> {
             Event event = new Event(Type.DATA_PLANE, new Payload(summary.id(), ReferenceType.ENVIRONMENT, summary.environmentId(), action));
             return eventService.create(event).ignoreElement();
@@ -192,9 +183,6 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                 .throwable(throwable));
     }
 
-    /**
-     * Drops the stored connection settings in favour of the credential-free summary.
-     */
     private DataPlaneDefinitionSummary toSummary(DataPlaneDefinition definition) {
         return DataPlaneDefinitionSummary.of(definition, connectionSummary(definition));
     }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
@@ -20,7 +20,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.common.audit.EntityType;
 import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.common.audit.Status;
+import io.gravitee.am.common.event.Action;
+import io.gravitee.am.common.event.Type;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Event;
+import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.reporter.api.audit.model.Audit;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
@@ -102,6 +106,9 @@ class DataPlaneDefinitionServiceTest {
     private AuditService auditService;
 
     @Mock
+    private EventService eventService;
+
+    @Mock
     private MultiDataPlaneLoader configurationLoader;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -121,6 +128,7 @@ class DataPlaneDefinitionServiceTest {
                 validatorsRegistry,
                 List.of(new MongoDataPlaneConfigHandler(), new JdbcDataPlaneConfigHandler()),
                 auditService,
+                eventService,
                 configurationLoader);
 
         when(dataPlanePluginManager.get("dataplane-am-mongodb")).thenReturn(mock(DataPlane.class));
@@ -131,6 +139,7 @@ class DataPlaneDefinitionServiceTest {
         when(dataPlaneDefinitionRepository.create(any())).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
         when(dataPlaneDefinitionRepository.delete(anyString())).thenReturn(Completable.complete());
         when(domainRepository.existsByDataPlaneId(anyString())).thenReturn(Single.just(false));
+        when(eventService.create(any())).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
     }
 
     @Test
@@ -631,6 +640,77 @@ class DataPlaneDefinitionServiceTest {
         service.delete("dp-acme").test().awaitDone(10, TimeUnit.SECONDS);
 
         assertThat(capturedAudit().toString()).doesNotContain("sup3r-s3cret", "am-user", "configuration");
+    }
+
+    @Test
+    void shouldPublishADeployEventOnCreate() {
+        service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+
+        Payload payload = capturedEvent(Type.DATA_PLANE).getPayload();
+        assertThat(payload.getId()).isEqualTo("dp-acme");
+        assertThat(payload.getReferenceType()).isEqualTo(ReferenceType.ENVIRONMENT);
+        assertThat(payload.getReferenceId()).isEqualTo(Environment.DEFAULT);
+        assertThat(payload.getAction()).isEqualTo(Action.CREATE);
+    }
+
+    @Test
+    void shouldPublishAnUndeployEventOnDelete() {
+        when(dataPlaneDefinitionRepository.findById("dp-acme")).thenReturn(Maybe.just(definition("dp-acme", "env-1")));
+
+        service.delete("dp-acme").test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        Payload payload = capturedEvent(Type.DATA_PLANE).getPayload();
+        assertThat(payload.getId()).isEqualTo("dp-acme");
+        assertThat(payload.getReferenceType()).isEqualTo(ReferenceType.ENVIRONMENT);
+        assertThat(payload.getReferenceId()).isEqualTo("env-1");
+        assertThat(payload.getAction()).isEqualTo(Action.DELETE);
+    }
+
+    /**
+     * The event carries no data plane id, so it reaches every gateway rather than one. They have no
+     * listener for it and drop it, which is what already happens to license events.
+     */
+    @Test
+    void shouldNotScopeTheEventToASingleDataPlane() {
+        service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        Event event = capturedEvent(Type.DATA_PLANE);
+        assertThat(event.getDataPlaneId()).isNull();
+        assertThat(event.getEnvironmentId()).isNull();
+    }
+
+    @Test
+    void shouldFailTheCreationWhenTheEventCannotBeWritten() {
+        // doReturn: when(...) would invoke the mock and hit the setUp stub with a null event
+        doReturn(Single.error(new TechnicalManagementException("events are down"))).when(eventService).create(any());
+
+        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload()).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertError(TechnicalManagementException.class);
+        // the row is committed and inert: no node registers it until a restart
+        verify(dataPlaneDefinitionRepository).create(any());
+        // the audit runs before the event, so the creation is still recorded as the success it was
+        assertThat(capturedAudit().getOutcome().getStatus()).isEqualTo(Status.SUCCESS);
+    }
+
+    @Test
+    void shouldNotPublishAnEventWhenTheDeleteIsRefused() {
+        when(dataPlaneDefinitionRepository.findById("dp-acme")).thenReturn(Maybe.just(definition("dp-acme", "env-1")));
+        when(domainRepository.existsByDataPlaneId("dp-acme")).thenReturn(Single.just(true));
+
+        service.delete("dp-acme").test().awaitDone(10, TimeUnit.SECONDS)
+                .assertError(DataPlaneInUseByDomainsException.class);
+
+        verify(eventService, never()).create(any());
+    }
+
+    private Event capturedEvent(Type expectedType) {
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(eventService).create(captor.capture());
+        Event event = captor.getValue();
+        assertThat(event.getType()).isEqualTo(expectedType);
+        return event;
     }
 
     private void assertRejected(NewDataPlaneDefinition payload, Class<? extends Throwable> type, String messageFragment) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
@@ -666,10 +666,6 @@ class DataPlaneDefinitionServiceTest {
         assertThat(payload.getAction()).isEqualTo(Action.DELETE);
     }
 
-    /**
-     * The event carries no data plane id, so it reaches every gateway rather than one. They have no
-     * listener for it and drop it, which is what already happens to license events.
-     */
     @Test
     void shouldNotScopeTheEventToASingleDataPlane() {
         service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
@@ -681,16 +677,13 @@ class DataPlaneDefinitionServiceTest {
 
     @Test
     void shouldFailTheCreationWhenTheEventCannotBeWritten() {
-        // doReturn: when(...) would invoke the mock and hit the setUp stub with a null event
         doReturn(Single.error(new TechnicalManagementException("events are down"))).when(eventService).create(any());
 
         TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload()).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertError(TechnicalManagementException.class);
-        // the row is committed and inert: no node registers it until a restart
         verify(dataPlaneDefinitionRepository).create(any());
-        // the audit runs before the event, so the creation is still recorded as the success it was
         assertThat(capturedAudit().getOutcome().getStatus()).isEqualTo(Status.SUCCESS);
     }
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -298,4 +298,56 @@ class ProvisionedDataPlaneLoaderTest {
 
         assertThat(loaded).isEmpty();
     }
+
+    @Test
+    void should_drop_the_published_properties_of_a_forgotten_definition() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://gone:27017/db\"}}")));
+        var loader = loader();
+        loader.load(loaded::add);
+
+        loader.forget("dp-1");
+
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.uri")).isNull();
+    }
+
+    @Test
+    void should_leave_other_definitions_alone_when_one_is_forgotten() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(
+                definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://one:27017/db\"}}"),
+                definition("dp-2", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://two:27017/db\"}}")));
+        var loader = loader();
+        loader.load(loaded::add);
+
+        loader.forget("dp-1");
+
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-2.mongodb.uri")).isEqualTo("mongodb://two:27017/db");
+    }
+
+    @Test
+    void should_let_a_forgotten_id_be_provisioned_again() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://old:27017/db\"}}")));
+        var loader = loader();
+        loader.load(loaded::add);
+        loader.forget("dp-1");
+        when(dataPlaneDefinitionRepository.findById("dp-1"))
+                .thenReturn(Maybe.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://new:27017/db\"}}")));
+
+        loader.register("dp-1").test().assertComplete();
+
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.uri")).isEqualTo("mongodb://new:27017/db");
+        assertThat(loaded).hasSize(2);
+    }
+
+    @Test
+    void should_ignore_forgetting_an_unknown_id() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
+        var loader = loader();
+        loader.load(loaded::add);
+
+        loader.forget("never-provisioned");
+
+        assertThat(loaded).isEmpty();
+    }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -30,6 +30,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -349,5 +350,59 @@ class ProvisionedDataPlaneLoaderTest {
         loader.forget("never-provisioned");
 
         assertThat(loaded).isEmpty();
+    }
+
+    @Test
+    void should_report_it_serves_a_definition_it_has_activated() {
+        var definition = definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}");
+        definition.setUpdatedAt(new Date(1000L));
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(definition));
+        var loader = loader();
+        loader.load(loaded::add);
+
+        assertThat(loader.isServing(definition)).isTrue();
+    }
+
+    @Test
+    void should_not_report_it_serves_a_definition_it_has_never_seen() {
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
+        var loader = loader();
+        loader.load(loaded::add);
+
+        var definition = definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}");
+        definition.setUpdatedAt(new Date(1000L));
+
+        assertThat(loader.isServing(definition)).isFalse();
+    }
+
+    /**
+     * A delete and a re-create of one id arrive collapsed as a lone deploy, carrying a definition the
+     * node has not seen. Reporting it as served would leave the node on the definition that has gone.
+     */
+    @Test
+    void should_not_report_it_serves_a_definition_carrying_a_later_timestamp() {
+        var activated = definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://old:27017/db\"}}");
+        activated.setUpdatedAt(new Date(1000L));
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(activated));
+        var loader = loader();
+        loader.load(loaded::add);
+
+        var recreated = definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://new:27017/db\"}}");
+        recreated.setUpdatedAt(new Date(2000L));
+
+        assertThat(loader.isServing(recreated)).isFalse();
+    }
+
+    @Test
+    void should_not_report_it_serves_a_forgotten_definition() {
+        var definition = definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}");
+        definition.setUpdatedAt(new Date(1000L));
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(definition));
+        var loader = loader();
+        loader.load(loaded::add);
+
+        loader.forget("dp-1");
+
+        assertThat(loader.isServing(definition)).isFalse();
     }
 }

--- a/gravitee-am-test/specs/management/internal-api/dataplane-provisioning.jest.spec.ts
+++ b/gravitee-am-test/specs/management/internal-api/dataplane-provisioning.jest.spec.ts
@@ -28,6 +28,7 @@ import {
 import {
   ALLOWED_SUMMARY_FIELDS,
   BoundDomain,
+  canBindADomainTo,
   createDomainOnDataPlane,
   DATABASE_NAME,
   dataPlanePayload,
@@ -339,6 +340,30 @@ describe('Data plane provisioning (management technical API)', () => {
       } finally {
         await releaseBoundDomain(bound);
       }
+    });
+
+    it('stops accepting domains on a data plane once it is deleted', async () => {
+      const provisioned = await provisionConnectableDataPlane(uniqueName('dp-e2e-undeploy', true));
+      expect(await canBindADomainTo(provisioned.id)).toBe(true);
+
+      const deleted = await deleteDataPlane(provisioned.id);
+      expect(deleted.status).toBe(204);
+
+      // the registry has to give the id up, not just the row: a domain bound to a deleted data plane
+      // would be created against a store nothing is meant to be using
+      expect(await canBindADomainTo(provisioned.id)).toBe(false);
+    });
+
+    it('serves a data plane again when its id is re-provisioned', async () => {
+      const id = uniqueName('dp-e2e-reprovision', true);
+      await provisionConnectableDataPlane(id);
+      expect((await deleteDataPlane(id)).status).toBe(204);
+
+      await provisionConnectableDataPlane(id);
+
+      // the published properties have to be released along with the id, or the second definition
+      // registers against the settings of the one that was deleted
+      expect(await canBindADomainTo(id)).toBe(true);
     });
   });
 

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -175,6 +175,22 @@ export async function releaseBoundDomain(bound: BoundDomain | undefined): Promis
   }
 }
 
+/**
+ * Whether a domain can still be bound to this data plane id. Domain creation validates the id against
+ * the registry, so this reports whether the node is still serving it, not whether the row exists.
+ */
+export async function canBindADomainTo(dataPlaneId: string): Promise<boolean> {
+  let bound: BoundDomain | undefined;
+  try {
+    bound = await createDomainOnDataPlane(dataPlaneId);
+    return true;
+  } catch (e) {
+    return false;
+  } finally {
+    await releaseBoundDomain(bound);
+  }
+}
+
 export const ALLOWED_SUMMARY_FIELDS = [
   'id',
   'name',

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -89,13 +89,6 @@ export function jdbcPayload(id: string): NewDataPlane {
   };
 }
 
-/**
- * A data plane the running stack can genuinely connect to, mirroring its own `dataPlanes[0]`.
- *
- * The payloads above are never dialled, because nothing connects at provisioning time. Registering one
- * does build a provider though, and that needs both a reachable store and the matching
- * ConnectionProvider bean, which only exists for the repository type the stack was started with.
- */
 export function connectablePayload(id: string): NewDataPlane {
   return process.env.REPOSITORY_TYPE === 'jdbc'
     ? {
@@ -158,11 +151,6 @@ export interface BoundDomain {
   accessToken: string;
 }
 
-/**
- * Creates a domain against a data plane provisioned since the node started. Domain creation checks the
- * id against the data plane registry, so this only succeeds once the definition has been registered
- * at runtime rather than at the next restart (AM-7260).
- */
 export async function createDomainOnDataPlane(dataPlaneId: string): Promise<BoundDomain> {
   const accessToken = await requestAdminAccessToken();
   const domain = await createDomain(accessToken, uniqueName('dp-e2e-bound', true), 'Bound to a provisioned data plane', dataPlaneId);
@@ -175,10 +163,6 @@ export async function releaseBoundDomain(bound: BoundDomain | undefined): Promis
   }
 }
 
-/**
- * Whether a domain can still be bound to this data plane id. Domain creation validates the id against
- * the registry, so this reports whether the node is still serving it, not whether the row exists.
- */
 export async function canBindADomainTo(dataPlaneId: string): Promise<boolean> {
   let bound: BoundDomain | undefined;
   try {

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -168,7 +168,11 @@ export async function canBindADomainTo(dataPlaneId: string): Promise<boolean> {
   try {
     bound = await createDomainOnDataPlane(dataPlaneId);
     return true;
-  } catch (e) {
+  } catch (err: any) {
+    // only an unknown data plane means "no": anything else is the test failing for another reason
+    if (err.response?.status !== 400) {
+      throw err;
+    }
     return false;
   } finally {
     await releaseBoundDomain(bound);


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7261

## :pencil2: A description of the changes proposed in the pull request

Tells the other management API instances about a data plane that was provisioned or deleted on one of them. The node serving the request registers it itself, as it already did, so this is only for the instances that never saw the call.

Provisioning and deleting now write a DATA_PLANE event. Every instance picks it up on its sync tick and registers or drops the definition, so a domain can be created against a provisioned data plane whichever node you hit.

It follows the manager pattern the certificate, entrypoint and license listeners already use, so there is no new mechanism here:

- A deploy rebuilds unconditionally rather than skipping an id already held. The sync poll keeps only the latest event per type and id, so a delete and a re-create of one id inside the window arrive as a single deploy, and skipping would leave the node serving the definition that was deleted.
- A deploy naming a definition that has since gone drops the id instead of failing, which is the same collapse in the other direction.
- Undeploy stops the provider and frees the id, and releases the properties it published, so a later definition reusing that id cannot resolve the settings of the one that has gone.
- Deleting over the internal API also unregisters on the node that served it, matching what create already does.

DataPlaneRegistry gains register and unregister. register still throws on a duplicate id, because that is what stops two gravitee.yml definitions claiming one id at startup, so the deploy path unregisters first.

## :memo: Test scenarios

Unit and e2e coverage in the branch, all green.

I also ran two management API instances against the same mongo, one in the local stack and a second on the host, and drove it by hand. Provision on the first and the second logs `registered from a sync event` a few seconds later, no restart. A domain bound to that data plane is then accepted against the second instance, deleting the data plane while the domain still exists is refused with a 409, and once the domain goes the second instance logs `unregistered`.

Manual steps are written up on AM-7261 if QA want to repeat it. One gotcha if you do: the mongo address in the definition has to resolve from inside docker and from the host, so use the machine's LAN IP, not `mongodb` or `localhost`. The driver connects lazily, so a bad address still logs `registered from a sync event` and only falls over later when something actually uses it.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

DataPlaneEvent carries UPDATE for consistency with the other event enums but nothing emits it, as there is no update endpoint. Updating a data plane was dropped along with the cockpit command approach in the design note, though the epic description still mentions it.

Two things this deliberately does not do. Nothing absorbs the gap between the event being written and a remote node registering, so provisioning and immediately creating a domain against another instance can still be refused. AM-7262 owns that, since its rule turns on whether a data plane is loaded. And an id that exists both as a provisioned row and in the gravitee.yml would be unregistered by an undeploy, which takes a contradictory configuration to reach and is already logged as an error when the two collide at startup.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am

