### PR TITLE
fix: stop a host-less access point breaking the entrypoint listing

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/entrypoints/EntrypointsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/entrypoints/EntrypointsResource.java
@@ -49,6 +49,7 @@ import jakarta.ws.rs.core.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.net.URI;
+import java.util.Comparator;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -82,7 +83,7 @@ public class EntrypointsResource extends AbstractResource {
         checkPermission(ReferenceType.ORGANIZATION, organizationId, Permission.ORGANIZATION_ENTRYPOINT, Acl.LIST)
                 .andThen(entrypointService.findAll(organizationId))
                 .map(this::filterEntrypointInfos)
-                .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()))
+                .sorted(Comparator.comparing(Entrypoint::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
                 .toList()
                 .subscribe(response::resume, response::resume);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointsResourceTest.java
@@ -83,6 +83,30 @@ public class EntrypointsResourceTest extends JerseySpringTest {
     }
 
     @Test
+    public void shouldGetEntrypoints_oneEntrypointWithoutName() {
+        final Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setId(ENTRYPOINT_ID);
+        entrypoint.setName("entrypoint-1-name");
+        entrypoint.setOrganizationId(ORGANIZATION_ID);
+
+        // A GATEWAY access point pushed by Cockpit with a null host persists an entrypoint with no name.
+        final Entrypoint namelessEntrypoint = new Entrypoint();
+        namelessEntrypoint.setId("entrypoint#2");
+        namelessEntrypoint.setUrl("https://null");
+        namelessEntrypoint.setOrganizationId(ORGANIZATION_ID);
+
+        doReturn(Flowable.just(entrypoint, namelessEntrypoint)).when(entrypointService).findAll(ORGANIZATION_ID);
+
+        final Response response = target("organizations")
+                .path(ORGANIZATION_ID)
+                .path("entrypoints").request().get();
+
+        // One malformed record must not take down the listing for the whole organization.
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        assertEquals(2, readEntity(response, List.class).size());
+    }
+
+    @Test
     public void shouldGetEntrypoints_technicalManagementException() {
         doReturn(Flowable.error(new TechnicalManagementException("error occurs"))).when(entrypointService).findAll(anyString());
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/EntrypointsResourceTest.java
@@ -32,8 +32,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
@@ -89,13 +91,14 @@ public class EntrypointsResourceTest extends JerseySpringTest {
         entrypoint.setName("entrypoint-1-name");
         entrypoint.setOrganizationId(ORGANIZATION_ID);
 
-        // A GATEWAY access point pushed by Cockpit with a null host persists an entrypoint with no name.
+        // Stands in for a record persisted before the handler started rejecting host-less access points.
         final Entrypoint namelessEntrypoint = new Entrypoint();
         namelessEntrypoint.setId("entrypoint#2");
         namelessEntrypoint.setUrl("https://null");
         namelessEntrypoint.setOrganizationId(ORGANIZATION_ID);
 
-        doReturn(Flowable.just(entrypoint, namelessEntrypoint)).when(entrypointService).findAll(ORGANIZATION_ID);
+        // Nameless first, so the assertion below fails if the comparator stops reordering.
+        doReturn(Flowable.just(namelessEntrypoint, entrypoint)).when(entrypointService).findAll(ORGANIZATION_ID);
 
         final Response response = target("organizations")
                 .path(ORGANIZATION_ID)
@@ -103,7 +106,11 @@ public class EntrypointsResourceTest extends JerseySpringTest {
 
         // One malformed record must not take down the listing for the whole organization.
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
-        assertEquals(2, readEntity(response, List.class).size());
+
+        final List<Map<String, Object>> entrypoints = readEntity(response, List.class);
+        assertEquals(2, entrypoints.size());
+        assertEquals("entrypoint-1-name", entrypoints.get(0).get("name"));
+        assertNull(entrypoints.get(1).get("name"));
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 @CustomLog
 public class EnvironmentCommandHandler implements CommandHandler<EnvironmentCommand, EnvironmentReply> {
 
+    private static final String MISSING_HOST_ERROR = "Environment command rejected due to a GATEWAY access point with a missing or blank host.";
 
     private final EnvironmentService environmentService;
     private final EntrypointService entrypointService;
@@ -75,9 +76,8 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         // Cockpit is told the command failed rather than left believing it provisioned a gateway URL
         // that AM silently dropped.
         if (hasGatewayAccessPointWithoutHost(environmentPayload)) {
-            String accessPointError = "Environment command rejected due to a GATEWAY access point with a missing or blank host.";
-            log.warn("{} Environment id [{}].", accessPointError, environmentPayload.id());
-            return Single.just(new EnvironmentReply(command.getId(), accessPointError));
+            log.warn(MISSING_HOST_ERROR + " Environment id [{}].", environmentPayload.id());
+            return Single.just(new EnvironmentReply(command.getId(), MISSING_HOST_ERROR));
         }
 
         NewEnvironment newEnvironment = new NewEnvironment();
@@ -87,7 +87,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         if (environmentPayload.accessPoints() != null && !CloudProperties.isManagedCloudEnabled(environment)) {
             newEnvironment.setDomainRestrictions(environmentPayload.accessPoints()
                     .stream()
-                    .filter(this::isUsableGatewayAccessPoint)
+                    .filter(this::isGatewayAccessPoint)
                     .map(AccessPoint::getHost)
                     .collect(Collectors.toList()));
         }
@@ -111,7 +111,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         List<AccessPoint> gatewayAccessPoints = environmentPayload.accessPoints() == null
                 ? List.of()
                 : environmentPayload.accessPoints().stream()
-                        .filter(this::isUsableGatewayAccessPoint)
+                        .filter(this::isGatewayAccessPoint)
                         .collect(Collectors.toList());
 
         return entrypointService.findByEnvironment(organizationId, environmentId)
@@ -124,15 +124,11 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
     private boolean hasGatewayAccessPointWithoutHost(EnvironmentCommandPayload environmentPayload) {
         return environmentPayload.accessPoints() != null
                 && environmentPayload.accessPoints().stream()
-                        .anyMatch(accessPoint -> accessPoint.getTarget() == AccessPoint.Target.GATEWAY && !hasHost(accessPoint));
+                        .anyMatch(accessPoint -> isGatewayAccessPoint(accessPoint) && !hasHost(accessPoint));
     }
 
-    private boolean isUsableGatewayAccessPoint(AccessPoint accessPoint) {
-        if (accessPoint.getTarget() != AccessPoint.Target.GATEWAY) {
-            return false;
-        }
-
-        return hasHost(accessPoint);
+    private boolean isGatewayAccessPoint(AccessPoint accessPoint) {
+        return accessPoint != null && accessPoint.getTarget() == AccessPoint.Target.GATEWAY;
     }
 
     private boolean hasHost(AccessPoint accessPoint) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
@@ -72,6 +72,14 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
             return Single.just(new EnvironmentReply(command.getId(), validationError.get()));
         }
 
+        // Cockpit is told the command failed rather than left believing it provisioned a gateway URL
+        // that AM silently dropped.
+        if (hasGatewayAccessPointWithoutHost(environmentPayload)) {
+            String accessPointError = "Environment command rejected due to a GATEWAY access point with a missing or blank host.";
+            log.warn("{} Environment id [{}].", accessPointError, environmentPayload.id());
+            return Single.just(new EnvironmentReply(command.getId(), accessPointError));
+        }
+
         NewEnvironment newEnvironment = new NewEnvironment();
         newEnvironment.setHrids(environmentPayload.hrids());
         newEnvironment.setName(environmentPayload.name());
@@ -79,7 +87,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         if (environmentPayload.accessPoints() != null && !CloudProperties.isManagedCloudEnabled(environment)) {
             newEnvironment.setDomainRestrictions(environmentPayload.accessPoints()
                     .stream()
-                    .filter(accessPoint -> accessPoint.getTarget() == AccessPoint.Target.GATEWAY)
+                    .filter(this::isUsableGatewayAccessPoint)
                     .map(AccessPoint::getHost)
                     .collect(Collectors.toList()));
         }
@@ -103,7 +111,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         List<AccessPoint> gatewayAccessPoints = environmentPayload.accessPoints() == null
                 ? List.of()
                 : environmentPayload.accessPoints().stream()
-                        .filter(accessPoint -> accessPoint.getTarget() == AccessPoint.Target.GATEWAY)
+                        .filter(this::isUsableGatewayAccessPoint)
                         .collect(Collectors.toList());
 
         return entrypointService.findByEnvironment(organizationId, environmentId)
@@ -111,6 +119,24 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
                 .andThen(Completable.defer(() -> Completable.merge(gatewayAccessPoints.stream()
                         .map(accessPoint -> createEntrypoint(organizationId, environmentId, accessPoint))
                         .collect(Collectors.toList()))));
+    }
+
+    private boolean hasGatewayAccessPointWithoutHost(EnvironmentCommandPayload environmentPayload) {
+        return environmentPayload.accessPoints() != null
+                && environmentPayload.accessPoints().stream()
+                        .anyMatch(accessPoint -> accessPoint.getTarget() == AccessPoint.Target.GATEWAY && !hasHost(accessPoint));
+    }
+
+    private boolean isUsableGatewayAccessPoint(AccessPoint accessPoint) {
+        if (accessPoint.getTarget() != AccessPoint.Target.GATEWAY) {
+            return false;
+        }
+
+        return hasHost(accessPoint);
+    }
+
+    private boolean hasHost(AccessPoint accessPoint) {
+        return accessPoint.getHost() != null && !accessPoint.getHost().isBlank();
     }
 
     private Completable createEntrypoint(String organizationId, String environmentId, AccessPoint accessPoint) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -346,7 +347,8 @@ class EnvironmentCommandHandlerTest {
                 .organizationId("orga#1")
                 .description("Environment description")
                 .name("Environment name")
-                .accessPoints(List.of(accessPoints))
+                // Arrays.asList, not List.of: one case deliberately passes a null entry.
+                .accessPoints(Arrays.asList(accessPoints))
                 .build());
     }
 
@@ -360,9 +362,9 @@ class EnvironmentCommandHandlerTest {
     }
 
     /**
-     * A host-less GATEWAY access point yields url "https://null" and a null name, and that nameless
-     * entrypoint then breaks the organization-wide entrypoint listing. Cockpit is told the command
-     * failed rather than left believing the gateway URL was provisioned.
+     * Rejecting here is what stops a host-less access point becoming an entrypoint with url
+     * "https://null" and no name, which used to break the organization-wide entrypoint listing.
+     * Cockpit is told the command failed rather than left believing the gateway URL was provisioned.
      */
     @Test
     void handleCloudMode_nullHostAccessPoint_isRejected() {
@@ -394,6 +396,25 @@ class EnvironmentCommandHandlerTest {
         assertRejectedForMissingHost(commandWithAccessPoints(
                 AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build(),
                 AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host(null).build()));
+    }
+
+    @Test
+    void handleCloudMode_nullAccessPointEntry_repliesWithoutThrowing() {
+        enableCloudMode();
+
+        // The guard runs before the reactive chain is built, so a null entry would escape handle() as a
+        // synchronous throw rather than reaching onErrorReturn.
+        EnvironmentCommand command = commandWithAccessPoints(new AccessPoint[]{null});
+
+        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
+        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.empty());
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()));
+        verify(entrypointService, never()).create(any(), any(NewEntrypoint.class), anyBoolean(), any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
@@ -339,6 +339,79 @@ class EnvironmentCommandHandlerTest {
                 .build(), true);
     }
 
+    private EnvironmentCommand commandWithAccessPoints(AccessPoint... accessPoints) {
+        return new EnvironmentCommand(EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
+                .organizationId("orga#1")
+                .description("Environment description")
+                .name("Environment name")
+                .accessPoints(List.of(accessPoints))
+                .build());
+    }
+
+    private void assertRejectedForMissingHost(EnvironmentCommand command) {
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(environmentService, entrypointService);
+    }
+
+    /**
+     * A host-less GATEWAY access point yields url "https://null" and a null name, and that nameless
+     * entrypoint then breaks the organization-wide entrypoint listing. Cockpit is told the command
+     * failed rather than left believing the gateway URL was provisioned.
+     */
+    @Test
+    void handleCloudMode_nullHostAccessPoint_isRejected() {
+        enableCloudMode();
+
+        assertRejectedForMissingHost(commandWithAccessPoints(
+                AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host(null).secured(true).build()));
+    }
+
+    @Test
+    void handleNonCloudMode_nullHostAccessPoint_isRejected() {
+        // A null reaching domainRestrictions blows up InternetDomainName.from during host validation.
+        assertRejectedForMissingHost(commandWithAccessPoints(
+                AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host(null).build()));
+    }
+
+    @Test
+    void handleCloudMode_blankHostAccessPoint_isRejected() {
+        enableCloudMode();
+
+        assertRejectedForMissingHost(commandWithAccessPoints(
+                AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("  ").build()));
+    }
+
+    @Test
+    void handleCloudMode_oneValidAndOneHostlessAccessPoint_rejectsTheWholeCommand() {
+        enableCloudMode();
+
+        assertRejectedForMissingHost(commandWithAccessPoints(
+                AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build(),
+                AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host(null).build()));
+    }
+
+    @Test
+    void handleNullHostConsoleAccessPoint_isAccepted() {
+        // Only GATEWAY access points become entrypoints, so a host-less CONSOLE one must not block the command.
+        EnvironmentCommand command = commandWithAccessPoints(
+                AccessPoint.builder().target(AccessPoint.Target.CONSOLE).host(null).build());
+
+        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(10, TimeUnit.SECONDS);
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+        verify(environmentService).createOrUpdate(eq("orga#1"), eq("env#1"),
+                argThat(newEnvironment -> newEnvironment.getDomainRestrictions().isEmpty()), isNull());
+    }
+
     @Test
     void handleCloudMode_entrypointSyncFailure_propagatesAsErrorReply() {
         enableCloudMode();

--- a/gravitee-am-test/specs/cloud/command-validation.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/command-validation.jest.spec.ts
@@ -46,4 +46,61 @@ describe('Cloud command payload validation (Cockpit -> AM)', () => {
     expect(reply.commandStatus).toBe('SUCCEEDED');
     // Note: organizations have no delete endpoint in the management API
   });
+
+  // A host-less GATEWAY access point used to persist an entrypoint with the url "https://null" and no
+  // name, and that nameless record then broke the organization-wide entrypoint listing with a 500.
+  // Cockpit is now told the command failed instead of believing the gateway URL was provisioned.
+  describe('ENVIRONMENT gateway access points', () => {
+    const organizationId = 'cloud-env-accesspoint-validation';
+    const missingHostError = 'GATEWAY access point with a missing or blank host';
+
+    // Fixed ids for the same reason as the organization above: neither organizations nor environments
+    // can be deleted, so a randomised id would leave a new set behind on every run.
+    const sendEnvironment = async (id: string, accessPoints: unknown[]) => {
+      const commandId = await sendCockpitCommand({
+        type: 'ENVIRONMENT',
+        payload: { id, organizationId, hrids: [id], name: `Access point validation ${id}`, accessPoints },
+      });
+      return waitForCockpitReply(commandId);
+    };
+
+    beforeAll(async () => {
+      const commandId = await sendCockpitCommand({
+        type: 'ORGANIZATION',
+        payload: { id: organizationId, name: 'Access point validation org', hrids: [organizationId] },
+      });
+      const reply = await waitForCockpitReply(commandId);
+      expect(reply.commandStatus).toBe('SUCCEEDED');
+    });
+
+    it('rejects a GATEWAY access point with a null host', async () => {
+      const reply = await sendEnvironment('cloud-env-ap-null-host', [{ target: 'GATEWAY', host: null, secured: true }]);
+
+      expect(reply.commandStatus).toBe('ERROR');
+      expect(reply.errorDetails).toContain(missingHostError);
+    });
+
+    it('rejects a GATEWAY access point with a blank host', async () => {
+      const reply = await sendEnvironment('cloud-env-ap-blank-host', [{ target: 'GATEWAY', host: '  ' }]);
+
+      expect(reply.commandStatus).toBe('ERROR');
+      expect(reply.errorDetails).toContain(missingHostError);
+    });
+
+    it('rejects the whole command when only one of two GATEWAY access points has a host', async () => {
+      const reply = await sendEnvironment('cloud-env-ap-mixed-hosts', [
+        { target: 'GATEWAY', host: 'gw-valid.example.com' },
+        { target: 'GATEWAY', host: null },
+      ]);
+
+      expect(reply.commandStatus).toBe('ERROR');
+      expect(reply.errorDetails).toContain(missingHostError);
+    });
+
+    it('accepts a CONSOLE access point with no host, since it never becomes an entrypoint', async () => {
+      const reply = await sendEnvironment('cloud-env-ap-console-no-host', [{ target: 'CONSOLE', host: null }]);
+
+      expect(reply.commandStatus).toBe('SUCCEEDED');
+    });
+  });
 });

--- a/gravitee-am-test/specs/cloud/command-validation.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/command-validation.jest.spec.ts
@@ -102,5 +102,15 @@ describe('Cloud command payload validation (Cockpit -> AM)', () => {
 
       expect(reply.commandStatus).toBe('SUCCEEDED');
     });
+
+    // The counterpart to the rejections above: the guard must not turn away a GATEWAY access point
+    // that is perfectly usable, which is the regression it could plausibly introduce.
+    it('accepts a GATEWAY access point that has a host', async () => {
+      const reply = await sendEnvironment('cloud-env-ap-valid-gateway', [
+        { target: 'GATEWAY', host: 'gw-am7443.example.com' },
+      ]);
+
+      expect(reply.commandStatus).toBe('SUCCEEDED');
+    });
   });
 });


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7443

## :pencil2: A description of the changes proposed in the pull request

A GATEWAY access point with a null host used to get through and persist an entrypoint with the url `https://null` and no name at all. That nameless record then took out `GET /organizations/{organizationId}/entrypoints` with a 500, for every environment in the organization rather than just the affected one.

Two changes:

- EnvironmentCommandHandler rejects the command when a GATEWAY access point has no host, so Cockpit gets an error reply instead of believing it provisioned a gateway URL that AM quietly dropped. It also filters host-less access points out of both the entrypoint sync and the domain restrictions, behind that check.
- The organization entrypoint listing sorts with a null-safe comparator, so a record that is already in the database stops breaking the whole listing.

The rejection covers GATEWAY targets only. A CONSOLE access point never becomes an entrypoint, so failing the command for one would start rejecting environment syncs that work today.

It rejects the whole command rather than dropping just the bad access point. That matches the payload validation already at the top of the handler, and applying half of a command while reporting failure would be worse to reason about.

Existing broken records are not cleaned up. The listing survives them now, but the entrypoint is still there and still can't be deleted in managed-cloud mode, so resending a valid ENVIRONMENT command is the only way to clear one.

## :memo: Test scenarios

Unit and cloud integration coverage in the branch, all green. The cloud cases drive real Cockpit commands, so they need the stack up with `--cloud`.

The listing half is unit-only on purpose. Once the command is rejected no API path creates a nameless entrypoint, so setting that state up means writing to the database directly, which the Jest specs don't do.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

The null-safe comparator sorts nameless entrypoints last rather than filtering them out. If one exists it stays visible in the Console, so a misconfigured environment doesn't look clean.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
