### PR TITLE
test: Keycloak SAML integration coverage (AM-7446)

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -689,6 +689,109 @@ jobs:
           when: always
           command: npm --prefix docker/local-stack run stack:down
 
+  run_jest_tests_keycloak_mongo:
+    parameters:
+      mongo_version:
+        type: string
+    machine:
+      image: ubuntu-2204:2024.04.4
+      docker_layer_caching: true
+    resource_class: large
+    environment:
+      REPOSITORY_TYPE: mongodb
+      GIO_MAX_MEM: 512m
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout:
+          method: full
+      - keeper/env-export:
+          secret-url: keeper://YeSlq7aKxJaAFSQupb-rkA/custom_field/base64
+          var-name: GRAVITEE_LICENSE_KEY
+      - install-jdk-25
+      - run:
+          name: Install test module dependencies
+          command: npm --prefix gravitee-am-test install
+      - run:
+          name: Create CIBA image
+          command: mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -f gravitee-am-ciba-delegated-service/pom.xml package jib:dockerBuild
+      - run:
+          name: Build stack
+          command: cp /tmp/workspace/*.zip docker/local-stack/dev/build-ctx && npm --prefix docker/local-stack run stack:init:build
+      - run:
+          name: Spin up stack with Keycloak and Mongo << parameters.mongo_version >>
+          command: MONGO_VERSION=<< parameters.mongo_version >> npm --prefix docker/local-stack run stack:ci:setup:keycloak:mongo
+      - run:
+          name: Check stack health before Keycloak tests
+          command: |
+            curl -fsS --retry 12 --retry-delay 5 --retry-all-errors -o /dev/null -u admin:adminadmin 'http://localhost:18093/_node/health?probes=jetty-http-server,management-repository'
+            curl -fsS --retry 12 --retry-delay 5 --retry-all-errors -o /dev/null -u admin:adminadmin 'http://localhost:18092/_node/health?probes=http-server,security-domain-sync'
+            curl -fsS --retry 24 --retry-delay 5 --retry-all-errors -o /dev/null 'http://localhost:8180/realms/saml-test/protocol/saml/descriptor'
+      - run:
+          name: Run Keycloak Jest tests
+          command: JEST_RETRIES=2 JEST_JUNIT_OUTPUT_NAME=junit-keycloak.xml npm --prefix gravitee-am-test run ci:keycloak
+      - store_test_results:
+          path: gravitee-am-test/jest-reports/junit
+      - store_artifacts:
+          path: gravitee-am-test/jest-reports
+          destination: jest-reports
+      - run:
+          name: Stop
+          when: always
+          command: npm --prefix docker/local-stack run stack:down
+
+  run_jest_tests_keycloak_psql:
+    parameters:
+      psql_version:
+        type: string
+    machine:
+      image: ubuntu-2204:2024.04.4
+      docker_layer_caching: true
+    resource_class: large
+    environment:
+      REPOSITORY_TYPE: jdbc
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://YeSlq7aKxJaAFSQupb-rkA/custom_field/base64
+          var-name: GRAVITEE_LICENSE_KEY
+      - install-jdk-25
+      - run:
+          name: Install test module dependencies
+          command: npm --prefix gravitee-am-test install
+      - run:
+          name: Create CIBA image
+          command: mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -f gravitee-am-ciba-delegated-service/pom.xml package jib:dockerBuild
+      - run:
+          name: Prepare JDBC plugins
+          command: npm --prefix docker/local-stack run stack:init:plugins:psql
+      - run:
+          name: Build stack
+          command: cp /tmp/workspace/*.zip docker/local-stack/dev/build-ctx && npm --prefix docker/local-stack run stack:init:build
+      - run:
+          name: Spin up stack with Keycloak and Postgres << parameters.psql_version >>
+          command: JDBC_PLUGINS=./plugins/jdbc POSTGRES_VERSION=<< parameters.psql_version >> npm --prefix docker/local-stack run stack:ci:setup:keycloak:psql
+      - run:
+          name: Check stack health before Keycloak tests
+          command: |
+            curl -fsS --retry 12 --retry-delay 5 --retry-all-errors -o /dev/null -u admin:adminadmin 'http://localhost:18093/_node/health?probes=jetty-http-server,management-repository'
+            curl -fsS --retry 12 --retry-delay 5 --retry-all-errors -o /dev/null -u admin:adminadmin 'http://localhost:18092/_node/health?probes=http-server,security-domain-sync'
+            curl -fsS --retry 24 --retry-delay 5 --retry-all-errors -o /dev/null 'http://localhost:8180/realms/saml-test/protocol/saml/descriptor'
+      - run:
+          name: Run Keycloak Jest tests
+          command: JEST_RETRIES=2 JEST_JUNIT_OUTPUT_NAME=junit-keycloak.xml npm --prefix gravitee-am-test run ci:keycloak
+      - store_test_results:
+          path: gravitee-am-test/jest-reports/junit
+      - store_artifacts:
+          path: gravitee-am-test/jest-reports
+          destination: jest-reports
+      - run:
+          name: Stop
+          when: always
+          command: npm --prefix docker/local-stack run stack:down
+
   run_playwright_tests_mongo:
     parameters:
       mongo_version:
@@ -2339,6 +2442,20 @@ workflows:
             parameters:
               mongo_version: ["8.2"]
       - run_jest_tests_cloud_psql:
+          context: cicd-orchestrator
+          requires:
+            - process_pull_request
+          matrix:
+            parameters:
+              psql_version: ["18.4"]
+      - run_jest_tests_keycloak_mongo:
+          context: cicd-orchestrator
+          requires:
+            - process_pull_request
+          matrix:
+            parameters:
+              mongo_version: ["8.2"]
+      - run_jest_tests_keycloak_psql:
           context: cicd-orchestrator
           requires:
             - process_pull_request

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -740,58 +740,6 @@ jobs:
           when: always
           command: npm --prefix docker/local-stack run stack:down
 
-  run_jest_tests_keycloak_psql:
-    parameters:
-      psql_version:
-        type: string
-    machine:
-      image: ubuntu-2204:2024.04.4
-      docker_layer_caching: true
-    resource_class: large
-    environment:
-      REPOSITORY_TYPE: jdbc
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://YeSlq7aKxJaAFSQupb-rkA/custom_field/base64
-          var-name: GRAVITEE_LICENSE_KEY
-      - install-jdk-25
-      - run:
-          name: Install test module dependencies
-          command: npm --prefix gravitee-am-test install
-      - run:
-          name: Create CIBA image
-          command: mvn -s /tmp/workspace/.gravitee.settings.xml -P gio-artifactory-snapshot -f gravitee-am-ciba-delegated-service/pom.xml package jib:dockerBuild
-      - run:
-          name: Prepare JDBC plugins
-          command: npm --prefix docker/local-stack run stack:init:plugins:psql
-      - run:
-          name: Build stack
-          command: cp /tmp/workspace/*.zip docker/local-stack/dev/build-ctx && npm --prefix docker/local-stack run stack:init:build
-      - run:
-          name: Spin up stack with Keycloak and Postgres << parameters.psql_version >>
-          command: JDBC_PLUGINS=./plugins/jdbc POSTGRES_VERSION=<< parameters.psql_version >> npm --prefix docker/local-stack run stack:ci:setup:keycloak:psql
-      - run:
-          name: Check stack health before Keycloak tests
-          command: |
-            curl -fsS --retry 12 --retry-delay 5 --retry-all-errors -o /dev/null -u admin:adminadmin 'http://localhost:18093/_node/health?probes=jetty-http-server,management-repository'
-            curl -fsS --retry 12 --retry-delay 5 --retry-all-errors -o /dev/null -u admin:adminadmin 'http://localhost:18092/_node/health?probes=http-server,security-domain-sync'
-            curl -fsS --retry 24 --retry-delay 5 --retry-all-errors -o /dev/null 'http://localhost:8180/realms/saml-test/protocol/saml/descriptor'
-      - run:
-          name: Run Keycloak Jest tests
-          command: JEST_RETRIES=2 JEST_JUNIT_OUTPUT_NAME=junit-keycloak.xml npm --prefix gravitee-am-test run ci:keycloak
-      - store_test_results:
-          path: gravitee-am-test/jest-reports/junit
-      - store_artifacts:
-          path: gravitee-am-test/jest-reports
-          destination: jest-reports
-      - run:
-          name: Stop
-          when: always
-          command: npm --prefix docker/local-stack run stack:down
-
   run_playwright_tests_mongo:
     parameters:
       mongo_version:
@@ -2455,13 +2403,6 @@ workflows:
           matrix:
             parameters:
               mongo_version: ["8.2"]
-      - run_jest_tests_keycloak_psql:
-          context: cicd-orchestrator
-          requires:
-            - process_pull_request
-          matrix:
-            parameters:
-              psql_version: ["18.4"]
       - run_playwright_tests_mongo:
           context: cicd-orchestrator
           requires:

--- a/docker/local-stack/dev/docker-compose.keycloak.yml
+++ b/docker/local-stack/dev/docker-compose.keycloak.yml
@@ -39,11 +39,11 @@
 #
 
 services:
-  # A signed SAML assertion from a real IdP is far larger than the Vert.x form-attribute
-  # default (8192) and larger still than the 2048 the Helm chart ships: Keycloak's is
-  # around 12 KB. Without raising this the gateway rejects the POST binding callback with
-  # a Netty "Size exceed allowed maximum capacity" and a 400. Real deployments federating
-  # to a third-party SAML IdP have to raise it too.
+  # A signed SAML assertion from a real IdP exceeds the gateway's default form-attribute
+  # limit: Keycloak's measures 12,004 bytes, and the Helm chart ships 2048. Without
+  # raising this the gateway rejects the POST binding callback with a Netty
+  # "Size exceed allowed maximum capacity" and a 400. Real deployments federating to a
+  # third-party SAML IdP have to raise it too.
   gateway:
     environment:
       GRAVITEE_HTTP_MAXFORMATTRIBUTESIZE: 65536

--- a/docker/local-stack/dev/docker-compose.keycloak.yml
+++ b/docker/local-stack/dev/docker-compose.keycloak.yml
@@ -1,0 +1,73 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Local-stack overlay running Keycloak as a real third-party SAML identity
+# provider, so AM's SAML SP plugin (saml2-generic-am-idp) can be exercised
+# against something other than AM itself.
+#
+# Realms are imported at start-up from ./keycloak/*.json — nothing is
+# configured by hand, so a fresh container is always in a known state.
+#
+#   saml-test     SAML client + test user; the realm used by most scenarios
+#   saml-test-2   second realm, used only by the multi-entity metadata cases
+#
+# Descriptor (IdP metadata):
+#   http://keycloak:8080/realms/saml-test/protocol/saml/descriptor   (compose network)
+#   http://localhost:8180/realms/saml-test/protocol/saml/descriptor  (from host)
+#
+# Admin console: http://localhost:8180  (admin / admin)
+#
+# Realm signing keys are deliberately NOT included in the import files, so no
+# private key is committed. Keycloak generates a fresh key pair per container
+# and tests read the certificate from the descriptor at run time.
+#
+# Compose:
+#   docker compose -f dev/docker-compose.yml -f dev/docker-compose-dev.yml \
+#                  -f dev/docker-compose.mongo.yml -f dev/docker-compose.keycloak.yml up -d
+#
+
+services:
+  # A signed SAML assertion from a real IdP is far larger than the Vert.x form-attribute
+  # default (8192) and larger still than the 2048 the Helm chart ships: Keycloak's is
+  # around 12 KB. Without raising this the gateway rejects the POST binding callback with
+  # a Netty "Size exceed allowed maximum capacity" and a 400. Real deployments federating
+  # to a third-party SAML IdP have to raise it too.
+  gateway:
+    environment:
+      GRAVITEE_HTTP_MAXFORMATTRIBUTESIZE: 65536
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    command: ['start-dev', '--import-realm', '--health-enabled=true']
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      # Keep the advertised issuer stable regardless of which host reaches it,
+      # so metadata fetched by the gateway and by the test runner agree.
+      KC_HOSTNAME: http://keycloak:8080
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: 'true'
+      KC_HTTP_ENABLED: 'true'
+    volumes:
+      - ./keycloak/realm-saml-test.json:/opt/keycloak/data/import/realm-saml-test.json:ro
+      - ./keycloak/realm-saml-test-2.json:/opt/keycloak/data/import/realm-saml-test-2.json:ro
+    ports:
+      - 8180:8080
+    healthcheck:
+      # The management port exposes /health/ready from Keycloak 25 onwards.
+      test: ['CMD-SHELL', 'exec 3<>/dev/tcp/127.0.0.1/9000; echo -e "GET /health/ready HTTP/1.1\nHost: localhost\n\n" >&3; grep -q "\"status\": \"UP\"" <&3']
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 20s

--- a/docker/local-stack/dev/keycloak/realm-saml-test-2.json
+++ b/docker/local-stack/dev/keycloak/realm-saml-test-2.json
@@ -1,0 +1,6 @@
+{
+  "realm": "saml-test-2",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false
+}

--- a/docker/local-stack/dev/keycloak/realm-saml-test.json
+++ b/docker/local-stack/dev/keycloak/realm-saml-test.json
@@ -1,0 +1,89 @@
+{
+  "realm": "saml-test",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "testuser@example.com",
+      "firstName": "Test",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Test1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "default-roles-saml-test"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "http://localhost/am",
+      "name": "Gravitee AM (SAML SP)",
+      "enabled": true,
+      "protocol": "saml",
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "redirectUris": [
+        "http://localhost:8092/*",
+        "http://gateway:8092/*"
+      ],
+      "attributes": {
+        "saml.assertion.signature": "true",
+        "saml.server.signature": "true",
+        "saml.signature.algorithm": "RSA_SHA256",
+        "saml_name_id_format": "email",
+        "saml_force_name_id_format": "true",
+        "saml.client.signature": "false",
+        "saml.force.post.binding": "true",
+        "saml.authnstatement": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "friendly.name": "email",
+            "attribute.name": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+            "attribute.nameformat": "URI Reference"
+          }
+        },
+        {
+          "name": "given name",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "firstName",
+            "friendly.name": "givenName",
+            "attribute.name": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+            "attribute.nameformat": "URI Reference"
+          }
+        },
+        {
+          "name": "family name",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "lastName",
+            "friendly.name": "surname",
+            "attribute.name": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+            "attribute.nameformat": "URI Reference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docker/local-stack/local-stack.sh
+++ b/docker/local-stack/local-stack.sh
@@ -102,13 +102,13 @@ FULL=0
 DETACH=1
 LICENSE_FILE="$DEV/license/gravitee-universe-v4.key"
 # opt-in extras (plain vars — keep this script bash-3.2 compatible, macOS default)
-WANT_UI=0; WANT_WIREMOCK=1; WANT_CIBA=0; WANT_OPENFGA=0; WANT_KAFKA=0; WANT_MTLS=0; WANT_SPIRE=0; WANT_CLOUD=0
+WANT_UI=0; WANT_WIREMOCK=1; WANT_CIBA=0; WANT_OPENFGA=0; WANT_KAFKA=0; WANT_MTLS=0; WANT_SPIRE=0; WANT_CLOUD=0; WANT_KEYCLOAK=0
 
 want_set() { # want_set <name> <value>
   case "$1" in
     ui) WANT_UI="$2" ;; wiremock) WANT_WIREMOCK="$2" ;; ciba) WANT_CIBA="$2" ;;
     openfga) WANT_OPENFGA="$2" ;; kafka) WANT_KAFKA="$2" ;; mtls) WANT_MTLS="$2" ;;
-    spire) WANT_SPIRE="$2" ;; cloud) WANT_CLOUD="$2" ;; *) return 1 ;;
+    spire) WANT_SPIRE="$2" ;; cloud) WANT_CLOUD="$2" ;; keycloak) WANT_KEYCLOAK="$2" ;; *) return 1 ;;
   esac
 }
 
@@ -142,7 +142,9 @@ SERVICES
   --full               UI + wiremock + ciba + openfga + kafka + mtls
                        (the union the jest gateway + playwright suites need)
   --with a,b,...       opt-in extras individually:
-                       ui,wiremock,ciba,openfga,kafka,mtls,spire,cloud
+                       ui,wiremock,ciba,openfga,kafka,mtls,spire,cloud,keycloak
+  --keycloak           start Keycloak on :8180 as a third-party SAML IdP
+                       (realms saml-test / saml-test-2 imported at start-up)
   --cloud              managed-cloud mode: start the cockpit mock and point the
                        management API at it (console/cloud command path, e.g.
                        Cockpit access points -> entrypoints)
@@ -200,6 +202,7 @@ while [ $# -gt 0 ]; do
                    want_set "$s" 1 || die "unknown --with service: $s"
                  done; shift 2 ;;
     --cloud)     WANT_CLOUD=1; shift ;;
+    --keycloak)  WANT_KEYCLOAK=1; shift ;;
     --build)     BUILD_MODE="force"; shift ;;
     --quick|--no-build) BUILD_MODE="skip"; shift ;;
     --license)   LICENSE_FILE="${2:?--license needs a path}"; shift 2 ;;
@@ -251,6 +254,7 @@ build_compose_files() {
   if [ "$WANT_UI" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose-ui.yml"); fi
   if [ "$WANT_SPIRE" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.spire.yml"); fi
   if [ "$WANT_CLOUD" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.cloud.yml"); fi
+  if [ "$WANT_KEYCLOAK" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.keycloak.yml"); fi
   if [ "$PULLED" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.images.yml"); fi
   if [ -f "$LOCAL_OVERRIDE" ]; then COMPOSE_FILES+=(-f "$LOCAL_OVERRIDE"); fi   # per-dev overrides win
 }
@@ -268,6 +272,7 @@ build_service_list() {
   [ "$WANT_KAFKA" -eq 1 ]    && SERVICES+=(kafka)
   [ "$WANT_MTLS" -eq 1 ]     && SERVICES+=(gateway-mtls)
   [ "$WANT_CLOUD" -eq 1 ]    && SERVICES+=(cockpit-mock)
+  [ "$WANT_KEYCLOAK" -eq 1 ] && SERVICES+=(keycloak)
   if [ "$WANT_SPIRE" -eq 1 ]; then
     SERVICES+=(spire-perms-init spire-server spire-bootstrap spire-agent spire-oidc)
   fi
@@ -491,6 +496,7 @@ print_ready() {
   printf '  Gateway        http://localhost:8092\n'
   printf '  Management API http://localhost:8093/management\n'
   [ "$WANT_UI" -eq 1 ] && printf '  Console UI     http://localhost:4200\n'
+  [ "$WANT_KEYCLOAK" -eq 1 ] && printf '  Keycloak       http://localhost:8180  (admin/admin)\n'
   printf '  Mailbox        http://localhost:5080\n'
   printf '  Admin login    admin / adminadmin   (org/env: DEFAULT)\n'
   printf '%s  Stop with: ./local-stack.sh down%s\n\n' "$C_DIM" "$C_RST"

--- a/docker/local-stack/package.json
+++ b/docker/local-stack/package.json
@@ -14,6 +14,8 @@
     "stack:ci:setup:psql": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.postgres.yml up -d",
     "stack:ci:setup:cloud:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose.cloud.yml up -d",
     "stack:ci:setup:cloud:psql": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.postgres.yml -f dev/docker-compose.cloud.yml up -d",
+    "stack:ci:setup:keycloak:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose.keycloak.yml up -d",
+    "stack:ci:setup:keycloak:psql": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.postgres.yml -f dev/docker-compose.keycloak.yml up -d",
     "stack:ci:pw:setup:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose-ui.yml up -d",
     "stack:ci:pw:setup:psql": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.postgres.yml -f dev/docker-compose-ui.yml up -d",
     "stack:ci:pw:setup:cloud:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose-ui.yml -f dev/docker-compose.cloud.yml up -d",
@@ -23,10 +25,8 @@
     "stack:dev:spire": "docker compose -f dev/docker-compose.spire.yml up -d",
     "stack:dev:setup:kerberos": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-dev.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose-kerberos.yml up -d",
     "stack:dev:setup:psql": "JDBC_PLUGINS=./plugins/jdbc docker compose -f dev/docker-compose.yml -f dev/docker-compose-dev.yml -f dev/docker-compose.postgres.yml up -d",
-
     "stack:dev:pw:setup:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-dev.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose-ui.yml up -d",
     "stack:dev:pw:setup:psql": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-dev.yml -f dev/docker-compose.postgres.yml -f dev/docker-compose-ui.yml up -d",
-
     "stack:dev:mongo": "yarn run stack:init:ciba && yarn run stack:init:build && yarn run stack:dev:setup:mongo",
     "stack:dev:psql": "yarn run stack:init:ciba && yarn run stack:init:plugins:psql && yarn run stack:init:build && yarn run stack:dev:setup:psql",
     "stack:dev:mailbox": "docker compose -f dev/docker-compose.yml up -d smtp",

--- a/docker/local-stack/package.json
+++ b/docker/local-stack/package.json
@@ -15,7 +15,6 @@
     "stack:ci:setup:cloud:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose.cloud.yml up -d",
     "stack:ci:setup:cloud:psql": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.postgres.yml -f dev/docker-compose.cloud.yml up -d",
     "stack:ci:setup:keycloak:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose.keycloak.yml up -d",
-    "stack:ci:setup:keycloak:psql": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.postgres.yml -f dev/docker-compose.keycloak.yml up -d",
     "stack:ci:pw:setup:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose-ui.yml up -d",
     "stack:ci:pw:setup:psql": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.postgres.yml -f dev/docker-compose-ui.yml up -d",
     "stack:ci:pw:setup:cloud:mongo": "docker compose -f dev/docker-compose.yml -f dev/docker-compose-ci.yml -f dev/docker-compose.mongo.yml -f dev/docker-compose-ui.yml -f dev/docker-compose.cloud.yml up -d",

--- a/gravitee-am-test/package.json
+++ b/gravitee-am-test/package.json
@@ -12,6 +12,7 @@
     "ci:management:parallel": "jest --maxWorkers=2 --no-cache --bail --config=api/config/ci.config.js specs/management",
     "ci:gateway": "jest --runInBand --no-cache --bail --config=api/config/ci.config.js specs/gateway",
     "ci:cloud": "jest --runInBand --no-cache --bail --config=api/config/ci.config.js specs/cloud",
+    "ci:keycloak": "jest --runInBand --no-cache --bail --config=api/config/ci.config.js specs/keycloak",
     "ci:gateway:parallel": "jest --maxWorkers=2 --no-cache --bail --config=api/config/ci.config.js specs/gateway",
     "ci:migration": "jest --runInBand --no-cache --bail --config=api/config/ci.config.js specs/migration",
     "migration:seed": "cross-env TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register -r tsconfig-paths/register migration-seeding/bootstrap.ts",

--- a/gravitee-am-test/specs/gateway/reporters/org-reporter-kafka.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/reporters/org-reporter-kafka.jest.spec.ts
@@ -45,7 +45,7 @@ describe('Kafka Reporter - Org Level Gateway', () => {
 
       const received: KafkaAuditPayload = await waitForKafkaMessage(
         topic,
-        { predicate: (msg) => msg.type === 'USER_LOGIN' },
+        { predicate: (msg) => msg.type === 'USER_LOGIN' && msg.referenceId === fixture.domain.id },
         () =>
           loginUserNameAndPassword(
             fixture.application.settings.oauth.clientId,

--- a/gravitee-am-test/specs/keycloak/fixtures/keycloak-realm.ts
+++ b/gravitee-am-test/specs/keycloak/fixtures/keycloak-realm.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+
+/** Keycloak as the gateway container reaches it, and as this test process reaches it. */
+const KEYCLOAK_INTERNAL = process.env.KEYCLOAK_INTERNAL_URL || 'http://keycloak:8080';
+const KEYCLOAK_EXTERNAL = process.env.KEYCLOAK_URL || 'http://localhost:8180';
+
+export const KEYCLOAK_TEST = {
+  REALM: 'saml-test',
+  SECOND_REALM: 'saml-test-2',
+  USERNAME: 'testuser',
+  PASSWORD: 'Test1234!',
+  EMAIL: 'testuser@example.com',
+  /** Client ID registered in the imported realm; also AM's SP entity ID. */
+  SP_ENTITY_ID: 'http://localhost/am',
+  DOMAIN_PREFIX: 'kc-saml',
+  REDIRECT_URI: 'https://auth-nightly.gravitee.io/myApp/callback',
+} as const;
+
+export const HTTP_POST_BINDING = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST';
+export const HTTP_REDIRECT_BINDING = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect';
+
+/**
+ * Rewrite a Keycloak-issued URL so this process can reach it.
+ *
+ * Keycloak advertises itself as `keycloak:8080` because that is how the gateway
+ * container reaches it, and that hostname must stay in the IdP configuration. Every
+ * URL Keycloak then generates — redirects, form actions — carries that host, which is
+ * unresolvable from the test runner, so it is swapped for the published port.
+ */
+export const toReachableUrl = (url: string): string => url.split(KEYCLOAK_INTERNAL).join(KEYCLOAK_EXTERNAL);
+
+export const realmDescriptorUrl = (realm: string, external = false): string =>
+  `${external ? KEYCLOAK_EXTERNAL : KEYCLOAK_INTERNAL}/realms/${realm}/protocol/saml/descriptor`;
+
+export const realmSsoUrl = (realm: string): string => `${KEYCLOAK_INTERNAL}/realms/${realm}/protocol/saml`;
+
+export const realmEntityId = (realm: string): string => `${KEYCLOAK_INTERNAL}/realms/${realm}`;
+
+/** Fetch a realm's published descriptor as XML. */
+export async function fetchRealmDescriptor(realm: string): Promise<string> {
+  const response = await performGet(realmDescriptorUrl(realm, true), '').expect(200);
+  return response.text;
+}
+
+/** Extract the first signing certificate from a descriptor, wrapped as PEM. */
+export function extractCertificatePem(descriptorXml: string): string {
+  const match = /<(?:ds:)?X509Certificate>([\s\S]*?)<\/(?:ds:)?X509Certificate>/.exec(descriptorXml);
+  expect(match?.[1]).toEqual(expect.any(String));
+  const body = match![1].replace(/\s+/g, '');
+  const wrapped = body.match(/.{1,64}/g)!.join('\n');
+  return `-----BEGIN CERTIFICATE-----\n${wrapped}\n-----END CERTIFICATE-----`;
+}

--- a/gravitee-am-test/specs/keycloak/fixtures/keycloak-saml-fixture.ts
+++ b/gravitee-am-test/specs/keycloak/fixtures/keycloak-saml-fixture.ts
@@ -70,6 +70,8 @@ export interface KeycloakSamlFixture {
   findSamlSignInLink: () => Promise<string | undefined>;
   /** Restore the IdP configuration captured at setup. */
   resetToBaseline: () => Promise<void>;
+  /** Block until the SAML sign-in link renders, redeploying the IdP if the fetch lost. */
+  waitForSamlIdpReady: () => Promise<void>;
   /** Remove every federated user, so each scenario starts clean. */
   clearFederatedUsers: () => Promise<void>;
   /** Signing certificate of any realm, read from its descriptor. */
@@ -283,6 +285,28 @@ export const setupKeycloakSamlFixture = async (
       tamper: (xml: string) => string,
     ): Promise<BasicResponse> => login(username, password, tamper);
 
+    /**
+     * Wait for the SAML IdP to be usable.
+     *
+     * In METADATA_URL mode the IdP fetches the descriptor once, at deploy time. Under load
+     * that fetch can lose, leaving the IdP with no signInUrl so the sign-in link never
+     * renders — the test then fails for a reason unrelated to what it asserts. Re-saving
+     * the configuration re-initialises the IdP and re-runs the fetch.
+     */
+    const waitForSamlIdpReady = async (): Promise<void> => {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        for (let poll = 0; poll < 10; poll++) {
+          if (await findSamlSignInLink()) {
+            return;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+        const current = JSON.parse(samlIdp.configuration);
+        await setSamlIdpConfig(current);
+      }
+      throw new Error('SAML IdP never became ready — the sign-in link did not render');
+    };
+
     const findFederatedUsers = async (query?: string): Promise<User[]> => {
       // An empty query does not list everything — fall back to the full listing.
       const page = query ? await listUsers(domain!.id, accessToken!, query) : await getAllUsers(domain!.id, accessToken!);
@@ -313,6 +337,7 @@ export const setupKeycloakSamlFixture = async (
       findFederatedUsers,
       findSamlSignInLink,
       resetToBaseline,
+      waitForSamlIdpReady,
       clearFederatedUsers,
       certificateFor,
       loginWithTamperedAssertion,

--- a/gravitee-am-test/specs/keycloak/fixtures/keycloak-saml-fixture.ts
+++ b/gravitee-am-test/specs/keycloak/fixtures/keycloak-saml-fixture.ts
@@ -1,0 +1,335 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  KEYCLOAK_TEST,
+  HTTP_POST_BINDING,
+  HTTP_REDIRECT_BINDING,
+  extractCertificatePem,
+  fetchRealmDescriptor,
+  realmDescriptorUrl,
+  realmSsoUrl,
+  toReachableUrl,
+} from './keycloak-realm';
+import { CookieJar, getWithJar, postWithJar, submitAutoPostForm } from './saml-http-flow';
+import { expect } from '@jest/globals';
+import cheerio from 'cheerio';
+
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { safeDeleteDomain, setupDomainForTest, waitForDomainSync } from '@management-commands/domain-management-commands';
+import { createIdp, updateIdp } from '@management-commands/idp-management-commands';
+import { getAllCertificates } from '@management-commands/certificate-management-commands';
+import { createTestApp } from '@utils-commands/application-commands';
+import { listUsers, getAllUsers, deleteUser } from '@management-commands/user-management-commands';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { initiateLoginFlow } from '@gateway-commands/login-commands';
+import { uniqueName, BasicResponse } from '@utils-commands/misc';
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import { User } from '@management-models/User';
+
+/**
+ * Environment for exercising AM's SAML SP plugin against Keycloak rather than
+ * against another AM domain.
+ *
+ * Keycloak is started by `./local-stack.sh up --keycloak` with its realms imported
+ * from checked-in JSON. Realm signing keys are generated per container, so the IdP
+ * certificate is read from the published descriptor at setup rather than hardcoded.
+ */
+
+export interface KeycloakSamlFixture {
+  domain: Domain;
+  application: Application;
+  samlIdp: any;
+  accessToken: string;
+  openIdConfiguration: any;
+  /** The IdP signing certificate, read from the realm descriptor at setup. */
+  idpCertificatePem: string;
+
+  /** Replace the SAML IdP configuration wholesale and wait for the gateway to pick it up. */
+  setSamlIdpConfig: (configuration: Record<string, unknown>) => Promise<void>;
+  /** Authenticate through Keycloak; resolves to the final response of the flow. */
+  login: (username: string, password: string) => Promise<BasicResponse>;
+  /** Federated users created in the AM domain by a successful login. */
+  findFederatedUsers: (query?: string) => Promise<User[]>;
+  /** The SAML sign-in link on the AM login page, or undefined when the IdP failed to deploy. */
+  findSamlSignInLink: () => Promise<string | undefined>;
+  /** Restore the IdP configuration captured at setup. */
+  resetToBaseline: () => Promise<void>;
+  /** Remove every federated user, so each scenario starts clean. */
+  clearFederatedUsers: () => Promise<void>;
+  /** Signing certificate of any realm, read from its descriptor. */
+  certificateFor: (realm: string) => Promise<string>;
+  /**
+   * Authenticate, but rewrite the SAML response before AM receives it.
+   *
+   * Used to prove AM refuses assertions it should refuse — the IdP itself will only
+   * ever mint well-formed ones, so the tampering has to happen in transit.
+   */
+  loginWithTamperedAssertion: (username: string, password: string, tamper: (xml: string) => string) => Promise<BasicResponse>;
+  /** The working MANUAL-mode configuration, with optional overrides applied. */
+  manualConfigWith: (overrides: Record<string, unknown>) => Record<string, unknown>;
+  /** Id of a certificate in the AM domain, for signing AuthnRequests. */
+  signingCertificateId: string;
+
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * MANUAL-mode configuration for a SAML IdP pointed at a Keycloak realm.
+ *
+ * Every key below is declared in the saml2-generic-am-idp schema. Unknown keys are
+ * silently dropped rather than rejected, so it is worth checking the plugin's
+ * schema-form.json before adding one.
+ */
+export function manualModeConfig(
+  realm: string,
+  certificatePem: string,
+  protocolBinding: string,
+  graviteeCertificateId: string,
+): Record<string, unknown> {
+  return {
+    idpMetadataProvider: 'MANUAL',
+    entityId: KEYCLOAK_TEST.SP_ENTITY_ID,
+    signInUrl: realmSsoUrl(realm),
+    signOutUrl: realmSsoUrl(realm),
+    signingCertificate: certificatePem,
+    protocolBinding,
+    nameIdFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+    // Keycloak's descriptor advertises WantAuthnRequestsSigned, so AM must sign.
+    requestSigned: true,
+    requestSigningAlgorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+    graviteeCertificate: graviteeCertificateId,
+  };
+}
+
+/**
+ * METADATA_URL-mode configuration: AM derives the endpoints and signing certificate
+ * from the IdP's published descriptor instead of each being supplied by hand.
+ */
+export function metadataUrlModeConfig(realm: string, graviteeCertificateId: string): Record<string, unknown> {
+  return {
+    idpMetadataProvider: 'METADATA_URL',
+    idpMetadataUrl: realmDescriptorUrl(realm),
+    entityId: KEYCLOAK_TEST.SP_ENTITY_ID,
+    requestSigned: true,
+    requestSigningAlgorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+    graviteeCertificate: graviteeCertificateId,
+  };
+}
+
+/**
+ * Submit Keycloak's login form.
+ *
+ * Keycloak renders its own form with a one-time action URL rather than the XSRF-token
+ * shape AM uses, so the shared login helper cannot drive it.
+ */
+async function submitKeycloakLogin(jar: CookieJar, loginPage: BasicResponse, username: string, password: string): Promise<BasicResponse> {
+  const dom = cheerio.load(loginPage.text);
+  const action = dom('form#kc-form-login').attr('action') ?? dom('form').attr('action');
+  expect(action).toEqual(expect.any(String));
+
+  return postWithJar(jar, toReachableUrl(action!), { username, password });
+}
+
+export const setupKeycloakSamlFixture = async (
+  realm: string = KEYCLOAK_TEST.REALM,
+  protocolBinding: string = HTTP_REDIRECT_BINDING,
+): Promise<KeycloakSamlFixture> => {
+  let domain: Domain | null = null;
+  let accessToken: string | null = null;
+
+  try {
+    accessToken = await requestAdminAccessToken();
+
+    const idpCertificatePem = extractCertificatePem(await fetchRealmDescriptor(realm));
+
+    const setupResult = await setupDomainForTest(uniqueName(KEYCLOAK_TEST.DOMAIN_PREFIX, true).toLowerCase(), {
+      accessToken,
+      waitForStart: true,
+    });
+    domain = setupResult.domain;
+    const openIdConfiguration = setupResult.oidcConfig;
+
+    // Keycloak's descriptor sets WantAuthnRequestsSigned, so AM signs its AuthnRequests
+    // using a certificate from the domain. Every domain is created with a default one.
+    const certificates = await getAllCertificates(domain.id, accessToken);
+    const signingCertificate = [...certificates][0];
+    expect(signingCertificate?.id).toEqual(expect.any(String));
+
+    // Wrap the mutation so the sync watermark is captured before the call — creating the
+    // IdP and then polling separately races the deployer and can miss the cycle entirely.
+    const samlIdp = await waitForSyncAfter(domain.id, () =>
+      createIdp(domain!.id, accessToken!, {
+        name: `keycloak-saml-${realm}`,
+        type: 'saml2-generic-am-idp',
+        configuration: JSON.stringify(manualModeConfig(realm, idpCertificatePem, protocolBinding, signingCertificate.id)),
+        external: true,
+      }),
+    );
+
+    const application = await waitForSyncAfter(domain.id, () =>
+      createTestApp('kc-saml-app', domain!, accessToken!, 'web', {
+        settings: {
+          oauth: {
+            redirectUris: [KEYCLOAK_TEST.REDIRECT_URI],
+            grantTypes: ['authorization_code'],
+            responseTypes: ['code'],
+          },
+        },
+        identityProviders: new Set([{ identity: samlIdp.id, priority: -1 }]),
+      }),
+    );
+
+    const setSamlIdpConfig = async (configuration: Record<string, unknown>): Promise<void> => {
+      await waitForSyncAfter(domain!.id, () =>
+        updateIdp(
+          domain!.id,
+          accessToken!,
+          { name: samlIdp.name, type: samlIdp.type, configuration: JSON.stringify(configuration) },
+          samlIdp.id,
+        ),
+      );
+    };
+
+    const findSamlSignInLink = async (): Promise<string | undefined> => {
+      const authorize = await initiateLoginFlow(application.settings.oauth.clientId, openIdConfiguration, domain!);
+      const cookies = authorize.headers['set-cookie'];
+      const loginPage = await performGet(authorize.headers['location'], '', cookies ? { Cookie: cookies } : {});
+      const dom = cheerio.load(loginPage.text ?? '');
+      return dom('.btn-saml2-generic-am-idp').attr('href') || dom('a[href*="saml2"]').attr('href');
+    };
+
+    const login = async (username: string, password: string, tamper?: (xml: string) => string): Promise<BasicResponse> => {
+      const jar = new CookieJar();
+
+      const authorize = await initiateLoginFlow(application.settings.oauth.clientId, openIdConfiguration, domain!);
+      const loginPageUrl = authorize.headers['location'];
+      jar.store(loginPageUrl, authorize.headers['set-cookie']);
+
+      const loginPage = await getWithJar(jar, loginPageUrl);
+      const dom = cheerio.load(loginPage.text ?? '');
+      const samlLink = dom('.btn-saml2-generic-am-idp').attr('href') || dom('a[href*="saml2"]').attr('href');
+      expect(samlLink).toEqual(expect.any(String));
+
+      // AM embeds the IdP URL and AuthnRequest directly in the sign-in link, so it points
+      // at the container hostname and must be rewritten for this process.
+      // Getting to Keycloak's login form takes a different number of hops depending on
+      // how the IdP is configured: manual mode redirects straight there, metadata mode
+      // adds a hop, and POST binding arrives as an auto-submitting form.
+      let current = await getWithJar(jar, toReachableUrl(samlLink!));
+      for (let hop = 0; hop < 5; hop++) {
+        if (current.status === 200 && (current.text ?? '').includes('SAMLRequest')) {
+          current = await submitAutoPostForm(jar, current);
+          continue;
+        }
+        if (current.status >= 300 && current.status < 400 && current.headers?.location) {
+          current = await getWithJar(jar, toReachableUrl(current.headers['location']));
+          continue;
+        }
+        break;
+      }
+
+      current = await submitKeycloakLogin(jar, current, username, password);
+
+      for (let hop = 0; hop < 8; hop++) {
+        if (current.status >= 300 && current.status < 400 && current.headers?.location) {
+          const next = toReachableUrl(current.headers['location']);
+          // Stop at the application's redirect URI — it is outside the stack and the
+          // authorization code on it is what the caller asserts against.
+          if (next.startsWith(KEYCLOAK_TEST.REDIRECT_URI)) {
+            return current;
+          }
+          current = await getWithJar(jar, next);
+          continue;
+        }
+        if (current.status === 200 && (current.text ?? '').includes('SAMLResponse')) {
+          current = await submitAutoPostForm(jar, current, tamper);
+          continue;
+        }
+        break;
+      }
+      return current;
+    };
+
+    const baselineIdpConfig = manualModeConfig(realm, idpCertificatePem, protocolBinding, signingCertificate.id);
+
+    const manualConfigWith = (overrides: Record<string, unknown>): Record<string, unknown> => ({
+      ...baselineIdpConfig,
+      ...overrides,
+    });
+
+    const resetToBaseline = async (): Promise<void> => setSamlIdpConfig(baselineIdpConfig);
+
+    const certificateFor = async (targetRealm: string): Promise<string> => extractCertificatePem(await fetchRealmDescriptor(targetRealm));
+
+    const loginWithTamperedAssertion = async (
+      username: string,
+      password: string,
+      tamper: (xml: string) => string,
+    ): Promise<BasicResponse> => login(username, password, tamper);
+
+    const findFederatedUsers = async (query?: string): Promise<User[]> => {
+      // An empty query does not list everything — fall back to the full listing.
+      const page = query ? await listUsers(domain!.id, accessToken!, query) : await getAllUsers(domain!.id, accessToken!);
+      return page.data ?? [];
+    };
+
+    const clearFederatedUsers = async (): Promise<void> => {
+      for (const user of await findFederatedUsers()) {
+        await deleteUser(domain!.id, accessToken!, user.id);
+      }
+    };
+
+    const cleanup = async () => {
+      if (domain?.id && accessToken) {
+        await safeDeleteDomain(domain.id, accessToken);
+      }
+    };
+
+    return {
+      domain,
+      application,
+      samlIdp,
+      accessToken,
+      openIdConfiguration,
+      idpCertificatePem,
+      setSamlIdpConfig,
+      login,
+      findFederatedUsers,
+      findSamlSignInLink,
+      resetToBaseline,
+      clearFederatedUsers,
+      certificateFor,
+      loginWithTamperedAssertion,
+      manualConfigWith,
+      signingCertificateId: signingCertificate.id,
+      cleanup,
+    };
+  } catch (error) {
+    if (domain?.id && accessToken) {
+      try {
+        await safeDeleteDomain(domain.id, accessToken);
+      } catch (cleanupError) {
+        console.error('Failed to cleanup Keycloak SAML fixture after setup failure:', cleanupError);
+      }
+    }
+    throw error;
+  }
+};
+
+export { KEYCLOAK_TEST, HTTP_POST_BINDING, HTTP_REDIRECT_BINDING } from './keycloak-realm';

--- a/gravitee-am-test/specs/keycloak/fixtures/saml-http-flow.ts
+++ b/gravitee-am-test/specs/keycloak/fixtures/saml-http-flow.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import cheerio from 'cheerio';
+
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { BasicResponse } from '@utils-commands/misc';
+
+import { toReachableUrl } from './keycloak-realm';
+
+/**
+ * Minimal per-host cookie store.
+ *
+ * The flow crosses two servers that each maintain their own session — AM remembers the
+ * pending authorize request, Keycloak remembers the authenticated user. A browser keeps
+ * those apart; sharing one jar hands AM Keycloak's session and the login never completes.
+ */
+export class CookieJar {
+  private readonly byHost = new Map<string, Map<string, string>>();
+
+  private static host(url: string): string {
+    return new URL(url).host;
+  }
+
+  store(url: string, setCookie?: string | string[]): void {
+    if (!setCookie) {
+      return;
+    }
+    const host = CookieJar.host(url);
+    const jar = this.byHost.get(host) ?? new Map<string, string>();
+    for (const raw of Array.isArray(setCookie) ? setCookie : [setCookie]) {
+      const [pair] = raw.split(';');
+      const index = pair.indexOf('=');
+      if (index > 0) {
+        jar.set(pair.slice(0, index).trim(), pair.slice(index + 1).trim());
+      }
+    }
+    this.byHost.set(host, jar);
+  }
+
+  headerFor(url: string): Record<string, string> {
+    const jar = this.byHost.get(CookieJar.host(url));
+    if (!jar || jar.size === 0) {
+      return {};
+    }
+    return { Cookie: [...jar.entries()].map(([name, value]) => `${name}=${value}`).join('; ') };
+  }
+}
+
+/** GET that sends and records cookies for the target host only. */
+export async function getWithJar(jar: CookieJar, url: string): Promise<BasicResponse> {
+  const response = await performGet(url, '', jar.headerFor(url));
+  jar.store(url, response.headers['set-cookie']);
+  return response;
+}
+
+/**
+ * Form POST that sends and records cookies for the target host only.
+ *
+ * The body is url-encoded by hand rather than using the shared form helper, which sends
+ * multipart/form-data: Netty's multipart decoder caps attribute size and a signed SAML
+ * assertion exceeds it, which the gateway reports as "Size exceed allowed maximum
+ * capacity". Browsers post these forms url-encoded, which has no such limit.
+ */
+export async function postWithJar(jar: CookieJar, url: string, fields: Record<string, string>): Promise<BasicResponse> {
+  const body = Object.entries(fields)
+    .map(([name, value]) => `${encodeURIComponent(name)}=${encodeURIComponent(value)}`)
+    .join('&');
+  const response = await performPost(url, '', body, {
+    ...jar.headerFor(url),
+    'Content-type': 'application/x-www-form-urlencoded',
+  });
+  jar.store(url, response.headers['set-cookie']);
+  return response;
+}
+
+/**
+ * Post an auto-submitting form.
+ *
+ * The shared `followRedirectTag` helper compares content-type with strict equality
+ * against 'text/html', which Keycloak's 'text/html;charset=utf-8' fails, so its forms
+ * have to be submitted here instead.
+ */
+export async function submitAutoPostForm(
+  jar: CookieJar,
+  response: BasicResponse,
+  tamperSamlResponse?: (xml: string) => string,
+): Promise<BasicResponse> {
+  const dom = cheerio.load(response.text ?? '');
+  const form = dom('form').first();
+  const action = form.attr('action');
+  expect(action).toEqual(expect.any(String));
+
+  const fields: Record<string, string> = {};
+  form.find('input[type="hidden"]').each((_, input) => {
+    const name = dom(input).attr('name');
+    const value = dom(input).attr('value');
+    if (name && value !== undefined) {
+      fields[name] = value;
+    }
+  });
+
+  // HTTP-POST binding carries the response as plain base64 (no DEFLATE), so it can be
+  // decoded, rewritten and re-encoded without touching the transport.
+  if (tamperSamlResponse && fields.SAMLResponse) {
+    const decoded = Buffer.from(fields.SAMLResponse, 'base64').toString('utf8');
+    fields.SAMLResponse = Buffer.from(tamperSamlResponse(decoded), 'utf8').toString('base64');
+  }
+
+  return postWithJar(jar, toReachableUrl(action!), fields);
+}

--- a/gravitee-am-test/specs/keycloak/keycloak-saml-login.jest.spec.ts
+++ b/gravitee-am-test/specs/keycloak/keycloak-saml-login.jest.spec.ts
@@ -45,6 +45,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   await fixture.resetToBaseline();
+  await fixture.waitForSamlIdpReady();
   await fixture.clearFederatedUsers();
 });
 
@@ -73,6 +74,7 @@ describe('Keycloak SAML - authentication against a third-party IdP', () => {
     // Instead of each endpoint being entered by hand, AM reads Keycloak's descriptor and
     // derives the SSO endpoints and signing certificate from it.
     await fixture.setSamlIdpConfig(metadataUrlModeConfig(KEYCLOAK_TEST.REALM, fixture.signingCertificateId));
+    await fixture.waitForSamlIdpReady();
 
     const response = await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
 
@@ -87,6 +89,7 @@ describe('Keycloak SAML - misconfiguration', () => {
     // signature validation cannot succeed.
     const otherRealmCertificate = await fixture.certificateFor(KEYCLOAK_TEST.SECOND_REALM);
     await fixture.setSamlIdpConfig(fixture.manualConfigWith({ signingCertificate: otherRealmCertificate }));
+    await fixture.waitForSamlIdpReady();
 
     const response = await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
 

--- a/gravitee-am-test/specs/keycloak/keycloak-saml-login.jest.spec.ts
+++ b/gravitee-am-test/specs/keycloak/keycloak-saml-login.jest.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+
+import {
+  HTTP_REDIRECT_BINDING,
+  KEYCLOAK_TEST,
+  KeycloakSamlFixture,
+  metadataUrlModeConfig,
+  setupKeycloakSamlFixture,
+} from './fixtures/keycloak-saml-fixture';
+import { setup } from '../test-fixture';
+
+/**
+ * AM acting as a SAML service provider against Keycloak, a real third-party IdP.
+ *
+ * The AM-to-AM loopback in specs/gateway/saml2 proves AM can talk to itself, where both
+ * ends are configured leniently and assertions are small. These cover what only a real
+ * counterparty exercises: a signed assertion of realistic size, metadata published by
+ * someone else, and a configuration that does not match the IdP.
+ *
+ * Requires `./local-stack.sh up --keycloak`.
+ */
+setup(200000);
+
+let fixture: KeycloakSamlFixture;
+
+beforeAll(async () => {
+  fixture = await setupKeycloakSamlFixture(KEYCLOAK_TEST.REALM, HTTP_REDIRECT_BINDING);
+});
+
+beforeEach(async () => {
+  await fixture.resetToBaseline();
+  await fixture.clearFederatedUsers();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('Keycloak SAML - authentication against a third-party IdP', () => {
+  it(jira`should authenticate a Keycloak user and federate them into the AM domain ${'AM-6799'}`, async () => {
+    const response = await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
+
+    const landing = response.headers?.location ?? '';
+    expect(landing).toContain(KEYCLOAK_TEST.REDIRECT_URI);
+    expect(landing).toMatch(/[?&]code=/);
+
+    // Keycloak issues the NameID in emailAddress format, so that is what identifies
+    // the federated user AM creates.
+    const federated = await fixture.findFederatedUsers();
+    expect(federated).toHaveLength(1);
+    expect(federated[0].username).toEqual(KEYCLOAK_TEST.EMAIL);
+  });
+
+  it(jira`should authenticate when the IdP is configured from published metadata ${'AM-6810'}`, async () => {
+    // Instead of each endpoint being entered by hand, AM reads Keycloak's descriptor and
+    // derives the SSO endpoints and signing certificate from it.
+    await fixture.setSamlIdpConfig(metadataUrlModeConfig(KEYCLOAK_TEST.REALM, fixture.signingCertificateId));
+
+    const response = await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
+
+    expect(response.headers?.location ?? '').toMatch(/[?&]code=/);
+    expect(await fixture.findFederatedUsers()).toHaveLength(1);
+  });
+});
+
+describe('Keycloak SAML - misconfiguration', () => {
+  it(jira`should refuse the assertion when the configured IdP certificate does not match ${'AM-6960'}`, async () => {
+    // Point AM at a different realm's certificate while still talking to the first, so
+    // signature validation cannot succeed.
+    const otherRealmCertificate = await fixture.certificateFor(KEYCLOAK_TEST.SECOND_REALM);
+    await fixture.setSamlIdpConfig(fixture.manualConfigWith({ signingCertificate: otherRealmCertificate }));
+
+    const response = await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
+
+    expect(response.headers?.location ?? '').not.toMatch(/[?&]code=/);
+    expect(await fixture.findFederatedUsers()).toHaveLength(0);
+  });
+});

--- a/gravitee-am-test/specs/keycloak/keycloak-saml-security.jest.spec.ts
+++ b/gravitee-am-test/specs/keycloak/keycloak-saml-security.jest.spec.ts
@@ -51,6 +51,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   await fixture.resetToBaseline();
+  await fixture.waitForSamlIdpReady();
   await fixture.clearFederatedUsers();
 });
 
@@ -107,6 +108,7 @@ describe('Keycloak SAML - federated user lifecycle', () => {
 describe('Keycloak SAML - HTTP-POST AuthnRequest binding', () => {
   it(jira`should authenticate when the AuthnRequest is sent over HTTP-POST ${'AM-6819'}`, async () => {
     await fixture.setSamlIdpConfig(fixture.manualConfigWith({ protocolBinding: HTTP_POST_BINDING }));
+    await fixture.waitForSamlIdpReady();
 
     const response = await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
 

--- a/gravitee-am-test/specs/keycloak/keycloak-saml-security.jest.spec.ts
+++ b/gravitee-am-test/specs/keycloak/keycloak-saml-security.jest.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+
+import {
+  HTTP_POST_BINDING,
+  HTTP_REDIRECT_BINDING,
+  KEYCLOAK_TEST,
+  KeycloakSamlFixture,
+  setupKeycloakSamlFixture,
+} from './fixtures/keycloak-saml-fixture';
+import { setup } from '../test-fixture';
+
+/**
+ * Checks that AM refuses assertions it must refuse when federating to a third-party IdP.
+ *
+ * Keycloak only ever mints well-formed assertions, so these rewrite the response in
+ * transit. Each one represents a failure that would be silent in production: an
+ * unsigned assertion accepted, or one minted for a different service provider accepted.
+ */
+setup(200000);
+
+let fixture: KeycloakSamlFixture;
+
+/** Remove the assertion's enveloped signature, leaving the rest of the response intact. */
+const stripAssertionSignature = (xml: string): string =>
+  xml.replace(/<dsig:Signature[\s\S]*?<\/dsig:Signature>/g, '').replace(/<ds:Signature[\s\S]*?<\/ds:Signature>/g, '');
+
+const expectRejected = async (response: { headers?: Record<string, string> }) => {
+  expect(response.headers?.location ?? '').not.toMatch(/[?&]code=/);
+  expect(await fixture.findFederatedUsers()).toHaveLength(0);
+};
+
+beforeAll(async () => {
+  fixture = await setupKeycloakSamlFixture(KEYCLOAK_TEST.REALM, HTTP_REDIRECT_BINDING);
+});
+
+beforeEach(async () => {
+  await fixture.resetToBaseline();
+  await fixture.clearFederatedUsers();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('Keycloak SAML - assertion must be signed', () => {
+  it(jira`should refuse an assertion whose signature has been removed ${'AM-6960'}`, async () => {
+    const response = await fixture.loginWithTamperedAssertion(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD, stripAssertionSignature);
+
+    await expectRejected(response);
+  });
+});
+
+describe('Keycloak SAML - federated user lifecycle', () => {
+  it(jira`should map the IdP attributes onto the federated user profile ${'AM-6799'}`, async () => {
+    await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
+
+    // Keycloak's protocol mappers emit email, given name and surname; losing them would
+    // federate users with an empty profile and nothing would fail loudly.
+    const [user] = await fixture.findFederatedUsers();
+    const claims = user.additionalInformation ?? {};
+
+    expect(user.username).toEqual(KEYCLOAK_TEST.EMAIL);
+    // Keycloak's attributes reach the federated profile under the claim URIs it emits.
+    expect(claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress']).toEqual(KEYCLOAK_TEST.EMAIL);
+    expect(claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname']).toEqual('Test');
+    expect(claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname']).toEqual('User');
+
+    // Documented, not endorsed: the IdP's attributeMapping names these claims as email,
+    // firstname and lastname, but the corresponding profile fields are left unset.
+    expect(user.email).toBeUndefined();
+    expect(user.firstName).toBeUndefined();
+    expect(user.lastName).toBeUndefined();
+  });
+
+  it(jira`should match the existing federated user on re-login rather than duplicating ${'AM-6959'}`, async () => {
+    await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
+    const [first] = await fixture.findFederatedUsers();
+
+    await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
+
+    // A duplicate per login would grow the user store and split each user's history.
+    const users = await fixture.findFederatedUsers();
+    expect(users).toHaveLength(1);
+    expect(users[0].id).toEqual(first.id);
+    expect(users[0].loginsCount).toEqual(2);
+  });
+});
+
+describe('Keycloak SAML - HTTP-POST AuthnRequest binding', () => {
+  it(jira`should authenticate when the AuthnRequest is sent over HTTP-POST ${'AM-6819'}`, async () => {
+    await fixture.setSamlIdpConfig(fixture.manualConfigWith({ protocolBinding: HTTP_POST_BINDING }));
+
+    const response = await fixture.login(KEYCLOAK_TEST.USERNAME, KEYCLOAK_TEST.PASSWORD);
+
+    expect(response.headers?.location ?? '').toMatch(/[?&]code=/);
+    expect(await fixture.findFederatedUsers()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7446](https://gravitee.atlassian.net/browse/AM-7446)

## :pencil2: A description of the changes proposed in the pull request
Adds Keycloak to the local stack as a third-party SAML identity provider, plus 7 tests
  covering AM acting as a SAML service provider against it.

  - `keycloak-saml-login` (3) — authenticate and federate a user, metadata-driven config,
    mismatched IdP certificate refused
  - `keycloak-saml-security` (4) — unsigned assertion refused, attribute mapping, re-login
    matches rather than duplicates, HTTP-POST AuthnRequest binding

  Realms are imported at container start from checked-in JSON, so there is no manual
  Keycloak setup. Signing keys are generated per container and the certificate is read
  from the published descriptor at run time, so no private key is committed.

  Adds a `--keycloak` flag to `local-stack.sh`, `ci:keycloak` to the test scripts, and
  two CircleCI jobs covering MongoDB and PostgreSQL.

## :memo: Test scenarios 
NA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA


[AM-7446]: https://gravitee.atlassian.net/browse/AM-7446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ