### PR TITLE
AM-7433 - Refactor VHost routing

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
@@ -19,7 +19,7 @@ import io.gravitee.am.common.event.DomainEvent;
 import io.gravitee.am.gateway.handler.vertx.VertxSecurityDomainHandler;
 import io.gravitee.am.gateway.reactor.Reactor;
 import io.gravitee.am.gateway.reactor.SecurityDomainHandlerRegistry;
-import io.gravitee.am.gateway.reactor.impl.router.VHostRouter;
+import io.gravitee.am.gateway.reactor.impl.router.VHostGroupRouter;
 import io.gravitee.am.gateway.reactor.impl.transaction.TransactionHandlerFactory;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.VirtualHost;
@@ -39,8 +39,11 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -67,6 +70,15 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
     // Root router is mutated only under this lock; heavy per-domain work
     // (Spring context refresh, component start) happens before, in parallel.
     private final ReentrantLock routerLock = new ReentrantLock();
+
+    // One VHostGroupRouter per distinct mount path, shared by every domain/vhost mounted on
+    // that path, so that the number of routes registered on the root router (and therefore the
+    // request-handling recursion depth) no longer grows with the number of domains.
+    private final Map<String, VHostGroupRouter> pathGroups = new ConcurrentHashMap<>();
+
+    // Handles removing a domain's members from the VHostGroupRouter(s) it was mounted on, keyed
+    // by domain id, so undeploy actually forgets the domain instead of only clearing its router.
+    private final Map<String, List<Runnable>> domainUnmountActions = new ConcurrentHashMap<>();
 
     @Autowired
     private TransactionHandlerFactory transactionHandlerFactory;
@@ -120,6 +132,7 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
         routerLock.lock();
         try {
             Domain domain = domainHandler.getDomain();
+            List<Runnable> unmountActions = new ArrayList<>();
 
             if (domain.isVhostMode()) {
                 // Mount the same router for each virtual host / path.
@@ -131,13 +144,35 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
                                 .thenComparing(Comparator.comparing(VirtualHost::getPath).reversed()))
                         .toList();
 
-                sortedVhosts.forEach(virtualHost -> this.router.route(sanitizePath(virtualHost.getPath())).subRouter(VHostRouter.router(vertx, domain, virtualHost, domainHandler.router())));
+                sortedVhosts.forEach(virtualHost -> {
+                    VHostGroupRouter group = groupFor(sanitizePath(virtualHost.getPath()));
+                    Object member = group.addMember(vertx, domain, virtualHost, domainHandler.router());
+                    unmountActions.add(() -> group.removeMember(member));
+                });
             } else {
-                this.router.route(sanitizePath(domain.getPath())).subRouter(VHostRouter.router(vertx, domain, domainHandler.router()));
+                VHostGroupRouter group = groupFor(sanitizePath(domain.getPath()));
+                Object member = group.addMember(vertx, domain, domainHandler.router());
+                unmountActions.add(() -> group.removeMember(member));
             }
+
+            domainUnmountActions.put(domain.getId(), unmountActions);
         } finally {
             routerLock.unlock();
         }
+    }
+
+    /**
+     * Returns the {@link VHostGroupRouter} handling the given (already sanitized) mount path,
+     * creating and mounting it on the root router the first time it is requested. Every
+     * domain/vhost sharing this path is later registered on the very same group, instead of
+     * each getting its own entry on the root router.
+     */
+    private VHostGroupRouter groupFor(String path) {
+        return pathGroups.computeIfAbsent(path, p -> {
+            VHostGroupRouter group = VHostGroupRouter.create(vertx);
+            this.router.route(p).subRouter(group.asRxRouter());
+            return group;
+        });
     }
 
     private String sanitizePath(String path) {
@@ -153,6 +188,13 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
     public void unMountDomain(VertxSecurityDomainHandler domainHandler) {
         routerLock.lock();
         try {
+            Domain domain = domainHandler.getDomain();
+
+            List<Runnable> unmountActions = domainUnmountActions.remove(domain.getId());
+            if (unmountActions != null) {
+                unmountActions.forEach(Runnable::run);
+            }
+
             domainHandler.router().clear();
         } finally {
             routerLock.unlock();

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/DefaultReactor.java
@@ -20,6 +20,7 @@ import io.gravitee.am.gateway.handler.vertx.VertxSecurityDomainHandler;
 import io.gravitee.am.gateway.reactor.Reactor;
 import io.gravitee.am.gateway.reactor.SecurityDomainHandlerRegistry;
 import io.gravitee.am.gateway.reactor.impl.router.VHostGroupRouter;
+import io.gravitee.am.gateway.reactor.impl.router.VHostRouter;
 import io.gravitee.am.gateway.reactor.impl.transaction.TransactionHandlerFactory;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.VirtualHost;
@@ -31,10 +32,11 @@ import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.service.AbstractService;
-import io.vertx.rxjava3.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
 import io.vertx.rxjava3.ext.web.Router;
+import lombok.CustomLog;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -51,6 +53,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class DefaultReactor extends AbstractService implements Reactor, EventListener<DomainEvent, Domain>, InitializingBean {
 
     @Autowired
@@ -146,16 +149,20 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
 
                 sortedVhosts.forEach(virtualHost -> {
                     VHostGroupRouter group = groupFor(sanitizePath(virtualHost.getPath()));
-                    Object member = group.addMember(vertx, domain, virtualHost, domainHandler.router());
+                    VHostRouter member = group.addMember(vertx, domain, virtualHost, domainHandler.router());
                     unmountActions.add(() -> group.removeMember(member));
                 });
             } else {
                 VHostGroupRouter group = groupFor(sanitizePath(domain.getPath()));
-                Object member = group.addMember(vertx, domain, domainHandler.router());
+                VHostRouter member = group.addMember(vertx, domain, domainHandler.router());
                 unmountActions.add(() -> group.removeMember(member));
             }
 
-            domainUnmountActions.put(domain.getId(), unmountActions);
+            List<Runnable> previous = domainUnmountActions.put(domain.getId(), unmountActions);
+            if (previous != null) {
+                log.warn("Domain {} was already mounted on a different path. Previous unmount actions will be discarded.", domain.getId());
+                previous.forEach(Runnable::run);
+            }
         } finally {
             routerLock.unlock();
         }
@@ -193,6 +200,8 @@ public class DefaultReactor extends AbstractService implements Reactor, EventLis
             List<Runnable> unmountActions = domainUnmountActions.remove(domain.getId());
             if (unmountActions != null) {
                 unmountActions.forEach(Runnable::run);
+            } else {
+                log.warn("No unmount actions found for domain {}", domain.getId());
             }
 
             domainHandler.router().clear();

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouter.java
@@ -18,11 +18,15 @@ package io.gravitee.am.gateway.reactor.impl.router;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.VirtualHost;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.RouterImpl;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -36,15 +40,18 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Java stack frame per candidate, which can blow the stack once a few thousand domains share a
  * path.
  *
- * <p>This router instead holds all the candidates for a given path in a flat list and resolves
- * the matching one with a simple iteration, so the request-handling stack depth no longer grows
- * with the number of domains/vhosts sharing that path.
+ * <p>This router instead resolves the matching candidate for a given path in O(1): host-bound
+ * members (regular vhosts) are indexed in a {@link Map} keyed by their literal, lower-cased host
+ * (host matching is an exact comparison, see {@link VHostRouter#hostKey()}), so a request is
+ * resolved with a single lookup instead of a scan. Host-agnostic members (non-vhost-mode
+ * domains) are kept in a small fallback list, checked only when no host-bound member matches.
  *
  * @author GraviteeSource Team
  */
 public class VHostGroupRouter extends RouterImpl {
 
-    private final List<VHostRouter> members = new CopyOnWriteArrayList<>();
+    private final Map<String, VHostRouter> byHost = new ConcurrentHashMap<>();
+    private final List<VHostRouter> hostAgnostic = new CopyOnWriteArrayList<>();
 
     private VHostGroupRouter(Vertx vertx) {
         super(vertx);
@@ -60,49 +67,79 @@ public class VHostGroupRouter extends RouterImpl {
 
     /**
      * Registers a new domain/vhost candidate on this group and returns an opaque handle that
-     * must be kept to later {@link #removeMember(Object)} it (e.g. on domain undeploy).
+     * must be kept to later {@link #removeMember(VHostRouter)} it (e.g. on domain undeploy).
      */
-    public Object addMember(io.vertx.rxjava3.core.Vertx vertx, Domain domain, VirtualHost vhost, io.vertx.rxjava3.ext.web.Router delegate) {
-        VHostRouter member = VHostRouter.member(vertx.getDelegate(), domain, vhost, delegate.getDelegate());
-        members.add(member);
+    public VHostRouter addMember(io.vertx.rxjava3.core.Vertx vertx, Domain domain, VirtualHost vhost, io.vertx.rxjava3.ext.web.Router delegate) {
+        return register(VHostRouter.member(vertx.getDelegate(), domain, vhost, delegate.getDelegate()));
+    }
+
+    public VHostRouter addMember(io.vertx.rxjava3.core.Vertx vertx, Domain domain, io.vertx.rxjava3.ext.web.Router delegate) {
+        return register(VHostRouter.member(vertx.getDelegate(), domain, delegate.getDelegate()));
+    }
+
+    private VHostRouter register(VHostRouter member) {
+        String hostKey = member.hostKey();
+        if (hostKey != null) {
+            // First registration for a given host wins, matching the previous first-match
+            // semantics of the sequential scan this class replaces.
+            byHost.putIfAbsent(hostKey, member);
+        } else {
+            hostAgnostic.add(member);
+        }
         return member;
     }
 
-    public Object addMember(io.vertx.rxjava3.core.Vertx vertx, Domain domain, io.vertx.rxjava3.ext.web.Router delegate) {
-        VHostRouter member = VHostRouter.member(vertx.getDelegate(), domain, delegate.getDelegate());
-        members.add(member);
-        return member;
-    }
-
-    public void removeMember(Object member) {
-        if (member instanceof VHostRouter vHostRouter) {
-            members.remove(vHostRouter);
+    public void removeMember(VHostRouter member) {
+        String hostKey = member.hostKey();
+        if (hostKey != null) {
+            byHost.computeIfPresent(hostKey, (key, current) -> current == member ? null : current);
+        } else {
+            hostAgnostic.remove(member);
         }
     }
 
     public boolean isEmpty() {
-        return members.isEmpty();
+        return byHost.isEmpty() && hostAgnostic.isEmpty();
     }
 
     @Override
     public void handleContext(RoutingContext context) {
-        for (VHostRouter member : members) {
-            if (member.matches(context)) {
-                member.dispatch(context);
-                return;
-            }
-        }
-        context.next();
+        dispatchTo(resolve(context), context, false);
     }
 
     @Override
     public void handleFailure(RoutingContext context) {
-        for (VHostRouter member : members) {
+        dispatchTo(resolve(context), context, true);
+    }
+
+    private void dispatchTo(VHostRouter member, RoutingContext context, boolean failure) {
+        if (member == null) {
+            context.next();
+        } else if (failure) {
+            member.dispatchFailure(context);
+        } else {
+            member.dispatch(context);
+        }
+    }
+
+    private VHostRouter resolve(RoutingContext context) {
+        String host = requestHost(context);
+        VHostRouter candidate = host == null ? null : byHost.get(host);
+        if (candidate != null && candidate.matches(context)) {
+            return candidate;
+        }
+
+        for (VHostRouter member : hostAgnostic) {
             if (member.matches(context)) {
-                member.dispatchFailure(context);
-                return;
+                return member;
             }
         }
-        context.next();
+
+        return null;
+    }
+
+    private String requestHost(RoutingContext context) {
+        HostAndPort authority = context.request().authority();
+        return authority == null ? null : authority.toString().toLowerCase(Locale.ROOT);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouter.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.reactor.impl.router;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.VirtualHost;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.impl.RouterImpl;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Aggregates every {@link VHostRouter} that shares the same mount path onto a single
+ * {@link Router} entry.
+ *
+ * <p>Vert.x's {@code RoutingContext.next()} walks the parent router's route list recursively:
+ * each non-matching sub-router calls {@code context.next()}, which recurses into the following
+ * one. When many domains/vhosts are deployed on the same path (differentiated only by the Host
+ * header), mounting one {@link VHostRouter} per domain/vhost therefore produces one recursive
+ * Java stack frame per candidate, which can blow the stack once a few thousand domains share a
+ * path.
+ *
+ * <p>This router instead holds all the candidates for a given path in a flat list and resolves
+ * the matching one with a simple iteration, so the request-handling stack depth no longer grows
+ * with the number of domains/vhosts sharing that path.
+ *
+ * @author GraviteeSource Team
+ */
+public class VHostGroupRouter extends RouterImpl {
+
+    private final List<VHostRouter> members = new CopyOnWriteArrayList<>();
+
+    private VHostGroupRouter(Vertx vertx) {
+        super(vertx);
+    }
+
+    public static VHostGroupRouter create(io.vertx.rxjava3.core.Vertx vertx) {
+        return new VHostGroupRouter(vertx.getDelegate());
+    }
+
+    public io.vertx.rxjava3.ext.web.Router asRxRouter() {
+        return io.vertx.rxjava3.ext.web.Router.newInstance(this);
+    }
+
+    /**
+     * Registers a new domain/vhost candidate on this group and returns an opaque handle that
+     * must be kept to later {@link #removeMember(Object)} it (e.g. on domain undeploy).
+     */
+    public Object addMember(io.vertx.rxjava3.core.Vertx vertx, Domain domain, VirtualHost vhost, io.vertx.rxjava3.ext.web.Router delegate) {
+        VHostRouter member = VHostRouter.member(vertx.getDelegate(), domain, vhost, delegate.getDelegate());
+        members.add(member);
+        return member;
+    }
+
+    public Object addMember(io.vertx.rxjava3.core.Vertx vertx, Domain domain, io.vertx.rxjava3.ext.web.Router delegate) {
+        VHostRouter member = VHostRouter.member(vertx.getDelegate(), domain, delegate.getDelegate());
+        members.add(member);
+        return member;
+    }
+
+    public void removeMember(Object member) {
+        if (member instanceof VHostRouter vHostRouter) {
+            members.remove(vHostRouter);
+        }
+    }
+
+    public boolean isEmpty() {
+        return members.isEmpty();
+    }
+
+    @Override
+    public void handleContext(RoutingContext context) {
+        for (VHostRouter member : members) {
+            if (member.matches(context)) {
+                member.dispatch(context);
+                return;
+            }
+        }
+        context.next();
+    }
+
+    @Override
+    public void handleFailure(RoutingContext context) {
+        for (VHostRouter member : members) {
+            if (member.matches(context)) {
+                member.dispatchFailure(context);
+                return;
+            }
+        }
+        context.next();
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouter.java
@@ -23,9 +23,12 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.RouterImpl;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -50,7 +53,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class VHostGroupRouter extends RouterImpl {
 
-    private final Map<String, VHostRouter> byHost = new ConcurrentHashMap<>();
+    private final Map<String, List<VHostRouter>> byHost = new ConcurrentHashMap<>();
     private final List<VHostRouter> hostAgnostic = new CopyOnWriteArrayList<>();
 
     private VHostGroupRouter(Vertx vertx) {
@@ -82,7 +85,8 @@ public class VHostGroupRouter extends RouterImpl {
         if (hostKey != null) {
             // First registration for a given host wins, matching the previous first-match
             // semantics of the sequential scan this class replaces.
-            byHost.putIfAbsent(hostKey, member);
+            byHost.putIfAbsent(hostKey, Collections.synchronizedList(new ArrayList<>()));
+            byHost.get(hostKey).add(member);
         } else {
             hostAgnostic.add(member);
         }
@@ -92,14 +96,14 @@ public class VHostGroupRouter extends RouterImpl {
     public void removeMember(VHostRouter member) {
         String hostKey = member.hostKey();
         if (hostKey != null) {
-            byHost.computeIfPresent(hostKey, (key, current) -> current == member ? null : current);
+            Optional.ofNullable(byHost.get(hostKey)).ifPresent(list -> list.remove(member));
         } else {
             hostAgnostic.remove(member);
         }
     }
 
     public boolean isEmpty() {
-        return byHost.isEmpty() && hostAgnostic.isEmpty();
+        return byHost.isEmpty()  && hostAgnostic.isEmpty();
     }
 
     @Override
@@ -124,9 +128,13 @@ public class VHostGroupRouter extends RouterImpl {
 
     private VHostRouter resolve(RoutingContext context) {
         String host = requestHost(context);
-        VHostRouter candidate = host == null ? null : byHost.get(host);
-        if (candidate != null && candidate.matches(context)) {
-            return candidate;
+        List<VHostRouter> candidates = host == null ? null : byHost.get(host);
+        if (candidates != null) {
+            for (VHostRouter member : candidates) {
+                if (member.matches(context)) {
+                    return member;
+                }
+            }
         }
 
         for (VHostRouter member : hostAgnostic) {

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostRouter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostRouter.java
@@ -28,6 +28,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.RouterImpl;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import static io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest.CONTEXT_PATH;
@@ -119,6 +120,16 @@ public class VHostRouter extends RouterImpl {
 
     boolean matches(RoutingContext context) {
         return routerMatches(context);
+    }
+
+    /**
+     * The literal (case-insensitive) host this member is bound to, or {@code null} when this
+     * member has no vhost restriction. {@link VHostGroupRouter} uses this as a map key to
+     * resolve the matching member in O(1) instead of scanning every candidate, since host
+     * matching is an exact comparison (see {@link #vhostPattern}, built with {@link Pattern#quote}).
+     */
+    String hostKey() {
+        return vhost != null ? vhost.getHost().toLowerCase(Locale.ROOT) : null;
     }
 
     void dispatch(RoutingContext context) {

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostRouter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/main/java/io/gravitee/am/gateway/reactor/impl/router/VHostRouter.java
@@ -82,16 +82,26 @@ public class VHostRouter extends RouterImpl {
         this.delegate = delegate;
     }
 
+    /**
+     * Creates a standalone {@link VHostRouter} member, meant to be aggregated inside a
+     * {@link VHostGroupRouter} instead of being mounted directly on a parent {@link Router}.
+     * This avoids one {@link io.vertx.core.Handler}/{@link Route} entry per domain/vhost on the
+     * parent router, which would otherwise force Vert.x to walk (and recurse into) every entry
+     * sharing the same path when a large number of domains/vhosts are deployed.
+     */
+    static VHostRouter member(Vertx vertx, Domain domain, VirtualHost vhost, Router delegate) {
+        return new VHostRouter(vertx, domain, vhost, delegate);
+    }
+
+    static VHostRouter member(Vertx vertx, Domain domain, Router delegate) {
+        return new VHostRouter(vertx, domain, delegate);
+    }
+
     @Override
     public void handleContext(RoutingContext context) {
 
-        if (routerMatches(context)) {
-            if (vhost != null) {
-                setContextPath(context, vhost.getPath());
-            } else {
-                setContextPath(context, domain.getPath());
-            }
-            delegate.handleContext(context);
+        if (matches(context)) {
+            dispatch(context);
         } else {
             context.next();
         }
@@ -100,11 +110,28 @@ public class VHostRouter extends RouterImpl {
     @Override
     public void handleFailure(RoutingContext context) {
 
-        if (routerMatches(context)) {
-            delegate.handleFailure(context);
+        if (matches(context)) {
+            dispatchFailure(context);
         } else {
             context.next();
         }
+    }
+
+    boolean matches(RoutingContext context) {
+        return routerMatches(context);
+    }
+
+    void dispatch(RoutingContext context) {
+        if (vhost != null) {
+            setContextPath(context, vhost.getPath());
+        } else {
+            setContextPath(context, domain.getPath());
+        }
+        delegate.handleContext(context);
+    }
+
+    void dispatchFailure(RoutingContext context) {
+        delegate.handleFailure(context);
     }
 
     private boolean routerMatches(RoutingContext context) {

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouterTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouterTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.reactor.impl.router;
+
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.VirtualHost;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.rxjava3.core.Vertx;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class VHostGroupRouterTest {
+
+    private Vertx vertx;
+
+    @Before
+    public void setUp() {
+        vertx = Vertx.vertx();
+    }
+
+    @After
+    public void tearDown() {
+        vertx.close();
+    }
+
+    @Test
+    public void shouldDispatchToMatchingMemberAmongManySharingTheSamePath() {
+        VHostGroupRouter group = VHostGroupRouter.create(vertx);
+
+        // Simulate several thousand domains/vhosts sharing the exact same mount path,
+        // differentiated only by their Host header (the scenario that used to blow the stack).
+        int memberCount = 5000;
+        Router targetDelegate = mock(Router.class);
+        for (int i = 0; i < memberCount; i++) {
+            io.vertx.rxjava3.ext.web.Router delegate = i == memberCount - 1
+                    ? io.vertx.rxjava3.ext.web.Router.newInstance(targetDelegate)
+                    : io.vertx.rxjava3.ext.web.Router.newInstance(mock(Router.class));
+            group.addMember(vertx, new Domain(), virtualHost("host-" + i + ".gravitee.io", "/"), delegate);
+        }
+
+        RoutingContext routingContext = routingContext("host-" + (memberCount - 1) + ".gravitee.io", "/login");
+
+        // Dispatching must not recurse through every non-matching member's context.next():
+        // a StackOverflowError here indicates the fix regressed to O(n) stack depth.
+        group.handleContext(routingContext);
+
+        verify(targetDelegate).handleContext(routingContext);
+        verify(routingContext, never()).next();
+    }
+
+    @Test
+    public void shouldFallThroughToNextWhenNoMemberMatches() {
+        VHostGroupRouter group = VHostGroupRouter.create(vertx);
+        io.vertx.rxjava3.ext.web.Router delegate = io.vertx.rxjava3.ext.web.Router.newInstance(mock(Router.class));
+        group.addMember(vertx, new Domain(), virtualHost("known.gravitee.io", "/"), delegate);
+
+        RoutingContext routingContext = routingContext("unknown.gravitee.io", "/login");
+
+        group.handleContext(routingContext);
+
+        verify(routingContext).next();
+    }
+
+    @Test
+    public void shouldStopMatchingRemovedMember() {
+        VHostGroupRouter group = VHostGroupRouter.create(vertx);
+        io.vertx.rxjava3.ext.web.Router delegate = io.vertx.rxjava3.ext.web.Router.newInstance(mock(Router.class));
+        Object member = group.addMember(vertx, new Domain(), virtualHost("known.gravitee.io", "/"), delegate);
+
+        assertFalse(group.isEmpty());
+        group.removeMember(member);
+        assertTrue(group.isEmpty());
+
+        RoutingContext routingContext = routingContext("known.gravitee.io", "/login");
+        group.handleContext(routingContext);
+
+        verify(routingContext).next();
+    }
+
+    private VirtualHost virtualHost(String host, String path) {
+        VirtualHost virtualHost = new VirtualHost();
+        virtualHost.setHost(host);
+        virtualHost.setPath(path);
+        return virtualHost;
+    }
+
+    private RoutingContext routingContext(String host, String path) {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.authority()).thenReturn(HostAndPort.authority(host));
+        when(request.path()).thenReturn(path);
+
+        RoutingContext routingContext = mock(RoutingContext.class);
+        when(routingContext.request()).thenReturn(request);
+
+        return routingContext;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouterTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouterTest.java
@@ -101,11 +101,14 @@ public class VHostGroupRouterTest {
         io.vertx.rxjava3.ext.web.Router delegate = io.vertx.rxjava3.ext.web.Router.newInstance(mock(Router.class));
         var member = group.addMember(vertx, new Domain(), virtualHost("known.gravitee.io", "/"), delegate);
 
-        assertFalse(group.isEmpty());
-        group.removeMember(member);
-        assertTrue(group.isEmpty());
-
         RoutingContext routingContext = routingContext("known.gravitee.io", "/login");
+        group.handleContext(routingContext);
+
+        verify(routingContext, never()).next();
+
+        group.removeMember(member);
+
+        routingContext = routingContext("known.gravitee.io", "/login");
         group.handleContext(routingContext);
 
         verify(routingContext).next();

--- a/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouterTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-reactor/src/test/java/io/gravitee/am/gateway/reactor/impl/router/VHostGroupRouterTest.java
@@ -26,10 +26,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Random;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -54,22 +57,29 @@ public class VHostGroupRouterTest {
         // Simulate several thousand domains/vhosts sharing the exact same mount path,
         // differentiated only by their Host header (the scenario that used to blow the stack).
         int memberCount = 5000;
+        int targetIndex = new Random().nextInt((memberCount / 2), memberCount);
         Router targetDelegate = mock(Router.class);
         for (int i = 0; i < memberCount; i++) {
-            io.vertx.rxjava3.ext.web.Router delegate = i == memberCount - 1
+            io.vertx.rxjava3.ext.web.Router delegate = i == targetIndex
                     ? io.vertx.rxjava3.ext.web.Router.newInstance(targetDelegate)
                     : io.vertx.rxjava3.ext.web.Router.newInstance(mock(Router.class));
             group.addMember(vertx, new Domain(), virtualHost("host-" + i + ".gravitee.io", "/"), delegate);
         }
 
-        RoutingContext routingContext = routingContext("host-" + (memberCount - 1) + ".gravitee.io", "/login");
+        RoutingContext routingContext = routingContext("host-" + targetIndex + ".gravitee.io", "/login");
 
-        // Dispatching must not recurse through every non-matching member's context.next():
-        // a StackOverflowError here indicates the fix regressed to O(n) stack depth.
+        // Dispatching is a direct map lookup on the Host header, not a scan through every
+        // registered member
         group.handleContext(routingContext);
 
         verify(targetDelegate).handleContext(routingContext);
         verify(routingContext, never()).next();
+        // request object access 3 times
+        // - get the host name and retrieve the member in the map
+        // - get the host name to test the matching rule
+        // - get the path to test the matching rule
+        // If we have more than 3 attempts, that mean the O(1) lookup is not in place
+        verify(routingContext, times(3)).request();
     }
 
     @Test
@@ -89,7 +99,7 @@ public class VHostGroupRouterTest {
     public void shouldStopMatchingRemovedMember() {
         VHostGroupRouter group = VHostGroupRouter.create(vertx);
         io.vertx.rxjava3.ext.web.Router delegate = io.vertx.rxjava3.ext.web.Router.newInstance(mock(Router.class));
-        Object member = group.addMember(vertx, new Domain(), virtualHost("known.gravitee.io", "/"), delegate);
+        var member = group.addMember(vertx, new Domain(), virtualHost("known.gravitee.io", "/"), delegate);
 
         assertFalse(group.isEmpty());
         group.removeMember(member);
@@ -98,6 +108,36 @@ public class VHostGroupRouterTest {
         RoutingContext routingContext = routingContext("known.gravitee.io", "/login");
         group.handleContext(routingContext);
 
+        verify(routingContext).next();
+    }
+
+    @Test
+    public void shouldDispatchFailureToMatchingMember() {
+        VHostGroupRouter group = VHostGroupRouter.create(vertx);
+        Router targetDelegate = mock(Router.class);
+        group.addMember(vertx, new Domain(), virtualHost("known.gravitee.io", "/"),
+                io.vertx.rxjava3.ext.web.Router.newInstance(targetDelegate));
+
+        RoutingContext routingContext = routingContext("known.gravitee.io", "/login");
+
+        group.handleFailure(routingContext);
+
+        verify(targetDelegate).handleFailure(routingContext);
+        verify(routingContext, never()).next();
+    }
+
+    @Test
+    public void shouldFallThroughFailureToNextWhenNoMemberMatches() {
+        VHostGroupRouter group = VHostGroupRouter.create(vertx);
+        Router targetDelegate = mock(Router.class);
+        group.addMember(vertx, new Domain(), virtualHost("known.gravitee.io", "/"),
+                io.vertx.rxjava3.ext.web.Router.newInstance(targetDelegate));
+
+        RoutingContext routingContext = routingContext("unknown.gravitee.io", "/login");
+
+        group.handleFailure(routingContext);
+
+        verify(targetDelegate, never()).handleFailure(routingContext);
         verify(routingContext).next();
     }
 


### PR DESCRIPTION
avoid StackOverflowError when many vhosts share the same path

Mounting one Route+subRouter per domain/vhost forced Vert.x to walk
and recursively call context.next() across every entry sharing a
mount path. With thousands of domains on the same vhost path
(differentiated only by Host header), this blew the stack.

Group domains/vhosts sharing the same path behind a single
VHostGroupRouter that resolves the match with a map instead of recursive routing, 
keeping stack depth constant regardless of domain count. Also makes domain undeploy actually
remove its routing entries instead of only clearing the inner
    router.

fix AM-7433