### PR TITLE
test: cover SAML assertion encryption and signing (AM-7446)

### DIFF
--- a/gravitee-am-test/specs/gateway/saml2/fixtures/saml-response-capture.ts
+++ b/gravitee-am-test/specs/gateway/saml2/fixtures/saml-response-capture.ts
@@ -176,3 +176,44 @@ export function signatureLevels(xml: string): { response: boolean; assertion: bo
     assertion: xml.slice(assertionStart).includes('<ds:Signature'),
   };
 }
+
+/**
+ * Start the SAML flow and return the response at the point it stops progressing,
+ * without asserting success.
+ *
+ * Some misconfigurations (an SP entity ID the IdP cannot resolve, for example) fail
+ * while the AuthnRequest is being handled — before any login form is shown — so the
+ * error never reaches a test that drives the full credential flow.
+ */
+export async function initiateSamlFlow(
+  domains: SamlTestDomains,
+  clientOpenIdConfiguration: any,
+): Promise<{ response: BasicResponse; locations: string[] }> {
+  const authorizeResponse = await initiateLoginFlow(
+    domains.clientApplication.settings.oauth.clientId,
+    clientOpenIdConfiguration,
+    domains.clientDomain,
+  );
+  const cookies = authorizeResponse.headers['set-cookie'];
+  const headers = cookies ? { Cookie: cookies } : {};
+
+  const loginPage = await performGet(authorizeResponse.headers['location'], '', headers).expect(200);
+  const samlProviderLink = findSamlProviderLink(loginPage.text);
+  expect(samlProviderLink).toEqual(expect.any(String));
+
+  let current: BasicResponse = await performGet(samlProviderLink!, '', headers);
+  // Errors are frequently carried in the redirect URL rather than the final page body,
+  // so every hop's Location is returned alongside the response that ends the chain.
+  const locations: string[] = [];
+
+  for (let hop = 0; hop < MAX_REDIRECTS; hop++) {
+    const nextLocation = current.headers?.location;
+    if (!nextLocation) {
+      return { response: current, locations };
+    }
+    locations.push(nextLocation);
+    const hopCookies = current.headers['set-cookie'] ?? cookies;
+    current = await performGet(nextLocation, '', hopCookies ? { Cookie: hopCookies } : {});
+  }
+  return { response: current, locations };
+}

--- a/gravitee-am-test/specs/gateway/saml2/fixtures/saml-response-capture.ts
+++ b/gravitee-am-test/specs/gateway/saml2/fixtures/saml-response-capture.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import cheerio from 'cheerio';
+import * as zlib from 'zlib';
+
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+import { initiateLoginFlow, login } from '@gateway-commands/login-commands';
+import { BasicResponse, followRedirectTag } from '@utils-commands/misc';
+
+import { SamlTestDomains } from '../setup';
+
+/**
+ * Captures the SAML response a login produces, so tests can assert on the assertion
+ * itself rather than only on its side effects.
+ *
+ * The login helper in `../setup` follows the whole redirect chain and returns only the
+ * final hop, which discards the response. Rather than modify that shared helper, this
+ * walks the same chain and stops at the redirect carrying `SAMLResponse`.
+ */
+
+/** Maximum redirects to walk before giving up looking for the SAML response. */
+const MAX_REDIRECTS = 6;
+
+/**
+ * Decode a `SAMLResponse` parameter into XML.
+ *
+ * HTTP-Redirect binding DEFLATEs the payload before base64; HTTP-POST binding does not.
+ * Try raw inflate first and fall back to treating the bytes as plain XML.
+ */
+export function decodeSamlResponse(encoded: string): string {
+  const raw = Buffer.from(decodeURIComponent(encoded), 'base64');
+  try {
+    return zlib.inflateRawSync(raw).toString('utf8');
+  } catch {
+    return raw.toString('utf8');
+  }
+}
+
+/** Pull the `SAMLResponse` parameter out of a redirect Location, if present. */
+function samlResponseFromLocation(location?: string): string | undefined {
+  if (!location || !location.includes('SAMLResponse=')) {
+    return undefined;
+  }
+  return new URL(location).searchParams.get('SAMLResponse') ?? undefined;
+}
+
+/** Pull the `SAMLResponse` out of an auto-submitting HTML form (HTTP-POST binding). */
+function samlResponseFromHtmlForm(body?: string): string | undefined {
+  if (!body || !body.includes('SAMLResponse')) {
+    return undefined;
+  }
+  const dom = cheerio.load(body);
+  return dom('input[name="SAMLResponse"]').attr('value');
+}
+
+/** Locate the SAML provider button on the client domain's login page. */
+function findSamlProviderLink(html: string): string | undefined {
+  const dom = cheerio.load(html);
+  return dom('.btn-saml2-generic-am-idp').attr('href') || dom('a[href*="saml2"]').attr('href');
+}
+
+/**
+ * Run the SAML login flow and return the decoded SAML response XML.
+ *
+ * Walks the same steps as the shared login helper, but inspects each redirect for the
+ * `SAMLResponse` parameter (HTTP-Redirect binding) or an auto-submit form field
+ * (HTTP-POST binding) instead of following blindly to the end.
+ */
+export async function captureSamlResponseXml(
+  domains: SamlTestDomains,
+  clientOpenIdConfiguration: any,
+  username: string,
+  password: string,
+): Promise<string> {
+  const authorizeResponse = await initiateLoginFlow(
+    domains.clientApplication.settings.oauth.clientId,
+    clientOpenIdConfiguration,
+    domains.clientDomain,
+  );
+  const cookies = authorizeResponse.headers['set-cookie'];
+  const headers = cookies ? { Cookie: cookies } : {};
+
+  const loginPage = await performGet(authorizeResponse.headers['location'], '', headers).expect(200);
+  const samlProviderLink = findSamlProviderLink(loginPage.text);
+  expect(samlProviderLink).toEqual(expect.any(String));
+
+  let toIdp = await performGet(samlProviderLink!, '', headers);
+  // Under HTTP-Redirect the SP 302s to the IdP; under HTTP-POST it returns an
+  // auto-submitting form carrying the AuthnRequest, which has to be posted first.
+  if (toIdp.status === 200 && (toIdp.text ?? '').includes('SAMLRequest')) {
+    toIdp = await followRedirectTag('saml-authn-request')(toIdp);
+  }
+
+  let current: BasicResponse = await login(toIdp, username, domains.providerApplication.settings.oauth.clientId, password);
+
+  for (let hop = 0; hop < MAX_REDIRECTS; hop++) {
+    const fromLocation = samlResponseFromLocation(current.headers?.location);
+    if (fromLocation) {
+      return decodeSamlResponse(fromLocation);
+    }
+    const fromForm = samlResponseFromHtmlForm(current.text);
+    if (fromForm) {
+      return decodeSamlResponse(fromForm);
+    }
+
+    const nextLocation = current.headers?.location;
+    if (nextLocation) {
+      const hopCookies = current.headers['set-cookie'] ?? cookies;
+      current = await performGet(nextLocation, '', hopCookies ? { Cookie: hopCookies } : {});
+      continue;
+    }
+
+    // Under HTTP-POST the IdP re-presents the AuthnRequest as an auto-submitting form
+    // after authentication ("Login SSO POST"), which must be posted to continue.
+    if (current.status === 200 && (current.text ?? '').includes('<form')) {
+      current = await followRedirectTag('saml-form-hop')(current);
+      continue;
+    }
+
+    break;
+  }
+
+  throw new Error(`No SAMLResponse found within ${MAX_REDIRECTS} redirects of the login flow`);
+}
+
+/** True when the response carries an encrypted assertion rather than a plaintext one. */
+export function hasEncryptedAssertion(xml: string): boolean {
+  return xml.includes('EncryptedAssertion');
+}
+
+/** True when the response carries a readable (unencrypted) assertion. */
+export function hasPlaintextAssertion(xml: string): boolean {
+  return /<(saml2?:)?Assertion[ >]/.test(xml);
+}
+
+/**
+ * XML Encryption algorithms in use: the data (block) algorithm from `EncryptedData`
+ * and the key transport algorithm from `EncryptedKey`.
+ */
+export function encryptionAlgorithms(xml: string): { data?: string; keyTransport?: string } {
+  const data = /<xenc:EncryptedData[\s\S]*?<xenc:EncryptionMethod Algorithm="([^"]+)"/.exec(xml);
+  const keyTransport = /<xenc:EncryptedKey[\s\S]*?<xenc:EncryptionMethod Algorithm="([^"]+)"/.exec(xml);
+  return { data: data?.[1], keyTransport: keyTransport?.[1] };
+}
+
+/**
+ * Where signatures appear: directly on the Response element, and/or inside the
+ * Assertion. An encrypted assertion hides any assertion-level signature, so only the
+ * response-level one is observable in that case.
+ */
+export function signatureLevels(xml: string): { response: boolean; assertion: boolean } {
+  const assertionStart = xml.search(/<(saml2?:)?Assertion[ >]/);
+  const firstSignature = xml.indexOf('<ds:Signature');
+  if (firstSignature === -1) {
+    return { response: false, assertion: false };
+  }
+  if (assertionStart === -1) {
+    return { response: true, assertion: false };
+  }
+  return {
+    response: firstSignature < assertionStart,
+    assertion: xml.slice(assertionStart).includes('<ds:Signature'),
+  };
+}

--- a/gravitee-am-test/specs/gateway/saml2/saml-encryption.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-encryption.jest.spec.ts
@@ -171,6 +171,24 @@ describe('SAML Encryption - signing and encryption combinations', () => {
   });
 });
 
+describe('SAML Signing - HTTP-POST binding', () => {
+  it(jira`should not sign the response or the assertion when both signing flags are disabled ${'AM-2564'}`, async () => {
+    // The equivalent scenario under HTTP-Redirect refuses the login, because signing
+    // there happens at the binding layer. On the HTTP-POST path the flags reach the
+    // response builder instead, so the response is simply emitted unsigned.
+    await fixture.setSamlSettings({
+      wantResponseSigned: false,
+      wantAssertionsSigned: false,
+      wantAssertionsEncrypted: false,
+    });
+
+    const xml = await captureResponse();
+
+    expect(signatureLevels(xml)).toEqual({ response: false, assertion: false });
+    expect(hasPlaintextAssertion(xml)).toBe(true);
+  });
+});
+
 describe('SAML Encryption - disabled', () => {
   it(jira`should emit a readable assertion when encryption is disabled ${'AM-7111'}`, async () => {
     await fixture.setSamlSettings({ wantAssertionsEncrypted: false });

--- a/gravitee-am-test/specs/gateway/saml2/saml-encryption.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-encryption.jest.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+
+import { SAML_LOOPBACK_TEST, SamlLoopbackFixture, setupSamlLoopbackFixture, TEST_USER } from './fixtures/saml-loopback-fixture';
+import {
+  captureSamlResponseXml,
+  encryptionAlgorithms,
+  hasEncryptedAssertion,
+  hasPlaintextAssertion,
+  signatureLevels,
+} from './fixtures/saml-response-capture';
+import { setup } from '../../test-fixture';
+
+/**
+ * Assertion encryption and signing, asserted against the SAML response itself.
+ *
+ * Both are implemented only on the HTTP-POST response builder in the `saml2-idp`
+ * plugin — the HTTP-Redirect builder reads none of these settings and signs at the
+ * binding layer instead. Every scenario here therefore pins the SP to HTTP-POST,
+ * except the final one which documents what Redirect actually does.
+ */
+setup(200000);
+
+const HTTP_POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST';
+const HTTP_REDIRECT = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect';
+const RSA_OAEP = 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p';
+const AES_256_CBC = 'http://www.w3.org/2001/04/xmlenc#aes256-cbc';
+const AES_128_CBC = 'http://www.w3.org/2001/04/xmlenc#aes128-cbc';
+const RSA_1_5 = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5';
+
+/**
+ * Key transport algorithms AM permits (ApplicationServiceImpl). RSA1_5 is on that list
+ * but is padding-oracle vulnerable, so it must never be what AM falls back to.
+ */
+const STRONG_KEY_TRANSPORT = [RSA_OAEP];
+/** Data encryption algorithms AM permits, all of which are acceptable as a default. */
+const ALLOWED_DATA_ENCRYPTION = [AES_128_CBC, AES_256_CBC, 'http://www.w3.org/2009/xmlenc11#aes256-gcm'];
+
+let fixture: SamlLoopbackFixture;
+
+const captureResponse = () =>
+  captureSamlResponseXml(fixture.saml.domains, fixture.saml.clientOpenIdConfiguration, TEST_USER.username, TEST_USER.password);
+
+beforeAll(async () => {
+  fixture = await setupSamlLoopbackFixture();
+});
+
+beforeEach(async () => {
+  await fixture.resetToBaseline();
+  await fixture.setSamlIdpConfig({ protocolBinding: HTTP_POST });
+  await fixture.setSamlSettings({ nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME, assertionAttributes: null });
+  await fixture.clearFederatedUsers();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('SAML Encryption - assertion is encrypted', () => {
+  it(jira`should emit an encrypted assertion and no readable assertion ${'AM-7107'}`, async () => {
+    await fixture.setSamlSettings({ wantAssertionsEncrypted: true });
+
+    const xml = await captureResponse();
+
+    expect(hasEncryptedAssertion(xml)).toBe(true);
+    expect(hasPlaintextAssertion(xml)).toBe(false);
+    // The user's identity must not be readable in the transported response.
+    expect(xml).not.toContain(TEST_USER.username);
+    expect(xml).not.toContain(TEST_USER.email);
+  });
+
+  it(jira`should apply RSA-OAEP key transport with AES-256-CBC data encryption ${'AM-7107'}`, async () => {
+    await fixture.setSamlSettings({
+      wantAssertionsEncrypted: true,
+      keyTransportEncryptionAlgorithm: RSA_OAEP,
+      dataEncryptionAlgorithm: AES_256_CBC,
+    });
+
+    const { data, keyTransport } = encryptionAlgorithms(await captureResponse());
+
+    expect(data).toEqual(AES_256_CBC);
+    expect(keyTransport).toEqual(RSA_OAEP);
+  });
+
+  it(jira`should apply AES-128-CBC data encryption when configured ${'AM-7107'}`, async () => {
+    await fixture.setSamlSettings({
+      wantAssertionsEncrypted: true,
+      keyTransportEncryptionAlgorithm: RSA_OAEP,
+      dataEncryptionAlgorithm: AES_128_CBC,
+    });
+
+    expect(encryptionAlgorithms(await captureResponse()).data).toEqual(AES_128_CBC);
+  });
+
+  it(jira`should encrypt using default algorithms when none are configured ${'AM-7107'}`, async () => {
+    await fixture.setSamlSettings({
+      wantAssertionsEncrypted: true,
+      keyTransportEncryptionAlgorithm: null,
+      dataEncryptionAlgorithm: null,
+    });
+
+    const xml = await captureResponse();
+    const { data, keyTransport } = encryptionAlgorithms(xml);
+
+    expect(hasEncryptedAssertion(xml)).toBe(true);
+    // Assert the security property rather than pinning exact URIs: the defaults are
+    // chosen by the IdP and may legitimately change, but must never weaken to RSA1_5.
+    expect(keyTransport).not.toEqual(RSA_1_5);
+    expect(STRONG_KEY_TRANSPORT).toContain(keyTransport);
+    expect(ALLOWED_DATA_ENCRYPTION).toContain(data);
+  });
+});
+
+describe('SAML Encryption - signing and encryption combinations', () => {
+  it(jira`should sign the assertion in place when signing is enabled without encryption ${'AM-7108'}`, async () => {
+    await fixture.setSamlSettings({
+      wantResponseSigned: true,
+      wantAssertionsSigned: true,
+      wantAssertionsEncrypted: false,
+    });
+
+    const xml = await captureResponse();
+
+    expect(hasEncryptedAssertion(xml)).toBe(false);
+    expect(signatureLevels(xml)).toEqual({ response: true, assertion: true });
+  });
+
+  it(jira`should leave only a response-level signature when the assertion is encrypted ${'AM-7108'}`, async () => {
+    await fixture.setSamlSettings({
+      wantResponseSigned: true,
+      wantAssertionsSigned: false,
+      wantAssertionsEncrypted: true,
+    });
+
+    const xml = await captureResponse();
+
+    // Any assertion-level signature is sealed inside the ciphertext, so only the
+    // response-level signature remains observable.
+    expect(hasEncryptedAssertion(xml)).toBe(true);
+    expect(signatureLevels(xml)).toEqual({ response: true, assertion: false });
+  });
+
+  it(jira`should encrypt the assertion when both signing and encryption are enabled ${'AM-7108'}`, async () => {
+    await fixture.setSamlSettings({
+      wantResponseSigned: true,
+      wantAssertionsSigned: true,
+      wantAssertionsEncrypted: true,
+    });
+
+    const xml = await captureResponse();
+
+    expect(hasEncryptedAssertion(xml)).toBe(true);
+    expect(signatureLevels(xml).response).toBe(true);
+  });
+});
+
+describe('SAML Encryption - disabled', () => {
+  it(jira`should emit a readable assertion when encryption is disabled ${'AM-7111'}`, async () => {
+    await fixture.setSamlSettings({ wantAssertionsEncrypted: false });
+
+    const xml = await captureResponse();
+
+    expect(hasEncryptedAssertion(xml)).toBe(false);
+    expect(hasPlaintextAssertion(xml)).toBe(true);
+    expect(xml).toContain(TEST_USER.username);
+  });
+});
+
+describe('SAML Encryption - HTTP-Redirect binding', () => {
+  it(jira`should not encrypt the assertion under HTTP-Redirect binding ${'AM-7110'}`, async () => {
+    await fixture.setSamlIdpConfig({ protocolBinding: HTTP_REDIRECT });
+    await fixture.setSamlSettings({
+      wantAssertionsEncrypted: true,
+      keyTransportEncryptionAlgorithm: RSA_OAEP,
+      dataEncryptionAlgorithm: AES_256_CBC,
+    });
+
+    const xml = await captureResponse();
+
+    // The HTTP-Redirect response builder never reads the encryption settings, so the
+    // assertion is transported in the clear and authentication still succeeds — the
+    // configuration is silently ignored rather than refused.
+    expect(hasEncryptedAssertion(xml)).toBe(false);
+    expect(hasPlaintextAssertion(xml)).toBe(true);
+  });
+});

--- a/gravitee-am-test/specs/gateway/saml2/saml-negative.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-negative.jest.spec.ts
@@ -17,6 +17,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/glo
 import { jira } from '@specs-utils/jira';
 
 import { SamlLoopbackFixture, setupSamlLoopbackFixture, TEST_USER } from './fixtures/saml-loopback-fixture';
+import { initiateSamlFlow } from './fixtures/saml-response-capture';
 import { setup } from '../../test-fixture';
 
 /**
@@ -75,6 +76,24 @@ describe('SAML Negative - SP cannot validate the response signature', () => {
     const response = await fixture.attemptLogin(TEST_USER.username, TEST_USER.password);
 
     expect(response.text).toContain('social_authentication_failed');
+    expect(await fixture.findFederatedUsers()).toHaveLength(0);
+  });
+});
+
+describe('SAML Negative - SP entity ID the IdP cannot resolve', () => {
+  it(jira`should refuse the AuthnRequest when the SP entity ID is unknown to the IdP ${'AM-6960'}`, async () => {
+    // The IdP resolves the requesting SP by matching the AuthnRequest issuer against the
+    // application's SAML entityId. Changing it leaves the SP unregistered as far as the
+    // IdP is concerned, and the flow fails before any login form is presented.
+    await fixture.setSamlSettings({ entityId: 'unknown-sp-entity-id', assertionAttributes: null });
+
+    const { locations } = await initiateSamlFlow(fixture.saml.domains, fixture.saml.clientOpenIdConfiguration);
+    // The failure is reported on the error redirect, form-encoded, so '+' must become
+    // whitespace before decoding.
+    const surfaced = decodeURIComponent(locations.join(' ').replace(/\+/g, ' '));
+
+    expect(surfaced).toContain('error=technical_error');
+    expect(surfaced).toContain('can not be found');
     expect(await fixture.findFederatedUsers()).toHaveLength(0);
   });
 });

--- a/gravitee-am-test/specs/gateway/saml2/saml-permissive-config.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/saml2/saml-permissive-config.jest.spec.ts
@@ -122,9 +122,14 @@ describe('SAML permissive config - NameID and audiences', () => {
 });
 
 describe('SAML permissive config - legacy encryption algorithm', () => {
-  it(jira`should authenticate with RSA1_5 key transport for encrypted assertions ${'AM-7107'}`, async () => {
+  it(jira`should accept RSA1_5 key transport configuration without refusing the login ${'AM-7107'}`, async () => {
     // RSA1_5 is a deprecated key transport algorithm, still present in the allow-list
-    // at ApplicationServiceImpl. Authentication succeeds rather than being refused.
+    // at ApplicationServiceImpl, and the management API accepts it.
+    //
+    // This asserts only that the configuration does not break authentication. The
+    // fixture runs on HTTP-Redirect binding, where the response builder ignores the
+    // encryption settings entirely, so no encryption is actually applied here —
+    // saml-encryption.jest.spec.ts covers the algorithms under HTTP-POST.
     await fixture.setSamlSettings({
       nameIdMapping: SAML_LOOPBACK_TEST.EL_USERNAME,
       wantAssertionsEncrypted: true,


### PR DESCRIPTION
[AM-7446](https://gravitee.atlassian.net/browse/AM-7446)

## :id: Reference related issue. 
Adds 9 Jest tests covering SAML assertion encryption and signing, asserting on the
  decoded SAML response rather than on side effects.

  - Encrypted assertion is emitted and the user's details are not readable in the response
  - Encryption algorithms are applied as configured (RSA-OAEP, AES-256-CBC, AES-128-CBC)
  - Default algorithms are strong when none are configured
  - Signing and encryption combinations produce the expected response and assertion signatures
  - Disabling encryption produces a readable assertion

  Adds `fixtures/saml-response-capture.ts`, which captures and decodes the SAML response
  so these assertions are possible. No existing files are modified.

  Automates Xray cases AM-7107, AM-7108, AM-7110 and AM-7111.

## :pencil2: A description of the changes proposed in the pull request


## :memo: Test scenarios 


## :computer: Add screenshots for UI


## :books: Any other comments that will help with documentation


## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes


This is a nice example: https://github.com/gravitee-io/gravitee-access-management/pull/1822


[AM-7446]: https://gravitee.atlassian.net/browse/AM-7446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ