### PR TITLE
fix: use dedicated object mapper for ClaimRequest

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestParseParametersHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/resources/handler/authorization/AuthorizationRequestParseParametersHandler.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.resources.handler.authorization;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.oauth2.CodeChallengeMethod;
 import io.gravitee.am.common.oauth2.GrantType;
@@ -35,7 +38,6 @@ import io.gravitee.am.gateway.handler.oidc.service.request.ClaimsRequestResolver
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.oidc.Client;
 import io.vertx.core.Handler;
-import io.vertx.core.json.Json;
 import io.vertx.rxjava3.ext.auth.User;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 
@@ -64,6 +66,8 @@ import static io.gravitee.am.service.utils.ResponseTypeUtils.requireNonce;
  * @author GraviteeSource Team
  */
 public class AuthorizationRequestParseParametersHandler extends AbstractAuthorizationRequestHandler implements Handler<RoutingContext> {
+
+    private static final ObjectMapper CLAIMS_MAPPER = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.ALWAYS);
 
     private final ClaimsRequestResolver claimsRequestResolver = new ClaimsRequestResolver();
     private final Domain domain;
@@ -237,8 +241,8 @@ public class AuthorizationRequestParseParametersHandler extends AbstractAuthoriz
                     }
                 }
                 // save claims request as json string value (will be use for id_token and/or UserInfo endpoint)
-                context.request().params().set(Parameters.CLAIMS, Json.encode(claimsRequest));
-            } catch (ClaimsRequestSyntaxException e) {
+                context.request().params().set(Parameters.CLAIMS, CLAIMS_MAPPER.writeValueAsString(claimsRequest));
+            } catch (ClaimsRequestSyntaxException | JsonProcessingException e) {
                 throw new InvalidRequestException("Invalid parameter: claims");
             }
         }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/AM-7525

the change is already on **master**

steps to reproduce:
- setup app with openid scope
- create a user and add additionalInformation entry nickname=aaa
- /authorize with special parameter `claims=%7B%22id_token%22%3A%7B%22nickname%22%3Anull%7D%7D` 
- obtain the token. the id_token should contain nickname claim

before:
neither access_token nor id_token cotain claim