### PR TITLE
fix: avoid StackOverflowError when mounting many vhost-mode domains

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
@@ -19,10 +19,10 @@ import io.gravitee.am.common.event.DomainEvent;
 import io.gravitee.am.gateway.handler.vertx.VertxSecurityDomainHandler;
 import io.gravitee.am.gateway.reactor.Reactor;
 import io.gravitee.am.gateway.reactor.SecurityDomainHandlerRegistry;
+import io.gravitee.am.gateway.reactor.impl.router.VHostDomainIndex;
 import io.gravitee.am.gateway.reactor.impl.router.VHostRouter;
 import io.gravitee.am.gateway.reactor.impl.transaction.TransactionHandlerFactory;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.monitoring.provider.GatewayMetricProvider;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
@@ -39,8 +39,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -67,6 +65,10 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
     // Root router is mutated only under this lock; heavy per-domain work
     // (Spring context refresh, component start) happens before, in parallel.
     private final ReentrantLock routerLock = new ReentrantLock();
+
+    // O(1) host-indexed dispatch for vhost-mode domains - see VHostDomainIndex
+    // javadoc for why per-domain route mounting doesn't scale.
+    private final VHostDomainIndex vhostIndex = new VHostDomainIndex();
 
     @Autowired
     private TransactionHandlerFactory transactionHandlerFactory;
@@ -122,16 +124,10 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
             Domain domain = domainHandler.getDomain();
 
             if (domain.isVhostMode()) {
-                // Mount the same router for each virtual host / path.
-                // Sort vhosts to ensure proper routing order:
-                // - More specific paths (longer) are checked first
-                // - "/" (catch-all) is always checked last
-                List<VirtualHost> sortedVhosts = domain.getVhosts().stream()
-                        .sorted(Comparator.comparing((VirtualHost vhost) -> vhost.getPath().equals("/") ? 1 : 0)
-                                .thenComparing(Comparator.comparing(VirtualHost::getPath).reversed()))
-                        .toList();
-
-                sortedVhosts.forEach(virtualHost -> this.router.route(sanitizePath(virtualHost.getPath())).subRouter(VHostRouter.router(vertx, domain, virtualHost, domainHandler.router())));
+                // Indexed by host instead of mounted as individual Vert.x routes -
+                // see VHostDomainIndex. Per-host ordering (specific path before "/")
+                // is handled inside VHostDomainIndex#mount; no need to pre-sort here.
+                domain.getVhosts().forEach(virtualHost -> vhostIndex.mount(domain, virtualHost, domainHandler.router().getDelegate()));
             } else {
                 this.router.route(sanitizePath(domain.getPath())).subRouter(VHostRouter.router(vertx, domain, domainHandler.router()));
             }
@@ -153,6 +149,10 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
     public void unMountDomain(VertxSecurityDomainHandler domainHandler) {
         routerLock.lock();
         try {
+            Domain domain = domainHandler.getDomain();
+            if (domain.isVhostMode()) {
+                vhostIndex.unmount(domain.getId());
+            }
             domainHandler.router().clear();
         } finally {
             routerLock.unlock();
@@ -163,6 +163,8 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
     public void afterPropertiesSet() {
         router = Router.router(vertx);
         router.route().handler(transactionHandlerFactory.create());
+        // Single route for ALL vhost-mode domains combined - see VHostDomainIndex.
+        router.getDelegate().route().handler(vhostIndex::dispatch);
         router.route().last().handler(context -> sendNotFound(context.response()));
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostDomainIndex.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostDomainIndex.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.reactor.impl.router;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.VirtualHost;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Pattern;
+
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+
+/**
+ * Host-indexed dispatcher for vhost-mode domains.
+ *
+ * The previous strategy ({@link VHostRouter} mounted individually via
+ * {@code this.router.route("/*").subRouter(...)} for every vhost, all on the
+ * SAME shared root router) makes Vert.x-web's route-chain traversal walk
+ * every previously-mounted vhost, in registration order, for every request -
+ * because all vhost routes share the same wildcard path pattern, so nothing
+ * about the route itself lets Vert.x skip non-matching candidates. That
+ * traversal is recursive (one Java stack frame per candidate route tested
+ * via RoutingContext.next()), so request latency AND stack depth both grow
+ * linearly with the number of mounted domains - guaranteed to
+ * StackOverflowError past some domain count (~3000 in practice).
+ *
+ * This class replaces per-domain route mounting with a single Vert.x route
+ * backed by a hashmap keyed on the Host header. Dispatch becomes an O(1)
+ * lookup plus a linear scan only across the candidates registered for THAT
+ * host (in practice 1, occasionally a handful if a host is deliberately
+ * reused with different paths) - no recursion, no dependency on total
+ * domain count.
+ *
+ * Only one Vert.x route needs to ever be mounted on the shared router for
+ * ALL vhost domains combined; call {@link #dispatch(RoutingContext)} from
+ * that route's handler.
+ */
+public class VHostDomainIndex {
+
+    private record Entry(String domainId, Pattern pathPattern, String contextPath, Router delegate) {
+    }
+
+    // hostname (lowercase) -> candidates for that host, most specific path first
+    private final Map<String, CopyOnWriteArrayList<Entry>> byHost = new ConcurrentHashMap<>();
+
+    // domainId -> hosts it registered, so unmount() doesn't need a full scan
+    private final Map<String, List<String>> hostsByDomainId = new ConcurrentHashMap<>();
+
+    public void mount(Domain domain, VirtualHost vhost, Router delegate) {
+        String hostKey = vhost.getHost().toLowerCase(Locale.ROOT);
+        Pattern pathPattern = Pattern.compile(Pattern.quote(vhost.getPath()) + ".*");
+        String contextPath = "/".equals(vhost.getPath()) ? "" : vhost.getPath();
+        Entry entry = new Entry(domain.getId(), pathPattern, contextPath, delegate);
+
+        CopyOnWriteArrayList<Entry> entries = byHost.computeIfAbsent(hostKey, k -> new CopyOnWriteArrayList<>());
+        entries.add(entry);
+        // longer (more specific) paths win over a catch-all "/" registered on the same host
+        entries.sort(Comparator.comparingInt((Entry e) -> e.pathPattern().pattern().length()).reversed());
+
+        hostsByDomainId.computeIfAbsent(domain.getId(), k -> new CopyOnWriteArrayList<>()).add(hostKey);
+    }
+
+    public void unmount(String domainId) {
+        List<String> hosts = hostsByDomainId.remove(domainId);
+        if (hosts == null) {
+            return;
+        }
+        for (String host : hosts) {
+            byHost.computeIfPresent(host, (h, entries) -> {
+                entries.removeIf(e -> e.domainId().equals(domainId));
+                return entries.isEmpty() ? null : entries;
+            });
+        }
+    }
+
+    public void dispatch(RoutingContext context) {
+        var authority = context.request().authority();
+        String host = authority == null ? null : authority.toString();
+
+        if (host != null) {
+            List<Entry> entries = byHost.get(host.toLowerCase(Locale.ROOT));
+            if (entries != null) {
+                String path = context.request().path();
+                for (Entry entry : entries) {
+                    if (entry.pathPattern().matcher(path).matches()) {
+                        context.put(CONTEXT_PATH, entry.contextPath());
+                        entry.delegate().handleContext(context);
+                        return;
+                    }
+                }
+            }
+        }
+
+        // no vhost matched this host/path - fall through (e.g. to the final 404 handler)
+        context.next();
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostDomainIndexTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostDomainIndexTest.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.reactor.impl.router;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.VirtualHost;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.Test;
+
+import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class VHostDomainIndexTest {
+
+    private final VHostDomainIndex index = new VHostDomainIndex();
+
+    @Test
+    public void shouldDispatchToMatchingHostAndSetEmptyContextPathForRootVhost() {
+        Router delegate = mock(Router.class);
+        mount(delegate, "domain1", "domain1.local.am", "/");
+
+        RoutingContext context = routingContext("domain1.local.am", "/oidc/.well-known/jwks.json");
+        index.dispatch(context);
+
+        verify(delegate).handleContext(context);
+        verify(context).put(CONTEXT_PATH, "");
+        verify(context, never()).next();
+    }
+
+    @Test
+    public void shouldSetContextPathForNonRootVhostPath() {
+        Router delegate = mock(Router.class);
+        mount(delegate, "domain1", "domain1.local.am", "/customers");
+
+        RoutingContext context = routingContext("domain1.local.am", "/customers/login");
+        index.dispatch(context);
+
+        verify(delegate).handleContext(context);
+        verify(context).put(CONTEXT_PATH, "/customers");
+    }
+
+    @Test
+    public void shouldMatchHostIgnoringCase() {
+        Router delegate = mock(Router.class);
+        mount(delegate, "domain1", "domain1.local.am", "/");
+
+        RoutingContext context = routingContext("DOMAIN1.LOCAL.AM", "/login");
+        index.dispatch(context);
+
+        verify(delegate).handleContext(context);
+    }
+
+    @Test
+    public void shouldCallNextWhenHostIsNotRegistered() {
+        Router delegate = mock(Router.class);
+        mount(delegate, "domain1", "domain1.local.am", "/");
+
+        RoutingContext context = routingContext("unknown.local.am", "/login");
+        index.dispatch(context);
+
+        verify(delegate, never()).handleContext(context);
+        verify(context).next();
+    }
+
+    @Test
+    public void shouldCallNextWhenPathDoesNotMatchForRegisteredHost() {
+        Router delegate = mock(Router.class);
+        mount(delegate, "domain1", "domain1.local.am", "/customers");
+
+        RoutingContext context = routingContext("domain1.local.am", "/other");
+        index.dispatch(context);
+
+        verify(delegate, never()).handleContext(context);
+        verify(context).next();
+    }
+
+    @Test
+    public void shouldPreferMoreSpecificPathOverCatchAllOnSameHost() {
+        Router catchAll = mock(Router.class);
+        Router specific = mock(Router.class);
+        mount(catchAll, "domain1", "shared.local.am", "/");
+        mount(specific, "domain1", "shared.local.am", "/customers");
+
+        RoutingContext specificContext = routingContext("shared.local.am", "/customers/login");
+        index.dispatch(specificContext);
+        verify(specific).handleContext(specificContext);
+        verify(catchAll, never()).handleContext(specificContext);
+
+        RoutingContext catchAllContext = routingContext("shared.local.am", "/other");
+        index.dispatch(catchAllContext);
+        verify(catchAll).handleContext(catchAllContext);
+        verify(specific, never()).handleContext(catchAllContext);
+    }
+
+    @Test
+    public void shouldNoLongerDispatchAfterUnmount() {
+        Router delegate = mock(Router.class);
+        mount(delegate, "domain1", "domain1.local.am", "/");
+
+        index.unmount("domain1");
+
+        RoutingContext context = routingContext("domain1.local.am", "/login");
+        index.dispatch(context);
+
+        verify(delegate, never()).handleContext(context);
+        verify(context).next();
+    }
+
+    @Test
+    public void unmountShouldNotAffectOtherDomains() {
+        Router domain1Router = mock(Router.class);
+        Router domain2Router = mock(Router.class);
+        mount(domain1Router, "domain1", "domain1.local.am", "/");
+        mount(domain2Router, "domain2", "domain2.local.am", "/");
+
+        index.unmount("domain1");
+
+        RoutingContext domain1Context = routingContext("domain1.local.am", "/login");
+        index.dispatch(domain1Context);
+        verify(domain1Router, never()).handleContext(domain1Context);
+
+        RoutingContext domain2Context = routingContext("domain2.local.am", "/login");
+        index.dispatch(domain2Context);
+        verify(domain2Router).handleContext(domain2Context);
+    }
+
+    /**
+     * Regression test for the bug this class fixes: mounting every vhost domain
+     * as its own Vert.x route on a shared router made request routing recurse
+     * one Java stack frame per previously-mounted domain (all vhost routes
+     * shared the same wildcard path, so none could be skipped by Vert.x's own
+     * path matching), causing a guaranteed StackOverflowError past ~3000
+     * domains. Dispatch here is an O(1) hashmap lookup regardless of how many
+     * domains are mounted, so this must succeed instantly and without error
+     * even for a domain mounted deep into a large set - not just the first
+     * few registered.
+     */
+    @Test
+    public void shouldDispatchCorrectlyWithManyMountedDomainsWithoutStackOverflow() {
+        int domainCount = 5000;
+        Router[] routers = new Router[domainCount];
+        for (int i = 0; i < domainCount; i++) {
+            routers[i] = mock(Router.class);
+            mount(routers[i], "domain" + i, "domain" + i + ".local.am", "/");
+        }
+
+        // last-registered domain: worst case for the old recursive/linear-scan approach
+        RoutingContext lastContext = routingContext("domain" + (domainCount - 1) + ".local.am", "/oidc/.well-known/jwks.json");
+        index.dispatch(lastContext);
+        verify(routers[domainCount - 1]).handleContext(lastContext);
+
+        // first-registered domain, and one in the middle, still resolve correctly too
+        RoutingContext firstContext = routingContext("domain0.local.am", "/oidc/.well-known/jwks.json");
+        index.dispatch(firstContext);
+        verify(routers[0]).handleContext(firstContext);
+
+        RoutingContext midContext = routingContext("domain2500.local.am", "/oidc/.well-known/jwks.json");
+        index.dispatch(midContext);
+        verify(routers[2500]).handleContext(midContext);
+    }
+
+    private void mount(Router delegate, String domainId, String host, String path) {
+        Domain domain = new Domain();
+        domain.setId(domainId);
+
+        VirtualHost vhost = new VirtualHost();
+        vhost.setHost(host);
+        vhost.setPath(path);
+
+        index.mount(domain, vhost, delegate);
+    }
+
+    private RoutingContext routingContext(String host, String path) {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.authority()).thenReturn(HostAndPort.authority(host));
+        when(request.path()).thenReturn(path);
+
+        RoutingContext context = mock(RoutingContext.class);
+        when(context.request()).thenReturn(request);
+
+        return context;
+    }
+}


### PR DESCRIPTION
DefaultReactor previously mounted every vhost-mode domain as its own Vert.x route ("/*") on the shared root router. Since all vhost routes share the same wildcard path, none of them can be skipped by Vert.x's own path matching, so a request has to walk every previously-mounted vhost, in registration order, via RoutingContext.next(). That traversal is recursive - one stack frame per candidate tested - so request latency and stack depth both grew linearly with the number of mounted domains, guaranteed to StackOverflowError past ~3000 domains.

Add VHostDomainIndex: a single Vert.x route backed by a hashmap keyed on the Host header. Dispatch becomes an O(1) lookup plus a linear scan only across the (typically one) candidates registered for that host - no recursion, no dependency on total domain count. Non-vhost (path-based) domains are unaffected; Vert.x's own path matching already skips them via a plain loop, not recursion.

fix AM-7433