### PR TITLE
feat: resolve data plane against the environment during domain creation

### DIFF
--- a/docker/local-stack/dev/docker-compose.cloud.yml
+++ b/docker/local-stack/dev/docker-compose.cloud.yml
@@ -68,3 +68,4 @@ services:
       # A managed cloud node has no platform license
       - GRAVITEE_LICENSE_KEY=
       - JAVA_OPTS=-Dgravitee.license=/opt/graviteeio-am-gateway/license/no-platform-license.key
+      - GRAVITEE_REPOSITORIES_GATEWAY_DATAPLANE_ID=cloud-test

--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -124,9 +124,10 @@ paths:
       tags:
       - Domains
     put:
-      description: Idempotent create-or-update. Uses the key field in the body to
-        identify the domain. On first apply the domain is created; subsequent applies
-        update it. dataPlaneId is required at creation and immutable afterwards.
+      description: "Idempotent create-or-update. Uses the key field in the body to\
+        \ identify the domain. On first apply the domain is created; subsequent applies\
+        \ update it. dataPlaneId is optional at creation, resolved from the environment's\
+        \ data planes when omitted, and immutable afterwards."
       operationId: automationCreateOrUpdateDomain
       parameters:
       - description: Identifier of the organization that owns the environment.
@@ -1724,12 +1725,13 @@ components:
           readOnly: true
         dataPlaneId:
           type: string
-          description: Identifier of the data plane this domain is connected to. Required
-            at creation and immutable afterwards; included in the desired-state document
-            but never re-applied on update.
+          description: "Identifier of the data plane this domain is connected to.\
+            \ Optional at creation, resolved from the environment's data planes when\
+            \ omitted, and immutable afterwards; included in the desired-state document\
+            \ but never re-applied on update."
           example: default
           maxLength: 255
-          minLength: 1
+          minLength: 0
         description:
           type: string
           description: Human-readable description of the domain.
@@ -1816,7 +1818,6 @@ components:
         webProtectionSettings:
           $ref: "#/components/schemas/WebProtectionSettings"
       required:
-      - dataPlaneId
       - key
       - name
       - path

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -15278,7 +15278,6 @@ components:
         name:
           type: string
       required:
-      - dataPlaneId
       - name
     NewEmail:
       type: object

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
@@ -113,14 +113,14 @@ public class AutomationDomain {
     private List<VirtualHost> vhosts;
 
     /**
-     * Required and immutable after creation. The domain cannot be created without a
-     * valid data plane, and it cannot be changed afterwards; it is part of the full
+     * Immutable after creation. Optional on create: when omitted the data plane is resolved from the
+     * ones linked to the environment, the same way the Management API does it. It is part of the full
      * desired-state document but is never re-applied on update.
      */
-    @NotNull
-    @Size(min = 1, max = 255)
-    @Schema(description = "Identifier of the data plane this domain is connected to. Required at creation and " +
-            "immutable afterwards; included in the desired-state document but never re-applied on update.",
+    @Size(max = 255)
+    @Schema(description = "Identifier of the data plane this domain is connected to. Optional at creation, " +
+            "resolved from the environment's data planes when omitted, and immutable afterwards; included in the " +
+            "desired-state document but never re-applied on update.",
             example = "default")
     private String dataPlaneId;
 

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainsResource.java
@@ -98,8 +98,8 @@ public class DomainsResource extends AbstractAutomationResource {
     @Operation(operationId = "automationCreateOrUpdateDomain",
             summary = "Create or update a domain",
             description = "Idempotent create-or-update. Uses the key field in the body to identify the domain. " +
-                    "On first apply the domain is created; subsequent applies update it. dataPlaneId is required " +
-                    "at creation and immutable afterwards.")
+                    "On first apply the domain is created; subsequent applies update it. dataPlaneId is optional " +
+                    "at creation, resolved from the environment's data planes when omitted, and immutable afterwards.")
     @ApiResponse(responseCode = "200", description = "The created or updated domain",
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = AutomationDomain.class)))

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -98,6 +99,24 @@ class DomainsResourceTest extends AutomationJerseySpringTest {
     }
 
     @Test
+    void put_creates_without_data_plane_id_and_lets_the_service_resolve_it() {
+        String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
+        Domain created = domain(domainId, "customer-auth");
+        AutomationDomain definition = definition("customer-auth");
+        definition.setDataPlaneId(null);
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.empty());
+        when(domainService.create(eq(ORG_ID), eq(ENV_ID), argThat(newDomain -> newDomain.getDataPlaneId() == null), any()))
+                .thenReturn(Single.just(created));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+        when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(created));
+
+        Response response = put(domainsTarget(), definition);
+
+        assertEquals(200, response.getStatus());
+        assertEquals("customer-auth", readEntity(response, AutomationDomain.class).getAutomationKey());
+    }
+
+    @Test
     void put_updates_when_domain_present() {
         String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
         Domain existing = domain(domainId, "customer-auth");
@@ -138,7 +157,7 @@ class DomainsResourceTest extends AutomationJerseySpringTest {
     @Test
     void put_is_rejected_when_required_fields_missing() {
         AutomationDomain invalid = new AutomationDomain();
-        invalid.setAutomationKey("customer-auth"); // name, path, dataPlaneId missing
+        invalid.setAutomationKey("customer-auth"); // name and path missing
 
         Response response = put(domainsTarget(), invalid);
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -390,12 +390,18 @@ public class DomainServiceImpl implements DomainService {
 
     /**
      * Picks the data plane a new domain will bind to. Both modes hold a supplied id to the planes
-     * provisioned against the environment; cloud requires one, while standalone falls back to
-     * {@code default} when the environment has none and only {@code default} is declared in
-     * {@code gravitee.yml}.
+     * provisioned against the environment; cloud requires the domain to land on one of them, while
+     * standalone also serves the planes {@code gravitee.yml} declares and falls back to
+     * {@code default} when the environment has none and only {@code default} is declared.
      */
     private Single<String> resolveDataPlaneId(String environmentId, String requestedId) {
         boolean cloudEnabled = CloudProperties.isManagedCloudEnabled(springEnvironment);
+        // A standalone caller naming a plane is not held to the environment's links: the planes
+        // gravitee.yml declares serve every environment, so `default` stays a valid choice for an
+        // environment that also has one provisioned against it. Saves the repository round-trip too.
+        if (!cloudEnabled && StringUtils.hasText(requestedId)) {
+            return resolveDataPlaneIdForStandalone(requestedId, List.of());
+        }
         return dataPlaneDefinitionService.findByEnvironmentId(environmentId)
                 .map(DataPlaneDefinitionSummary::id)
                 .toList()
@@ -425,12 +431,6 @@ public class DomainServiceImpl implements DomainService {
 
     private Single<String> resolveDataPlaneIdForStandalone(String requestedId, List<String> linkedForEnv) {
         if (StringUtils.hasText(requestedId)) {
-            // The environment's links win whenever it has any, so a domain and the entrypoint events
-            // for its environment (which EntrypointServiceImpl routes by the same links) agree on the plane.
-            if (!linkedForEnv.isEmpty() && !linkedForEnv.contains(requestedId)) {
-                return Single.error(new InvalidDataPlaneException(
-                        "Data Plane [" + requestedId + "] is not linked to this environment."));
-            }
             return requireLoadedOnThisNode(requestedId);
         }
         boolean onlyDefaultDeclared = Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -378,31 +378,24 @@ public class DomainServiceImpl implements DomainService {
         String hrid = IdGenerator.generate(newDomain.getName());
 
         return resolveDataPlaneId(environmentId, newDomain.getDataPlaneId())
-                .flatMap(resolvedId -> {
-                    newDomain.setDataPlaneId(resolvedId);
-                    return dataPlaneRegistry.verified(resolvedId)
-                            .onErrorResumeNext(error -> {
-                                log.error("Failed to verify Data Plane configuration", error);
-                                return Completable.error(new InvalidDataPlaneException(
-                                        "An error occurred while trying to create a domain. Data Plane [" + resolvedId
-                                                + "] did not answer with the settings it was provisioned with."));
-                            })
-                            .andThen(createDomain(organizationId, environmentId, newDomain, principal, automationDomain, hrid));
-                });
+                .flatMap(resolvedId -> dataPlaneRegistry.verified(resolvedId)
+                        .onErrorResumeNext(error -> {
+                            log.error("Failed to verify Data Plane configuration", error);
+                            return Completable.error(new InvalidDataPlaneException(
+                                    "An error occurred while trying to create a domain. Data Plane [" + resolvedId
+                                            + "] did not answer with the settings it was provisioned with."));
+                        })
+                        .andThen(createDomain(organizationId, environmentId, newDomain, resolvedId, principal, automationDomain, hrid)));
     }
 
     /**
-     * Picks the data plane a new domain will bind to. Cloud mode drives everything off the DPs
-     * provisioned against the environment; standalone falls back to {@code default} when the caller
-     * hasn't asked for anything and only {@code default} is declared in {@code gravitee.yml}.
+     * Picks the data plane a new domain will bind to. Both modes hold a supplied id to the planes
+     * provisioned against the environment; cloud requires one, while standalone falls back to
+     * {@code default} when the environment has none and only {@code default} is declared in
+     * {@code gravitee.yml}.
      */
     private Single<String> resolveDataPlaneId(String environmentId, String requestedId) {
         boolean cloudEnabled = CloudProperties.isManagedCloudEnabled(springEnvironment);
-        // Standalone with an explicit id doesn't need the environment's linked planes: the id has
-        // to exist in the registry, and that's the whole check. Save the repository round-trip.
-        if (!cloudEnabled && StringUtils.hasText(requestedId)) {
-            return resolveDataPlaneIdForStandalone(requestedId, List.of());
-        }
         return dataPlaneDefinitionService.findByEnvironmentId(environmentId)
                 .map(DataPlaneDefinitionSummary::id)
                 .toList()
@@ -421,25 +414,24 @@ public class DomainServiceImpl implements DomainService {
                 return Single.error(new InvalidDataPlaneException(
                         "Multiple data planes are linked to this environment; dataPlaneId must be provided."));
             }
-            return Single.just(linkedForEnv.get(0));
+            return requireLoadedOnThisNode(linkedForEnv.get(0));
         }
         if (!linkedForEnv.contains(requestedId)) {
             return Single.error(new InvalidDataPlaneException(
                     "Data Plane [" + requestedId + "] is not linked to this environment."));
         }
-        return Single.just(requestedId);
+        return requireLoadedOnThisNode(requestedId);
     }
 
     private Single<String> resolveDataPlaneIdForStandalone(String requestedId, List<String> linkedForEnv) {
         if (StringUtils.hasText(requestedId)) {
-            boolean known = dataPlaneRegistry.getDataPlanes().stream()
-                    .map(DataPlaneDescription::id)
-                    .anyMatch(requestedId::equals);
-            if (!known) {
+            // The environment's links win whenever it has any, so a domain and the entrypoint events
+            // for its environment (which EntrypointServiceImpl routes by the same links) agree on the plane.
+            if (!linkedForEnv.isEmpty() && !linkedForEnv.contains(requestedId)) {
                 return Single.error(new InvalidDataPlaneException(
-                        "An error occurred while trying to create a domain. Data Plane with provided Id doesn't exist."));
+                        "Data Plane [" + requestedId + "] is not linked to this environment."));
             }
-            return Single.just(requestedId);
+            return requireLoadedOnThisNode(requestedId);
         }
         boolean onlyDefaultDeclared = Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)
                 .equals(dataPlaneConfigurationLoader.declaredIds());
@@ -450,7 +442,23 @@ public class DomainServiceImpl implements DomainService {
         return Single.just(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
     }
 
-    private Single<Domain> createDomain(String organizationId, String environmentId, NewDomain newDomain, User principal, AutomationNewDomain automationDomain, String hrid) {
+    /**
+     * A linked definition only means the id is claimed, not that this node serves it: activation can
+     * fail, and {@code verified()} answers complete for an id it was never handed. Without this the
+     * domain would be persisted against a plane nothing can read or write.
+     */
+    private Single<String> requireLoadedOnThisNode(String dataPlaneId) {
+        boolean known = dataPlaneRegistry.getDataPlanes().stream()
+                .map(DataPlaneDescription::id)
+                .anyMatch(dataPlaneId::equals);
+        if (!known) {
+            return Single.error(new InvalidDataPlaneException(
+                    "An error occurred while trying to create a domain. Data Plane [" + dataPlaneId + "] is not loaded on this node."));
+        }
+        return Single.just(dataPlaneId);
+    }
+
+    private Single<Domain> createDomain(String organizationId, String environmentId, NewDomain newDomain, String dataPlaneId, User principal, AutomationNewDomain automationDomain, String hrid) {
         return domainRepository.findByHrid(ReferenceType.ENVIRONMENT, environmentId, hrid)
                 .isEmpty()
                 .flatMap(empty -> {
@@ -473,7 +481,7 @@ public class DomainServiceImpl implements DomainService {
                         domain.setReferenceId(environmentId);
                         domain.setCreatedAt(new Date());
                         domain.setUpdatedAt(domain.getCreatedAt());
-                        domain.setDataPlaneId(newDomain.getDataPlaneId());
+                        domain.setDataPlaneId(dataPlaneId);
                         if (automationDomain != null) {
                             domain.setManagedBy(ManagedBy.AUTOMATION_API);
                             domain.setAutomationKey(automationDomain.getAutomationKey());

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -49,6 +49,7 @@ import io.gravitee.am.model.oidc.CIMDSettings;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.permissions.SystemRole;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.plugins.dataplane.core.MultiDataPlaneLoader;
 import io.gravitee.am.repository.management.api.DomainRepository;
 import io.gravitee.am.repository.management.api.search.AlertNotifierCriteria;
 import io.gravitee.am.repository.management.api.search.AlertTriggerCriteria;
@@ -61,6 +62,7 @@ import io.gravitee.am.service.AuthenticationDeviceNotifierService;
 import io.gravitee.am.service.AuthorizationEngineService;
 import io.gravitee.am.service.CertificateService;
 import io.gravitee.am.service.CimdClientStateService;
+import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.DeviceIdentifierService;
 import io.gravitee.am.service.DomainReadService;
 import io.gravitee.am.service.EmailTemplateService;
@@ -95,6 +97,7 @@ import io.gravitee.am.service.exception.InvalidWebAuthnConfigurationException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.I18nDictionaryService;
 import io.gravitee.am.service.model.AutomationNewDomain;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.model.NewDomain;
 import io.gravitee.am.service.model.NewSystemScope;
 import io.gravitee.am.service.model.PatchDomain;
@@ -131,6 +134,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -167,6 +171,12 @@ public class DomainServiceImpl implements DomainService {
 
     @Autowired
     private DataPlaneRegistry dataPlaneRegistry;
+
+    @Autowired
+    private DataPlaneDefinitionService dataPlaneDefinitionService;
+
+    @Autowired
+    private MultiDataPlaneLoader dataPlaneConfigurationLoader;
 
     /** every store that holds domain data in the data plane, collected rather than named one by one */
     @Autowired
@@ -367,18 +377,77 @@ public class DomainServiceImpl implements DomainService {
         var automationDomain = newDomain instanceof AutomationNewDomain auto ? auto : null;
         String hrid = IdGenerator.generate(newDomain.getName());
 
-        if (dataPlaneRegistry.getDataPlanes().stream().map(DataPlaneDescription::id).noneMatch(id -> id.equals(newDomain.getDataPlaneId()))) {
-            return Single.error(new InvalidDataPlaneException("An error occurred while trying to create a domain. Data Plane with provided Id doesn't exist."));
-        }
+        return resolveDataPlaneId(environmentId, newDomain.getDataPlaneId())
+                .flatMap(resolvedId -> {
+                    newDomain.setDataPlaneId(resolvedId);
+                    return dataPlaneRegistry.verified(resolvedId)
+                            .onErrorResumeNext(error -> {
+                                log.error("Failed to verify Data Plane configuration", error);
+                                return Completable.error(new InvalidDataPlaneException(
+                                        "An error occurred while trying to create a domain. Data Plane [" + resolvedId
+                                                + "] did not answer with the settings it was provisioned with."));
+                            })
+                            .andThen(createDomain(organizationId, environmentId, newDomain, principal, automationDomain, hrid));
+                });
+    }
 
-        return dataPlaneRegistry.verified(newDomain.getDataPlaneId())
-                .onErrorResumeNext(error -> {
-                    log.error("Failed to verify Data Plane configuration", error);
-                    return Completable.error(new InvalidDataPlaneException(
-                            "An error occurred while trying to create a domain. Data Plane [" + newDomain.getDataPlaneId()
-                                    + "] did not answer with the settings it was provisioned with."));
-                })
-                .andThen(createDomain(organizationId, environmentId, newDomain, principal, automationDomain, hrid));
+    /**
+     * Picks the data plane a new domain will bind to. Cloud mode drives everything off the DPs
+     * provisioned against the environment; standalone falls back to {@code default} when the caller
+     * hasn't asked for anything and only {@code default} is declared in {@code gravitee.yml}.
+     */
+    private Single<String> resolveDataPlaneId(String environmentId, String requestedId) {
+        boolean cloudEnabled = CloudProperties.isManagedCloudEnabled(springEnvironment);
+        // Standalone with an explicit id doesn't need the environment's linked planes: the id has
+        // to exist in the registry, and that's the whole check. Save the repository round-trip.
+        if (!cloudEnabled && StringUtils.hasText(requestedId)) {
+            return resolveDataPlaneIdForStandalone(requestedId, List.of());
+        }
+        return dataPlaneDefinitionService.findByEnvironmentId(environmentId)
+                .map(DataPlaneDefinitionSummary::id)
+                .toList()
+                .flatMap(linkedForEnv -> cloudEnabled
+                        ? resolveDataPlaneIdForCloud(requestedId, linkedForEnv)
+                        : resolveDataPlaneIdForStandalone(requestedId, linkedForEnv));
+    }
+
+    private Single<String> resolveDataPlaneIdForCloud(String requestedId, List<String> linkedForEnv) {
+        if (!StringUtils.hasText(requestedId)) {
+            if (linkedForEnv.isEmpty()) {
+                return Single.error(new InvalidDataPlaneException(
+                        "No data plane is linked to this environment; a domain cannot be created without one."));
+            }
+            if (linkedForEnv.size() > 1) {
+                return Single.error(new InvalidDataPlaneException(
+                        "Multiple data planes are linked to this environment; dataPlaneId must be provided."));
+            }
+            return Single.just(linkedForEnv.get(0));
+        }
+        if (!linkedForEnv.contains(requestedId)) {
+            return Single.error(new InvalidDataPlaneException(
+                    "Data Plane [" + requestedId + "] is not linked to this environment."));
+        }
+        return Single.just(requestedId);
+    }
+
+    private Single<String> resolveDataPlaneIdForStandalone(String requestedId, List<String> linkedForEnv) {
+        if (StringUtils.hasText(requestedId)) {
+            boolean known = dataPlaneRegistry.getDataPlanes().stream()
+                    .map(DataPlaneDescription::id)
+                    .anyMatch(requestedId::equals);
+            if (!known) {
+                return Single.error(new InvalidDataPlaneException(
+                        "An error occurred while trying to create a domain. Data Plane with provided Id doesn't exist."));
+            }
+            return Single.just(requestedId);
+        }
+        boolean onlyDefaultDeclared = Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)
+                .equals(dataPlaneConfigurationLoader.declaredIds());
+        if (!linkedForEnv.isEmpty() || !onlyDefaultDeclared) {
+            return Single.error(new InvalidDataPlaneException(
+                    "dataPlaneId is required when the environment has linked data planes or gravitee.yml declares non-default planes."));
+        }
+        return Single.just(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
     }
 
     private Single<Domain> createDomain(String organizationId, String environmentId, NewDomain newDomain, User principal, AutomationNewDomain automationDomain, String hrid) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -391,14 +391,14 @@ public class DomainServiceImpl implements DomainService {
     /**
      * Picks the data plane a new domain will bind to. Both modes hold a supplied id to the planes
      * provisioned against the environment; cloud requires the domain to land on one of them, while
-     * standalone also serves the planes {@code gravitee.yml} declares and falls back to
-     * {@code default} when the environment has none and only {@code default} is declared.
+     * standalone also serves the planes the node's configuration declares and falls back to
+     * {@code default} when the environment has none loaded here and only {@code default} is declared.
      */
     private Single<String> resolveDataPlaneId(String environmentId, String requestedId) {
         boolean cloudEnabled = CloudProperties.isManagedCloudEnabled(springEnvironment);
-        // A standalone caller naming a plane is not held to the environment's links: the planes
-        // gravitee.yml declares serve every environment, so `default` stays a valid choice for an
-        // environment that also has one provisioned against it. Saves the repository round-trip too.
+        // A standalone caller naming a plane is not held to the environment's links: the planes the
+        // node's configuration declares serve every environment, so `default` stays a valid choice for
+        // an environment that also has one provisioned against it. Saves the repository round-trip too.
         if (!cloudEnabled && StringUtils.hasText(requestedId)) {
             return resolveDataPlaneIdForStandalone(requestedId, List.of());
         }
@@ -435,9 +435,12 @@ public class DomainServiceImpl implements DomainService {
         }
         boolean onlyDefaultDeclared = Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)
                 .equals(dataPlaneConfigurationLoader.declaredIds());
-        if (!linkedForEnv.isEmpty() || !onlyDefaultDeclared) {
+        // A linked plane this node has not loaded cannot take the domain anyway, so it does not stop
+        // the fall back to `default`.
+        boolean linkedAndLoaded = linkedForEnv.stream().anyMatch(this::isLoadedOnThisNode);
+        if (linkedAndLoaded || !onlyDefaultDeclared) {
             return Single.error(new InvalidDataPlaneException(
-                    "dataPlaneId is required when the environment has linked data planes or gravitee.yml declares non-default planes."));
+                    "dataPlaneId is required when the environment has linked data planes or the node's configuration declares non-default planes."));
         }
         return Single.just(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
     }
@@ -448,14 +451,17 @@ public class DomainServiceImpl implements DomainService {
      * domain would be persisted against a plane nothing can read or write.
      */
     private Single<String> requireLoadedOnThisNode(String dataPlaneId) {
-        boolean known = dataPlaneRegistry.getDataPlanes().stream()
-                .map(DataPlaneDescription::id)
-                .anyMatch(dataPlaneId::equals);
-        if (!known) {
+        if (!isLoadedOnThisNode(dataPlaneId)) {
             return Single.error(new InvalidDataPlaneException(
                     "An error occurred while trying to create a domain. Data Plane [" + dataPlaneId + "] is not loaded on this node."));
         }
         return Single.just(dataPlaneId);
+    }
+
+    private boolean isLoadedOnThisNode(String dataPlaneId) {
+        return dataPlaneRegistry.getDataPlanes().stream()
+                .map(DataPlaneDescription::id)
+                .anyMatch(dataPlaneId::equals);
     }
 
     private Single<Domain> createDomain(String organizationId, String environmentId, NewDomain newDomain, String dataPlaneId, User principal, AutomationNewDomain automationDomain, String hrid) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -212,6 +212,12 @@ public class DomainServiceTest {
     private DataPlaneRegistry dataPlaneRegistry;
 
     @Mock
+    private io.gravitee.am.service.DataPlaneDefinitionService dataPlaneDefinitionService;
+
+    @Mock
+    private io.gravitee.am.plugins.dataplane.core.MultiDataPlaneLoader dataPlaneConfigurationLoader;
+
+    @Mock
     private DomainValidator domainValidator;
 
     @Mock
@@ -690,6 +696,187 @@ public class DomainServiceTest {
 
         testObserver.assertError(DomainAlreadyExistsException.class);
         testObserver.assertNotComplete();
+
+        verify(domainRepository, never()).create(any(Domain.class));
+    }
+
+    // --- AM-7262: dataPlaneId resolution during domain creation ---
+
+    private void stubCreateDomainPersistence(String hrid) {
+        Domain persisted = new Domain();
+        persisted.setId("domain-id");
+        persisted.setReferenceType(ReferenceType.ENVIRONMENT);
+        persisted.setReferenceId(ENVIRONMENT_ID);
+        persisted.setVersion(DomainVersion.V2_0);
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(Single.just(new Environment()));
+        when(domainReadService.listAll()).thenReturn(Flowable.empty());
+        when(domainRepository.findByHrid(ReferenceType.ENVIRONMENT, ENVIRONMENT_ID, hrid)).thenReturn(Maybe.empty());
+        when(domainRepository.create(any(Domain.class))).thenReturn(Single.just(persisted));
+        when(scopeService.create(any(), any(NewSystemScope.class))).thenReturn(Single.just(new Scope()));
+        when(certificateService.create(any())).thenReturn(Single.just(new Certificate()));
+        when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
+        when(reporterService.notifyInheritedReporters(any(), any(), any())).thenReturn(Completable.complete());
+        when(reporterService.createDefault(any())).thenReturn(Single.just(new Reporter()));
+        when(defaultIdentityProviderService.create(any())).thenReturn(Single.just(new IdentityProvider()));
+        doReturn(Single.just(List.of()).ignoreElement()).when(domainValidator).validate(any(), any());
+        doReturn(Single.just(List.of()).ignoreElement()).when(virtualHostValidator).validateDomainVhosts(any(), any());
+    }
+
+    private io.gravitee.am.service.model.DataPlaneDefinitionSummary dpSummary(String id) {
+        return new io.gravitee.am.service.model.DataPlaneDefinitionSummary(
+                id, id, "mongodb", null, ORGANIZATION_ID, ENVIRONMENT_ID, null, List.of(), null, null);
+    }
+
+    @Test
+    public void shouldCreate_standalone_omittedId_resolvesToDefault() {
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        // dataPlaneId intentionally not set
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Flowable.empty());
+        when(dataPlaneConfigurationLoader.declaredIds())
+                .thenReturn(Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
+        when(dataPlaneRegistry.verified(DataPlaneDescription.DEFAULT_DATA_PLANE_ID))
+                .thenReturn(Completable.complete());
+        stubCreateDomainPersistence("my-domain");
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(domainRepository).create(argThat(d -> DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(d.getDataPlaneId())));
+    }
+
+    @Test
+    public void shouldReject_standalone_omittedId_extraDpDeclared() {
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Flowable.empty());
+        when(dataPlaneConfigurationLoader.declaredIds())
+                .thenReturn(Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID, "extra-dp"));
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+
+        verify(domainRepository, never()).create(any(Domain.class));
+    }
+
+    @Test
+    public void shouldReject_standalone_omittedId_provisionedDpLinked() {
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(Flowable.just(dpSummary("provisioned-dp")));
+        when(dataPlaneConfigurationLoader.declaredIds())
+                .thenReturn(Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+
+        verify(domainRepository, never()).create(any(Domain.class));
+    }
+
+    @Test
+    public void shouldReject_standalone_suppliedId_unknown() {
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        newDomain.setDataPlaneId("ghost");
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(List.of(
+                new DataPlaneDescription(DataPlaneDescription.DEFAULT_DATA_PLANE_ID, "default", "mongodb", "test", null)));
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+
+        verify(domainRepository, never()).create(any(Domain.class));
+    }
+
+    @Test
+    public void shouldCreate_cloud_omittedId_singleLinkedDp() {
+        enableCloudMode();
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(Flowable.just(dpSummary("env-dp")));
+        when(dataPlaneRegistry.verified("env-dp")).thenReturn(Completable.complete());
+        stubCreateDomainPersistence("my-domain");
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(domainRepository).create(argThat(d -> "env-dp".equals(d.getDataPlaneId())));
+    }
+
+    @Test
+    public void shouldReject_cloud_omittedId_noLinkedDp() {
+        enableCloudMode();
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID)).thenReturn(Flowable.empty());
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+
+        verify(domainRepository, never()).create(any(Domain.class));
+    }
+
+    @Test
+    public void shouldReject_cloud_omittedId_multipleLinkedDps() {
+        enableCloudMode();
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(Flowable.just(dpSummary("dp-a"), dpSummary("dp-b")));
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+
+        verify(domainRepository, never()).create(any(Domain.class));
+    }
+
+    @Test
+    public void shouldCreate_cloud_suppliedId_matchesLinked() {
+        enableCloudMode();
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        newDomain.setDataPlaneId("env-dp");
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(Flowable.just(dpSummary("env-dp")));
+        when(dataPlaneRegistry.verified("env-dp")).thenReturn(Completable.complete());
+        stubCreateDomainPersistence("my-domain");
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(domainRepository).create(argThat(d -> "env-dp".equals(d.getDataPlaneId())));
+    }
+
+    @Test
+    public void shouldReject_cloud_suppliedId_notLinked() {
+        enableCloudMode();
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        newDomain.setDataPlaneId("other-dp");
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(Flowable.just(dpSummary("env-dp")));
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
 
         verify(domainRepository, never()).create(any(Domain.class));
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -68,6 +68,7 @@ import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.permissions.SystemRole;
 import io.gravitee.am.model.uma.Resource;
 import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.plugins.dataplane.core.MultiDataPlaneLoader;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.repository.management.api.DomainRepository;
 import io.gravitee.am.repository.management.api.search.AlertNotifierCriteria;
@@ -81,6 +82,7 @@ import io.gravitee.am.service.AuthenticationDeviceNotifierService;
 import io.gravitee.am.service.AuthorizationEngineService;
 import io.gravitee.am.service.CertificateCredentialService;
 import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.DeviceIdentifierService;
 import io.gravitee.am.service.DomainReadService;
 import io.gravitee.am.service.EmailTemplateService;
@@ -103,6 +105,7 @@ import io.gravitee.am.service.ThemeService;
 import io.gravitee.am.service.dataplane.DomainDataPlaneCleanup;
 import io.gravitee.am.service.exception.DomainAlreadyExistsException;
 import io.gravitee.am.service.exception.DomainNotFoundException;
+import io.gravitee.am.service.exception.InvalidDataPlaneException;
 import io.gravitee.am.service.exception.InvalidDomainException;
 import io.gravitee.am.service.exception.InvalidParameterException;
 import io.gravitee.am.service.exception.InvalidWebAuthnConfigurationException;
@@ -110,6 +113,7 @@ import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.I18nDictionaryService;
 import io.gravitee.am.service.impl.PasswordHistoryService;
 import io.gravitee.am.service.model.AutomationNewDomain;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.model.NewDomain;
 import io.gravitee.am.service.model.NewSystemScope;
 import io.gravitee.am.service.model.PatchDomain;
@@ -149,6 +153,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static io.gravitee.am.model.ReferenceType.DOMAIN;
 import static io.gravitee.am.model.ReferenceType.ORGANIZATION;
@@ -212,10 +217,10 @@ public class DomainServiceTest {
     private DataPlaneRegistry dataPlaneRegistry;
 
     @Mock
-    private io.gravitee.am.service.DataPlaneDefinitionService dataPlaneDefinitionService;
+    private DataPlaneDefinitionService dataPlaneDefinitionService;
 
     @Mock
-    private io.gravitee.am.plugins.dataplane.core.MultiDataPlaneLoader dataPlaneConfigurationLoader;
+    private MultiDataPlaneLoader dataPlaneConfigurationLoader;
 
     @Mock
     private DomainValidator domainValidator;
@@ -399,6 +404,12 @@ public class DomainServiceTest {
     @BeforeEach
     void stubCimdClientStateServiceDefaults() {
         Mockito.lenient().when(cimdClientStateService.deleteByDomain(any(Domain.class))).thenReturn(Completable.complete());
+    }
+
+    /** Domain creation always reads the environment's linked planes; most tests have none. */
+    @BeforeEach
+    void stubNoLinkedDataPlanes() {
+        Mockito.lenient().when(dataPlaneDefinitionService.findByEnvironmentId(anyString())).thenReturn(Flowable.empty());
     }
 
     /**
@@ -700,8 +711,6 @@ public class DomainServiceTest {
         verify(domainRepository, never()).create(any(Domain.class));
     }
 
-    // --- AM-7262: dataPlaneId resolution during domain creation ---
-
     private void stubCreateDomainPersistence(String hrid) {
         Domain persisted = new Domain();
         persisted.setId("domain-id");
@@ -722,8 +731,14 @@ public class DomainServiceTest {
         doReturn(Single.just(List.of()).ignoreElement()).when(virtualHostValidator).validateDomainVhosts(any(), any());
     }
 
-    private io.gravitee.am.service.model.DataPlaneDefinitionSummary dpSummary(String id) {
-        return new io.gravitee.am.service.model.DataPlaneDefinitionSummary(
+    private void stubLoadedDataPlanes(String... ids) {
+        when(dataPlaneRegistry.getDataPlanes()).thenReturn(Stream.of(ids)
+                .map(id -> new DataPlaneDescription(id, id, "mongodb", "test", null))
+                .toList());
+    }
+
+    private DataPlaneDefinitionSummary dpSummary(String id) {
+        return new DataPlaneDefinitionSummary(
                 id, id, "mongodb", null, ORGANIZATION_ID, ENVIRONMENT_ID, null, List.of(), null, null);
     }
 
@@ -758,7 +773,7 @@ public class DomainServiceTest {
         domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
-                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+                .assertError(InvalidDataPlaneException.class);
 
         verify(domainRepository, never()).create(any(Domain.class));
     }
@@ -775,7 +790,7 @@ public class DomainServiceTest {
         domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
-                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+                .assertError(InvalidDataPlaneException.class);
 
         verify(domainRepository, never()).create(any(Domain.class));
     }
@@ -791,7 +806,7 @@ public class DomainServiceTest {
         domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
-                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+                .assertError(InvalidDataPlaneException.class);
 
         verify(domainRepository, never()).create(any(Domain.class));
     }
@@ -803,6 +818,7 @@ public class DomainServiceTest {
         newDomain.setName("my-domain");
         when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
                 .thenReturn(Flowable.just(dpSummary("env-dp")));
+        stubLoadedDataPlanes("env-dp");
         when(dataPlaneRegistry.verified("env-dp")).thenReturn(Completable.complete());
         stubCreateDomainPersistence("my-domain");
 
@@ -824,7 +840,7 @@ public class DomainServiceTest {
         domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
-                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+                .assertError(InvalidDataPlaneException.class);
 
         verify(domainRepository, never()).create(any(Domain.class));
     }
@@ -840,7 +856,7 @@ public class DomainServiceTest {
         domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
-                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+                .assertError(InvalidDataPlaneException.class);
 
         verify(domainRepository, never()).create(any(Domain.class));
     }
@@ -853,6 +869,7 @@ public class DomainServiceTest {
         newDomain.setDataPlaneId("env-dp");
         when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
                 .thenReturn(Flowable.just(dpSummary("env-dp")));
+        stubLoadedDataPlanes("env-dp");
         when(dataPlaneRegistry.verified("env-dp")).thenReturn(Completable.complete());
         stubCreateDomainPersistence("my-domain");
 
@@ -862,6 +879,41 @@ public class DomainServiceTest {
                 .assertComplete();
 
         verify(domainRepository).create(argThat(d -> "env-dp".equals(d.getDataPlaneId())));
+    }
+
+    @Test
+    public void shouldReject_standalone_suppliedId_notLinkedToEnvironment() {
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        newDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(Flowable.just(dpSummary("provisioned-dp")));
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(InvalidDataPlaneException.class);
+
+        verify(domainRepository, never()).create(any(Domain.class));
+    }
+
+    @Test
+    public void shouldReject_cloud_linkedDpNotLoadedOnThisNode() {
+        enableCloudMode();
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(Flowable.just(dpSummary("env-dp")));
+        // the definition is linked, but activation failed so the registry never took it
+        stubLoadedDataPlanes(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertError(InvalidDataPlaneException.class);
+
+        verify(domainRepository, never()).create(any(Domain.class));
+        verify(dataPlaneRegistry, never()).verified(anyString());
     }
 
     @Test
@@ -876,7 +928,7 @@ public class DomainServiceTest {
         domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
-                .assertError(io.gravitee.am.service.exception.InvalidDataPlaneException.class);
+                .assertError(InvalidDataPlaneException.class);
 
         verify(domainRepository, never()).create(any(Domain.class));
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -779,13 +779,14 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldReject_standalone_omittedId_provisionedDpLinked() {
+    public void shouldReject_standalone_omittedId_provisionedDpLinkedAndLoaded() {
         NewDomain newDomain = new NewDomain();
         newDomain.setName("my-domain");
         when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
                 .thenReturn(Flowable.just(dpSummary("provisioned-dp")));
         when(dataPlaneConfigurationLoader.declaredIds())
                 .thenReturn(Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
+        stubLoadedDataPlanes(DataPlaneDescription.DEFAULT_DATA_PLANE_ID, "provisioned-dp");
 
         domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
                 .test()
@@ -793,6 +794,29 @@ public class DomainServiceTest {
                 .assertError(InvalidDataPlaneException.class);
 
         verify(domainRepository, never()).create(any(Domain.class));
+    }
+
+    @Test
+    public void shouldCreate_standalone_omittedId_resolvesToDefault_whenLinkedDpNotLoadedOnThisNode() {
+        NewDomain newDomain = new NewDomain();
+        newDomain.setName("my-domain");
+        // Linked to the environment but not loaded here: it cannot take the domain, so it does not
+        // count against the fall back to default.
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+                .thenReturn(Flowable.just(dpSummary("provisioned-dp")));
+        when(dataPlaneConfigurationLoader.declaredIds())
+                .thenReturn(Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
+        stubLoadedDataPlanes(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(dataPlaneRegistry.verified(DataPlaneDescription.DEFAULT_DATA_PLANE_ID))
+                .thenReturn(Completable.complete());
+        stubCreateDomainPersistence("my-domain");
+
+        domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(domainRepository).create(argThat(d -> DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(d.getDataPlaneId())));
     }
 
     @Test
@@ -886,7 +910,7 @@ public class DomainServiceTest {
         NewDomain newDomain = new NewDomain();
         newDomain.setName("my-domain");
         newDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
-        // A plane provisioned against the environment must not stop a domain landing on a gravitee.yml
+        // A plane provisioned against the environment must not stop a domain landing on a declared
         // one. Lenient because resolution short-circuits before the lookup, which is the point.
         Mockito.lenient().when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
                 .thenReturn(Flowable.just(dpSummary("provisioned-dp")));

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -882,19 +882,24 @@ public class DomainServiceTest {
     }
 
     @Test
-    public void shouldReject_standalone_suppliedId_notLinkedToEnvironment() {
+    public void shouldCreate_standalone_suppliedDefault_whileEnvironmentHasAProvisionedPlane() {
         NewDomain newDomain = new NewDomain();
         newDomain.setName("my-domain");
         newDomain.setDataPlaneId(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
-        when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
+        // A plane provisioned against the environment must not stop a domain landing on a gravitee.yml
+        // one. Lenient because resolution short-circuits before the lookup, which is the point.
+        Mockito.lenient().when(dataPlaneDefinitionService.findByEnvironmentId(ENVIRONMENT_ID))
                 .thenReturn(Flowable.just(dpSummary("provisioned-dp")));
+        stubLoadedDataPlanes(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        when(dataPlaneRegistry.verified(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)).thenReturn(Completable.complete());
+        stubCreateDomainPersistence("my-domain");
 
         domainService.create(ORGANIZATION_ID, ENVIRONMENT_ID, newDomain)
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
-                .assertError(InvalidDataPlaneException.class);
+                .assertComplete();
 
-        verify(domainRepository, never()).create(any(Domain.class));
+        verify(domainRepository).create(argThat(d -> DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(d.getDataPlaneId())));
     }
 
     @Test

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/MultiDataPlaneLoader.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/MultiDataPlaneLoader.java
@@ -23,7 +23,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.springframework.util.StringUtils.hasText;
@@ -57,6 +59,14 @@ public class MultiDataPlaneLoader implements DataPlaneLoader {
             }
         }
         return false;
+    }
+
+    public Set<String> declaredIds() {
+        Set<String> ids = new LinkedHashSet<>();
+        for (int i = 0; configuration.containsProperty(propertyBase(i) + ".id"); i++) {
+            ids.add(configuration.getProperty(propertyBase(i) + ".id", String.class));
+        }
+        return ids;
     }
 
     private List<DataPlaneDescription> readList() {

--- a/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/MultiDataPlaneLoader.java
+++ b/gravitee-am-plugins-handlers/gravitee-am-plugins-handlers-dataplane/src/main/java/io/gravitee/am/plugins/dataplane/core/MultiDataPlaneLoader.java
@@ -53,14 +53,10 @@ public class MultiDataPlaneLoader implements DataPlaneLoader {
      * declaration too broken to describe is the node's problem at startup, not the caller's.
      */
     public boolean isDeclared(String id) {
-        for (int i = 0; configuration.containsProperty(propertyBase(i) + ".id"); i++) {
-            if (id.equals(configuration.getProperty(propertyBase(i) + ".id", String.class))) {
-                return true;
-            }
-        }
-        return false;
+        return declaredIds().contains(id);
     }
 
+    /** Ids of every data plane the configuration declares, in declaration order. */
     public Set<String> declaredIds() {
         Set<String> ids = new LinkedHashSet<>();
         for (int i = 0; configuration.containsProperty(propertyBase(i) + ".id"); i++) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DataPlaneDefinitionService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DataPlaneDefinitionService.java
@@ -33,6 +33,8 @@ public interface DataPlaneDefinitionService {
 
     Flowable<DataPlaneDefinitionSummary> findAll();
 
+    Flowable<DataPlaneDefinitionSummary> findByEnvironmentId(String environmentId);
+
     Single<DataPlaneDefinitionSummary> findById(String id);
 
     /**

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
@@ -149,6 +149,12 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
     }
 
     @Override
+    public Flowable<DataPlaneDefinitionSummary> findByEnvironmentId(String environmentId) {
+        log.debug("Find data plane definitions for environment {}", environmentId);
+        return dataPlaneDefinitionRepository.findByEnvironmentId(environmentId).map(this::toSummary);
+    }
+
+    @Override
     public Single<DataPlaneDefinitionSummary> findById(String id) {
         log.debug("Find data plane definition by id: {}", id);
         return dataPlaneDefinitionRepository.findById(id)

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
@@ -58,7 +58,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -259,9 +261,9 @@ public class EntrypointServiceImpl implements EntrypointService {
      * a gateway pinned to any other one would never see the change. Org-scoped entrypoints go to
      * {@code default}.
      */
-    private Single<List<String>> resolveDataPlaneIds(Entrypoint entrypoint) {
+    private Single<Set<String>> resolveDataPlaneIds(Entrypoint entrypoint) {
         if (entrypoint.getEnvironmentId() == null) {
-            return Single.just(List.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
+            return Single.just(Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
         }
         return dataPlaneDefinitionService.findByEnvironmentId(entrypoint.getEnvironmentId())
                 .map(DataPlaneDefinitionSummary::id)
@@ -269,20 +271,15 @@ public class EntrypointServiceImpl implements EntrypointService {
                 .map(this::targetPlanes);
     }
 
-    private List<String> targetPlanes(List<String> linkedForEnv) {
+    private Set<String> targetPlanes(List<String> linkedForEnv) {
+        Set<String> targets = new LinkedHashSet<>(linkedForEnv);
         // Cloud binds every domain to one of the environment's linked planes, so those are the only
-        // gateways that can be serving it.
-        if (managedCloudEnabled) {
-            return linkedForEnv.isEmpty() ? List.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID) : linkedForEnv;
+        // gateways that can be serving it. Outside managed cloud a domain may also sit on a plane the
+        // node's configuration declares while the environment has another provisioned against it, and
+        // dropping `default` there strands the entrypoints of every domain bound to it.
+        if (!managedCloudEnabled || targets.isEmpty()) {
+            targets.add(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
         }
-        // Standalone also serves the planes gravitee.yml declares, and a domain may sit on one of
-        // those while the environment has another provisioned against it. Dropping `default` here
-        // strands the entrypoints of every domain bound to it.
-        if (linkedForEnv.contains(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)) {
-            return linkedForEnv;
-        }
-        List<String> targets = new ArrayList<>(linkedForEnv);
-        targets.add(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
         return targets;
     }
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
@@ -253,11 +253,11 @@ public class EntrypointServiceImpl implements EntrypointService {
     }
 
     /**
-     * Route an entrypoint event to every data plane its environment is linked to, so whichever gateway
-     * serves that environment picks it up (SyncManager polls events by data-plane id). One event per
-     * plane rather than one for the first row: an environment may hold several linked planes, and a
-     * gateway pinned to any other one would never see the change. Falls back to {@code default} for
-     * org-scoped entrypoints, or when the environment has no linked data plane.
+     * Route an entrypoint event to every data plane that can serve a domain in this environment, so
+     * whichever gateway holds one picks it up (SyncManager polls events by data-plane id). One event
+     * per plane rather than one for the first row: an environment may hold several linked planes, and
+     * a gateway pinned to any other one would never see the change. Org-scoped entrypoints go to
+     * {@code default}.
      */
     private Single<List<String>> resolveDataPlaneIds(Entrypoint entrypoint) {
         if (entrypoint.getEnvironmentId() == null) {
@@ -266,7 +266,24 @@ public class EntrypointServiceImpl implements EntrypointService {
         return dataPlaneDefinitionService.findByEnvironmentId(entrypoint.getEnvironmentId())
                 .map(DataPlaneDefinitionSummary::id)
                 .toList()
-                .map(linked -> linked.isEmpty() ? List.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID) : linked);
+                .map(this::targetPlanes);
+    }
+
+    private List<String> targetPlanes(List<String> linkedForEnv) {
+        // Cloud binds every domain to one of the environment's linked planes, so those are the only
+        // gateways that can be serving it.
+        if (managedCloudEnabled) {
+            return linkedForEnv.isEmpty() ? List.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID) : linkedForEnv;
+        }
+        // Standalone also serves the planes gravitee.yml declares, and a domain may sit on one of
+        // those while the environment has another provisioned against it. Dropping `default` here
+        // strands the entrypoints of every domain bound to it.
+        if (linkedForEnv.contains(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)) {
+            return linkedForEnv;
+        }
+        List<String> targets = new ArrayList<>(linkedForEnv);
+        targets.add(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        return targets;
     }
 
     private Completable validate(Entrypoint entrypoint) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
@@ -30,8 +30,10 @@ import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.repository.management.api.EntrypointRepository;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.EntrypointService;
+import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.OrganizationService;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.exception.EntrypointNotFoundException;
 import io.gravitee.am.service.exception.InvalidEntrypointException;
 import io.gravitee.am.service.exception.LastDefaultEntrypointException;
@@ -71,6 +73,7 @@ public class EntrypointServiceImpl implements EntrypointService {
     private final AuditService auditService;
     private final VirtualHostValidator virtualHostValidator;
     private final EventService eventService;
+    private final DataPlaneDefinitionService dataPlaneDefinitionService;
     private final String gatewayUrl;
     private final boolean managedCloudEnabled;
 
@@ -79,6 +82,7 @@ public class EntrypointServiceImpl implements EntrypointService {
                                  AuditService auditService,
                                  VirtualHostValidator virtualHostValidator,
                                  EventService eventService,
+                                 @Lazy DataPlaneDefinitionService dataPlaneDefinitionService,
                                  @Value("${gateway.url:http://localhost:8092}") String gatewayUrl,
                                  Environment environment) {
         this.entrypointRepository = entrypointRepository;
@@ -86,6 +90,7 @@ public class EntrypointServiceImpl implements EntrypointService {
         this.auditService = auditService;
         this.virtualHostValidator = virtualHostValidator;
         this.eventService = eventService;
+        this.dataPlaneDefinitionService = dataPlaneDefinitionService;
         this.gatewayUrl = gatewayUrl;
         this.managedCloudEnabled = CloudProperties.isManagedCloudEnabled(environment);
     }
@@ -240,10 +245,25 @@ public class EntrypointServiceImpl implements EntrypointService {
         ReferenceType referenceType = entrypoint.getEnvironmentId() != null ? ReferenceType.ENVIRONMENT : ReferenceType.ORGANIZATION;
         String referenceId = entrypoint.getEnvironmentId() != null ? entrypoint.getEnvironmentId() : entrypoint.getOrganizationId();
         Payload payload = new Payload(entrypoint.getId(), referenceType, referenceId, action);
-        // Tag with a data-plane id so the gateway sync (which polls events by data-plane) picks it up.
-        // No environment->data-plane mapping exists; sharded multi-data-plane is out of scope (AM-7226).
-        Event event = new Event(Type.ENTRYPOINT, payload, DataPlaneDescription.DEFAULT_DATA_PLANE_ID, entrypoint.getEnvironmentId());
-        return eventService.create(event).ignoreElement();
+        return resolveDataPlaneId(entrypoint)
+                .map(dataPlaneId -> new Event(Type.ENTRYPOINT, payload, dataPlaneId, entrypoint.getEnvironmentId()))
+                .flatMap(event -> eventService.create(event))
+                .ignoreElement();
+    }
+
+    /**
+     * Route an entrypoint event to the data plane its environment is linked to, so the gateway serving
+     * that environment picks it up (SyncManager polls events by data-plane id). Falls back to
+     * {@code default} for org-scoped entrypoints, or when the environment has no linked data plane.
+     */
+    private Single<String> resolveDataPlaneId(Entrypoint entrypoint) {
+        if (entrypoint.getEnvironmentId() == null) {
+            return Single.just(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+        }
+        return dataPlaneDefinitionService.findByEnvironmentId(entrypoint.getEnvironmentId())
+                .map(DataPlaneDefinitionSummary::id)
+                .defaultIfEmpty(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)
+                .firstOrError();
     }
 
     private Completable validate(Entrypoint entrypoint) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
@@ -245,25 +245,28 @@ public class EntrypointServiceImpl implements EntrypointService {
         ReferenceType referenceType = entrypoint.getEnvironmentId() != null ? ReferenceType.ENVIRONMENT : ReferenceType.ORGANIZATION;
         String referenceId = entrypoint.getEnvironmentId() != null ? entrypoint.getEnvironmentId() : entrypoint.getOrganizationId();
         Payload payload = new Payload(entrypoint.getId(), referenceType, referenceId, action);
-        return resolveDataPlaneId(entrypoint)
-                .map(dataPlaneId -> new Event(Type.ENTRYPOINT, payload, dataPlaneId, entrypoint.getEnvironmentId()))
-                .flatMap(event -> eventService.create(event))
-                .ignoreElement();
+        return resolveDataPlaneIds(entrypoint)
+                .flatMapCompletable(dataPlaneIds -> Flowable.fromIterable(dataPlaneIds)
+                        .flatMapCompletable(dataPlaneId -> eventService
+                                .create(new Event(Type.ENTRYPOINT, payload, dataPlaneId, entrypoint.getEnvironmentId()))
+                                .ignoreElement()));
     }
 
     /**
-     * Route an entrypoint event to the data plane its environment is linked to, so the gateway serving
-     * that environment picks it up (SyncManager polls events by data-plane id). Falls back to
-     * {@code default} for org-scoped entrypoints, or when the environment has no linked data plane.
+     * Route an entrypoint event to every data plane its environment is linked to, so whichever gateway
+     * serves that environment picks it up (SyncManager polls events by data-plane id). One event per
+     * plane rather than one for the first row: an environment may hold several linked planes, and a
+     * gateway pinned to any other one would never see the change. Falls back to {@code default} for
+     * org-scoped entrypoints, or when the environment has no linked data plane.
      */
-    private Single<String> resolveDataPlaneId(Entrypoint entrypoint) {
+    private Single<List<String>> resolveDataPlaneIds(Entrypoint entrypoint) {
         if (entrypoint.getEnvironmentId() == null) {
-            return Single.just(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
+            return Single.just(List.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
         }
         return dataPlaneDefinitionService.findByEnvironmentId(entrypoint.getEnvironmentId())
                 .map(DataPlaneDefinitionSummary::id)
-                .defaultIfEmpty(DataPlaneDescription.DEFAULT_DATA_PLANE_ID)
-                .firstOrError();
+                .toList()
+                .map(linked -> linked.isEmpty() ? List.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID) : linked);
     }
 
     private Completable validate(Entrypoint entrypoint) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewDomain.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewDomain.java
@@ -32,7 +32,6 @@ public class NewDomain {
 
     private String description;
 
-    @NotNull
     private String dataPlaneId;
 
     @Override

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
@@ -805,6 +805,9 @@ public class EntrypointServiceTest {
                 event.getType() == Type.ENTRYPOINT && "dp-a".equals(event.getDataPlaneId())));
         verify(eventService, times(1)).create(argThat(event ->
                 event.getType() == Type.ENTRYPOINT && "dp-b".equals(event.getDataPlaneId())));
+        // standalone domains can sit on a gravitee.yml plane, so default is a target as well
+        verify(eventService, times(1)).create(argThat(event ->
+                DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(event.getDataPlaneId())));
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
@@ -32,6 +32,8 @@ import io.gravitee.am.service.exception.EntrypointNotFoundException;
 import io.gravitee.am.service.exception.InvalidEntrypointException;
 import io.gravitee.am.service.exception.LastDefaultEntrypointException;
 import io.gravitee.am.service.impl.EntrypointServiceImpl;
+import io.gravitee.am.dataplane.api.DataPlaneDescription;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.model.NewEntrypoint;
 import io.gravitee.am.service.model.UpdateEntrypoint;
 import io.gravitee.am.service.validators.virtualhost.VirtualHostValidator;
@@ -92,7 +94,7 @@ public class EntrypointServiceTest {
     private EventService eventService;
 
     @Mock
-    private io.gravitee.am.service.DataPlaneDefinitionService dataPlaneDefinitionService;
+    private DataPlaneDefinitionService dataPlaneDefinitionService;
 
     private EntrypointService cut;
 
@@ -101,7 +103,7 @@ public class EntrypointServiceTest {
 
         cut = newEntrypointService(new MockEnvironment());
         lenient().when(eventService.create(any())).thenAnswer(i -> Single.just(i.getArgument(0)));
-        lenient().when(dataPlaneDefinitionService.findByEnvironmentId(any())).thenReturn(io.reactivex.rxjava3.core.Flowable.empty());
+        lenient().when(dataPlaneDefinitionService.findByEnvironmentId(any())).thenReturn(Flowable.empty());
     }
 
     private EntrypointService newEntrypointService(Environment environment) {
@@ -780,6 +782,52 @@ public class EntrypointServiceTest {
                         && "env#1".equals(event.getPayload().getReferenceId())
                         && "env#1".equals(event.getEnvironmentId())
                         && event.getDataPlaneId() != null));
+    }
+
+    @Test
+    public void shouldPublishOneEntrypointEventPerLinkedDataPlane() {
+
+        Entrypoint existingEntrypoint = new Entrypoint();
+        existingEntrypoint.setId(ENTRYPOINT_ID);
+        existingEntrypoint.setOrganizationId(ORGANIZATION_ID);
+        existingEntrypoint.setEnvironmentId("env#1");
+
+        when(entrypointRepository.findById(ENTRYPOINT_ID, ORGANIZATION_ID)).thenReturn(Maybe.just(existingEntrypoint));
+        when(entrypointRepository.delete(ENTRYPOINT_ID)).thenReturn(Completable.complete());
+        when(dataPlaneDefinitionService.findByEnvironmentId("env#1"))
+                .thenReturn(Flowable.just(dpSummary("dp-a"), dpSummary("dp-b")));
+
+        cut.delete(ENTRYPOINT_ID, ORGANIZATION_ID, null).test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(eventService, times(1)).create(argThat(event ->
+                event.getType() == Type.ENTRYPOINT && "dp-a".equals(event.getDataPlaneId())));
+        verify(eventService, times(1)).create(argThat(event ->
+                event.getType() == Type.ENTRYPOINT && "dp-b".equals(event.getDataPlaneId())));
+    }
+
+    @Test
+    public void shouldPublishEntrypointEventToDefaultWhenEnvironmentHasNoLinkedDataPlane() {
+
+        Entrypoint existingEntrypoint = new Entrypoint();
+        existingEntrypoint.setId(ENTRYPOINT_ID);
+        existingEntrypoint.setOrganizationId(ORGANIZATION_ID);
+        existingEntrypoint.setEnvironmentId("env#1");
+
+        when(entrypointRepository.findById(ENTRYPOINT_ID, ORGANIZATION_ID)).thenReturn(Maybe.just(existingEntrypoint));
+        when(entrypointRepository.delete(ENTRYPOINT_ID)).thenReturn(Completable.complete());
+
+        cut.delete(ENTRYPOINT_ID, ORGANIZATION_ID, null).test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
+
+        verify(eventService, times(1)).create(argThat(event ->
+                DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(event.getDataPlaneId())));
+    }
+
+    private DataPlaneDefinitionSummary dpSummary(String id) {
+        return new DataPlaneDefinitionSummary(id, id, "mongodb", null, ORGANIZATION_ID, "env#1", null, List.of(), null, null);
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
@@ -91,6 +91,9 @@ public class EntrypointServiceTest {
     @Mock
     private EventService eventService;
 
+    @Mock
+    private io.gravitee.am.service.DataPlaneDefinitionService dataPlaneDefinitionService;
+
     private EntrypointService cut;
 
     @Before
@@ -98,10 +101,11 @@ public class EntrypointServiceTest {
 
         cut = newEntrypointService(new MockEnvironment());
         lenient().when(eventService.create(any())).thenAnswer(i -> Single.just(i.getArgument(0)));
+        lenient().when(dataPlaneDefinitionService.findByEnvironmentId(any())).thenReturn(io.reactivex.rxjava3.core.Flowable.empty());
     }
 
     private EntrypointService newEntrypointService(Environment environment) {
-        return new EntrypointServiceImpl(entrypointRepository, organizationService, auditService, virtualHostValidator, eventService, "https://gravitee.io", environment);
+        return new EntrypointServiceImpl(entrypointRepository, organizationService, auditService, virtualHostValidator, eventService, dataPlaneDefinitionService, "https://gravitee.io", environment);
     }
 
     private EntrypointService cloudModeEntrypointService() {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
@@ -805,7 +805,7 @@ public class EntrypointServiceTest {
                 event.getType() == Type.ENTRYPOINT && "dp-a".equals(event.getDataPlaneId())));
         verify(eventService, times(1)).create(argThat(event ->
                 event.getType() == Type.ENTRYPOINT && "dp-b".equals(event.getDataPlaneId())));
-        // standalone domains can sit on a gravitee.yml plane, so default is a target as well
+        // outside managed cloud a domain can sit on a plane the node declares itself, so default is a target as well
         verify(eventService, times(1)).create(argThat(event ->
                 DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(event.getDataPlaneId())));
     }

--- a/gravitee-am-test/api/management/models/NewDomain.ts
+++ b/gravitee-am-test/api/management/models/NewDomain.ts
@@ -37,7 +37,7 @@ export interface NewDomain {
    * @type {string}
    * @memberof NewDomain
    */
-  dataPlaneId: string;
+  dataPlaneId?: string;
   /**
    *
    * @type {string}
@@ -56,7 +56,6 @@ export interface NewDomain {
  * Check if a given object implements the NewDomain interface.
  */
 export function instanceOfNewDomain(value: object): value is NewDomain {
-  if (!('dataPlaneId' in value) || value['dataPlaneId'] === undefined) return false;
   if (!('name' in value) || value['name'] === undefined) return false;
   return true;
 }
@@ -70,7 +69,7 @@ export function NewDomainFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     return json;
   }
   return {
-    dataPlaneId: json['dataPlaneId'],
+    dataPlaneId: json['dataPlaneId'] == null ? undefined : json['dataPlaneId'],
     description: json['description'] == null ? undefined : json['description'],
     name: json['name'],
   };

--- a/gravitee-am-test/playwright.config.ts
+++ b/gravitee-am-test/playwright.config.ts
@@ -25,6 +25,8 @@ process.env.AM_MANAGEMENT_URL = process.env.AM_MANAGEMENT_URL || 'http://localho
 process.env.AM_MANAGEMENT_ENDPOINT = process.env.AM_MANAGEMENT_ENDPOINT || process.env.AM_MANAGEMENT_URL + '/management';
 process.env.AM_GATEWAY_URL = process.env.AM_GATEWAY_URL || 'http://localhost:8092';
 process.env.AM_GATEWAY_NODE_MONITORING_URL = process.env.AM_GATEWAY_NODE_MONITORING_URL || 'http://localhost:18092/_node';
+// Management technical API — the cloud fixtures provision their data plane through it.
+process.env.AM_MANAGEMENT_NODE_URL = process.env.AM_MANAGEMENT_NODE_URL || 'http://localhost:18093/_node';
 process.env.AM_ADMIN_USERNAME = process.env.AM_ADMIN_USERNAME || 'admin';
 process.env.AM_ADMIN_PASSWORD = process.env.AM_ADMIN_PASSWORD || 'adminadmin';
 process.env.AM_DEF_ORG_ID = process.env.AM_DEF_ORG_ID || 'DEFAULT';
@@ -92,7 +94,7 @@ export default defineConfig({
     // Cloud specs need a managed-cloud stack (cockpit-mock + empty platform license — see
     // docker-compose.cloud.yml) and are excluded from the 'chromium' project above. Run
     // explicitly via `pw:ci:cloud` / `--project=cloud` against `local-stack.sh up --cloud --ui`.
-   {
+    {
       name: 'cloud',
       testMatch: '**/cloud/**',
       use: {

--- a/gravitee-am-test/playwright.config.ts
+++ b/gravitee-am-test/playwright.config.ts
@@ -35,6 +35,11 @@ process.env.AM_DEF_ENV_ID = process.env.AM_DEF_ENV_ID || 'DEFAULT';
 process.env.AM_DEF_ENV_HRID = process.env.AM_DEF_ENV_HRID || 'default';
 // Cockpit mock — cloud specs only (local-stack.sh up --cloud).
 process.env.AM_COCKPIT_MOCK_URL = process.env.AM_COCKPIT_MOCK_URL || 'http://localhost:8085';
+// Stores as the management API container reaches them — the cloud fixture's data plane definition
+// names the same store the gateway is configured with. Matches api/config/ci.setup.js; the cloud
+// stack only runs in docker, so these are service names rather than dev.setup.js' localhost.
+process.env.AM_INTERNAL_MONGODB_URI = process.env.AM_INTERNAL_MONGODB_URI || 'mongodb://mongodb:27017';
+process.env.AM_INTERNAL_POSTGRES_HOST = process.env.AM_INTERNAL_POSTGRES_HOST || 'postgres';
 // fakeSMTP UI (matches api/config/dev.setup.js) — forgot-password Playwright specs
 process.env.FAKE_SMTP = process.env.FAKE_SMTP || 'http://localhost:5080';
 process.env.INTERNAL_FAKE_SMTP_HOST = process.env.INTERNAL_FAKE_SMTP_HOST || 'smtp';

--- a/gravitee-am-test/playwright/fixtures/cloud-plugin-license.fixture.ts
+++ b/gravitee-am-test/playwright/fixtures/cloud-plugin-license.fixture.ts
@@ -21,13 +21,11 @@ globalThis.fetch = crossFetch;
 import { getDomainApi } from '@management-commands/service/utils';
 import { waitForDomainSync } from '@management-commands/domain-management-commands';
 import { OrgLicenseFixture, setupOrgLicenseFixture } from '../../specs/cloud/fixtures/org-license-fixture';
+import { setupCloudSharedFixture } from '../../specs/cloud/fixtures/cloud-shared-fixture';
 import { quietly, uniqueTestName as uniqueName } from '../utils/fixture-helpers';
 import { cockpitBrowserSignIn } from '../utils/cockpit-browser-signin';
 import type { Domain } from '@management-models/Domain';
 import type { Page } from '@playwright/test';
-
-const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
-const ORGANIZATION_NAME = 'plugin-license-ui';
 
 export type CloudPluginLicenseFixtures = {
   /** Cockpit-provisioned org + license helpers. */
@@ -48,14 +46,17 @@ export const test = base.extend<CloudPluginLicenseFixtures>({
   // Cloud has no inline admin — do not reuse the chromium project's admin storageState.
   storageState: { cookies: [], origins: [] },
 
+  // The shared cloud org/env, whose data plane is the one the gateway is pinned to: cloud mode
+  // resolves the data plane from the environment link, so a domain elsewhere is never served.
   licenseFixture: async ({}, use) => {
-    const fixture = await setupOrgLicenseFixture(ORGANIZATION_NAME);
+    const fixture = await setupOrgLicenseFixture(await setupCloudSharedFixture());
     await use(fixture);
     await fixture.cleanup();
   },
 
   testDomain: async ({ licenseFixture }, use) => {
     const { accessToken, organizationId, environmentId } = licenseFixture;
+    const { dataPlaneId } = await setupCloudSharedFixture();
     const domainApi = getDomainApi(accessToken);
     const domain = await quietly(() =>
       domainApi.createDomain({
@@ -64,7 +65,7 @@ export const test = base.extend<CloudPluginLicenseFixtures>({
         newDomain: {
           name: uniqueName('pw-license-ui'),
           description: 'Playwright EE plugin license UI',
-          dataPlaneId: DATA_PLANE_ID,
+          dataPlaneId,
         },
       }),
     );
@@ -77,7 +78,7 @@ export const test = base.extend<CloudPluginLicenseFixtures>({
   },
 
   environmentHrid: async ({ licenseFixture }, use) => {
-    // setupCloudOrganizationFixture sets hrids to [environmentId].
+    // The shared cloud fixture sets hrids to [environmentId].
     await use(licenseFixture.environmentId);
   },
 

--- a/gravitee-am-test/specs/cloud/domain-dataplane-resolution.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-dataplane-resolution.jest.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+import { getDomainApi } from '@management-commands/service/utils';
+import { safeDeleteCloudDomains } from '@cloud-commands/domain-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { jira } from '@specs-utils/jira';
+import { setup } from '../test-fixture';
+import { CloudSharedFixture, setupCloudSharedFixture } from './fixtures/cloud-shared-fixture';
+
+setup(120000);
+
+/**
+ * Cloud resolves a new domain's data plane from the ones linked to its environment, rather than from
+ * gravitee.yml. The shared fixture links exactly one, which is the shape the resolution is built for.
+ *
+ * Managed-cloud stack only (local-stack.sh --cloud).
+ */
+describe('AM - Cloud - data plane resolution on domain creation', () => {
+  let shared: CloudSharedFixture;
+  const createdDomainIds: Array<string | null | undefined> = [];
+
+  beforeAll(async () => {
+    shared = await setupCloudSharedFixture();
+  });
+
+  afterEach(async () => {
+    await safeDeleteCloudDomains(shared, createdDomainIds.splice(0));
+  });
+
+  it(jira`should resolve the environment's data plane when dataPlaneId is omitted ${'AM-7262'}`, async () => {
+    const domain = await getDomainApi(shared.accessToken).createDomain({
+      organizationId: shared.organizationId,
+      environmentId: shared.environmentId,
+      newDomain: { name: uniqueName('cloud-dp-omitted', true), description: 'AM-7262' } as any,
+    });
+    createdDomainIds.push(domain.id);
+
+    expect(domain.dataPlaneId).toEqual(shared.dataPlaneId);
+  });
+
+  it(jira`should accept the environment's data plane when supplied explicitly ${'AM-7262'}`, async () => {
+    const domain = await getDomainApi(shared.accessToken).createDomain({
+      organizationId: shared.organizationId,
+      environmentId: shared.environmentId,
+      newDomain: { name: uniqueName('cloud-dp-supplied', true), description: 'AM-7262', dataPlaneId: shared.dataPlaneId },
+    });
+    createdDomainIds.push(domain.id);
+
+    expect(domain.dataPlaneId).toEqual(shared.dataPlaneId);
+  });
+
+  it(jira`should reject a data plane that is not linked to the environment ${'AM-7262'}`, async () => {
+    const created = getDomainApi(shared.accessToken).createDomain({
+      organizationId: shared.organizationId,
+      environmentId: shared.environmentId,
+      newDomain: { name: uniqueName('cloud-dp-unlinked', true), description: 'AM-7262', dataPlaneId: 'not-linked-dp' },
+    });
+
+    await expect(created).rejects.toMatchObject({ response: { status: 400 } });
+  });
+});

--- a/gravitee-am-test/specs/cloud/domain-dataplane-resolution.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-dataplane-resolution.jest.spec.ts
@@ -18,7 +18,6 @@ import { afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { getDomainApi } from '@management-commands/service/utils';
 import { safeDeleteCloudDomains } from '@cloud-commands/domain-commands';
 import { uniqueName } from '@utils-commands/misc';
-import { jira } from '@specs-utils/jira';
 import { setup } from '../test-fixture';
 import { CloudSharedFixture, setupCloudSharedFixture } from './fixtures/cloud-shared-fixture';
 
@@ -42,7 +41,7 @@ describe('AM - Cloud - data plane resolution on domain creation', () => {
     await safeDeleteCloudDomains(shared, createdDomainIds.splice(0));
   });
 
-  it(jira`should resolve the environment's data plane when dataPlaneId is omitted ${'AM-7262'}`, async () => {
+  it("should resolve the environment's data plane when dataPlaneId is omitted", async () => {
     const domain = await getDomainApi(shared.accessToken).createDomain({
       organizationId: shared.organizationId,
       environmentId: shared.environmentId,
@@ -53,7 +52,7 @@ describe('AM - Cloud - data plane resolution on domain creation', () => {
     expect(domain.dataPlaneId).toEqual(shared.dataPlaneId);
   });
 
-  it(jira`should accept the environment's data plane when supplied explicitly ${'AM-7262'}`, async () => {
+  it("should accept the environment's data plane when supplied explicitly", async () => {
     const domain = await getDomainApi(shared.accessToken).createDomain({
       organizationId: shared.organizationId,
       environmentId: shared.environmentId,
@@ -64,7 +63,7 @@ describe('AM - Cloud - data plane resolution on domain creation', () => {
     expect(domain.dataPlaneId).toEqual(shared.dataPlaneId);
   });
 
-  it(jira`should reject a data plane that is not linked to the environment ${'AM-7262'}`, async () => {
+  it('should reject a data plane that is not linked to the environment', async () => {
     const created = getDomainApi(shared.accessToken).createDomain({
       organizationId: shared.organizationId,
       environmentId: shared.environmentId,

--- a/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/domain-entrypoint-url.jest.spec.ts
@@ -16,36 +16,33 @@
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { waitForCockpitConnection } from '@cloud-commands/cockpit-commands';
-import { CloudOrganizationFixture, setupCloudOrganizationFixture } from './fixtures/cloud-organization-fixture';
 import { getDomainApi } from '@management-commands/service/utils';
 import { retryUntil } from '@utils-commands/retry';
 import { setup } from '../test-fixture';
 import { CloudEntrypointFixture, setupCloudEntrypointFixture } from './fixtures/cloud-entrypoint-fixture';
+import { setupCloudSharedFixture } from './fixtures/cloud-shared-fixture';
 
 setup(120000);
 
-const ORGANIZATION_NAME = 'cloud-org-domain-ep';
-
 const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
 
-let organization: CloudOrganizationFixture;
+let accessToken: string;
 let fixture: CloudEntrypointFixture;
 
 beforeAll(async () => {
   await waitForCockpitConnection();
-  organization = await setupCloudOrganizationFixture(ORGANIZATION_NAME);
-  fixture = await setupCloudEntrypointFixture(organization);
+  accessToken = (await setupCloudSharedFixture()).accessToken;
+  fixture = await setupCloudEntrypointFixture();
 });
 
 afterAll(async () => {
   await fixture?.cleanup();
-  await organization?.cleanup();
 });
 
 // The urls the management API resolves for the domain's Overview/Endpoints pages
 // (GET /organizations/{org}/environments/{env}/domains/{domain}/entrypoints).
 const domainEntrypointUrls = async (): Promise<string[]> => {
-  const entrypoints = await getDomainApi(organization.accessToken).getDomainEntrypoints({
+  const entrypoints = await getDomainApi(accessToken).getDomainEntrypoints({
     organizationId: fixture.organizationId,
     environmentId: fixture.environmentId,
     domain: fixture.domainId,

--- a/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/email-entrypoint-url.jest.spec.ts
@@ -17,7 +17,6 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/glob
 import { clearEmails, getLastEmail } from '@utils-commands/email-commands';
 import { uniqueName } from '@utils-commands/misc';
 import { CloudEmailFixture, setupCloudEmailFixture } from './fixtures/cloud-email-fixture';
-import { CloudOrganizationFixture, setupCloudOrganizationFixture } from './fixtures/cloud-organization-fixture';
 import { setup } from '../test-fixture';
 
 setup(200000);
@@ -30,14 +29,12 @@ setup(200000);
  * The entrypoint host is synthetic and never resolves: assert on the link string, never follow it.
  */
 describe('AM - Cloud - entrypoint url in email links', () => {
-  let organization: CloudOrganizationFixture;
   let fixture: CloudEmailFixture;
   let expectedOrigin: string;
   let generatedOrigin: string;
 
   beforeAll(async () => {
-    organization = await setupCloudOrganizationFixture('cloud-org-email');
-    fixture = await setupCloudEmailFixture(organization);
+    fixture = await setupCloudEmailFixture();
     // Through URL rather than string concatenation: uniqueName produces mixed case and hostnames are
     // case-insensitive, so both sides have to be normalised the same way.
     expectedOrigin = new URL(`https://${fixture.overridingHost}`).origin;
@@ -46,7 +43,6 @@ describe('AM - Cloud - entrypoint url in email links', () => {
 
   afterAll(async () => {
     if (fixture) await fixture.cleanup();
-    await organization?.cleanup();
   });
 
   // Cleared per address rather than a blanket delete: the fake SMTP inbox is shared with whatever

--- a/gravitee-am-test/specs/cloud/entrypoint-cache.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/entrypoint-cache.jest.spec.ts
@@ -16,7 +16,6 @@
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { waitForCockpitConnection } from '@cloud-commands/cockpit-commands';
-import { CloudOrganizationFixture, setupCloudOrganizationFixture } from './fixtures/cloud-organization-fixture';
 import { getDomainState } from '@gateway-commands/monitoring-commands';
 import { retryUntil } from '@utils-commands/retry';
 import { setup } from '../test-fixture';
@@ -24,23 +23,18 @@ import { CloudEntrypointFixture, setupCloudEntrypointFixture } from './fixtures/
 
 setup(120000);
 
-const ORGANIZATION_NAME = 'cloud-org-ep-cache';
-
 const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
 const sameUrls = (urls: string[], expected: string[]) => urls.length === expected.length && expected.every((u) => urls.includes(u));
 
-let organization: CloudOrganizationFixture;
 let fixture: CloudEntrypointFixture;
 
 beforeAll(async () => {
   await waitForCockpitConnection();
-  organization = await setupCloudOrganizationFixture(ORGANIZATION_NAME);
-  fixture = await setupCloudEntrypointFixture(organization);
+  fixture = await setupCloudEntrypointFixture();
 });
 
 afterAll(async () => {
   await fixture?.cleanup();
-  await organization?.cleanup();
 });
 
 // These specs share one environment/domain and run in order (jest --runInBand): the initial access

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-email-fixture.ts
@@ -28,11 +28,10 @@ import {
 import { applicationBase64Token } from '@gateway-commands/utils';
 import { retryUntil, withRetry } from '@utils-commands/retry';
 import { uniqueName } from '@utils-commands/misc';
-import { CloudOrganizationFixture } from './cloud-organization-fixture';
+import { setupCloudSharedFixture } from './cloud-shared-fixture';
 import { expect } from '@jest/globals';
 
 const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
-const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 const SCIM_CUSTOM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:extension:custom:2.0:User';
 const RESET_REDIRECT_URI = 'http://localhost:4000';
 const LOGIN_PASSWORD = 'Password123!';
@@ -72,17 +71,16 @@ export interface CloudEmailFixture {
  *
  * Managed-cloud stack only (local-stack.sh --cloud).
  */
-export const setupCloudEmailFixture = async (organization: CloudOrganizationFixture): Promise<CloudEmailFixture> => {
-  const organizationId = organization.organizationId;
-  const accessToken = organization.accessToken;
-  const environmentId = `${organizationId}-env`;
+export const setupCloudEmailFixture = async (): Promise<CloudEmailFixture> => {
+  const shared = await setupCloudSharedFixture();
+  const { organizationId, environmentId, accessToken, dataPlaneId } = shared;
   const entrypointHost = `${uniqueName('gw', true)}.example.com`;
   const overridingHost = `${uniqueName('custom', true)}.example.com`;
   const entrypointUrl = `https://${entrypointHost}`;
   const overridingUrl = `https://${overridingHost}`;
 
-  // 1. Cockpit provisions the environment. The access point it generates itself is the environment's
-  //    default entrypoint; the customer's overriding one is what resolution prefers.
+  // 1. Set this spec's access points on the shared env. The access point Cockpit generates itself is
+  //    the environment's default entrypoint; the customer's overriding one is what resolution prefers.
   await sendCockpitCommand({
     type: 'ENVIRONMENT',
     payload: {
@@ -103,16 +101,13 @@ export const setupCloudEmailFixture = async (organization: CloudOrganizationFixt
     POLL,
   );
 
-  // 1b. Cockpit grants the environment owner right after creating the environment.
-  await organization.grantEnvironmentOwnership(environmentId);
-
   // 2. A domain in that environment, with SCIM on and a service app able to call it. Configure before
   //    enabling the domain so the initial sync picks everything up.
   const domainApi = getDomainApi(accessToken);
   const domain = await domainApi.createDomain({
     organizationId,
     environmentId,
-    newDomain: { name: uniqueName('email-entrypoint-domain', true), dataPlaneId: DATA_PLANE_ID },
+    newDomain: { name: uniqueName('email-entrypoint-domain', true), dataPlaneId },
   });
 
   await domainApi.patchDomain({

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-entrypoint-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-entrypoint-fixture.ts
@@ -20,10 +20,9 @@ import { sendCockpitCommand } from '@cloud-commands/cockpit-commands';
 import { bindSafeDeleteCloudDomain } from '@cloud-commands/domain-commands';
 import { retryUntil } from '@utils-commands/retry';
 import { uniqueName } from '@utils-commands/misc';
-import { CloudOrganizationFixture } from './cloud-organization-fixture';
+import { setupCloudSharedFixture } from './cloud-shared-fixture';
 
 const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
-const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 
 const urlFor = (host: string) => `https://${host}`;
 
@@ -55,18 +54,16 @@ export interface CloudEntrypointFixture {
 }
 
 /**
- * Provisions an environment via a Cockpit ENVIRONMENT command whose GATEWAY access points become
- * entrypoints, then deploys a domain in that environment so its cached entrypoints can be observed
- * through the domain state endpoint. `resyncAccessPoints` re-issues the command to exercise the live
- * update/eviction path (the handler deletes-and-recreates the environment's entrypoints each time).
+ * Deploys an enabled domain in the shared cloud environment so its cached entrypoints can be
+ * observed through the domain state endpoint. `resyncAccessPoints` re-issues the ENVIRONMENT
+ * command to exercise the live update/eviction path (the handler deletes-and-recreates the
+ * environment's entrypoints each time).
+ *
  * Managed-cloud stack only (local-stack.sh --cloud).
  */
-export const setupCloudEntrypointFixture = async (organization: CloudOrganizationFixture): Promise<CloudEntrypointFixture> => {
-  const organizationId = organization.organizationId;
-  const accessToken = organization.accessToken;
-  // Derived from the organization so two specs using this fixture never collide on the environment id
-  // (ids are unique across organizations in AM), while staying fixed so each command is an upsert.
-  const environmentId = `${organizationId}-env`;
+export const setupCloudEntrypointFixture = async (): Promise<CloudEntrypointFixture> => {
+  const shared = await setupCloudSharedFixture();
+  const { organizationId, environmentId, accessToken, dataPlaneId } = shared;
   const uniqueHost = () => `${uniqueName('gw', true)}.example.com`;
 
   // Track every host we ever provision so cleanup removes all of them, not just the current set
@@ -88,26 +85,23 @@ export const setupCloudEntrypointFixture = async (organization: CloudOrganizatio
     return hosts.map(urlFor);
   };
 
-  // 1. Cockpit provisions the environment; its GATEWAY access points are turned into entrypoints.
+  // 1. Set this spec's access points on the shared env.
   const initialHosts = [uniqueHost(), uniqueHost()];
   const expectedUrls = await resyncAccessPoints(initialHosts);
 
-  // 2. Wait until AM has processed the command (environment created + entrypoints persisted).
+  // 2. Wait until AM has processed the command (entrypoints persisted).
   await retryUntil(
     () => getEntrypointsApi(accessToken).listEntrypoints({ organizationId }),
     (entrypoints: any[]) => expectedUrls.every((url) => entrypoints.some((e) => e.url === url)),
     POLL,
   );
 
-  // 2b. Cockpit grants the environment owner right after creating the environment.
-  await organization.grantEnvironmentOwnership(environmentId);
-
-  // 3. Deploy an enabled domain in that environment so its cached entrypoints surface on domain state.
+  // 3. Deploy an enabled domain so its cached entrypoints surface on domain state.
   const domainApi = getDomainApi(accessToken);
   const domain = await domainApi.createDomain({
     organizationId,
     environmentId,
-    newDomain: { name: uniqueName('ep-cache-domain', true), dataPlaneId: DATA_PLANE_ID },
+    newDomain: { name: uniqueName('ep-cache-domain', true), dataPlaneId },
   });
   await domainApi.patchDomain({ organizationId, environmentId, domain: domain.id, patchDomain: { enabled: true } });
   await waitForDomainReady(domain.id);
@@ -137,7 +131,6 @@ export const setupCloudEntrypointFixture = async (organization: CloudOrganizatio
             .catch((err) => console.warn(`cleanup: failed to delete entrypoint ${e.id}: ${err.message}`)),
         ),
     );
-    // Note: organizations and environments have no delete endpoint in the management API
   };
 
   return {

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-license-enforcement-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-license-enforcement-fixture.ts
@@ -17,12 +17,10 @@
 import { getDomainApi } from '@management-commands/service/utils';
 import { getDomainState, waitForDomainReady } from '@gateway-commands/monitoring-commands';
 import { uniqueName } from '@utils-commands/misc';
-import { sendCockpitCommand, waitForCockpitReply } from '@cloud-commands/cockpit-commands';
 import { safeDeleteCloudDomains } from '@cloud-commands/domain-commands';
 import { DomainState } from '../../../api/gateway/apis/MonitoringApi';
 import { CloudLicenseFixture, setupCloudLicenseFixture } from './cloud-license-fixture';
-
-const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
+import { setupCloudSharedFixture } from './cloud-shared-fixture';
 
 export const GATED_PLUGIN = 'magiclink-am-authenticator';
 
@@ -40,37 +38,21 @@ export interface CloudLicenseEnforcementFixture extends CloudLicenseFixture {
 /**
  * Adds domain deployment to the license fixture, so the gateway's decisions can be read off domain state.
  *
- * The domains must live in the same organization the license is pushed to, so the environment is
- * provisioned in the fixture's Cockpit-created organization rather than the default one.
+ * The domains must live in the same organization the license is pushed to, so both come from the
+ * shared cloud org/env whose data plane the gateway is pinned to.
  */
 export const setupCloudLicenseEnforcementFixture = async (): Promise<CloudLicenseEnforcementFixture> => {
-  const licenseFixture = await setupCloudLicenseFixture('cloud-license-gate');
-  const organizationId = licenseFixture.organizationId;
-  const accessToken = licenseFixture.accessToken;
-  const environmentId = 'lic-gate-env';
+  const shared = await setupCloudSharedFixture();
+  const licenseFixture = await setupCloudLicenseFixture(shared);
+  const { organizationId, environmentId, accessToken, dataPlaneId } = shared;
   const domainApi = getDomainApi(accessToken);
   const domainIds: string[] = [];
-
-  const environmentReply = await sendCockpitCommand({
-    type: 'ENVIRONMENT',
-    payload: {
-      id: environmentId,
-      organizationId,
-      hrids: [environmentId],
-      name: `License enforcement env ${environmentId}`,
-      // Required: cloud mode rejects an ENVIRONMENT command with no non-overriding GATEWAY access point.
-      accessPoints: [{ target: 'GATEWAY', host: `${environmentId}.example.com` }],
-    },
-  }).then(waitForCockpitReply);
-  if (environmentReply.commandStatus !== 'SUCCEEDED') {
-    throw new Error(`Cockpit refused to create environment ${environmentId}: ${environmentReply.errorDetails}`);
-  }
 
   const deployDomain = async (): Promise<DomainState> => {
     const domain = await domainApi.createDomain({
       organizationId,
       environmentId,
-      newDomain: { name: uniqueName('lic-gate', true), dataPlaneId: DATA_PLANE_ID },
+      newDomain: { name: uniqueName('lic-gate', true), dataPlaneId },
     });
     domainIds.push(domain.id!);
     await domainApi.patchDomain({ organizationId, environmentId, domain: domain.id!, patchDomain: { enabled: true } });

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-license-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-license-fixture.ts
@@ -19,7 +19,7 @@ import { CockpitQueueEntry } from '@cloud-commands/cockpit-commands';
 import { stackLicenseBase64 } from '@cloud-commands/license-key';
 import { retryUntil } from '@utils-commands/retry';
 import { GraviteeLicense } from '../../../api/management/models/GraviteeLicense';
-import { setupCloudOrganizationFixture } from './cloud-organization-fixture';
+import { CloudOrganizationFixture } from './cloud-organization-fixture';
 
 const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
 
@@ -48,8 +48,7 @@ export interface CloudLicenseFixture {
  *
  * Managed-cloud stack only (local-stack.sh --cloud).
  */
-export const setupCloudLicenseFixture = async (organizationName = 'cloud-license'): Promise<CloudLicenseFixture> => {
-  const organization = await setupCloudOrganizationFixture(organizationName);
+export const setupCloudLicenseFixture = async (organization: CloudOrganizationFixture): Promise<CloudLicenseFixture> => {
   const organizationId = organization.organizationId;
   const licenseApi = getLicenseApi(organization.accessToken);
   const licenseKey = stackLicenseBase64();

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
@@ -39,12 +39,13 @@ const DATA_PLANE_ID = 'cloud-test';
 
 // The definition has to name the same store the gateway is configured with, otherwise the management
 // API writes users the gateway then cannot read. Both stacks run one database, so the branch follows
-// REPOSITORY_TYPE the same way the internal-api data plane fixtures do. The store details are the
-// local stack's own (docker-compose.mongo.yml / docker-compose.postgres.yml), which is the only thing
-// that runs the cloud stack today; the hosts take the same overrides as the internal-api fixtures for
-// a stack that runs the stores elsewhere.
-const MONGO_HOST = process.env.AM_DATAPLANE_MONGO_HOST ?? 'mongodb';
-const JDBC_HOST = process.env.AM_DATAPLANE_JDBC_HOST ?? 'postgres';
+// REPOSITORY_TYPE the same way the internal-api data plane fixtures do. The connection comes from the
+// setup files: AM_INTERNAL_* is the store as the management API reaches it (a docker service name when
+// it runs in the stack), falling back to the runner's view when the node runs natively, same as
+// idps-commands.ts. The database and credentials are the local stack's own and do not move with the
+// runner (GRAVITEE_DATAPLANES_0_* in docker-compose.mongo.yml / docker-compose.postgres.yml).
+const MONGO_URI = process.env.AM_INTERNAL_MONGODB_URI ?? process.env.AM_MONGODB_URI;
+const JDBC_HOST = process.env.AM_INTERNAL_POSTGRES_HOST ?? process.env.AM_POSTGRES_HOST;
 const dataPlaneStore = () =>
   process.env.REPOSITORY_TYPE === 'jdbc'
     ? {
@@ -60,7 +61,7 @@ const dataPlaneStore = () =>
           },
         },
       }
-    : { type: 'mongodb', configuration: { mongodb: { dbname: 'graviteeam', host: MONGO_HOST, port: 27017 } } };
+    : { type: 'mongodb', configuration: { mongodb: { uri: `${MONGO_URI}/graviteeam` } } };
 
 export interface CloudSharedFixture extends CloudOrganizationFixture {
   /** Id of the data plane linked to the shared environment, and the one the gateway is pinned to. */

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
@@ -31,6 +31,26 @@ const ENVIRONMENT_ID = 'cloud-shared-env';
 const USER_ID = 'cloud-shared-owner';
 const DATA_PLANE_ID = 'cloud-test';
 
+// The definition has to name the same store the gateway is configured with, otherwise the management
+// API writes users the gateway then cannot read. Both stacks run one database, so the branch follows
+// REPOSITORY_TYPE the same way the internal-api data plane fixtures do.
+const dataPlaneStore = () =>
+  process.env.REPOSITORY_TYPE === 'jdbc'
+    ? {
+        type: 'jdbc',
+        configuration: {
+          jdbc: {
+            driver: 'postgresql',
+            host: 'postgres',
+            port: 5432,
+            database: 'postgres',
+            username: 'postgres',
+            password: 'postgres',
+          },
+        },
+      }
+    : { type: 'mongodb', configuration: { mongodb: { dbname: 'graviteeam', host: 'mongodb', port: 27017 } } };
+
 export interface CloudSharedFixture extends CloudOrganizationFixture {
   /** Id of the data plane linked to the shared environment, and the one the gateway is pinned to. */
   dataPlaneId: string;
@@ -103,10 +123,9 @@ const provision = async (): Promise<CloudSharedFixture> => {
   const dpResponse = await createDataPlane({
     id: DATA_PLANE_ID,
     name: 'Cloud shared data plane',
-    type: 'mongodb',
     organizationId: ORGANIZATION_ID,
     environmentId: ENVIRONMENT_ID,
-    configuration: { mongodb: { dbname: 'graviteeam', host: 'mongodb', port: 27017 } },
+    ...dataPlaneStore(),
   });
   if (dpResponse.status !== 201 && dpResponse.status !== 409) {
     throw new Error(`Failed to provision shared data plane: status=${dpResponse.status} body=${dpResponse.raw}`);

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
@@ -39,7 +39,12 @@ const DATA_PLANE_ID = 'cloud-test';
 
 // The definition has to name the same store the gateway is configured with, otherwise the management
 // API writes users the gateway then cannot read. Both stacks run one database, so the branch follows
-// REPOSITORY_TYPE the same way the internal-api data plane fixtures do.
+// REPOSITORY_TYPE the same way the internal-api data plane fixtures do. The store details are the
+// local stack's own (docker-compose.mongo.yml / docker-compose.postgres.yml), which is the only thing
+// that runs the cloud stack today; the hosts take the same overrides as the internal-api fixtures for
+// a stack that runs the stores elsewhere.
+const MONGO_HOST = process.env.AM_DATAPLANE_MONGO_HOST ?? 'mongodb';
+const JDBC_HOST = process.env.AM_DATAPLANE_JDBC_HOST ?? 'postgres';
 const dataPlaneStore = () =>
   process.env.REPOSITORY_TYPE === 'jdbc'
     ? {
@@ -47,7 +52,7 @@ const dataPlaneStore = () =>
         configuration: {
           jdbc: {
             driver: 'postgresql',
-            host: 'postgres',
+            host: JDBC_HOST,
             port: 5432,
             database: 'postgres',
             username: 'postgres',
@@ -55,7 +60,7 @@ const dataPlaneStore = () =>
           },
         },
       }
-    : { type: 'mongodb', configuration: { mongodb: { dbname: 'graviteeam', host: 'mongodb', port: 27017 } } };
+    : { type: 'mongodb', configuration: { mongodb: { dbname: 'graviteeam', host: MONGO_HOST, port: 27017 } } };
 
 export interface CloudSharedFixture extends CloudOrganizationFixture {
   /** Id of the data plane linked to the shared environment, and the one the gateway is pinned to. */

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cockpitSignIn, CockpitQueueEntry, sendCockpitCommand, waitForCockpitReply } from '@cloud-commands/cockpit-commands';
+import { createDataPlane } from '@management-commands/dataplane-provisioning-commands';
+import { CloudOrganizationFixture } from './cloud-organization-fixture';
+
+/**
+ * One organization, one environment, one data plane. The `--cloud` local stack pins its gateway to
+ * data plane id {@code cloud-test} (GRAVITEE_REPOSITORIES_GATEWAY_DATAPLANE_ID), and each row in
+ * data_plane_definitions carries a single environmentId, so a single row is the only shape that
+ * lets every cloud spec's domains land on the gateway's DP. Cloud specs run --runInBand, so the
+ * shared environment is safe to reuse across suites; per-spec state (access points, domains) is
+ * reset in each fixture.
+ */
+const ORGANIZATION_ID = 'cloud-shared';
+const ENVIRONMENT_ID = 'cloud-shared-env';
+const USER_ID = 'cloud-shared-owner';
+const DATA_PLANE_ID = 'cloud-test';
+
+export interface CloudSharedFixture extends CloudOrganizationFixture {
+  /** Id of the data plane linked to the shared environment, and the one the gateway is pinned to. */
+  dataPlaneId: string;
+}
+
+let cached: Promise<CloudSharedFixture> | null = null;
+
+/**
+ * Returns the shared cloud org/env/DP, provisioning it on first call and reusing it thereafter.
+ * Managed-cloud stack only (local-stack.sh --cloud).
+ */
+export const setupCloudSharedFixture = (): Promise<CloudSharedFixture> => {
+  if (cached === null) {
+    cached = provision();
+  }
+  return cached;
+};
+
+const provision = async (): Promise<CloudSharedFixture> => {
+  const awaitCommand = async (type: string, payload: Record<string, any>): Promise<CockpitQueueEntry> => {
+    const commandId = await sendCockpitCommand({ type, payload });
+    const reply = await waitForCockpitReply(commandId);
+    if (reply.commandStatus !== 'SUCCEEDED') {
+      throw new Error(`Cockpit ${type} command failed: ${reply.errorDetails}`);
+    }
+    return reply;
+  };
+
+  const resync = (payload: Record<string, any> = {}): Promise<CockpitQueueEntry> =>
+    awaitCommand('ORGANIZATION', {
+      id: ORGANIZATION_ID,
+      name: `Cloud shared organization ${ORGANIZATION_ID}`,
+      hrids: [ORGANIZATION_ID],
+      ...payload,
+    });
+
+  await resync();
+  await awaitCommand('USER', {
+    id: USER_ID,
+    username: USER_ID,
+    firstName: 'Cloud',
+    lastName: 'Owner',
+    email: `${USER_ID}@example.com`,
+    organizationId: ORGANIZATION_ID,
+  });
+  await awaitCommand('MEMBERSHIP', {
+    organizationId: ORGANIZATION_ID,
+    referenceType: 'ORGANIZATION',
+    referenceId: ORGANIZATION_ID,
+    userId: USER_ID,
+    role: 'ORGANIZATION_PRIMARY_OWNER',
+  });
+  await awaitCommand('ENVIRONMENT', {
+    id: ENVIRONMENT_ID,
+    organizationId: ORGANIZATION_ID,
+    hrids: [ENVIRONMENT_ID],
+    name: `Cloud shared environment ${ENVIRONMENT_ID}`,
+    accessPoints: [{ target: 'GATEWAY', host: `${ENVIRONMENT_ID}.example.com` }],
+  });
+  const grantEnvironmentOwnership = (environmentId: string): Promise<CockpitQueueEntry> =>
+    awaitCommand('MEMBERSHIP', {
+      organizationId: ORGANIZATION_ID,
+      referenceType: 'ENVIRONMENT',
+      referenceId: environmentId,
+      userId: USER_ID,
+      role: 'ENVIRONMENT_PRIMARY_OWNER',
+    });
+  await grantEnvironmentOwnership(ENVIRONMENT_ID);
+
+  const dpResponse = await createDataPlane({
+    id: DATA_PLANE_ID,
+    name: 'Cloud shared data plane',
+    type: 'mongodb',
+    organizationId: ORGANIZATION_ID,
+    environmentId: ENVIRONMENT_ID,
+    configuration: { mongodb: { dbname: 'graviteeam', host: 'mongodb', port: 27017 } },
+  });
+  if (dpResponse.status !== 201 && dpResponse.status !== 409) {
+    throw new Error(`Failed to provision shared data plane: status=${dpResponse.status} body=${dpResponse.raw}`);
+  }
+
+  const accessToken = await cockpitSignIn({ sub: USER_ID, organizationId: ORGANIZATION_ID, environmentId: ENVIRONMENT_ID });
+
+  return {
+    organizationId: ORGANIZATION_ID,
+    environmentId: ENVIRONMENT_ID,
+    userId: USER_ID,
+    accessToken,
+    dataPlaneId: DATA_PLANE_ID,
+    resync,
+    grantEnvironmentOwnership,
+    // Nothing to reset: every spec sharing this organization owns its own state and clears it itself.
+    cleanup: async () => undefined,
+  };
+};

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-import { cockpitSignIn, CockpitQueueEntry, sendCockpitCommand, waitForCockpitReply } from '@cloud-commands/cockpit-commands';
-import { createDataPlane } from '@management-commands/dataplane-provisioning-commands';
+import {
+  cockpitSignIn,
+  CockpitQueueEntry,
+  sendCockpitCommand,
+  waitForCockpitConnection,
+  waitForCockpitReply,
+} from '@cloud-commands/cockpit-commands';
+import { createDataPlane, getDataPlane } from '@management-commands/dataplane-provisioning-commands';
 import { CloudOrganizationFixture } from './cloud-organization-fixture';
 
 /**
@@ -87,6 +93,10 @@ const provision = async (): Promise<CloudSharedFixture> => {
       ...payload,
     });
 
+  // Before the first command, not after: waitForCockpitReply gives up at 15s while AM's websocket
+  // to the mock can take up to 30s to come up on a cold --cloud stack.
+  await waitForCockpitConnection();
+
   await resync();
   await awaitCommand('USER', {
     id: USER_ID,
@@ -103,13 +113,16 @@ const provision = async (): Promise<CloudSharedFixture> => {
     userId: USER_ID,
     role: 'ORGANIZATION_PRIMARY_OWNER',
   });
-  await awaitCommand('ENVIRONMENT', {
-    id: ENVIRONMENT_ID,
-    organizationId: ORGANIZATION_ID,
-    hrids: [ENVIRONMENT_ID],
-    name: `Cloud shared environment ${ENVIRONMENT_ID}`,
-    accessPoints: [{ target: 'GATEWAY', host: `${ENVIRONMENT_ID}.example.com` }],
-  });
+  const syncEnvironment = (): Promise<CockpitQueueEntry> =>
+    awaitCommand('ENVIRONMENT', {
+      id: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      hrids: [ENVIRONMENT_ID],
+      name: `Cloud shared environment ${ENVIRONMENT_ID}`,
+      accessPoints: [{ target: 'GATEWAY', host: `${ENVIRONMENT_ID}.example.com` }],
+    });
+
+  await syncEnvironment();
   const grantEnvironmentOwnership = (environmentId: string): Promise<CockpitQueueEntry> =>
     awaitCommand('MEMBERSHIP', {
       organizationId: ORGANIZATION_ID,
@@ -120,16 +133,33 @@ const provision = async (): Promise<CloudSharedFixture> => {
     });
   await grantEnvironmentOwnership(ENVIRONMENT_ID);
 
+  // The data plane can only be created once the environment exists: DataPlaneDefinitionServiceImpl
+  // resolves environmentId and rejects an unknown one.
+  const store = dataPlaneStore();
   const dpResponse = await createDataPlane({
     id: DATA_PLANE_ID,
     name: 'Cloud shared data plane',
     organizationId: ORGANIZATION_ID,
     environmentId: ENVIRONMENT_ID,
-    ...dataPlaneStore(),
+    ...store,
   });
-  if (dpResponse.status !== 201 && dpResponse.status !== 409) {
+  if (dpResponse.status === 409) {
+    // A row left by an earlier run under the other REPOSITORY_TYPE points at a store the gateway is
+    // not reading, and the suite then fails much later with users the gateway cannot see.
+    const existing = await getDataPlane(DATA_PLANE_ID);
+    if (existing.body?.type !== store.type) {
+      throw new Error(
+        `Data plane ${DATA_PLANE_ID} already exists with type=${existing.body?.type}, expected ${store.type}. ` +
+          `Reset the stack (local-stack.sh down) before switching REPOSITORY_TYPE.`,
+      );
+    }
+  } else if (dpResponse.status !== 201) {
     throw new Error(`Failed to provision shared data plane: status=${dpResponse.status} body=${dpResponse.raw}`);
   }
+
+  // The ENVIRONMENT command above created the entrypoints while the environment had no linked plane,
+  // so those events went to `default`. Replay it now the link exists and they route to DATA_PLANE_ID.
+  await syncEnvironment();
 
   const accessToken = await cockpitSignIn({ sub: USER_ID, organizationId: ORGANIZATION_ID, environmentId: ENVIRONMENT_ID });
 

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-webauthn-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-webauthn-fixture.ts
@@ -21,10 +21,9 @@ import { sendCockpitCommand } from '@cloud-commands/cockpit-commands';
 import { bindSafeDeleteCloudDomain } from '@cloud-commands/domain-commands';
 import { retryUntil } from '@utils-commands/retry';
 import { uniqueName } from '@utils-commands/misc';
-import { CloudOrganizationFixture } from './cloud-organization-fixture';
+import { setupCloudSharedFixture } from './cloud-shared-fixture';
 
 const POLL = { timeoutMillis: 30000, intervalMillis: 1000 };
-const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 const REDIRECT_URI = 'https://callback.example.com';
 const PATH_LOGIN_CREDENTIALS = '/webauthn/login/credentials';
 const CONFIGURED_RELYING_PARTY_ID = 'configured.example.com';
@@ -67,10 +66,9 @@ export interface CloudWebAuthnFixture {
  *
  * Managed-cloud stack only (local-stack.sh --cloud).
  */
-export const setupCloudWebAuthnFixture = async (organization: CloudOrganizationFixture): Promise<CloudWebAuthnFixture> => {
-  const organizationId = organization.organizationId;
-  const accessToken = organization.accessToken;
-  const environmentId = uniqueName('env-wa', true);
+export const setupCloudWebAuthnFixture = async (): Promise<CloudWebAuthnFixture> => {
+  const shared = await setupCloudSharedFixture();
+  const { organizationId, environmentId, accessToken, dataPlaneId } = shared;
   // Lowercased: uniqueName capitalises a word, and a host is case-insensitive, so the browser lowercases
   // it when it parses the origin. The relying party id has to match that, not the stored spelling.
   const uniqueHost = () => `${uniqueName('gw', true)}.example.com`.toLowerCase();
@@ -103,9 +101,6 @@ export const setupCloudWebAuthnFixture = async (organization: CloudOrganizationF
 
   await resyncAccessPoints({ generated: generatedHost, overriding: overridingHost });
 
-  // Cockpit grants the environment owner right after creating the environment.
-  await organization.grantEnvironmentOwnership(environmentId);
-
   const domainApi = getDomainApi(accessToken);
   const gatewayUrl = process.env.AM_GATEWAY_URL;
 
@@ -115,7 +110,7 @@ export const setupCloudWebAuthnFixture = async (organization: CloudOrganizationF
     const domain = await domainApi.createDomain({
       organizationId,
       environmentId,
-      newDomain: { name: uniqueName(namePrefix, true), dataPlaneId: DATA_PLANE_ID },
+      newDomain: { name: uniqueName(namePrefix, true), dataPlaneId },
     });
     await domainApi.patchDomain({
       organizationId,

--- a/gravitee-am-test/specs/cloud/fixtures/org-license-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/org-license-fixture.ts
@@ -19,7 +19,7 @@ import { drainCockpitQueue, waitForCockpitConnection } from '@cloud-commands/coc
 import { bindSafeDeleteCloudDomain } from '@cloud-commands/domain-commands';
 import { waitForOrgLicenseScope } from '@management-commands/license-management-commands';
 import { stackLicenseBase64 } from '@cloud-commands/license-key';
-import { setupCloudOrganizationFixture } from './cloud-organization-fixture';
+import { CloudOrganizationFixture } from './cloud-organization-fixture';
 
 export interface OrgLicenseFixture {
   /** Id of the Cockpit-provisioned organization. */
@@ -46,11 +46,10 @@ export interface OrgLicenseFixture {
   cleanup: () => Promise<void>;
 }
 
-export const setupOrgLicenseFixture = async (organizationName = 'org-license'): Promise<OrgLicenseFixture> => {
+export const setupOrgLicenseFixture = async (organization: CloudOrganizationFixture): Promise<OrgLicenseFixture> => {
   await waitForCockpitConnection();
   await drainCockpitQueue();
 
-  const organization = await setupCloudOrganizationFixture(organizationName);
   const organizationId = organization.organizationId;
   const environmentId = organization.environmentId;
   const userId = organization.userId;

--- a/gravitee-am-test/specs/cloud/gateway-org-license.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/gateway-org-license.jest.spec.ts
@@ -36,13 +36,13 @@ import { uniqueName } from '@utils-commands/misc';
 import { setup, retryImmediatelyForThisFile } from '../test-fixture';
 import { jira } from '@specs-utils/jira';
 import { OrgLicenseFixture, setupOrgLicenseFixture } from './fixtures/org-license-fixture';
+import { setupCloudSharedFixture } from './fixtures/cloud-shared-fixture';
 
 setup(300000);
 retryImmediatelyForThisFile();
 
 // Computed at module load (not from the async fixture) so it's known before `it`/`it.skip` is chosen below.
 const hasExpiredLicense = Boolean(process.env.AM_ORG_LICENSE_EXPIRED_PATH);
-const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 
 const AZURE_AD_TYPE = 'azure-ad-am-idp';
 const JKS_CONFIG = JSON.stringify({
@@ -86,7 +86,8 @@ async function patchDomain(body: Record<string, unknown>): Promise<void> {
 }
 
 beforeAll(async () => {
-  fixture = await setupOrgLicenseFixture('gateway-org-license');
+  const shared = await setupCloudSharedFixture();
+  fixture = await setupOrgLicenseFixture(shared);
 
   // Set universe license before domain creation so the gateway enforces it when the
   // domain first deploys. License enforcement applies on domain startup/update, not
@@ -96,7 +97,7 @@ beforeAll(async () => {
   const domainApi = getDomainApi(fixture.accessToken);
   const domain = await domainApi.createDomain({
     ...orgEnv(),
-    newDomain: { name: uniqueName('am7238', true), description: 'AM-7238 gateway license', dataPlaneId: DATA_PLANE_ID },
+    newDomain: { name: uniqueName('am7238', true), description: 'AM-7238 gateway license', dataPlaneId: shared.dataPlaneId },
   });
   domainId = domain.id!;
   domainHrid = domain.hrid!;

--- a/gravitee-am-test/specs/cloud/organization-license-commands.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/organization-license-commands.jest.spec.ts
@@ -29,6 +29,7 @@ import { getOrgLicense, waitForOrgLicenseScope } from '@management-commands/lice
 import { setup, retryImmediatelyForThisFile } from '../test-fixture';
 import { jira } from '@specs-utils/jira';
 import { OrgLicenseFixture, setupOrgLicenseFixture } from './fixtures/org-license-fixture';
+import { setupCloudOrganizationFixture } from './fixtures/cloud-organization-fixture';
 
 setup(300000);
 retryImmediatelyForThisFile();
@@ -36,7 +37,7 @@ retryImmediatelyForThisFile();
 let fixture: OrgLicenseFixture;
 
 beforeAll(async () => {
-  fixture = await setupOrgLicenseFixture('org-license-commands');
+  fixture = await setupOrgLicenseFixture(await setupCloudOrganizationFixture('org-license-commands'));
   // Start from a clean no-license state so tests are predictable.
   await fixture.clearOrgLicense();
 });

--- a/gravitee-am-test/specs/cloud/organization-license-endpoint.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/organization-license-endpoint.jest.spec.ts
@@ -34,6 +34,7 @@ import {
 import { setup, retryImmediatelyForThisFile } from '../test-fixture';
 import { jira } from '@specs-utils/jira';
 import { OrgLicenseFixture, setupOrgLicenseFixture } from './fixtures/org-license-fixture';
+import { setupCloudOrganizationFixture } from './fixtures/cloud-organization-fixture';
 
 setup(300000);
 retryImmediatelyForThisFile();
@@ -41,7 +42,7 @@ retryImmediatelyForThisFile();
 let fixture: OrgLicenseFixture;
 
 beforeAll(async () => {
-  fixture = await setupOrgLicenseFixture('org-license-endpoint');
+  fixture = await setupOrgLicenseFixture(await setupCloudOrganizationFixture('org-license-endpoint'));
   await fixture.clearOrgLicense();
 });
 

--- a/gravitee-am-test/specs/cloud/organization-license.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/organization-license.jest.spec.ts
@@ -18,6 +18,7 @@ import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { waitForCockpitConnection } from '@cloud-commands/cockpit-commands';
 import { setup } from '../test-fixture';
 import { CloudLicenseFixture, OSS_TIER, EXAMPLE_EE_FEATURES, setupCloudLicenseFixture } from './fixtures/cloud-license-fixture';
+import { setupCloudOrganizationFixture } from './fixtures/cloud-organization-fixture';
 
 setup(120000);
 
@@ -25,7 +26,7 @@ let fixture: CloudLicenseFixture;
 
 beforeAll(async () => {
   await waitForCockpitConnection();
-  fixture = await setupCloudLicenseFixture();
+  fixture = await setupCloudLicenseFixture(await setupCloudOrganizationFixture('cloud-license'));
 });
 
 afterAll(async () => {

--- a/gravitee-am-test/specs/cloud/plugin-license-gate.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/plugin-license-gate.jest.spec.ts
@@ -30,11 +30,11 @@ import { uniqueName } from '@utils-commands/misc';
 import { setup, retryImmediatelyForThisFile } from '../test-fixture';
 import { jira } from '@specs-utils/jira';
 import { OrgLicenseFixture, setupOrgLicenseFixture } from './fixtures/org-license-fixture';
+import { setupCloudSharedFixture } from './fixtures/cloud-shared-fixture';
 
 setup(300000);
 retryImmediatelyForThisFile();
 
-const DATA_PLANE_ID = process.env.AM_DOMAIN_DATA_PLANE_ID || 'default';
 const AZURE_AD_TYPE = 'azure-ad-am-idp';
 const INLINE_TYPE = 'inline-am-idp';
 
@@ -79,14 +79,15 @@ const deleteIdp = (idpId: string) =>
   });
 
 beforeAll(async () => {
-  fixture = await setupOrgLicenseFixture('plugin-license-gate');
+  const shared = await setupCloudSharedFixture();
+  fixture = await setupOrgLicenseFixture(shared);
   // Universe license required to start the domain without EE-gate interference.
   await fixture.setUniverseLicense();
 
   const domainApi = getDomainApi(fixture.accessToken);
   const domain = await domainApi.createDomain({
     ...orgEnv(),
-    newDomain: { name: uniqueName('am7241', true), description: 'AM-7241 plugin license gate', dataPlaneId: DATA_PLANE_ID },
+    newDomain: { name: uniqueName('am7241', true), description: 'AM-7241 plugin license gate', dataPlaneId: shared.dataPlaneId },
   });
   await domainApi.patchDomain({ ...orgEnv(), domain: domain.id!, patchDomain: { enabled: true } });
   const started = await waitForDomainStart(domain);

--- a/gravitee-am-test/specs/cloud/webauthn-entrypoint-origin.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/webauthn-entrypoint-origin.jest.spec.ts
@@ -19,7 +19,6 @@ import { waitForCockpitConnection } from '@cloud-commands/cockpit-commands';
 import { retryUntil } from '@utils-commands/retry';
 import { setup } from '../test-fixture';
 import { CloudWebAuthnFixture, setupCloudWebAuthnFixture } from './fixtures/cloud-webauthn-fixture';
-import { CloudOrganizationFixture, setupCloudOrganizationFixture } from './fixtures/cloud-organization-fixture';
 
 setup(200000);
 
@@ -34,18 +33,15 @@ setup(200000);
  * one has to survive, because existing credentials are bound to it.
  */
 describe('AM - Cloud - webauthn relying party from the environment entrypoint', () => {
-  let organization: CloudOrganizationFixture;
   let fixture: CloudWebAuthnFixture;
 
   beforeAll(async () => {
     await waitForCockpitConnection();
-    organization = await setupCloudOrganizationFixture('cloud-org-webauthn');
-    fixture = await setupCloudWebAuthnFixture(organization);
+    fixture = await setupCloudWebAuthnFixture();
   });
 
   afterAll(async () => {
     await fixture?.cleanup();
-    await organization?.cleanup();
   });
 
   it('scopes the ceremony to the environment entrypoint rather than the configured localhost', async () => {

--- a/gravitee-am-test/specs/management/domain-create.jest.spec.ts
+++ b/gravitee-am-test/specs/management/domain-create.jest.spec.ts
@@ -55,7 +55,7 @@ describe('Domain Create', () => {
     expect(fetched.description).toEqual(description);
   });
 
-  it(jira`should default dataPlaneId when omitted on a standalone stack ${'AM-7262'}`, async () => {
+  it('should default dataPlaneId when omitted on a standalone stack', async () => {
     const name = uniqueName('domain-create-nodp', true);
 
     // Bypass the helper: send NewDomain without dataPlaneId at all.
@@ -71,7 +71,7 @@ describe('Domain Create', () => {
     expect(created.dataPlaneId).toBe('default');
   });
 
-  it(jira`should reject an unknown dataPlaneId ${'AM-7262'}`, async () => {
+  it('should reject an unknown dataPlaneId', async () => {
     const name = uniqueName('domain-create-baddp', true);
 
     let status: number | undefined;

--- a/gravitee-am-test/specs/management/domain-create.jest.spec.ts
+++ b/gravitee-am-test/specs/management/domain-create.jest.spec.ts
@@ -55,6 +55,43 @@ describe('Domain Create', () => {
     expect(fetched.description).toEqual(description);
   });
 
+  it(jira`should default dataPlaneId when omitted on a standalone stack ${'AM-7262'}`, async () => {
+    const name = uniqueName('domain-create-nodp', true);
+
+    // Bypass the helper: send NewDomain without dataPlaneId at all.
+    const raw = await getDomainApi(accessToken).createDomainRaw({
+      organizationId: process.env.AM_DEF_ORG_ID,
+      environmentId: process.env.AM_DEF_ENV_ID,
+      newDomain: { name, description: 'AM-7262' } as any,
+    });
+    expect(raw.raw.status).toBe(201);
+    const created = await raw.raw.json();
+    domainId = created.id;
+
+    expect(created.dataPlaneId).toBe('default');
+  });
+
+  it(jira`should reject an unknown dataPlaneId ${'AM-7262'}`, async () => {
+    const name = uniqueName('domain-create-baddp', true);
+
+    let status: number | undefined;
+    let message = '';
+    try {
+      await getDomainApi(accessToken).createDomainRaw({
+        organizationId: process.env.AM_DEF_ORG_ID,
+        environmentId: process.env.AM_DEF_ENV_ID,
+        newDomain: { name, description: 'AM-7262', dataPlaneId: 'ghost-dp' },
+      });
+    } catch (e: any) {
+      status = e?.response?.status;
+      // runtime.request() already drained the body into e.message; re-reading it throws
+      message = e?.message ?? '';
+    }
+    expect(status).toBeGreaterThanOrEqual(400);
+    expect(status).toBeLessThan(500);
+    expect(message).toMatch(/data plane/i);
+  });
+
   it('should return createdAt and updatedAt as epoch-millisecond numbers', async () => {
     const name = uniqueName('domain-create-test', true);
     const description = 'Test domain created by regression test AM-2217';

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -33,13 +33,15 @@ export const DATABASE_NAME = 'gravitee-am-e2e-dataplane';
 
 /**
  * The store as the management API reaches it, which is a docker service name when it runs in the
- * stack and localhost when it is run natively against a standalone container. Only the checks that
- * expect a store to answer care, but they all read the same value so a definition cannot be half
- * reachable.
+ * stack and localhost when it is run natively, so it comes from the setup files' AM_INTERNAL_* pair
+ * falling back to the runner's view, same as idps-commands.ts and the cloud fixture. Only the checks
+ * that expect a store to answer care, but they all read the same value so a definition cannot be half
+ * reachable. The payloads take a host and port rather than a uri, hence the parse.
  */
-const MONGO_HOST = process.env.AM_DATAPLANE_MONGO_HOST ?? 'mongodb';
-const MONGO_PORT = 27017;
-const JDBC_HOST = process.env.AM_DATAPLANE_JDBC_HOST ?? 'postgres';
+const mongoUri = new URL(process.env.AM_INTERNAL_MONGODB_URI ?? process.env.AM_MONGODB_URI);
+const MONGO_HOST = mongoUri.hostname;
+const MONGO_PORT = Number(mongoUri.port);
+const JDBC_HOST = process.env.AM_INTERNAL_POSTGRES_HOST ?? process.env.AM_POSTGRES_HOST;
 const JDBC_PORT = 5432;
 
 export const MONGO_SUMMARY = { database: DATABASE_NAME, hosts: [`${MONGO_HOST}:${MONGO_PORT}`] };
@@ -135,7 +137,7 @@ export function unreachablePayload(id: string): NewDataPlane {
         configuration: {
           jdbc: {
             driver: 'postgresql',
-            host: 'postgres',
+            host: JDBC_HOST,
             port: 9999,
             database: 'postgres',
             username: 'postgres',
@@ -147,7 +149,7 @@ export function unreachablePayload(id: string): NewDataPlane {
         id,
         name: 'E2E unreachable data plane',
         type: 'mongodb',
-        configuration: { mongodb: { dbname: 'gravitee-am', host: 'mongodb', port: 9999 } },
+        configuration: { mongodb: { dbname: 'gravitee-am', host: MONGO_HOST, port: 9999 } },
       };
 }
 


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-7262

## :pencil2: A description of the changes proposed in the pull request

`dataPlaneId` is now optional on domain creation. Dropped the `@NotNull`, and the openapi required list and the TS SDK are regenerated to match.

Cloud resolves the plane from the ones provisioned against the environment. It picks the single linked one when the caller omits the id, rejects zero or many, and rejects a supplied id that isn't linked. Standalone is looser on purpose, because the planes `gravitee.yml` declares serve every environment. A supplied id just has to exist in the registry, so `default` stays valid for an environment that also has one provisioned against it. An omitted id only falls back to `default` when `gravitee.yml` declares just `default` and nothing is provisioned for the environment.

Any id that comes from the caller or from an environment link is checked against the registry on this node before a domain gets bound to it. A linked row only means the id is claimed. Activation can still fail, and `verified()` returns complete for an id it was never handed, so without the check you get a domain pointing at a store nothing can read or write. The standalone fallback to `default` is the one path that skips it, because it only fires when `default` is the single declared plane.

Entrypoint events publish one event per target plane now instead of taking whichever row the repository hands back first. An environment can hold several linked planes and a gateway pinned to any of the others would never see the change. Standalone adds `default` to the targets, since a domain there can sit on a `gravitee.yml` plane while the environment has another provisioned against it.

The cloud jest specs needed reshaping before any of this could be tested. Each fixture provisioned its own org and environment and no data plane at all, so every cloud domain fell back to `default`. There's now one shared org, environment and data plane in `cloud-shared-fixture.ts`, the compose overlay pins the cloud gateway to `cloud-test` to match, and every cloud spec and fixture moved onto it. Per suite state is still torn down per suite, and `ci:cloud` runs `--runInBand`, so sharing the environment is safe. That's most of the file count in this PR.

Still open, worth knowing: a standalone domain on a `gravitee.yml` plane that isn't `default` won't get entrypoint events. `EntrypointServiceImpl` targets the environment's linked planes plus `default` and nothing else. Reading the declared ids there is doable, the module dependency is already in place, it just felt like more than this PR should carry.

## :memo: Test scenarios 

`DomainServiceTest` and `EntrypointServiceTest` cover every resolution branch, including the not-linked and not-loaded rejections and the entrypoint fan out.

New spec at `specs/cloud/domain-dataplane-resolution.jest.spec.ts` covers omitted, supplied and unlinked against a real gateway. `specs/management/domain-create.jest.spec.ts` covers the standalone side: omitting the id lands the domain on `default`, an unknown id gets a 4xx.

Ran the cloud jest suite and the playwright cloud project on both mongo and postgres, plus the full management suite on `--maxWorkers=2`, all green.

## :computer: Add screenshots for UI

No UI change.

## :books: Any other comments that will help with documentation

One trade off worth a look. Management nodes register provisioned planes from sync events, so during that propagation window a node that hasn't seen a newly provisioned plane will 400 on domain creation instead of binding the domain to a plane it can't reach. I'd rather have the clear rejection than the silent bad write, but shout if you disagree.

The SDK regen is a two line change to `NewDomain.ts`, kept in its own `chore(sdk)` commit.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

