### PR TITLE
test: cover token revocation triggers and RFC 7009 endpoint (AM-7450)

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/RevocationTokenEndpointTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/resources/endpoint/RevocationTokenEndpointTest.java
@@ -19,7 +19,9 @@ import io.gravitee.am.gateway.handler.common.vertx.RxWebTestBase;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidGrantException;
 import io.gravitee.am.gateway.handler.oauth2.resources.endpoint.revocation.RevocationTokenEndpoint;
 import io.gravitee.am.gateway.handler.oauth2.resources.handler.ExceptionHandler;
+import io.gravitee.am.common.oauth2.TokenTypeHint;
 import io.gravitee.am.gateway.handler.oauth2.service.revocation.OAuthRevocationTokenService;
+import io.gravitee.am.gateway.handler.oauth2.service.revocation.RevocationTokenRequest;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
@@ -30,11 +32,15 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -119,6 +125,48 @@ public class RevocationTokenEndpointTest extends RxWebTestBase {
                 HttpMethod.POST, "/oauth/revoke?token=toto",
                 req -> req.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED),
                 HttpStatusCode.OK_200, "OK", null);
+    }
+
+    @Test
+    public void shouldInvokeRevocationTokenEndpoint_propagatesTokenTypeHint() throws Exception {
+        router.route().order(-1).handler(routingContext -> {
+            routingContext.put("client", new Client());
+            routingContext.next();
+        });
+
+        when(revocationTokenService.revoke(any(), any())).thenReturn(Completable.complete());
+
+        testRequest(
+                HttpMethod.POST, "/oauth/revoke?token=toto&token_type_hint=refresh_token",
+                req -> req.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED),
+                HttpStatusCode.OK_200, "OK", null);
+
+        ArgumentCaptor<RevocationTokenRequest> requestCaptor = ArgumentCaptor.forClass(RevocationTokenRequest.class);
+        verify(revocationTokenService).revoke(requestCaptor.capture(), any());
+        assertEquals(TokenTypeHint.REFRESH_TOKEN, requestCaptor.getValue().getHint());
+    }
+
+    /**
+     * RFC 7009 section 2.1: an unrecognised hint must not fail the request — the server falls back
+     * to searching every token type, which here means leaving the hint unset.
+     */
+    @Test
+    public void shouldInvokeRevocationTokenEndpoint_ignoresUnknownTokenTypeHint() throws Exception {
+        router.route().order(-1).handler(routingContext -> {
+            routingContext.put("client", new Client());
+            routingContext.next();
+        });
+
+        when(revocationTokenService.revoke(any(), any())).thenReturn(Completable.complete());
+
+        testRequest(
+                HttpMethod.POST, "/oauth/revoke?token=toto&token_type_hint=not_a_token_type",
+                req -> req.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED),
+                HttpStatusCode.OK_200, "OK", null);
+
+        ArgumentCaptor<RevocationTokenRequest> requestCaptor = ArgumentCaptor.forClass(RevocationTokenRequest.class);
+        verify(revocationTokenService).revoke(requestCaptor.capture(), any());
+        assertNull(requestCaptor.getValue().getHint());
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/revocation/RevocationServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/revocation/RevocationServiceTest.java
@@ -133,6 +133,89 @@ public class RevocationServiceTest {
 
     }
 
+    /**
+     * RFC 7009 section 2.1: if the server cannot locate the token using the given hint, it MUST
+     * extend its search across all supported token types.
+     */
+    @Test
+    public void shouldRevoke_accessToken_whenHintIncorrectlySaysRefreshToken() {
+        final RevocationTokenRequest revocationTokenRequest = new RevocationTokenRequest("token");
+        revocationTokenRequest.setHint(TokenTypeHint.REFRESH_TOKEN);
+
+        Client client = new Client();
+        client.setClientId("client-id");
+
+        AccessToken accessToken = new AccessToken("token");
+        accessToken.setClientId("client-id");
+
+        when(tokenService.getRefreshToken("token", client)).thenReturn(Maybe.empty());
+        when(tokenService.getAccessToken("token", client)).thenReturn(Maybe.just(accessToken));
+        when(tokenService.deleteAccessToken("token")).thenReturn(Completable.complete());
+
+        TestObserver testObserver = revocationTokenService.revoke(revocationTokenRequest, client).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(tokenService, times(1)).getRefreshToken("token", client);
+        verify(tokenService, times(1)).getAccessToken("token", client);
+        verify(tokenService, times(1)).deleteAccessToken("token");
+        verify(tokenService, never()).deleteRefreshToken(anyString());
+    }
+
+    @Test
+    public void shouldRevoke_refreshToken_whenNoHintProvided() {
+        final RevocationTokenRequest revocationTokenRequest = new RevocationTokenRequest("token");
+
+        Client client = new Client();
+        client.setClientId("client-id");
+
+        Token refreshToken = new RefreshToken("token");
+        refreshToken.setClientId("client-id");
+
+        when(tokenService.getAccessToken("token", client)).thenReturn(Maybe.empty());
+        when(tokenService.getRefreshToken("token", client)).thenReturn(Maybe.just(refreshToken));
+        when(tokenService.deleteRefreshToken("token")).thenReturn(Completable.complete());
+
+        TestObserver testObserver = revocationTokenService.revoke(revocationTokenRequest, client).test();
+
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(tokenService, times(1)).getAccessToken("token", client);
+        verify(tokenService, times(1)).getRefreshToken("token", client);
+        verify(tokenService, times(1)).deleteRefreshToken("token");
+        verify(tokenService, never()).deleteAccessToken(anyString());
+    }
+
+    /**
+     * The cross-client guard exists separately on the refresh-token path, so it needs its own
+     * coverage — shouldNotRevoke_WrongRequestedClientId only exercises the access-token path.
+     */
+    @Test
+    public void shouldNotRevoke_refreshToken_WrongRequestedClientId() {
+        final RevocationTokenRequest revocationTokenRequest = new RevocationTokenRequest("token");
+        revocationTokenRequest.setHint(TokenTypeHint.REFRESH_TOKEN);
+
+        Token refreshToken = new RefreshToken("token");
+        refreshToken.setClientId("client-id");
+
+        Client client = new Client();
+        client.setClientId("wrong-client-id");
+
+        when(tokenService.getRefreshToken("token", client)).thenReturn(Maybe.just(refreshToken));
+
+        TestObserver testObserver = revocationTokenService.revoke(revocationTokenRequest, client).test();
+
+        testObserver.assertNotComplete();
+        testObserver.assertError(InvalidGrantException.class);
+
+        verify(tokenService, times(1)).getRefreshToken("token", client);
+        verify(tokenService, never()).deleteRefreshToken(anyString());
+        verify(tokenService, never()).getAccessToken(anyString(), any());
+        verify(tokenService, never()).deleteAccessToken(anyString());
+    }
+
     @Test
     public void shouldRevoke_refreshToken() {
         final RevocationTokenRequest revocationTokenRequest = new RevocationTokenRequest("token");

--- a/gravitee-am-test/specs/gateway/revocation/fixtures/revocation-fixture.ts
+++ b/gravitee-am-test/specs/gateway/revocation/fixtures/revocation-fixture.ts
@@ -36,13 +36,17 @@ import {
   performPatch,
   performPost,
 } from '@gateway-commands/oauth-oidc-commands';
-import { withRetry } from '@utils-commands/retry';
+import { retryUntil, withRetry } from '@utils-commands/retry';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
 import { applicationBase64Token } from '@gateway-commands/utils';
 import { uniqueName } from '@utils-commands/misc';
 import { decodeJwt } from '@utils-commands/jwt';
 import { JWT_FORMAT } from '@specs-utils/jwt-format';
 import { Domain } from '@management-models/Domain';
 import { Application } from '@management-models/Application';
+// Type-only: jest's moduleNameMapper has no @management-models entry, so a value import from here
+// resolves under tsc but blows up at runtime. Keep every model import in a type position.
+import type { NewApplication } from '@management-models/NewApplication';
 import { IdentityProvider } from '@management-models/IdentityProvider';
 import { User } from '@management-models/User';
 import request from 'supertest';
@@ -122,6 +126,14 @@ export interface RevocationFixture {
   createAdditionalUser: (index: number) => Promise<User>;
   /** Run the authorization_code flow as an arbitrary user, defaulting to the fixture's primary client. */
   obtainAuthorizationCodeTokensAs: (asUser: User, client?: RevocationClient) => Promise<SubjectTokens>;
+  /**
+   * Poll until the gateway rejects this token at the userinfo endpoint. Use instead of a fixed
+   * wait when asserting a token has been revoked — it tolerates slow propagation and still fails
+   * honestly, because a token that was never revoked keeps returning 200 until the timeout.
+   */
+  waitUntilTokenRejected: (token: string) => Promise<void>;
+  /** As `waitUntilTokenRejected`, but polls the introspection endpoint for `active: false`. */
+  waitUntilTokenInactive: (token: string) => Promise<void>;
   /** Present only when the fixture was built with `withScim: true`. */
   scim?: {
     endpoint: string;
@@ -131,20 +143,35 @@ export interface RevocationFixture {
   };
 }
 
-/** Default of `handlers.oauth2.introspect.offlineVerificationTimerSeconds`, plus a second of slack. */
-const OFFLINE_VERIFICATION_WINDOW_MS = 11000;
+/**
+ * `handlers.oauth2.introspect.offlineVerificationTimerSeconds`. Within this many seconds of a
+ * token being issued the gateway trusts the JWT and never looks it up, so a revoked token still
+ * works. The stack these tests run against disables it
+ * (`GRAVITEE_HANDLERS_OAUTH2_INTROSPECT_OFFLINEVERIFICATIONTIMERSECONDS=0` in
+ * docker/local-stack/dev/docker-compose.yml, which the CI compose layers), hence the default of 0
+ * here. Override to match if you point the suite at a stack that leaves the product default of 10.
+ */
+const OFFLINE_VERIFICATION_SECONDS = Number(process.env.AM_OFFLINE_VERIFICATION_SECONDS ?? 0);
+
+/** Headroom for the revoke event to reach the gateway and the delete to land. */
+const REVOKE_PROPAGATION_SETTLE_MS = 2000;
+
+/** How long to keep polling before deciding a token was never revoked. */
+const REVOCATION_POLL_TIMEOUT_MS = 20000;
 
 /**
- * Block until the gateway will consult the token store for this token rather than trusting the
- * JWT alone. Deliberately a wait and not a poll: the point is to reach a state where a single
- * check is meaningful, and polling for a status would mask a token that is still valid.
+ * Wait until the gateway will consult the token store for this token rather than trusting the JWT.
+ *
+ * Only needed before asserting a token is STILL VALID. Inside the offline-verification window such
+ * an assertion is meaningless — the JWT is trusted, so it passes even if the token has been revoked.
+ * To assert a token HAS been revoked, poll with `waitUntilTokenRejected` / `waitUntilTokenInactive`
+ * instead: polling for the revoked state cannot produce a false pass, because a token that was
+ * never revoked simply stays valid until the timeout.
  */
 export const waitPastOfflineVerification = async (token: string): Promise<void> => {
   const { iat } = decodeJwt(token) as { iat: number };
-  const remainingMs = iat * 1000 + OFFLINE_VERIFICATION_WINDOW_MS - Date.now();
-  if (remainingMs > 0) {
-    await new Promise((resolve) => setTimeout(resolve, remainingMs));
-  }
+  const remainingWindowMs = Math.max(0, (iat + OFFLINE_VERIFICATION_SECONDS) * 1000 - Date.now());
+  await new Promise((resolve) => setTimeout(resolve, remainingWindowMs + REVOKE_PROPAGATION_SETTLE_MS));
 };
 
 const REVOCATION_TEST = {
@@ -304,20 +331,28 @@ const buildAuthorizationCodeFlow =
  * Service application used to obtain a SCIM bearer token. Mirrors specs/gateway/scim/fixture.
  */
 const setupScimApp = async (domainId: string, accessToken: string): Promise<Application> => {
-  const createAppRequest: Application = {
+  // OAuth settings can't be supplied at create time, hence create-then-update.
+  const createAppRequest: NewApplication = {
     name: uniqueName('revocation-scim-app', true),
     type: 'SERVICE',
-    settings: {
-      oauth: {
-        grantTypes: ['client_credentials'],
-        tokenCustomClaim: [],
-        accessTokenValiditySeconds: 7200,
-        scopeSettings: [{ scope: 'scim', defaultScope: true }],
-      },
-    },
   };
   const app = await createApplication(domainId, accessToken, createAppRequest);
-  await updateApplication(domainId, accessToken, createAppRequest, app.id);
+
+  await updateApplication(
+    domainId,
+    accessToken,
+    {
+      settings: {
+        oauth: {
+          grantTypes: ['client_credentials'],
+          accessTokenValiditySeconds: 7200,
+          scopeSettings: [{ scope: 'scim', defaultScope: true }],
+        },
+      },
+    },
+    app.id,
+  );
+
   return app;
 };
 
@@ -445,13 +480,10 @@ export const setupRevocationFixture = async (options: RevocationFixtureOptions =
       namePrefix: string = REVOCATION_TEST.SECONDARY_CLIENT_NAME,
       clientOptions: { exactName?: boolean } = {},
     ): Promise<RevocationClient> => {
-      const additionalApplication = await createRevocationApp(
-        namePrefix,
-        startedDomain,
-        accessToken!,
-        defaultIdp,
-        enableTokenExchange,
-        clientOptions.exactName,
+      // Callers run an authorization_code flow against this client straight away, so it has to be
+      // on the gateway before we hand it back — createTestApp does not wait.
+      const additionalApplication = await waitForSyncAfter(startedDomain.id, () =>
+        createRevocationApp(namePrefix, startedDomain, accessToken!, defaultIdp, enableTokenExchange, clientOptions.exactName),
       );
       const additionalBasicAuth = applicationBase64Token(additionalApplication);
 
@@ -460,6 +492,25 @@ export const setupRevocationFixture = async (options: RevocationFixtureOptions =
         basicAuth: additionalBasicAuth,
         obtainAuthorizationCodeTokens: buildAuthorizationCodeFlow(oidc, additionalApplication, additionalBasicAuth, user),
       };
+    };
+
+    const waitUntilTokenRejected = async (token: string): Promise<void> => {
+      await retryUntil(
+        () => getUserInfo(token).then((response) => response.status),
+        (status) => status === 401,
+        { timeoutMillis: REVOCATION_POLL_TIMEOUT_MS, intervalMillis: 250 },
+      );
+    };
+
+    const waitUntilTokenInactive = async (token: string): Promise<void> => {
+      await retryUntil(
+        () => introspectToken(token).then((body) => body.active),
+        (active) => active === false,
+        {
+          timeoutMillis: REVOCATION_POLL_TIMEOUT_MS,
+          intervalMillis: 250,
+        },
+      );
     };
 
     const createAdditionalUser = async (index: number): Promise<User> => {
@@ -518,6 +569,8 @@ export const setupRevocationFixture = async (options: RevocationFixtureOptions =
       createAdditionalClient,
       createAdditionalUser,
       obtainAuthorizationCodeTokensAs,
+      waitUntilTokenRejected,
+      waitUntilTokenInactive,
       scim,
       cleanup,
     };

--- a/gravitee-am-test/specs/gateway/revocation/fixtures/revocation-fixture.ts
+++ b/gravitee-am-test/specs/gateway/revocation/fixtures/revocation-fixture.ts
@@ -15,7 +15,14 @@
  */
 
 import { expect } from '@jest/globals';
-import { createDomain, safeDeleteDomain, startDomain, waitForOidcReady } from '@management-commands/domain-management-commands';
+import {
+  createDomain,
+  patchDomain,
+  safeDeleteDomain,
+  startDomain,
+  waitForOidcReady,
+} from '@management-commands/domain-management-commands';
+import { createApplication, updateApplication } from '@management-commands/application-management-commands';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { getAllIdps } from '@management-commands/idp-management-commands';
 import { buildCreateAndTestUser } from '@management-commands/user-management-commands';
@@ -26,10 +33,14 @@ import {
   introspectToken as introspectOidcToken,
   performFormPost,
   performGet,
+  performPatch,
   performPost,
 } from '@gateway-commands/oauth-oidc-commands';
+import { withRetry } from '@utils-commands/retry';
 import { applicationBase64Token } from '@gateway-commands/utils';
 import { uniqueName } from '@utils-commands/misc';
+import { decodeJwt } from '@utils-commands/jwt';
+import { JWT_FORMAT } from '@specs-utils/jwt-format';
 import { Domain } from '@management-models/Domain';
 import { Application } from '@management-models/Application';
 import { IdentityProvider } from '@management-models/IdentityProvider';
@@ -54,9 +65,40 @@ export interface SubjectTokens {
   expiresIn: number;
 }
 
+/**
+ * An application plus everything a test needs to drive it: its Basic auth header
+ * and a helper that runs a full authorization_code flow against it.
+ */
+export interface RevocationClient {
+  application: Application;
+  basicAuth: string;
+  obtainAuthorizationCodeTokens: (scope?: string) => Promise<SubjectTokens>;
+}
+
+export interface RevocationFixtureOptions {
+  /** Domain name prefix; a random suffix is always appended. */
+  domainNamePrefix?: string;
+  /** Enable domain-level token exchange and add the grant type to each client. Defaults to true. */
+  enableTokenExchange?: boolean;
+  /**
+   * Create a second, independent application in the same domain. Used to assert that
+   * revocation targeting one client leaves other clients' tokens alone.
+   */
+  withSecondaryApplication?: boolean;
+  /**
+   * Enable SCIM on the domain and provision a service client, so tests can drive SCIM user
+   * updates. SCIM disable takes a different revocation route to everything else in this folder:
+   * ProvisioningUserServiceImpl calls RevokeTokenGatewayService#deleteByUser directly rather
+   * than emitting a REVOKE_TOKEN event.
+   */
+  withScim?: boolean;
+}
+
 export interface RevocationFixture {
   domain: Domain;
   application: Application;
+  /** Present only when the fixture was built with `withSecondaryApplication: true`. */
+  secondaryClient?: RevocationClient;
   user: User;
   defaultIdp: IdentityProvider;
   oidc: OidcConfiguration;
@@ -64,30 +106,69 @@ export interface RevocationFixture {
   accessToken: string;
   cleanup: () => Promise<void>;
   obtainAuthorizationCodeTokens: (scope?: string) => Promise<SubjectTokens>;
-  introspectToken: (token: string) => Promise<any>;
+  introspectToken: (token: string, basicAuth?: string) => Promise<any>;
   exchangeToken: (subjectToken: string, subjectTokenType: 'access_token' | 'refresh_token') => Promise<string>;
+  /** GET the userinfo endpoint with a bearer token. Returns the raw response so tests can assert on status. */
+  getUserInfo: (token: string) => Promise<any>;
+  /** POST the RFC 7009 revocation endpoint. Returns the raw response so tests can assert on status and body. */
+  revokeToken: (token: string, options?: { basicAuth?: string; tokenTypeHint?: string }) => Promise<any>;
+  /**
+   * Create a further application in the same domain, on demand. Lets a test that mutates an
+   * application (disable, delete) own a client nobody else depends on, keeping it independent
+   * of the other tests in the file.
+   */
+  createAdditionalClient: (namePrefix?: string, options?: { exactName?: boolean }) => Promise<RevocationClient>;
+  /** Create a further user in the domain. `index` must be unique within a test file. */
+  createAdditionalUser: (index: number) => Promise<User>;
+  /** Run the authorization_code flow as an arbitrary user, defaulting to the fixture's primary client. */
+  obtainAuthorizationCodeTokensAs: (asUser: User, client?: RevocationClient) => Promise<SubjectTokens>;
+  /** Present only when the fixture was built with `withScim: true`. */
+  scim?: {
+    endpoint: string;
+    accessToken: string;
+    /** PATCH a user's `active` flag. Returns the raw response so tests can assert on it. */
+    setUserActive: (userId: string, active: boolean) => Promise<any>;
+  };
 }
 
+/** Default of `handlers.oauth2.introspect.offlineVerificationTimerSeconds`, plus a second of slack. */
+const OFFLINE_VERIFICATION_WINDOW_MS = 11000;
+
+/**
+ * Block until the gateway will consult the token store for this token rather than trusting the
+ * JWT alone. Deliberately a wait and not a poll: the point is to reach a state where a single
+ * check is meaningful, and polling for a status would mask a token that is still valid.
+ */
+export const waitPastOfflineVerification = async (token: string): Promise<void> => {
+  const { iat } = decodeJwt(token) as { iat: number };
+  const remainingMs = iat * 1000 + OFFLINE_VERIFICATION_WINDOW_MS - Date.now();
+  if (remainingMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, remainingMs));
+  }
+};
+
 const REVOCATION_TEST = {
+  // Kept as the original consent-revocation prefix so existing callers that pass no
+  // options keep producing the same domain names. New specs pass their own prefix.
   DOMAIN_NAME_PREFIX: 'revoke-consents',
-  DOMAIN_DESCRIPTION: 'Revoke user consents domain',
+  DOMAIN_DESCRIPTION: 'Token revocation domain',
   CLIENT_NAME: 'revoke-consents-client',
+  SECONDARY_CLIENT_NAME: 'revocation-secondary-client',
   USER_PASSWORD: 'SomeP@ssw0rd',
   REDIRECT_URI: 'https://gravitee.io/callback',
+  DEFAULT_SCOPE: 'openid%20profile%20offline_access',
   DEFAULT_SCOPES: [
     { scope: 'openid', defaultScope: true },
     { scope: 'profile', defaultScope: true },
     { scope: 'offline_access', defaultScope: false },
   ],
-  DEFAULT_GRANT_TYPES: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:token-exchange'],
-  ALLOWED_SUBJECT_TOKEN_TYPES: [
-    'urn:ietf:params:oauth:token-type:access_token',
-    'urn:ietf:params:oauth:token-type:refresh_token',
-  ],
+  BASE_GRANT_TYPES: ['authorization_code', 'refresh_token'],
+  TOKEN_EXCHANGE_GRANT_TYPE: 'urn:ietf:params:oauth:grant-type:token-exchange',
+  ALLOWED_SUBJECT_TOKEN_TYPES: ['urn:ietf:params:oauth:token-type:access_token', 'urn:ietf:params:oauth:token-type:refresh_token'],
   ALLOWED_REQUESTED_TOKEN_TYPES: ['urn:ietf:params:oauth:token-type:access_token'],
 };
 
-const enableTokenExchange = async (domainId: string, token: string): Promise<void> => {
+const enableTokenExchangeOnDomain = async (domainId: string, token: string): Promise<void> => {
   await request(getDomainManagerUrl(domainId))
     .patch('')
     .set('Authorization', `Bearer ${token}`)
@@ -104,39 +185,202 @@ const enableTokenExchange = async (domainId: string, token: string): Promise<voi
     .expect(200);
 };
 
-export const setupRevocationFixture = async (): Promise<RevocationFixture> => {
+const createRevocationApp = async (
+  name: string,
+  domain: Domain,
+  accessToken: string,
+  defaultIdp: IdentityProvider,
+  withTokenExchange: boolean,
+  exactName: boolean = false,
+): Promise<Application> => {
+  const grantTypes = withTokenExchange
+    ? [...REVOCATION_TEST.BASE_GRANT_TYPES, REVOCATION_TEST.TOKEN_EXCHANGE_GRANT_TYPE]
+    : [...REVOCATION_TEST.BASE_GRANT_TYPES];
+
+  // createTestApp derives clientId from the name, so an exact name pins the clientId. Only safe
+  // across separate domains — clientId uniqueness in AM is per-domain.
+  const applicationName = exactName ? name : uniqueName(name, true);
+
+  const application = await createTestApp(applicationName, domain, accessToken, 'WEB', {
+    settings: {
+      oauth: {
+        redirectUris: [REVOCATION_TEST.REDIRECT_URI],
+        grantTypes,
+        scopeSettings: REVOCATION_TEST.DEFAULT_SCOPES,
+      },
+    },
+    identityProviders: new Set([{ identity: defaultIdp.id, priority: 0 }]),
+  });
+
+  expect(application.settings.oauth.clientId).toEqual(expect.any(String));
+  return application;
+};
+
+/**
+ * Runs a full authorization_code flow (login, optional consent, code exchange) for one client.
+ */
+const buildAuthorizationCodeFlow =
+  (oidc: OidcConfiguration, application: Application, basicAuth: string, user: User) =>
+  async (scope: string = REVOCATION_TEST.DEFAULT_SCOPE): Promise<SubjectTokens> => {
+    const clientId = application.settings.oauth.clientId;
+    const authorizationRequestParams = `?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
+      REVOCATION_TEST.REDIRECT_URI,
+    )}&scope=${scope}`;
+
+    const authResponse = await performGet(oidc.authorization_endpoint, authorizationRequestParams).expect(302);
+    const loginResult = await extractXsrfTokenAndActionResponse(authResponse);
+
+    const postLogin = await performFormPost(
+      loginResult.action,
+      '',
+      {
+        'X-XSRF-TOKEN': loginResult.token,
+        username: user.username,
+        password: REVOCATION_TEST.USER_PASSWORD,
+        client_id: clientId,
+      },
+      {
+        Cookie: loginResult.headers['set-cookie'],
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
+    ).expect(302);
+
+    const postLoginRedirect = await performGet(postLogin.headers['location'], '', {
+      Cookie: postLogin.headers['set-cookie'],
+    }).expect(302);
+
+    let redirectWithCodeLocation = postLoginRedirect.headers['location'];
+
+    if (redirectWithCodeLocation.includes('/oauth/consent')) {
+      const consentResult = await extractXsrfTokenAndActionResponse(postLoginRedirect);
+      const postConsent = await performFormPost(
+        consentResult.action,
+        '',
+        {
+          'X-XSRF-TOKEN': consentResult.token,
+          'scope.openid': true,
+          'scope.profile': true,
+          'scope.offline_access': true,
+          user_oauth_approval: true,
+        },
+        {
+          Cookie: consentResult.headers['set-cookie'],
+          'Content-type': 'application/x-www-form-urlencoded',
+        },
+      ).expect(302);
+
+      const postConsentRedirect = await performGet(postConsent.headers['location'], '', {
+        Cookie: postConsent.headers['set-cookie'] || consentResult.headers['set-cookie'],
+      }).expect(302);
+
+      redirectWithCodeLocation = postConsentRedirect.headers['location'];
+    }
+
+    const codeMatch = redirectWithCodeLocation.match(/[?&]code=([-_a-zA-Z0-9]+)&?/);
+    expect(codeMatch).not.toBeNull();
+    const authorizationCode = codeMatch![1];
+
+    const response = await performPost(
+      oidc.token_endpoint,
+      '',
+      `grant_type=authorization_code&code=${authorizationCode}&redirect_uri=${encodeURIComponent(REVOCATION_TEST.REDIRECT_URI)}`,
+      {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${basicAuth}`,
+      },
+    ).expect(200);
+
+    expect(response.body.access_token).toMatch(JWT_FORMAT);
+
+    return {
+      accessToken: response.body.access_token,
+      refreshToken: response.body.refresh_token,
+      idToken: response.body.id_token,
+      expiresIn: response.body.expires_in,
+    };
+  };
+
+/**
+ * Service application used to obtain a SCIM bearer token. Mirrors specs/gateway/scim/fixture.
+ */
+const setupScimApp = async (domainId: string, accessToken: string): Promise<Application> => {
+  const createAppRequest: Application = {
+    name: uniqueName('revocation-scim-app', true),
+    type: 'SERVICE',
+    settings: {
+      oauth: {
+        grantTypes: ['client_credentials'],
+        tokenCustomClaim: [],
+        accessTokenValiditySeconds: 7200,
+        scopeSettings: [{ scope: 'scim', defaultScope: true }],
+      },
+    },
+  };
+  const app = await createApplication(domainId, accessToken, createAppRequest);
+  await updateApplication(domainId, accessToken, createAppRequest, app.id);
+  return app;
+};
+
+const generateScimAccessToken = async (oidc: OidcConfiguration, scimClient: Application): Promise<string> => {
+  const auth = 'Basic ' + applicationBase64Token(scimClient);
+  // The SCIM service app may not have reached the gateway when the OIDC endpoint first answers,
+  // so retry rather than returning an undefined token that 401s on every later call.
+  return withRetry(
+    async () => {
+      const response = await performPost(oidc.token_endpoint, '', 'grant_type=client_credentials', {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: auth,
+      }).expect(200);
+      expect(response.body.access_token).toMatch(JWT_FORMAT);
+      return response.body.access_token;
+    },
+    60,
+    500,
+  );
+};
+
+export const setupRevocationFixture = async (options: RevocationFixtureOptions = {}): Promise<RevocationFixture> => {
+  const {
+    domainNamePrefix = REVOCATION_TEST.DOMAIN_NAME_PREFIX,
+    enableTokenExchange = true,
+    withSecondaryApplication = false,
+    withScim = false,
+  } = options;
+
   let domain: Domain | null = null;
   let accessToken: string | null = null;
 
   try {
     accessToken = await requestAdminAccessToken();
-    expect(accessToken).toBeDefined();
+    expect(accessToken).toMatch(JWT_FORMAT);
 
-    const createdDomain = await createDomain(accessToken, uniqueName(REVOCATION_TEST.DOMAIN_NAME_PREFIX, true), REVOCATION_TEST.DOMAIN_DESCRIPTION);
-    expect(createdDomain).toBeDefined();
-    expect(createdDomain.id).toBeDefined();
+    const createdDomain = await createDomain(accessToken, uniqueName(domainNamePrefix, true), REVOCATION_TEST.DOMAIN_DESCRIPTION);
+    expect(createdDomain.id).toEqual(expect.any(String));
     domain = createdDomain;
 
     const idpSet = await getAllIdps(createdDomain.id, accessToken);
     const defaultIdp = idpSet.values().next().value;
-    expect(defaultIdp).toBeDefined();
+    expect(defaultIdp?.id).toEqual(expect.any(String));
 
-    await enableTokenExchange(createdDomain.id, accessToken);
+    if (enableTokenExchange) {
+      await enableTokenExchangeOnDomain(createdDomain.id, accessToken);
+    }
 
-    const application = await createTestApp(uniqueName(REVOCATION_TEST.CLIENT_NAME, true), createdDomain, accessToken, 'WEB', {
-      settings: {
-        oauth: {
-          redirectUris: [REVOCATION_TEST.REDIRECT_URI],
-          grantTypes: REVOCATION_TEST.DEFAULT_GRANT_TYPES,
-          scopeSettings: REVOCATION_TEST.DEFAULT_SCOPES,
-        },
-      },
-      identityProviders: new Set([{ identity: defaultIdp.id, priority: 0 }]),
-    });
-    expect(application).toBeDefined();
+    const application = await createRevocationApp(REVOCATION_TEST.CLIENT_NAME, createdDomain, accessToken, defaultIdp, enableTokenExchange);
+
+    const secondaryApplication = withSecondaryApplication
+      ? await createRevocationApp(REVOCATION_TEST.SECONDARY_CLIENT_NAME, createdDomain, accessToken, defaultIdp, enableTokenExchange)
+      : null;
+
+    // SCIM settings and the service client must exist before the domain starts, so the initial
+    // sync picks them both up.
+    let scimApplication: Application | null = null;
+    if (withScim) {
+      await patchDomain(createdDomain.id, accessToken, { scim: { enabled: true, idpSelectionEnabled: false } });
+      scimApplication = await setupScimApp(createdDomain.id, accessToken);
+    }
 
     const startedDomain = await startDomain(createdDomain.id, accessToken);
-    expect(startedDomain).toBeDefined();
     domain = startedDomain;
 
     const oidcResponse = await waitForOidcReady(startedDomain.hrid, { timeoutMs: 30000, intervalMs: 500 });
@@ -144,92 +388,47 @@ export const setupRevocationFixture = async (): Promise<RevocationFixture> => {
     const oidc = oidcResponse.body as OidcConfiguration;
 
     const user = await buildCreateAndTestUser(startedDomain.id, accessToken, 0);
-    expect(user).toBeDefined();
+    expect(user.username).toEqual(expect.any(String));
 
     const basicAuth = applicationBase64Token(application);
 
-    const obtainAuthorizationCodeTokens = async (scope: string = 'openid%20profile%20offline_access'): Promise<SubjectTokens> => {
-      const clientId = application.settings.oauth.clientId;
-      const authorizationRequestParams = `?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(REVOCATION_TEST.REDIRECT_URI)}&scope=${scope}`;
+    const obtainAuthorizationCodeTokens = buildAuthorizationCodeFlow(oidc, application, basicAuth, user);
 
-      const authResponse = await performGet(oidc.authorization_endpoint, authorizationRequestParams).expect(302);
-      const loginResult = await extractXsrfTokenAndActionResponse(authResponse);
+    const secondaryClient: RevocationClient | undefined = secondaryApplication
+      ? {
+          application: secondaryApplication,
+          basicAuth: applicationBase64Token(secondaryApplication),
+          obtainAuthorizationCodeTokens: buildAuthorizationCodeFlow(
+            oidc,
+            secondaryApplication,
+            applicationBase64Token(secondaryApplication),
+            user,
+          ),
+        }
+      : undefined;
 
-      const postLogin = await performFormPost(
-        loginResult.action,
-        '',
-        {
-          'X-XSRF-TOKEN': loginResult.token,
-          username: user.username,
-          password: REVOCATION_TEST.USER_PASSWORD,
-          client_id: clientId,
-        },
-        {
-          Cookie: loginResult.headers['set-cookie'],
-          'Content-type': 'application/x-www-form-urlencoded',
-        },
-      ).expect(302);
+    const introspectToken = (token: string, auth: string = basicAuth): Promise<any> =>
+      introspectOidcToken(oidc.introspection_endpoint, token, auth);
 
-      const postLoginRedirect = await performGet(postLogin.headers['location'], '', {
-        Cookie: postLogin.headers['set-cookie'],
-      }).expect(302);
+    const getUserInfo = (token: string): Promise<any> => performGet(oidc.userinfo_endpoint, '', { Authorization: `Bearer ${token}` });
 
-      let redirectWithCodeLocation = postLoginRedirect.headers['location'];
+    const revokeToken = (token: string, revokeOptions: { basicAuth?: string; tokenTypeHint?: string } = {}): Promise<any> => {
+      const { basicAuth: auth = basicAuth, tokenTypeHint } = revokeOptions;
+      const body = tokenTypeHint
+        ? `token=${encodeURIComponent(token)}&token_type_hint=${tokenTypeHint}`
+        : `token=${encodeURIComponent(token)}`;
 
-      if (redirectWithCodeLocation.includes('/oauth/consent')) {
-        const consentResult = await extractXsrfTokenAndActionResponse(postLoginRedirect);
-        const postConsent = await performFormPost(
-          consentResult.action,
-          '',
-          {
-            'X-XSRF-TOKEN': consentResult.token,
-            'scope.openid': true,
-            'scope.profile': true,
-            'scope.offline_access': true,
-            user_oauth_approval: true,
-          },
-          {
-            Cookie: consentResult.headers['set-cookie'],
-            'Content-type': 'application/x-www-form-urlencoded',
-          },
-        ).expect(302);
-
-        const postConsentRedirect = await performGet(postConsent.headers['location'], '', {
-          Cookie: postConsent.headers['set-cookie'] || consentResult.headers['set-cookie'],
-        }).expect(302);
-
-        redirectWithCodeLocation = postConsentRedirect.headers['location'];
-      }
-
-      const codeMatch = redirectWithCodeLocation.match(/[?&]code=([-_a-zA-Z0-9]+)&?/);
-      expect(codeMatch).toBeDefined();
-      const authorizationCode = codeMatch![1];
-
-      const response = await performPost(
-        oidc.token_endpoint,
-        '',
-        `grant_type=authorization_code&code=${authorizationCode}&redirect_uri=${encodeURIComponent(REVOCATION_TEST.REDIRECT_URI)}`,
-        {
-          'Content-type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${basicAuth}`,
-        },
-      ).expect(200);
-
-      return {
-        accessToken: response.body.access_token,
-        refreshToken: response.body.refresh_token,
-        idToken: response.body.id_token,
-        expiresIn: response.body.expires_in,
-      };
+      return performPost(oidc.revocation_endpoint, '', body, {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${auth}`,
+      });
     };
-
-    const introspectToken = (token: string): Promise<any> => introspectOidcToken(oidc.introspection_endpoint, token, basicAuth);
 
     const exchangeToken = async (subjectToken: string, subjectTokenType: 'access_token' | 'refresh_token'): Promise<string> => {
       const response = await performPost(
         oidc.token_endpoint,
         '',
-        `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` +
+        `grant_type=${REVOCATION_TEST.TOKEN_EXCHANGE_GRANT_TYPE}` +
           `&subject_token=${subjectToken}` +
           `&subject_token_type=urn:ietf:params:oauth:token-type:${subjectTokenType}`,
         {
@@ -238,10 +437,63 @@ export const setupRevocationFixture = async (): Promise<RevocationFixture> => {
         },
       ).expect(200);
 
-      const exchangedToken = response.body.access_token;
-      expect(exchangedToken).toBeDefined();
-      return exchangedToken;
+      expect(response.body.access_token).toMatch(JWT_FORMAT);
+      return response.body.access_token;
     };
+
+    const createAdditionalClient = async (
+      namePrefix: string = REVOCATION_TEST.SECONDARY_CLIENT_NAME,
+      clientOptions: { exactName?: boolean } = {},
+    ): Promise<RevocationClient> => {
+      const additionalApplication = await createRevocationApp(
+        namePrefix,
+        startedDomain,
+        accessToken!,
+        defaultIdp,
+        enableTokenExchange,
+        clientOptions.exactName,
+      );
+      const additionalBasicAuth = applicationBase64Token(additionalApplication);
+
+      return {
+        application: additionalApplication,
+        basicAuth: additionalBasicAuth,
+        obtainAuthorizationCodeTokens: buildAuthorizationCodeFlow(oidc, additionalApplication, additionalBasicAuth, user),
+      };
+    };
+
+    const createAdditionalUser = async (index: number): Promise<User> => {
+      const additionalUser = await buildCreateAndTestUser(startedDomain.id, accessToken!, index, false, REVOCATION_TEST.USER_PASSWORD);
+      expect(additionalUser.username).toEqual(expect.any(String));
+      return additionalUser;
+    };
+
+    const obtainAuthorizationCodeTokensAs = (asUser: User, client?: RevocationClient): Promise<SubjectTokens> =>
+      buildAuthorizationCodeFlow(oidc, client?.application ?? application, client?.basicAuth ?? basicAuth, asUser)();
+
+    let scim: RevocationFixture['scim'];
+    if (scimApplication) {
+      const scimAccessToken = await generateScimAccessToken(oidc, scimApplication);
+      const scimEndpoint = `${process.env.AM_GATEWAY_URL}/${startedDomain.hrid}/scim`;
+
+      scim = {
+        endpoint: scimEndpoint,
+        accessToken: scimAccessToken,
+        setUserActive: (userId: string, active: boolean) =>
+          performPatch(
+            scimEndpoint,
+            `/Users/${userId}`,
+            JSON.stringify({
+              schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+              Operations: [{ op: 'Replace', path: 'active', value: active }],
+            }),
+            {
+              Authorization: `Bearer ${scimAccessToken}`,
+              'Content-type': 'application/json',
+            },
+          ),
+      };
+    }
 
     const cleanup = async () => {
       if (domain?.id && accessToken) {
@@ -252,6 +504,7 @@ export const setupRevocationFixture = async (): Promise<RevocationFixture> => {
     return {
       domain: startedDomain,
       application,
+      secondaryClient,
       user,
       defaultIdp,
       oidc,
@@ -260,6 +513,12 @@ export const setupRevocationFixture = async (): Promise<RevocationFixture> => {
       obtainAuthorizationCodeTokens,
       introspectToken,
       exchangeToken,
+      getUserInfo,
+      revokeToken,
+      createAdditionalClient,
+      createAdditionalUser,
+      obtainAuthorizationCodeTokensAs,
+      scim,
       cleanup,
     };
   } catch (error) {

--- a/gravitee-am-test/specs/gateway/revocation/revoke-cross-domain-isolation.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-cross-domain-isolation.jest.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { patchApplication } from '@management-commands/application-management-commands';
+import { waitForOidcReady } from '@management-commands/domain-management-commands';
+import { updateUserStatus } from '@management-commands/user-management-commands';
+import { setup } from '../../test-fixture';
+import { setupRevocationFixture, waitPastOfflineVerification, RevocationFixture } from './fixtures/revocation-fixture';
+
+setup(300000);
+
+/**
+ * Tenancy guard for revocation. Revoke events carry the originating domain id and the gateway
+ * listener filters on it (RevokeTokenGatewayServiceImpl#onEvent), while the repository deletes are
+ * themselves domain-scoped — so a leak needs two independent failures. This is defence in depth
+ * rather than a suspected bug, but multi-tenant token loss is severe enough to be worth pinning.
+ *
+ * The BY_CLIENT case deliberately gives both domains an application with the *same* clientId,
+ * since clientId uniqueness in AM is per-domain. That is the shape a scoping regression would
+ * actually take: `deleteByDomainIdAndClientId` losing its domain predicate.
+ */
+const SHARED_CLIENT_NAME = 'revoke-isolation-shared-client';
+
+let domainA: RevocationFixture;
+let domainB: RevocationFixture;
+
+beforeAll(async () => {
+  domainA = await setupRevocationFixture({ domainNamePrefix: 'revoke-isolation-a', enableTokenExchange: false });
+  domainB = await setupRevocationFixture({ domainNamePrefix: 'revoke-isolation-b', enableTokenExchange: false });
+});
+
+afterAll(async () => {
+  if (domainA) {
+    await domainA.cleanup();
+  }
+  if (domainB) {
+    await domainB.cleanup();
+  }
+});
+
+describe('Revocation isolation - across domains', () => {
+  it('should not revoke tokens in another domain when a user is disabled', async () => {
+    const tokensA = await domainA.obtainAuthorizationCodeTokens();
+    const tokensB = await domainB.obtainAuthorizationCodeTokens();
+
+    expect((await domainA.getUserInfo(tokensA.accessToken)).status).toBe(200);
+    expect((await domainB.getUserInfo(tokensB.accessToken)).status).toBe(200);
+
+    await updateUserStatus(domainA.domain.id, domainA.accessToken, domainA.user.id, false);
+    await updateUserStatus(domainA.domain.id, domainA.accessToken, domainA.user.id, true);
+
+    await waitPastOfflineVerification(tokensA.accessToken);
+    await waitPastOfflineVerification(tokensB.accessToken);
+
+    expect((await domainA.getUserInfo(tokensA.accessToken)).status).toBe(401);
+    expect((await domainB.getUserInfo(tokensB.accessToken)).status).toBe(200);
+  });
+
+  it('should not revoke tokens for an identically named client in another domain', async () => {
+    const clientA = await domainA.createAdditionalClient(SHARED_CLIENT_NAME, { exactName: true });
+    const clientB = await domainB.createAdditionalClient(SHARED_CLIENT_NAME, { exactName: true });
+
+    // The premise of the test: one clientId, two domains.
+    expect(clientB.application.settings.oauth.clientId).toEqual(clientA.application.settings.oauth.clientId);
+
+    const tokensA = await clientA.obtainAuthorizationCodeTokens();
+    const tokensB = await clientB.obtainAuthorizationCodeTokens();
+
+    expect((await domainA.getUserInfo(tokensA.accessToken)).status).toBe(200);
+    expect((await domainB.getUserInfo(tokensB.accessToken)).status).toBe(200);
+
+    await patchApplication(domainA.domain.id, domainA.accessToken, { enabled: false }, clientA.application.id);
+    await waitForOidcReady(domainA.domain.hrid, { timeoutMs: 5000, intervalMs: 200 });
+
+    // No explicit sync wait: the offline-verification wait below is an order of magnitude longer
+    // than a gateway sync cycle, so the disable has certainly propagated by the time we assert.
+    await waitPastOfflineVerification(tokensA.accessToken);
+    await waitPastOfflineVerification(tokensB.accessToken);
+
+    expect((await domainA.getUserInfo(tokensA.accessToken)).status).toBe(401);
+    expect((await domainB.getUserInfo(tokensB.accessToken)).status).toBe(200);
+  });
+});

--- a/gravitee-am-test/specs/gateway/revocation/revoke-cross-domain-isolation.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-cross-domain-isolation.jest.spec.ts
@@ -53,6 +53,13 @@ afterAll(async () => {
 });
 
 describe('Revocation isolation - across domains', () => {
+  /**
+   * Weak by construction, kept for symmetry with the BY_CLIENT case below. The two domains' users
+   * are separate records with different UUIDs, so even `deleteByUser` — which calls
+   * `deleteByUserId` with no domain predicate, unlike every other path in
+   * RevokeTokenGatewayServiceImpl — would only ever match domain A's user. This passes whether or
+   * not domain scoping works. The BY_CLIENT test below is the one that would catch a regression.
+   */
   it('should not revoke tokens in another domain when a user is disabled', async () => {
     const tokensA = await domainA.obtainAuthorizationCodeTokens();
     const tokensB = await domainB.obtainAuthorizationCodeTokens();
@@ -63,7 +70,8 @@ describe('Revocation isolation - across domains', () => {
     await updateUserStatus(domainA.domain.id, domainA.accessToken, domainA.user.id, false);
     await updateUserStatus(domainA.domain.id, domainA.accessToken, domainA.user.id, true);
 
-    await waitPastOfflineVerification(tokensA.accessToken);
+    await domainA.waitUntilTokenRejected(tokensA.accessToken);
+    // The surviving token must clear the offline-verification window before it proves anything.
     await waitPastOfflineVerification(tokensB.accessToken);
 
     expect((await domainA.getUserInfo(tokensA.accessToken)).status).toBe(401);
@@ -83,12 +91,16 @@ describe('Revocation isolation - across domains', () => {
     expect((await domainA.getUserInfo(tokensA.accessToken)).status).toBe(200);
     expect((await domainB.getUserInfo(tokensB.accessToken)).status).toBe(200);
 
+    // Deliberately not wrapped in waitForSyncAfter. Disabling an application does not advance the
+    // domain's `lastSync`, so that helper waits for a signal that never arrives and times out after
+    // 90s — measured: lastSync held steady for 24s afterwards while the domain reported
+    // stable + synchronized. The propagation guard here is waitUntilTokenRejected below, which
+    // polls, so there is no fixed-sleep race to lose.
     await patchApplication(domainA.domain.id, domainA.accessToken, { enabled: false }, clientA.application.id);
     await waitForOidcReady(domainA.domain.hrid, { timeoutMs: 5000, intervalMs: 200 });
 
-    // No explicit sync wait: the offline-verification wait below is an order of magnitude longer
-    // than a gateway sync cycle, so the disable has certainly propagated by the time we assert.
-    await waitPastOfflineVerification(tokensA.accessToken);
+    await domainA.waitUntilTokenRejected(tokensA.accessToken);
+    // The surviving token must clear the offline-verification window before it proves anything.
     await waitPastOfflineVerification(tokensB.accessToken);
 
     expect((await domainA.getUserInfo(tokensA.accessToken)).status).toBe(401);

--- a/gravitee-am-test/specs/gateway/revocation/revoke-on-application-disable.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-on-application-disable.jest.spec.ts
@@ -17,9 +17,8 @@
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { patchApplication } from '@management-commands/application-management-commands';
 import { waitForOidcReady } from '@management-commands/domain-management-commands';
-import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
 import { performPost } from '@gateway-commands/oauth-oidc-commands';
-import { retryUntil } from '@utils-commands/retry';
+import { withRetry } from '@utils-commands/retry';
 import { setup } from '../../test-fixture';
 import { setupRevocationFixture, waitPastOfflineVerification, RevocationFixture, SubjectTokens } from './fixtures/revocation-fixture';
 
@@ -33,12 +32,11 @@ setup(200000);
  * Both are asserted here, along with the blast radius: another application in the same
  * domain must be unaffected.
  *
- * Revocation is not immediate — `handlers.oauth2.introspect.offlineVerificationTimerSeconds`
- * (default 10s) lets the gateway skip the token-store lookup for freshly issued tokens.
- * Post-disable assertions therefore poll rather than checking once.
+ * Assertions that a token is now rejected poll (`waitUntilTokenRejected`). Assertions that a token
+ * is still valid first clear the offline-verification window (`waitPastOfflineVerification`),
+ * without which the gateway may still be trusting the JWT and the assertion would hold even for a
+ * revoked token. See the fixture for how that window is configured.
  */
-const REVOCATION_TIMEOUT_MS = 30000;
-
 let fixture: RevocationFixture;
 let disabledAppTokens: SubjectTokens;
 let otherAppTokens: SubjectTokens;
@@ -57,10 +55,10 @@ beforeAll(async () => {
   expect((await fixture.getUserInfo(disabledAppTokens.accessToken)).status).toBe(200);
   expect((await fixture.getUserInfo(otherAppTokens.accessToken)).status).toBe(200);
 
-  await waitForSyncAfter(fixture.domain.id, () =>
-    patchApplication(fixture.domain.id, fixture.accessToken, { enabled: false }, fixture.application.id),
-  );
-  // Sync completion does not imply the gateway has finished rebuilding its routes (GUIDELINES §3).
+  // Not wrapped in waitForSyncAfter: disabling an application does not reliably advance the
+  // domain's `lastSync`, so that helper can wait 90s for a signal that never arrives. Every
+  // assertion below polls for the outcome instead. See the comment on the re-enable test.
+  await patchApplication(fixture.domain.id, fixture.accessToken, { enabled: false }, fixture.application.id);
   await waitForOidcReady(fixture.domain.hrid, { timeoutMs: 5000, intervalMs: 200 });
 });
 
@@ -78,13 +76,9 @@ describe('Application disable - tokens already issued', () => {
    * what the 'survives the application being re-enabled' test below is for.
    */
   it('should reject the access token at the userinfo endpoint', async () => {
-    const status = await retryUntil(
-      () => fixture.getUserInfo(disabledAppTokens.accessToken).then((response) => response.status),
-      (responseStatus) => responseStatus === 401,
-      { timeoutMillis: REVOCATION_TIMEOUT_MS, intervalMillis: 500 },
-    );
+    await fixture.waitUntilTokenRejected(disabledAppTokens.accessToken);
 
-    expect(status).toBe(401);
+    expect((await fixture.getUserInfo(disabledAppTokens.accessToken)).status).toBe(401);
   });
 
   it('should refuse to mint a new access token from the refresh token', async () => {
@@ -132,21 +126,24 @@ describe('Application disable - tokens are revoked, not just unresolvable', () =
     const preDisableTokens = await client.obtainAuthorizationCodeTokens();
     expect((await fixture.getUserInfo(preDisableTokens.accessToken)).status).toBe(200);
 
-    await waitForSyncAfter(fixture.domain.id, () =>
-      patchApplication(fixture.domain.id, fixture.accessToken, { enabled: false }, client.application.id),
-    );
-    await waitForSyncAfter(fixture.domain.id, () =>
-      patchApplication(fixture.domain.id, fixture.accessToken, { enabled: true }, client.application.id),
-    );
+    // waitForSyncAfter is not usable around these: an application enable/disable does not reliably
+    // advance the domain's `lastSync`, so it waits 90s for a signal that never arrives (measured —
+    // lastSync held steady for 24s after a disable while the domain reported stable + synchronized).
+    // Sequence on the observable outcome instead. The wait between disable and enable is load
+    // bearing: without it the BY_CLIENT revoke event can land after the new token is minted and
+    // revoke that one too.
+    await patchApplication(fixture.domain.id, fixture.accessToken, { enabled: false }, client.application.id);
+    await fixture.waitUntilTokenRejected(preDisableTokens.accessToken);
+
+    await patchApplication(fixture.domain.id, fixture.accessToken, { enabled: true }, client.application.id);
     await waitForOidcReady(fixture.domain.hrid, { timeoutMs: 5000, intervalMs: 200 });
 
     // The client is usable again — proves any 401 below is about the token, not the application.
-    const postEnableTokens = await client.obtainAuthorizationCodeTokens();
+    const postEnableTokens = await withRetry(() => client.obtainAuthorizationCodeTokens(), 40, 500);
     expect((await fixture.getUserInfo(postEnableTokens.accessToken)).status).toBe(200);
 
-    // Both tokens must be past their offline-verification window, otherwise the gateway short
-    // circuits on the JWT alone and never looks either of them up in the token store.
-    await waitPastOfflineVerification(preDisableTokens.accessToken);
+    // The surviving token must clear the offline-verification window, otherwise the gateway short
+    // circuits on the JWT alone and this assertion would hold even if it had been revoked.
     await waitPastOfflineVerification(postEnableTokens.accessToken);
 
     // Same client, same audience, same signing certificate — so the only difference the gateway
@@ -158,6 +155,10 @@ describe('Application disable - tokens are revoked, not just unresolvable', () =
 
 describe('Application disable - blast radius', () => {
   it('should keep the access token issued to another application in the domain valid', async () => {
+    // Without this the gateway may still be trusting the JWT, so the assertion would hold even if
+    // disabling the first application had wrongly revoked this token too.
+    await waitPastOfflineVerification(otherAppTokens.accessToken);
+
     const response = await fixture.getUserInfo(otherAppTokens.accessToken);
 
     expect(response.status).toBe(200);

--- a/gravitee-am-test/specs/gateway/revocation/revoke-on-application-disable.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-on-application-disable.jest.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { patchApplication } from '@management-commands/application-management-commands';
+import { waitForOidcReady } from '@management-commands/domain-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { retryUntil } from '@utils-commands/retry';
+import { setup } from '../../test-fixture';
+import { setupRevocationFixture, waitPastOfflineVerification, RevocationFixture, SubjectTokens } from './fixtures/revocation-fixture';
+
+setup(200000);
+
+/**
+ * Disabling an application has two independent effects (AM-4044):
+ *   1. the gateway undeploys the client, so it can no longer obtain new tokens;
+ *   2. the management API emits a BY_CLIENT revoke event, so tokens already issued die.
+ *
+ * Both are asserted here, along with the blast radius: another application in the same
+ * domain must be unaffected.
+ *
+ * Revocation is not immediate — `handlers.oauth2.introspect.offlineVerificationTimerSeconds`
+ * (default 10s) lets the gateway skip the token-store lookup for freshly issued tokens.
+ * Post-disable assertions therefore poll rather than checking once.
+ */
+const REVOCATION_TIMEOUT_MS = 30000;
+
+let fixture: RevocationFixture;
+let disabledAppTokens: SubjectTokens;
+let otherAppTokens: SubjectTokens;
+
+beforeAll(async () => {
+  fixture = await setupRevocationFixture({
+    domainNamePrefix: 'revoke-app-disable',
+    enableTokenExchange: false,
+    withSecondaryApplication: true,
+  });
+
+  disabledAppTokens = await fixture.obtainAuthorizationCodeTokens();
+  otherAppTokens = await fixture.secondaryClient!.obtainAuthorizationCodeTokens();
+
+  // Control: both tokens are accepted while both applications are enabled.
+  expect((await fixture.getUserInfo(disabledAppTokens.accessToken)).status).toBe(200);
+  expect((await fixture.getUserInfo(otherAppTokens.accessToken)).status).toBe(200);
+
+  await waitForSyncAfter(fixture.domain.id, () =>
+    patchApplication(fixture.domain.id, fixture.accessToken, { enabled: false }, fixture.application.id),
+  );
+  // Sync completion does not imply the gateway has finished rebuilding its routes (GUIDELINES §3).
+  await waitForOidcReady(fixture.domain.hrid, { timeoutMs: 5000, intervalMs: 200 });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('Application disable - tokens already issued', () => {
+  /**
+   * Note this passes on the undeploy effect alone: with the client removed from the gateway,
+   * the token's `aud` no longer resolves and introspection fails before the token store is
+   * ever consulted. It asserts the user-visible outcome, not that revocation ran — that is
+   * what the 'survives the application being re-enabled' test below is for.
+   */
+  it('should reject the access token at the userinfo endpoint', async () => {
+    const status = await retryUntil(
+      () => fixture.getUserInfo(disabledAppTokens.accessToken).then((response) => response.status),
+      (responseStatus) => responseStatus === 401,
+      { timeoutMillis: REVOCATION_TIMEOUT_MS, intervalMillis: 500 },
+    );
+
+    expect(status).toBe(401);
+  });
+
+  it('should refuse to mint a new access token from the refresh token', async () => {
+    const response = await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      `grant_type=refresh_token&refresh_token=${disabledAppTokens.refreshToken}`,
+      {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${fixture.basicAuth}`,
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('invalid_client');
+  });
+});
+
+describe('Application disable - new token requests', () => {
+  it('should reject the authorization_code grant for the disabled client', async () => {
+    const response = await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      'grant_type=authorization_code&code=any-code&redirect_uri=https%3A%2F%2Fgravitee.io%2Fcallback',
+      {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${fixture.basicAuth}`,
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('invalid_client');
+  });
+});
+
+describe('Application disable - tokens are revoked, not just unresolvable', () => {
+  /**
+   * Discriminates real BY_CLIENT revocation from the undeploy side effect. Re-enabling the
+   * application redeploys the client, so the token's audience resolves again and introspection
+   * reaches the token-store lookup. Past the offline-verification window, the only thing that
+   * can still reject the old token is its absence from the store — i.e. it really was revoked.
+   */
+  it('should keep rejecting a pre-disable access token after the application is re-enabled', async () => {
+    const client = await fixture.createAdditionalClient('revoke-cycle-client');
+    const preDisableTokens = await client.obtainAuthorizationCodeTokens();
+    expect((await fixture.getUserInfo(preDisableTokens.accessToken)).status).toBe(200);
+
+    await waitForSyncAfter(fixture.domain.id, () =>
+      patchApplication(fixture.domain.id, fixture.accessToken, { enabled: false }, client.application.id),
+    );
+    await waitForSyncAfter(fixture.domain.id, () =>
+      patchApplication(fixture.domain.id, fixture.accessToken, { enabled: true }, client.application.id),
+    );
+    await waitForOidcReady(fixture.domain.hrid, { timeoutMs: 5000, intervalMs: 200 });
+
+    // The client is usable again — proves any 401 below is about the token, not the application.
+    const postEnableTokens = await client.obtainAuthorizationCodeTokens();
+    expect((await fixture.getUserInfo(postEnableTokens.accessToken)).status).toBe(200);
+
+    // Both tokens must be past their offline-verification window, otherwise the gateway short
+    // circuits on the JWT alone and never looks either of them up in the token store.
+    await waitPastOfflineVerification(preDisableTokens.accessToken);
+    await waitPastOfflineVerification(postEnableTokens.accessToken);
+
+    // Same client, same audience, same signing certificate — so the only difference the gateway
+    // can act on is whether the token is still in the store.
+    expect((await fixture.getUserInfo(preDisableTokens.accessToken)).status).toBe(401);
+    expect((await fixture.getUserInfo(postEnableTokens.accessToken)).status).toBe(200);
+  });
+});
+
+describe('Application disable - blast radius', () => {
+  it('should keep the access token issued to another application in the domain valid', async () => {
+    const response = await fixture.getUserInfo(otherAppTokens.accessToken);
+
+    expect(response.status).toBe(200);
+    expect(response.body.sub).toEqual(expect.any(String));
+  });
+
+  it('should still issue tokens to another application in the domain', async () => {
+    const tokens = await fixture.secondaryClient!.obtainAuthorizationCodeTokens();
+
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+  });
+});

--- a/gravitee-am-test/specs/gateway/revocation/revoke-on-scim-disable.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-on-scim-disable.jest.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import { setupRevocationFixture, waitPastOfflineVerification, RevocationFixture } from './fixtures/revocation-fixture';
+
+setup(200000);
+
+/**
+ * SCIM-driven offboarding. When an identity provider pushes `active: false`, AM must invalidate
+ * that user's tokens — the same outcome as an admin disabling them in the Console, but via a
+ * different route: ProvisioningUserServiceImpl#updateUser calls RevokeTokenGatewayService's
+ * deleteByUser directly, bypassing the REVOKE_TOKEN event bus that every other spec here exercises.
+ *
+ * As in the other admin-triggered specs, the user is re-activated before asserting so that a
+ * surviving 401 can only mean the token left the store.
+ */
+let fixture: RevocationFixture;
+
+beforeAll(async () => {
+  fixture = await setupRevocationFixture({
+    domainNamePrefix: 'revoke-scim-disable',
+    enableTokenExchange: false,
+    withScim: true,
+  });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('SCIM disable - token revocation', () => {
+  it('should revoke the user tokens when SCIM sets the user inactive', async () => {
+    const tokens = await fixture.obtainAuthorizationCodeTokens();
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+
+    const deactivate = await fixture.scim!.setUserActive(fixture.user.id, false);
+    expect(deactivate.status).toBe(200);
+    expect(deactivate.body.active).toBe(false);
+
+    const reactivate = await fixture.scim!.setUserActive(fixture.user.id, true);
+    expect(reactivate.status).toBe(200);
+    expect(reactivate.body.active).toBe(true);
+
+    await waitPastOfflineVerification(tokens.accessToken);
+
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(401);
+  });
+
+  /**
+   * Control for the test above: a SCIM update that does not deactivate the user writes to the same
+   * record through the same code path, so if it left the token intact then the 401 above is
+   * attributable to the deactivation rather than to the user simply having been modified.
+   */
+  it('should not revoke tokens when SCIM updates a user without deactivating them', async () => {
+    const activeUser = await fixture.createAdditionalUser(1);
+    const tokens = await fixture.obtainAuthorizationCodeTokensAs(activeUser);
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+
+    const update = await fixture.scim!.setUserActive(activeUser.id, true);
+    expect(update.status).toBe(200);
+
+    await waitPastOfflineVerification(tokens.accessToken);
+
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+  });
+});

--- a/gravitee-am-test/specs/gateway/revocation/revoke-on-scim-disable.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-on-scim-disable.jest.spec.ts
@@ -58,7 +58,7 @@ describe('SCIM disable - token revocation', () => {
     expect(reactivate.status).toBe(200);
     expect(reactivate.body.active).toBe(true);
 
-    await waitPastOfflineVerification(tokens.accessToken);
+    await fixture.waitUntilTokenRejected(tokens.accessToken);
 
     expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(401);
   });

--- a/gravitee-am-test/specs/gateway/revocation/revoke-on-user-lifecycle.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-on-user-lifecycle.jest.spec.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { deleteUser, resetUserPassword } from '@management-commands/user-management-commands';
+import { setup } from '../../test-fixture';
+import { setupRevocationFixture, waitPastOfflineVerification, RevocationFixture } from './fixtures/revocation-fixture';
+
+setup(200000);
+
+/**
+ * Admin lifecycle actions that revoke tokens, separate from the enable/disable status changes in
+ * revoke-on-user-status-change. Both emit BY_USER (ManagementUserServiceImpl lines 486 and 838).
+ */
+const NEW_PASSWORD = 'An0therP@ssw0rd!';
+
+let fixture: RevocationFixture;
+
+beforeAll(async () => {
+  fixture = await setupRevocationFixture({
+    domainNamePrefix: 'revoke-user-lifecycle',
+    enableTokenExchange: false,
+  });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('Admin password reset', () => {
+  it('should revoke the user tokens so they must log in again', async () => {
+    const user = await fixture.createAdditionalUser(1);
+    const tokens = await fixture.obtainAuthorizationCodeTokensAs(user);
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+
+    await resetUserPassword(fixture.domain.id, fixture.accessToken, user.id, NEW_PASSWORD);
+
+    await waitPastOfflineVerification(tokens.accessToken);
+
+    // The user is untouched otherwise — still present and enabled — so a 401 means the token was
+    // removed from the store, not that the subject lookup failed.
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(401);
+  });
+});
+
+describe('User deletion', () => {
+  /**
+   * Asserted through introspection rather than userinfo on purpose. Userinfo resolves the subject
+   * and would 401 for a deleted user whether or not revocation ran, so it cannot tell the two
+   * apart. Introspection never loads the user — it answers purely from the token store — so
+   * `active: false` here is direct evidence the token was revoked.
+   *
+   * This is the case that matters for resource servers doing introspection-based authorization:
+   * without revocation they would keep accepting a deleted user's token until it expired.
+   */
+  it('should revoke the user tokens so introspection reports them inactive', async () => {
+    const user = await fixture.createAdditionalUser(2);
+    const tokens = await fixture.obtainAuthorizationCodeTokensAs(user);
+    expect((await fixture.introspectToken(tokens.accessToken)).active).toBe(true);
+
+    await deleteUser(fixture.domain.id, fixture.accessToken, user.id);
+
+    await waitPastOfflineVerification(tokens.accessToken);
+
+    expect((await fixture.introspectToken(tokens.accessToken)).active).toBe(false);
+  });
+});

--- a/gravitee-am-test/specs/gateway/revocation/revoke-on-user-lifecycle.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-on-user-lifecycle.jest.spec.ts
@@ -17,13 +17,14 @@
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { deleteUser, resetUserPassword } from '@management-commands/user-management-commands';
 import { setup } from '../../test-fixture';
-import { setupRevocationFixture, waitPastOfflineVerification, RevocationFixture } from './fixtures/revocation-fixture';
+import { setupRevocationFixture, RevocationFixture } from './fixtures/revocation-fixture';
 
 setup(200000);
 
 /**
  * Admin lifecycle actions that revoke tokens, separate from the enable/disable status changes in
- * revoke-on-user-status-change. Both emit BY_USER (ManagementUserServiceImpl lines 486 and 838).
+ * revoke-on-user-status-change. Both emit BY_USER, from ManagementUserServiceImpl#resetPassword
+ * and ManagementUserServiceImpl#delete.
  */
 const NEW_PASSWORD = 'An0therP@ssw0rd!';
 
@@ -50,7 +51,7 @@ describe('Admin password reset', () => {
 
     await resetUserPassword(fixture.domain.id, fixture.accessToken, user.id, NEW_PASSWORD);
 
-    await waitPastOfflineVerification(tokens.accessToken);
+    await fixture.waitUntilTokenRejected(tokens.accessToken);
 
     // The user is untouched otherwise — still present and enabled — so a 401 means the token was
     // removed from the store, not that the subject lookup failed.
@@ -75,7 +76,7 @@ describe('User deletion', () => {
 
     await deleteUser(fixture.domain.id, fixture.accessToken, user.id);
 
-    await waitPastOfflineVerification(tokens.accessToken);
+    await fixture.waitUntilTokenInactive(tokens.accessToken);
 
     expect((await fixture.introspectToken(tokens.accessToken)).active).toBe(false);
   });

--- a/gravitee-am-test/specs/gateway/revocation/revoke-on-user-status-change.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-on-user-status-change.jest.spec.ts
@@ -58,19 +58,27 @@ describe('User disable - scope across applications', () => {
     await updateUserStatus(fixture.domain.id, fixture.accessToken, fixture.user.id, false);
     await updateUserStatus(fixture.domain.id, fixture.accessToken, fixture.user.id, true);
 
-    await waitPastOfflineVerification(primaryTokens.accessToken);
-    await waitPastOfflineVerification(secondaryTokens.accessToken);
+    await fixture.waitUntilTokenRejected(primaryTokens.accessToken);
+    await fixture.waitUntilTokenRejected(secondaryTokens.accessToken);
 
     expect((await fixture.getUserInfo(primaryTokens.accessToken)).status).toBe(401);
     expect((await fixture.getUserInfo(secondaryTokens.accessToken)).status).toBe(401);
   });
 
-  it('should let the re-enabled user obtain a working token again', async () => {
-    const freshTokens = await fixture.obtainAuthorizationCodeTokens();
+  it('should let the user obtain a working token again once re-enabled', async () => {
+    const user = await fixture.createAdditionalUser(4);
+    const tokensBeforeDisable = await fixture.obtainAuthorizationCodeTokensAs(user);
+    expect((await fixture.getUserInfo(tokensBeforeDisable.accessToken)).status).toBe(200);
 
-    await waitPastOfflineVerification(freshTokens.accessToken);
+    await updateUserStatus(fixture.domain.id, fixture.accessToken, user.id, false);
+    await fixture.waitUntilTokenRejected(tokensBeforeDisable.accessToken);
 
-    expect((await fixture.getUserInfo(freshTokens.accessToken)).status).toBe(200);
+    await updateUserStatus(fixture.domain.id, fixture.accessToken, user.id, true);
+
+    const tokensAfterEnable = await fixture.obtainAuthorizationCodeTokensAs(user);
+    await waitPastOfflineVerification(tokensAfterEnable.accessToken);
+
+    expect((await fixture.getUserInfo(tokensAfterEnable.accessToken)).status).toBe(200);
   });
 });
 
@@ -88,7 +96,8 @@ describe('User disable - scope across users', () => {
     await updateUserStatus(fixture.domain.id, fixture.accessToken, disabledUser.id, false);
     await updateUserStatus(fixture.domain.id, fixture.accessToken, disabledUser.id, true);
 
-    await waitPastOfflineVerification(disabledUserTokens.accessToken);
+    await fixture.waitUntilTokenRejected(disabledUserTokens.accessToken);
+    // The surviving token must clear the offline-verification window before it proves anything.
     await waitPastOfflineVerification(untouchedUserTokens.accessToken);
 
     expect((await fixture.getUserInfo(disabledUserTokens.accessToken)).status).toBe(401);

--- a/gravitee-am-test/specs/gateway/revocation/revoke-on-user-status-change.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-on-user-status-change.jest.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { updateUserStatus } from '@management-commands/user-management-commands';
+import { setup } from '../../test-fixture';
+import { setupRevocationFixture, waitPastOfflineVerification, RevocationFixture } from './fixtures/revocation-fixture';
+
+setup(200000);
+
+/**
+ * Disabling a user emits a BY_USER revoke event (ManagementUserServiceImpl#updateStatus), which
+ * must kill that user's tokens across *every* application in the domain — this is what separates
+ * BY_USER from the BY_USER_AND_CLIENT path already covered by revoke-user-consents.
+ *
+ * Each test re-enables the user before asserting. Re-enabling removes any rejection that could
+ * stem from the user's own state, so a token that is still refused past the offline-verification
+ * window can only have been deleted from the token store. Without that step these assertions
+ * would pass on a disabled-user check alone and prove nothing about revocation.
+ */
+let fixture: RevocationFixture;
+
+beforeAll(async () => {
+  fixture = await setupRevocationFixture({
+    domainNamePrefix: 'revoke-user-status',
+    enableTokenExchange: false,
+    withSecondaryApplication: true,
+  });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('User disable - scope across applications', () => {
+  it('should revoke the user tokens issued to every application in the domain', async () => {
+    const primaryTokens = await fixture.obtainAuthorizationCodeTokens();
+    const secondaryTokens = await fixture.secondaryClient!.obtainAuthorizationCodeTokens();
+
+    expect((await fixture.getUserInfo(primaryTokens.accessToken)).status).toBe(200);
+    expect((await fixture.getUserInfo(secondaryTokens.accessToken)).status).toBe(200);
+
+    await updateUserStatus(fixture.domain.id, fixture.accessToken, fixture.user.id, false);
+    await updateUserStatus(fixture.domain.id, fixture.accessToken, fixture.user.id, true);
+
+    await waitPastOfflineVerification(primaryTokens.accessToken);
+    await waitPastOfflineVerification(secondaryTokens.accessToken);
+
+    expect((await fixture.getUserInfo(primaryTokens.accessToken)).status).toBe(401);
+    expect((await fixture.getUserInfo(secondaryTokens.accessToken)).status).toBe(401);
+  });
+
+  it('should let the re-enabled user obtain a working token again', async () => {
+    const freshTokens = await fixture.obtainAuthorizationCodeTokens();
+
+    await waitPastOfflineVerification(freshTokens.accessToken);
+
+    expect((await fixture.getUserInfo(freshTokens.accessToken)).status).toBe(200);
+  });
+});
+
+describe('User disable - scope across users', () => {
+  it('should leave another user tokens untouched', async () => {
+    const disabledUser = await fixture.createAdditionalUser(1);
+    const untouchedUser = await fixture.createAdditionalUser(2);
+
+    const disabledUserTokens = await fixture.obtainAuthorizationCodeTokensAs(disabledUser);
+    const untouchedUserTokens = await fixture.obtainAuthorizationCodeTokensAs(untouchedUser);
+
+    expect((await fixture.getUserInfo(disabledUserTokens.accessToken)).status).toBe(200);
+    expect((await fixture.getUserInfo(untouchedUserTokens.accessToken)).status).toBe(200);
+
+    await updateUserStatus(fixture.domain.id, fixture.accessToken, disabledUser.id, false);
+    await updateUserStatus(fixture.domain.id, fixture.accessToken, disabledUser.id, true);
+
+    await waitPastOfflineVerification(disabledUserTokens.accessToken);
+    await waitPastOfflineVerification(untouchedUserTokens.accessToken);
+
+    expect((await fixture.getUserInfo(disabledUserTokens.accessToken)).status).toBe(401);
+    expect((await fixture.getUserInfo(untouchedUserTokens.accessToken)).status).toBe(200);
+  });
+});
+
+describe('User enable', () => {
+  /**
+   * Doubles as the control for the disable tests above. This also writes to the user record, yet
+   * the token survives past the offline-verification window — so those 401s cannot be explained by
+   * "the user was updated", only by the revoke event that the disable branch alone emits.
+   */
+  it('should not revoke tokens when a user is enabled', async () => {
+    const enabledUser = await fixture.createAdditionalUser(3);
+    const tokens = await fixture.obtainAuthorizationCodeTokensAs(enabledUser);
+
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+
+    await updateUserStatus(fixture.domain.id, fixture.accessToken, enabledUser.id, true);
+
+    await waitPastOfflineVerification(tokens.accessToken);
+
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+  });
+});

--- a/gravitee-am-test/specs/gateway/revocation/revoke-token-endpoint.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-token-endpoint.jest.spec.ts
@@ -79,8 +79,10 @@ describe('Revocation endpoint - access token', () => {
    * Characterisation test, not an endorsement. RFC 7009 §2.1 says the authorization server SHOULD
    * revoke every token issued from the same grant; AM deletes only the presented JTI plus any
    * token-exchange children (MongoTokenRepository#deleteByJtis matches jti or parentJtis), so the
-   * sibling refresh token survives and can still mint a new access token. Raised with the team —
-   * if this is changed deliberately, this test should be updated to match.
+   * sibling refresh token survives and can still mint a new access token.
+   *
+   * Whether that is intended is an open question — see AM-7550. If it changes, invert this test
+   * rather than assuming it has broken.
    */
   it('should leave the sibling refresh token usable after the access token is revoked', async () => {
     const tokens = await fixture.obtainAuthorizationCodeTokens();

--- a/gravitee-am-test/specs/gateway/revocation/revoke-token-endpoint.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-token-endpoint.jest.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { setup } from '../../test-fixture';
+import { setupRevocationFixture, waitPastOfflineVerification, RevocationFixture } from './fixtures/revocation-fixture';
+
+setup(200000);
+
+/**
+ * RFC 7009 client-initiated revocation via POST /oauth/revoke (AM-6865).
+ *
+ * Unlike the admin-triggered specs in this folder, nothing here changes the state of the client
+ * or the user — so once past the offline-verification window, a rejected token can only have been
+ * removed from the token store. No re-enable step is needed to make these assertions meaningful.
+ *
+ * Note the window itself is not asserted: a token stays usable for up to
+ * `handlers.oauth2.introspect.offlineVerificationTimerSeconds` (default 10s) after revocation, and
+ * pinning that would mean asserting a response inside a race against wall-clock time. The tests
+ * below therefore always wait past it and assert the settled outcome.
+ */
+let fixture: RevocationFixture;
+
+beforeAll(async () => {
+  fixture = await setupRevocationFixture({
+    domainNamePrefix: 'revoke-token-endpoint',
+    enableTokenExchange: false,
+    withSecondaryApplication: true,
+  });
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+  }
+});
+
+describe('Revocation endpoint - access token', () => {
+  it('should reject a revoked access token at the userinfo endpoint', async () => {
+    const tokens = await fixture.obtainAuthorizationCodeTokens();
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+
+    const revocation = await fixture.revokeToken(tokens.accessToken);
+    expect(revocation.status).toBe(200);
+
+    await waitPastOfflineVerification(tokens.accessToken);
+
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(401);
+  });
+
+  it('should report a revoked access token as inactive at the introspection endpoint', async () => {
+    const tokens = await fixture.obtainAuthorizationCodeTokens();
+    expect((await fixture.introspectToken(tokens.accessToken)).active).toBe(true);
+
+    const revocation = await fixture.revokeToken(tokens.accessToken);
+    expect(revocation.status).toBe(200);
+
+    await waitPastOfflineVerification(tokens.accessToken);
+
+    expect((await fixture.introspectToken(tokens.accessToken)).active).toBe(false);
+  });
+
+  /**
+   * Characterisation test, not an endorsement. RFC 7009 §2.1 says the authorization server SHOULD
+   * revoke every token issued from the same grant; AM deletes only the presented JTI plus any
+   * token-exchange children (MongoTokenRepository#deleteByJtis matches jti or parentJtis), so the
+   * sibling refresh token survives and can still mint a new access token. Raised with the team —
+   * if this is changed deliberately, this test should be updated to match.
+   */
+  it('should leave the sibling refresh token usable after the access token is revoked', async () => {
+    const tokens = await fixture.obtainAuthorizationCodeTokens();
+
+    const revocation = await fixture.revokeToken(tokens.accessToken);
+    expect(revocation.status).toBe(200);
+
+    await waitPastOfflineVerification(tokens.accessToken);
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(401);
+
+    const refreshed = await performPost(fixture.oidc.token_endpoint, '', `grant_type=refresh_token&refresh_token=${tokens.refreshToken}`, {
+      'Content-type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${fixture.basicAuth}`,
+    });
+
+    expect(refreshed.status).toBe(200);
+    expect((await fixture.getUserInfo(refreshed.body.access_token)).status).toBe(200);
+  });
+});
+
+describe('Revocation endpoint - refresh token', () => {
+  it('should revoke the refresh token when token_type_hint is refresh_token', async () => {
+    const tokens = await fixture.obtainAuthorizationCodeTokens();
+
+    const revocation = await fixture.revokeToken(tokens.refreshToken!, { tokenTypeHint: 'refresh_token' });
+    expect(revocation.status).toBe(200);
+
+    const refreshed = await performPost(fixture.oidc.token_endpoint, '', `grant_type=refresh_token&refresh_token=${tokens.refreshToken}`, {
+      'Content-type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${fixture.basicAuth}`,
+    });
+
+    expect(refreshed.status).toBe(400);
+    expect(refreshed.body.error).toBe('invalid_grant');
+  });
+});
+
+describe('Revocation endpoint - client scoping', () => {
+  it('should refuse to revoke a token issued to another client and leave that token valid', async () => {
+    const tokens = await fixture.obtainAuthorizationCodeTokens();
+
+    const revocation = await fixture.revokeToken(tokens.accessToken, {
+      basicAuth: fixture.secondaryClient!.basicAuth,
+    });
+
+    expect(revocation.status).toBe(400);
+    expect(revocation.body.error).toBe('invalid_grant');
+
+    // The refusal must be a no-op, not a partial revocation.
+    await waitPastOfflineVerification(tokens.accessToken);
+    expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(200);
+  });
+});
+
+describe('Revocation endpoint - unknown tokens', () => {
+  it('should return 200 for a token it cannot find', async () => {
+    const revocation = await fixture.revokeToken('not-a-token-issued-by-this-server');
+
+    expect(revocation.status).toBe(200);
+  });
+});

--- a/gravitee-am-test/specs/gateway/revocation/revoke-token-endpoint.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/revocation/revoke-token-endpoint.jest.spec.ts
@@ -28,10 +28,11 @@ setup(200000);
  * or the user — so once past the offline-verification window, a rejected token can only have been
  * removed from the token store. No re-enable step is needed to make these assertions meaningful.
  *
- * Note the window itself is not asserted: a token stays usable for up to
- * `handlers.oauth2.introspect.offlineVerificationTimerSeconds` (default 10s) after revocation, and
- * pinning that would mean asserting a response inside a race against wall-clock time. The tests
- * below therefore always wait past it and assert the settled outcome.
+ * The offline-verification window itself is not asserted: pinning it would mean asserting a
+ * response inside a race against wall-clock time. Instead, assertions that a token is now rejected
+ * poll (`waitUntilTokenRejected` / `waitUntilTokenInactive`), and assertions that a token is still
+ * valid first clear the window (`waitPastOfflineVerification`) so they cannot pass on a trusted
+ * JWT alone. See the fixture for how that window is configured.
  */
 let fixture: RevocationFixture;
 
@@ -57,7 +58,7 @@ describe('Revocation endpoint - access token', () => {
     const revocation = await fixture.revokeToken(tokens.accessToken);
     expect(revocation.status).toBe(200);
 
-    await waitPastOfflineVerification(tokens.accessToken);
+    await fixture.waitUntilTokenRejected(tokens.accessToken);
 
     expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(401);
   });
@@ -69,7 +70,7 @@ describe('Revocation endpoint - access token', () => {
     const revocation = await fixture.revokeToken(tokens.accessToken);
     expect(revocation.status).toBe(200);
 
-    await waitPastOfflineVerification(tokens.accessToken);
+    await fixture.waitUntilTokenInactive(tokens.accessToken);
 
     expect((await fixture.introspectToken(tokens.accessToken)).active).toBe(false);
   });
@@ -87,7 +88,7 @@ describe('Revocation endpoint - access token', () => {
     const revocation = await fixture.revokeToken(tokens.accessToken);
     expect(revocation.status).toBe(200);
 
-    await waitPastOfflineVerification(tokens.accessToken);
+    await fixture.waitUntilTokenRejected(tokens.accessToken);
     expect((await fixture.getUserInfo(tokens.accessToken)).status).toBe(401);
 
     const refreshed = await performPost(fixture.oidc.token_endpoint, '', `grant_type=refresh_token&refresh_token=${tokens.refreshToken}`, {


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7450

## :pencil2: A description of the changes proposed in the pull request

Adds 22 Jest tests across 6 new spec files plus 5 unit tests, covering token revocation between the management API and the gateway. Revocation was well covered at the unit layer, but those tests stop at "the revoke callback was
  invoked" against a mock — consent revocation was the only trigger verified end to end.

  - `revoke-token-endpoint` (6) — RFC 7009 `/oauth/revoke`: rejection at userinfo and introspection, `token_type_hint`, cross-client refusal, unknown tokens
  - `revoke-on-application-disable` (6) — disable revokes issued tokens, blocks new ones, leaves other applications untouched
  - `revoke-on-user-status-change` (4) — `BY_USER` reaches every application and is scoped to one user; enabling a user does not revoke
  - `revoke-on-user-lifecycle` (2) — admin password reset and user deletion
  - `revoke-on-scim-disable` (2) — SCIM `active: false`, which revokes via `deleteByUser` rather than the `REVOKE_TOKEN` event bus
  - `revoke-cross-domain-isolation` (2) — no leakage across domains, including when both hold an application with the same `clientId`
  
**Unit tests cover** `token_type_hint` fallback in both directions and cross-client refusal on the refresh-token path (`RevocationServiceTest`), plus hint propagation and unrecognised-hint handling (`RevocationTokenEndpointTest`).
  
  `revocation-fixture.ts` is generalised to support multiple clients and users, optional SCIM, and a shared offline-verification helper. `revoke-user-consents.jest.spec.ts` is untouched and still passes.

## :memo: Test scenarios 
NA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA