### PR TITLE
fix(dataplane): purge every store when a domain is deleted

### DIFF
--- a/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/DeviceRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/DeviceRepository.java
@@ -20,6 +20,7 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.UserId;
 import io.gravitee.am.repository.common.CrudRepository;
 import io.gravitee.am.repository.common.ExpiredDataSweeper;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 
@@ -41,5 +42,7 @@ public interface DeviceRepository extends CrudRepository<Device, String>, Expire
     default Flowable<Device> findByDomainAndClientAndUser(String domain, UserId user) {
         return findByReferenceAndUser(ReferenceType.DOMAIN, domain, user);
     }
+
+    Completable deleteByReference(ReferenceType referenceType, String referenceId);
 
 }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/LoginAttemptRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/LoginAttemptRepository.java
@@ -32,4 +32,6 @@ public interface LoginAttemptRepository extends CrudRepository<LoginAttempt, Str
 
     Completable delete(LoginAttemptCriteria criteria);
 
+    Completable deleteByDomain(String domain);
+
 }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/ScopeApprovalRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-api/src/main/java/io/gravitee/am/dataplane/api/repository/ScopeApprovalRepository.java
@@ -46,4 +46,6 @@ public interface ScopeApprovalRepository extends CrudRepository<ScopeApproval, S
 
     Completable deleteByDomainAndClient(String domain, String clientId);
 
+    Completable deleteByDomain(String domain);
+
 }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcDeviceRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcDeviceRepository.java
@@ -139,6 +139,17 @@ public class JdbcDeviceRepository extends AbstractJdbcRepository implements Devi
     }
 
     @Override
+    public Completable deleteByReference(ReferenceType referenceType, String referenceId) {
+        LOGGER.debug("deleteByReference({} - {})", referenceType, referenceId);
+        return monoToCompletable(getTemplate().delete(JdbcDevice.class)
+                .matching(Query.query(
+                        where(REFERENCE_ID_FIELD).is(referenceId)
+                                .and(where(REF_TYPE_FIELD).is(referenceType.name()))))
+                .all())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
     public Completable purgeExpiredData() {
         LOGGER.debug("purgeExpiredData()");
         LocalDateTime now = LocalDateTime.now(UTC);

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcLoginAttemptRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcLoginAttemptRepository.java
@@ -111,6 +111,14 @@ public class JdbcLoginAttemptRepository extends AbstractJdbcRepository implement
     }
 
     @Override
+    public Completable deleteByDomain(String domain) {
+        LOGGER.debug("deleteByDomain({})", domain);
+        return monoToCompletable(getTemplate().delete(JdbcLoginAttempt.class)
+                .matching(Query.query(where("domain").is(domain))).all())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
     public Maybe<LoginAttempt> findById(String id) {
         LOGGER.debug("findById({})", id);
         LocalDateTime now = LocalDateTime.now(UTC);

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcPermissionTicketRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcPermissionTicketRepository.java
@@ -151,6 +151,14 @@ public class JdbcPermissionTicketRepository extends AbstractJdbcRepository imple
     }
 
     @Override
+    public Completable deleteByDomain(String domain) {
+        LOGGER.debug("deleteByDomain({})", domain);
+        return monoToCompletable(getTemplate().delete(JdbcPermissionTicket.class)
+                .matching(Query.query(where(COL_DOMAIN).is(domain))).all())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
     public Completable purgeExpiredData() {
         LOGGER.debug("purgeExpiredData()");
         LocalDateTime now = LocalDateTime.now(UTC);

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcScopeApprovalRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/repository/JdbcScopeApprovalRepository.java
@@ -180,6 +180,14 @@ public class JdbcScopeApprovalRepository extends AbstractJdbcRepository implemen
     }
 
     @Override
+    public Completable deleteByDomain(String domain) {
+        LOGGER.debug("deleteByDomain({})", domain);
+        return monoToCompletable(getTemplate().delete(JdbcScopeApproval.class)
+                .matching(Query.query(domain(domain))).all())
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
     public Maybe<ScopeApproval> findById(String id) {
         LOGGER.debug("findById({})", id);
         LocalDateTime now = LocalDateTime.now(UTC);

--- a/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/spring/JdbcDataPlaneSpringConfiguration.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-jdbc/src/main/java/io/gravitee/am/dataplane/jdbc/spring/JdbcDataPlaneSpringConfiguration.java
@@ -90,7 +90,14 @@ public class JdbcDataPlaneSpringConfiguration extends AbstractRepositoryConfigur
     }
 
     @Override
-    public void afterPropertiesSet() throws Exception {
-        initializeDatabaseSchema(getPoolWrapper(), environment, description.propertiesBase() + ".jdbc.");
+    public void afterPropertiesSet() {
+        // resolved outside the catch, is required for API to run
+        var poolWrapper = getPoolWrapper();
+        try {
+            initializeDatabaseSchema(poolWrapper, environment, description.propertiesBase() + ".jdbc.");
+        } catch (Exception e) {
+            LOGGER.error("Schema initialisation failed for data plane [{}], which cannot serve a domain until its database is reachable and the schema is up to date",
+                    description.id(), e);
+        }
     }
 }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-junit/src/main/java/io/gravitee/am/dataplane/junit/gateway/MemoryScopeApprovalRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-junit/src/main/java/io/gravitee/am/dataplane/junit/gateway/MemoryScopeApprovalRepository.java
@@ -75,6 +75,11 @@ public class MemoryScopeApprovalRepository extends MemoryRepository<ScopeApprova
     }
 
     @Override
+    public Completable deleteByDomain(String domain) {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    @Override
     public Completable purgeExpiredData() {
         return ScopeApprovalRepository.super.purgeExpiredData();
     }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoDeviceRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoDeviceRepository.java
@@ -128,6 +128,13 @@ public class MongoDeviceRepository extends AbstractDataPlaneMongoRepository impl
                 .observeOn(Schedulers.computation());
     }
 
+    @Override
+    public Completable deleteByReference(ReferenceType referenceType, String referenceId) {
+        return Completable.fromPublisher(rememberDeviceMongoCollection.deleteMany(
+                and(eq(FIELD_REFERENCE_ID, referenceId), eq(FIELD_REFERENCE_TYPE, referenceType.name()))))
+                .observeOn(Schedulers.computation());
+    }
+
     private Device convert(DeviceMongo entity) {
         return ofNullable(entity).map(device -> new Device().setId(device.getId())
                 .setType(device.getType())

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoLoginAttemptRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoLoginAttemptRepository.java
@@ -119,6 +119,12 @@ public class MongoLoginAttemptRepository extends AbstractDataPlaneMongoRepositor
                 .observeOn(Schedulers.computation());
     }
 
+    @Override
+    public Completable deleteByDomain(String domain) {
+        return Completable.fromPublisher(loginAttemptsCollection.deleteMany(eq(FIELD_DOMAIN, domain)))
+                .observeOn(Schedulers.computation());
+    }
+
     private Bson query(LoginAttemptCriteria criteria) {
         List<Bson> filters = new ArrayList<>();
         // domain

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoPermissionTicketRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoPermissionTicketRepository.java
@@ -43,6 +43,7 @@ import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.gt;
 import static com.mongodb.client.model.Filters.or;
+import static io.gravitee.am.repository.mongodb.common.MongoUtils.FIELD_DOMAIN;
 import static io.gravitee.am.repository.mongodb.common.MongoUtils.FIELD_ID;
 
 /**
@@ -89,6 +90,12 @@ public class MongoPermissionTicketRepository extends AbstractDataPlaneMongoRepos
     @Override
     public Completable delete(String id) {
         return Completable.fromPublisher(permissionTicketCollection.deleteOne(eq(FIELD_ID, id)))
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable deleteByDomain(String domain) {
+        return Completable.fromPublisher(permissionTicketCollection.deleteMany(eq(FIELD_DOMAIN, domain)))
                 .observeOn(Schedulers.computation());
     }
 

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoScopeApprovalRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoScopeApprovalRepository.java
@@ -198,6 +198,12 @@ public class MongoScopeApprovalRepository extends AbstractDataPlaneMongoReposito
                 .observeOn(Schedulers.computation());
     }
 
+    @Override
+    public Completable deleteByDomain(String domain) {
+        return Completable.fromPublisher(scopeApprovalsCollection.deleteMany(eq(FIELD_DOMAIN, domain)))
+                .observeOn(Schedulers.computation());
+    }
+
     private ScopeApproval convert(ScopeApprovalMongo scopeApprovalMongo) {
         if (scopeApprovalMongo == null) {
             return null;

--- a/gravitee-am-dataplane/gravitee-am-dataplane-test/src/test/java/io/gravitee/am/dataplane/api/repository/DeviceRepositoryTest.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-test/src/test/java/io/gravitee/am/dataplane/api/repository/DeviceRepositoryTest.java
@@ -67,6 +67,20 @@ public class DeviceRepositoryTest extends AbstractDataPlaneTest {
         observer.assertNoErrors();
     }
 
+    @Test
+    public void testDeleteByReference() {
+        Device device = repository.create(buildDevice()).blockingGet();
+        Device otherDomain = repository.create(buildDevice()).blockingGet();
+
+        var observer = repository.deleteByReference(ReferenceType.DOMAIN, device.getReferenceId()).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertComplete();
+        observer.assertNoErrors();
+
+        repository.findById(device.getId()).test().awaitDone(10, TimeUnit.SECONDS).assertNoValues();
+        repository.findById(otherDomain.getId()).test().awaitDone(10, TimeUnit.SECONDS).assertValueCount(1);
+    }
+
     private Device buildDevice() {
         return buildDevice(new Date(System.currentTimeMillis() + 10000));
     }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-test/src/test/java/io/gravitee/am/dataplane/api/repository/LoginAttemptRepositoryTest.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-test/src/test/java/io/gravitee/am/dataplane/api/repository/LoginAttemptRepositoryTest.java
@@ -181,6 +181,21 @@ public class LoginAttemptRepositoryTest extends AbstractDataPlaneTest {
     }
 
 
+    @Test
+    public void shouldDeleteByDomain() {
+        LoginAttempt attempt = buildLoginAttempt();
+        attempt.setDomain("domain-to-purge");
+        LoginAttempt purged = repository.create(attempt).blockingGet();
+        LoginAttempt kept = repository.create(buildLoginAttempt()).blockingGet();
+
+        TestObserver<Void> deleteObserver = repository.deleteByDomain("domain-to-purge").test();
+        deleteObserver.awaitDone(10, TimeUnit.SECONDS);
+        deleteObserver.assertNoErrors();
+
+        repository.findById(purged.getId()).test().awaitDone(10, TimeUnit.SECONDS).assertNoValues();
+        repository.findById(kept.getId()).test().awaitDone(10, TimeUnit.SECONDS).assertValueCount(1);
+    }
+
     private void assertEqualsTo(LoginAttempt attempt, TestObserver<LoginAttempt> testObserver) {
         testObserver.assertValue(l -> l.getAttempts() == attempt.getAttempts());
         testObserver.assertValue(l -> l.getClient().equals(attempt.getClient()));

--- a/gravitee-am-dataplane/gravitee-am-dataplane-test/src/test/java/io/gravitee/am/dataplane/api/repository/PermissionTicketRepositoryTest.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-test/src/test/java/io/gravitee/am/dataplane/api/repository/PermissionTicketRepositoryTest.java
@@ -92,6 +92,31 @@ public class PermissionTicketRepositoryTest extends AbstractDataPlaneTest {
         testObserver.assertNoValues();
     }
 
+    @Test
+    public void deleteByDomain() {
+        String domain = UUID.randomUUID().toString();
+        PermissionTicket purged = repository.create(permissionTicket(domain)).blockingGet();
+        PermissionTicket kept = repository.create(permissionTicket(UUID.randomUUID().toString())).blockingGet();
+
+        TestObserver<Void> testObserver = repository.deleteByDomain(domain).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        repository.findById(purged.getId()).test().awaitDone(10, TimeUnit.SECONDS).assertNoValues();
+        repository.findById(kept.getId()).test().awaitDone(10, TimeUnit.SECONDS).assertValueCount(1);
+    }
+
+    private PermissionTicket permissionTicket(String domain) {
+        PermissionTicket permissionTicket = new PermissionTicket().setPermissionRequest(Arrays.asList(permission));
+        permissionTicket.setClientId(UUID.randomUUID().toString());
+        permissionTicket.setDomain(domain);
+        permissionTicket.setUserId(UUID.randomUUID().toString());
+        permissionTicket.setCreatedAt(new Date());
+        permissionTicket.setExpireAt(new Date(Instant.now().plus(1, ChronoUnit.MINUTES).toEpochMilli()));
+        return permissionTicket;
+    }
+
     private boolean isValid(PermissionTicket pt) {
         return  pt.getPermissionRequest().size() == 1 &&
                 pt.getPermissionRequest().get(0).getResourceId().equals("one") &&

--- a/gravitee-am-dataplane/gravitee-am-dataplane-test/src/test/java/io/gravitee/am/dataplane/api/repository/ScopeApprovalRepositoryTest.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-test/src/test/java/io/gravitee/am/dataplane/api/repository/ScopeApprovalRepositoryTest.java
@@ -205,6 +205,23 @@ public class ScopeApprovalRepositoryTest extends AbstractDataPlaneTest {
                 .forEach(x -> repository.create(x).blockingSubscribe());
     }
 
+    @Test
+    public void shouldDeleteByDomain() {
+        var purged = repository.create(basicApproval()).blockingGet();
+        var otherDomain = basicApproval();
+        otherDomain.setDomain("another-domain");
+        var kept = repository.create(otherDomain).blockingGet();
+
+        repository.deleteByDomain(TEST_DOMAIN)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertNoErrors();
+
+        repository.findById(purged.getId()).test().awaitDone(10, TimeUnit.SECONDS).assertNoValues();
+        repository.findById(kept.getId()).test().awaitDone(10, TimeUnit.SECONDS).assertValueCount(1);
+    }
+
     private ScopeApproval basicApproval() {
         var it = new ScopeApproval();
         it.setId(UUID.randomUUID().toString());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DomainGroupService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DomainGroupService.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.management.service;
 
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.Group;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.common.Page;
@@ -32,7 +33,13 @@ import java.util.List;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface DomainGroupService {
+public interface DomainGroupService extends DomainDataPlaneCleanup {
+
+    @Override
+    default Completable purgeDataPlane(Domain domain) {
+        return findAll(domain).flatMapCompletable(group -> delete(domain, group.getId(), null));
+    }
+
 
     Single<Page<Group>> findAll(Domain domain, int page, int size);
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DomainGroupService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DomainGroupService.java
@@ -16,10 +16,10 @@
 package io.gravitee.am.management.service;
 
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.Group;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.common.Page;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.model.NewGroup;
 import io.gravitee.am.service.model.UpdateGroup;
 import io.reactivex.rxjava3.core.Completable;
@@ -36,10 +36,9 @@ import java.util.List;
 public interface DomainGroupService extends DomainDataPlaneCleanup {
 
     @Override
-    default Completable purgeDataPlane(Domain domain) {
-        return findAll(domain).flatMapCompletable(group -> delete(domain, group.getId(), null));
+    default Completable purgeDataPlane(Domain domain, io.gravitee.am.identityprovider.api.User principal) {
+        return findAll(domain).flatMapCompletable(group -> delete(domain, group.getId(), principal));
     }
-
 
     Single<Page<Group>> findAll(Domain domain, int page, int size);
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/ManagementUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/ManagementUserService.java
@@ -16,11 +16,11 @@
 package io.gravitee.am.management.service;
 
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.factor.EnrolledFactor;
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.model.NewUser;
 import io.gravitee.am.service.model.UpdateUser;
 import io.reactivex.rxjava3.core.Completable;

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/ManagementUserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/ManagementUserService.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.management.service;
 
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.factor.EnrolledFactor;
@@ -32,7 +33,7 @@ import java.util.List;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ManagementUserService {
+public interface ManagementUserService extends DomainDataPlaneCleanup {
     Single<User> updateUsername(Domain domain, String id, String username, io.gravitee.am.identityprovider.api.User principal);
 
     Maybe<User> findById(Domain domain, String id);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/CredentialManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/CredentialManagementService.java
@@ -19,6 +19,7 @@ package io.gravitee.am.management.service.dataplane;
 
 import io.gravitee.am.model.Credential;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.dataplane.CredentialCommonService;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
@@ -28,7 +29,7 @@ import io.reactivex.rxjava3.core.Maybe;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface CredentialManagementService extends CredentialCommonService {
+public interface CredentialManagementService extends CredentialCommonService, DomainDataPlaneCleanup {
 
     Maybe<Credential> findById(Domain domain, String id);
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/CredentialManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/CredentialManagementService.java
@@ -19,8 +19,8 @@ package io.gravitee.am.management.service.dataplane;
 
 import io.gravitee.am.model.Credential;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.dataplane.CredentialCommonService;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/DeviceManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/DeviceManagementService.java
@@ -20,8 +20,8 @@ package io.gravitee.am.management.service.dataplane;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Device;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.UserId;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/DeviceManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/DeviceManagementService.java
@@ -20,6 +20,7 @@ package io.gravitee.am.management.service.dataplane;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Device;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.UserId;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
@@ -28,7 +29,7 @@ import io.reactivex.rxjava3.core.Flowable;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface DeviceManagementService {
+public interface DeviceManagementService extends DomainDataPlaneCleanup {
 
     Flowable<Device> findByDomainAndUser(Domain domain, UserId user);
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/LoginAttemptManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/LoginAttemptManagementService.java
@@ -18,8 +18,9 @@ package io.gravitee.am.management.service.dataplane;
 
 import io.gravitee.am.dataplane.api.search.LoginAttemptCriteria;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.reactivex.rxjava3.core.Completable;
 
-public interface LoginAttemptManagementService {
+public interface LoginAttemptManagementService extends DomainDataPlaneCleanup {
     Completable reset(Domain domain, LoginAttemptCriteria criteria);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/UMAResourceManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/UMAResourceManagementService.java
@@ -18,6 +18,7 @@ package io.gravitee.am.management.service.dataplane;
 
 
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.uma.Resource;
 import io.gravitee.am.model.uma.policy.AccessPolicy;
@@ -33,7 +34,7 @@ import java.util.Map;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface UMAResourceManagementService {
+public interface UMAResourceManagementService extends DomainDataPlaneCleanup {
     Flowable<AccessPolicy> findAccessPoliciesByResources(Domain domain, List<String> resourceIds);
     Maybe<AccessPolicy> findAccessPolicy(Domain domain, String accessPolicy);
     Maybe<Resource> findByDomainAndClientResource(Domain domain, String client, String resourceId);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/UMAResourceManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/UMAResourceManagementService.java
@@ -18,10 +18,10 @@ package io.gravitee.am.management.service.dataplane;
 
 
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.uma.Resource;
 import io.gravitee.am.model.uma.policy.AccessPolicy;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/UserActivityManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/UserActivityManagementService.java
@@ -18,13 +18,20 @@ package io.gravitee.am.management.service.dataplane;
 
 
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.reactivex.rxjava3.core.Completable;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface UserActivityManagementService {
+public interface UserActivityManagementService extends DomainDataPlaneCleanup {
+
+    @Override
+    default Completable purgeDataPlane(Domain domain) {
+        return deleteByDomain(domain);
+    }
+
     Completable deleteByDomain(Domain domain);
     Completable deleteByDomainAndUser(Domain domain, String userId);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/UserActivityManagementService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/UserActivityManagementService.java
@@ -17,6 +17,7 @@
 package io.gravitee.am.management.service.dataplane;
 
 
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.reactivex.rxjava3.core.Completable;
@@ -28,7 +29,7 @@ import io.reactivex.rxjava3.core.Completable;
 public interface UserActivityManagementService extends DomainDataPlaneCleanup {
 
     @Override
-    default Completable purgeDataPlane(Domain domain) {
+    default Completable purgeDataPlane(Domain domain, User principal) {
         return deleteByDomain(domain);
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/CredentialManagementServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/CredentialManagementServiceImpl.java
@@ -183,6 +183,11 @@ public class CredentialManagementServiceImpl implements CredentialManagementServ
     }
 
     @Override
+    public Completable purgeDataPlane(Domain domain) {
+        return dataPlaneRegistry.getCredentialRepository(domain).deleteByReference(DOMAIN, domain.getId());
+    }
+
+    @Override
     public Completable deleteByUserId(Domain domain, String userId) {
         log.debug("Delete all credentials for domain {} and user {}", domain.getId(), userId);
         return dataPlaneRegistry.getCredentialRepository(domain)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/CredentialManagementServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/CredentialManagementServiceImpl.java
@@ -19,6 +19,7 @@ package io.gravitee.am.management.service.dataplane.impl;
 
 import io.gravitee.am.management.service.dataplane.CredentialManagementService;
 import io.gravitee.am.model.Credential;
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.UserId;
 import io.gravitee.am.model.factor.EnrolledFactor;
@@ -183,7 +184,7 @@ public class CredentialManagementServiceImpl implements CredentialManagementServ
     }
 
     @Override
-    public Completable purgeDataPlane(Domain domain) {
+    public Completable purgeDataPlane(Domain domain, User principal) {
         return dataPlaneRegistry.getCredentialRepository(domain).deleteByReference(DOMAIN, domain.getId());
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/DeviceManagementServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/DeviceManagementServiceImpl.java
@@ -22,6 +22,7 @@ import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.service.dataplane.DeviceManagementService;
 import io.gravitee.am.model.Device;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.UserId;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.AuditService;
@@ -58,6 +59,11 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
             log.error("An error occurs while trying to find Devices by {} {}", domain, userId, ex);
             return Flowable.error(new TechnicalManagementException(String.format("An error occurs while trying to find Devices by %s %s", domain, userId), ex));
         });
+    }
+
+    @Override
+    public Completable purgeDataPlane(Domain domain) {
+        return dataPlaneRegistry.getDeviceRepository(domain).deleteByReference(ReferenceType.DOMAIN, domain.getId());
     }
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/DeviceManagementServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/DeviceManagementServiceImpl.java
@@ -62,7 +62,7 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
     }
 
     @Override
-    public Completable purgeDataPlane(Domain domain) {
+    public Completable purgeDataPlane(Domain domain, User principal) {
         return dataPlaneRegistry.getDeviceRepository(domain).deleteByReference(ReferenceType.DOMAIN, domain.getId());
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/LoginAttemptManagementServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/LoginAttemptManagementServiceImpl.java
@@ -39,6 +39,11 @@ public class LoginAttemptManagementServiceImpl implements LoginAttemptManagement
     private DataPlaneRegistry dataPlaneRegistry;
 
     @Override
+    public Completable purgeDataPlane(Domain domain) {
+        return dataPlaneRegistry.getLoginAttemptRepository(domain).deleteByDomain(domain.getId());
+    }
+
+    @Override
     public Completable reset(Domain domain, LoginAttemptCriteria criteria) {
         log.debug("Delete login attempt for {}", criteria);
         return dataPlaneRegistry.getLoginAttemptRepository(domain).delete(criteria)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/LoginAttemptManagementServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/LoginAttemptManagementServiceImpl.java
@@ -19,6 +19,7 @@ package io.gravitee.am.management.service.dataplane.impl;
 
 import io.gravitee.am.dataplane.api.search.LoginAttemptCriteria;
 import io.gravitee.am.management.service.dataplane.LoginAttemptManagementService;
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.exception.TechnicalManagementException;
@@ -39,7 +40,7 @@ public class LoginAttemptManagementServiceImpl implements LoginAttemptManagement
     private DataPlaneRegistry dataPlaneRegistry;
 
     @Override
-    public Completable purgeDataPlane(Domain domain) {
+    public Completable purgeDataPlane(Domain domain, User principal) {
         return dataPlaneRegistry.getLoginAttemptRepository(domain).deleteByDomain(domain.getId());
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/UMAResourceManagementServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/UMAResourceManagementServiceImpl.java
@@ -116,7 +116,7 @@ public class UMAResourceManagementServiceImpl implements UMAResourceManagementSe
     }
 
     @Override
-    public Completable purgeDataPlane(Domain domain) {
+    public Completable purgeDataPlane(Domain domain, io.gravitee.am.identityprovider.api.User principal) {
         // a permission ticket outlives neither its resource nor the domain, but it is keyed by domain
         // rather than by resource, so it has to be dropped in its own right
         return findByDomain(domain)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/UMAResourceManagementServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/dataplane/impl/UMAResourceManagementServiceImpl.java
@@ -116,6 +116,15 @@ public class UMAResourceManagementServiceImpl implements UMAResourceManagementSe
     }
 
     @Override
+    public Completable purgeDataPlane(Domain domain) {
+        // a permission ticket outlives neither its resource nor the domain, but it is keyed by domain
+        // rather than by resource, so it has to be dropped in its own right
+        return findByDomain(domain)
+                .flatMapCompletable(resource -> delete(domain, resource))
+                .andThen(dataPlaneRegistry.getPermissionTicketRepository(domain).deleteByDomain(domain.getId()));
+    }
+
+    @Override
     public Completable delete(Domain domain, Resource resource) {
         log.debug("Deleting resource id {} on domain {}", resource.getId(), resource.getDomain());
         // delete policies and then the resource

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -665,6 +665,8 @@ public class DomainServiceImpl implements DomainService {
                             .andThen(formService.findByDomain(domainId)
                                     .flatMapCompletable(formTemplate -> formService.delete(domainId, formTemplate.getId()))
                             )
+                            // clear the data plane while the domain's reporters are still around to audit it
+                            .andThen(clearDataPlane(domain, principal))
                             // delete reporters
                             .andThen(reporterService.findByReference(Reference.domain(domainId))
                                     .flatMapCompletable(reporter ->
@@ -717,8 +719,6 @@ public class DomainServiceImpl implements DomainService {
                             .andThen(authorizationEngineService.deleteByDomain(domainId))
                             .andThen(domainRepository.delete(domainId))
                             .andThen(Completable.fromSingle(eventService.create(new Event(Type.DOMAIN, new Payload(domainId, DOMAIN, domainId, Action.DELETE), domain.getDataPlaneId(), domain.getReferenceId()), domain)))
-                            // the domain is gone, so what it left in its data plane can be cleaned up after it
-                            .andThen(clearDataPlane(domain, principal))
                             .doOnComplete(() -> auditService.report(AuditBuilder.builder(DomainAuditBuilder.class)
                                     .principal(principal)
                                     .type(EventType.DOMAIN_DELETED)
@@ -742,18 +742,22 @@ public class DomainServiceImpl implements DomainService {
     }
 
     /**
-     * Everything the deleted domain leaves in its data plane, from every store that declares itself a
-     * {@link DomainDataPlaneCleanup}. It runs once the domain itself is gone, and a failure is only
-     * logged: a domain pins its data plane, so a domain that cannot be deleted while its store is
-     * unreachable would leave the pair impossible to delete. Stores are purged with delayed errors so
-     * one unreachable repository does not skip the rest.
+     * Everything the domain holds in its data plane, from every store that declares itself a
+     * {@link DomainDataPlaneCleanup}. A failure is only logged rather than propagated: a domain pins its
+     * data plane, so a domain that could not be deleted while its store is unreachable would leave the
+     * pair impossible to delete. Stores are purged with delayed errors so one unreachable repository does
+     * not skip the rest. It runs before the reporters are deleted, because the stores that audit what
+     * they drop need somewhere to report it.
+     * <p>
+     * Deferred on purpose: asking a store for its repository can throw when the data plane is unreachable,
+     * and outside the defer that throw would escape before onErrorComplete is attached and fail the delete.
      */
     private Completable clearDataPlane(Domain domain, User principal) {
-        return Completable.concatDelayError(dataPlaneCleanups.stream()
+        return Completable.defer(() -> Completable.concatDelayError(dataPlaneCleanups.stream()
                         .map(store -> store.purgeDataPlane(domain, principal))
-                        .toList())
+                        .toList()))
                 .onErrorComplete(error -> {
-                    log.warn("Domain {} is deleted but data plane {} could not be cleaned up, that data is left behind",
+                    log.warn("Domain {} is being deleted but data plane {} could not be cleaned up, that data is left behind",
                             domain.getId(), domain.getDataPlaneId(), error);
                     return true;
                 });

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -85,6 +85,7 @@ import io.gravitee.am.service.ScopeService;
 import io.gravitee.am.service.ServiceResourceService;
 import io.gravitee.am.service.ThemeService;
 import io.gravitee.am.service.CertificateCredentialService;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.exception.AbstractManagementException;
 import io.gravitee.am.service.exception.DomainAlreadyExistsException;
 import io.gravitee.am.service.exception.DomainNotFoundException;
@@ -171,6 +172,10 @@ public class DomainServiceImpl implements DomainService {
 
     @Autowired
     private DataPlaneRegistry dataPlaneRegistry;
+
+    /** every store that holds domain data in the data plane, collected rather than named one by one */
+    @Autowired
+    private List<DomainDataPlaneCleanup> dataPlaneCleanups;
 
     @Lazy
     @Autowired
@@ -670,24 +675,6 @@ public class DomainServiceImpl implements DomainService {
                                         return Completable.concat(deleteRolesCompletable);
                                     })
                             )
-                            //Delete all trace of activity of users for this domain
-                            .andThen(userActivityService.deleteByDomain(domain))
-                            // delete users
-                            // do not delete one by one for memory consumption issue
-                            // https://github.com/gravitee-io/issues/issues/6999
-                            .andThen(dataPlaneRegistry.getUserRepository(domain).deleteByReference(domain.asReference()))
-                            // delete groups
-                            .andThen(domainGroupService.findAll(domain)
-                                    .flatMapCompletable(group ->
-                                            domainGroupService.delete(domain, group.getId(), principal))
-                            )
-                            // delete scopes
-                            .andThen(scopeService.findByDomain(domainId, 0, Integer.MAX_VALUE)
-                                    .flatMapCompletable(scopes -> {
-                                        List<Completable> deleteScopesCompletable = scopes.getData().stream().map(s -> scopeService.delete(domain, s.getId(), true)).toList();
-                                        return Completable.concat(deleteScopesCompletable);
-                                    })
-                            )
                             // delete email templates
                             .andThen(emailTemplateService.findAll(DOMAIN, domainId)
                                     .flatMapCompletable(emailTemplate -> emailTemplateService.delete(emailTemplate.getId()))
@@ -716,10 +703,6 @@ public class DomainServiceImpl implements DomainService {
                             .andThen(factorService.findByDomain(domainId)
                                     .flatMapCompletable(factor -> factorService.delete(domainId, factor.getId()))
                             )
-                            // delete uma resources
-                            .andThen(resourceService.findByDomain(domain)
-                                    .flatMapCompletable(resource -> resourceService.delete(domain, resource))
-                            )
                             // delete alert triggers
                             .andThen(alertTriggerService.findByDomainAndCriteria(domainId, new AlertTriggerCriteria())
                                     .flatMapCompletable(alertTrigger -> alertTriggerService.delete(alertTrigger.getReferenceType(), alertTrigger.getReferenceId(), alertTrigger.getId(), principal)
@@ -746,16 +729,14 @@ public class DomainServiceImpl implements DomainService {
                                     .flatMapCompletable(theme -> themeService.delete(domain, theme.getId(), principal)
                                     )
                             )
-                            .andThen(passwordHistoryService.deleteByReference(domain))
                             .andThen(passwordPolicyService.deleteByReference(ReferenceType.DOMAIN, domainId))
                             .andThen(serviceResourceService.deleteByDomain(domainId))
                             .andThen(deviceIdentifierService.deleteByDomain(domainId))
-                            // delete certificate credentials
-                            .andThen(certificateCredentialService.deleteByDomain(domain))
                             .andThen(authorizationEngineService.deleteByDomain(domainId))
-                            .andThen(cimdClientStateService.deleteByDomain(domain))
                             .andThen(domainRepository.delete(domainId))
                             .andThen(Completable.fromSingle(eventService.create(new Event(Type.DOMAIN, new Payload(domainId, DOMAIN, domainId, Action.DELETE), domain.getDataPlaneId(), domain.getReferenceId()), domain)))
+                            // the domain is gone, so what it left in its data plane can be cleaned up after it
+                            .andThen(clearDataPlane(domainId, domain))
                             .doOnComplete(() -> auditService.report(AuditBuilder.builder(DomainAuditBuilder.class)
                                     .principal(principal)
                                     .type(EventType.DOMAIN_DELETED)
@@ -775,6 +756,24 @@ public class DomainServiceImpl implements DomainService {
 
                     log.error("An error occurred while trying to delete security domain {}", domainId, ex);
                     return Completable.error(new TechnicalManagementException("An error occurred while trying to delete security domain " + domainId, ex));
+                });
+    }
+
+    /**
+     * Everything the deleted domain leaves in its data plane, from every store that declares itself a
+     * {@link DomainDataPlaneCleanup}. It runs once the domain itself is gone, and a failure is only
+     * logged: a domain pins its data plane, so a domain that cannot be deleted while its store is
+     * unreachable would leave the pair impossible to delete. Stores are purged with delayed errors so
+     * one unreachable repository does not skip the rest.
+     */
+    private Completable clearDataPlane(String domainId, Domain domain) {
+        return Completable.defer(() -> Completable.concatDelayError(dataPlaneCleanups.stream()
+                        .map(store -> store.purgeDataPlane(domain))
+                        .toList()))
+                .onErrorComplete(error -> {
+                    log.warn("Domain {} is deleted but data plane {} could not be cleaned up, that data is left behind",
+                            domainId, domain.getDataPlaneId(), error);
+                    return true;
                 });
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -28,10 +28,7 @@ import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
-import io.gravitee.am.management.service.DomainGroupService;
 import io.gravitee.am.management.service.DomainService;
-import io.gravitee.am.management.service.dataplane.UMAResourceManagementService;
-import io.gravitee.am.management.service.dataplane.UserActivityManagementService;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.CertificateSettings;
 import io.gravitee.am.model.CorsSettings;
@@ -84,7 +81,6 @@ import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.ScopeService;
 import io.gravitee.am.service.ServiceResourceService;
 import io.gravitee.am.service.ThemeService;
-import io.gravitee.am.service.CertificateCredentialService;
 import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.exception.AbstractManagementException;
 import io.gravitee.am.service.exception.DomainAlreadyExistsException;
@@ -98,7 +94,6 @@ import io.gravitee.am.service.exception.InvalidTargetUrlException;
 import io.gravitee.am.service.exception.InvalidWebAuthnConfigurationException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.I18nDictionaryService;
-import io.gravitee.am.service.impl.PasswordHistoryService;
 import io.gravitee.am.service.model.AutomationNewDomain;
 import io.gravitee.am.service.model.NewDomain;
 import io.gravitee.am.service.model.NewSystemScope;
@@ -185,9 +180,6 @@ public class DomainServiceImpl implements DomainService {
     private DomainReadService domainReadService;
 
     @Autowired
-    private UserActivityManagementService userActivityService;
-
-    @Autowired
     private DomainValidator domainValidator;
 
     @Autowired
@@ -218,9 +210,6 @@ public class DomainServiceImpl implements DomainService {
     private ScopeService scopeService;
 
     @Autowired
-    private DomainGroupService domainGroupService;
-
-    @Autowired
     private EmailTemplateService emailTemplateService;
 
     @Autowired
@@ -248,9 +237,6 @@ public class DomainServiceImpl implements DomainService {
     private EnvironmentService environmentService;
 
     @Autowired
-    private UMAResourceManagementService resourceService;
-
-    @Autowired
     private AlertTriggerService alertTriggerService;
 
     @Autowired
@@ -266,13 +252,7 @@ public class DomainServiceImpl implements DomainService {
     private ThemeService themeService;
 
     @Autowired
-    private PasswordHistoryService passwordHistoryService;
-
-    @Autowired
     private PasswordPolicyService passwordPolicyService;
-
-    @Autowired
-    private CertificateCredentialService certificateCredentialService;
 
     @Autowired
     private EntrypointService entrypointService;
@@ -675,6 +655,8 @@ public class DomainServiceImpl implements DomainService {
                                         return Completable.concat(deleteRolesCompletable);
                                     })
                             )
+                            // delete scopes, which are control plane rows: their approvals go with the data plane
+                            .andThen(scopeService.deleteByDomain(domain))
                             // delete email templates
                             .andThen(emailTemplateService.findAll(DOMAIN, domainId)
                                     .flatMapCompletable(emailTemplate -> emailTemplateService.delete(emailTemplate.getId()))
@@ -736,7 +718,7 @@ public class DomainServiceImpl implements DomainService {
                             .andThen(domainRepository.delete(domainId))
                             .andThen(Completable.fromSingle(eventService.create(new Event(Type.DOMAIN, new Payload(domainId, DOMAIN, domainId, Action.DELETE), domain.getDataPlaneId(), domain.getReferenceId()), domain)))
                             // the domain is gone, so what it left in its data plane can be cleaned up after it
-                            .andThen(clearDataPlane(domainId, domain))
+                            .andThen(clearDataPlane(domain, principal))
                             .doOnComplete(() -> auditService.report(AuditBuilder.builder(DomainAuditBuilder.class)
                                     .principal(principal)
                                     .type(EventType.DOMAIN_DELETED)
@@ -766,13 +748,13 @@ public class DomainServiceImpl implements DomainService {
      * unreachable would leave the pair impossible to delete. Stores are purged with delayed errors so
      * one unreachable repository does not skip the rest.
      */
-    private Completable clearDataPlane(String domainId, Domain domain) {
-        return Completable.defer(() -> Completable.concatDelayError(dataPlaneCleanups.stream()
-                        .map(store -> store.purgeDataPlane(domain))
-                        .toList()))
+    private Completable clearDataPlane(Domain domain, User principal) {
+        return Completable.concatDelayError(dataPlaneCleanups.stream()
+                        .map(store -> store.purgeDataPlane(domain, principal))
+                        .toList())
                 .onErrorComplete(error -> {
                     log.warn("Domain {} is deleted but data plane {} could not be cleaned up, that data is left behind",
-                            domainId, domain.getDataPlaneId(), error);
+                            domain.getId(), domain.getDataPlaneId(), error);
                     return true;
                 });
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementUserServiceImpl.java
@@ -176,7 +176,7 @@ public class ManagementUserServiceImpl implements ManagementUserService {
     private EventService eventService;
 
     @Override
-    public Completable purgeDataPlane(Domain domain) {
+    public Completable purgeDataPlane(Domain domain, io.gravitee.am.identityprovider.api.User principal) {
         // not one by one, for memory consumption reasons
         // https://github.com/gravitee-io/issues/issues/6999
         return dataPlaneRegistry.getUserRepository(domain).deleteByReference(domain.asReference());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementUserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementUserServiceImpl.java
@@ -176,6 +176,13 @@ public class ManagementUserServiceImpl implements ManagementUserService {
     private EventService eventService;
 
     @Override
+    public Completable purgeDataPlane(Domain domain) {
+        // not one by one, for memory consumption reasons
+        // https://github.com/gravitee-io/issues/issues/6999
+        return dataPlaneRegistry.getUserRepository(domain).deleteByReference(domain.asReference());
+    }
+
+    @Override
     public Single<Page<User>> search(Domain domain, String query, int page, int size) {
         return dataPlaneRegistry.getUserRepository(domain).search(domain.asReference(), query, page, size);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainGroupServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/DomainGroupServiceTest.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.am.management.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.dataplane.api.repository.GroupRepository;
 import io.gravitee.am.dataplane.api.repository.UserRepository;
+import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.management.service.impl.DomainGroupServiceImpl;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.Group;
@@ -290,6 +292,30 @@ public class DomainGroupServiceTest {
         testObserver.assertNoErrors();
 
         verify(groupRepository, times(1)).delete("my-group");
+    }
+
+    @Test
+    public void shouldPurgeEveryGroupOfADeletedDomain() {
+        var principal = new DefaultUser("an-admin");
+        principal.setId("admin-id");
+        Group group = new Group();
+        group.setId("my-group");
+        group.setReferenceId(DOMAIN);
+        group.setReferenceType(ReferenceType.DOMAIN);
+        when(groupRepository.findAll(ReferenceType.DOMAIN, DOMAIN)).thenReturn(Flowable.just(group));
+        when(groupRepository.findById(ReferenceType.DOMAIN, DOMAIN, "my-group")).thenReturn(Maybe.just(group));
+        when(groupRepository.delete("my-group")).thenReturn(Completable.complete());
+
+        TestObserver<Void> testObserver = domainGroupService.purgeDataPlane(DOMAIN_ENTITY, principal).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(groupRepository, times(1)).delete("my-group");
+        // the audit has to name whoever deleted the domain, not nobody
+        verify(auditService, times(1)).report(argThat(builder ->
+                principal.getId().equals(builder.build(new ObjectMapper()).getActor().getId())));
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/ManagementUserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/ManagementUserServiceTest.java
@@ -1953,4 +1953,16 @@ public class ManagementUserServiceTest {
         verify(userRepository).update(userCaptor.capture(), any());
         assertEquals("Dr. John Doe", userCaptor.getValue().getDisplayName());
     }
+    @Test
+    public void shouldPurgeTheUsersOfADeletedDomain() {
+        when(dataPlaneRegistry.getUserRepository(DOMAIN)).thenReturn(userRepository);
+        when(userRepository.deleteByReference(DOMAIN.asReference())).thenReturn(Completable.complete());
+
+        var testObserver = userService.purgeDataPlane(DOMAIN).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(userRepository).deleteByReference(DOMAIN.asReference());
+    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/ManagementUserServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/ManagementUserServiceTest.java
@@ -1958,7 +1958,7 @@ public class ManagementUserServiceTest {
         when(dataPlaneRegistry.getUserRepository(DOMAIN)).thenReturn(userRepository);
         when(userRepository.deleteByReference(DOMAIN.asReference())).thenReturn(Completable.complete());
 
-        var testObserver = userService.purgeDataPlane(DOMAIN).test();
+        var testObserver = userService.purgeDataPlane(DOMAIN, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertComplete();
         testObserver.assertNoErrors();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/CredentialManagementServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/CredentialManagementServiceTest.java
@@ -333,7 +333,7 @@ public class CredentialManagementServiceTest {
     public void shouldPurgeTheWebAuthnCredentialsOfADeletedDomain() {
         when(credentialRepository.deleteByReference(ReferenceType.DOMAIN, DOMAIN)).thenReturn(Completable.complete());
 
-        TestObserver testObserver = credentialService.purgeDataPlane(domain).test();
+        TestObserver testObserver = credentialService.purgeDataPlane(domain, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
 
         testObserver.assertComplete();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/CredentialManagementServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/CredentialManagementServiceTest.java
@@ -329,4 +329,16 @@ public class CredentialManagementServiceTest {
         verify(credentialRepository, times(1)).deleteByUserId(ReferenceType.DOMAIN, DOMAIN, userId);
     }
 
+    @Test
+    public void shouldPurgeTheWebAuthnCredentialsOfADeletedDomain() {
+        when(credentialRepository.deleteByReference(ReferenceType.DOMAIN, DOMAIN)).thenReturn(Completable.complete());
+
+        TestObserver testObserver = credentialService.purgeDataPlane(domain).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        verify(credentialRepository, times(1)).deleteByReference(ReferenceType.DOMAIN, DOMAIN);
+    }
+
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/DeviceManagementServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/DeviceManagementServiceTest.java
@@ -150,7 +150,7 @@ public class DeviceManagementServiceTest {
     public void mustPurgeTheDevicesOfADeletedDomain() {
         doReturn(Completable.complete()).when(deviceRepository).deleteByReference(any(), any());
 
-        TestObserver<Void> testObserver = deviceService.purgeDataPlane(DOMAIN).test();
+        TestObserver<Void> testObserver = deviceService.purgeDataPlane(DOMAIN, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertComplete();
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/DeviceManagementServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/DeviceManagementServiceTest.java
@@ -146,4 +146,15 @@ public class DeviceManagementServiceTest {
         verify(auditService, times(1)).report(any());
     }
 
+    @Test
+    public void mustPurgeTheDevicesOfADeletedDomain() {
+        doReturn(Completable.complete()).when(deviceRepository).deleteByReference(any(), any());
+
+        TestObserver<Void> testObserver = deviceService.purgeDataPlane(DOMAIN).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+
+        verify(deviceRepository, times(1)).deleteByReference(ReferenceType.DOMAIN, DOMAIN.getId());
+    }
+
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/LoginAttemptManagementServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/LoginAttemptManagementServiceTest.java
@@ -100,7 +100,7 @@ public class LoginAttemptManagementServiceTest {
     public void should_purge_the_login_attempts_of_a_deleted_domain() {
         when(loginAttemptRepository.deleteByDomain("domain-1")).thenReturn(Completable.complete());
 
-        var testObserver = service.purgeDataPlane(new Domain("domain-1")).test();
+        var testObserver = service.purgeDataPlane(new Domain("domain-1"), null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertComplete();
         testObserver.assertNoErrors();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/LoginAttemptManagementServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/LoginAttemptManagementServiceTest.java
@@ -95,4 +95,16 @@ public class LoginAttemptManagementServiceTest {
 
         verify(loginAttemptRepository).delete(any(LoginAttemptCriteria.class));
     }
+
+    @Test
+    public void should_purge_the_login_attempts_of_a_deleted_domain() {
+        when(loginAttemptRepository.deleteByDomain("domain-1")).thenReturn(Completable.complete());
+
+        var testObserver = service.purgeDataPlane(new Domain("domain-1")).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(loginAttemptRepository).deleteByDomain("domain-1");
+    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/UMAResourceManagementServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/UMAResourceManagementServiceTest.java
@@ -241,7 +241,7 @@ public class UMAResourceManagementServiceTest {
         when(resourceRepository.delete(RESOURCE_ID)).thenReturn(Completable.complete());
         when(permissionTicketRepository.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
 
-        var testObserver = service.purgeDataPlane(DOMAIN).test();
+        var testObserver = service.purgeDataPlane(DOMAIN, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertComplete();
         testObserver.assertNoErrors();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/UMAResourceManagementServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/dataplane/UMAResourceManagementServiceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.am.management.service.dataplane;
 
 
 import io.gravitee.am.dataplane.api.repository.AccessPolicyRepository;
+import io.gravitee.am.dataplane.api.repository.PermissionTicketRepository;
 import io.gravitee.am.dataplane.api.repository.ResourceRepository;
 import io.gravitee.am.dataplane.api.repository.UserRepository;
 import io.gravitee.am.management.service.dataplane.impl.UMAResourceManagementServiceImpl;
@@ -30,6 +31,7 @@ import io.gravitee.am.model.uma.policy.AccessPolicy;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.ApplicationServiceImpl;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -76,6 +78,9 @@ public class UMAResourceManagementServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PermissionTicketRepository permissionTicketRepository;
 
     @InjectMocks
     private UMAResourceManagementService service = new UMAResourceManagementServiceImpl();
@@ -226,5 +231,22 @@ public class UMAResourceManagementServiceTest {
         when(applicationService.findByIdIn(anyList())).thenReturn(Flowable.just(new Application()));
         TestObserver<Map<String, Map<String, Object>>> testObserver = service.getMetadata(DOMAIN, resources).test();
         testObserver.assertComplete().assertNoErrors();
+    }
+    @Test
+    public void purgeDataPlane_dropsTheResourcesAndTheTicketsTheyLeaveBehind() {
+        var resource = new Resource().setId(RESOURCE_ID).setDomain(DOMAIN_ID);
+        when(dataPlaneRegistry.getPermissionTicketRepository(any())).thenReturn(permissionTicketRepository);
+        when(resourceRepository.findByDomain(DOMAIN_ID)).thenReturn(Flowable.just(resource));
+        when(accessPolicyRepository.findByDomainAndResource(DOMAIN_ID, RESOURCE_ID)).thenReturn(Flowable.empty());
+        when(resourceRepository.delete(RESOURCE_ID)).thenReturn(Completable.complete());
+        when(permissionTicketRepository.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
+
+        var testObserver = service.purgeDataPlane(DOMAIN).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(resourceRepository).delete(RESOURCE_ID);
+        verify(permissionTicketRepository).deleteByDomain(DOMAIN_ID);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -130,6 +130,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -158,6 +159,7 @@ import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -1493,6 +1495,10 @@ public class DomainServiceTest {
         verify(scopeService, times(1)).deleteByDomain(domain);
         // every store holding domain data in the data plane is purged, none of them named here
         dataPlaneCleanups.forEach(store -> verify(store, times(1)).purgeDataPlane(domain, null));
+        // the purge audits what it drops, so it has to run while the domain's reporters are still there
+        InOrder purgeThenReporters = inOrder(domainGroupService, reporterService);
+        purgeThenReporters.verify(domainGroupService).purgeDataPlane(domain, null);
+        purgeThenReporters.verify(reporterService).delete(REPORTER_ID);
         verify(formService, times(1)).delete(eq(DOMAIN_ID), eq(FORM_ID));
         verify(emailTemplateService, times(1)).delete(EMAIL_ID);
         verify(reporterService, times(1)).delete(REPORTER_ID);
@@ -1506,8 +1512,8 @@ public class DomainServiceTest {
         }));
     }
 
-    @Test
-    public void shouldDeleteWithoutRelatedData() {
+    /** A domain with nothing hanging off it, so a delete test can say only what it is about. */
+    private void stubADomainWithNoRelatedData() {
         when(protectedResourceService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
         when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
         when(domainRepository.delete(DOMAIN_ID)).thenReturn(complete());
@@ -1534,6 +1540,11 @@ public class DomainServiceTest {
         when(serviceResourceService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(authorizationEngineService.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
         when(scopeService.deleteByDomain(domain)).thenReturn(complete());
+    }
+
+    @Test
+    public void shouldDeleteWithoutRelatedData() {
+        stubADomainWithNoRelatedData();
 
         var testObserver = domainService.delete(GraviteeContext.defaultContext(DOMAIN_ID), DOMAIN_ID, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
@@ -1561,32 +1572,7 @@ public class DomainServiceTest {
     @Test
     public void shouldDeleteWhenTheDataPlaneCannotBeReached() {
         // a domain pins its data plane, so a domain that cannot be deleted would wedge the pair for good
-        when(protectedResourceService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
-        when(domainRepository.delete(DOMAIN_ID)).thenReturn(complete());
-        when(applicationService.findByDomain(DOMAIN_ID)).thenReturn(Single.just(Collections.emptySet()));
-        when(certificateService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(identityProviderService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(extensionGrantService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(roleService.findByDomain(DOMAIN_ID)).thenReturn(Single.just(Collections.emptySet()));
-        when(formService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(emailTemplateService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(reporterService.findByReference(Reference.domain(DOMAIN_ID))).thenReturn(Flowable.empty());
-        when(flowService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(membershipService.findByReference(DOMAIN_ID, DOMAIN)).thenReturn(Flowable.empty());
-        when(factorService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(alertTriggerService.findByDomainAndCriteria(DOMAIN_ID, new AlertTriggerCriteria())).thenReturn(Flowable.empty());
-        when(alertNotifierService.findByDomainAndCriteria(DOMAIN_ID, new AlertNotifierCriteria())).thenReturn(Flowable.empty());
-        when(authenticationDeviceNotifierService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(i18nDictionaryService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
-        when(themeService.findByReference(any(), any())).thenReturn(Maybe.empty());
-        when(passwordPolicyService.deleteByReference(any(), any())).thenReturn(complete());
-        when(reporterService.notifyInheritedReporters(any(), any(), any())).thenReturn(Completable.complete());
-        when(deviceIdentifierService.deleteByDomain(any())).thenReturn(Completable.complete());
-        when(serviceResourceService.deleteByDomain(any())).thenReturn(Completable.complete());
-        when(authorizationEngineService.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
-        when(scopeService.deleteByDomain(domain)).thenReturn(complete());
+        stubADomainWithNoRelatedData();
 
         // every store the domain holds data in is out of reach
         var unreachable = new TechnicalException("Timed out while waiting for a server");
@@ -1604,6 +1590,23 @@ public class DomainServiceTest {
         verify(scopeService, times(1)).deleteByDomain(domain);
         // the purge carries on past the stores it cannot reach, rather than stopping at the first
         dataPlaneCleanups.forEach(store -> verify(store, times(1)).purgeDataPlane(domain, null));
+    }
+
+    @Test
+    public void shouldDeleteWhenAStoreThrowsInsteadOfReturningAnError() {
+        // asking an unreachable data plane for a repository throws there and then, rather than
+        // handing back a Completable that fails later
+        stubADomainWithNoRelatedData();
+        when(domainGroupService.purgeDataPlane(any(Domain.class), any()))
+                .thenThrow(new IllegalStateException("No data plane found for id unreachable-plane"));
+
+        var testObserver = domainService.delete(GraviteeContext.defaultContext(DOMAIN_ID), DOMAIN_ID, null).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(domainRepository, times(1)).delete(DOMAIN_ID);
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -22,7 +22,11 @@ import io.gravitee.am.dataplane.api.repository.UserRepository;
 import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
 import io.gravitee.am.management.service.DomainGroupService;
+import io.gravitee.am.management.service.ManagementUserService;
 import io.gravitee.am.management.service.dataplane.UMAResourceManagementService;
+import io.gravitee.am.management.service.dataplane.CredentialManagementService;
+import io.gravitee.am.management.service.dataplane.DeviceManagementService;
+import io.gravitee.am.management.service.dataplane.LoginAttemptManagementService;
 import io.gravitee.am.management.service.dataplane.UserActivityManagementService;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.AuthenticationDeviceNotifier;
@@ -96,6 +100,7 @@ import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.ScopeService;
 import io.gravitee.am.service.ServiceResourceService;
 import io.gravitee.am.service.ThemeService;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.exception.DomainAlreadyExistsException;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.InvalidDomainException;
@@ -131,6 +136,7 @@ import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import io.gravitee.am.service.EntryPointManager;
 
@@ -367,9 +373,37 @@ public class DomainServiceTest {
     @Mock
     private io.gravitee.am.service.CimdClientStateService cimdClientStateService;
 
+    @Mock
+    private ManagementUserService managementUserService;
+
+    @Mock
+    private CredentialManagementService credentialService;
+
+    @Mock
+    private DeviceManagementService deviceService;
+
+    @Mock
+    private LoginAttemptManagementService loginAttemptService;
+
+    private List<DomainDataPlaneCleanup> dataPlaneCleanups;
+
     @BeforeEach
     void stubCimdClientStateServiceDefaults() {
         Mockito.lenient().when(cimdClientStateService.deleteByDomain(any(Domain.class))).thenReturn(Completable.complete());
+    }
+
+    /**
+     * The stores the domain deletion purges are collected by Spring, so the test has to hand them over
+     * itself. Every one of them completes unless a test says otherwise.
+     */
+    @BeforeEach
+    void stubDataPlaneCleanups() {
+        dataPlaneCleanups = List.of(userActivityService, managementUserService, domainGroupService, scopeService,
+                resourceService, passwordHistoryService, certificateCredentialService, cimdClientStateService,
+                credentialService, deviceService, loginAttemptService);
+        dataPlaneCleanups.forEach(store ->
+                Mockito.lenient().when(store.purgeDataPlane(any(Domain.class))).thenReturn(Completable.complete()));
+        ReflectionTestUtils.setField(domainService, "dataPlaneCleanups", dataPlaneCleanups);
     }
 
     @Test
@@ -1387,7 +1421,6 @@ public class DomainServiceTest {
         final AuthenticationDeviceNotifier authDeviceNotifier = new AuthenticationDeviceNotifier();
         authDeviceNotifier.setId(AUTH_DEVICE_ID);
 
-        when(dataPlaneRegistry.getUserRepository(any())).thenReturn(userRepository);
         when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
         when(domainRepository.delete(DOMAIN_ID)).thenReturn(complete());
         when(applicationService.findByDomain(DOMAIN_ID)).thenReturn(Single.just(mockApplications));
@@ -1404,14 +1437,6 @@ public class DomainServiceTest {
         when(role.getId()).thenReturn(ROLE_ID);
         when(roleService.findByDomain(DOMAIN_ID)).thenReturn(Single.just(Collections.singleton(role)));
         when(roleService.delete(eq(DOMAIN), eq(DOMAIN_ID), anyString())).thenReturn(complete());
-        when(userRepository.deleteByReference(any())).thenReturn(complete());
-        when(userActivityService.deleteByDomain(any())).thenReturn(complete());
-        when(scope.getId()).thenReturn(SCOPE_ID);
-        when(scopeService.findByDomain(DOMAIN_ID, 0, Integer.MAX_VALUE)).thenReturn(Single.just(new Page<>(Collections.singleton(scope), 0, 1)));
-        when(scopeService.delete(any(), eq(SCOPE_ID), eq(true))).thenReturn(complete());
-        when(group.getId()).thenReturn(GROUP_ID);
-        when(domainGroupService.findAll(any())).thenReturn(Flowable.just(group));
-        when(domainGroupService.delete(any(), anyString(), any())).thenReturn(complete());
         when(form.getId()).thenReturn(FORM_ID);
         when(formService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.just(form));
         when(formService.delete(eq(DOMAIN_ID), anyString())).thenReturn(complete());
@@ -1432,8 +1457,6 @@ public class DomainServiceTest {
         when(factor.getId()).thenReturn(FACTOR_ID);
         when(factorService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.just(factor));
         when(factorService.delete(DOMAIN_ID, FACTOR_ID)).thenReturn(complete());
-        when(resourceService.findByDomain(any())).thenReturn(Flowable.just(resource));
-        when(resourceService.delete(any(), any())).thenReturn(complete());
         when(alertTriggerService.findByDomainAndCriteria(DOMAIN_ID, new AlertTriggerCriteria())).thenReturn(Flowable.just(alertTrigger));
         when(alertTriggerService.delete(eq(DOMAIN), eq(DOMAIN_ID), eq(ALERT_TRIGGER_ID), isNull())).thenReturn(complete());
         when(alertNotifierService.findByDomainAndCriteria(DOMAIN_ID, new AlertNotifierCriteria())).thenReturn(Flowable.just(alertNotifier));
@@ -1442,14 +1465,12 @@ public class DomainServiceTest {
         when(authenticationDeviceNotifierService.delete(any(), eq(AUTH_DEVICE_ID), any())).thenReturn(complete());
         when(i18nDictionaryService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.just(new I18nDictionary()));
         when(i18nDictionaryService.delete(eq(DOMAIN), eq(DOMAIN_ID), any(), any())).thenReturn(complete());
-        when(passwordHistoryService.deleteByReference(any())).thenReturn(complete());
         when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
         when(themeService.findByReference(any(), any())).thenReturn(Maybe.empty());
         when(passwordPolicyService.deleteByReference(any(), any())).thenReturn(complete());
         when(reporterService.notifyInheritedReporters(any(), any(), any())).thenReturn(Completable.complete());
         when(deviceIdentifierService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(serviceResourceService.deleteByDomain(any())).thenReturn(Completable.complete());
-        when(certificateCredentialService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(authorizationEngineService.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
 
         final var graviteeContext = GraviteeContext.defaultContext(DOMAIN_ID);
@@ -1464,13 +1485,11 @@ public class DomainServiceTest {
         verify(identityProviderService, times(1)).delete(DOMAIN_ID, IDP_ID);
         verify(extensionGrantService, times(1)).delete(DOMAIN_ID, EXTENSION_GRANT_ID);
         verify(roleService, times(1)).delete(eq(DOMAIN), eq(DOMAIN_ID), eq(ROLE_ID));
-        verify(userRepository, times(1)).deleteByReference(any());
-        verify(userActivityService, times(1)).deleteByDomain(any());
         verify(deviceIdentifierService, times(1)).deleteByDomain(DOMAIN_ID);
         verify(serviceResourceService, times(1)).deleteByDomain(DOMAIN_ID);
         verify(authorizationEngineService, times(1)).deleteByDomain(DOMAIN_ID);
-        verify(scopeService, times(1)).delete(any(), eq(SCOPE_ID), eq(true));
-        verify(domainGroupService, times(1)).delete(any(), eq(GROUP_ID), any());
+        // every store holding domain data in the data plane is purged, none of them named here
+        dataPlaneCleanups.forEach(store -> verify(store, times(1)).purgeDataPlane(domain));
         verify(formService, times(1)).delete(eq(DOMAIN_ID), eq(FORM_ID));
         verify(emailTemplateService, times(1)).delete(EMAIL_ID);
         verify(reporterService, times(1)).delete(REPORTER_ID);
@@ -1487,7 +1506,6 @@ public class DomainServiceTest {
     @Test
     public void shouldDeleteWithoutRelatedData() {
         when(protectedResourceService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(dataPlaneRegistry.getUserRepository(any())).thenReturn(userRepository);
         when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
         when(domainRepository.delete(DOMAIN_ID)).thenReturn(complete());
         when(applicationService.findByDomain(DOMAIN_ID)).thenReturn(Single.just(Collections.emptySet()));
@@ -1495,29 +1513,22 @@ public class DomainServiceTest {
         when(identityProviderService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
         when(extensionGrantService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
         when(roleService.findByDomain(DOMAIN_ID)).thenReturn(Single.just(Collections.emptySet()));
-        when(scopeService.findByDomain(DOMAIN_ID, 0, Integer.MAX_VALUE)).thenReturn(Single.just(new Page<>(Collections.emptySet(), 0, 1)));
-        when(userRepository.deleteByReference(any())).thenReturn(complete());
-        when(userActivityService.deleteByDomain(any())).thenReturn(complete());
-        when(domainGroupService.findAll(any())).thenReturn(Flowable.empty());
         when(formService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
         when(emailTemplateService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
         when(reporterService.findByReference(Reference.domain(DOMAIN_ID))).thenReturn(Flowable.empty());
         when(flowService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
         when(membershipService.findByReference(DOMAIN_ID, DOMAIN)).thenReturn(Flowable.empty());
         when(factorService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
-        when(resourceService.findByDomain(any())).thenReturn(Flowable.empty());
         when(alertTriggerService.findByDomainAndCriteria(DOMAIN_ID, new AlertTriggerCriteria())).thenReturn(Flowable.empty());
         when(alertNotifierService.findByDomainAndCriteria(DOMAIN_ID, new AlertNotifierCriteria())).thenReturn(Flowable.empty());
         when(authenticationDeviceNotifierService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
         when(i18nDictionaryService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
         when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
         when(themeService.findByReference(any(), any())).thenReturn(Maybe.empty());
-        when(passwordHistoryService.deleteByReference(any())).thenReturn(complete());
         when(passwordPolicyService.deleteByReference(any(), any())).thenReturn(complete());
         when(reporterService.notifyInheritedReporters(any(), any(), any())).thenReturn(Completable.complete());
         when(deviceIdentifierService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(serviceResourceService.deleteByDomain(any())).thenReturn(Completable.complete());
-        when(certificateCredentialService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(authorizationEngineService.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
 
         var testObserver = domainService.delete(GraviteeContext.defaultContext(DOMAIN_ID), DOMAIN_ID, null).test();
@@ -1541,6 +1552,51 @@ public class DomainServiceTest {
         verify(alertTriggerService, never()).delete(any(ReferenceType.class), anyString(), anyString(), any(io.gravitee.am.identityprovider.api.User.class));
         verify(alertNotifierService, never()).delete(any(ReferenceType.class), anyString(), anyString(), any(io.gravitee.am.identityprovider.api.User.class));
         verify(eventService, times(1)).create(any(), any());
+    }
+
+    @Test
+    public void shouldDeleteWhenTheDataPlaneCannotBeReached() {
+        // a domain pins its data plane, so a domain that cannot be deleted would wedge the pair for good
+        when(protectedResourceService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(domainRepository.findById(DOMAIN_ID)).thenReturn(Maybe.just(domain));
+        when(domainRepository.delete(DOMAIN_ID)).thenReturn(complete());
+        when(applicationService.findByDomain(DOMAIN_ID)).thenReturn(Single.just(Collections.emptySet()));
+        when(certificateService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(identityProviderService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(extensionGrantService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(roleService.findByDomain(DOMAIN_ID)).thenReturn(Single.just(Collections.emptySet()));
+        when(formService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(emailTemplateService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(reporterService.findByReference(Reference.domain(DOMAIN_ID))).thenReturn(Flowable.empty());
+        when(flowService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(membershipService.findByReference(DOMAIN_ID, DOMAIN)).thenReturn(Flowable.empty());
+        when(factorService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(alertTriggerService.findByDomainAndCriteria(DOMAIN_ID, new AlertTriggerCriteria())).thenReturn(Flowable.empty());
+        when(alertNotifierService.findByDomainAndCriteria(DOMAIN_ID, new AlertNotifierCriteria())).thenReturn(Flowable.empty());
+        when(authenticationDeviceNotifierService.findByDomain(DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(i18nDictionaryService.findAll(DOMAIN, DOMAIN_ID)).thenReturn(Flowable.empty());
+        when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
+        when(themeService.findByReference(any(), any())).thenReturn(Maybe.empty());
+        when(passwordPolicyService.deleteByReference(any(), any())).thenReturn(complete());
+        when(reporterService.notifyInheritedReporters(any(), any(), any())).thenReturn(Completable.complete());
+        when(deviceIdentifierService.deleteByDomain(any())).thenReturn(Completable.complete());
+        when(serviceResourceService.deleteByDomain(any())).thenReturn(Completable.complete());
+        when(authorizationEngineService.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
+
+        // every store the domain holds data in is out of reach
+        var unreachable = new TechnicalException("Timed out while waiting for a server");
+        dataPlaneCleanups.forEach(store -> when(store.purgeDataPlane(any(Domain.class))).thenReturn(Completable.error(unreachable)));
+
+        var testObserver = domainService.delete(GraviteeContext.defaultContext(DOMAIN_ID), DOMAIN_ID, null).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(domainRepository, times(1)).delete(DOMAIN_ID);
+        verify(eventService, times(1)).create(any(), any());
+        // the purge carries on past the stores it cannot reach, rather than stopping at the first
+        dataPlaneCleanups.forEach(store -> verify(store, times(1)).purgeDataPlane(domain));
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -402,7 +402,7 @@ public class DomainServiceTest {
                 resourceService, passwordHistoryService, certificateCredentialService, cimdClientStateService,
                 credentialService, deviceService, loginAttemptService);
         dataPlaneCleanups.forEach(store ->
-                Mockito.lenient().when(store.purgeDataPlane(any(Domain.class))).thenReturn(Completable.complete()));
+                Mockito.lenient().when(store.purgeDataPlane(any(Domain.class), any())).thenReturn(Completable.complete()));
         ReflectionTestUtils.setField(domainService, "dataPlaneCleanups", dataPlaneCleanups);
     }
 
@@ -1472,6 +1472,7 @@ public class DomainServiceTest {
         when(deviceIdentifierService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(serviceResourceService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(authorizationEngineService.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
+        when(scopeService.deleteByDomain(domain)).thenReturn(complete());
 
         final var graviteeContext = GraviteeContext.defaultContext(DOMAIN_ID);
         final var testObserver = domainService.delete(graviteeContext, DOMAIN_ID, null).test();
@@ -1488,8 +1489,10 @@ public class DomainServiceTest {
         verify(deviceIdentifierService, times(1)).deleteByDomain(DOMAIN_ID);
         verify(serviceResourceService, times(1)).deleteByDomain(DOMAIN_ID);
         verify(authorizationEngineService, times(1)).deleteByDomain(DOMAIN_ID);
+        // the scopes are control plane rows, so they go before the domain does rather than with the purge
+        verify(scopeService, times(1)).deleteByDomain(domain);
         // every store holding domain data in the data plane is purged, none of them named here
-        dataPlaneCleanups.forEach(store -> verify(store, times(1)).purgeDataPlane(domain));
+        dataPlaneCleanups.forEach(store -> verify(store, times(1)).purgeDataPlane(domain, null));
         verify(formService, times(1)).delete(eq(DOMAIN_ID), eq(FORM_ID));
         verify(emailTemplateService, times(1)).delete(EMAIL_ID);
         verify(reporterService, times(1)).delete(REPORTER_ID);
@@ -1530,6 +1533,7 @@ public class DomainServiceTest {
         when(deviceIdentifierService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(serviceResourceService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(authorizationEngineService.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
+        when(scopeService.deleteByDomain(domain)).thenReturn(complete());
 
         var testObserver = domainService.delete(GraviteeContext.defaultContext(DOMAIN_ID), DOMAIN_ID, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
@@ -1582,10 +1586,11 @@ public class DomainServiceTest {
         when(deviceIdentifierService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(serviceResourceService.deleteByDomain(any())).thenReturn(Completable.complete());
         when(authorizationEngineService.deleteByDomain(DOMAIN_ID)).thenReturn(Completable.complete());
+        when(scopeService.deleteByDomain(domain)).thenReturn(complete());
 
         // every store the domain holds data in is out of reach
         var unreachable = new TechnicalException("Timed out while waiting for a server");
-        dataPlaneCleanups.forEach(store -> when(store.purgeDataPlane(any(Domain.class))).thenReturn(Completable.error(unreachable)));
+        dataPlaneCleanups.forEach(store -> when(store.purgeDataPlane(any(Domain.class), any())).thenReturn(Completable.error(unreachable)));
 
         var testObserver = domainService.delete(GraviteeContext.defaultContext(DOMAIN_ID), DOMAIN_ID, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
@@ -1595,8 +1600,10 @@ public class DomainServiceTest {
 
         verify(domainRepository, times(1)).delete(DOMAIN_ID);
         verify(eventService, times(1)).create(any(), any());
+        // the scopes live in the control plane, so an unreachable data plane must not strand them
+        verify(scopeService, times(1)).deleteByDomain(domain);
         // the purge carries on past the stores it cannot reach, rather than stopping at the first
-        dataPlaneCleanups.forEach(store -> verify(store, times(1)).purgeDataPlane(domain));
+        dataPlaneCleanups.forEach(store -> verify(store, times(1)).purgeDataPlane(domain, null));
     }
 
     @Test

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/CertificateCredentialService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/CertificateCredentialService.java
@@ -18,6 +18,7 @@ package io.gravitee.am.service;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.CertificateCredential;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -26,7 +27,7 @@ import io.reactivex.rxjava3.core.Single;
 /**
  * @author GraviteeSource Team
  */
-public interface CertificateCredentialService {
+public interface CertificateCredentialService extends DomainDataPlaneCleanup {
 
     /**
      * Enroll a certificate for a user.
@@ -115,5 +116,10 @@ public interface CertificateCredentialService {
      * @return completable
      */
     Completable deleteByDomain(Domain domain);
+
+    @Override
+    default Completable purgeDataPlane(Domain domain) {
+        return deleteByDomain(domain);
+    }
 }
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/CertificateCredentialService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/CertificateCredentialService.java
@@ -118,7 +118,7 @@ public interface CertificateCredentialService extends DomainDataPlaneCleanup {
     Completable deleteByDomain(Domain domain);
 
     @Override
-    default Completable purgeDataPlane(Domain domain) {
+    default Completable purgeDataPlane(Domain domain, User principal) {
         return deleteByDomain(domain);
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/CimdClientStateService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/CimdClientStateService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service;
 
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.CimdClientState;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
@@ -34,7 +35,7 @@ public interface CimdClientStateService extends DomainDataPlaneCleanup {
     Completable deleteByDomain(Domain domain);
 
     @Override
-    default Completable purgeDataPlane(Domain domain) {
+    default Completable purgeDataPlane(Domain domain, User principal) {
         return deleteByDomain(domain);
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/CimdClientStateService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/CimdClientStateService.java
@@ -17,6 +17,7 @@ package io.gravitee.am.service;
 
 import io.gravitee.am.model.CimdClientState;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -24,11 +25,16 @@ import io.reactivex.rxjava3.core.Single;
 /**
  * @author GraviteeSource Team
  */
-public interface CimdClientStateService {
+public interface CimdClientStateService extends DomainDataPlaneCleanup {
 
     Maybe<CimdClientState> findByDomainAndClientId(Domain domain, String clientId);
 
     Single<CimdClientState> upsert(Domain domain, String clientId, String monitoredPropertiesHash);
 
     Completable deleteByDomain(Domain domain);
+
+    @Override
+    default Completable purgeDataPlane(Domain domain) {
+        return deleteByDomain(domain);
+    }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/ScopeService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/ScopeService.java
@@ -17,9 +17,9 @@ package io.gravitee.am.service;
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.oauth2.Scope;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.model.NewScope;
 import io.gravitee.am.service.model.NewSystemScope;
 import io.gravitee.am.service.model.PatchScope;
@@ -58,6 +58,13 @@ public interface ScopeService extends DomainDataPlaneCleanup {
     Single<Scope> update(Domain domain, String id, UpdateSystemScope updateScope);
 
     Completable delete(Domain domain, String scopeId, boolean force, User principal);
+
+    /**
+     * Drop every scope of the domain. Unlike {@link #delete(Domain, String, boolean, User)} this stays in the
+     * control plane: it does not unpick the scope from roles and applications, which go with the domain anyway,
+     * and it leaves the approvals to {@link #purgeDataPlane(Domain, User)}.
+     */
+    Completable deleteByDomain(Domain domain);
 
     Single<Page<Scope>> search(String domain, String query, int page, int size);
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/ScopeService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/ScopeService.java
@@ -17,6 +17,7 @@ package io.gravitee.am.service;
 
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.oauth2.Scope;
 import io.gravitee.am.service.model.NewScope;
@@ -36,7 +37,7 @@ import java.util.List;
  * @author Alexandre FARIA (contact at alexandrefaria.net)
  * @author GraviteeSource Team
  */
-public interface ScopeService {
+public interface ScopeService extends DomainDataPlaneCleanup {
 
     Maybe<Scope> findById(String id);
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/DomainDataPlaneCleanup.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/DomainDataPlaneCleanup.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service.dataplane;
 
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
 import io.reactivex.rxjava3.core.Completable;
 
@@ -31,6 +32,8 @@ public interface DomainDataPlaneCleanup {
     /**
      * Remove everything this store holds for the domain. Called once the domain itself is deleted,
      * on a best effort basis: the data plane may be unreachable, and the domain still has to go.
+     *
+     * @param principal who asked for the domain to be deleted, for the stores that audit what they drop
      */
-    Completable purgeDataPlane(Domain domain);
+    Completable purgeDataPlane(Domain domain, User principal);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/DomainDataPlaneCleanup.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/DomainDataPlaneCleanup.java
@@ -13,18 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.am.dataplane.api.repository;
+package io.gravitee.am.service.dataplane;
 
-import io.gravitee.am.model.uma.PermissionTicket;
-import io.gravitee.am.repository.common.CrudRepository;
-import io.gravitee.am.repository.common.ExpiredDataSweeper;
+import io.gravitee.am.model.Domain;
 import io.reactivex.rxjava3.core.Completable;
 
 /**
- * @author Alexandre FARIA (contact at alexandrefaria.net)
+ * A store in the data plane that holds data of its own for a domain. Implement this on the service
+ * that owns the store, and the domain deletion picks it up: the management API collects every
+ * implementation rather than naming them one by one, so a store added later is purged without
+ * anyone remembering to extend the deletion.
+ *
  * @author GraviteeSource Team
  */
-public interface PermissionTicketRepository extends CrudRepository<PermissionTicket, String>, ExpiredDataSweeper {
+public interface DomainDataPlaneCleanup {
 
-    Completable deleteByDomain(String domain);
+    /**
+     * Remove everything this store holds for the domain. Called once the domain itself is deleted,
+     * on a best effort basis: the data plane may be unreachable, and the domain still has to go.
+     */
+    Completable purgeDataPlane(Domain domain);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PasswordHistoryService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PasswordHistoryService.java
@@ -18,6 +18,7 @@ package io.gravitee.am.service.impl;
 import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.PasswordHistory;
 import io.gravitee.am.model.PasswordPolicy;
 import io.gravitee.am.model.Reference;
@@ -50,7 +51,13 @@ import lombok.CustomLog;
  */
 @Component
 @CustomLog
-public class PasswordHistoryService {
+public class PasswordHistoryService implements DomainDataPlaneCleanup {
+
+    @Override
+    public Completable purgeDataPlane(Domain domain) {
+        return deleteByReference(domain);
+    }
+
 
     private final AuditService auditService;
     private final PasswordEncoder passwordEncoder;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PasswordHistoryService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/PasswordHistoryService.java
@@ -18,13 +18,13 @@ package io.gravitee.am.service.impl;
 import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.model.PasswordHistory;
 import io.gravitee.am.model.PasswordPolicy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.authentication.crypto.password.PasswordEncoder;
+import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.exception.PasswordHistoryException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
@@ -52,12 +52,6 @@ import lombok.CustomLog;
 @Component
 @CustomLog
 public class PasswordHistoryService implements DomainDataPlaneCleanup {
-
-    @Override
-    public Completable purgeDataPlane(Domain domain) {
-        return deleteByReference(domain);
-    }
-
 
     private final AuditService auditService;
     private final PasswordEncoder passwordEncoder;
@@ -173,6 +167,11 @@ public class PasswordHistoryService implements DomainDataPlaneCleanup {
     public Completable deleteByReference(Domain domain) {
         final var repository = dataPlaneRegistry.getPasswordHistoryRepository(domain);
         return repository.deleteByReference(domain.asReference());
+    }
+
+    @Override
+    public Completable purgeDataPlane(Domain domain, User principal) {
+        return deleteByReference(domain);
     }
 
     /**

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ScopeServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ScopeServiceImpl.java
@@ -294,9 +294,17 @@ public class ScopeServiceImpl implements ScopeService {
     }
 
     @Override
-    public Completable purgeDataPlane(Domain domain) {
+    public Completable purgeDataPlane(Domain domain, User principal) {
         // the scopes themselves are control plane rows, only what users approved lives out here
         return dataPlaneRegistry.getScopeApprovalRepository(domain).deleteByDomain(domain.getId());
+    }
+
+    @Override
+    public Completable deleteByDomain(Domain domain) {
+        log.debug("Delete every scope of domain {}", domain.getId());
+        return scopeRepository.findByDomain(domain.getId(), 0, Integer.MAX_VALUE)
+                .flatMapCompletable(scopes -> Completable.concat(
+                        scopes.getData().stream().map(scope -> scopeRepository.delete(scope.getId())).toList()));
     }
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ScopeServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ScopeServiceImpl.java
@@ -294,6 +294,12 @@ public class ScopeServiceImpl implements ScopeService {
     }
 
     @Override
+    public Completable purgeDataPlane(Domain domain) {
+        // the scopes themselves are control plane rows, only what users approved lives out here
+        return dataPlaneRegistry.getScopeApprovalRepository(domain).deleteByDomain(domain.getId());
+    }
+
+    @Override
     public Completable delete(Domain domain, String scopeId, boolean force, User principal) {
         log.debug("Delete scope {}", scopeId);
         return scopeRepository.findById(scopeId)

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ScopeServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ScopeServiceTest.java
@@ -76,6 +76,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -754,11 +755,31 @@ public class ScopeServiceTest {
     public void shouldPurgeTheApprovalsOfADeletedDomain() {
         when(scopeApprovalRepository.deleteByDomain(DOMAIN.getId())).thenReturn(Completable.complete());
 
-        var testObserver = scopeService.purgeDataPlane(DOMAIN).test();
+        var testObserver = scopeService.purgeDataPlane(DOMAIN, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
         verify(scopeApprovalRepository).deleteByDomain(DOMAIN.getId());
+    }
+
+    @Test
+    public void shouldDeleteEveryScopeOfADeletedDomain() {
+        var first = new Scope();
+        first.setId("scope-1");
+        var second = new Scope();
+        second.setId("scope-2");
+        when(scopeRepository.findByDomain(DOMAIN.getId(), 0, Integer.MAX_VALUE)).thenReturn(Single.just(new Page<>(List.of(first, second), 0, 2)));
+        when(scopeRepository.delete(anyString())).thenReturn(Completable.complete());
+
+        var testObserver = scopeService.deleteByDomain(DOMAIN).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(scopeRepository).delete("scope-1");
+        verify(scopeRepository).delete("scope-2");
+        // the approvals belong to the data plane, which this must not reach into
+        verifyNoInteractions(scopeApprovalRepository);
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/ScopeServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/ScopeServiceTest.java
@@ -750,4 +750,15 @@ public class ScopeServiceTest {
         testObserver.assertNoErrors();
         testObserver.assertValue(isValid -> isValid);
     }
+    @Test
+    public void shouldPurgeTheApprovalsOfADeletedDomain() {
+        when(scopeApprovalRepository.deleteByDomain(DOMAIN.getId())).thenReturn(Completable.complete());
+
+        var testObserver = scopeService.purgeDataPlane(DOMAIN).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(scopeApprovalRepository).deleteByDomain(DOMAIN.getId());
+    }
 }

--- a/gravitee-am-test/api/commands/management/dataplane-provisioning-commands.ts
+++ b/gravitee-am-test/api/commands/management/dataplane-provisioning-commands.ts
@@ -75,13 +75,30 @@ async function read<T>(response: Response): Promise<DataPlaneResponse<T>> {
   return { status: response.status, body, raw };
 }
 
+/**
+ * Ids provisioned by the spec file that loaded this module. Jest gives each test file its own module
+ * registry, so this stays that file's own list: cleanup can drop what the file made without touching
+ * the data planes a spec running on another worker is still using.
+ */
+const provisionedByThisSpec = new Set<string>();
+
+export const provisionedDataPlaneIds = (): string[] => [...provisionedByThisSpec];
+
+export const forgetDataPlane = (id: string): void => {
+  provisionedByThisSpec.delete(id);
+};
+
 export const createDataPlane = async (payload: NewDataPlane | string): Promise<DataPlaneResponse<any>> => {
   const response = await fetch(`${basePath}/dataplanes`, {
     method: 'POST',
     headers: { ...authHeader(), 'Content-Type': 'application/json' },
     body: typeof payload === 'string' ? payload : JSON.stringify(payload),
   });
-  return read(response);
+  const result = await read<any>(response);
+  if (result.status === 201 && result.body?.id) {
+    provisionedByThisSpec.add(result.body.id);
+  }
+  return result;
 };
 
 export const listDataPlanes = async (): Promise<DataPlaneResponse<DataPlaneSummary[]>> => {
@@ -96,7 +113,11 @@ export const getDataPlane = async (id: string): Promise<DataPlaneResponse<DataPl
 
 export const deleteDataPlane = async (id: string): Promise<DataPlaneResponse<void>> => {
   const response = await fetch(`${basePath}/dataplanes/${id}`, { method: 'DELETE', headers: authHeader() });
-  return read(response);
+  const result = await read<void>(response);
+  if (result.status === 204) {
+    provisionedByThisSpec.delete(id);
+  }
+  return result;
 };
 
 /** Same requests without credentials, to prove the technical API stays behind basic auth. */

--- a/gravitee-am-test/specs/management/internal-api/dataplane-provisioning.jest.spec.ts
+++ b/gravitee-am-test/specs/management/internal-api/dataplane-provisioning.jest.spec.ts
@@ -32,6 +32,7 @@ import {
   createDomainOnDataPlane,
   DATABASE_NAME,
   dataPlanePayload,
+  dataPlanesOfferedByTheConsole,
   deleteProvisionedDataPlanes,
   JDBC_SUMMARY,
   jdbcPayload,
@@ -352,6 +353,16 @@ describe('Data plane provisioning (management technical API)', () => {
       // the registry has to give the id up, not just the row: a domain bound to a deleted data plane
       // would be created against a store nothing is meant to be using
       expect(await canBindADomainTo(provisioned.id)).toBe(false);
+    });
+
+    it('stops offering a deleted data plane to the console', async () => {
+      const provisioned = await provisionConnectableDataPlane(uniqueName('dp-e2e-offered', true));
+      expect(await dataPlanesOfferedByTheConsole()).toContain(provisioned.id);
+
+      expect((await deleteDataPlane(provisioned.id)).status).toBe(204);
+
+      // the new domain form lists the registry, so a deleted plane left in it is one a user can pick
+      expect(await dataPlanesOfferedByTheConsole()).not.toContain(provisioned.id);
     });
 
     it('serves a data plane again when its id is re-provisioned', async () => {

--- a/gravitee-am-test/specs/management/internal-api/dataplane-unreachable.jest.spec.ts
+++ b/gravitee-am-test/specs/management/internal-api/dataplane-unreachable.jest.spec.ts
@@ -18,9 +18,11 @@ import { afterEach, describe, expect, it } from '@jest/globals';
 import { deleteDataPlane } from '@management-commands/dataplane-provisioning-commands';
 import { deleteDomain } from '@management-commands/domain-management-commands';
 import {
+  BoundDomain,
   createDomainOnDataPlane,
   deleteProvisionedDataPlanes,
   provisionUnreachableDataPlane,
+  releaseBoundDomain,
 } from './fixtures/dataplane-provisioning-fixture';
 import { setup } from '../../test-fixture';
 import { uniqueName } from '@utils-commands/misc';
@@ -29,15 +31,23 @@ import { uniqueName } from '@utils-commands/misc';
 setup(180000);
 
 describe('Domains bound to an unreachable data plane', () => {
-  afterEach(deleteProvisionedDataPlanes);
+  let bound: BoundDomain | undefined;
+
+  afterEach(async () => {
+    // a domain left bound blocks its data plane from being deleted, which would poison every later run
+    await releaseBoundDomain(bound);
+    bound = undefined;
+    await deleteProvisionedDataPlanes();
+  });
 
   it('deletes the domain anyway, so the data plane can be deleted after it', async () => {
     const dataPlaneId = uniqueName('dp-e2e-unreachable', true);
     await provisionUnreachableDataPlane(dataPlaneId);
-    const bound = await createDomainOnDataPlane(dataPlaneId);
+    bound = await createDomainOnDataPlane(dataPlaneId);
 
     // a domain pins its data plane, so a domain that cannot be deleted wedges the pair for good
     await deleteDomain(bound.domainId, bound.accessToken);
+    bound = undefined;
 
     expect((await deleteDataPlane(dataPlaneId)).status).toBe(204);
   });

--- a/gravitee-am-test/specs/management/internal-api/dataplane-unreachable.jest.spec.ts
+++ b/gravitee-am-test/specs/management/internal-api/dataplane-unreachable.jest.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { deleteDataPlane } from '@management-commands/dataplane-provisioning-commands';
+import { deleteDomain } from '@management-commands/domain-management-commands';
+import {
+  createDomainOnDataPlane,
+  deleteProvisionedDataPlanes,
+  provisionUnreachableDataPlane,
+} from './fixtures/dataplane-provisioning-fixture';
+import { setup } from '../../test-fixture';
+import { uniqueName } from '@utils-commands/misc';
+
+// every read and write against the broken store waits for its own connection timeout
+setup(180000);
+
+describe('Domains bound to an unreachable data plane', () => {
+  afterEach(deleteProvisionedDataPlanes);
+
+  it('deletes the domain anyway, so the data plane can be deleted after it', async () => {
+    const dataPlaneId = uniqueName('dp-e2e-unreachable', true);
+    await provisionUnreachableDataPlane(dataPlaneId);
+    const bound = await createDomainOnDataPlane(dataPlaneId);
+
+    // a domain pins its data plane, so a domain that cannot be deleted wedges the pair for good
+    await deleteDomain(bound.domainId, bound.accessToken);
+
+    expect((await deleteDataPlane(dataPlaneId)).status).toBe(204);
+  });
+});

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -114,6 +114,56 @@ export function connectablePayload(id: string): NewDataPlane {
       };
 }
 
+/**
+ * A data plane whose store cannot be reached. Everything about the definition is valid, so it is
+ * provisioned and registered like any other: only the connection is broken.
+ */
+export function unreachablePayload(id: string): NewDataPlane {
+  return process.env.REPOSITORY_TYPE === 'jdbc'
+    ? {
+        id,
+        name: 'E2E unreachable data plane',
+        type: 'jdbc',
+        configuration: {
+          jdbc: {
+            driver: 'postgresql',
+            host: 'postgres',
+            port: 9999,
+            database: 'postgres',
+            username: 'postgres',
+            password: 'postgres',
+          },
+        },
+      }
+    : {
+        id,
+        name: 'E2E unreachable data plane',
+        type: 'mongodb',
+        configuration: { mongodb: { dbname: 'gravitee-am', host: 'mongodb', port: 9999 } },
+      };
+}
+
+export async function provisionUnreachableDataPlane(id: string): Promise<DataPlaneSummary> {
+  const created = await createDataPlane(unreachablePayload(id));
+  if (created.status !== 201) {
+    throw new Error(`Unable to provision an unreachable data plane: status=${created.status} body=${created.raw}`);
+  }
+  return created.body;
+}
+
+/** What the console offers in the new domain form, which reads the registry rather than the stored rows. */
+export async function dataPlanesOfferedByTheConsole(): Promise<string[]> {
+  const accessToken = await requestAdminAccessToken();
+  const response = await fetch(
+    `${process.env.AM_MANAGEMENT_URL}/management/organizations/${process.env.AM_DEF_ORG_ID}/environments/${ENVIRONMENT_ID}/data-planes`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  if (response.status !== 200) {
+    throw new Error(`Unable to list the data planes the console offers: status=${response.status}`);
+  }
+  return (await response.json()).map((dataPlane) => dataPlane.id);
+}
+
 export async function provisionConnectableDataPlane(id: string): Promise<DataPlaneSummary> {
   const created = await createDataPlane(connectablePayload(id));
   if (created.status !== 201) {

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -18,8 +18,9 @@ import {
   createDataPlane,
   DataPlaneSummary,
   deleteDataPlane,
-  listDataPlanes,
+  forgetDataPlane,
   NewDataPlane,
+  provisionedDataPlaneIds,
 } from '@management-commands/dataplane-provisioning-commands';
 import { createDomain, safeDeleteDomain } from '@management-commands/domain-management-commands';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
@@ -172,18 +173,19 @@ export async function provisionConnectableDataPlane(id: string): Promise<DataPla
   return created.body;
 }
 
+/**
+ * Drops only the data planes this spec file provisioned. Sweeping the whole environment instead would
+ * delete the ones a spec on another jest worker is still using, and that spec then fails to bind a
+ * domain to a data plane that vanished under it.
+ */
 export async function deleteProvisionedDataPlanes(): Promise<void> {
-  const listed = await listDataPlanes();
-  if (listed.status !== 200) {
-    console.warn(`⚠️  Could not list data planes for cleanup: status=${listed.status}`);
-    return;
-  }
-  const provisioned = listed.body.filter((dataPlane) => dataPlane.environmentId === ENVIRONMENT_ID);
-  for (const dataPlane of provisioned) {
-    const deleted = await deleteDataPlane(dataPlane.id);
-    if (deleted.status !== 204) {
-      console.warn(`⚠️  Could not clean up data plane [${dataPlane.id}]: status=${deleted.status} body=${deleted.raw}`);
+  for (const id of provisionedDataPlaneIds()) {
+    const deleted = await deleteDataPlane(id);
+    // 404 is fine: the test deleted it itself, which is what several of them are about
+    if (deleted.status !== 204 && deleted.status !== 404) {
+      console.warn(`⚠️  Could not clean up data plane [${id}]: status=${deleted.status} body=${deleted.raw}`);
     }
+    forgetDataPlane(id);
   }
 }
 

--- a/gravitee-am-ui/src/app/domain/settings/audits/audits.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/audits.component.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { AuditService } from '../../../services/audit.service';
+import { OrganizationService } from '../../../services/organization.service';
+import { EnvironmentService } from '../../../services/environment.service';
+import { UserService } from '../../../services/user.service';
+import { AuthService } from '../../../services/auth.service';
+
+import { AuditsComponent } from './audits.component';
+
+function organizationAudit(targetType: string) {
+  return {
+    type: `${targetType}_CREATED`,
+    outcome: { status: 'success' },
+    referenceType: 'organization',
+    target: { id: 'target-id', type: targetType, referenceType: 'organization', displayName: 'A target' },
+  };
+}
+
+describe('AuditsComponent', () => {
+  let component: AuditsComponent;
+
+  beforeEach(() => {
+    const route = {
+      snapshot: { data: {}, paramMap: { get: () => 'a-value' } },
+    } as unknown as ActivatedRoute;
+    const router = { routerState: { snapshot: { url: '/settings/audits' } } } as unknown as Router;
+    const auditService = { search: jest.fn().mockReturnValue(of({ totalCount: 0, data: [] })) } as unknown as AuditService;
+    const organizationService = { auditEventTypes: jest.fn().mockReturnValue(of([])) } as unknown as OrganizationService;
+    const userService = { search: jest.fn().mockReturnValue(of({ data: [] })) } as unknown as UserService;
+    const authService = { hasPermissions: jest.fn().mockReturnValue(true) } as unknown as AuthService;
+
+    component = new AuditsComponent(route, router, auditService, organizationService, {} as EnvironmentService, userService, authService);
+  });
+
+  it.each(['ENVIRONMENT', 'DATA_PLANE', 'ENTRYPOINT', 'MEMBERSHIP'])('does not link a %s target', (targetType) => {
+    const audit = organizationAudit(targetType);
+
+    expect(component.getTargetUrl(audit)).toEqual([]);
+    expect(component.hasLinkableTarget(audit)).toBe(false);
+  });
+
+  it('still links a target the console has a page for', () => {
+    const audit = organizationAudit('FORM');
+
+    expect(component.hasLinkableTarget(audit)).toBe(true);
+    expect(component.getTargetUrl(audit)).toEqual(['/settings', 'forms', 'form']);
+  });
+});

--- a/gravitee-am-ui/src/app/domain/settings/audits/audits.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/audits.component.ts
@@ -29,6 +29,11 @@ import { AuthService } from '../../../services/auth.service';
 import { availableTimeRanges, defaultTimeRangeId } from '../../../utils/time-range-utils';
 import { EnvironmentService } from '../../../services/environment.service';
 
+// Targets with no page of their own in the console: the generic link builder would send environments
+// and data planes to a route that does not exist, and entrypoints to the standalone editor, which is
+// read-only and out of context once these are provisioned outside the console.
+const UNLINKABLE_TARGET_TYPES = ['MEMBERSHIP', 'ENVIRONMENT', 'DATA_PLANE', 'ENTRYPOINT'];
+
 @Component({
   selector: 'app-audits',
   templateUrl: './audits.component.html',
@@ -143,8 +148,7 @@ export class AuditsComponent implements OnInit {
   }
 
   getTargetUrl(row): string[] {
-    if (row.target.type === 'MEMBERSHIP') {
-      // Membership doesn't have link
+    if (UNLINKABLE_TARGET_TYPES.includes(row.target.type)) {
       return [];
     }
     return this.buildLink(row);


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7440
https://gravitee.atlassian.net/browse/AM-7441
https://gravitee.atlassian.net/browse/AM-7442

## :pencil2: A description of the changes proposed in the pull request

A domain pins its data plane, so a domain that could not be deleted took its data plane with it: the definition cannot be deleted while a domain still binds to it, and a store that did not answer failed the whole delete. Point a domain at a data plane that does not answer and the pair was stuck for good.

The purge is now best effort. It runs while the domain's reporters are still around to audit it, and a failure is only logged, because the domain has to go regardless of whether its store is reachable.

While in there, the purge was also incomplete. Deleting a domain left its devices, login attempts, webauthn credentials and permission tickets behind. The team called it a long standing bug, so it is fixed here rather than left for later.

Also in here:

- Stores that hold domain data declare themselves through DomainDataPlaneCleanup and the deletion collects them, so it never names a store and the next one added is purged without anyone remembering.
- Devices, login attempts, permission tickets and scope approvals get bulk deletes on the data plane repositories, for mongodb and jdbc.
- Scopes go through a bulk deleteByDomain instead of the per scope delete the deletion used to loop over. That skips unpicking each scope from the roles and applications that reference it, which go with the domain anyway.
- Audit targets with no page in the console render as text instead of a link, so environments and data planes stop leading to a 404 and entrypoints stop leading to the standalone editor.

The purge runs with delayed errors on purpose. One unreachable repository must not skip the stores queued behind it, or a single broken connection leaves most of the domain's data in place.

AM-7442 needed no change. #8368 landed after it was raised and already unregisters a deleted data plane, so what is here is the regression test through the endpoint the new domain form actually reads.

## :memo: Test scenarios

Unit, repository and e2e coverage in the branch, all green. The repository tests run against mongodb and every supported jdbc database. Manual test steps are in the Jira tickets.

## :computer: Add screenshots for UI

No screenshots. The console change removes links from three audit target types, the rows render as plain text instead.

## :books: Any other comments that will help with documentation

Deleting a domain now removes data that AM used to leave behind, so anyone relying on that residue will notice. Worth calling out in release notes.

The retention rules this falls under are still undefined. AM-7167 lists "data plane decommission and environment deletion need clear retention and migration rules" as an open risk, and nothing has settled it since, so the behaviour here is the code's own intent rather than a spec.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
