### PR TITLE
test: cover SAML mapping, signing and permissive config (AM-7446)

### DIFF
--- a/gravitee-am-test/specs/gateway/saml2/fixtures/saml-loopback-fixture.ts
+++ b/gravitee-am-test/specs/gateway/saml2/fixtures/saml-loopback-fixture.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import { uniqueName } from '@utils-commands/misc';
+import { patchApplication } from '@management-commands/application-management-commands';
+import { updateIdp } from '@management-commands/idp-management-commands';
+import { listUsers, getAllUsers, deleteUser } from '@management-commands/user-management-commands';
+import { safeDeleteDomain } from '@management-commands/domain-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { User } from '@management-models/User';
+import { BasicResponse } from '@utils-commands/misc';
+
+import { SamlFixture, SamlProviderDomain, setupSamlProviderDomain, setupSamlProviderTest, TEST_USER } from '../setup';
+
+/**
+ * Poll window for gateway sync after patching the provider application.
+ * Matches the value used by the existing SAML gateway spec.
+ */
+const SYNC_OPTS = { timeoutMillis: 60000, intervalMillis: 500 };
+
+export const SAML_LOOPBACK_TEST = {
+  PROVIDER_PREFIX: 'saml-loopback-provider',
+  CLIENT_PREFIX: 'saml-loopback',
+  /** EL resolving to the authenticating user's username. */
+  EL_USERNAME: `{#context.attributes['user'].username}`,
+  /** EL resolving to the authenticating user's email. */
+  EL_EMAIL: `{#context.attributes['user'].email}`,
+} as const;
+
+/**
+ * Fixture for the AM-to-AM SAML loopback used by the gateway SAML specs.
+ *
+ * Wraps the loopback environment built by `../setup` (provider domain acting as the
+ * SAML IdP, client domain consuming it through `saml2-generic-am-idp`) and adds the
+ * helpers these tests need: mutating the provider application's SAML settings, and
+ * inspecting or removing the federated user the login produces in the client domain.
+ */
+export interface SamlLoopbackFixture {
+  /** Underlying loopback fixture: domains, `login()`, `expectRedirectToClient()`. */
+  saml: SamlFixture;
+  accessToken: string;
+
+  /** Patch the provider application's SAML settings and wait for the gateway to pick them up. */
+  setSamlSettings: (saml: Record<string, unknown>) => Promise<void>;
+  /**
+   * Run the SAML login flow and assert it lands back on the client with an auth code.
+   *
+   * Deliberately does NOT look the federated user up: the federated user's username is
+   * the NameID, which is what these tests vary, so the caller decides how to find it.
+   */
+  authenticate: (username: string, password: string) => Promise<void>;
+  /** Patch the client domain's SAML IdP configuration (merged over the current config). */
+  setSamlIdpConfig: (configPatch: Record<string, unknown>) => Promise<void>;
+  /** Run the login flow WITHOUT asserting success — for negative scenarios. */
+  attemptLogin: (username: string, password: string) => Promise<BasicResponse>;
+  /** Federated users in the client domain; `query` omitted lists them all. */
+  findFederatedUsers: (query?: string) => Promise<User[]>;
+  /** The single federated user in the client domain — fails if there is not exactly one. */
+  getOnlyFederatedUser: () => Promise<User>;
+  /** Delete every federated user in the client domain, so each test starts clean. */
+  clearFederatedUsers: () => Promise<void>;
+  /** Restore the SAML configuration on both sides to the values captured at setup. */
+  resetToBaseline: () => Promise<void>;
+
+  cleanup: () => Promise<void>;
+}
+
+export const setupSamlLoopbackFixture = async (): Promise<SamlLoopbackFixture> => {
+  let provider: SamlProviderDomain | null = null;
+  let saml: SamlFixture | null = null;
+
+  try {
+    const accessToken = await requestAdminAccessToken();
+
+    provider = await setupSamlProviderDomain(uniqueName(SAML_LOOPBACK_TEST.PROVIDER_PREFIX, true).toLowerCase());
+    saml = await setupSamlProviderTest(uniqueName(SAML_LOOPBACK_TEST.CLIENT_PREFIX, true).toLowerCase(), undefined, provider);
+
+    const providerDomainId = saml.domains.providerDomain.id;
+    const providerAppId = saml.domains.providerApplication.id;
+    const clientDomainId = saml.domains.clientDomain.id;
+
+    // Known-good configuration captured at setup, so a scenario that breaks the SAML
+    // wiring on purpose can hand the next test a working environment back.
+    const baselineProviderSaml: Record<string, unknown> = {
+      ...(saml.domains.providerApplication.settings?.saml ?? {}),
+    };
+    const baselineIdpConfig: Record<string, unknown> = JSON.parse(saml.domains.samlIdp.configuration);
+
+    const setSamlSettings = async (samlSettings: Record<string, unknown>): Promise<void> => {
+      await waitForSyncAfter(
+        providerDomainId,
+        () => patchApplication(providerDomainId, accessToken, { settings: { saml: samlSettings } }, providerAppId),
+        SYNC_OPTS,
+      );
+    };
+
+    const setSamlIdpConfig = async (configPatch: Record<string, unknown>): Promise<void> => {
+      const current = JSON.parse(saml!.domains.samlIdp.configuration);
+      const merged = { ...current, ...configPatch };
+      await waitForSyncAfter(
+        clientDomainId,
+        () =>
+          updateIdp(
+            clientDomainId,
+            accessToken,
+            {
+              name: saml!.domains.samlIdp.name,
+              // `type` is mandatory on update — omitting it fails with "[type: must not be blank]".
+              type: saml!.domains.samlIdp.type,
+              configuration: JSON.stringify(merged),
+            },
+            saml!.domains.samlIdp.id,
+          ),
+        SYNC_OPTS,
+      );
+    };
+
+    const attemptLogin = async (username: string, password: string) => saml!.login(username, password);
+
+    const findFederatedUsers = async (query?: string): Promise<User[]> => {
+      const page = query ? await listUsers(clientDomainId, accessToken, query) : await getAllUsers(clientDomainId, accessToken);
+      return page.data ?? [];
+    };
+
+    const authenticate = async (username: string, password: string): Promise<void> => {
+      const loginResponse = await saml!.login(username, password);
+      const authCode = await saml!.expectRedirectToClient(loginResponse);
+      expect(authCode).toEqual(expect.any(String));
+    };
+
+    const getOnlyFederatedUser = async (): Promise<User> => {
+      const users = await findFederatedUsers();
+      expect(users).toHaveLength(1);
+      return users[0];
+    };
+
+    const clearFederatedUsers = async (): Promise<void> => {
+      const users = await findFederatedUsers();
+      for (const user of users) {
+        await deleteUser(clientDomainId, accessToken, user.id);
+      }
+    };
+
+    /**
+     * Restore both sides of the SAML wiring to the configuration captured at setup.
+     * Scenarios that deliberately break the config must call this so the next test
+     * starts from a working environment (guidelines: tests run in any order).
+     */
+    const resetToBaseline = async (): Promise<void> => {
+      await setSamlSettings(baselineProviderSaml);
+      await setSamlIdpConfig(baselineIdpConfig);
+    };
+
+    const cleanup = async () => {
+      if (saml) {
+        await saml.cleanup();
+      }
+      if (provider) {
+        await safeDeleteDomain(provider.domain.id, provider.accessToken);
+      }
+    };
+
+    return {
+      saml,
+      accessToken,
+      setSamlSettings,
+      setSamlIdpConfig,
+      authenticate,
+      attemptLogin,
+      findFederatedUsers,
+      getOnlyFederatedUser,
+      clearFederatedUsers,
+      resetToBaseline,
+      cleanup,
+    };
+  } catch (error) {
+    // Cleanup on setup failure so a partial environment does not leak.
+    try {
+      if (saml) {
+        await saml.cleanup();
+      }
+      if (provider) {
+        await safeDeleteDomain(provider.domain.id, provider.accessToken);
+      }
+    } catch (cleanupError) {
+      console.error('Failed to cleanup SAML mapping fixture after setup failure:', cleanupError);
+    }
+    throw error;
+  }
+};
+
+export { TEST_USER };

--- a/gravitee-am-test/specs/gateway/saml2/saml-assertion-mapping.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-assertion-mapping.jest.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+
+import { SAML_LOOPBACK_TEST, SamlLoopbackFixture, setupSamlLoopbackFixture, TEST_USER } from './fixtures/saml-loopback-fixture';
+import { setup } from '../../test-fixture';
+
+/**
+ * SAML assertion mapping when AM acts as the IdP: how the NameID is derived and which
+ * attributes are emitted.
+ *
+ * Verified through the federated user the client domain builds from the assertion —
+ * note its username IS the NameID, so each test looks the user up accordingly rather
+ * than by the username used to authenticate.
+ */
+setup(200000);
+
+const UUID_FORMAT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+let fixture: SamlLoopbackFixture;
+
+beforeAll(async () => {
+  fixture = await setupSamlLoopbackFixture();
+});
+
+beforeEach(async () => {
+  // Each scenario asserts on the single federated user its own login produces.
+  await fixture.clearFederatedUsers();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('SAML Assertion Mapping - NameID derivation', () => {
+  it(jira`should use the internal user id as NameID when no assertion mapping is configured ${'AM-6954'}`, async () => {
+    await fixture.setSamlSettings({ nameIdMapping: null, assertionAttributes: null });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    // Default behaviour: the IdP emits the internal user id, so the federated user is
+    // keyed on a UUID rather than the name the user actually logged in with.
+    const federatedUser = await fixture.getOnlyFederatedUser();
+    expect(federatedUser.username).toMatch(UUID_FORMAT);
+    expect(federatedUser.username).not.toEqual(TEST_USER.username);
+  });
+
+  it(jira`should use the email as NameID when assertion mapping resolves to email ${'AM-6954'}`, async () => {
+    await fixture.setSamlSettings({ nameIdMapping: SAML_LOOPBACK_TEST.EL_EMAIL });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    const federatedUser = await fixture.getOnlyFederatedUser();
+    expect(federatedUser.username).toEqual(TEST_USER.email);
+    expect(federatedUser.externalId).toEqual(TEST_USER.email);
+  });
+});
+
+describe('SAML Assertion Mapping - Custom attributes', () => {
+  it(jira`should emit both EL-resolved and literal assertion attributes ${'AM-6961'}`, async () => {
+    await fixture.setSamlSettings({
+      nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME,
+      assertionAttributes: [
+        { name: 'customAttr1', value: SAML_LOOPBACK_TEST.EL_EMAIL },
+        { name: 'customAttr2', value: SAML_LOOPBACK_TEST.EL_USERNAME },
+        // A plain string literal rather than an EL expression — the mapper must pass it
+        // through verbatim instead of attempting to resolve it.
+        { name: 'customAttr3', value: 'quality-assurance' },
+      ],
+    });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    const federatedUser = await fixture.getOnlyFederatedUser();
+    expect(federatedUser.username).toEqual(TEST_USER.username);
+    expect(federatedUser.additionalInformation?.customAttr1).toEqual(TEST_USER.email);
+    expect(federatedUser.additionalInformation?.customAttr2).toEqual(TEST_USER.username);
+    expect(federatedUser.additionalInformation?.customAttr3).toEqual('quality-assurance');
+  });
+});

--- a/gravitee-am-test/specs/gateway/saml2/saml-federated-user.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-federated-user.jest.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+
+import { SAML_LOOPBACK_TEST, SamlLoopbackFixture, setupSamlLoopbackFixture, TEST_USER } from './fixtures/saml-loopback-fixture';
+import { setup } from '../../test-fixture';
+
+/**
+ * Lifecycle of the federated user that a SAML login creates in the client domain:
+ * how repeat logins are matched, what happens when the NameID cannot be resolved,
+ * and what happens when the NameID mapping changes after a user already exists.
+ */
+setup(200000);
+
+const UUID_FORMAT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+let fixture: SamlLoopbackFixture;
+
+beforeAll(async () => {
+  fixture = await setupSamlLoopbackFixture();
+});
+
+beforeEach(async () => {
+  await fixture.clearFederatedUsers();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('SAML Federated User - repeat authentication', () => {
+  it(jira`should update the existing federated user on re-login rather than duplicating it ${'AM-6959'}`, async () => {
+    await fixture.setSamlSettings({ nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME, assertionAttributes: null });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+    const afterFirstLogin = await fixture.getOnlyFederatedUser();
+    expect(afterFirstLogin.loginsCount).toEqual(1);
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    // Same NameID resolves to the same externalId, so the existing record is updated.
+    const afterSecondLogin = await fixture.getOnlyFederatedUser();
+    expect(afterSecondLogin.id).toEqual(afterFirstLogin.id);
+    expect(afterSecondLogin.loginsCount).toEqual(2);
+  });
+});
+
+describe('SAML Federated User - unresolvable NameID', () => {
+  it(jira`should fall back to the internal user id when the NameID mapping references a missing attribute ${'AM-6960'}`, async () => {
+    // `employeeId` is not present on the inline IdP user, so the expression cannot resolve.
+    await fixture.setSamlSettings({
+      nameIdMapping: `{#context.attributes['user'].employeeId}`,
+      assertionAttributes: null,
+    });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    // Authentication still succeeds — the IdP degrades to the internal user id
+    // rather than failing the flow.
+    const federatedUser = await fixture.getOnlyFederatedUser();
+    expect(federatedUser.username).toMatch(UUID_FORMAT);
+    expect(federatedUser.username).not.toEqual(TEST_USER.username);
+  });
+});
+
+describe('SAML Federated User - NameID mapping changed after first login', () => {
+  it(jira`should orphan the original federated user when the NameID mapping changes ${'AM-6960'}`, async () => {
+    await fixture.setSamlSettings({ nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME, assertionAttributes: null });
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+    const original = await fixture.getOnlyFederatedUser();
+    expect(original.username).toEqual(TEST_USER.username);
+
+    // Change what the NameID resolves to, leaving the existing federated user in place.
+    await fixture.setSamlSettings({ nameIdMapping: SAML_LOOPBACK_TEST.EL_EMAIL });
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    // The new NameID does not match the stored externalId, so a second record is
+    // created and the original is left behind rather than being migrated.
+    const users = await fixture.findFederatedUsers();
+    expect(users).toHaveLength(2);
+    expect(users.map((user) => user.username).sort()).toEqual([TEST_USER.email, TEST_USER.username].sort());
+  });
+
+  it(jira`should create a single federated user when the old one is deleted before re-login ${'AM-6961'}`, async () => {
+    await fixture.setSamlSettings({ nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME, assertionAttributes: null });
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+    expect(await fixture.getOnlyFederatedUser()).toEqual(expect.objectContaining({ username: TEST_USER.username }));
+
+    await fixture.setSamlSettings({ nameIdMapping: SAML_LOOPBACK_TEST.EL_EMAIL });
+    await fixture.clearFederatedUsers();
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    const federatedUser = await fixture.getOnlyFederatedUser();
+    expect(federatedUser.username).toEqual(TEST_USER.email);
+  });
+});

--- a/gravitee-am-test/specs/gateway/saml2/saml-idp-metadata.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-idp-metadata.jest.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+
+import { SamlLoopbackFixture, setupSamlLoopbackFixture } from './fixtures/saml-loopback-fixture';
+import { getProviderMetadataUrl } from './setup';
+import { setup } from '../../test-fixture';
+
+/**
+ * The IdP metadata document AM publishes when it acts as a SAML IdP.
+ *
+ * The existing SAML suite only ever fetches metadata from WireMock; nothing asserts
+ * what AM itself serves on /{domain}/saml2/idp/metadata.
+ */
+setup(200000);
+
+let fixture: SamlLoopbackFixture;
+
+beforeAll(async () => {
+  fixture = await setupSamlLoopbackFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('SAML IdP metadata endpoint', () => {
+  it(jira`should publish IdP metadata describing the SSO endpoints and certificates ${'AM-6959'}`, async () => {
+    const metadataUrl = getProviderMetadataUrl(fixture.saml.domains.providerDomain);
+
+    const response = await performGet(metadataUrl, '').expect(200);
+
+    // Descriptor identity and role.
+    expect(response.text).toContain('EntityDescriptor');
+    expect(response.text).toContain('IDPSSODescriptor');
+
+    // Key material the SP needs: a signing key to verify responses, and an encryption
+    // key so it can be offered encrypted assertions.
+    expect(response.text).toContain('use="signing"');
+    expect(response.text).toContain('use="encryption"');
+    expect(response.text).toContain('X509Certificate');
+
+    // AM advertises the HTTP-Redirect binding only, for both SSO and SLO — an SP
+    // reading this metadata will never negotiate HTTP-POST from it.
+    expect(response.text).toMatch(/SingleSignOnService Binding="urn:oasis:names:tc:SAML:2\.0:bindings:HTTP-Redirect"/);
+    expect(response.text).toMatch(/SingleLogoutService Binding="urn:oasis:names:tc:SAML:2\.0:bindings:HTTP-Redirect"/);
+    expect(response.text).not.toContain('urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST');
+
+    // Signed AuthnRequests are required.
+    expect(response.text).toContain('WantAuthnRequestsSigned="true"');
+  });
+
+  it(jira`should return 404 for the metadata of a domain that does not exist ${'AM-6959'}`, async () => {
+    const unknownDomainMetadata = getProviderMetadataUrl({
+      ...fixture.saml.domains.providerDomain,
+      hrid: 'domain-that-does-not-exist',
+    });
+
+    await performGet(unknownDomainMetadata, '').expect(404);
+  });
+});

--- a/gravitee-am-test/specs/gateway/saml2/saml-negative.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-negative.jest.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+
+import { SamlLoopbackFixture, setupSamlLoopbackFixture, TEST_USER } from './fixtures/saml-loopback-fixture';
+import { setup } from '../../test-fixture';
+
+/**
+ * SAML failure paths: bad credentials, and misconfiguration between the IdP and the SP.
+ *
+ * Each scenario asserts that authentication is refused AND that no federated user is
+ * left behind in the client domain — a failed login must not provision anyone.
+ */
+setup(200000);
+
+let fixture: SamlLoopbackFixture;
+
+beforeAll(async () => {
+  fixture = await setupSamlLoopbackFixture();
+});
+
+beforeEach(async () => {
+  // Several scenarios here deliberately break the SAML wiring, so restore a known-good
+  // configuration first — tests must be runnable in any order.
+  await fixture.resetToBaseline();
+  await fixture.clearFederatedUsers();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('SAML Negative - invalid credentials', () => {
+  it(jira`should reject unknown credentials and provision no federated user ${'AM-6960'}`, async () => {
+    const response = await fixture.attemptLogin('not-a-real-user', 'wrong-password');
+
+    expect(response.status).toEqual(200);
+    expect(response.text).toContain('login_failed');
+
+    // A rejected authentication must not create a federated identity.
+    expect(await fixture.findFederatedUsers()).toHaveLength(0);
+  });
+
+  it(jira`should reject a known user with the wrong password ${'AM-6960'}`, async () => {
+    const response = await fixture.attemptLogin(TEST_USER.username, 'definitely-not-the-password');
+
+    expect(response.status).toEqual(200);
+    expect(response.text).toContain('login_failed');
+    expect(await fixture.findFederatedUsers()).toHaveLength(0);
+  });
+});
+
+describe('SAML Negative - SP cannot validate the response signature', () => {
+  it(jira`should fail authentication when the SP has no signing certificate to validate with ${'AM-6960'}`, async () => {
+    // Strip the IdP's public certificate from the SP-side configuration, leaving the SP
+    // unable to verify the signature on the SAML response it receives.
+    await fixture.setSamlIdpConfig({ signingCertificate: null });
+
+    const response = await fixture.attemptLogin(TEST_USER.username, TEST_USER.password);
+
+    expect(response.text).toContain('social_authentication_failed');
+    expect(await fixture.findFederatedUsers()).toHaveLength(0);
+  });
+});

--- a/gravitee-am-test/specs/gateway/saml2/saml-permissive-config.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-permissive-config.jest.spec.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+
+import { SAML_LOOPBACK_TEST, SamlLoopbackFixture, setupSamlLoopbackFixture, TEST_USER } from './fixtures/saml-loopback-fixture';
+import { setup } from '../../test-fixture';
+
+/**
+ * Behaviour for SAML application settings that the management API accepts without
+ * validating — `validateApplicationSamlSettings` checks only the encryption certificate,
+ * the algorithm URIs and the numeric time fields, so duplicate attribute names, blank
+ * names, null values, malformed EL and non-URI audiences all persist.
+ *
+ * These tests pin what the gateway then does with that configuration. They document
+ * current behaviour rather than asserting it is desirable — notably a blank attribute
+ * name breaks authentication outright.
+ */
+setup(200000);
+
+const UUID_FORMAT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+let fixture: SamlLoopbackFixture;
+
+beforeAll(async () => {
+  fixture = await setupSamlLoopbackFixture();
+});
+
+beforeEach(async () => {
+  await fixture.resetToBaseline();
+  await fixture.clearFederatedUsers();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('SAML permissive config - assertion attributes', () => {
+  it(jira`should emit the last value when two assertion attributes share a name ${'AM-6961'}`, async () => {
+    // The Console rejects duplicate names; the management API accepts them.
+    await fixture.setSamlSettings({
+      nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME,
+      assertionAttributes: [
+        { name: 'dept', value: SAML_LOOPBACK_TEST.EL_USERNAME },
+        { name: 'dept', value: SAML_LOOPBACK_TEST.EL_EMAIL },
+      ],
+    });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    const federatedUser = await fixture.getOnlyFederatedUser();
+    expect(federatedUser.additionalInformation?.dept).toEqual(TEST_USER.email);
+  });
+
+  it(jira`should break authentication when an assertion attribute has a blank name ${'AM-6960'}`, async () => {
+    await fixture.setSamlSettings({
+      nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME,
+      assertionAttributes: [{ name: '', value: 'literal-value' }],
+    });
+
+    // A blank attribute name is accepted by the management API but leaves the IdP
+    // unable to complete the flow — the SP never receives a usable response.
+    await expect(fixture.attemptLogin(TEST_USER.username, TEST_USER.password)).rejects.toThrow(/got 401/);
+    expect(await fixture.findFederatedUsers()).toHaveLength(0);
+  });
+
+  it(jira`should omit an assertion attribute whose value is null ${'AM-6961'}`, async () => {
+    await fixture.setSamlSettings({
+      nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME,
+      assertionAttributes: [{ name: 'dept', value: null }],
+    });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    // `value` is declared @NotNull on SAMLAssertionAttribute but is neither rejected
+    // nor emitted — the attribute simply never reaches the federated profile.
+    const federatedUser = await fixture.getOnlyFederatedUser();
+    expect(federatedUser.additionalInformation?.dept).toBeUndefined();
+  });
+});
+
+describe('SAML permissive config - NameID and audiences', () => {
+  it(jira`should fall back to the internal user id when the NameID expression is malformed ${'AM-6960'}`, async () => {
+    await fixture.setSamlSettings({
+      nameIdMapping: `{#context.attributes['user'].username`,
+      assertionAttributes: null,
+    });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    // Syntactically broken EL degrades the same way an unresolvable attribute does,
+    // rather than failing the flow.
+    expect((await fixture.getOnlyFederatedUser()).username).toMatch(UUID_FORMAT);
+  });
+
+  it(jira`should authenticate despite blank and non-URI audience entries ${'AM-6959'}`, async () => {
+    await fixture.setSamlSettings({
+      nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME,
+      includeAssertionConditions: true,
+      audiences: ['', 'not a uri'],
+    });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    expect((await fixture.getOnlyFederatedUser()).username).toEqual(TEST_USER.username);
+  });
+});
+
+describe('SAML permissive config - legacy encryption algorithm', () => {
+  it(jira`should authenticate with RSA1_5 key transport for encrypted assertions ${'AM-7107'}`, async () => {
+    // RSA1_5 is a deprecated key transport algorithm, still present in the allow-list
+    // at ApplicationServiceImpl. Authentication succeeds rather than being refused.
+    await fixture.setSamlSettings({
+      nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME,
+      wantAssertionsEncrypted: true,
+      keyTransportEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5',
+      dataEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+    });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    expect((await fixture.getOnlyFederatedUser()).username).toEqual(TEST_USER.username);
+  });
+});

--- a/gravitee-am-test/specs/gateway/saml2/saml-signing.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-signing.jest.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+
+import { SAML_LOOPBACK_TEST, SamlLoopbackFixture, setupSamlLoopbackFixture, TEST_USER } from './fixtures/saml-loopback-fixture';
+import { setup } from '../../test-fixture';
+
+/**
+ * Signature requirements between the IdP (provider application SAML settings) and the
+ * SP (saml2-generic-am-idp configuration).
+ *
+ * The SP accepts the response when it can verify *something*: the response signature,
+ * the assertion signature, or — when it holds no signing certificate — neither. It only
+ * refuses when it expects a signature it cannot obtain or cannot verify.
+ */
+setup(200000);
+
+let fixture: SamlLoopbackFixture;
+
+beforeAll(async () => {
+  fixture = await setupSamlLoopbackFixture();
+});
+
+beforeEach(async () => {
+  await fixture.resetToBaseline();
+  await fixture.setSamlSettings({ nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME, assertionAttributes: null });
+  await fixture.clearFederatedUsers();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('SAML Signing - SP holds the IdP signing certificate', () => {
+  it(jira`should authenticate when both the response and the assertions are signed ${'AM-2551'}`, async () => {
+    await fixture.setSamlSettings({ wantResponseSigned: true, wantAssertionsSigned: true });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    expect((await fixture.getOnlyFederatedUser()).username).toEqual(TEST_USER.username);
+  });
+
+  it(jira`should authenticate when only the assertions are signed ${'AM-2548'}`, async () => {
+    await fixture.setSamlSettings({ wantResponseSigned: false, wantAssertionsSigned: true });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    expect((await fixture.getOnlyFederatedUser()).username).toEqual(TEST_USER.username);
+  });
+
+  it(jira`should authenticate when only the response is signed ${'AM-2551'}`, async () => {
+    await fixture.setSamlSettings({ wantResponseSigned: true, wantAssertionsSigned: false });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    expect((await fixture.getOnlyFederatedUser()).username).toEqual(TEST_USER.username);
+  });
+
+  it(jira`should refuse an entirely unsigned response when the SP can verify signatures ${'AM-2564'}`, async () => {
+    // Neither the response nor the assertions are signed, but the SP still holds the
+    // IdP certificate and therefore expects a signature it never receives.
+    await fixture.setSamlSettings({ wantResponseSigned: false, wantAssertionsSigned: false });
+
+    const response = await fixture.attemptLogin(TEST_USER.username, TEST_USER.password);
+
+    expect(response.text).toContain('social_authentication_failed');
+    expect(await fixture.findFederatedUsers()).toHaveLength(0);
+  });
+});
+
+describe('SAML Signing - SP holds no signing certificate', () => {
+  it(jira`should authenticate an unsigned response when the SP cannot verify signatures ${'AM-2564'}`, async () => {
+    // With nothing signed and no certificate to verify against, the SP has no signature
+    // expectation to violate, so the flow completes.
+    await fixture.setSamlSettings({ wantResponseSigned: false, wantAssertionsSigned: false });
+    await fixture.setSamlIdpConfig({ signingCertificate: null });
+
+    await fixture.authenticate(TEST_USER.username, TEST_USER.password);
+
+    expect((await fixture.getOnlyFederatedUser()).username).toEqual(TEST_USER.username);
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7446
](https://gravitee.atlassian.net/browse/AM-7446)

## :pencil2: A description of the changes proposed in the pull request
 Adds 23 Jest tests across 6 spec files plus a shared fixture, covering SAML gateway
  behaviour with no previous automated coverage. Purely additive — `saml.spec.ts` and
  `setup.ts` are untouched.

  - `saml-signing` (5) — signature truth table across response/assertion signing
  - `saml-permissive-config` (6) — config the management API accepts without validating
  - `saml-federated-user` (4) — re-login matching, NameID fallback, mapping-change orphaning
  - `saml-assertion-mapping` (3) — NameID derivation and custom attributes
  - `saml-negative` (3) — invalid credentials, unverifiable signature
  - `saml-idp-metadata` (2) — the metadata document AM publishes

  Automates Xray cases AM-2548, AM-2551, AM-2564, AM-6954, AM-6959, AM-6960, AM-6961, AM-7107.

## :memo: Test scenarios 
NA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA