### PR TITLE
test: permissions and roles regression automation (AM-7448)

### DIFF
--- a/gravitee-am-test/api/commands/management/group-management-commands.ts
+++ b/gravitee-am-test/api/commands/management/group-management-commands.ts
@@ -118,3 +118,40 @@ export const getGroupRoles = (domainId: string, accessToken: string, groupId: st
     domain: domainId,
     group: groupId,
   });
+
+// --- Organization-level groups ----------------------------------------------------------------
+// The commands above are domain-scoped. Console users are grouped at organization level, and a
+// role assigned to such a group applies to every member of it.
+
+/**
+ * The create endpoint declares no response body, so the SDK returns `void` and the new group's id
+ * has to be recovered by name — the same shape as organization role creation.
+ */
+export const createOrganizationGroup = async (accessToken: string, name: string) => {
+  await getGroupApi(accessToken).createPlatformGroup({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    newGroup: { name },
+  });
+  // listGroups() is typed as returning an array, but the endpoint answers with a page object, so
+  // the generated transformer throws. Read the raw response instead of going through it.
+  const listing = await getGroupApi(accessToken).listGroupsRaw({ organizationId: process.env.AM_DEF_ORG_ID, size: 1000 });
+  const body = await listing.raw.json();
+  const created = (body.data ?? body).find((group) => group.name === name);
+  if (!created) {
+    throw new Error(`Organization group "${name}" was not found after creation`);
+  }
+  return created;
+};
+
+export const addOrganizationGroupMember = (accessToken: string, groupId: string, memberId: string) =>
+  getGroupApi(accessToken).addGroupMember1({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    group: groupId,
+    member: memberId,
+  });
+
+export const deleteOrganizationGroup = (accessToken: string, groupId: string) =>
+  getGroupApi(accessToken).deleteOrganizationGroup({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    group: groupId,
+  });

--- a/gravitee-am-test/api/commands/management/membership-management-commands.ts
+++ b/gravitee-am-test/api/commands/management/membership-management-commands.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getApplicationApi, getDefaultApi, getDomainApi } from './service/utils';
+// Type-only: `@management-models` is deliberately absent from the jest moduleNameMapper in
+// api/config/*.config.js, so these imports must stay erasable. Importing a *value* from
+// @management-models (an enum object, say) compiles but fails at runtime with
+// "Cannot find module". Use string literals for enum members instead.
+import type { NewMembership } from '@management-models/NewMembership';
+import type { MembershipListItem } from '@management-models/MembershipListItem';
+
+/**
+ * A membership is the (member, level, role) triple that grants access in AM. The generated SDK
+ * exposes these across four different APIs with ambiguous generated names (addOrUpdateMember,
+ * addOrUpdateMember1, addOrUpdateMember2). This module maps them to the level they act on.
+ *
+ * `role` is always the role **id**, never the role name.
+ */
+
+/** Builds a USER membership payload. Use {@link groupMembership} for groups. */
+export const userMembership = (memberId: string, roleId: string): NewMembership => ({
+  memberId,
+  memberType: 'USER',
+  role: roleId,
+});
+
+/** Builds a GROUP membership payload. AM rejects PRIMARY_OWNER roles assigned this way. */
+export const groupMembership = (memberId: string, roleId: string): NewMembership => ({
+  memberId,
+  memberType: 'GROUP',
+  role: roleId,
+});
+
+// --- Organization level -------------------------------------------------------------------
+
+export const addOrganizationMembership = (accessToken: string, newMembership: NewMembership): Promise<void> =>
+  getDefaultApi(accessToken).addOrUpdateOrganizationMember({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    newMembership,
+  });
+
+export const listOrganizationMemberships = (accessToken: string): Promise<MembershipListItem> =>
+  getDefaultApi(accessToken).listOrganizationMembers({
+    organizationId: process.env.AM_DEF_ORG_ID,
+  });
+
+export const removeOrganizationMembership = (accessToken: string, membershipId: string): Promise<void> =>
+  getDefaultApi(accessToken).removeOrganizationMember({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    member: membershipId,
+  });
+
+// --- Domain level -------------------------------------------------------------------------
+
+export const addDomainMembership = (domainId: string, accessToken: string, newMembership: NewMembership): Promise<void> =>
+  getDomainApi(accessToken).addOrUpdateMember1({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    newMembership,
+  });
+
+export const listDomainMemberships = (domainId: string, accessToken: string): Promise<MembershipListItem> =>
+  getDomainApi(accessToken).listMembers({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+  });
+
+export const removeDomainMembership = (domainId: string, accessToken: string, membershipId: string): Promise<void> =>
+  getDomainApi(accessToken).removeDomainMember({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    member: membershipId,
+  });
+
+// --- Application level --------------------------------------------------------------------
+
+export const addApplicationMembership = (
+  domainId: string,
+  applicationId: string,
+  accessToken: string,
+  newMembership: NewMembership,
+): Promise<void> =>
+  getApplicationApi(accessToken).addOrUpdateMember({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    application: applicationId,
+    newMembership,
+  });
+
+export const listApplicationMemberships = (domainId: string, applicationId: string, accessToken: string): Promise<MembershipListItem> =>
+  getApplicationApi(accessToken).getMembers({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    application: applicationId,
+  });
+
+export const removeApplicationMembership = (
+  domainId: string,
+  applicationId: string,
+  accessToken: string,
+  membershipId: string,
+): Promise<void> =>
+  getApplicationApi(accessToken).removeApplicationMember({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    application: applicationId,
+    member: membershipId,
+  });
+
+// --- Protected resource level ---------------------------------------------------------------
+
+export const addProtectedResourceMembership = (
+  domainId: string,
+  protectedResourceId: string,
+  accessToken: string,
+  newMembership: NewMembership,
+): Promise<void> =>
+  getDomainApi(accessToken).addOrUpdateMember2({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    protectedResource: protectedResourceId,
+    newMembership,
+  });
+
+export const listProtectedResourceMemberships = (
+  domainId: string,
+  protectedResourceId: string,
+  accessToken: string,
+): Promise<MembershipListItem> =>
+  getDomainApi(accessToken).getMembers1({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    protectedResource: protectedResourceId,
+  });
+
+export const removeProtectedResourceMembership = (
+  domainId: string,
+  protectedResourceId: string,
+  accessToken: string,
+  membershipId: string,
+): Promise<void> =>
+  getDomainApi(accessToken).removeProtectedResourceMember({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    protectedResource: protectedResourceId,
+    member: membershipId,
+  });
+
+// --- Effective permissions (what the caller resolves to at a given level) --------------------
+
+/**
+ * The OpenAPI spec types these endpoints as returning a plain string, so the generator emits a
+ * TextApiResponse and the SDK hands back an unparsed body. They actually return a JSON array of
+ * flattened `permission_acl` strings (e.g. "domain_read"), so parse here rather than in each test.
+ */
+const parsePermissions = (raw: string): string[] => JSON.parse(raw);
+
+export const getDomainMemberPermissions = (domainId: string, accessToken: string): Promise<string[]> =>
+  getDomainApi(accessToken)
+    .getDomainMemberPermissions({
+      organizationId: process.env.AM_DEF_ORG_ID,
+      environmentId: process.env.AM_DEF_ENV_ID,
+      domain: domainId,
+    })
+    .then(parsePermissions);
+
+export const getApplicationMemberPermissions = (domainId: string, applicationId: string, accessToken: string): Promise<string[]> =>
+  getApplicationApi(accessToken)
+    .getApplicationMemberPermissions({
+      organizationId: process.env.AM_DEF_ORG_ID,
+      environmentId: process.env.AM_DEF_ENV_ID,
+      domain: domainId,
+      application: applicationId,
+    })
+    .then(parsePermissions);
+
+/**
+ * Environment memberships cannot be listed — the environment resource exposes only this
+ * permissions endpoint — so this is the sole way to observe what a caller resolves to at the
+ * environment tier, and therefore the only way to see memberships created there implicitly.
+ */
+export const getEnvironmentMemberPermissions = (accessToken: string): Promise<string[]> =>
+  getDefaultApi(accessToken)
+    .getMemberPermissions({
+      organizationId: process.env.AM_DEF_ORG_ID,
+      environmentId: process.env.AM_DEF_ENV_ID,
+    })
+    .then(parsePermissions);

--- a/gravitee-am-test/api/commands/management/role-management-commands.ts
+++ b/gravitee-am-test/api/commands/management/role-management-commands.ts
@@ -15,6 +15,12 @@
  */
 
 import { getRoleApi } from './service/utils';
+import { ListRolesTypeEnum } from '@management-apis/RoleApi';
+// Type-only: `@management-models` is not mapped in the jest moduleNameMapper, so these must stay
+// erasable. `@management-apis` above *is* mapped, which is why ListRolesTypeEnum can be a value.
+import type { NewRole, NewRoleAssignableTypeEnum } from '@management-models/NewRole';
+import type { UpdateRole } from '@management-models/UpdateRole';
+import type { RoleEntity } from '@management-models/RoleEntity';
 
 export const createRole = (domainId, accessToken, role) =>
   getRoleApi(accessToken).createRole({
@@ -64,3 +70,75 @@ export const deleteRole = (domainId, accessToken, roleId) =>
     domain: domainId,
     role: roleId,
   });
+
+// --- Organization-level roles ----------------------------------------------------------------
+// The commands above are domain-scoped. Administrative roles (the ones assigned to console users
+// at organization, environment, domain, application or protected-resource level) live on the
+// organization instead, under /organizations/{organizationId}/roles.
+
+export const createOrganizationRole = (accessToken: string, newRole: NewRole) =>
+  getRoleApi(accessToken).createRole1({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    newRole,
+  });
+
+export const getOrganizationRole = (accessToken: string, roleId: string) =>
+  getRoleApi(accessToken).getRole({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    role: roleId,
+  });
+
+export const listOrganizationRoles = (accessToken: string, type?: ListRolesTypeEnum) =>
+  getRoleApi(accessToken).listRoles({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    ...(type ? { type } : {}),
+  });
+
+export const updateOrganizationRole = (accessToken: string, roleId: string, payload: UpdateRole) =>
+  getRoleApi(accessToken).updateRole1({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    role: roleId,
+    updateRole: payload,
+  });
+
+export const deleteOrganizationRole = (accessToken: string, roleId: string) =>
+  getRoleApi(accessToken).deleteRole1({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    role: roleId,
+  });
+
+/**
+ * Memberships reference a role by **id**, but tests and specs name roles ("DOMAIN_OWNER",
+ * "ORGANIZATION_USER"). Resolves a built-in or custom role to its entity.
+ */
+export const findOrganizationRoleByName = async (accessToken: string, name: string, type?: ListRolesTypeEnum): Promise<RoleEntity> => {
+  const roles = await listOrganizationRoles(accessToken, type);
+  const match = roles.find((role) => role.name === name);
+  if (!match) {
+    throw new Error(`No organization role named "${name}"${type ? ` assignable to ${type}` : ''}`);
+  }
+  return match;
+};
+
+/**
+ * Creates a custom administrative role carrying the given permissions.
+ *
+ * Two API calls are required, for two separate reasons:
+ *  1. Role creation does **not** accept permissions — `NewRole` has no such field and the service
+ *     stores an empty permission set, so permissions must be applied by a follow-up update.
+ *     A caller that skips the update ends up with a role that silently grants nothing.
+ *  2. The spec declares no response body for the create, so the SDK returns `void` and the new
+ *     role's id has to be recovered by name before it can be updated.
+ *
+ * @param permissions flattened `permission_acl` strings, e.g. ['domain_read', 'application_read']
+ */
+export const createCustomOrganizationRole = async (
+  accessToken: string,
+  name: string,
+  assignableType: NewRoleAssignableTypeEnum,
+  permissions: string[],
+): Promise<RoleEntity> => {
+  await createOrganizationRole(accessToken, { name, assignableType });
+  const created = await findOrganizationRoleByName(accessToken, name);
+  return updateOrganizationRole(accessToken, created.id, { name, permissions });
+};

--- a/gravitee-am-test/playwright/fixtures/domain-permissions.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/domain-permissions.fixture.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test as base } from '@playwright/test';
+import crossFetch from 'cross-fetch';
+// Native Node fetch makes the generated SDK drop fields silently — see GUIDELINES §10.
+globalThis.fetch = crossFetch;
+
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createDomain, safeDeleteDomain } from '@management-commands/domain-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { findOrganizationRoleByName } from '@management-commands/role-management-commands';
+import { addApplicationMembership, addDomainMembership, userMembership } from '@management-commands/membership-management-commands';
+import { createTestApp } from '@utils-commands/application-commands';
+import { ListRolesTypeEnum } from '@management-apis/RoleApi';
+import type { Application } from '@management-models/Application';
+import type { Domain } from '@management-models/Domain';
+import { ConsolePersona, createConsolePersona, signInToConsole, workerScope } from '../utils/permissions-helpers';
+import { quietly, uniqueTestName } from '../utils/fixture-helpers';
+
+/**
+ * The world described by AM-6032: two independent domains with a different owner each, an
+ * application owner one tier below, and a user holding nothing but the default organization role.
+ * Between them they cover every rung of the ladder the Console reveals.
+ */
+export interface DomainPermissionsWorld {
+  adminToken: string;
+  /** Domain owned by `devManager`, containing both applications below. */
+  devDomain: Domain;
+  /** Separate domain owned by `qaManager` — nobody from the dev side has any membership on it. */
+  qaDomain: Domain;
+  /** Application in devDomain that `devAppOwner` owns. */
+  devApplication: Application;
+  /** Second application in devDomain that nobody below is a member of. */
+  devOtherApplication: Application;
+  devManager: ConsolePersona;
+  qaManager: ConsolePersona;
+  devAppOwner: ConsolePersona;
+  /** Holds only the default ORGANIZATION_USER role — no domain anywhere. */
+  basicUser: ConsolePersona;
+}
+
+export type DomainPermissionsFixtures = {
+  domainWorld: DomainPermissionsWorld;
+  signInAs: (persona: ConsolePersona) => Promise<void>;
+};
+
+const APP_SETTINGS = {
+  settings: { oauth: { redirectUris: ['https://example.com/callback'], grantTypes: ['authorization_code'] } },
+};
+
+export const test = base.extend<DomainPermissionsFixtures>({
+  domainWorld: async ({}, use) => {
+    const adminToken = await requestAdminAccessToken();
+
+    const devDomain = await quietly(() => createDomain(adminToken, uniqueTestName(workerScope('pw-dev')), 'Playwright dev domain'));
+    const qaDomain = await quietly(() => createDomain(adminToken, uniqueTestName(workerScope('pw-qa')), 'Playwright qa domain'));
+
+    // The domains are deliberately never started: the Console reads from the management API and
+    // nothing here touches the gateway, so starting them only adds sync latency to every test.
+    const devApplication = await quietly(() =>
+      createTestApp(uniqueTestName(workerScope('devapp')), devDomain, adminToken, 'web', APP_SETTINGS),
+    );
+    const devOtherApplication = await quietly(() =>
+      createTestApp(uniqueTestName(workerScope('otherapp')), devDomain, adminToken, 'web', APP_SETTINGS),
+    );
+
+    const domainOwnerRole = await findOrganizationRoleByName(adminToken, 'DOMAIN_OWNER', ListRolesTypeEnum.Domain);
+    const applicationOwnerRole = await findOrganizationRoleByName(adminToken, 'APPLICATION_OWNER', ListRolesTypeEnum.Application);
+
+    const devManager = await createConsolePersona(adminToken, 'devmgr');
+    const qaManager = await createConsolePersona(adminToken, 'qamgr');
+    const devAppOwner = await createConsolePersona(adminToken, 'devappowner');
+    const basicUser = await createConsolePersona(adminToken, 'basicuser');
+
+    await quietly(() => addDomainMembership(devDomain.id, adminToken, userMembership(devManager.userId, domainOwnerRole.id)));
+    await quietly(() => addDomainMembership(qaDomain.id, adminToken, userMembership(qaManager.userId, domainOwnerRole.id)));
+    await quietly(() =>
+      addApplicationMembership(devDomain.id, devApplication.id, adminToken, userMembership(devAppOwner.userId, applicationOwnerRole.id)),
+    );
+
+    await use({
+      adminToken,
+      devDomain,
+      qaDomain,
+      devApplication,
+      devOtherApplication,
+      devManager,
+      qaManager,
+      devAppOwner,
+      basicUser,
+    });
+
+    for (const domain of [devDomain, qaDomain]) {
+      await quietly(() => safeDeleteDomain(domain.id, adminToken));
+    }
+    for (const persona of [devManager, qaManager, devAppOwner, basicUser]) {
+      await quietly(() => deleteOrganisationUser(adminToken, persona.userId)).catch(() => undefined);
+    }
+  },
+
+  signInAs: async ({ page }, use) => {
+    await use(async (persona: ConsolePersona) => signInToConsole(page, persona));
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/gravitee-am-test/playwright/fixtures/org-permissions.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/org-permissions.fixture.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test as base } from '@playwright/test';
+import crossFetch from 'cross-fetch';
+// Native Node fetch makes the generated SDK drop fields silently — see GUIDELINES §10.
+globalThis.fetch = crossFetch;
+
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createDomain, safeDeleteDomain } from '@management-commands/domain-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { createCustomOrganizationRole, deleteOrganizationRole } from '@management-commands/role-management-commands';
+import { addOrganizationMembership, userMembership } from '@management-commands/membership-management-commands';
+import type { Domain } from '@management-models/Domain';
+import type { RoleEntity } from '@management-models/RoleEntity';
+import { ConsolePersona, createConsolePersona, signInToConsole, workerScope } from '../utils/permissions-helpers';
+import { quietly, uniqueTestName } from '../utils/fixture-helpers';
+
+/**
+ * The world described by AM-6031, seen from the organization tier: a domain that exists, a user
+ * holding nothing but the default organization role, and an auditor carrying a custom
+ * organization-level role that grants reading a domain but not listing or creating one.
+ */
+export interface OrgPermissionsWorld {
+  adminToken: string;
+  /** A domain that exists so that "cannot see it" is a real absence rather than an empty instance. */
+  domain: Domain;
+  /** Holds only the default ORGANIZATION_USER role. */
+  orgUser: ConsolePersona;
+  /**
+   * Holds *only* a custom organization role granting DOMAIN[READ]. Assigning a role at a reference
+   * replaces the membership there rather than adding a second one, so this also removes the default
+   * ORGANIZATION_USER — which is precisely the "user with only a custom ORGANIZATION role" the
+   * manual case describes.
+   */
+  auditor: ConsolePersona;
+  auditorRole: RoleEntity;
+}
+
+export type OrgPermissionsFixtures = {
+  orgWorld: OrgPermissionsWorld;
+  signInAs: (persona: ConsolePersona) => Promise<void>;
+};
+
+export const test = base.extend<OrgPermissionsFixtures>({
+  orgWorld: async ({}, use) => {
+    const adminToken = await requestAdminAccessToken();
+
+    // Never started: the Console reads from the management API and nothing here reaches the gateway.
+    const domain = await quietly(() => createDomain(adminToken, uniqueTestName(workerScope('pw-org')), 'Playwright org domain'));
+
+    // DOMAIN[READ] without DOMAIN[LIST] is the interesting shape: the holder could read this domain
+    // by id, yet it must not appear in the list, and they must not be offered a way to create one.
+    const auditorRole = await createCustomOrganizationRole(adminToken, uniqueTestName(workerScope('Org-QA-Auditor')), 'ORGANIZATION', [
+      'domain_read',
+    ]);
+
+    const orgUser = await createConsolePersona(adminToken, 'orgbasic');
+    const auditor = await createConsolePersona(adminToken, 'auditor');
+
+    // Replaces the default ORGANIZATION_USER granted at creation: a member holds one role per
+    // reference, so this leaves the auditor with DOMAIN[READ] and nothing else.
+    await quietly(() => addOrganizationMembership(adminToken, userMembership(auditor.userId, auditorRole.id)));
+
+    await use({ adminToken, domain, orgUser, auditor, auditorRole });
+
+    await quietly(() => safeDeleteDomain(domain.id, adminToken));
+    for (const persona of [orgUser, auditor]) {
+      await quietly(() => deleteOrganisationUser(adminToken, persona.userId)).catch(() => undefined);
+    }
+    await quietly(() => deleteOrganizationRole(adminToken, auditorRole.id)).catch(() => undefined);
+  },
+
+  signInAs: async ({ page }, use) => {
+    await use(async (persona: ConsolePersona) => signInToConsole(page, persona));
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/gravitee-am-test/playwright/fixtures/permissions.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/permissions.fixture.ts
@@ -32,6 +32,7 @@ import { createTestApp } from '@utils-commands/application-commands';
 import { ListRolesTypeEnum } from '@management-apis/RoleApi';
 import type { Application } from '@management-models/Application';
 import type { Domain } from '@management-models/Domain';
+import type { RoleEntity } from '@management-models/RoleEntity';
 import { ConsolePersona, createConsolePersona, signInToConsole, workerScope } from '../utils/permissions-helpers';
 import { quietly, uniqueTestName } from '../utils/fixture-helpers';
 
@@ -51,6 +52,10 @@ export interface PermissionsWorld {
   appOwner: ConsolePersona;
   /** Custom APPLICATION-assignable role with only APPLICATION[READ] on `ownedApplication`. */
   appViewer: ConsolePersona;
+  /** The built-in APPLICATION_OWNER role, for tests that assign it themselves. */
+  applicationOwnerRole: RoleEntity;
+  /** The custom read-only application role, for tests that assign it themselves. */
+  applicationViewerRole: RoleEntity;
 }
 
 export type PermissionsFixtures = {
@@ -95,7 +100,16 @@ export const test = base.extend<PermissionsFixtures>({
       addApplicationMembership(domain.id, ownedApplication.id, adminToken, userMembership(appViewer.userId, applicationViewerRole.id)),
     );
 
-    await use({ adminToken, domain, ownedApplication, otherApplication, appOwner, appViewer });
+    await use({
+      adminToken,
+      domain,
+      ownedApplication,
+      otherApplication,
+      appOwner,
+      appViewer,
+      applicationOwnerRole,
+      applicationViewerRole,
+    });
 
     // Domain deletion cascades applications and their memberships; organization users and the
     // custom role live outside the domain and must be removed explicitly.

--- a/gravitee-am-test/playwright/fixtures/permissions.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/permissions.fixture.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test as base } from '@playwright/test';
+import crossFetch from 'cross-fetch';
+// Native Node fetch makes the generated SDK drop fields silently — see GUIDELINES §10.
+globalThis.fetch = crossFetch;
+
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createDomain, safeDeleteDomain } from '@management-commands/domain-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import {
+  createCustomOrganizationRole,
+  deleteOrganizationRole,
+  findOrganizationRoleByName,
+} from '@management-commands/role-management-commands';
+import { addApplicationMembership, userMembership } from '@management-commands/membership-management-commands';
+import { createTestApp } from '@utils-commands/application-commands';
+import { ListRolesTypeEnum } from '@management-apis/RoleApi';
+import type { Application } from '@management-models/Application';
+import type { Domain } from '@management-models/Domain';
+import { ConsolePersona, createConsolePersona, signInToConsole, workerScope } from '../utils/permissions-helpers';
+import { quietly, uniqueTestName } from '../utils/fixture-helpers';
+
+/**
+ * The world described by AM-6036: one domain holding two applications, and two organization users
+ * who differ only in the role they hold on the *first* application — one owns it, the other holds
+ * a custom read-only role. Everything the Console shows them should follow from that difference.
+ */
+export interface PermissionsWorld {
+  adminToken: string;
+  domain: Domain;
+  /** The application both personas are members of. */
+  ownedApplication: Application;
+  /** Second application in the same domain, which neither persona is a member of. */
+  otherApplication: Application;
+  /** APPLICATION_OWNER on `ownedApplication`. */
+  appOwner: ConsolePersona;
+  /** Custom APPLICATION-assignable role with only APPLICATION[READ] on `ownedApplication`. */
+  appViewer: ConsolePersona;
+}
+
+export type PermissionsFixtures = {
+  permissionsWorld: PermissionsWorld;
+  /** Signs in through the Console login form as the given persona. */
+  signInAs: (persona: ConsolePersona) => Promise<void>;
+};
+
+export const test = base.extend<PermissionsFixtures>({
+  permissionsWorld: async ({}, use) => {
+    const adminToken = await requestAdminAccessToken();
+
+    const domain = await quietly(() => createDomain(adminToken, uniqueTestName(workerScope('pw-perm')), 'Playwright permissions domain'));
+
+    // The domain is deliberately never started: the Console reads from the management API and
+    // nothing here touches the gateway, so starting it only adds sync latency to every test.
+    const appSettings = {
+      settings: { oauth: { redirectUris: ['https://example.com/callback'], grantTypes: ['authorization_code'] } },
+    };
+    const ownedApplication = await quietly(() =>
+      createTestApp(uniqueTestName(workerScope('mywebapp')), domain, adminToken, 'web', appSettings),
+    );
+    const otherApplication = await quietly(() =>
+      createTestApp(uniqueTestName(workerScope('otherwebapp')), domain, adminToken, 'web', appSettings),
+    );
+
+    const applicationOwnerRole = await findOrganizationRoleByName(adminToken, 'APPLICATION_OWNER', ListRolesTypeEnum.Application);
+    const applicationViewerRole = await createCustomOrganizationRole(
+      adminToken,
+      uniqueTestName(workerScope('Application Viewer')),
+      'APPLICATION',
+      ['application_read'],
+    );
+
+    const appOwner = await createConsolePersona(adminToken, 'devappowner');
+    const appViewer = await createConsolePersona(adminToken, 'appviewer');
+
+    await quietly(() =>
+      addApplicationMembership(domain.id, ownedApplication.id, adminToken, userMembership(appOwner.userId, applicationOwnerRole.id)),
+    );
+    await quietly(() =>
+      addApplicationMembership(domain.id, ownedApplication.id, adminToken, userMembership(appViewer.userId, applicationViewerRole.id)),
+    );
+
+    await use({ adminToken, domain, ownedApplication, otherApplication, appOwner, appViewer });
+
+    // Domain deletion cascades applications and their memberships; organization users and the
+    // custom role live outside the domain and must be removed explicitly.
+    await quietly(() => safeDeleteDomain(domain.id, adminToken));
+    for (const persona of [appOwner, appViewer]) {
+      await quietly(() => deleteOrganisationUser(adminToken, persona.userId)).catch(() => undefined);
+    }
+    await quietly(() => deleteOrganizationRole(adminToken, applicationViewerRole.id)).catch(() => undefined);
+  },
+
+  signInAs: async ({ page }, use) => {
+    await use(async (persona: ConsolePersona) => signInToConsole(page, persona));
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/gravitee-am-test/playwright/tests/permissions/application-permission-isolation.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/application-permission-isolation.spec.ts
@@ -19,9 +19,13 @@ import { addApplicationMembership, userMembership } from '@management-commands/m
 import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
 import { ConsolePersona, createConsolePersona, submenuItem } from '../../utils/permissions-helpers';
 import { linkJira } from '../../utils/jira';
-import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+import { APPLICATION_OVERVIEW_URL, MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
 
 test.use({ storageState: { cookies: [], origins: [] } });
+
+// Every test here builds its own permissions world, and that setup counts against the test
+// timeout, so the extended budget applies uniformly across the file.
+test.beforeEach(({}, testInfo) => testInfo.setTimeout(MULTI_PHASE_TEST_TIMEOUT));
 
 /**
  * One user, two applications, a different role on each. This is the case the Console is most
@@ -54,7 +58,7 @@ test.describe('Application permission isolation - moving between applications', 
 
   const openApplication = async (page: import('@playwright/test').Page, name: string) => {
     await page.getByRole('link', { name, exact: true }).click();
-    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+    await page.waitForURL(APPLICATION_OVERVIEW_URL);
   };
 
   const backToApplicationList = async (page: import('@playwright/test').Page, domainId: string) => {
@@ -68,7 +72,6 @@ test.describe('Application permission isolation - moving between applications', 
     signInAs,
   }, testInfo) => {
     linkJira(testInfo, 'AM-7473');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     const { domain, ownedApplication, otherApplication } = permissionsWorld;
 
@@ -92,7 +95,6 @@ test.describe('Application permission isolation - moving between applications', 
     signInAs,
   }, testInfo) => {
     linkJira(testInfo, 'AM-7473');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     const { domain, ownedApplication, otherApplication } = permissionsWorld;
 
@@ -114,7 +116,6 @@ test.describe('Application permission isolation - moving between applications', 
     signInAs,
   }, testInfo) => {
     linkJira(testInfo, 'AM-7473');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     const { domain, ownedApplication, otherApplication } = permissionsWorld;
 

--- a/gravitee-am-test/playwright/tests/permissions/application-permission-isolation.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/application-permission-isolation.spec.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '../../fixtures/permissions.fixture';
+import { addApplicationMembership, userMembership } from '@management-commands/membership-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { ConsolePersona, createConsolePersona, submenuItem } from '../../utils/permissions-helpers';
+import { linkJira } from '../../utils/jira';
+import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+/**
+ * One user, two applications, a different role on each. This is the case the Console is most
+ * likely to get wrong, because `AuthService` holds a single `applicationPermissions` list for
+ * "the application" rather than one per application, and `hasPermissions` consults every cached
+ * tier at once. Moving between applications must therefore replace that list, not add to it —
+ * otherwise the richer role visited first keeps granting affordances on the second.
+ *
+ * Both directions matter. Carrying permissions forward offers editing on an application the user
+ * may only read; failing to restore them withholds editing on one they own.
+ */
+test.describe('Application permission isolation - moving between applications', () => {
+  let mixedUser: ConsolePersona;
+
+  test.beforeEach(async ({ permissionsWorld }) => {
+    const { adminToken, domain, ownedApplication, otherApplication, applicationOwnerRole, applicationViewerRole } = permissionsWorld;
+
+    // Owner of one application, read-only on the other — the two roles differ only in what the
+    // Console should offer once each application is open.
+    mixedUser = await createConsolePersona(adminToken, 'mixedroles');
+    await addApplicationMembership(domain.id, ownedApplication.id, adminToken, userMembership(mixedUser.userId, applicationOwnerRole.id));
+    await addApplicationMembership(domain.id, otherApplication.id, adminToken, userMembership(mixedUser.userId, applicationViewerRole.id));
+  });
+
+  test.afterEach(async ({ permissionsWorld }) => {
+    if (mixedUser) {
+      await deleteOrganisationUser(permissionsWorld.adminToken, mixedUser.userId).catch(() => undefined);
+    }
+  });
+
+  const openApplication = async (page: import('@playwright/test').Page, name: string) => {
+    await page.getByRole('link', { name, exact: true }).click();
+    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+  };
+
+  const backToApplicationList = async (page: import('@playwright/test').Page, domainId: string) => {
+    await page.getByRole('link', { name: 'Applications', exact: true }).click();
+    await page.waitForURL(new RegExp(`/domains/${domainId}/applications`));
+  };
+
+  test('AM-7473: editing menus are not carried into an application the user may only read', async ({
+    page,
+    permissionsWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-7473');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    const { domain, ownedApplication, otherApplication } = permissionsWorld;
+
+    await signInAs(mixedUser);
+
+    // Visit the owned application first, so the richer permission set is the one already cached.
+    await openApplication(page, ownedApplication.name);
+    await expect(submenuItem(page, 'Settings')).toBeVisible();
+
+    // Then move to the read-only one without reloading the application.
+    await backToApplicationList(page, domain.id);
+    await openApplication(page, otherApplication.name);
+
+    await expect(submenuItem(page, 'Overview')).toBeVisible();
+    await expect(submenuItem(page, 'Settings')).toHaveCount(0);
+  });
+
+  test('AM-7473: editing menus are restored on returning to an application the user owns', async ({
+    page,
+    permissionsWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-7473');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    const { domain, ownedApplication, otherApplication } = permissionsWorld;
+
+    await signInAs(mixedUser);
+
+    // The other direction: start from the narrower role, then return to the owned application.
+    await openApplication(page, otherApplication.name);
+    await expect(submenuItem(page, 'Settings')).toHaveCount(0);
+
+    await backToApplicationList(page, domain.id);
+    await openApplication(page, ownedApplication.name);
+
+    await expect(submenuItem(page, 'Settings')).toBeVisible();
+  });
+
+  test('AM-7473: a reloaded application shows the same menus as one reached by navigation', async ({
+    page,
+    permissionsWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-7473');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    const { domain, ownedApplication, otherApplication } = permissionsWorld;
+
+    await signInAs(mixedUser);
+    await openApplication(page, ownedApplication.name);
+    await backToApplicationList(page, domain.id);
+    await openApplication(page, otherApplication.name);
+
+    // Reloading rebuilds the cached permissions from scratch. If in-session navigation had left
+    // anything behind, the two views would disagree here.
+    const navigated = await page.locator('.gv-submenu a').evaluateAll((links) => links.map((link) => link.getAttribute('title')));
+    await page.reload();
+    await expect(submenuItem(page, 'Overview')).toBeVisible();
+    const reloaded = await page.locator('.gv-submenu a').evaluateAll((links) => links.map((link) => link.getAttribute('title')));
+
+    expect(navigated).toEqual(reloaded);
+  });
+});

--- a/gravitee-am-test/playwright/tests/permissions/application-role-visibility.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/application-role-visibility.spec.ts
@@ -18,15 +18,18 @@ import { test, expect } from '../../fixtures/permissions.fixture';
 import { ApplicationGeneralSettingsPage } from '../../pages/application-general-settings.page';
 import { Oauth2SettingsPage } from '../../pages/oauth2-settings.page';
 import { linkJira } from '../../utils/jira';
-import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+import { submenuItem } from '../../utils/permissions-helpers';
+import { APPLICATION_OVERVIEW_URL, MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
 
 // Each test signs in as its own persona, so no shared authenticated state.
 test.use({ storageState: { cookies: [], origins: [] } });
 
-type Page = import('@playwright/test').Page;
+// Every test here builds its own permissions world (domains, applications, personas, memberships)
+// and that setup counts against the test timeout, so the extended budget applies to all of them
+// rather than to the few that happened to ask for it.
+test.beforeEach(({}, testInfo) => testInfo.setTimeout(MULTI_PHASE_TEST_TIMEOUT));
 
-/** A submenu entry in the application sidebar, rendered as <a title="{label}">. */
-const submenuItem = (page: Page, label: string) => page.locator(`.gv-submenu a[title="${label}"]`);
+type Page = import('@playwright/test').Page;
 
 /** An application row in the list, rendered as <a [routerLink]="[row.id]">{{ row.name }}</a>. */
 const applicationLink = (page: Page, name: string) => page.getByRole('link', { name, exact: true });
@@ -40,7 +43,6 @@ const oauthSaveButton = (page: Page) => page.getByRole('button', { name: /^SAVE$
 test.describe('Application-level roles - Console visibility', () => {
   test('AM-6036: an application owner can rename the application they own', async ({ page, permissionsWorld, signInAs }, testInfo) => {
     linkJira(testInfo, 'AM-6036');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     await signInAs(permissionsWorld.appOwner);
 
@@ -61,7 +63,6 @@ test.describe('Application-level roles - Console visibility', () => {
     signInAs,
   }, testInfo) => {
     linkJira(testInfo, 'AM-6036');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     await signInAs(permissionsWorld.appOwner);
 
@@ -100,7 +101,7 @@ test.describe('Application-level roles - Console visibility', () => {
     await signInAs(permissionsWorld.appViewer);
 
     await applicationLink(page, permissionsWorld.ownedApplication.name).click();
-    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+    await page.waitForURL(APPLICATION_OVERVIEW_URL);
 
     // Anchor on the menus a reader is entitled to before asserting the rest are absent.
     await expect(submenuItem(page, 'Overview')).toBeVisible();
@@ -122,7 +123,7 @@ test.describe('Application-level roles - Console visibility', () => {
     await signInAs(permissionsWorld.appOwner);
 
     await applicationLink(page, permissionsWorld.ownedApplication.name).click();
-    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+    await page.waitForURL(APPLICATION_OVERVIEW_URL);
 
     await expect(submenuItem(page, 'Overview')).toBeVisible();
     await expect(submenuItem(page, 'Settings')).toBeVisible();

--- a/gravitee-am-test/playwright/tests/permissions/application-role-visibility.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/application-role-visibility.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '../../fixtures/permissions.fixture';
+import { ApplicationGeneralSettingsPage } from '../../pages/application-general-settings.page';
+import { Oauth2SettingsPage } from '../../pages/oauth2-settings.page';
+import { linkJira } from '../../utils/jira';
+import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+
+// Each test signs in as its own persona, so no shared authenticated state.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+type Page = import('@playwright/test').Page;
+
+/** A submenu entry in the application sidebar, rendered as <a title="{label}">. */
+const submenuItem = (page: Page, label: string) => page.locator(`.gv-submenu a[title="${label}"]`);
+
+/** An application row in the list, rendered as <a [routerLink]="[row.id]">{{ row.name }}</a>. */
+const applicationLink = (page: Page, name: string) => page.getByRole('link', { name, exact: true });
+
+/**
+ * The OAuth2 settings form saves through a plain mat-raised-button, not a submit button, so
+ * BasePage.clickSave() cannot reach it. It stays disabled until the form is dirty.
+ */
+const oauthSaveButton = (page: Page) => page.getByRole('button', { name: /^SAVE$/ });
+
+test.describe('Application-level roles - Console visibility', () => {
+  test('AM-6036: an application owner can rename the application they own', async ({ page, permissionsWorld, signInAs }, testInfo) => {
+    linkJira(testInfo, 'AM-6036');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    await signInAs(permissionsWorld.appOwner);
+
+    const settings = new ApplicationGeneralSettingsPage(page);
+    await settings.navigateTo(permissionsWorld.domain.id, permissionsWorld.ownedApplication.id);
+
+    const renamed = `${permissionsWorld.ownedApplication.name}-renamed`;
+    await settings.fillName(renamed);
+    await settings.clickSave();
+
+    await settings.expectSnackbar(/updated|saved/i);
+    await expect(settings.nameInput).toHaveValue(renamed);
+  });
+
+  test('AM-6036: an application owner can change the client authentication method', async ({
+    page,
+    permissionsWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6036');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    await signInAs(permissionsWorld.appOwner);
+
+    const oauth = new Oauth2SettingsPage(page);
+    await oauth.navigateTo(permissionsWorld.domain.id, permissionsWorld.ownedApplication.id);
+
+    await expect(oauth.tokenAuthMethodSelect).toBeVisible();
+    await oauth.tokenAuthMethodSelect.click();
+    await oauth.tokenAuthMethodOption(/client_secret_post/).click();
+
+    await expect(oauthSaveButton(page)).toBeEnabled();
+    await oauthSaveButton(page).click();
+
+    await oauth.expectSnackbar(/updated|saved/i);
+    expect(await oauth.getTokenAuthMethodText()).toContain('client_secret_post');
+  });
+
+  test('AM-6036: an application owner sees only the application they are a member of', async ({
+    page,
+    permissionsWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6036');
+
+    await signInAs(permissionsWorld.appOwner);
+
+    // Positive anchor before the absence assertion — on an unrendered page every row is missing,
+    // so the owned application must be shown first for the exclusion below to mean anything.
+    await expect(applicationLink(page, permissionsWorld.ownedApplication.name)).toBeVisible();
+    await expect(applicationLink(page, permissionsWorld.otherApplication.name)).toHaveCount(0);
+  });
+
+  test('AM-6036: a read-only application role hides the editing menus', async ({ page, permissionsWorld, signInAs }, testInfo) => {
+    linkJira(testInfo, 'AM-6036');
+
+    await signInAs(permissionsWorld.appViewer);
+
+    await applicationLink(page, permissionsWorld.ownedApplication.name).click();
+    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+
+    // Anchor on the menus a reader is entitled to before asserting the rest are absent.
+    await expect(submenuItem(page, 'Overview')).toBeVisible();
+    await expect(submenuItem(page, 'Endpoints')).toBeVisible();
+
+    await expect(submenuItem(page, 'Settings')).toHaveCount(0);
+    await expect(submenuItem(page, 'Identity Providers')).toHaveCount(0);
+    await expect(submenuItem(page, 'Design')).toHaveCount(0);
+    await expect(submenuItem(page, 'Analytics')).toHaveCount(0);
+  });
+
+  test('AM-6036: an application owner keeps the editing menus the reader is denied', async ({
+    page,
+    permissionsWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6036');
+
+    await signInAs(permissionsWorld.appOwner);
+
+    await applicationLink(page, permissionsWorld.ownedApplication.name).click();
+    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+
+    await expect(submenuItem(page, 'Overview')).toBeVisible();
+    await expect(submenuItem(page, 'Settings')).toBeVisible();
+  });
+});

--- a/gravitee-am-test/playwright/tests/permissions/domain-role-visibility.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/domain-role-visibility.spec.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '../../fixtures/domain-permissions.fixture';
+import { ApplicationCreationPage } from '../../pages/application-creation.page';
+import { linkJira } from '../../utils/jira';
+import { uniqueTestName } from '../../utils/fixture-helpers';
+import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+
+// Every test signs in as its own persona, so no shared authenticated state.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const DOMAIN_LIST = '/environments/default/domains';
+
+/** Left-hand navigation entries for the domain a user is currently inside. */
+const domainMenuLink = (page: import('@playwright/test').Page, label: string) => page.getByRole('link', { name: label, exact: true });
+
+test.describe('Domain-level roles - Console visibility', () => {
+  test('AM-6032: a domain owner can create an application inside their own domain', async ({ page, domainWorld, signInAs }, testInfo) => {
+    linkJira(testInfo, 'AM-6032');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    await signInAs(domainWorld.devManager);
+
+    await page.goto(`/environments/default/domains/${domainWorld.devDomain.id}/applications`);
+    const wizard = new ApplicationCreationPage(page);
+    await wizard.openWizard();
+
+    const created = uniqueTestName('made-by-domain-owner');
+    await wizard.selectAppType('Web');
+    await wizard.clickNext();
+    await wizard.fillAppName(created);
+    await wizard.fillRedirectUri('https://example.com/callback');
+    await wizard.clickCreate();
+
+    // The wizard's own route is .../applications/new, so waiting for an /applications/ URL would
+    // match before anything happened. Go back to the list instead and look for the application:
+    // it appearing there is the outcome the scenario actually asks for.
+    await page.goto(`/environments/default/domains/${domainWorld.devDomain.id}/applications`);
+    await expect(page.getByRole('link', { name: created, exact: true })).toBeVisible();
+  });
+
+  test('AM-6032: a domain owner sees only the domain they are assigned to', async ({ page, domainWorld, signInAs }, testInfo) => {
+    linkJira(testInfo, 'AM-6032');
+
+    await signInAs(domainWorld.qaManager);
+    await page.goto(DOMAIN_LIST);
+
+    // Positive anchor before the exclusion — an unrendered list would otherwise satisfy it.
+    await expect(page.getByRole('link', { name: domainWorld.qaDomain.name, exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: domainWorld.devDomain.name, exact: true })).toHaveCount(0);
+  });
+
+  test('AM-6032: a domain owner is offered no way to create another domain', async ({ page, domainWorld, signInAs }, testInfo) => {
+    linkJira(testInfo, 'AM-6032');
+
+    await signInAs(domainWorld.qaManager);
+    await page.goto(DOMAIN_LIST);
+
+    await expect(page.getByRole('link', { name: domainWorld.qaDomain.name, exact: true })).toBeVisible();
+    // DOMAIN[CREATE] is authorised at environment and organization level, never at domain level,
+    // so a domain owner never gets the affordance regardless of what their role carries.
+    await expect(page.locator('a[mat-fab], button[mat-fab]')).toHaveCount(0);
+  });
+
+  test('AM-6032: a user holding only the default organization role reaches no domain at all', async ({
+    page,
+    domainWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6032');
+
+    await signInAs(domainWorld.basicUser);
+
+    // They are not merely shown an empty list — the Console tells them they have no environment.
+    await expect(page.getByText(/you don't have any environment yet/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: domainWorld.devDomain.name, exact: true })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: domainWorld.qaDomain.name, exact: true })).toHaveCount(0);
+  });
+
+  test('AM-6032: an application owner lands on the applications list with the domain menus withheld', async ({
+    page,
+    domainWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6032');
+
+    await signInAs(domainWorld.devAppOwner);
+
+    // Sign-in takes them straight to the applications list of the domain holding their application.
+    await expect(page).toHaveURL(new RegExp(`/domains/${domainWorld.devDomain.id}/applications`));
+
+    // Anchor on the one menu they are entitled to before asserting the rest are withheld.
+    await expect(domainMenuLink(page, 'Applications')).toBeVisible();
+    for (const withheld of ['Dashboard', 'Settings', 'Alerts', 'Authorization']) {
+      await expect(domainMenuLink(page, withheld)).toHaveCount(0);
+    }
+  });
+
+  test('AM-6032: an application owner sees only the application they are a member of', async ({
+    page,
+    domainWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6032');
+
+    await signInAs(domainWorld.devAppOwner);
+
+    await expect(page.getByRole('link', { name: domainWorld.devApplication.name, exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: domainWorld.devOtherApplication.name, exact: true })).toHaveCount(0);
+  });
+
+  test('AM-6032: a domain owner keeps the domain menus the application owner is denied', async ({
+    page,
+    domainWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6032');
+
+    await signInAs(domainWorld.devManager);
+
+    // The counterpart to the withheld-menus case: proves those entries are role-dependent rather
+    // than simply absent from this build of the Console.
+    for (const granted of ['Dashboard', 'Applications', 'Settings', 'Alerts']) {
+      await expect(domainMenuLink(page, granted)).toBeVisible();
+    }
+  });
+});

--- a/gravitee-am-test/playwright/tests/permissions/domain-role-visibility.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/domain-role-visibility.spec.ts
@@ -18,12 +18,17 @@ import { test, expect } from '../../fixtures/domain-permissions.fixture';
 import { ApplicationCreationPage } from '../../pages/application-creation.page';
 import { linkJira } from '../../utils/jira';
 import { uniqueTestName } from '../../utils/fixture-helpers';
-import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+import { CREATE_FAB_SELECTOR, domainListPath, MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
 
 // Every test signs in as its own persona, so no shared authenticated state.
 test.use({ storageState: { cookies: [], origins: [] } });
 
-const DOMAIN_LIST = '/environments/default/domains';
+// Every test here builds its own permissions world (domains, applications, personas, memberships)
+// and that setup counts against the test timeout, so the extended budget applies to all of them
+// rather than to the few that happened to ask for it.
+test.beforeEach(({}, testInfo) => testInfo.setTimeout(MULTI_PHASE_TEST_TIMEOUT));
+
+const DOMAIN_LIST = domainListPath();
 
 /** Left-hand navigation entries for the domain a user is currently inside. */
 const domainMenuLink = (page: import('@playwright/test').Page, label: string) => page.getByRole('link', { name: label, exact: true });
@@ -31,11 +36,10 @@ const domainMenuLink = (page: import('@playwright/test').Page, label: string) =>
 test.describe('Domain-level roles - Console visibility', () => {
   test('AM-6032: a domain owner can create an application inside their own domain', async ({ page, domainWorld, signInAs }, testInfo) => {
     linkJira(testInfo, 'AM-6032');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     await signInAs(domainWorld.devManager);
 
-    await page.goto(`/environments/default/domains/${domainWorld.devDomain.id}/applications`);
+    await page.goto(`${domainListPath()}/${domainWorld.devDomain.id}/applications`);
     const wizard = new ApplicationCreationPage(page);
     await wizard.openWizard();
 
@@ -49,7 +53,7 @@ test.describe('Domain-level roles - Console visibility', () => {
     // The wizard's own route is .../applications/new, so waiting for an /applications/ URL would
     // match before anything happened. Go back to the list instead and look for the application:
     // it appearing there is the outcome the scenario actually asks for.
-    await page.goto(`/environments/default/domains/${domainWorld.devDomain.id}/applications`);
+    await page.goto(`${domainListPath()}/${domainWorld.devDomain.id}/applications`);
     await expect(page.getByRole('link', { name: created, exact: true })).toBeVisible();
   });
 
@@ -73,7 +77,7 @@ test.describe('Domain-level roles - Console visibility', () => {
     await expect(page.getByRole('link', { name: domainWorld.qaDomain.name, exact: true })).toBeVisible();
     // DOMAIN[CREATE] is authorised at environment and organization level, never at domain level,
     // so a domain owner never gets the affordance regardless of what their role carries.
-    await expect(page.locator('a[mat-fab], button[mat-fab]')).toHaveCount(0);
+    await expect(page.locator(CREATE_FAB_SELECTOR)).toHaveCount(0);
   });
 
   test('AM-6032: a user holding only the default organization role reaches no domain at all', async ({

--- a/gravitee-am-test/playwright/tests/permissions/org-role-visibility.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/org-role-visibility.spec.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '../../fixtures/org-permissions.fixture';
+import { deleteOrganizationRole, findOrganizationRoleByName, getOrganizationRole } from '@management-commands/role-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { linkJira } from '../../utils/jira';
+import { uniqueTestName } from '../../utils/fixture-helpers';
+import { workerScope } from '../../utils/permissions-helpers';
+import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+
+type Page = import('@playwright/test').Page;
+
+const ROLES_PAGE = '/settings/roles';
+const DOMAIN_LIST = '/environments/default/domains';
+
+/** The five permission columns in the role editor, in the order the grid renders them. */
+const ACL_COLUMN = { create: 0, read: 1, list: 2, update: 3, delete: 4 };
+
+/** A row of the role editor's permission grid, addressed by the permission it carries. */
+const permissionRow = (page: Page, permission: string) =>
+  page.locator('tr').filter({ has: page.locator('td').filter({ hasText: new RegExp(`^${permission}$`) }) });
+
+/**
+ * These run as the administrator, using the signed-in state the setup project produces. The
+ * organization tier is where roles themselves are administered, so most of AM-6031 is about what
+ * that editor lets you do rather than about a restricted persona's view.
+ */
+test.describe('Organization-level roles - administering roles in the Console', () => {
+  test('AM-6031: an organization administrator can create a custom role carrying a chosen permission', async ({ page }, testInfo) => {
+    linkJira(testInfo, 'AM-6031');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    const roleName = uniqueTestName(workerScope('Org-QA-Auditor'));
+
+    await page.goto('/settings/roles/new');
+    await page.locator('input[name="name"]').fill(roleName);
+    await page.locator('mat-select[name="type"]').click();
+    await page
+      .locator('mat-option')
+      .filter({ hasText: /^\s*ORGANIZATION\s*$/ })
+      .first()
+      .click();
+    await page.getByRole('button', { name: /^CREATE$/ }).click();
+
+    // Creation lands on the new role's editor, where permissions are granted separately — the API
+    // rejects a permissions property at creation, so this second step is required, not cosmetic.
+    await page.waitForURL(/\/settings\/roles\/(?!new)[\w-]+/);
+    await permissionRow(page, 'DOMAIN').locator('mat-checkbox').nth(ACL_COLUMN.read).click();
+    await page.getByRole('button', { name: /^SAVE$/ }).click();
+
+    // Reopened from scratch, the grid must still show the permission as granted.
+    await page.reload();
+    const readBox = permissionRow(page, 'DOMAIN').locator('mat-checkbox').nth(ACL_COLUMN.read).locator('input');
+    await expect(readBox).toBeChecked();
+
+    const adminToken = await requestAdminAccessToken();
+    const listed = await findOrganizationRoleByName(adminToken, roleName);
+    const created = await getOrganizationRole(adminToken, listed.id);
+    expect(created.permissions).toEqual(['domain_read']);
+
+    await deleteOrganizationRole(adminToken, created.id).catch(() => undefined);
+  });
+
+  test('AM-6031: the permissions of a system role cannot be edited', async ({ page }, testInfo) => {
+    linkJira(testInfo, 'AM-6031');
+
+    await page.goto(ROLES_PAGE);
+    await page.getByText('ORGANIZATION_PRIMARY_OWNER', { exact: true }).first().click();
+    await page.waitForURL(/\/settings\/roles\/[\w-]+/);
+
+    // Positive anchor: the grid has to have rendered before "everything is disabled" means anything.
+    const checkboxes = page.locator('mat-checkbox input');
+    await expect(checkboxes.first()).toBeVisible();
+    const total = await checkboxes.count();
+    expect(total).toBeGreaterThan(0);
+
+    const enabled = await checkboxes.evaluateAll((inputs) => inputs.filter((input) => !(input as HTMLInputElement).disabled).length);
+    expect(enabled).toBe(0);
+  });
+
+  test('AM-6031: the permissions of a non-system role remain editable', async ({ page }, testInfo) => {
+    linkJira(testInfo, 'AM-6031');
+
+    // The counterpart to the case above: without it, a Console that disabled every checkbox
+    // everywhere would still look correct.
+    await page.goto(ROLES_PAGE);
+    await page.getByText('DOMAIN_OWNER', { exact: true }).first().click();
+    await page.waitForURL(/\/settings\/roles\/[\w-]+/);
+
+    const checkboxes = page.locator('mat-checkbox input');
+    await expect(checkboxes.first()).toBeVisible();
+
+    const disabled = await checkboxes.evaluateAll((inputs) => inputs.filter((input) => (input as HTMLInputElement).disabled).length);
+    expect(disabled).toBe(0);
+  });
+});
+
+/**
+ * The restricted views. Each signs in as its own persona, so the administrator session above must
+ * not leak into them.
+ */
+test.describe('Organization-level roles - what a restricted organization user reaches', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('AM-6031: a user holding only the default organization role is offered no way to create a domain', async ({
+    page,
+    orgWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6031');
+
+    await signInAs(orgWorld.orgUser);
+
+    // They cannot reach the domain list at all — the Console reports no environment rather than
+    // showing an empty one, so there is nowhere to offer a create control.
+    await expect(page.getByText(/you don't have any environment yet/i)).toBeVisible();
+    await expect(page.locator('a[mat-fab], button[mat-fab]')).toHaveCount(0);
+  });
+
+  test('AM-6031: a custom organization role granting only DOMAIN[READ] exposes no domains and no way to create one', async ({
+    page,
+    orgWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-6031');
+
+    await signInAs(orgWorld.auditor);
+    await page.goto(DOMAIN_LIST);
+
+    // Anchor: the Console shell rendered and the session is real, so the absences below are about
+    // this role rather than an unloaded page.
+    await expect(page.getByText('Access Management').first()).toBeVisible();
+
+    // DOMAIN[READ] is neither DOMAIN[LIST] nor ENVIRONMENT[LIST]. The domain exists and this role
+    // could read it by id, but the Console offers no route to it: asking for the domain list does
+    // not even stay on that URL, nothing lists the domain, and no control creates one.
+    await expect(page).not.toHaveURL(/\/domains\/?$/);
+    await expect(page.getByRole('link', { name: orgWorld.domain.name, exact: true })).toHaveCount(0);
+    await expect(page.locator('a[mat-fab], button[mat-fab]')).toHaveCount(0);
+  });
+});

--- a/gravitee-am-test/playwright/tests/permissions/org-role-visibility.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/org-role-visibility.spec.ts
@@ -20,12 +20,12 @@ import { requestAdminAccessToken } from '@management-commands/token-management-c
 import { linkJira } from '../../utils/jira';
 import { uniqueTestName } from '../../utils/fixture-helpers';
 import { workerScope } from '../../utils/permissions-helpers';
-import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+import { CREATE_FAB_SELECTOR, domainListPath, MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
 
 type Page = import('@playwright/test').Page;
 
 const ROLES_PAGE = '/settings/roles';
-const DOMAIN_LIST = '/environments/default/domains';
+const DOMAIN_LIST = domainListPath();
 
 /** The five permission columns in the role editor, in the order the grid renders them. */
 const ACL_COLUMN = { create: 0, read: 1, list: 2, update: 3, delete: 4 };
@@ -33,6 +33,11 @@ const ACL_COLUMN = { create: 0, read: 1, list: 2, update: 3, delete: 4 };
 /** A row of the role editor's permission grid, addressed by the permission it carries. */
 const permissionRow = (page: Page, permission: string) =>
   page.locator('tr').filter({ has: page.locator('td').filter({ hasText: new RegExp(`^${permission}$`) }) });
+
+// Every test here builds its own permissions world (domains, roles, personas) and that setup
+// counts against the test timeout, so the extended budget applies to all of them rather than to
+// the one that happened to ask for it.
+test.beforeEach(({}, testInfo) => testInfo.setTimeout(MULTI_PHASE_TEST_TIMEOUT));
 
 /**
  * These run as the administrator, using the signed-in state the setup project produces. The
@@ -42,7 +47,6 @@ const permissionRow = (page: Page, permission: string) =>
 test.describe('Organization-level roles - administering roles in the Console', () => {
   test('AM-6031: an organization administrator can create a custom role carrying a chosen permission', async ({ page }, testInfo) => {
     linkJira(testInfo, 'AM-6031');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     const roleName = uniqueTestName(workerScope('Org-QA-Auditor'));
 
@@ -128,7 +132,7 @@ test.describe('Organization-level roles - what a restricted organization user re
     // They cannot reach the domain list at all — the Console reports no environment rather than
     // showing an empty one, so there is nowhere to offer a create control.
     await expect(page.getByText(/you don't have any environment yet/i)).toBeVisible();
-    await expect(page.locator('a[mat-fab], button[mat-fab]')).toHaveCount(0);
+    await expect(page.locator(CREATE_FAB_SELECTOR)).toHaveCount(0);
   });
 
   test('AM-6031: a custom organization role granting only DOMAIN[READ] exposes no domains and no way to create one', async ({
@@ -150,6 +154,6 @@ test.describe('Organization-level roles - what a restricted organization user re
     // not even stay on that URL, nothing lists the domain, and no control creates one.
     await expect(page).not.toHaveURL(/\/domains\/?$/);
     await expect(page.getByRole('link', { name: orgWorld.domain.name, exact: true })).toHaveCount(0);
-    await expect(page.locator('a[mat-fab], button[mat-fab]')).toHaveCount(0);
+    await expect(page.locator(CREATE_FAB_SELECTOR)).toHaveCount(0);
   });
 });

--- a/gravitee-am-test/playwright/tests/permissions/ui-api-parity.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/ui-api-parity.spec.ts
@@ -21,9 +21,13 @@ import { createConsolePersona, submenuItem } from '../../utils/permissions-helpe
 import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
 import { linkJira } from '../../utils/jira';
 import { uniqueTestName } from '../../utils/fixture-helpers';
-import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+import { APPLICATION_OVERVIEW_URL, CREATE_FAB_SELECTOR, MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
 
 test.use({ storageState: { cookies: [], origins: [] } });
+
+// Every test here builds its own permissions world, and that setup counts against the test
+// timeout, so the extended budget applies uniformly across the file.
+test.beforeEach(({}, testInfo) => testInfo.setTimeout(MULTI_PHASE_TEST_TIMEOUT));
 
 const managementUrl = () => `${process.env.AM_MANAGEMENT_URL}/management`;
 const authHeaders = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
@@ -44,13 +48,12 @@ const applicationPath = (domainId: string, applicationId: string) =>
 test.describe('UI and API parity - the Console agrees with the management API', () => {
   test('AM-7472: a control the Console withholds is also refused by the API', async ({ page, permissionsWorld, signInAs }, testInfo) => {
     linkJira(testInfo, 'AM-7472');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     const { appViewer, domain, ownedApplication } = permissionsWorld;
 
     await signInAs(appViewer);
     await page.getByRole('link', { name: ownedApplication.name, exact: true }).click();
-    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+    await page.waitForURL(APPLICATION_OVERVIEW_URL);
 
     // Anchor on what this role is entitled to before asserting what it is not offered.
     await expect(submenuItem(page, 'Overview')).toBeVisible();
@@ -71,13 +74,12 @@ test.describe('UI and API parity - the Console agrees with the management API', 
 
   test('AM-7472: a control the Console offers is accepted by the API', async ({ page, permissionsWorld, signInAs }, testInfo) => {
     linkJira(testInfo, 'AM-7472');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     const { appOwner, domain, ownedApplication } = permissionsWorld;
 
     await signInAs(appOwner);
     await page.getByRole('link', { name: ownedApplication.name, exact: true }).click();
-    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+    await page.waitForURL(APPLICATION_OVERVIEW_URL);
 
     await expect(submenuItem(page, 'Settings')).toBeVisible();
 
@@ -104,7 +106,6 @@ test.describe('UI and API parity - the Console agrees with the management API', 
     signInAs,
   }, testInfo) => {
     linkJira(testInfo, 'AM-7472');
-    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
     // A user holding nothing but the default organization role, created here because this is the
     // only case that needs one.
@@ -114,7 +115,7 @@ test.describe('UI and API parity - the Console agrees with the management API', 
       await signInAs(bareUser);
 
       // Nothing anywhere offers domain creation to them.
-      await expect(page.locator('a[mat-fab], button[mat-fab]')).toHaveCount(0);
+      await expect(page.locator(CREATE_FAB_SELECTOR)).toHaveCount(0);
 
       const token = await requestAccessToken(bareUser.username, bareUser.password);
       const response = await performPost(

--- a/gravitee-am-test/playwright/tests/permissions/ui-api-parity.spec.ts
+++ b/gravitee-am-test/playwright/tests/permissions/ui-api-parity.spec.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '../../fixtures/permissions.fixture';
+import { requestAccessToken } from '@management-commands/token-management-commands';
+import { performGet, performPatch, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { createConsolePersona, submenuItem } from '../../utils/permissions-helpers';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { linkJira } from '../../utils/jira';
+import { uniqueTestName } from '../../utils/fixture-helpers';
+import { MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const managementUrl = () => `${process.env.AM_MANAGEMENT_URL}/management`;
+const authHeaders = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+const applicationPath = (domainId: string, applicationId: string) =>
+  `/organizations/${process.env.AM_DEF_ORG_ID}/environments/${process.env.AM_DEF_ENV_ID}/domains/${domainId}/applications/${applicationId}`;
+
+/**
+ * The Console does not display the management API's verdict — it reaches its own. `AuthService`
+ * keeps a flattened list of permission strings per tier and decides visibility by looking a value
+ * up in it, entirely client-side, while the API resolves memberships and acls server-side. They are
+ * two implementations of one rule, and nothing else in this suite compares them.
+ *
+ * So each case drives both channels as the *same* user: what the browser shows, and what the API
+ * answers for the corresponding request. A divergence in either direction is a defect — a control
+ * offered that the API refuses wastes the user's time and misrepresents their access; a control
+ * withheld that the API would have allowed silently removes function they are entitled to.
+ */
+test.describe('UI and API parity - the Console agrees with the management API', () => {
+  test('AM-7472: a control the Console withholds is also refused by the API', async ({ page, permissionsWorld, signInAs }, testInfo) => {
+    linkJira(testInfo, 'AM-7472');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    const { appViewer, domain, ownedApplication } = permissionsWorld;
+
+    await signInAs(appViewer);
+    await page.getByRole('link', { name: ownedApplication.name, exact: true }).click();
+    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+
+    // Anchor on what this role is entitled to before asserting what it is not offered.
+    await expect(submenuItem(page, 'Overview')).toBeVisible();
+    await expect(submenuItem(page, 'Settings')).toHaveCount(0);
+
+    // The same user, asking the API directly for the change that menu would have led to.
+    const token = await requestAccessToken(appViewer.username, appViewer.password);
+    const response = await performPatch(
+      managementUrl(),
+      applicationPath(domain.id, ownedApplication.id),
+      { description: 'attempted by a read-only application role' },
+      authHeaders(token),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+
+  test('AM-7472: a control the Console offers is accepted by the API', async ({ page, permissionsWorld, signInAs }, testInfo) => {
+    linkJira(testInfo, 'AM-7472');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    const { appOwner, domain, ownedApplication } = permissionsWorld;
+
+    await signInAs(appOwner);
+    await page.getByRole('link', { name: ownedApplication.name, exact: true }).click();
+    await page.waitForURL(/.*\/applications\/.*\/overview.*/i);
+
+    await expect(submenuItem(page, 'Settings')).toBeVisible();
+
+    // The counterpart: an offered control must correspond to a request the API actually allows,
+    // otherwise the Console is advertising access its holder does not have.
+    const token = await requestAccessToken(appOwner.username, appOwner.password);
+    const response = await performPatch(
+      managementUrl(),
+      applicationPath(domain.id, ownedApplication.id),
+      { description: 'applied by the application owner' },
+      authHeaders(token),
+    );
+
+    expect(response.status).toBeLessThan(400);
+
+    // And the change is real, not merely accepted.
+    const reread = await performGet(managementUrl(), applicationPath(domain.id, ownedApplication.id), authHeaders(token));
+    expect(reread.body.description).toEqual('applied by the application owner');
+  });
+
+  test('AM-7472: a user offered no way to create a domain is also refused by the API', async ({
+    page,
+    permissionsWorld,
+    signInAs,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-7472');
+    test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+    // A user holding nothing but the default organization role, created here because this is the
+    // only case that needs one.
+    const bareUser = await createConsolePersona(permissionsWorld.adminToken, 'parity-bare');
+
+    try {
+      await signInAs(bareUser);
+
+      // Nothing anywhere offers domain creation to them.
+      await expect(page.locator('a[mat-fab], button[mat-fab]')).toHaveCount(0);
+
+      const token = await requestAccessToken(bareUser.username, bareUser.password);
+      const response = await performPost(
+        managementUrl(),
+        `/organizations/${process.env.AM_DEF_ORG_ID}/environments/${process.env.AM_DEF_ENV_ID}/domains`,
+        {
+          name: uniqueTestName('parity-should-never-exist'),
+          description: 'must never be created',
+          dataPlaneId: process.env.AM_DOMAIN_DATA_PLANE_ID || 'default',
+        },
+        authHeaders(token),
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toEqual('Permission denied');
+    } finally {
+      await deleteOrganisationUser(permissionsWorld.adminToken, bareUser.userId).catch(() => undefined);
+    }
+  });
+});

--- a/gravitee-am-test/playwright/utils/permissions-helpers.ts
+++ b/gravitee-am-test/playwright/utils/permissions-helpers.ts
@@ -77,5 +77,5 @@ export async function signInToConsole(page: Page, persona: ConsolePersona): Prom
   await page.waitForURL((url) => !/\/login/.test(url.pathname) && !/\/oauth\/authorize/.test(url.pathname));
 }
 
-/** A submenu entry in the Console sidebar, rendered as <a title="{label}">. */
-export const submenuItem = (page: Page, label: string) => page.locator(`.gv-submenu a[title="${label}"]`);
+// Re-exported from the suite-wide helper so there is one definition of this locator.
+export { submenuItem } from './selectors';

--- a/gravitee-am-test/playwright/utils/permissions-helpers.ts
+++ b/gravitee-am-test/playwright/utils/permissions-helpers.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Page } from '@playwright/test';
+import { createOrganisationUser } from '@management-commands/organisation-user-commands';
+import { LoginPage } from '../pages/login.page';
+import { quietly, uniqueTestName } from './fixture-helpers';
+import { UI_USER_PASSWORD } from './test-constants';
+
+/**
+ * Playwright runs spec files in separate worker processes and faker reseeds identically in each,
+ * so uniqueTestName() alone yields the same sequence per worker. Fixtures in this area share their
+ * prefixes, so without this the workers collide on "already exists". The process id separates them.
+ */
+export const workerScope = (prefix: string) => `${prefix}-${process.pid}`;
+
+/** A console user a test can sign in as. */
+export interface ConsolePersona {
+  username: string;
+  password: string;
+  userId: string;
+}
+
+/**
+ * Creates an organization user that can sign in to the Console.
+ *
+ * Creating the user is enough on its own: AM grants the default ORGANIZATION_USER role at
+ * creation, and holding an organization role is what makes the Console reachable at all. Roles at
+ * domain or application level are layered on afterwards as memberships.
+ */
+export async function createConsolePersona(adminToken: string, label: string): Promise<ConsolePersona> {
+  const username = uniqueTestName(workerScope(label)).toLowerCase();
+  const user = await quietly(() =>
+    createOrganisationUser(adminToken, {
+      firstName: label,
+      lastName: 'Persona',
+      email: `${username}@test.com`,
+      username,
+      password: UI_USER_PASSWORD,
+      preRegistration: false,
+    }),
+  );
+  return { username, password: UI_USER_PASSWORD, userId: user.id };
+}
+
+/**
+ * Signs in through the Console login form as the given persona.
+ *
+ * `LoginPage.login()` waits for a URL containing environments/dashboard/domains, which assumes the
+ * user has somewhere to land. A user holding no domain at all — exactly the case these tests need
+ * to cover — is left on the application root instead, so that wait never resolves. Waiting for the
+ * login route to be *left* behind works for every persona regardless of what they can reach.
+ */
+export async function signInToConsole(page: Page, persona: ConsolePersona): Promise<void> {
+  const login = new LoginPage(page);
+  await page.goto('/');
+  await page.waitForURL(/.*login.*|.*auth\/authorize.*/i);
+
+  await login.usernameInput.waitFor({ state: 'visible' });
+  await login.usernameInput.fill(persona.username);
+  await login.passwordInput.fill(persona.password);
+  await login.signInButton.click();
+
+  await page.waitForURL((url) => !/\/login/.test(url.pathname) && !/\/oauth\/authorize/.test(url.pathname));
+}
+
+/** A submenu entry in the Console sidebar, rendered as <a title="{label}">. */
+export const submenuItem = (page: Page, label: string) => page.locator(`.gv-submenu a[title="${label}"]`);

--- a/gravitee-am-test/playwright/utils/test-constants.ts
+++ b/gravitee-am-test/playwright/utils/test-constants.ts
@@ -74,3 +74,19 @@ export const RESET_PASSWORD_GATEWAY_SETTLE_MS = 2_000;
 
 /** New password set on gateway reset-password form; distinct from {@link API_USER_PASSWORD} (AM-2196). */
 export const FORGOT_PASSWORD_NEW_PASSWORD_AFTER_RESET = 'V@l1dNewP@ss99';
+
+/* ------------------------------------------------------------------ */
+/*  Console route and selector constants                               */
+/* ------------------------------------------------------------------ */
+
+/** Environment hrid used in Console route paths; the standalone form of `BasePage.envHrid`. */
+export const envHrid = (): string => process.env.AM_DEF_ENV_HRID || 'default';
+
+/** Console route for the domain list of the default environment. */
+export const domainListPath = (): string => `/environments/${envHrid()}/domains`;
+
+/** URL an application settles on once opened from the application list. */
+export const APPLICATION_OVERVIEW_URL = /.*\/applications\/.*\/overview.*/i;
+
+/** The Console's floating create button, absent wherever the user may not create. */
+export const CREATE_FAB_SELECTOR = 'a[mat-fab], button[mat-fab]';

--- a/gravitee-am-test/scripts/generate-permission-endpoints.js
+++ b/gravitee-am-test/scripts/generate-permission-endpoints.js
@@ -125,12 +125,22 @@ ${entries}
 `;
 }
 
-const rows = collect();
-fs.writeFileSync(OUT, render(rows));
-// The repo lints every .ts file, generated or not, so format the output here rather than leaving
-// whoever regenerates it to discover a prettier failure afterwards.
-require('child_process').execSync(`npx prettier --write ${JSON.stringify(OUT)}`, { stdio: 'ignore' });
-const byMethod = rows.reduce((acc, row) => ({ ...acc, [row.method]: (acc[row.method] || 0) + 1 }), {});
-console.log(`Wrote ${rows.length} endpoints to ${path.relative(process.cwd(), OUT)}`);
-console.log('  by method   :', byMethod);
-console.log('  permissions :', new Set(rows.map((row) => row.permission)).size);
+function write() {
+  const rows = collect();
+  fs.writeFileSync(OUT, render(rows));
+  // The repo lints every .ts file, generated or not, so format the output here rather than leaving
+  // whoever regenerates it to discover a prettier failure afterwards.
+  require('child_process').execSync(`npx prettier --write ${JSON.stringify(OUT)}`, { stdio: 'ignore' });
+  const byMethod = rows.reduce((acc, row) => ({ ...acc, [row.method]: (acc[row.method] || 0) + 1 }), {});
+  console.log(`Wrote ${rows.length} endpoints to ${path.relative(process.cwd(), OUT)}`);
+  console.log('  by method   :', byMethod);
+  console.log('  permissions :', new Set(rows.map((row) => row.permission)).size);
+}
+
+// Only regenerate when run as a script. Importing this module must stay side-effect free so
+// permission-table-freshness.jest.spec.ts can call collect() to compare against the committed file.
+if (require.main === module) {
+  write();
+}
+
+module.exports = { collect, render, write, SPEC, OUT };

--- a/gravitee-am-test/scripts/generate-permission-endpoints.js
+++ b/gravitee-am-test/scripts/generate-permission-endpoints.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regenerates the endpoint/permission table driven by endpoint-permission-sweep.jest.spec.ts.
+ *
+ *   node scripts/generate-permission-endpoints.js
+ *
+ * Every management operation documents the permission it requires in its OpenAPI description
+ * ("User must have DOMAIN_USER[LIST] permission on ..."). Reading that gives an authoritative,
+ * always-current list of what each endpoint is supposed to be guarded by, so a newly added
+ * endpoint joins the sweep as soon as the spec is regenerated rather than whenever someone
+ * remembers to extend a hand-written list.
+ *
+ * Only operations whose every path parameter can be filled with a real id are emitted — the
+ * sweep must not provoke a refusal by quoting a resource that does not exist, because that is a
+ * different denial to the one being tested.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const SPEC = path.resolve(__dirname, '../../docs/mapi/openapi.yaml');
+const OUT = path.resolve(__dirname, '../specs/management/permissions/fixtures/permission-endpoints.generated.ts');
+
+/** Path params the sweep fixture can substitute with a genuinely existing resource. */
+const FILLABLE = new Set(['{organizationId}', '{environmentId}', '{domain}', '{application}']);
+
+/** Methods that carry no request body, so a refusal cannot be confused with payload validation. */
+const BODYLESS = new Set(['GET', 'DELETE']);
+
+const REQUIREMENT = /User must have (?:the )?([A-Z_]+)\[([A-Z/]+)\]/;
+
+function collect() {
+  const spec = yaml.load(fs.readFileSync(SPEC, 'utf8'));
+  const rows = [];
+
+  for (const [route, operations] of Object.entries(spec.paths || {})) {
+    for (const [method, operation] of Object.entries(operations || {})) {
+      const verb = method.toUpperCase();
+      if (!BODYLESS.has(verb)) continue;
+
+      const requirement = REQUIREMENT.exec((operation && operation.description) || '');
+      if (!requirement) continue;
+
+      const params = route.match(/\{[^}]+\}/g) || [];
+      if (!params.every((param) => FILLABLE.has(param))) continue;
+
+      const [, permission, acls] = requirement;
+      // A handful of operations document several acceptable acls ("CREATE/UPDATE/DELETE"); the
+      // first is enough to decide whether a caller holding none of them should be refused.
+      const acl = acls.split('/')[0];
+
+      rows.push({
+        method: verb,
+        route,
+        permission: `${permission.toLowerCase()}_${acl.toLowerCase()}`,
+        summary: (operation.summary || '').trim(),
+      });
+    }
+  }
+
+  rows.sort((a, b) => a.route.localeCompare(b.route) || a.method.localeCompare(b.method));
+  return rows;
+}
+
+function render(rows) {
+  const entries = rows
+    .map(
+      (row) =>
+        `  { method: '${row.method}', route: '${row.route}', permission: '${row.permission}', summary: ${JSON.stringify(row.summary)} },`,
+    )
+    .join('\n');
+
+  return `/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable */
+// GENERATED FILE — do not edit by hand.
+// Regenerate with: node scripts/generate-permission-endpoints.js
+//
+// Source: docs/mapi/openapi.yaml, from each operation's stated permission requirement.
+// Only bodyless operations (GET, DELETE) whose path parameters are all fillable with real ids are
+// included, so a refusal can only be about permissions.
+
+export interface PermissionEndpoint {
+  method: 'GET' | 'DELETE';
+  /** OpenAPI route, with {organizationId}/{environmentId}/{domain}/{application} placeholders. */
+  route: string;
+  /** Flattened permission the operation documents as required, e.g. "domain_user_list". */
+  permission: string;
+  summary: string;
+}
+
+export const PERMISSION_ENDPOINTS: PermissionEndpoint[] = [
+${entries}
+];
+`;
+}
+
+const rows = collect();
+fs.writeFileSync(OUT, render(rows));
+// The repo lints every .ts file, generated or not, so format the output here rather than leaving
+// whoever regenerates it to discover a prettier failure afterwards.
+require('child_process').execSync(`npx prettier --write ${JSON.stringify(OUT)}`, { stdio: 'ignore' });
+const byMethod = rows.reduce((acc, row) => ({ ...acc, [row.method]: (acc[row.method] || 0) + 1 }), {});
+console.log(`Wrote ${rows.length} endpoints to ${path.relative(process.cwd(), OUT)}`);
+console.log('  by method   :', byMethod);
+console.log('  permissions :', new Set(rows.map((row) => row.permission)).size);

--- a/gravitee-am-test/specs/management/permissions/cross-reference-isolation.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/cross-reference-isolation.jest.spec.ts
@@ -20,7 +20,7 @@ import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
 import { performGet, performPatch } from '@gateway-commands/oauth-oidc-commands';
 import { getOrganisationManagementUrl } from '@management-commands/service/utils';
 
-setup();
+setup(200000);
 
 let fixture: RbacFixture;
 

--- a/gravitee-am-test/specs/management/permissions/cross-reference-isolation.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/cross-reference-isolation.jest.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import { performGet, performPatch } from '@gateway-commands/oauth-oidc-commands';
+import { getOrganisationManagementUrl } from '@management-commands/service/utils';
+
+setup();
+
+let fixture: RbacFixture;
+
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+const domainPath = (domainId: string, suffix = '') => `/environments/${process.env.AM_DEF_ENV_ID}/domains/${domainId}${suffix}`;
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * Management API paths name a whole chain of resources — organization, environment, domain,
+ * application. Authorising only the leaf would let a caller reach a resource by quoting a parent
+ * they are entitled to instead of the one that actually owns it. `haveConsistentReferenceIds`
+ * exists to reject that, and these cases are issued **as the administrator**: a caller with every
+ * permission on both domains. Permissions therefore cannot account for the refusal — only the
+ * inconsistent path can.
+ */
+describe('Cross-reference isolation - a resource cannot be reached through a parent that does not own it', () => {
+  it('should serve an application addressed through its own domain', async () => {
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      domainPath(fixture.domain.id, `/applications/${fixture.application.id}`),
+      headers(fixture.adminToken),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual(fixture.application.id);
+  });
+
+  it('should refuse an application addressed through an unrelated domain', async () => {
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      domainPath(fixture.otherDomain.id, `/applications/${fixture.application.id}`),
+      headers(fixture.adminToken),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+
+  it('should refuse a sub-resource addressed through an unrelated domain', async () => {
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      domainPath(fixture.otherDomain.id, `/applications/${fixture.application.id}/members`),
+      headers(fixture.adminToken),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+});
+
+describe('Cross-reference isolation - a domain owner is confined to their own domain', () => {
+  it('should let a DOMAIN_OWNER read the domain they are assigned to', async () => {
+    const response = await performGet(getOrganisationManagementUrl(), domainPath(fixture.domain.id), headers(fixture.domainOwner.token));
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual(fixture.domain.id);
+  });
+
+  it('should refuse a DOMAIN_OWNER reading a domain they have no membership on', async () => {
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      domainPath(fixture.otherDomain.id),
+      headers(fixture.domainOwner.token),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+
+  it('should refuse a DOMAIN_OWNER modifying a domain they have no membership on', async () => {
+    const response = await performPatch(
+      getOrganisationManagementUrl(),
+      domainPath(fixture.otherDomain.id),
+      { description: 'modified by a domain owner from elsewhere' },
+      headers(fixture.domainOwner.token),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+});
+
+describe('Cross-reference isolation - an application owner is confined to their own application', () => {
+  it('should let an APPLICATION_OWNER read the application they are assigned to', async () => {
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      domainPath(fixture.domain.id, `/applications/${fixture.application.id}`),
+      headers(fixture.appOwner.token),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual(fixture.application.id);
+  });
+
+  it('should refuse an APPLICATION_OWNER reading a sibling application in the same domain', async () => {
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      domainPath(fixture.domain.id, `/applications/${fixture.otherApplication.id}`),
+      headers(fixture.appOwner.token),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+
+  it('should refuse an APPLICATION_OWNER modifying a sibling application in the same domain', async () => {
+    const response = await performPatch(
+      getOrganisationManagementUrl(),
+      domainPath(fixture.domain.id, `/applications/${fixture.otherApplication.id}`),
+      { description: 'modified by the owner of a different application' },
+      headers(fixture.appOwner.token),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/custom-role-lifecycle.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/custom-role-lifecycle.jest.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import {
+  createOrganizationRole,
+  deleteOrganizationRole,
+  findOrganizationRoleByName,
+  getOrganizationRole,
+  updateOrganizationRole,
+} from '@management-commands/role-management-commands';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { getOrganisationManagementUrl } from '@management-commands/service/utils';
+import { uniqueName } from '@utils-commands/misc';
+import { ListRolesTypeEnum } from '@management-apis/RoleApi';
+import { JWT_FORMAT } from '@specs-utils/jwt-format';
+
+setup();
+
+let accessToken: string;
+const createdRoleIds: string[] = [];
+
+const newRoleNamed = async (label: string, assignableType: 'DOMAIN' | 'APPLICATION' | 'ORGANIZATION' = 'DOMAIN') => {
+  const name = uniqueName(label, true);
+  await createOrganizationRole(accessToken, { name, assignableType });
+  const role = await findOrganizationRoleByName(accessToken, name);
+  createdRoleIds.push(role.id);
+  return role;
+};
+
+beforeAll(async () => {
+  accessToken = await requestAdminAccessToken();
+  expect(accessToken).toMatch(JWT_FORMAT);
+});
+
+afterAll(async () => {
+  for (const id of createdRoleIds) {
+    await deleteOrganizationRole(accessToken, id).catch(() => undefined);
+  }
+});
+
+/**
+ * Creating a custom role and giving it permissions are two separate calls, and not by convention —
+ * the create endpoint rejects a `permissions` property outright. A caller who assumes one call
+ * ends up with a role that grants nothing, which is silent and easy to miss.
+ */
+describe('Custom role lifecycle - permissions are applied by a second call, never at creation', () => {
+  it('should reject a permissions property supplied at creation', async () => {
+    const response = await performPost(
+      getOrganisationManagementUrl(),
+      '/roles',
+      { name: uniqueName('rejected-at-create', true), assignableType: 'DOMAIN', permissions: ['domain_read'] },
+      { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toEqual('Property [permissions] is not recognized as a valid property');
+  });
+
+  it('should create the role carrying no permissions at all', async () => {
+    const role = await newRoleNamed('lifecycle-empty');
+
+    expect(role.permissions ?? []).toEqual([]);
+  });
+
+  it('should apply permissions on update', async () => {
+    const role = await newRoleNamed('lifecycle-updated');
+
+    const updated = await updateOrganizationRole(accessToken, role.id, {
+      name: role.name,
+      permissions: ['domain_read'],
+    });
+
+    expect(updated.permissions).toEqual(['domain_read']);
+  });
+});
+
+/**
+ * A role's `assignableType` constrains where it may be assigned, but not which permissions it may
+ * carry — a domain-scoped role is allowed to hold application permissions it can never exercise.
+ * This is deliberate to record, because it is the precondition that makes AM-7475 reachable.
+ */
+describe('Custom role lifecycle - permissions are not validated against the assignable type', () => {
+  it('should accept an application permission on a domain-assignable role', async () => {
+    const role = await newRoleNamed('lifecycle-mismatched');
+
+    const updated = await updateOrganizationRole(accessToken, role.id, {
+      name: role.name,
+      permissions: ['domain_read', 'application_read'],
+    });
+
+    expect(updated.permissions.sort()).toEqual(['application_read', 'domain_read']);
+    // Case-insensitive: create and list report the assignable type lowercase, update reports it
+    // uppercase. The casing is incidental here — what matters is that the type stayed DOMAIN while
+    // an application permission was accepted onto it.
+    expect(updated.assignableType.toLowerCase()).toEqual('domain');
+  });
+});
+
+describe('Custom role lifecycle - naming and deletion', () => {
+  it('should refuse a second role with a name already in use', async () => {
+    const role = await newRoleNamed('lifecycle-duplicate');
+
+    await expect(createOrganizationRole(accessToken, { name: role.name, assignableType: 'DOMAIN' })).rejects.toMatchObject({
+      response: { status: 400 },
+      message: expect.stringContaining('already exists'),
+    });
+  });
+
+  it('should delete a custom role and stop resolving it afterwards', async () => {
+    const role = await newRoleNamed('lifecycle-deleted');
+
+    await deleteOrganizationRole(accessToken, role.id);
+
+    await expect(getOrganizationRole(accessToken, role.id)).rejects.toMatchObject({ response: { status: 404 } });
+  });
+});
+
+/**
+ * Built-in roles are protected from edits that would change what the product itself relies on.
+ * System roles are not addressable through the organization endpoint at all, so the refusal
+ * surfaces as a 404 rather than the 400 the service's own guard would produce; either way the
+ * edit does not happen, which is the property worth holding.
+ */
+describe('Custom role lifecycle - built-in roles resist modification', () => {
+  it('should refuse to update a system role', async () => {
+    const systemRole = await findOrganizationRoleByName(accessToken, 'ORGANIZATION_PRIMARY_OWNER');
+
+    await expect(
+      updateOrganizationRole(accessToken, systemRole.id, { name: 'ORGANIZATION_PRIMARY_OWNER', permissions: [] }),
+    ).rejects.toMatchObject({ response: { status: 404 } });
+  });
+
+  it('should refuse to delete a system role', async () => {
+    const systemRole = await findOrganizationRoleByName(accessToken, 'ORGANIZATION_PRIMARY_OWNER');
+
+    await expect(deleteOrganizationRole(accessToken, systemRole.id)).rejects.toMatchObject({ response: { status: 404 } });
+  });
+
+  it('should refuse to rename a default role', async () => {
+    const defaultRole = await findOrganizationRoleByName(accessToken, 'DOMAIN_USER', ListRolesTypeEnum.Domain);
+
+    await expect(
+      updateOrganizationRole(accessToken, defaultRole.id, { name: 'RENAMED_DOMAIN_USER', permissions: ['domain_read'] }),
+    ).rejects.toMatchObject({
+      response: { status: 400 },
+      message: expect.stringContaining('name cannot be updated'),
+    });
+  });
+
+  it('should leave the default role untouched after the rejected rename', async () => {
+    const defaultRole = await findOrganizationRoleByName(accessToken, 'DOMAIN_USER', ListRolesTypeEnum.Domain);
+
+    expect(defaultRole.name).toEqual('DOMAIN_USER');
+    expect(defaultRole.defaultRole).toBe(true);
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/custom-role-lifecycle.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/custom-role-lifecycle.jest.spec.ts
@@ -16,7 +16,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { setup } from '../../test-fixture';
-import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { RoleFixture, setupRoleFixture } from './fixtures/role-fixture';
 import {
   createOrganizationRole,
   deleteOrganizationRole,
@@ -28,29 +28,18 @@ import { performPost } from '@gateway-commands/oauth-oidc-commands';
 import { getOrganisationManagementUrl } from '@management-commands/service/utils';
 import { uniqueName } from '@utils-commands/misc';
 import { ListRolesTypeEnum } from '@management-apis/RoleApi';
-import { JWT_FORMAT } from '@specs-utils/jwt-format';
 
-setup();
+setup(200000);
 
-let accessToken: string;
-const createdRoleIds: string[] = [];
-
-const newRoleNamed = async (label: string, assignableType: 'DOMAIN' | 'APPLICATION' | 'ORGANIZATION' = 'DOMAIN') => {
-  const name = uniqueName(label, true);
-  await createOrganizationRole(accessToken, { name, assignableType });
-  const role = await findOrganizationRoleByName(accessToken, name);
-  createdRoleIds.push(role.id);
-  return role;
-};
+let fixture: RoleFixture;
 
 beforeAll(async () => {
-  accessToken = await requestAdminAccessToken();
-  expect(accessToken).toMatch(JWT_FORMAT);
+  fixture = await setupRoleFixture();
 });
 
 afterAll(async () => {
-  for (const id of createdRoleIds) {
-    await deleteOrganizationRole(accessToken, id).catch(() => undefined);
+  if (fixture) {
+    await fixture.cleanup();
   }
 });
 
@@ -65,7 +54,7 @@ describe('Custom role lifecycle - permissions are applied by a second call, neve
       getOrganisationManagementUrl(),
       '/roles',
       { name: uniqueName('rejected-at-create', true), assignableType: 'DOMAIN', permissions: ['domain_read'] },
-      { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+      { 'Content-Type': 'application/json', Authorization: `Bearer ${fixture.adminToken}` },
     );
 
     expect(response.status).toBe(400);
@@ -73,15 +62,15 @@ describe('Custom role lifecycle - permissions are applied by a second call, neve
   });
 
   it('should create the role carrying no permissions at all', async () => {
-    const role = await newRoleNamed('lifecycle-empty');
+    const role = await fixture.createRole('lifecycle-empty');
 
     expect(role.permissions ?? []).toEqual([]);
   });
 
   it('should apply permissions on update', async () => {
-    const role = await newRoleNamed('lifecycle-updated');
+    const role = await fixture.createRole('lifecycle-updated');
 
-    const updated = await updateOrganizationRole(accessToken, role.id, {
+    const updated = await updateOrganizationRole(fixture.adminToken, role.id, {
       name: role.name,
       permissions: ['domain_read'],
     });
@@ -97,9 +86,9 @@ describe('Custom role lifecycle - permissions are applied by a second call, neve
  */
 describe('Custom role lifecycle - permissions are not validated against the assignable type', () => {
   it('should accept an application permission on a domain-assignable role', async () => {
-    const role = await newRoleNamed('lifecycle-mismatched');
+    const role = await fixture.createRole('lifecycle-mismatched');
 
-    const updated = await updateOrganizationRole(accessToken, role.id, {
+    const updated = await updateOrganizationRole(fixture.adminToken, role.id, {
       name: role.name,
       permissions: ['domain_read', 'application_read'],
     });
@@ -114,20 +103,20 @@ describe('Custom role lifecycle - permissions are not validated against the assi
 
 describe('Custom role lifecycle - naming and deletion', () => {
   it('should refuse a second role with a name already in use', async () => {
-    const role = await newRoleNamed('lifecycle-duplicate');
+    const role = await fixture.createRole('lifecycle-duplicate');
 
-    await expect(createOrganizationRole(accessToken, { name: role.name, assignableType: 'DOMAIN' })).rejects.toMatchObject({
+    await expect(createOrganizationRole(fixture.adminToken, { name: role.name, assignableType: 'DOMAIN' })).rejects.toMatchObject({
       response: { status: 400 },
       message: expect.stringContaining('already exists'),
     });
   });
 
   it('should delete a custom role and stop resolving it afterwards', async () => {
-    const role = await newRoleNamed('lifecycle-deleted');
+    const role = await fixture.createRole('lifecycle-deleted');
 
-    await deleteOrganizationRole(accessToken, role.id);
+    await deleteOrganizationRole(fixture.adminToken, role.id);
 
-    await expect(getOrganizationRole(accessToken, role.id)).rejects.toMatchObject({ response: { status: 404 } });
+    await expect(getOrganizationRole(fixture.adminToken, role.id)).rejects.toMatchObject({ response: { status: 404 } });
   });
 });
 
@@ -139,24 +128,24 @@ describe('Custom role lifecycle - naming and deletion', () => {
  */
 describe('Custom role lifecycle - built-in roles resist modification', () => {
   it('should refuse to update a system role', async () => {
-    const systemRole = await findOrganizationRoleByName(accessToken, 'ORGANIZATION_PRIMARY_OWNER');
+    const systemRole = await findOrganizationRoleByName(fixture.adminToken, 'ORGANIZATION_PRIMARY_OWNER');
 
     await expect(
-      updateOrganizationRole(accessToken, systemRole.id, { name: 'ORGANIZATION_PRIMARY_OWNER', permissions: [] }),
+      updateOrganizationRole(fixture.adminToken, systemRole.id, { name: 'ORGANIZATION_PRIMARY_OWNER', permissions: [] }),
     ).rejects.toMatchObject({ response: { status: 404 } });
   });
 
   it('should refuse to delete a system role', async () => {
-    const systemRole = await findOrganizationRoleByName(accessToken, 'ORGANIZATION_PRIMARY_OWNER');
+    const systemRole = await findOrganizationRoleByName(fixture.adminToken, 'ORGANIZATION_PRIMARY_OWNER');
 
-    await expect(deleteOrganizationRole(accessToken, systemRole.id)).rejects.toMatchObject({ response: { status: 404 } });
+    await expect(deleteOrganizationRole(fixture.adminToken, systemRole.id)).rejects.toMatchObject({ response: { status: 404 } });
   });
 
   it('should refuse to rename a default role', async () => {
-    const defaultRole = await findOrganizationRoleByName(accessToken, 'DOMAIN_USER', ListRolesTypeEnum.Domain);
+    const defaultRole = await findOrganizationRoleByName(fixture.adminToken, 'DOMAIN_USER', ListRolesTypeEnum.Domain);
 
     await expect(
-      updateOrganizationRole(accessToken, defaultRole.id, { name: 'RENAMED_DOMAIN_USER', permissions: ['domain_read'] }),
+      updateOrganizationRole(fixture.adminToken, defaultRole.id, { name: 'RENAMED_DOMAIN_USER', permissions: ['domain_read'] }),
     ).rejects.toMatchObject({
       response: { status: 400 },
       message: expect.stringContaining('name cannot be updated'),
@@ -164,7 +153,7 @@ describe('Custom role lifecycle - built-in roles resist modification', () => {
   });
 
   it('should leave the default role untouched after the rejected rename', async () => {
-    const defaultRole = await findOrganizationRoleByName(accessToken, 'DOMAIN_USER', ListRolesTypeEnum.Domain);
+    const defaultRole = await findOrganizationRoleByName(fixture.adminToken, 'DOMAIN_USER', ListRolesTypeEnum.Domain);
 
     expect(defaultRole.name).toEqual('DOMAIN_USER');
     expect(defaultRole.defaultRole).toBe(true);

--- a/gravitee-am-test/specs/management/permissions/delegated-admin.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/delegated-admin.jest.spec.ts
@@ -26,7 +26,7 @@ import {
 } from '@management-commands/membership-management-commands';
 import { getCurrentUser } from '@management-commands/organisation-user-commands';
 
-setup();
+setup(200000);
 
 let fixture: RbacFixture;
 

--- a/gravitee-am-test/specs/management/permissions/delegated-admin.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/delegated-admin.jest.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import {
+  addApplicationMembership,
+  addDomainMembership,
+  listApplicationMemberships,
+  listDomainMemberships,
+  userMembership,
+} from '@management-commands/membership-management-commands';
+import { getCurrentUser } from '@management-commands/organisation-user-commands';
+
+setup();
+
+let fixture: RbacFixture;
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * Managing memberships is gated by its own permissions (DOMAIN_MEMBER, APPLICATION_MEMBER) that
+ * are separate from the permissions to manage the resource itself. Delegated administration is
+ * therefore the place where privilege escalation would surface: an owner who can grant roles can
+ * grant roles they do not themselves hold, or grant them somewhere they have no authority.
+ */
+describe('Delegated administration - owners can manage members within their own scope', () => {
+  it('should allow a DOMAIN_OWNER to add a member to their own domain', async () => {
+    await addDomainMembership(
+      fixture.domain.id,
+      fixture.domainOwner.token,
+      userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id),
+    );
+
+    const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
+    expect(memberships.map((m) => m.memberId)).toContain(fixture.assignee.userId);
+  });
+
+  it('should allow an APPLICATION_OWNER to add a member to their own application', async () => {
+    await addApplicationMembership(
+      fixture.domain.id,
+      fixture.application.id,
+      fixture.appOwner.token,
+      userMembership(fixture.assignee.userId, fixture.roles.applicationOwner.id),
+    );
+
+    const { memberships } = await listApplicationMemberships(fixture.domain.id, fixture.application.id, fixture.adminToken);
+    expect(memberships.map((m) => m.memberId)).toContain(fixture.assignee.userId);
+  });
+});
+
+describe('Delegated administration - membership management is refused outside that scope', () => {
+  // A 403 on its own is weak evidence: an unauthenticated or malformed request fails the same way,
+  // so these would stay green even if the permission check were removed entirely. Each case below
+  // therefore asserts the denial message, and the bare organization user is separately shown to
+  // hold a working token so its refusal cannot be vacuous.
+  it('should authenticate a bare ORGANIZATION_USER successfully despite holding no permissions', async () => {
+    const currentUser = await getCurrentUser(fixture.orgUser.token);
+    expect(currentUser.email).toEqual(fixture.orgUser.email);
+  });
+
+  it('should refuse a bare ORGANIZATION_USER adding a member to a domain', async () => {
+    await expect(
+      addDomainMembership(fixture.domain.id, fixture.orgUser.token, userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id)),
+    ).rejects.toMatchObject({ response: { status: 403 }, message: expect.stringContaining('Permission denied') });
+  });
+
+  it('should refuse an APPLICATION_OWNER adding a member to the parent domain', async () => {
+    await expect(
+      addDomainMembership(fixture.domain.id, fixture.appOwner.token, userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id)),
+    ).rejects.toMatchObject({ response: { status: 403 }, message: expect.stringContaining('Permission denied') });
+  });
+
+  it('should refuse a DOMAIN_OWNER adding a member to a domain they have no membership on', async () => {
+    await expect(
+      addDomainMembership(
+        fixture.otherDomain.id,
+        fixture.domainOwner.token,
+        userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id),
+      ),
+    ).rejects.toMatchObject({ response: { status: 403 }, message: expect.stringContaining('Permission denied') });
+  });
+});
+
+describe('Delegated administration - escalation guards', () => {
+  // Both guards below answer with 400, as does ordinary payload validation, so each asserts the
+  // specific message — otherwise an unrelated validation failure would keep these green.
+  it('should refuse granting a second DOMAIN_PRIMARY_OWNER on the same domain', async () => {
+    await expect(
+      addDomainMembership(
+        fixture.domain.id,
+        fixture.adminToken,
+        userMembership(fixture.assignee.userId, fixture.roles.domainPrimaryOwner.id),
+      ),
+    ).rejects.toMatchObject({
+      response: { status: 400 },
+      message: expect.stringContaining('DOMAIN can only have one PRIMARY_OWNER'),
+    });
+  });
+
+  it('should refuse a domain-assignable role used for an application membership', async () => {
+    await expect(
+      addApplicationMembership(
+        fixture.domain.id,
+        fixture.application.id,
+        fixture.adminToken,
+        userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id),
+      ),
+    ).rejects.toMatchObject({
+      response: { status: 400 },
+      message: expect.stringContaining('Invalid role'),
+    });
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/deny-by-default.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/deny-by-default.jest.spec.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { RBAC_TEST, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { getOrganisationManagementUrl } from '@management-commands/service/utils';
+
+setup();
+
+let fixture: RbacFixture;
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+
+const domainPath = (suffix = '') => `/environments/${process.env.AM_DEF_ENV_ID}/domains/${fixture.domain.id}${suffix}`;
+
+/** Mirrors the default in domain-management-commands.ts, which does not export it. */
+const dataPlaneId = () => process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
+
+interface EndpointCase {
+  name: string;
+  path: () => string;
+  body?: () => Record<string, unknown>;
+}
+
+const NEVER_CREATED = 'deny-by-default-should-never-exist';
+
+/**
+ * Read endpoints a bare ORGANIZATION_USER must not reach.
+ *
+ * The value of this sweep is breadth: an endpoint shipped without a permission check is invisible
+ * to any per-feature test and shows up only here.
+ *
+ * Each case is anchored by first issuing the identical request as admin. Without that anchor a
+ * mistyped path would answer 404 for everyone and the denial would look like it passed for the
+ * right reason. The anchor proves the path exists and is not permission-blocked for a privileged
+ * caller, so the org user's 403 can only be about permissions.
+ */
+const DENIED_READS: EndpointCase[] = [
+  // --- organization tier -------------------------------------------------------------------
+  { name: 'list organization users', path: () => '/users' },
+  { name: 'list organization members', path: () => '/members' },
+  { name: 'list organization entrypoints', path: () => '/entrypoints' },
+  { name: 'list organization audits', path: () => '/audits' },
+  { name: 'list organization reporters', path: () => '/reporters' },
+  { name: 'list organization identity providers', path: () => '/identities' },
+  // Gated by ORGANIZATION_SETTINGS[READ], which is distinct from the ORGANIZATION[READ] that
+  // ORGANIZATION_USER holds — reading the organization does not extend to reading its settings.
+  { name: 'read organization settings', path: () => '/settings' },
+
+  // --- environment / domain tier -----------------------------------------------------------
+  { name: 'read a domain', path: () => domainPath() },
+  { name: 'list domain applications', path: () => domainPath('/applications') },
+  { name: 'list domain users', path: () => domainPath('/users') },
+  { name: 'list domain members', path: () => domainPath('/members') },
+  { name: 'list domain certificates', path: () => domainPath('/certificates') },
+  { name: 'list domain identity providers', path: () => domainPath('/identities') },
+  { name: 'list domain scopes', path: () => domainPath('/scopes') },
+  { name: 'list domain groups', path: () => domainPath('/groups') },
+  { name: 'list domain roles', path: () => domainPath('/roles') },
+  { name: 'list domain audits', path: () => domainPath('/audits') },
+  { name: 'list domain factors', path: () => domainPath('/factors') },
+];
+
+/**
+ * Write endpoints a bare ORGANIZATION_USER must not reach.
+ *
+ * These deliberately carry *valid* payloads. An invalid one is rejected by bean validation during
+ * parameter binding — before the resource method and therefore before the permission check — so
+ * the request would never exercise the authorization path at all. (Domain creation demonstrates
+ * this: omitting `dataPlaneId` returns 400 to admin and org user alike.)
+ *
+ * They are not admin-anchored like the reads above, because issuing them as admin would genuinely
+ * create the resource. Their anchor is the denial message itself: a mistyped path answers 404 and
+ * carries no "Permission denied" body, so the message assertion still rules out a bad URL.
+ */
+const DENIED_WRITES: EndpointCase[] = [
+  {
+    name: 'create a domain',
+    path: () => `/environments/${process.env.AM_DEF_ENV_ID}/domains`,
+    body: () => ({ name: NEVER_CREATED, description: 'should never be created', dataPlaneId: dataPlaneId() }),
+  },
+  {
+    name: 'create an organization role',
+    path: () => '/roles',
+    body: () => ({ name: NEVER_CREATED }),
+  },
+  {
+    name: 'create an organization user',
+    path: () => '/users',
+    body: () => ({
+      username: NEVER_CREATED,
+      password: RBAC_TEST.USER_PASSWORD,
+      firstName: 'Deny',
+      lastName: 'Default',
+      email: `${NEVER_CREATED}@test.com`,
+      preRegistration: false,
+    }),
+  },
+  {
+    name: 'create an application',
+    path: () => domainPath('/applications'),
+    body: () => ({ name: NEVER_CREATED, type: 'WEB' }),
+  },
+];
+
+/**
+ * ORGANIZATION_USER is not permission-less — it ships with a small read-only allowance. Pinning it
+ * matters as much as pinning the denials: if the built-in role were ever widened, the sweep above
+ * would start failing without explaining why, and these cases state the intended baseline.
+ */
+const ALLOWED: EndpointCase[] = [
+  { name: 'list environments', path: () => '/environments' },
+  { name: 'list organization roles', path: () => '/roles' },
+  { name: 'list organization groups', path: () => '/groups' },
+  { name: 'list organization tags', path: () => '/tags' },
+  { name: 'list data planes', path: () => `/environments/${process.env.AM_DEF_ENV_ID}/data-planes` },
+];
+
+describe('Deny by default - read endpoints refused to a bare ORGANIZATION_USER', () => {
+  DENIED_READS.forEach((endpoint) => {
+    it(`should refuse to ${endpoint.name}`, async () => {
+      const asAdmin = await performGet(getOrganisationManagementUrl(), endpoint.path(), headers(fixture.adminToken));
+      expect(asAdmin.status).not.toBe(404); // the endpoint exists
+      expect(asAdmin.status).not.toBe(403); // and admin is not permission-blocked on it
+
+      const asOrgUser = await performGet(getOrganisationManagementUrl(), endpoint.path(), headers(fixture.orgUser.token));
+      expect(asOrgUser.status).toBe(403);
+      expect(asOrgUser.body.message).toEqual('Permission denied');
+    });
+  });
+});
+
+describe('Deny by default - write endpoints refused to a bare ORGANIZATION_USER', () => {
+  DENIED_WRITES.forEach((endpoint) => {
+    it(`should refuse to ${endpoint.name}`, async () => {
+      const response = await performPost(getOrganisationManagementUrl(), endpoint.path(), endpoint.body(), headers(fixture.orgUser.token));
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toEqual('Permission denied');
+    });
+  });
+});
+
+describe('Deny by default - the ORGANIZATION_USER read-only allowance', () => {
+  ALLOWED.forEach((endpoint) => {
+    it(`should permit a bare ORGANIZATION_USER to ${endpoint.name}`, async () => {
+      const response = await performGet(getOrganisationManagementUrl(), endpoint.path(), headers(fixture.orgUser.token));
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/deny-by-default.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/deny-by-default.jest.spec.ts
@@ -20,7 +20,7 @@ import { RBAC_TEST, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixtur
 import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
 import { getOrganisationManagementUrl } from '@management-commands/service/utils';
 
-setup();
+setup(200000);
 
 let fixture: RbacFixture;
 
@@ -170,7 +170,9 @@ describe('Deny by default - the ORGANIZATION_USER read-only allowance', () => {
   ALLOWED.forEach((endpoint) => {
     it(`should permit a bare ORGANIZATION_USER to ${endpoint.name}`, async () => {
       const response = await performGet(getOrganisationManagementUrl(), endpoint.path(), headers(fixture.orgUser.token));
-      expect(response.status).toBe(200);
+      // 204 rather than 200 is a legitimate answer here when the collection is empty, so assert
+      // success instead of a specific code — the point is that the allowance opens the endpoint.
+      expect(response.status).toBeLessThan(400);
     });
   });
 });

--- a/gravitee-am-test/specs/management/permissions/endpoint-permission-sweep.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/endpoint-permission-sweep.jest.spec.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import { PERMISSION_ENDPOINTS, PermissionEndpoint } from './fixtures/permission-endpoints.generated';
+import { performDelete, performGet } from '@gateway-commands/oauth-oidc-commands';
+
+setup();
+
+let fixture: RbacFixture;
+
+const managementUrl = () => `${process.env.AM_MANAGEMENT_URL}/management`;
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+
+/** Substitutes the four path parameters with resources that genuinely exist. */
+const fill = (route: string) =>
+  route
+    .replace('{organizationId}', process.env.AM_DEF_ORG_ID)
+    .replace('{environmentId}', process.env.AM_DEF_ENV_ID)
+    .replace('{domain}', fixture.domain.id)
+    .replace('{application}', fixture.application.id);
+
+/**
+ * The read-only allowance the built-in ORGANIZATION_USER role ships with.
+ *
+ * Held here rather than read back from the API on purpose: deriving the expectation from the live
+ * role would make this suite agree with whatever the role happens to grant, and silently widening
+ * the default role is exactly the regression worth catching.
+ */
+const ORGANIZATION_USER_PERMISSIONS = [
+  'organization_read',
+  'organization_role_list',
+  'organization_group_list',
+  'organization_tag_list',
+  'environment_list',
+  'data_plane_list',
+  'data_plane_read',
+];
+
+/**
+ * Routes whose OpenAPI description names a different permission to the one actually enforced.
+ * Both were found by this sweep: each is documented as ORGANIZATION[LIST], but a caller holding
+ * only the resource-specific permission is admitted, so that is what the code really checks.
+ * Corrected here rather than in the generated file, which stays a faithful copy of the spec.
+ */
+const DOCUMENTED_PERMISSION_OVERRIDES: Record<string, string> = {
+  '/organizations/{organizationId}/groups': 'organization_group_list',
+  '/organizations/{organizationId}/tags': 'organization_tag_list',
+};
+
+/**
+ * Routes the sweep cannot drive, each for a stated reason. Kept as data so the exclusions are
+ * visible and countable rather than quietly missing from the generated set.
+ */
+const EXCLUDED: Record<string, string> = {
+  // Mandatory query parameter that cannot be supplied generically — the request is rejected by
+  // bean validation (400 "[formTemplate: must not be null]") before authorisation is reached.
+  '/organizations/{organizationId}/forms': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/forms': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/emails': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/forms':
+    'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/emails':
+    'requires a template query parameter',
+
+  // Answer 500 before any permission check, so an unauthorised caller receives a server error
+  // rather than a refusal. Same defect class as AM-7476; re-include once fixed.
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/analytics': 'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/analytics':
+    'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/search/_cursor':
+    'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/protected-resources':
+    'AM-7476: type query parameter parsed before the permission check',
+};
+
+const requiredPermission = (endpoint: PermissionEndpoint) => DOCUMENTED_PERMISSION_OVERRIDES[endpoint.route] ?? endpoint.permission;
+
+const isAllowedForOrganizationUser = (endpoint: PermissionEndpoint) => ORGANIZATION_USER_PERMISSIONS.includes(requiredPermission(endpoint));
+
+const sweepable = PERMISSION_ENDPOINTS.filter((endpoint) => !EXCLUDED[endpoint.route]);
+
+const denied = sweepable.filter((endpoint) => endpoint.method === 'GET' && !isAllowedForOrganizationUser(endpoint));
+const allowed = sweepable.filter((endpoint) => endpoint.method === 'GET' && isAllowedForOrganizationUser(endpoint));
+const destructive = sweepable.filter((endpoint) => endpoint.method === 'DELETE');
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * Every management operation states the permission it requires in its OpenAPI description, and
+ * fixtures/permission-endpoints.generated.ts is built from those statements. Driving the whole set
+ * means a newly added endpoint is covered as soon as the spec is regenerated, instead of whenever
+ * someone remembers to extend a hand-written list — which is the only way this keeps pace with an
+ * API of roughly 290 permission-guarded operations.
+ *
+ * Generated cases are used deliberately here (GUIDELINES §8 allows it for large sets of otherwise
+ * identical tests): the route is in every test name, so a failure identifies its endpoint exactly.
+ *
+ * What this proves: every listed endpoint refuses a caller who lacks its permission, and the
+ * default role's allowance is exactly the set above. What it cannot prove is that an endpoint
+ * declares the *right* permission — if it were guarded by some other permission this caller also
+ * lacks, the refusal would look identical. That needs a positive per-permission matrix.
+ */
+describe(`Endpoint permission sweep - ${denied.length} endpoints refuse a bare ORGANIZATION_USER`, () => {
+  denied.forEach((endpoint) => {
+    it(`should refuse ${endpoint.method} ${endpoint.route} (needs ${requiredPermission(endpoint)})`, async () => {
+      const route = fill(endpoint.route);
+
+      // Anchor: the same request as admin proves the route exists and is not blocked for a
+      // privileged caller, so the refusal below can only be about permissions.
+      const asAdmin = await performGet(managementUrl(), route, headers(fixture.adminToken));
+      expect(asAdmin.status).not.toBe(404);
+      expect(asAdmin.status).not.toBe(403);
+
+      const asOrgUser = await performGet(managementUrl(), route, headers(fixture.orgUser.token));
+      expect(asOrgUser.status).toBe(403);
+      expect(asOrgUser.body.message).toEqual('Permission denied');
+    });
+  });
+});
+
+describe(`Endpoint permission sweep - ${allowed.length} endpoints within the default allowance`, () => {
+  allowed.forEach((endpoint) => {
+    it(`should permit ${endpoint.method} ${endpoint.route} (${requiredPermission(endpoint)})`, async () => {
+      const response = await performGet(managementUrl(), fill(endpoint.route), headers(fixture.orgUser.token));
+
+      expect(response.status).toBe(200);
+    });
+  });
+});
+
+/**
+ * Deletions are swept without an administrator anchor for the obvious reason — issuing them as
+ * admin would destroy the fixture. Instead each one asserts the resource is still there
+ * afterwards, which is a stronger outcome than the status code alone.
+ */
+describe(`Endpoint permission sweep - ${destructive.length} deletions are refused and take effect on nothing`, () => {
+  destructive.forEach((endpoint) => {
+    it(`should refuse ${endpoint.method} ${endpoint.route} (needs ${endpoint.permission})`, async () => {
+      const route = fill(endpoint.route);
+
+      const asOrgUser = await performDelete(managementUrl(), route, headers(fixture.orgUser.token));
+      expect(asOrgUser.status).toBe(403);
+      expect(asOrgUser.body.message).toEqual('Permission denied');
+
+      const stillThere = await performGet(managementUrl(), route, headers(fixture.adminToken));
+      expect(stillThere.status).toBe(200);
+    });
+  });
+});
+
+/**
+ * Guards the exclusions themselves: if an excluded route disappears or is renamed the list would
+ * quietly stop matching anything, and the sweep would look complete while covering less.
+ */
+describe('Endpoint permission sweep - bookkeeping', () => {
+  it('should exclude only routes that exist in the generated table', () => {
+    const known = new Set(PERMISSION_ENDPOINTS.map((endpoint) => endpoint.route));
+    expect(Object.keys(EXCLUDED).filter((route) => !known.has(route))).toEqual([]);
+  });
+
+  it('should override permissions only for routes that exist in the generated table', () => {
+    const known = new Set(PERMISSION_ENDPOINTS.map((endpoint) => endpoint.route));
+    expect(Object.keys(DOCUMENTED_PERMISSION_OVERRIDES).filter((route) => !known.has(route))).toEqual([]);
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/endpoint-permission-sweep.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/endpoint-permission-sweep.jest.spec.ts
@@ -18,9 +18,15 @@ import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { setup } from '../../test-fixture';
 import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
 import { PERMISSION_ENDPOINTS, PermissionEndpoint } from './fixtures/permission-endpoints.generated';
+import {
+  DOCUMENTED_PERMISSION_OVERRIDES,
+  EXCLUDED_ROUTES,
+  SUFFICIENCY_ONLY_EXCLUDED,
+  requiredPermission,
+} from './fixtures/permission-sweep-tables';
 import { performDelete, performGet } from '@gateway-commands/oauth-oidc-commands';
 
-setup();
+setup(200000);
 
 let fixture: RbacFixture;
 
@@ -52,48 +58,9 @@ const ORGANIZATION_USER_PERMISSIONS = [
   'data_plane_read',
 ];
 
-/**
- * Routes whose OpenAPI description names a different permission to the one actually enforced.
- * Both were found by this sweep: each is documented as ORGANIZATION[LIST], but a caller holding
- * only the resource-specific permission is admitted, so that is what the code really checks.
- * Corrected here rather than in the generated file, which stays a faithful copy of the spec.
- */
-const DOCUMENTED_PERMISSION_OVERRIDES: Record<string, string> = {
-  '/organizations/{organizationId}/groups': 'organization_group_list',
-  '/organizations/{organizationId}/tags': 'organization_tag_list',
-};
-
-/**
- * Routes the sweep cannot drive, each for a stated reason. Kept as data so the exclusions are
- * visible and countable rather than quietly missing from the generated set.
- */
-const EXCLUDED: Record<string, string> = {
-  // Mandatory query parameter that cannot be supplied generically — the request is rejected by
-  // bean validation (400 "[formTemplate: must not be null]") before authorisation is reached.
-  '/organizations/{organizationId}/forms': 'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/forms': 'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/emails': 'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/forms':
-    'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/emails':
-    'requires a template query parameter',
-
-  // Answer 500 before any permission check, so an unauthorised caller receives a server error
-  // rather than a refusal. Same defect class as AM-7476; re-include once fixed.
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/analytics': 'AM-7476 class: 500 before authorisation',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/analytics':
-    'AM-7476 class: 500 before authorisation',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/search/_cursor':
-    'AM-7476 class: 500 before authorisation',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/protected-resources':
-    'AM-7476: type query parameter parsed before the permission check',
-};
-
-const requiredPermission = (endpoint: PermissionEndpoint) => DOCUMENTED_PERMISSION_OVERRIDES[endpoint.route] ?? endpoint.permission;
-
 const isAllowedForOrganizationUser = (endpoint: PermissionEndpoint) => ORGANIZATION_USER_PERMISSIONS.includes(requiredPermission(endpoint));
 
-const sweepable = PERMISSION_ENDPOINTS.filter((endpoint) => !EXCLUDED[endpoint.route]);
+const sweepable = PERMISSION_ENDPOINTS.filter((endpoint) => !EXCLUDED_ROUTES[endpoint.route]);
 
 const denied = sweepable.filter((endpoint) => endpoint.method === 'GET' && !isAllowedForOrganizationUser(endpoint));
 const allowed = sweepable.filter((endpoint) => endpoint.method === 'GET' && isAllowedForOrganizationUser(endpoint));
@@ -147,7 +114,10 @@ describe(`Endpoint permission sweep - ${allowed.length} endpoints within the def
     it(`should permit ${endpoint.method} ${endpoint.route} (${requiredPermission(endpoint)})`, async () => {
       const response = await performGet(managementUrl(), fill(endpoint.route), headers(fixture.orgUser.token));
 
-      expect(response.status).toBe(200);
+      // Success rather than 200 exactly: several of these answer 204 when the collection is empty,
+      // which is what a freshly provisioned instance looks like. The claim being made is that the
+      // default allowance opens the endpoint, and any non-error status carries it.
+      expect(response.status).toBeLessThan(400);
     });
   });
 });
@@ -179,7 +149,8 @@ describe(`Endpoint permission sweep - ${destructive.length} deletions are refuse
 describe('Endpoint permission sweep - bookkeeping', () => {
   it('should exclude only routes that exist in the generated table', () => {
     const known = new Set(PERMISSION_ENDPOINTS.map((endpoint) => endpoint.route));
-    expect(Object.keys(EXCLUDED).filter((route) => !known.has(route))).toEqual([]);
+    const excluded = [...Object.keys(EXCLUDED_ROUTES), ...Object.keys(SUFFICIENCY_ONLY_EXCLUDED)];
+    expect(excluded.filter((route) => !known.has(route))).toEqual([]);
   });
 
   it('should override permissions only for routes that exist in the generated table', () => {

--- a/gravitee-am-test/specs/management/permissions/fixtures/permission-endpoints.generated.ts
+++ b/gravitee-am-test/specs/management/permissions/fixtures/permission-endpoints.generated.ts
@@ -1,0 +1,374 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable */
+// GENERATED FILE — do not edit by hand.
+// Regenerate with: node scripts/generate-permission-endpoints.js
+//
+// Source: docs/mapi/openapi.yaml, from each operation's stated permission requirement.
+// Only bodyless operations (GET, DELETE) whose path parameters are all fillable with real ids are
+// included, so a refusal can only be about permissions.
+
+export interface PermissionEndpoint {
+  method: 'GET' | 'DELETE';
+  /** OpenAPI route, with {organizationId}/{environmentId}/{domain}/{application} placeholders. */
+  route: string;
+  /** Flattened permission the operation documents as required, e.g. "domain_user_list". */
+  permission: string;
+  summary: string;
+}
+
+export const PERMISSION_ENDPOINTS: PermissionEndpoint[] = [
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/audits',
+    permission: 'organization_audit_list',
+    summary: 'List audit logs for the organization',
+  },
+  { method: 'GET', route: '/organizations/{organizationId}/entrypoints', permission: 'organization_list', summary: 'List entrypoints' },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments',
+    permission: 'environment_list',
+    summary: 'List all the environments',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/data-planes',
+    permission: 'data_plane_read',
+    summary: 'List of data planes',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains',
+    permission: 'domain_list',
+    summary: 'List security domains for an environment',
+  },
+  {
+    method: 'DELETE',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}',
+    permission: 'domain_delete',
+    summary: 'Delete the security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}',
+    permission: 'domain_read',
+    summary: 'Get a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/alerts/notifiers',
+    permission: 'domain_alert_notifier_list',
+    summary: 'List alert notifiers',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/alerts/triggers',
+    permission: 'domain_alert_list',
+    summary: 'List alert triggers',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/analytics',
+    permission: 'domain_analytics_read',
+    summary: 'Find domain analytics',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications',
+    permission: 'application_list',
+    summary: 'List registered applications for a security domain',
+  },
+  {
+    method: 'DELETE',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}',
+    permission: 'application_delete',
+    summary: 'Delete an application',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}',
+    permission: 'application_read',
+    summary: 'Get an application',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/analytics',
+    permission: 'application_analytics_read',
+    summary: 'Find application analytics',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/emails',
+    permission: 'application_email_template_read',
+    summary: 'Find a email for an application',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/flows',
+    permission: 'application_flow_list',
+    summary: 'List registered flows for an application',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/forms',
+    permission: 'application_form_read',
+    summary: 'Find a form for an application',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/members',
+    permission: 'application_member_list',
+    summary: 'List members for an application',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/members/permissions',
+    permission: 'application_read',
+    summary: "List application member's permissions",
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/resources',
+    permission: 'application_resource_list',
+    summary: 'List resources for an application',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/secrets',
+    permission: 'application_openid_list',
+    summary: 'List secrets of an application',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/search',
+    permission: 'application_list',
+    summary: 'List applications with cursor-based pagination',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/search/_cursor',
+    permission: 'application_list',
+    summary: 'List applications with cursor-based pagination',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/audits',
+    permission: 'domain_audit_list',
+    summary: 'List audit logs for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/auth-device-notifiers',
+    permission: 'domain_authdevice_notifier_list',
+    summary: 'List registered Authentication Device Notifiers for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/authorization-engines',
+    permission: 'domain_authorization_engine_list',
+    summary: 'List registered authorization engines for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/bot-detections',
+    permission: 'domain_bot_detection_list',
+    summary: 'List registered bot detections for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/certificates',
+    permission: 'domain_certificate_list',
+    summary: 'List registered certificates for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/device-identifiers',
+    permission: 'domain_device_identifiers_list',
+    summary: 'List registered device identifiers for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/emails',
+    permission: 'domain_email_template_read',
+    summary: 'Find a email',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/entrypoints',
+    permission: 'domain_read',
+    summary: 'Get the matching gateway entrypoint of the domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/extensionGrants',
+    permission: 'domain_extension_grant_list',
+    summary: 'List registered extension grants for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/factors',
+    permission: 'domain_factor_list',
+    summary: 'List registered factors for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/flows',
+    permission: 'domain_flow_list',
+    summary: 'List registered flows for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/forms',
+    permission: 'domain_form_read',
+    summary: 'Find a form',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/groups',
+    permission: 'domain_group_list',
+    summary: 'List groups for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/identities',
+    permission: 'domain_identity_provider_list',
+    summary: 'List registered identity providers for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/members',
+    permission: 'domain_member_list',
+    summary: 'List members for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/members/permissions',
+    permission: 'domain_read',
+    summary: "List domain member's permissions",
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/password-policies',
+    permission: 'domain_settings_read',
+    summary: 'List registered password policies for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/protected-resources',
+    permission: 'protected_resource_list',
+    summary: 'List registered protected resources for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/reporters',
+    permission: 'domain_reporter_list',
+    summary: 'List registered reporters for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/resources',
+    permission: 'domain_resource_list',
+    summary: 'List registered resources for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/roles',
+    permission: 'domain_role_list',
+    summary: 'List registered roles for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/scopes',
+    permission: 'domain_scope_list',
+    summary: 'List scopes for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/themes',
+    permission: 'domain_theme_list',
+    summary: 'List themes on the specified security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/trust-domains',
+    permission: 'domain_trust_domain_list',
+    summary: 'List trust domains registered against the security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/users',
+    permission: 'domain_user_list',
+    summary: 'List users for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/members/permissions',
+    permission: 'environment_read',
+    summary: "List environment member's permissions",
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/forms',
+    permission: 'organization_form_read',
+    summary: 'Find an organization form template',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/groups',
+    permission: 'organization_list',
+    summary: 'List groups of the organization',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/identities',
+    permission: 'organization_identity_provider_list',
+    summary: 'List registered identity providers of the organization',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/members',
+    permission: 'organization_member_list',
+    summary: 'List members for an organization',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/reporters',
+    permission: 'organization_reporter_list',
+    summary: 'List registered reporters for a security domain',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/roles',
+    permission: 'organization_role_list',
+    summary: 'List registered roles of the organization',
+  },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/settings',
+    permission: 'organization_settings_read',
+    summary: 'Get organization main settings',
+  },
+  { method: 'GET', route: '/organizations/{organizationId}/tags', permission: 'organization_list', summary: 'List sharding tags' },
+  {
+    method: 'GET',
+    route: '/organizations/{organizationId}/users',
+    permission: 'organization_user_list',
+    summary: 'List users of the organization',
+  },
+  { method: 'GET', route: '/platform/installation', permission: 'installation_read', summary: 'Get installation information' },
+];

--- a/gravitee-am-test/specs/management/permissions/fixtures/permission-sweep-tables.ts
+++ b/gravitee-am-test/specs/management/permissions/fixtures/permission-sweep-tables.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PermissionEndpoint } from './permission-endpoints.generated';
+
+/**
+ * Shared between `endpoint-permission-sweep` (which proves a caller *without* a permission is
+ * refused) and `permission-sufficiency` (which proves the documented permission *alone* admits).
+ * Both drive the same generated endpoint table, so keeping these corrections in one place stops
+ * the two sweeps disagreeing about what the table means.
+ */
+
+/**
+ * Routes whose OpenAPI description names a different permission to the one actually enforced.
+ * Each was found by these sweeps and confirmed against the guard in the resource class; corrected
+ * here rather than in the generated file, which stays a faithful copy of the spec.
+ *
+ *  - groups/tags/entrypoints are documented as ORGANIZATION[LIST] but check the resource-specific
+ *    permission, which is what a caller holding only that permission demonstrates.
+ *  - device-identifiers documents `domain_device_identifiers_list`, which is not a permission at
+ *    all — the enum constant is singular, and the plural form makes role updates fail (AM-7477).
+ */
+export const DOCUMENTED_PERMISSION_OVERRIDES: Record<string, string> = {
+  '/organizations/{organizationId}/groups': 'organization_group_list',
+  '/organizations/{organizationId}/tags': 'organization_tag_list',
+  '/organizations/{organizationId}/entrypoints': 'organization_entrypoint_list',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/device-identifiers': 'domain_device_identifier_list',
+};
+
+/**
+ * Routes neither sweep can drive, each for a stated reason. Kept as data so the exclusions are
+ * visible and countable rather than quietly missing from the generated set.
+ */
+export const EXCLUDED_ROUTES: Record<string, string> = {
+  // Mandatory query parameter that cannot be supplied generically — the request is rejected by
+  // bean validation (400 "[formTemplate: must not be null]") before authorisation is reached.
+  '/organizations/{organizationId}/forms': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/forms': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/emails': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/forms':
+    'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/emails':
+    'requires a template query parameter',
+
+  // Answer 500 before any permission check, so an unauthorised caller receives a server error
+  // rather than a refusal. Same defect class as AM-7476; re-include once fixed.
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/analytics': 'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/analytics':
+    'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/search/_cursor':
+    'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/protected-resources':
+    'AM-7476: type query parameter parsed before the permission check',
+};
+
+/**
+ * Additional exclusions that apply only when a test *grants* the documented permission and expects
+ * to be admitted. They are deliberately not in the shared table above: a caller who holds nothing
+ * is still correctly refused on both routes, so the negative sweep must keep covering them.
+ */
+export const SUFFICIENCY_ONLY_EXCLUDED: Record<string, string> = {
+  // INSTALLATION is only relevant to the PLATFORM tier, so it cannot be granted by an
+  // organization-assignable role and this technique cannot reach it.
+  '/platform/installation': 'PLATFORM-tier permission, not grantable at organization level',
+  // Guarded by DOMAIN_FACTOR instead of DOMAIN_RESOURCE, so the documented permission does not
+  // open it. Re-include once AM-7478 is fixed — asserting today's behaviour would enshrine it.
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/resources': 'AM-7478: guarded by the wrong permission',
+};
+
+/** The permission a route really enforces, preferring a confirmed override over the spec. */
+export const requiredPermission = (endpoint: PermissionEndpoint): string =>
+  DOCUMENTED_PERMISSION_OVERRIDES[endpoint.route] ?? endpoint.permission;

--- a/gravitee-am-test/specs/management/permissions/fixtures/rbac-fixture.ts
+++ b/gravitee-am-test/specs/management/permissions/fixtures/rbac-fixture.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from '@jest/globals';
+import { requestAccessToken, requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { safeDeleteDomain, setupDomainForTest } from '@management-commands/domain-management-commands';
+import { createOrganisationUser, deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { findOrganizationRoleByName } from '@management-commands/role-management-commands';
+import {
+  addApplicationMembership,
+  addDomainMembership,
+  addOrganizationMembership,
+  userMembership,
+} from '@management-commands/membership-management-commands';
+import { createTestApp } from '@utils-commands/application-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { ListRolesTypeEnum } from '@management-apis/RoleApi';
+// Type-only: `@management-models` is not mapped in the jest moduleNameMapper (see
+// membership-management-commands.ts), so model imports must stay erasable.
+import type { Application } from '@management-models/Application';
+import type { Domain } from '@management-models/Domain';
+import type { RoleEntity } from '@management-models/RoleEntity';
+import { JWT_FORMAT } from '@specs-utils/jwt-format';
+
+/**
+ * Jest runs spec files in separate worker processes, and faker reseeds identically in each one, so
+ * uniqueName() alone yields the *same* sequence per worker. Every spec in this folder shares this
+ * fixture and therefore its prefixes, which made parallel runs collide on
+ * "A domain [...] already exists". The process id disambiguates the workers.
+ */
+const workerScope = (prefix: string) => `${prefix}-${process.pid}`;
+
+export const RBAC_TEST = {
+  DOMAIN_PREFIX: 'rbac-primary',
+  OTHER_DOMAIN_PREFIX: 'rbac-other',
+  APP_NAME: 'rbac-app',
+  OTHER_APP_NAME: 'rbac-other-app',
+  USER_PASSWORD: 'RbacP@ssw0rd123!',
+  REDIRECT_URI: 'https://example.com/callback',
+} as const;
+
+/** A console user plus a token acting as that user, so tests can call the API as them. */
+export interface Persona {
+  username: string;
+  email: string;
+  userId: string;
+  token: string;
+}
+
+export interface RbacFixture {
+  adminToken: string;
+  /** Domain the personas below are scoped to. */
+  domain: Domain;
+  /** Second domain nobody below has a membership on — used to prove isolation. */
+  otherDomain: Domain;
+  application: Application;
+  /** Second application in the same domain that `appOwner` has no membership on. */
+  otherApplication: Application;
+  roles: {
+    organizationUser: RoleEntity;
+    domainOwner: RoleEntity;
+    /** The role the membership cascade provisions implicitly on a parent domain. */
+    domainUser: RoleEntity;
+    domainPrimaryOwner: RoleEntity;
+    applicationOwner: RoleEntity;
+  };
+  /** Holds ORGANIZATION_USER only — the built-in role that grants almost nothing. */
+  orgUser: Persona;
+  /** DOMAIN_OWNER on `domain`. */
+  domainOwner: Persona;
+  /** APPLICATION_OWNER on `application`, one tier below `domainOwner`. */
+  appOwner: Persona;
+  /** Holds only the default ORGANIZATION_USER role; used as the target of assignment attempts. */
+  assignee: Persona;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Creates an organization user and authenticates as them.
+ *
+ * Every console user is an organization user; roles at domain or application level are layered on
+ * afterwards as memberships. Creating a user already grants them the default ORGANIZATION_USER
+ * role, so a fresh persona is never permission-less — it starts from that small read-only
+ * allowance, which is the baseline the deny-by-default cases are measured against.
+ */
+export async function createPersona(adminToken: string, label: string): Promise<Persona> {
+  const username = uniqueName(workerScope(label), true).toLowerCase();
+  const email = `${username}@test.com`;
+  const user = await createOrganisationUser(adminToken, {
+    firstName: label,
+    lastName: 'Persona',
+    email,
+    username,
+    password: RBAC_TEST.USER_PASSWORD,
+    preRegistration: false,
+  });
+  expect(user.id).toEqual(expect.any(String));
+
+  const token = await requestAccessToken(username, RBAC_TEST.USER_PASSWORD);
+  expect(token).toMatch(JWT_FORMAT);
+
+  // `/auth/token` authenticates from the HTTP Basic header, not the JSON body. If the header were
+  // ever wrong the endpoint would happily return a token for a *different* principal (in practice
+  // admin), and every deny-case in this folder would then be asserting the wrong user's
+  // permissions. Confirm the token really belongs to this persona before handing it out.
+  expect(decodeUsername(token)).toEqual(username);
+
+  return { username, email, userId: user.id, token };
+}
+
+/** Reads `preferred_username` out of a JWT payload without pulling in a verification library. */
+function decodeUsername(token: string): string {
+  const payload = token.split('.')[1];
+  const decoded = Buffer.from(payload, 'base64url').toString('utf8');
+  return JSON.parse(decoded).preferred_username;
+}
+
+export const setupRbacFixture = async (): Promise<RbacFixture> => {
+  let adminToken: string | null = null;
+  let domain: Domain | null = null;
+  let otherDomain: Domain | null = null;
+  const personas: Persona[] = [];
+
+  try {
+    adminToken = await requestAdminAccessToken();
+    expect(adminToken).toMatch(JWT_FORMAT);
+
+    // Management-only tests: the domain must exist and be started, but nothing here reaches the
+    // gateway, so there is no reason to wait for OIDC routing to come up.
+    domain = (await setupDomainForTest(uniqueName(workerScope(RBAC_TEST.DOMAIN_PREFIX), true), { accessToken: adminToken })).domain;
+    otherDomain = (await setupDomainForTest(uniqueName(workerScope(RBAC_TEST.OTHER_DOMAIN_PREFIX), true), { accessToken: adminToken }))
+      .domain;
+
+    const appSettings = {
+      settings: {
+        oauth: {
+          redirectUris: [RBAC_TEST.REDIRECT_URI],
+          grantTypes: ['authorization_code'],
+        },
+      },
+    };
+    const application = await createTestApp(uniqueName(workerScope(RBAC_TEST.APP_NAME), true), domain, adminToken, 'web', appSettings);
+    expect(application.id).toEqual(expect.any(String));
+
+    const otherApplication = await createTestApp(
+      uniqueName(workerScope(RBAC_TEST.OTHER_APP_NAME), true),
+      domain,
+      adminToken,
+      'web',
+      appSettings,
+    );
+    expect(otherApplication.id).toEqual(expect.any(String));
+
+    const [organizationUser, domainOwner, domainUser, domainPrimaryOwner, applicationOwner] = await Promise.all([
+      findOrganizationRoleByName(adminToken, 'ORGANIZATION_USER', ListRolesTypeEnum.Organization),
+      findOrganizationRoleByName(adminToken, 'DOMAIN_OWNER', ListRolesTypeEnum.Domain),
+      findOrganizationRoleByName(adminToken, 'DOMAIN_USER', ListRolesTypeEnum.Domain),
+      findOrganizationRoleByName(adminToken, 'DOMAIN_PRIMARY_OWNER', ListRolesTypeEnum.Domain),
+      findOrganizationRoleByName(adminToken, 'APPLICATION_OWNER', ListRolesTypeEnum.Application),
+    ]);
+
+    const [orgUser, domainOwnerPersona, appOwner, assignee] = await Promise.all([
+      createPersona(adminToken, 'orguser'),
+      createPersona(adminToken, 'domainowner'),
+      createPersona(adminToken, 'appowner'),
+      createPersona(adminToken, 'assignee'),
+    ]);
+    personas.push(orgUser, domainOwnerPersona, appOwner, assignee);
+
+    // ORGANIZATION_USER is already granted at user creation; these calls are upserts that make the
+    // starting point explicit, matching how the manual test cases describe the setup.
+    await addOrganizationMembership(adminToken, userMembership(orgUser.userId, organizationUser.id));
+    await addOrganizationMembership(adminToken, userMembership(domainOwnerPersona.userId, organizationUser.id));
+    await addOrganizationMembership(adminToken, userMembership(appOwner.userId, organizationUser.id));
+
+    await addDomainMembership(domain.id, adminToken, userMembership(domainOwnerPersona.userId, domainOwner.id));
+    await addApplicationMembership(domain.id, application.id, adminToken, userMembership(appOwner.userId, applicationOwner.id));
+
+    const cleanup = async () => {
+      for (const id of [domain?.id, otherDomain?.id]) {
+        if (id) {
+          await safeDeleteDomain(id, adminToken);
+        }
+      }
+      // Organization users are not domain-scoped, so domain deletion does not cascade to them.
+      for (const persona of personas) {
+        try {
+          await deleteOrganisationUser(adminToken, persona.userId);
+        } catch {
+          // best effort — a failed persona delete must not mask the test result
+        }
+      }
+    };
+
+    return {
+      adminToken,
+      domain,
+      otherDomain,
+      application,
+      otherApplication,
+      roles: { organizationUser, domainOwner, domainUser, domainPrimaryOwner, applicationOwner },
+      orgUser,
+      domainOwner: domainOwnerPersona,
+      appOwner,
+      assignee,
+      cleanup,
+    };
+  } catch (error) {
+    for (const id of [domain?.id, otherDomain?.id]) {
+      if (id && adminToken) {
+        try {
+          await safeDeleteDomain(id, adminToken);
+        } catch (cleanupError) {
+          console.error('Failed to clean up domain after setup failure:', cleanupError);
+        }
+      }
+    }
+    for (const persona of personas) {
+      if (adminToken) {
+        try {
+          await deleteOrganisationUser(adminToken, persona.userId);
+        } catch {
+          // best effort
+        }
+      }
+    }
+    throw error;
+  }
+};

--- a/gravitee-am-test/specs/management/permissions/fixtures/rbac-fixture.ts
+++ b/gravitee-am-test/specs/management/permissions/fixtures/rbac-fixture.ts
@@ -172,13 +172,27 @@ export const setupRbacFixture = async (): Promise<RbacFixture> => {
       findOrganizationRoleByName(adminToken, 'APPLICATION_OWNER', ListRolesTypeEnum.Application),
     ]);
 
-    const [orgUser, domainOwnerPersona, appOwner, assignee] = await Promise.all([
-      createPersona(adminToken, 'orguser'),
-      createPersona(adminToken, 'domainowner'),
-      createPersona(adminToken, 'appowner'),
-      createPersona(adminToken, 'assignee'),
+    // Each persona is registered for cleanup the moment it resolves, not once all four have.
+    // `Promise.all` would reject on the first failure and skip the registration entirely, leaking
+    // the users that had already been created; `allSettled` additionally guarantees that none is
+    // still in flight when the catch block below starts deleting.
+    const trackPersona = async (token: string, label: string): Promise<Persona> => {
+      const persona = await createPersona(token, label);
+      personas.push(persona);
+      return persona;
+    };
+
+    const created = await Promise.allSettled([
+      trackPersona(adminToken, 'orguser'),
+      trackPersona(adminToken, 'domainowner'),
+      trackPersona(adminToken, 'appowner'),
+      trackPersona(adminToken, 'assignee'),
     ]);
-    personas.push(orgUser, domainOwnerPersona, appOwner, assignee);
+    const failed = created.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+    if (failed) {
+      throw failed.reason;
+    }
+    const [orgUser, domainOwnerPersona, appOwner, assignee] = created.map((result) => (result as PromiseFulfilledResult<Persona>).value);
 
     // ORGANIZATION_USER is already granted at user creation; these calls are upserts that make the
     // starting point explicit, matching how the manual test cases describe the setup.

--- a/gravitee-am-test/specs/management/permissions/fixtures/role-fixture.ts
+++ b/gravitee-am-test/specs/management/permissions/fixtures/role-fixture.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createOrganizationRole, deleteOrganizationRole, findOrganizationRoleByName } from '@management-commands/role-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import type { RoleEntity } from '@management-models/RoleEntity';
+import { JWT_FORMAT } from '@specs-utils/jwt-format';
+
+export type AssignableType = 'ORGANIZATION' | 'ENVIRONMENT' | 'DOMAIN' | 'APPLICATION';
+
+export interface RoleFixture {
+  adminToken: string;
+  /** Creates a uniquely named custom role and registers it for deletion. */
+  createRole: (label: string, assignableType?: AssignableType) => Promise<RoleEntity>;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * The role-only counterpart to `setupRbacFixture`, for specs that exercise roles themselves rather
+ * than what a role grants. Deliberately provisions nothing else: the heavier fixture builds two
+ * domains, two applications and four personas, none of which a role lifecycle test touches.
+ *
+ * Creation is two calls, not one — the create endpoint rejects a `permissions` property outright,
+ * and returns no body, so the role is read back by name to recover its id.
+ */
+export const setupRoleFixture = async (): Promise<RoleFixture> => {
+  const adminToken = await requestAdminAccessToken();
+  expect(adminToken).toMatch(JWT_FORMAT);
+
+  const createdRoleIds: string[] = [];
+
+  const createRole = async (label: string, assignableType: AssignableType = 'DOMAIN'): Promise<RoleEntity> => {
+    const name = uniqueName(label, true);
+    await createOrganizationRole(adminToken, { name, assignableType });
+    const role = await findOrganizationRoleByName(adminToken, name);
+    createdRoleIds.push(role.id);
+    return role;
+  };
+
+  const cleanup = async () => {
+    for (const id of createdRoleIds) {
+      // Best effort: a role a test deleted on purpose must not fail the teardown.
+      await deleteOrganizationRole(adminToken, id).catch(() => undefined);
+    }
+  };
+
+  return { adminToken, createRole, cleanup };
+};

--- a/gravitee-am-test/specs/management/permissions/list-scoping.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/list-scoping.jest.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import { listDomains } from '@management-commands/domain-management-commands';
+import { listApplications } from '@management-commands/application-management-commands';
+
+setup();
+
+let fixture: RbacFixture;
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+const domainIds = async (token: string) => (await listDomains(token, { size: 100 })).data.map((domain) => domain.id);
+const applicationIds = async (token: string) =>
+  (await listApplications(fixture.domain.id, token, { size: 100 })).data.map((application) => application.id);
+
+/**
+ * Listing is a second, separate authorisation path: rather than a single yes/no on one resource,
+ * the resource set is narrowed to the ids the caller holds a membership on. A regression here does
+ * not produce an error — it silently widens what a user can see, which is why each case asserts
+ * both the presence of the permitted resource and the absence of the unpermitted one.
+ */
+describe('List scoping - domains are narrowed to those the caller is a member of', () => {
+  it('should return every domain to an unrestricted administrator', async () => {
+    const ids = await domainIds(fixture.adminToken);
+
+    expect(ids).toContain(fixture.domain.id);
+    expect(ids).toContain(fixture.otherDomain.id);
+  });
+
+  it('should return only the assigned domain to a DOMAIN_OWNER', async () => {
+    const ids = await domainIds(fixture.domainOwner.token);
+
+    expect(ids).toContain(fixture.domain.id);
+    expect(ids).not.toContain(fixture.otherDomain.id);
+  });
+
+  it('should return only the parent domain to an APPLICATION_OWNER', async () => {
+    // The membership cascade provisions DOMAIN_USER on the parent domain, so an application owner
+    // can see that one domain — and must not gain sight of any other.
+    const ids = await domainIds(fixture.appOwner.token);
+
+    expect(ids).toContain(fixture.domain.id);
+    expect(ids).not.toContain(fixture.otherDomain.id);
+  });
+
+  it('should refuse the domain list outright to a bare ORGANIZATION_USER', async () => {
+    // ORGANIZATION_USER holds no DOMAIN[LIST], so the request is rejected before any narrowing.
+    await expect(listDomains(fixture.orgUser.token, { size: 100 })).rejects.toMatchObject({
+      response: { status: 403 },
+      message: expect.stringContaining('Permission denied'),
+    });
+  });
+});
+
+describe('List scoping - applications are narrowed to those the caller is a member of', () => {
+  it('should return every application in the domain to an unrestricted administrator', async () => {
+    const ids = await applicationIds(fixture.adminToken);
+
+    expect(ids).toContain(fixture.application.id);
+    expect(ids).toContain(fixture.otherApplication.id);
+  });
+
+  it('should return only the assigned application to an APPLICATION_OWNER', async () => {
+    const ids = await applicationIds(fixture.appOwner.token);
+
+    expect(ids).toContain(fixture.application.id);
+    expect(ids).not.toContain(fixture.otherApplication.id);
+  });
+
+  it('should return every application in the domain to a DOMAIN_OWNER', async () => {
+    // A domain owner holds APPLICATION[READ] across the whole domain, so no narrowing applies and
+    // both applications are visible. This is the counterpart to the case above.
+    const ids = await applicationIds(fixture.domainOwner.token);
+
+    expect(ids).toContain(fixture.application.id);
+    expect(ids).toContain(fixture.otherApplication.id);
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/list-scoping.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/list-scoping.jest.spec.ts
@@ -20,7 +20,7 @@ import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
 import { listDomains } from '@management-commands/domain-management-commands';
 import { listApplications } from '@management-commands/application-management-commands';
 
-setup();
+setup(200000);
 
 let fixture: RbacFixture;
 

--- a/gravitee-am-test/specs/management/permissions/membership-cascade.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/membership-cascade.jest.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import { setup } from '../../test-fixture';
+import { retryImmediatelyForThisFile, setup } from '../../test-fixture';
 import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
 import {
   addApplicationMembership,
@@ -26,7 +26,10 @@ import {
 } from '@management-commands/membership-management-commands';
 import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
 
-setup();
+setup(200000);
+// These cases run as one ordered narrative, so a retry must not resume after a later step has
+// already mutated the state an earlier one asserts against (GUIDELINES §3).
+retryImmediatelyForThisFile();
 
 let fixture: RbacFixture;
 const created: Persona[] = [];

--- a/gravitee-am-test/specs/management/permissions/membership-cascade.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/membership-cascade.jest.spec.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import {
+  addApplicationMembership,
+  addDomainMembership,
+  getEnvironmentMemberPermissions,
+  listDomainMemberships,
+  userMembership,
+} from '@management-commands/membership-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+
+setup();
+
+let fixture: RbacFixture;
+const created: Persona[] = [];
+
+/** ENVIRONMENT_USER, the role the cascade grants, carries exactly these. */
+const ENVIRONMENT_USER_PERMISSIONS = ['environment_read', 'domain_list', 'data_plane_list', 'data_plane_read'];
+
+const newPersona = async (label: string): Promise<Persona> => {
+  const persona = await createPersona(fixture.adminToken, label);
+  created.push(persona);
+  return persona;
+};
+
+const domainMembershipOf = async (userId: string) => {
+  const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
+  return memberships.filter((membership) => membership.memberId === userId);
+};
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  for (const persona of created) {
+    await deleteOrganisationUser(fixture.adminToken, persona.userId).catch(() => undefined);
+  }
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * Adding a member at one tier silently creates memberships on the tiers above it: an application
+ * assignment provisions DOMAIN_USER on the parent domain and ENVIRONMENT_USER on the environment,
+ * and a domain assignment provisions ENVIRONMENT_USER. This is what makes an assigned user able to
+ * see the domain at all, so it has failure modes in both directions — under-provision and the user
+ * sees nothing, over-provision and they gain visibility they were never granted.
+ *
+ * Environment memberships cannot be listed through the API, so they are observed through the
+ * effective permissions the assigned user resolves to at the environment tier.
+ */
+describe('Membership cascade - assigning at application level provisions the tiers above', () => {
+  let appMember: Persona;
+
+  beforeAll(async () => {
+    appMember = await newPersona('cascadeapp');
+  });
+
+  it('should start with no domain membership and no environment access at all', async () => {
+    expect(await domainMembershipOf(appMember.userId)).toHaveLength(0);
+    // The endpoint is itself gated by ENVIRONMENT[READ], so an unprovisioned user cannot even
+    // reach it — a stronger baseline than resolving to an empty permission set.
+    await expect(getEnvironmentMemberPermissions(appMember.token)).rejects.toMatchObject({
+      response: { status: 403 },
+      message: expect.stringContaining('Permission denied'),
+    });
+  });
+
+  it('should provision a DOMAIN_USER membership on the parent domain', async () => {
+    await addApplicationMembership(
+      fixture.domain.id,
+      fixture.application.id,
+      fixture.adminToken,
+      userMembership(appMember.userId, fixture.roles.applicationOwner.id),
+    );
+
+    const memberships = await domainMembershipOf(appMember.userId);
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].roleId).toEqual(fixture.roles.domainUser.id);
+  });
+
+  it('should provision environment permissions for the assigned user', async () => {
+    const permissions = await getEnvironmentMemberPermissions(appMember.token);
+    expect(permissions.sort()).toEqual([...ENVIRONMENT_USER_PERMISSIONS].sort());
+  });
+});
+
+describe('Membership cascade - assigning at domain level provisions the environment only', () => {
+  let domainMember: Persona;
+
+  beforeAll(async () => {
+    domainMember = await newPersona('cascadedomain');
+  });
+
+  it('should start with no environment access at all', async () => {
+    await expect(getEnvironmentMemberPermissions(domainMember.token)).rejects.toMatchObject({
+      response: { status: 403 },
+      message: expect.stringContaining('Permission denied'),
+    });
+  });
+
+  it('should keep the explicitly assigned domain role rather than substituting DOMAIN_USER', async () => {
+    await addDomainMembership(fixture.domain.id, fixture.adminToken, userMembership(domainMember.userId, fixture.roles.domainOwner.id));
+
+    const memberships = await domainMembershipOf(domainMember.userId);
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].roleId).toEqual(fixture.roles.domainOwner.id);
+  });
+
+  it('should provision environment permissions for the assigned user', async () => {
+    const permissions = await getEnvironmentMemberPermissions(domainMember.token);
+    expect(permissions.sort()).toEqual([...ENVIRONMENT_USER_PERMISSIONS].sort());
+  });
+});
+
+/**
+ * The cascade provisions only where nothing exists yet. A member who already holds a domain role
+ * and is later added to an application inside that domain must keep the role they were given — a
+ * cascade that overwrote it would silently demote a domain owner to DOMAIN_USER.
+ */
+describe('Membership cascade - an existing membership is never downgraded', () => {
+  let existingOwner: Persona;
+
+  beforeAll(async () => {
+    existingOwner = await newPersona('cascadeowner');
+    await addDomainMembership(fixture.domain.id, fixture.adminToken, userMembership(existingOwner.userId, fixture.roles.domainOwner.id));
+  });
+
+  it('should leave the domain role untouched when the member is added to an application', async () => {
+    await addApplicationMembership(
+      fixture.domain.id,
+      fixture.application.id,
+      fixture.adminToken,
+      userMembership(existingOwner.userId, fixture.roles.applicationOwner.id),
+    );
+
+    const memberships = await domainMembershipOf(existingOwner.userId);
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].roleId).toEqual(fixture.roles.domainOwner.id);
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/organization-role-baseline.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/organization-role-baseline.jest.spec.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import {
+  addDomainMembership,
+  addOrganizationMembership,
+  groupMembership,
+  listOrganizationMemberships,
+  removeOrganizationMembership,
+  userMembership,
+} from '@management-commands/membership-management-commands';
+import { createCustomOrganizationRole, deleteOrganizationRole } from '@management-commands/role-management-commands';
+import {
+  addOrganizationGroupMember,
+  createOrganizationGroup,
+  deleteOrganizationGroup,
+} from '@management-commands/group-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+import { getOrganisationManagementUrl } from '@management-commands/service/utils';
+import { uniqueName } from '@utils-commands/misc';
+
+setup();
+
+let fixture: RbacFixture;
+const createdUsers: Persona[] = [];
+const createdGroupIds: string[] = [];
+
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+const domainPath = (domainId: string) => `/environments/${process.env.AM_DEF_ENV_ID}/domains/${domainId}`;
+
+const newPersona = async (label: string) => {
+  const persona = await createPersona(fixture.adminToken, label);
+  createdUsers.push(persona);
+  return persona;
+};
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  for (const groupId of createdGroupIds) {
+    await deleteOrganizationGroup(fixture.adminToken, groupId).catch(() => undefined);
+  }
+  for (const persona of createdUsers) {
+    await deleteOrganisationUser(fixture.adminToken, persona.userId).catch(() => undefined);
+  }
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * "Users must have at least one ORGANIZATION role to access the AM Console."
+ *
+ * Console access is not a property of authentication — a user stripped of every organization role
+ * still signs in and still receives a token. What they lose is the ability to resolve anything, so
+ * the distinction only shows up on a request, which is what makes it worth pinning.
+ */
+describe('Organization role baseline - an organization role is what makes the Console usable', () => {
+  it('should let a user holding the default organization role list environments', async () => {
+    const persona = await newPersona('orgbaseline');
+
+    const response = await performGet(getOrganisationManagementUrl(), '/environments', headers(persona.token));
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should refuse the same request once every organization role is removed', async () => {
+    const persona = await newPersona('strippedbaseline');
+
+    const { memberships } = await listOrganizationMemberships(fixture.adminToken);
+    const theirs = memberships.filter((membership) => membership.memberId === persona.userId);
+    expect(theirs).toHaveLength(1);
+
+    await removeOrganizationMembership(fixture.adminToken, theirs[0].id);
+
+    const response = await performGet(getOrganisationManagementUrl(), '/environments', headers(persona.token));
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+});
+
+/**
+ * "Direct user permissions and group permissions merge when applied to the same user."
+ *
+ * Group memberships are resolved by a separate branch of the permission lookup to the one every
+ * other test in this folder exercises, so nothing else here would notice if it broke.
+ */
+describe('Organization role baseline - a role assigned to a group reaches its members', () => {
+  let groupMember: Persona;
+
+  beforeAll(async () => {
+    groupMember = await newPersona('groupmember');
+  });
+
+  it('should refuse the domain before the group is given any role', async () => {
+    const response = await performGet(getOrganisationManagementUrl(), domainPath(fixture.domain.id), headers(groupMember.token));
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+
+  it('should grant the domain through group membership alone', async () => {
+    const group = await createOrganizationGroup(fixture.adminToken, uniqueName('perm-group', true));
+    createdGroupIds.push(group.id);
+    await addOrganizationGroupMember(fixture.adminToken, group.id, groupMember.userId);
+
+    // The role is assigned to the group, never to the user.
+    await addDomainMembership(fixture.domain.id, fixture.adminToken, groupMembership(group.id, fixture.roles.domainOwner.id));
+
+    const response = await performGet(getOrganisationManagementUrl(), domainPath(fixture.domain.id), headers(groupMember.token));
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual(fixture.domain.id);
+  });
+
+  it('should still confine a group-derived role to the domain it was assigned to', async () => {
+    const response = await performGet(getOrganisationManagementUrl(), domainPath(fixture.otherDomain.id), headers(groupMember.token));
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+});
+
+/**
+ * "DOMAIN READ allows reading a specific domain when assigned to that domain, but reading all
+ * domains when assigned to an organization." The same permission, two meanings, chosen by the tier
+ * it is granted at — so an organization-level grant must reach every domain, not merely one.
+ */
+describe('Organization role baseline - an organization-level grant spans every domain', () => {
+  it('should let a user assigned the role at organization level read both domains', async () => {
+    const orgReader = await newPersona('orgspanreader');
+
+    const { memberships } = await listOrganizationMemberships(fixture.adminToken);
+    const theirs = memberships.filter((membership) => membership.memberId === orgReader.userId);
+    await removeOrganizationMembership(fixture.adminToken, theirs[0].id);
+
+    const spanningRole = await createCustomOrganizationRole(fixture.adminToken, uniqueName('org-span-reader', true), 'ORGANIZATION', [
+      'domain_read',
+      'domain_list',
+    ]);
+    await addOrganizationMembership(fixture.adminToken, userMembership(orgReader.userId, spanningRole.id));
+
+    for (const domainId of [fixture.domain.id, fixture.otherDomain.id]) {
+      const response = await performGet(getOrganisationManagementUrl(), domainPath(domainId), headers(orgReader.token));
+      expect(response.status).toBe(200);
+      expect(response.body.id).toEqual(domainId);
+    }
+
+    await deleteOrganizationRole(fixture.adminToken, spanningRole.id).catch(() => undefined);
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/organization-role-baseline.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/organization-role-baseline.jest.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import { setup } from '../../test-fixture';
+import { retryImmediatelyForThisFile, setup } from '../../test-fixture';
 import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
 import {
   addDomainMembership,
@@ -36,7 +36,10 @@ import { performGet } from '@gateway-commands/oauth-oidc-commands';
 import { getOrganisationManagementUrl } from '@management-commands/service/utils';
 import { uniqueName } from '@utils-commands/misc';
 
-setup();
+setup(200000);
+// These cases run as one ordered narrative, so a retry must not resume after a later step has
+// already mutated the state an earlier one asserts against (GUIDELINES §3).
+retryImmediatelyForThisFile();
 
 let fixture: RbacFixture;
 const createdUsers: Persona[] = [];
@@ -134,6 +137,12 @@ describe('Organization role baseline - a role assigned to a group reaches its me
   });
 
   it('should still confine a group-derived role to the domain it was assigned to', async () => {
+    // Anchored within the test rather than relying on the previous one: a caller who never
+    // received the role at all is refused here too, so the 403 alone cannot tell confinement
+    // apart from the group membership silently not applying.
+    const granted = await performGet(getOrganisationManagementUrl(), domainPath(fixture.domain.id), headers(groupMember.token));
+    expect(granted.status).toBe(200);
+
     const response = await performGet(getOrganisationManagementUrl(), domainPath(fixture.otherDomain.id), headers(groupMember.token));
 
     expect(response.status).toBe(403);
@@ -152,6 +161,7 @@ describe('Organization role baseline - an organization-level grant spans every d
 
     const { memberships } = await listOrganizationMemberships(fixture.adminToken);
     const theirs = memberships.filter((membership) => membership.memberId === orgReader.userId);
+    expect(theirs).toHaveLength(1);
     await removeOrganizationMembership(fixture.adminToken, theirs[0].id);
 
     const spanningRole = await createCustomOrganizationRole(fixture.adminToken, uniqueName('org-span-reader', true), 'ORGANIZATION', [

--- a/gravitee-am-test/specs/management/permissions/permission-sufficiency.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/permission-sufficiency.jest.spec.ts
@@ -17,7 +17,8 @@
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { setup } from '../../test-fixture';
 import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
-import { PERMISSION_ENDPOINTS, PermissionEndpoint } from './fixtures/permission-endpoints.generated';
+import { PERMISSION_ENDPOINTS } from './fixtures/permission-endpoints.generated';
+import { EXCLUDED_ROUTES, SUFFICIENCY_ONLY_EXCLUDED, requiredPermission } from './fixtures/permission-sweep-tables';
 import {
   createCustomOrganizationRole,
   deleteOrganizationRole,
@@ -29,7 +30,7 @@ import { performGet } from '@gateway-commands/oauth-oidc-commands';
 import { uniqueName } from '@utils-commands/misc';
 import type { RoleEntity } from '@management-models/RoleEntity';
 
-setup();
+setup(200000);
 
 let fixture: RbacFixture;
 let holder: Persona;
@@ -45,48 +46,9 @@ const fill = (route: string) =>
     .replace('{domain}', fixture.domain.id)
     .replace('{application}', fixture.application.id);
 
-/** See endpoint-permission-sweep for why each of these cannot be driven generically. */
-const EXCLUDED: Record<string, string> = {
-  '/organizations/{organizationId}/forms': 'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/forms': 'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/emails': 'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/forms':
-    'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/emails':
-    'requires a template query parameter',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/analytics': 'AM-7476 class: 500 before authorisation',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/analytics':
-    'AM-7476 class: 500 before authorisation',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/search/_cursor':
-    'AM-7476 class: 500 before authorisation',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/protected-resources':
-    'AM-7476: type query parameter parsed before the permission check',
-  // INSTALLATION is only relevant to the PLATFORM tier, so it cannot be granted by an
-  // organization-assignable role and this technique cannot reach it.
-  '/platform/installation': 'PLATFORM-tier permission, not grantable at organization level',
-  // Guarded by DOMAIN_FACTOR instead of DOMAIN_RESOURCE, so the documented permission does not
-  // open it. Re-include once AM-7478 is fixed — asserting today's behaviour would enshrine it.
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/resources': 'AM-7478: guarded by the wrong permission',
-};
-
-/**
- * The OpenAPI description misnames the permission for these routes; each was found by this sweep
- * and confirmed against the guard in the resource class.
- *  - groups/tags are documented as ORGANIZATION[LIST] but check the resource-specific permission
- *  - entrypoints is documented as ORGANIZATION[LIST] but checks ORGANIZATION_ENTRYPOINT[LIST]
- *  - device-identifiers documents DOMAIN_DEVICE_IDENTIFIERS, which is not a permission at all —
- *    the enum constant is singular, and the plural form makes role updates fail outright (AM-7477)
- */
-const DOCUMENTED_PERMISSION_OVERRIDES: Record<string, string> = {
-  '/organizations/{organizationId}/groups': 'organization_group_list',
-  '/organizations/{organizationId}/tags': 'organization_tag_list',
-  '/organizations/{organizationId}/entrypoints': 'organization_entrypoint_list',
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/device-identifiers': 'domain_device_identifier_list',
-};
-
-const requiredPermission = (endpoint: PermissionEndpoint) => DOCUMENTED_PERMISSION_OVERRIDES[endpoint.route] ?? endpoint.permission;
-
-const candidates = PERMISSION_ENDPOINTS.filter((endpoint) => endpoint.method === 'GET' && !EXCLUDED[endpoint.route]);
+const candidates = PERMISSION_ENDPOINTS.filter(
+  (endpoint) => endpoint.method === 'GET' && !EXCLUDED_ROUTES[endpoint.route] && !SUFFICIENCY_ONLY_EXCLUDED[endpoint.route],
+);
 
 beforeAll(async () => {
   fixture = await setupRbacFixture();

--- a/gravitee-am-test/specs/management/permissions/permission-sufficiency.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/permission-sufficiency.jest.spec.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import { PERMISSION_ENDPOINTS, PermissionEndpoint } from './fixtures/permission-endpoints.generated';
+import {
+  createCustomOrganizationRole,
+  deleteOrganizationRole,
+  updateOrganizationRole,
+} from '@management-commands/role-management-commands';
+import { addOrganizationMembership, userMembership } from '@management-commands/membership-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+import { uniqueName } from '@utils-commands/misc';
+import type { RoleEntity } from '@management-models/RoleEntity';
+
+setup();
+
+let fixture: RbacFixture;
+let holder: Persona;
+let probeRole: RoleEntity;
+
+const managementUrl = () => `${process.env.AM_MANAGEMENT_URL}/management`;
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+
+const fill = (route: string) =>
+  route
+    .replace('{organizationId}', process.env.AM_DEF_ORG_ID)
+    .replace('{environmentId}', process.env.AM_DEF_ENV_ID)
+    .replace('{domain}', fixture.domain.id)
+    .replace('{application}', fixture.application.id);
+
+/** See endpoint-permission-sweep for why each of these cannot be driven generically. */
+const EXCLUDED: Record<string, string> = {
+  '/organizations/{organizationId}/forms': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/forms': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/emails': 'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/forms':
+    'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/emails':
+    'requires a template query parameter',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/analytics': 'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/{application}/analytics':
+    'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/applications/search/_cursor':
+    'AM-7476 class: 500 before authorisation',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/protected-resources':
+    'AM-7476: type query parameter parsed before the permission check',
+  // INSTALLATION is only relevant to the PLATFORM tier, so it cannot be granted by an
+  // organization-assignable role and this technique cannot reach it.
+  '/platform/installation': 'PLATFORM-tier permission, not grantable at organization level',
+  // Guarded by DOMAIN_FACTOR instead of DOMAIN_RESOURCE, so the documented permission does not
+  // open it. Re-include once AM-7478 is fixed — asserting today's behaviour would enshrine it.
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/resources': 'AM-7478: guarded by the wrong permission',
+};
+
+/**
+ * The OpenAPI description misnames the permission for these routes; each was found by this sweep
+ * and confirmed against the guard in the resource class.
+ *  - groups/tags are documented as ORGANIZATION[LIST] but check the resource-specific permission
+ *  - entrypoints is documented as ORGANIZATION[LIST] but checks ORGANIZATION_ENTRYPOINT[LIST]
+ *  - device-identifiers documents DOMAIN_DEVICE_IDENTIFIERS, which is not a permission at all —
+ *    the enum constant is singular, and the plural form makes role updates fail outright (AM-7477)
+ */
+const DOCUMENTED_PERMISSION_OVERRIDES: Record<string, string> = {
+  '/organizations/{organizationId}/groups': 'organization_group_list',
+  '/organizations/{organizationId}/tags': 'organization_tag_list',
+  '/organizations/{organizationId}/entrypoints': 'organization_entrypoint_list',
+  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/device-identifiers': 'domain_device_identifier_list',
+};
+
+const requiredPermission = (endpoint: PermissionEndpoint) => DOCUMENTED_PERMISSION_OVERRIDES[endpoint.route] ?? endpoint.permission;
+
+const candidates = PERMISSION_ENDPOINTS.filter((endpoint) => endpoint.method === 'GET' && !EXCLUDED[endpoint.route]);
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+  holder = await createPersona(fixture.adminToken, 'sufficiency');
+
+  // One organization-assignable role, rewritten before each case to carry exactly one permission.
+  // Organization level is chosen because a grant there is consulted for checks at every tier below,
+  // so a single membership can stand in for whichever tier the endpoint belongs to.
+  probeRole = await createCustomOrganizationRole(fixture.adminToken, uniqueName('sufficiency-probe', true), 'ORGANIZATION', []);
+  await addOrganizationMembership(fixture.adminToken, userMembership(holder.userId, probeRole.id));
+});
+
+afterAll(async () => {
+  if (holder) {
+    await deleteOrganisationUser(fixture.adminToken, holder.userId).catch(() => undefined);
+  }
+  if (probeRole) {
+    await deleteOrganizationRole(fixture.adminToken, probeRole.id).catch(() => undefined);
+  }
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * The counterpart to endpoint-permission-sweep, which proves only that a caller *without* an
+ * endpoint's permission is refused. That is satisfied just as well by the wrong guard: if an
+ * endpoint were changed to check some other permission the caller also lacks, the refusal would
+ * look identical and every negative test would stay green.
+ *
+ * Here the holder is granted exactly one permission — the one the endpoint documents — and nothing
+ * else. Reaching the endpoint therefore demonstrates that this specific permission is what opens
+ * it. Together the two sweeps pin each endpoint to its own permission from both directions.
+ *
+ * The role is rewritten in place rather than a role created per endpoint: permission resolution
+ * reads roles per request and caches only parent references, so an update takes effect immediately.
+ */
+describe(`Permission sufficiency - ${candidates.length} endpoints open to exactly their own permission`, () => {
+  candidates.forEach((endpoint) => {
+    it(`should admit ${requiredPermission(endpoint)} alone to ${endpoint.route}`, async () => {
+      const permission = requiredPermission(endpoint);
+      await updateOrganizationRole(fixture.adminToken, probeRole.id, { name: probeRole.name, permissions: [permission] });
+
+      const response = await performGet(managementUrl(), fill(endpoint.route), headers(holder.token));
+
+      // Success, not a specific code: several of these answer 204 when the collection is empty.
+      // What matters is that the single granted permission opened the endpoint rather than being
+      // refused, which is precisely the claim a negative sweep cannot make.
+      expect(response.status).toBeLessThan(400);
+    });
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/permission-table-freshness.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/permission-table-freshness.jest.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import fs from 'fs';
+import { setup } from '../../test-fixture';
+import { PERMISSION_ENDPOINTS, PermissionEndpoint } from './fixtures/permission-endpoints.generated';
+
+// The generator is CommonJS and importing it must stay side-effect free — it only regenerates when
+// run as a script, so requiring it here reads the spec without writing anything.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { collect, SPEC } = require('../../../scripts/generate-permission-endpoints');
+
+setup(200000);
+
+/**
+ * `permission-endpoints.generated.ts` is produced by hand-running the generator, and both sweeps
+ * that drive it (endpoint-permission-sweep, permission-sufficiency) size themselves from whatever
+ * it happens to contain. That makes staleness invisible in the worst way: adding a guarded endpoint
+ * to the OpenAPI spec without regenerating leaves every existing test green while the sweep quietly
+ * covers less than it claims, and the missing endpoint is exactly the untested one.
+ *
+ * Comparing against a fresh generation closes that. It needs no running stack — the check is
+ * `docs/mapi/openapi.yaml` against a committed file — so it rides the jest jobs that already run on
+ * every pull request rather than requiring a CI step of its own.
+ */
+describe('Permission table freshness - the committed table still matches the OpenAPI spec', () => {
+  it('should find the OpenAPI spec the table is generated from', () => {
+    // Asserted separately so a moved or missing spec reports as itself rather than as drift.
+    expect(fs.existsSync(SPEC)).toBe(true);
+  });
+
+  it('should match a fresh generation from the OpenAPI spec', () => {
+    const regenerated: PermissionEndpoint[] = collect();
+
+    // Compared as data rather than as file text: formatting is prettier's business, and a diff here
+    // should only ever mean the endpoints themselves have changed.
+    expect(PERMISSION_ENDPOINTS).toEqual(regenerated);
+  });
+
+  it('should carry every endpoint the sweeps rely on being present', () => {
+    // Guards the degenerate pass: an empty table would satisfy the comparison above if the
+    // generator silently stopped matching anything, and both sweeps would then assert nothing.
+    expect(PERMISSION_ENDPOINTS.length).toBeGreaterThan(50);
+    expect(PERMISSION_ENDPOINTS.every((endpoint) => endpoint.route && endpoint.permission)).toBe(true);
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/protected-resource-tier.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/protected-resource-tier.jest.spec.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import {
+  addApplicationMembership,
+  addDomainMembership,
+  listDomainMemberships,
+  removeDomainMembership,
+  addOrganizationMembership,
+  addProtectedResourceMembership,
+  listProtectedResourceMemberships,
+  removeProtectedResourceMembership,
+  userMembership,
+} from '@management-commands/membership-management-commands';
+import { createProtectedResource } from '@management-commands/protected-resources-management-commands';
+import { findOrganizationRoleByName } from '@management-commands/role-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+import { ListRolesTypeEnum } from '@management-apis/RoleApi';
+import { uniqueName } from '@utils-commands/misc';
+import type { RoleEntity } from '@management-models/RoleEntity';
+
+setup();
+
+let fixture: RbacFixture;
+let member: Persona;
+let protectedResourceId: string;
+let resourceUserRole: RoleEntity;
+let resourcePrimaryOwnerRole: RoleEntity;
+
+const managementUrl = () => `${process.env.AM_MANAGEMENT_URL}/management`;
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+
+/**
+ * Reading a protected resource by id answers 500 regardless of permissions — the type parameter is
+ * parsed before authorisation, the same defect as AM-7476 — so the type-qualified list is the only
+ * usable way to observe what this tier grants.
+ */
+const listResourcesAs = (token: string) =>
+  performGet(
+    managementUrl(),
+    `/organizations/${process.env.AM_DEF_ORG_ID}/environments/${process.env.AM_DEF_ENV_ID}/domains/${fixture.domain.id}` +
+      `/protected-resources?type=MCP_SERVER`,
+    headers(token),
+  );
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+
+  const created = await createProtectedResource(fixture.domain.id, fixture.adminToken, {
+    name: uniqueName('rbac-mcp', true),
+    type: 'MCP_SERVER',
+    resourceIdentifiers: [`https://mcp.test/${uniqueName('rbac', true)}`],
+  });
+  protectedResourceId = created.id;
+
+  [resourceUserRole, resourcePrimaryOwnerRole] = await Promise.all([
+    findOrganizationRoleByName(fixture.adminToken, 'PROTECTED_RESOURCE_USER', ListRolesTypeEnum.ProtectedResource),
+    findOrganizationRoleByName(fixture.adminToken, 'PROTECTED_RESOURCE_PRIMARY_OWNER', ListRolesTypeEnum.ProtectedResource),
+  ]);
+
+  member = await createPersona(fixture.adminToken, 'resourcemember');
+});
+
+afterAll(async () => {
+  if (member) {
+    await deleteOrganisationUser(fixture.adminToken, member.userId).catch(() => undefined);
+  }
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * Protected resources are the fifth assignable tier and the newest, and until now the only one
+ * with no permission coverage at all. The mechanics are meant to be the same as the tiers above,
+ * which is exactly why they are worth asserting rather than assumed: the tier is wired into the
+ * same resolution path, and a gap in that wiring would be silent.
+ */
+describe('Protected resource tier - a role is confined to the tier it is assignable to', () => {
+  it('should accept a protected-resource role on a protected resource', async () => {
+    await addProtectedResourceMembership(
+      fixture.domain.id,
+      protectedResourceId,
+      fixture.adminToken,
+      userMembership(member.userId, resourceUserRole.id),
+    );
+
+    const { memberships } = await listProtectedResourceMemberships(fixture.domain.id, protectedResourceId, fixture.adminToken);
+    expect(memberships.map((membership) => membership.memberId)).toContain(member.userId);
+  });
+
+  it('should refuse a protected-resource role at domain level', async () => {
+    await expect(
+      addDomainMembership(fixture.domain.id, fixture.adminToken, userMembership(fixture.assignee.userId, resourceUserRole.id)),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+
+  it('should refuse a protected-resource role at application level', async () => {
+    await expect(
+      addApplicationMembership(
+        fixture.domain.id,
+        fixture.application.id,
+        fixture.adminToken,
+        userMembership(fixture.assignee.userId, resourceUserRole.id),
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+
+  it('should refuse a protected-resource role at organization level', async () => {
+    await expect(
+      addOrganizationMembership(fixture.adminToken, userMembership(fixture.assignee.userId, resourceUserRole.id)),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+
+  it('should refuse a domain role on a protected resource', async () => {
+    // The mirror of the cases above: the tier rejects roles belonging to another tier just as the
+    // other tiers reject its own.
+    await expect(
+      addProtectedResourceMembership(
+        fixture.domain.id,
+        protectedResourceId,
+        fixture.adminToken,
+        userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id),
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+
+  it('should refuse a second primary owner on the same protected resource', async () => {
+    // Creating the resource already made its creator primary owner, so this is the tier's own
+    // instance of the single-primary-owner rule.
+    await expect(
+      addProtectedResourceMembership(
+        fixture.domain.id,
+        protectedResourceId,
+        fixture.adminToken,
+        userMembership(fixture.assignee.userId, resourcePrimaryOwnerRole.id),
+      ),
+    ).rejects.toMatchObject({
+      response: { status: 400 },
+      message: expect.stringContaining('can only have one PRIMARY_OWNER'),
+    });
+  });
+});
+
+describe('Protected resource tier - membership grants and revokes access', () => {
+  it('should refuse the resource list to someone with no membership on it', async () => {
+    const outsider = await createPersona(fixture.adminToken, 'resourceoutsider');
+
+    try {
+      const response = await listResourcesAs(outsider.token);
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toEqual('Permission denied');
+    } finally {
+      await deleteOrganisationUser(fixture.adminToken, outsider.userId).catch(() => undefined);
+    }
+  });
+
+  it('should show the resource to the member assigned to it', async () => {
+    const response = await listResourcesAs(member.token);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.map((resource) => resource.id)).toContain(protectedResourceId);
+  });
+
+  it('should remove them from the resource when the membership is deleted', async () => {
+    const { memberships } = await listProtectedResourceMemberships(fixture.domain.id, protectedResourceId, fixture.adminToken);
+    const theirs = memberships.find((membership) => membership.memberId === member.userId);
+
+    await removeProtectedResourceMembership(fixture.domain.id, protectedResourceId, fixture.adminToken, theirs.id);
+
+    const after = await listProtectedResourceMemberships(fixture.domain.id, protectedResourceId, fixture.adminToken);
+    expect(after.memberships.map((membership) => membership.memberId)).not.toContain(member.userId);
+  });
+
+  it('should leave the domain access the assignment implicitly granted', async () => {
+    // Assigning at resource level provisioned DOMAIN_USER on the parent domain, and deleting the
+    // resource membership does not take it back. DOMAIN_USER carries protected_resource_list, so
+    // the resource is still listed — the caller has lost the resource, not the domain.
+    const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
+    const domainMembership = memberships.find((membership) => membership.memberId === member.userId);
+
+    expect(domainMembership.roleId).toEqual(fixture.roles.domainUser.id);
+    expect((await listResourcesAs(member.token)).status).toBe(200);
+  });
+
+  it('should refuse the list once that domain membership is removed too', async () => {
+    // Only when both are gone is the access actually revoked, which is the part an administrator
+    // revoking someone from a resource would most easily miss.
+    const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
+    const domainMembership = memberships.find((membership) => membership.memberId === member.userId);
+
+    await removeDomainMembership(fixture.domain.id, fixture.adminToken, domainMembership.id);
+
+    const response = await listResourcesAs(member.token);
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/protected-resource-tier.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/protected-resource-tier.jest.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import { setup } from '../../test-fixture';
+import { retryImmediatelyForThisFile, setup } from '../../test-fixture';
 import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
 import {
   addApplicationMembership,
@@ -36,7 +36,10 @@ import { ListRolesTypeEnum } from '@management-apis/RoleApi';
 import { uniqueName } from '@utils-commands/misc';
 import type { RoleEntity } from '@management-models/RoleEntity';
 
-setup();
+setup(200000);
+// These cases run as one ordered narrative, so a retry must not resume after a later step has
+// already mutated the state an earlier one asserts against (GUIDELINES §3).
+retryImmediatelyForThisFile();
 
 let fixture: RbacFixture;
 let member: Persona;
@@ -182,9 +185,10 @@ describe('Protected resource tier - membership grants and revokes access', () =>
 
   it('should remove them from the resource when the membership is deleted', async () => {
     const { memberships } = await listProtectedResourceMemberships(fixture.domain.id, protectedResourceId, fixture.adminToken);
-    const theirs = memberships.find((membership) => membership.memberId === member.userId);
+    const theirs = memberships.filter((membership) => membership.memberId === member.userId);
+    expect(theirs).toHaveLength(1);
 
-    await removeProtectedResourceMembership(fixture.domain.id, protectedResourceId, fixture.adminToken, theirs.id);
+    await removeProtectedResourceMembership(fixture.domain.id, protectedResourceId, fixture.adminToken, theirs[0].id);
 
     const after = await listProtectedResourceMemberships(fixture.domain.id, protectedResourceId, fixture.adminToken);
     expect(after.memberships.map((membership) => membership.memberId)).not.toContain(member.userId);
@@ -195,9 +199,10 @@ describe('Protected resource tier - membership grants and revokes access', () =>
     // resource membership does not take it back. DOMAIN_USER carries protected_resource_list, so
     // the resource is still listed — the caller has lost the resource, not the domain.
     const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
-    const domainMembership = memberships.find((membership) => membership.memberId === member.userId);
+    const domainMembership = memberships.filter((membership) => membership.memberId === member.userId);
+    expect(domainMembership).toHaveLength(1);
 
-    expect(domainMembership.roleId).toEqual(fixture.roles.domainUser.id);
+    expect(domainMembership[0].roleId).toEqual(fixture.roles.domainUser.id);
     expect((await listResourcesAs(member.token)).status).toBe(200);
   });
 
@@ -205,9 +210,10 @@ describe('Protected resource tier - membership grants and revokes access', () =>
     // Only when both are gone is the access actually revoked, which is the part an administrator
     // revoking someone from a resource would most easily miss.
     const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
-    const domainMembership = memberships.find((membership) => membership.memberId === member.userId);
+    const domainMembership = memberships.filter((membership) => membership.memberId === member.userId);
+    expect(domainMembership).toHaveLength(1);
 
-    await removeDomainMembership(fixture.domain.id, fixture.adminToken, domainMembership.id);
+    await removeDomainMembership(fixture.domain.id, fixture.adminToken, domainMembership[0].id);
 
     const response = await listResourcesAs(member.token);
     expect(response.status).toBe(403);

--- a/gravitee-am-test/specs/management/permissions/role-assignment-journey.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/role-assignment-journey.jest.spec.ts
@@ -31,7 +31,7 @@ import { getOrganisationManagementUrl } from '@management-commands/service/utils
 import { uniqueName } from '@utils-commands/misc';
 import type { RoleEntity } from '@management-models/RoleEntity';
 
-setup();
+setup(200000);
 // The steps below are one continuous narrative and depend on each other, so a mid-file retry must
 // not restart from a later step (GUIDELINES §3).
 retryImmediatelyForThisFile();
@@ -118,10 +118,11 @@ describe('Role assignment journey - a new administrator is onboarded and later r
 
   it('should take the access away again when the membership is removed', async () => {
     const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
-    const theirs = memberships.find((membership) => membership.memberId === newAdmin.userId);
-    expect(theirs.roleId).toEqual(readOnlyRole.id);
+    const theirs = memberships.filter((membership) => membership.memberId === newAdmin.userId);
+    expect(theirs).toHaveLength(1);
+    expect(theirs[0].roleId).toEqual(readOnlyRole.id);
 
-    await removeDomainMembership(fixture.domain.id, fixture.adminToken, theirs.id);
+    await removeDomainMembership(fixture.domain.id, fixture.adminToken, theirs[0].id);
 
     const response = await readDomainAs(newAdmin.token);
     expect(response.status).toBe(403);

--- a/gravitee-am-test/specs/management/permissions/role-assignment-journey.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/role-assignment-journey.jest.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { retryImmediatelyForThisFile, setup } from '../../test-fixture';
+import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import {
+  addDomainMembership,
+  listDomainMemberships,
+  listOrganizationMemberships,
+  removeDomainMembership,
+  userMembership,
+} from '@management-commands/membership-management-commands';
+import { createCustomOrganizationRole, deleteOrganizationRole } from '@management-commands/role-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { performGet, performPatch } from '@gateway-commands/oauth-oidc-commands';
+import { getOrganisationManagementUrl } from '@management-commands/service/utils';
+import { uniqueName } from '@utils-commands/misc';
+import type { RoleEntity } from '@management-models/RoleEntity';
+
+setup();
+// The steps below are one continuous narrative and depend on each other, so a mid-file retry must
+// not restart from a later step (GUIDELINES §3).
+retryImmediatelyForThisFile();
+
+let fixture: RbacFixture;
+let newAdmin: Persona;
+let readOnlyRole: RoleEntity;
+
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+const domainPath = () => `/environments/${process.env.AM_DEF_ENV_ID}/domains/${fixture.domain.id}`;
+
+const readDomainAs = (token: string) => performGet(getOrganisationManagementUrl(), domainPath(), headers(token));
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  if (newAdmin) {
+    await deleteOrganisationUser(fixture.adminToken, newAdmin.userId).catch(() => undefined);
+  }
+  if (readOnlyRole) {
+    await deleteOrganizationRole(fixture.adminToken, readOnlyRole.id).catch(() => undefined);
+  }
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * The administrator's actual workflow, start to finish: take on a new colleague, build a role that
+ * grants precisely what they need, hand it to them, and later take it away again. Each step is
+ * covered somewhere in this folder in isolation; running them as one story is what proves they
+ * compose — in particular that granting is reversible, which nothing else here checks.
+ */
+describe('Role assignment journey - a new administrator is onboarded and later revoked', () => {
+  it('should give a newly created user the default organization role without being asked', async () => {
+    newAdmin = await createPersona(fixture.adminToken, 'journeyadmin');
+
+    const { memberships } = await listOrganizationMemberships(fixture.adminToken);
+    const theirs = memberships.filter((membership) => membership.memberId === newAdmin.userId);
+
+    expect(theirs).toHaveLength(1);
+    expect(theirs[0].roleId).toEqual(fixture.roles.organizationUser.id);
+  });
+
+  it('should not let that default role reach any domain', async () => {
+    const response = await readDomainAs(newAdmin.token);
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+
+  it('should create a custom role granting domain read but deliberately not domain update', async () => {
+    readOnlyRole = await createCustomOrganizationRole(fixture.adminToken, uniqueName('journey-domain-reader', true), 'DOMAIN', [
+      'domain_read',
+    ]);
+
+    expect(readOnlyRole.permissions).toEqual(['domain_read']);
+  });
+
+  it('should grant domain access once the role is assigned', async () => {
+    await addDomainMembership(fixture.domain.id, fixture.adminToken, userMembership(newAdmin.userId, readOnlyRole.id));
+
+    const response = await readDomainAs(newAdmin.token);
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual(fixture.domain.id);
+  });
+
+  it('should still refuse the action whose verb the role withholds', async () => {
+    // The role carries READ on exactly this resource but not UPDATE, so the two must diverge —
+    // holding a permission is not the same as holding every action on it.
+    const response = await performPatch(
+      getOrganisationManagementUrl(),
+      domainPath(),
+      { description: 'changed by a read-only role' },
+      headers(newAdmin.token),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+
+  it('should take the access away again when the membership is removed', async () => {
+    const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
+    const theirs = memberships.find((membership) => membership.memberId === newAdmin.userId);
+    expect(theirs.roleId).toEqual(readOnlyRole.id);
+
+    await removeDomainMembership(fixture.domain.id, fixture.adminToken, theirs.id);
+
+    const response = await readDomainAs(newAdmin.token);
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+
+  it('should leave the user in place with only their default organization role', async () => {
+    const { memberships } = await listOrganizationMemberships(fixture.adminToken);
+    const theirs = memberships.filter((membership) => membership.memberId === newAdmin.userId);
+
+    expect(theirs).toHaveLength(1);
+    expect(theirs[0].roleId).toEqual(fixture.roles.organizationUser.id);
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/role-scope-confinement.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/role-scope-confinement.jest.spec.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { createPersona, Persona, RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import {
+  addApplicationMembership,
+  addDomainMembership,
+  addOrganizationMembership,
+  userMembership,
+} from '@management-commands/membership-management-commands';
+import { createCustomOrganizationRole, deleteOrganizationRole } from '@management-commands/role-management-commands';
+import { deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { getOrganisationManagementUrl } from '@management-commands/service/utils';
+import { uniqueName } from '@utils-commands/misc';
+import type { RoleEntity } from '@management-models/RoleEntity';
+
+setup();
+
+let fixture: RbacFixture;
+let domainCreatorRole: RoleEntity;
+let orgDomainReaderRole: RoleEntity;
+let domainCreator: Persona;
+let orgDomainReader: Persona;
+
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+
+  // A DOMAIN-assignable role that nonetheless carries DOMAIN[CREATE]. Nothing validates that a
+  // permission is relevant to the role's assignable type, so this role is accepted on save.
+  domainCreatorRole = await createCustomOrganizationRole(fixture.adminToken, uniqueName('domain-creator', true), 'DOMAIN', [
+    'domain_create',
+    'domain_read',
+  ]);
+  // An ORGANIZATION-assignable role carrying the same domain read permission, for the contrast.
+  orgDomainReaderRole = await createCustomOrganizationRole(fixture.adminToken, uniqueName('org-domain-reader', true), 'ORGANIZATION', [
+    'domain_read',
+    'domain_list',
+  ]);
+
+  domainCreator = await createPersona(fixture.adminToken, 'domaincreator');
+  orgDomainReader = await createPersona(fixture.adminToken, 'orgdomainreader');
+
+  await addDomainMembership(fixture.domain.id, fixture.adminToken, userMembership(domainCreator.userId, domainCreatorRole.id));
+  await addOrganizationMembership(fixture.adminToken, userMembership(orgDomainReader.userId, orgDomainReaderRole.id));
+});
+
+afterAll(async () => {
+  for (const persona of [domainCreator, orgDomainReader]) {
+    if (persona) {
+      await deleteOrganisationUser(fixture.adminToken, persona.userId).catch(() => undefined);
+    }
+  }
+  for (const role of [domainCreatorRole, orgDomainReaderRole]) {
+    if (role) {
+      await deleteOrganizationRole(fixture.adminToken, role.id).catch(() => undefined);
+    }
+  }
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * A role declares the tier it may be assigned to via `assignableType`. Assignment is refused
+ * outright when that does not match the tier of the membership, which is the first of two
+ * independent gates confining a role to its scope.
+ */
+describe('Role scope confinement - a role can only be assigned at its own tier', () => {
+  it('should accept an ORGANIZATION-assignable role at organization level', async () => {
+    await addOrganizationMembership(fixture.adminToken, userMembership(fixture.assignee.userId, fixture.roles.organizationUser.id));
+  });
+
+  it('should accept a DOMAIN-assignable role at domain level', async () => {
+    await addDomainMembership(fixture.domain.id, fixture.adminToken, userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id));
+  });
+
+  it('should accept an APPLICATION-assignable role at application level', async () => {
+    await addApplicationMembership(
+      fixture.domain.id,
+      fixture.application.id,
+      fixture.adminToken,
+      userMembership(fixture.assignee.userId, fixture.roles.applicationOwner.id),
+    );
+  });
+
+  it('should refuse an ORGANIZATION-assignable role at domain level', async () => {
+    await expect(
+      addDomainMembership(
+        fixture.domain.id,
+        fixture.adminToken,
+        userMembership(fixture.assignee.userId, fixture.roles.organizationUser.id),
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+
+  it('should refuse an ORGANIZATION-assignable role at application level', async () => {
+    await expect(
+      addApplicationMembership(
+        fixture.domain.id,
+        fixture.application.id,
+        fixture.adminToken,
+        userMembership(fixture.assignee.userId, fixture.roles.organizationUser.id),
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+
+  it('should refuse a DOMAIN-assignable role at organization level', async () => {
+    await expect(
+      addOrganizationMembership(fixture.adminToken, userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id)),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+
+  it('should refuse an APPLICATION-assignable role at domain level', async () => {
+    await expect(
+      addDomainMembership(
+        fixture.domain.id,
+        fixture.adminToken,
+        userMembership(fixture.assignee.userId, fixture.roles.applicationOwner.id),
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+
+  it('should refuse an APPLICATION-assignable role at organization level', async () => {
+    await expect(
+      addOrganizationMembership(fixture.adminToken, userMembership(fixture.assignee.userId, fixture.roles.applicationOwner.id)),
+    ).rejects.toMatchObject({ response: { status: 400 }, message: expect.stringContaining('Invalid role') });
+  });
+});
+
+/**
+ * The second gate. Nothing prevents a DOMAIN-assignable role from carrying DOMAIN[CREATE], and the
+ * assignment above is perfectly valid, so the role looks like it grants domain creation. It does
+ * not: creating a domain is authorised against the environment and organization tiers only, and a
+ * domain-level membership is never consulted for it. The permission is unreachable by construction.
+ */
+describe('Role scope confinement - a permission is only honoured on a tier that is consulted', () => {
+  it('should let the domain-scoped role read the domain it is assigned to', async () => {
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      `/environments/${process.env.AM_DEF_ENV_ID}/domains/${fixture.domain.id}`,
+      headers(domainCreator.token),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual(fixture.domain.id);
+  });
+
+  it('should refuse domain creation to a domain-scoped role holding DOMAIN[CREATE]', async () => {
+    const response = await performPost(
+      getOrganisationManagementUrl(),
+      `/environments/${process.env.AM_DEF_ENV_ID}/domains`,
+      {
+        name: uniqueName('scope-confinement-should-never-exist', true),
+        description: 'must never be created',
+        dataPlaneId: process.env.AM_DOMAIN_DATA_PLANE_ID || 'default',
+      },
+      headers(domainCreator.token),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toEqual('Permission denied');
+  });
+});
+
+/**
+ * The mirror image: a permission granted at organization level does reach every domain beneath it,
+ * because domain reads are authorised against the domain, environment and organization tiers.
+ * Together with the case above this pins which direction authority actually flows.
+ */
+describe('Role scope confinement - an organization-level grant reaches domains beneath it', () => {
+  it('should let an organization-scoped role read a domain it was never assigned to', async () => {
+    const response = await performGet(
+      getOrganisationManagementUrl(),
+      `/environments/${process.env.AM_DEF_ENV_ID}/domains/${fixture.otherDomain.id}`,
+      headers(orgDomainReader.token),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual(fixture.otherDomain.id);
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/role-scope-confinement.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/role-scope-confinement.jest.spec.ts
@@ -21,6 +21,9 @@ import {
   addApplicationMembership,
   addDomainMembership,
   addOrganizationMembership,
+  listApplicationMemberships,
+  listDomainMemberships,
+  listOrganizationMemberships,
   userMembership,
 } from '@management-commands/membership-management-commands';
 import { createCustomOrganizationRole, deleteOrganizationRole } from '@management-commands/role-management-commands';
@@ -30,7 +33,7 @@ import { getOrganisationManagementUrl } from '@management-commands/service/utils
 import { uniqueName } from '@utils-commands/misc';
 import type { RoleEntity } from '@management-models/RoleEntity';
 
-setup();
+setup(200000);
 
 let fixture: RbacFixture;
 let domainCreatorRole: RoleEntity;
@@ -84,12 +87,25 @@ afterAll(async () => {
  * independent gates confining a role to its scope.
  */
 describe('Role scope confinement - a role can only be assigned at its own tier', () => {
+  // Each accept case reads the membership back rather than relying on the call not throwing:
+  // a create that silently stopped persisting would leave the negative cases below passing and
+  // this half of the matrix green, which is precisely the regression the file exists to catch.
   it('should accept an ORGANIZATION-assignable role at organization level', async () => {
     await addOrganizationMembership(fixture.adminToken, userMembership(fixture.assignee.userId, fixture.roles.organizationUser.id));
+
+    const { memberships } = await listOrganizationMemberships(fixture.adminToken);
+    expect(memberships).toContainEqual(
+      expect.objectContaining({ memberId: fixture.assignee.userId, roleId: fixture.roles.organizationUser.id }),
+    );
   });
 
   it('should accept a DOMAIN-assignable role at domain level', async () => {
     await addDomainMembership(fixture.domain.id, fixture.adminToken, userMembership(fixture.assignee.userId, fixture.roles.domainOwner.id));
+
+    const { memberships } = await listDomainMemberships(fixture.domain.id, fixture.adminToken);
+    expect(memberships).toContainEqual(
+      expect.objectContaining({ memberId: fixture.assignee.userId, roleId: fixture.roles.domainOwner.id }),
+    );
   });
 
   it('should accept an APPLICATION-assignable role at application level', async () => {
@@ -98,6 +114,11 @@ describe('Role scope confinement - a role can only be assigned at its own tier',
       fixture.application.id,
       fixture.adminToken,
       userMembership(fixture.assignee.userId, fixture.roles.applicationOwner.id),
+    );
+
+    const { memberships } = await listApplicationMemberships(fixture.domain.id, fixture.application.id, fixture.adminToken);
+    expect(memberships).toContainEqual(
+      expect.objectContaining({ memberId: fixture.assignee.userId, roleId: fixture.roles.applicationOwner.id }),
     );
   });
 

--- a/gravitee-am-test/specs/management/permissions/write-endpoint-sweep.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/write-endpoint-sweep.jest.spec.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+
+setup();
+
+let fixture: RbacFixture;
+
+const managementUrl = () => `${process.env.AM_MANAGEMENT_URL}/management`;
+const headers = (token: string) => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` });
+const org = () => `/organizations/${process.env.AM_DEF_ORG_ID}`;
+const domainRoot = () => `${org()}/environments/${process.env.AM_DEF_ENV_ID}/domains/${fixture.domain.id}`;
+
+interface WriteCase {
+  name: string;
+  path: () => string;
+  body: () => Record<string, unknown>;
+  /** The permission the operation documents as required. */
+  permission: string;
+  /** Collection to re-read afterwards to prove the refusal left nothing behind. */
+  collection?: () => string;
+}
+
+/**
+ * Bodies are hand-written rather than generated, and that is forced by the API's own behaviour:
+ * 48 of the 53 write operations reject an empty payload with 400 before the permission check ever
+ * runs, so a generated empty-body sweep would prove nothing about authorisation. Each body below
+ * is the minimum that gets past validation and reaches the check — verified by the fact that an
+ * unprivileged caller receives 403 rather than 400.
+ *
+ * Nothing here can create anything: every request is made by a caller the API refuses, and the
+ * collections are re-read afterwards to confirm that.
+ */
+const WRITE_CASES: WriteCase[] = [
+  // --- organization tier ---------------------------------------------------------------------
+  {
+    name: 'create an organization group',
+    permission: 'organization_group_create',
+    path: () => `${org()}/groups`,
+    body: () => ({ name: 'sweep-should-never-exist' }),
+  },
+  {
+    name: 'create an organization tag',
+    permission: 'organization_tag_create',
+    path: () => `${org()}/tags`,
+    body: () => ({ name: 'sweep-should-never-exist' }),
+  },
+  {
+    name: 'create an organization identity provider',
+    permission: 'organization_identity_provider_create',
+    path: () => `${org()}/identities`,
+    body: () => ({ name: 'sweep-should-never-exist', type: 'inline-am-idp', configuration: '{}' }),
+  },
+  {
+    name: 'create an organization role',
+    permission: 'organization_role_create',
+    path: () => `${org()}/roles`,
+    body: () => ({ name: 'sweep-should-never-exist', assignableType: 'ORGANIZATION' }),
+  },
+  {
+    name: 'create an organization entrypoint',
+    permission: 'organization_entrypoint_create',
+    path: () => `${org()}/entrypoints`,
+    body: () => ({ name: 'sweep-should-never-exist', url: 'https://sweep.example.com', tags: [] }),
+  },
+  {
+    name: 'add an organization member',
+    permission: 'organization_member_create',
+    path: () => `${org()}/members`,
+    body: () => ({ memberId: fixture.assignee.userId, memberType: 'USER', role: fixture.roles.organizationUser.id }),
+  },
+
+  // --- domain tier ---------------------------------------------------------------------------
+  {
+    name: 'create a domain certificate',
+    permission: 'domain_certificate_create',
+    path: () => `${domainRoot()}/certificates`,
+    body: () => ({ name: 'sweep-should-never-exist', type: 'pkcs12-am-certificate', configuration: '{}' }),
+    collection: () => `${domainRoot()}/certificates`,
+  },
+  {
+    name: 'create a domain identity provider',
+    permission: 'domain_identity_provider_create',
+    path: () => `${domainRoot()}/identities`,
+    body: () => ({ name: 'sweep-should-never-exist', type: 'inline-am-idp', configuration: '{}' }),
+  },
+  {
+    name: 'create a domain group',
+    permission: 'domain_group_create',
+    path: () => `${domainRoot()}/groups`,
+    body: () => ({ name: 'sweep-should-never-exist' }),
+    collection: () => `${domainRoot()}/groups`,
+  },
+  {
+    name: 'create a domain role',
+    permission: 'domain_role_create',
+    path: () => `${domainRoot()}/roles`,
+    body: () => ({ name: 'sweep-should-never-exist' }),
+    collection: () => `${domainRoot()}/roles`,
+  },
+  {
+    name: 'create a domain scope',
+    permission: 'domain_scope_create',
+    path: () => `${domainRoot()}/scopes`,
+    body: () => ({ key: 'sweepscope', name: 'sweep-should-never-exist', description: 'never' }),
+  },
+  {
+    name: 'create a domain factor',
+    permission: 'domain_factor_create',
+    path: () => `${domainRoot()}/factors`,
+    body: () => ({ name: 'sweep-should-never-exist', type: 'otp-am-factor', configuration: '{}', factorType: 'OTP' }),
+    collection: () => `${domainRoot()}/factors`,
+  },
+  {
+    name: 'create a domain reporter',
+    permission: 'domain_reporter_create',
+    path: () => `${domainRoot()}/reporters`,
+    body: () => ({ name: 'sweep-should-never-exist', type: 'reporter-am-file', configuration: '{}' }),
+  },
+  {
+    name: 'create a domain bot detection',
+    permission: 'domain_bot_detection_create',
+    path: () => `${domainRoot()}/bot-detections`,
+    body: () => ({ name: 'sweep-should-never-exist', type: 'x', configuration: '{}', detectionType: 'CAPTCHA' }),
+  },
+  {
+    name: 'create a domain user',
+    permission: 'domain_user_create',
+    path: () => `${domainRoot()}/users`,
+    body: () => ({
+      username: 'sweep-should-never-exist',
+      password: 'SweepP@ssw0rd1',
+      firstName: 'a',
+      lastName: 'b',
+      email: 'sweep@test.com',
+      preRegistration: false,
+    }),
+    collection: () => `${domainRoot()}/users`,
+  },
+  {
+    name: 'add a domain member',
+    permission: 'domain_member_create',
+    path: () => `${domainRoot()}/members`,
+    body: () => ({ memberId: fixture.assignee.userId, memberType: 'USER', role: fixture.roles.domainOwner.id }),
+  },
+
+  // --- application tier ----------------------------------------------------------------------
+  {
+    name: 'add an application member',
+    permission: 'application_member_create',
+    path: () => `${domainRoot()}/applications/${fixture.application.id}/members`,
+    body: () => ({ memberId: fixture.assignee.userId, memberType: 'USER', role: fixture.roles.applicationOwner.id }),
+  },
+];
+
+beforeAll(async () => {
+  fixture = await setupRbacFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+/**
+ * The read sweeps prove a caller without a permission cannot see things. This proves they cannot
+ * change them, which is where a missing check does the real damage — creating administrators,
+ * identity providers or certificates rather than merely reading a list.
+ */
+describe(`Write endpoint sweep - ${WRITE_CASES.length} write operations refuse a bare ORGANIZATION_USER`, () => {
+  WRITE_CASES.forEach((writeCase) => {
+    it(`should refuse to ${writeCase.name} (needs ${writeCase.permission})`, async () => {
+      const response = await performPost(managementUrl(), writeCase.path(), writeCase.body(), headers(fixture.orgUser.token));
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toEqual('Permission denied');
+    });
+  });
+});
+
+describe('Write endpoint sweep - the refusals left nothing behind', () => {
+  WRITE_CASES.filter((writeCase) => writeCase.collection).forEach((writeCase) => {
+    it(`should leave nothing created by the attempt to ${writeCase.name}`, async () => {
+      // Read back as administrator: a refusal that still wrote something would be far worse than
+      // the wrong status code, and the status alone cannot rule it out.
+      const response = await performGet(managementUrl(), writeCase.collection(), headers(fixture.adminToken));
+
+      expect(response.status).toBe(200);
+      expect(JSON.stringify(response.body)).not.toContain('sweep-should-never-exist');
+    });
+  });
+});

--- a/gravitee-am-test/specs/management/permissions/write-endpoint-sweep.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/write-endpoint-sweep.jest.spec.ts
@@ -19,7 +19,7 @@ import { setup } from '../../test-fixture';
 import { RbacFixture, setupRbacFixture } from './fixtures/rbac-fixture';
 import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
 
-setup();
+setup(200000);
 
 let fixture: RbacFixture;
 
@@ -36,7 +36,16 @@ interface WriteCase {
   permission: string;
   /** Collection to re-read afterwards to prove the refusal left nothing behind. */
   collection?: () => string;
+  /**
+   * Value that must be absent from that collection. Defaults to the marker name, which suits every
+   * case that creates a named resource; membership writes carry no name, so they identify the
+   * would-be member instead.
+   */
+  residue?: () => string;
 }
+
+/** Present in every create payload below, and therefore the fingerprint of a write that landed. */
+const MARKER = 'sweep-should-never-exist';
 
 /**
  * Bodies are hand-written rather than generated, and that is forced by the API's own behaviour:
@@ -54,37 +63,45 @@ const WRITE_CASES: WriteCase[] = [
     name: 'create an organization group',
     permission: 'organization_group_create',
     path: () => `${org()}/groups`,
-    body: () => ({ name: 'sweep-should-never-exist' }),
+    body: () => ({ name: MARKER }),
+    collection: () => `${org()}/groups`,
   },
   {
     name: 'create an organization tag',
     permission: 'organization_tag_create',
     path: () => `${org()}/tags`,
-    body: () => ({ name: 'sweep-should-never-exist' }),
+    body: () => ({ name: MARKER }),
+    collection: () => `${org()}/tags`,
   },
   {
     name: 'create an organization identity provider',
     permission: 'organization_identity_provider_create',
     path: () => `${org()}/identities`,
-    body: () => ({ name: 'sweep-should-never-exist', type: 'inline-am-idp', configuration: '{}' }),
+    body: () => ({ name: MARKER, type: 'inline-am-idp', configuration: '{}' }),
+    collection: () => `${org()}/identities`,
   },
   {
     name: 'create an organization role',
     permission: 'organization_role_create',
     path: () => `${org()}/roles`,
-    body: () => ({ name: 'sweep-should-never-exist', assignableType: 'ORGANIZATION' }),
+    body: () => ({ name: MARKER, assignableType: 'ORGANIZATION' }),
+    collection: () => `${org()}/roles`,
   },
   {
     name: 'create an organization entrypoint',
     permission: 'organization_entrypoint_create',
     path: () => `${org()}/entrypoints`,
-    body: () => ({ name: 'sweep-should-never-exist', url: 'https://sweep.example.com', tags: [] }),
+    body: () => ({ name: MARKER, url: 'https://sweep.example.com', tags: [] }),
+    collection: () => `${org()}/entrypoints`,
   },
   {
     name: 'add an organization member',
     permission: 'organization_member_create',
     path: () => `${org()}/members`,
     body: () => ({ memberId: fixture.assignee.userId, memberType: 'USER', role: fixture.roles.organizationUser.id }),
+    // No residue check: ORGANIZATION_USER is granted at user creation, so the assignee already
+    // holds exactly the membership this request tries to add. Its presence afterwards proves
+    // nothing either way, and asserting on it would be a test that cannot fail.
   },
 
   // --- domain tier ---------------------------------------------------------------------------
@@ -92,60 +109,64 @@ const WRITE_CASES: WriteCase[] = [
     name: 'create a domain certificate',
     permission: 'domain_certificate_create',
     path: () => `${domainRoot()}/certificates`,
-    body: () => ({ name: 'sweep-should-never-exist', type: 'pkcs12-am-certificate', configuration: '{}' }),
+    body: () => ({ name: MARKER, type: 'pkcs12-am-certificate', configuration: '{}' }),
     collection: () => `${domainRoot()}/certificates`,
   },
   {
     name: 'create a domain identity provider',
     permission: 'domain_identity_provider_create',
     path: () => `${domainRoot()}/identities`,
-    body: () => ({ name: 'sweep-should-never-exist', type: 'inline-am-idp', configuration: '{}' }),
+    body: () => ({ name: MARKER, type: 'inline-am-idp', configuration: '{}' }),
+    collection: () => `${domainRoot()}/identities`,
   },
   {
     name: 'create a domain group',
     permission: 'domain_group_create',
     path: () => `${domainRoot()}/groups`,
-    body: () => ({ name: 'sweep-should-never-exist' }),
+    body: () => ({ name: MARKER }),
     collection: () => `${domainRoot()}/groups`,
   },
   {
     name: 'create a domain role',
     permission: 'domain_role_create',
     path: () => `${domainRoot()}/roles`,
-    body: () => ({ name: 'sweep-should-never-exist' }),
+    body: () => ({ name: MARKER }),
     collection: () => `${domainRoot()}/roles`,
   },
   {
     name: 'create a domain scope',
     permission: 'domain_scope_create',
     path: () => `${domainRoot()}/scopes`,
-    body: () => ({ key: 'sweepscope', name: 'sweep-should-never-exist', description: 'never' }),
+    body: () => ({ key: 'sweepscope', name: MARKER, description: 'never' }),
+    collection: () => `${domainRoot()}/scopes`,
   },
   {
     name: 'create a domain factor',
     permission: 'domain_factor_create',
     path: () => `${domainRoot()}/factors`,
-    body: () => ({ name: 'sweep-should-never-exist', type: 'otp-am-factor', configuration: '{}', factorType: 'OTP' }),
+    body: () => ({ name: MARKER, type: 'otp-am-factor', configuration: '{}', factorType: 'OTP' }),
     collection: () => `${domainRoot()}/factors`,
   },
   {
     name: 'create a domain reporter',
     permission: 'domain_reporter_create',
     path: () => `${domainRoot()}/reporters`,
-    body: () => ({ name: 'sweep-should-never-exist', type: 'reporter-am-file', configuration: '{}' }),
+    body: () => ({ name: MARKER, type: 'reporter-am-file', configuration: '{}' }),
+    collection: () => `${domainRoot()}/reporters`,
   },
   {
     name: 'create a domain bot detection',
     permission: 'domain_bot_detection_create',
     path: () => `${domainRoot()}/bot-detections`,
-    body: () => ({ name: 'sweep-should-never-exist', type: 'x', configuration: '{}', detectionType: 'CAPTCHA' }),
+    body: () => ({ name: MARKER, type: 'x', configuration: '{}', detectionType: 'CAPTCHA' }),
+    collection: () => `${domainRoot()}/bot-detections`,
   },
   {
     name: 'create a domain user',
     permission: 'domain_user_create',
     path: () => `${domainRoot()}/users`,
     body: () => ({
-      username: 'sweep-should-never-exist',
+      username: MARKER,
       password: 'SweepP@ssw0rd1',
       firstName: 'a',
       lastName: 'b',
@@ -159,6 +180,8 @@ const WRITE_CASES: WriteCase[] = [
     permission: 'domain_member_create',
     path: () => `${domainRoot()}/members`,
     body: () => ({ memberId: fixture.assignee.userId, memberType: 'USER', role: fixture.roles.domainOwner.id }),
+    collection: () => `${domainRoot()}/members`,
+    residue: () => fixture.assignee.userId,
   },
 
   // --- application tier ----------------------------------------------------------------------
@@ -167,6 +190,8 @@ const WRITE_CASES: WriteCase[] = [
     permission: 'application_member_create',
     path: () => `${domainRoot()}/applications/${fixture.application.id}/members`,
     body: () => ({ memberId: fixture.assignee.userId, memberType: 'USER', role: fixture.roles.applicationOwner.id }),
+    collection: () => `${domainRoot()}/applications/${fixture.application.id}/members`,
+    residue: () => fixture.assignee.userId,
   },
 ];
 
@@ -203,8 +228,8 @@ describe('Write endpoint sweep - the refusals left nothing behind', () => {
       // the wrong status code, and the status alone cannot rule it out.
       const response = await performGet(managementUrl(), writeCase.collection(), headers(fixture.adminToken));
 
-      expect(response.status).toBe(200);
-      expect(JSON.stringify(response.body)).not.toContain('sweep-should-never-exist');
+      expect(response.status).toBeLessThan(400);
+      expect(JSON.stringify(response.body)).not.toContain(writeCase.residue?.() ?? MARKER);
     });
   });
 });


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7448

## :pencil2: A description of the changes proposed in the pull request
Automates the **Regression > Permissions and Roles** area — who can do what at organization, domain, application and protected-resource level, and what the Console shows them.

  ## Jest — 13 specs, 223 tests
  
  `gravitee-am-test/specs/management/permissions/`

  - **Endpoint sweeps** — every endpoint refuses a caller without its permission, and opens to one granted exactly that permission. Table generated from`docs/mapi/openapi.yaml`.
  - **Write sweep** — 17 write operations refused, collections re-read to confirm nothing was created.
  - **Role scope confinement** — a role only works at the tier it is assignable to.
  - **Delegated administration** — who may grant roles, plus escalation guards.
  - **Membership cascade** — assignment provisions parent-tier memberships.
  - **Cross-reference isolation** — a resource can't be reached via the wrong parent.
  - **List scoping** — lists narrowed to what the caller may see.
  - **Custom role lifecycle** — create, grant, built-in roles resist modification.
  - **Assignment journey** — onboard, grant, verify, revoke, verify.
  - **Organization baseline** — default role, Console access, group permissions.
  - **Protected-resource tier** — the fifth tier end to end.

  ## Playwright — 5 specs, 23 tests
  
  `gravitee-am-test/playwright/tests/permissions/`

Console visibility per role: which domains and applications appear, which menus are shown or withheld, role creation through the Console, system-role permissions greyed out, and that what the Console offers matches what the API allows for the same user.

  ## Xray automated

  | Spec | Xray |
  |---|---|
  | `org-role-visibility` | AM-6031 |
  | `domain-role-visibility` | AM-6032 |
  | `application-role-visibility` | AM-6036 |
  | `ui-api-parity` | AM-7472 |
  | `application-permission-isolation` | AM-7473 |
  
**A few routes are excluded from the sweeps with a Jira reference where current behaviour is defective.**

## :memo: Test scenarios 
NA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
