### PR TITLE
feat: AM-7386 CSP directives validation

### DIFF
--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -2109,16 +2109,26 @@ components:
       properties:
         directives:
           type: array
-          description: "CSP directives, each in the form \"directive-name value;\"\
-            ."
+          description: "CSP directives, one per entry, in the form \"directive-name\
+            \ value\". A trailing semicolon is optional. Directive names must be valid\
+            \ CSP tokens and must not repeat; values are not interpreted. Directives\
+            \ that take no value, such as \"upgrade-insecure-requests\", may be supplied\
+            \ on their own. When reportOnly is enabled, a \"report-uri\" or \"report-to\"\
+            \ directive is required."
           example:
-          - default-src 'self';
-          - script-src 'self';
+          - default-src 'self'
+          - script-src 'self'
+          - upgrade-insecure-requests
           items:
             type: string
-            description: "CSP directives, each in the form \"directive-name value;\"\
-              ."
-            example: "[\"default-src 'self';\",\"script-src 'self';\"]"
+            description: "CSP directives, one per entry, in the form \"directive-name\
+              \ value\". A trailing semicolon is optional. Directive names must be\
+              \ valid CSP tokens and must not repeat; values are not interpreted.\
+              \ Directives that take no value, such as \"upgrade-insecure-requests\"\
+              , may be supplied on their own. When reportOnly is enabled, a \"report-uri\"\
+              \ or \"report-to\" directive is required."
+            example: "[\"default-src 'self'\",\"script-src 'self'\",\"upgrade-insecure-requests\"\
+              ]"
         enabled:
           type: boolean
           default: false

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -13936,16 +13936,26 @@ components:
       properties:
         directives:
           type: array
-          description: "CSP directives, each in the form \"directive-name value;\"\
-            ."
+          description: "CSP directives, one per entry, in the form \"directive-name\
+            \ value\". A trailing semicolon is optional. Directive names must be valid\
+            \ CSP tokens and must not repeat; values are not interpreted. Directives\
+            \ that take no value, such as \"upgrade-insecure-requests\", may be supplied\
+            \ on their own. When reportOnly is enabled, a \"report-uri\" or \"report-to\"\
+            \ directive is required."
           example:
-          - default-src 'self';
-          - script-src 'self';
+          - default-src 'self'
+          - script-src 'self'
+          - upgrade-insecure-requests
           items:
             type: string
-            description: "CSP directives, each in the form \"directive-name value;\"\
-              ."
-            example: "[\"default-src 'self';\",\"script-src 'self';\"]"
+            description: "CSP directives, one per entry, in the form \"directive-name\
+              \ value\". A trailing semicolon is optional. Directive names must be\
+              \ valid CSP tokens and must not repeat; values are not interpreted.\
+              \ Directives that take no value, such as \"upgrade-insecure-requests\"\
+              , may be supplied on their own. When reportOnly is enabled, a \"report-uri\"\
+              \ or \"report-to\" directive is required."
+            example: "[\"default-src 'self'\",\"script-src 'self'\",\"upgrade-insecure-requests\"\
+              ]"
         enabled:
           type: boolean
           default: false

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSPHandlerFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSPHandlerFactory.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.common.vertx.web.handler;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.csp.CspHandlerImpl;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.csp.NoOpCspHandler;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.webprotection.CspDirective;
 import io.gravitee.am.model.webprotection.CspSettings;
 import io.gravitee.am.model.webprotection.WebProtectionResolution;
 import org.slf4j.Logger;
@@ -31,8 +32,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static java.lang.Boolean.TRUE;
 import static java.util.Objects.isNull;
 
 /**
@@ -69,6 +72,9 @@ public class CSPHandlerFactory implements FactoryBean<CSPHandler> {
                     domain.getName());
             return createFromEnvironment();
         }
+        if (missingReportTarget(settings.isReportOnly(), directives)) {
+            return new NoOpCspHandler();
+        }
         return new CspHandlerImpl(settings.isReportOnly(), directives, settings.isScriptInlineNonce());
     }
 
@@ -81,7 +87,31 @@ public class CSPHandlerFactory implements FactoryBean<CSPHandler> {
         if ((isNull(reportOnly) && isNull(directives) && !scriptInlineNonce) || notEnabled) {
             return new NoOpCspHandler();
         }
+        if (missingReportTarget(TRUE.equals(reportOnly), directives)) {
+            return new NoOpCspHandler();
+        }
         return new CspHandlerImpl(reportOnly, directives, scriptInlineNonce);
+    }
+
+    /**
+     * Vert.x fails the request with HTTP 500 when report-only is set and the policy carries neither
+     * {@code report-uri} nor {@code report-to}, so send no CSP header at all to avoid breaking the login page.
+     */
+    private boolean missingReportTarget(boolean reportOnly, List<String> directives) {
+        if (!reportOnly) {
+            return false;
+        }
+        final boolean hasReportTarget = directives != null && directives.stream()
+                .map(CspDirective::parse)
+                .filter(Objects::nonNull)
+                .anyMatch(directive -> directive.isReportTarget() && directive.hasValue());
+        if (!hasReportTarget) {
+            logger.error("CSP is report-only for domain: {} but no report-uri or report-to directive is configured. " +
+                    "No Content-Security-Policy header will be sent. Add a report target or disable report-only.",
+                    domain.getName());
+            return true;
+        }
+        return false;
     }
 
     private List<String> resolveDirectives(List<String> domainDirectives) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/csp/CspHandlerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/csp/CspHandlerImpl.java
@@ -18,11 +18,13 @@ package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.csp;
 
 import io.gravitee.am.common.utils.SecureRandomString;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.CSPHandler;
+import io.gravitee.am.model.webprotection.CspDirective;
 import io.vertx.rxjava3.ext.web.RoutingContext;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static io.gravitee.am.common.utils.ConstantKeys.CSP_SCRIPT_INLINE_NONCE;
@@ -51,7 +53,7 @@ public class CspHandlerImpl implements CSPHandler {
     }
 
     private void addDirectives(List<String> directives) {
-        if (nonNull(directives) && directives.size() > 0) {
+        if (nonNull(directives) && !directives.isEmpty()) {
             final Map<String, String> mapOfDirectives = buildDirectivesMap(directives);
 
             if (mapOfDirectives.containsKey(SCRIPT_SRC_DIRECTIVE)) {
@@ -59,24 +61,20 @@ public class CspHandlerImpl implements CSPHandler {
             }
 
             mapOfDirectives.entrySet().stream()
-                    .filter(e -> !e.getKey().isEmpty() && !e.getValue().isEmpty())
+                    .filter(e -> !e.getKey().isEmpty())
                     .forEach(e -> this.delegate.addDirective(e.getKey(), e.getValue()));
         }
     }
 
     private Map<String, String> buildDirectivesMap(List<String> directives) {
-        return directives.stream().map(directive -> directive.split("[ \t]", 2))
-                .filter(directive -> directive.length == 2)
-                .map(this::getDirectiveEntry)
-                .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
-    }
-
-    private Entry<String, String> getDirectiveEntry(String[] directive) {
-        var value = directive[1].trim();
-        if (value.endsWith(";")) {
-            value = value.substring(0, value.length() - 1);
-        }
-        return Map.entry(directive[0].trim(), value.trim());
+        return directives.stream()
+                .map(CspDirective::parse)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(
+                        CspDirective::canonicalName,
+                        CspDirective::value,
+                        (first, last) -> last,
+                        LinkedHashMap::new));
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSPHandlerFactoryTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/CSPHandlerFactoryTest.java
@@ -101,4 +101,87 @@ public class CSPHandlerFactoryTest {
 
         assertTrue(factory.getObject() instanceof CspHandlerImpl);
     }
+
+    @Test
+    public void shouldSendNoHeaderWhenDomainIsReportOnlyWithoutReportTarget() {
+        final CspSettings cspSettings = new CspSettings();
+        cspSettings.setInherited(false);
+        cspSettings.setEnabled(true);
+        cspSettings.setReportOnly(true);
+        cspSettings.setDirectives(List.of("default-src 'self'"));
+
+        final WebProtectionSettings webProtectionSettings = new WebProtectionSettings();
+        webProtectionSettings.setCsp(cspSettings);
+
+        when(domain.getWebProtectionSettings()).thenReturn(webProtectionSettings);
+
+        assertTrue(factory.getObject() instanceof NoOpCspHandler);
+    }
+
+    @Test
+    public void shouldBuildHandlerWhenDomainIsReportOnlyWithReportUri() {
+        assertReportOnlyDomainAccepts("report-uri /csp-reports");
+    }
+
+    @Test
+    public void shouldBuildHandlerWhenDomainIsReportOnlyWithReportTo() {
+        assertReportOnlyDomainAccepts("report-to csp-endpoint");
+    }
+
+    @Test
+    public void shouldSendNoHeaderWhenDomainReportTargetHasNoValue() {
+        final CspSettings cspSettings = new CspSettings();
+        cspSettings.setInherited(false);
+        cspSettings.setEnabled(true);
+        cspSettings.setReportOnly(true);
+        cspSettings.setDirectives(List.of("default-src 'self'", "report-uri"));
+
+        final WebProtectionSettings webProtectionSettings = new WebProtectionSettings();
+        webProtectionSettings.setCsp(cspSettings);
+
+        when(domain.getWebProtectionSettings()).thenReturn(webProtectionSettings);
+
+        assertTrue(factory.getObject() instanceof NoOpCspHandler);
+    }
+
+    @Test
+    public void shouldSendNoHeaderWhenEnvironmentIsReportOnlyWithoutReportTarget() {
+        when(domain.getWebProtectionSettings()).thenReturn(null);
+        when(environment.getProperty("http.csp.reportOnly", Boolean.class)).thenReturn(true);
+
+        assertTrue(factory.getObject() instanceof NoOpCspHandler);
+    }
+
+    @Test
+    public void shouldSendNoHeaderWhenDomainIsReportOnlyAndDirectivesFallBackToDefaults() {
+        // An empty domain list resolves to the bundled default-csp-directives.properties, which carries no
+        // report target — the safety net has to look at the resolved list, not the configured one.
+        final CspSettings cspSettings = new CspSettings();
+        cspSettings.setInherited(false);
+        cspSettings.setEnabled(true);
+        cspSettings.setReportOnly(true);
+        cspSettings.setDirectives(List.of());
+
+        final WebProtectionSettings webProtectionSettings = new WebProtectionSettings();
+        webProtectionSettings.setCsp(cspSettings);
+
+        when(domain.getWebProtectionSettings()).thenReturn(webProtectionSettings);
+
+        assertTrue(factory.getObject() instanceof NoOpCspHandler);
+    }
+
+    private void assertReportOnlyDomainAccepts(String reportDirective) {
+        final CspSettings cspSettings = new CspSettings();
+        cspSettings.setInherited(false);
+        cspSettings.setEnabled(true);
+        cspSettings.setReportOnly(true);
+        cspSettings.setDirectives(List.of("default-src 'self'", reportDirective));
+
+        final WebProtectionSettings webProtectionSettings = new WebProtectionSettings();
+        webProtectionSettings.setCsp(cspSettings);
+
+        when(domain.getWebProtectionSettings()).thenReturn(webProtectionSettings);
+
+        assertTrue(factory.getObject() instanceof CspHandlerImpl);
+    }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/csp/CspHandlerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/csp/CspHandlerImplTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.csp;
+
+import io.vertx.core.http.HttpServerResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CspHandlerImplTest {
+
+    private static final String CSP_HEADER = "Content-Security-Policy";
+    private static final String CSP_REPORT_ONLY_HEADER = "Content-Security-Policy-Report-Only";
+
+    private io.vertx.rxjava3.ext.web.RoutingContext rxRoutingContext;
+    private HttpServerResponse response;
+
+    @Before
+    public void setUp() {
+        response = mock(HttpServerResponse.class);
+        final io.vertx.ext.web.RoutingContext coreRoutingContext = mock(io.vertx.ext.web.RoutingContext.class);
+        when(coreRoutingContext.response()).thenReturn(response);
+
+        rxRoutingContext = mock(io.vertx.rxjava3.ext.web.RoutingContext.class);
+        when(rxRoutingContext.getDelegate()).thenReturn(coreRoutingContext);
+    }
+
+    private String handleAndCaptureHeader(CspHandlerImpl handler, String headerName) {
+        handler.handle(rxRoutingContext);
+
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response).putHeader(eq(headerName), captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void shouldResolveDuplicateDirectivesLastWinsInsteadOfThrowing() {
+        final CspHandlerImpl handler = new CspHandlerImpl(
+                false, List.of("script-src 'self'", "script-src 'none'"), false);
+
+        final String policy = handleAndCaptureHeader(handler, CSP_HEADER);
+
+        assertTrue(policy, policy.contains("script-src 'none'"));
+        assertEquals("script-src should appear once", 1, countOccurrences(policy, "script-src"));
+    }
+
+    @Test
+    public void shouldResolveDuplicatesAcrossDifferentCasing() {
+        final CspHandlerImpl handler = new CspHandlerImpl(
+                false, List.of("Script-Src 'self'", "script-src 'none'"), false);
+
+        final String policy = handleAndCaptureHeader(handler, CSP_HEADER);
+
+        assertEquals("script-src should appear once", 1, countOccurrences(policy, "script-src"));
+        assertTrue(policy, policy.contains("'none'"));
+    }
+
+    @Test
+    public void shouldEmitDirectivesWithoutAValue() {
+        final CspHandlerImpl handler = new CspHandlerImpl(
+                false, List.of("default-src 'self'", "upgrade-insecure-requests"), false);
+
+        final String policy = handleAndCaptureHeader(handler, CSP_HEADER);
+
+        assertTrue(policy, policy.contains("upgrade-insecure-requests"));
+    }
+
+    @Test
+    public void shouldTreatTrailingSemicolonAsOptional() {
+        final CspHandlerImpl withSemicolon = new CspHandlerImpl(false, List.of("default-src 'self';"), false);
+        final String policy = handleAndCaptureHeader(withSemicolon, CSP_HEADER);
+
+        assertTrue(policy, policy.contains("default-src 'self'"));
+        assertEquals("value must not keep the trailing semicolon", 0, countOccurrences(policy, "'self';"));
+    }
+
+    @Test
+    public void shouldApplyNonceToMixedCaseScriptSrcWithoutDuplicatingIt() {
+        final CspHandlerImpl handler = new CspHandlerImpl(
+                false, List.of("Script-Src 'self'"), true);
+
+        final String policy = handleAndCaptureHeader(handler, CSP_HEADER);
+
+        // Two script-src entries would make the browser discard the second, silently dropping the nonce.
+        assertEquals("script-src should appear once", 1, countOccurrences(policy, "script-src"));
+        assertTrue(policy, policy.contains("'self'"));
+        assertTrue(policy, policy.contains("'nonce-"));
+    }
+
+    @Test
+    public void shouldNotAccumulateNoncesAcrossRequests() {
+        final CspHandlerImpl handler = new CspHandlerImpl(false, List.of("script-src 'self'"), true);
+
+        handler.handle(rxRoutingContext);
+        handler.handle(rxRoutingContext);
+
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response, org.mockito.Mockito.times(2)).putHeader(eq(CSP_HEADER), captor.capture());
+
+        final String secondPolicy = captor.getAllValues().get(1);
+        assertEquals("only one nonce should be present", 1, countOccurrences(secondPolicy, "'nonce-"));
+    }
+
+    @Test
+    public void shouldUseReportOnlyHeaderWhenReportOnly() {
+        final CspHandlerImpl handler = new CspHandlerImpl(
+                true, List.of("default-src 'self'", "report-uri /csp-reports"), false);
+
+        final String policy = handleAndCaptureHeader(handler, CSP_REPORT_ONLY_HEADER);
+
+        assertTrue(policy, policy.contains("report-uri /csp-reports"));
+    }
+
+    @Test
+    public void shouldIgnoreBlankEntries() {
+        final CspHandlerImpl handler = new CspHandlerImpl(
+                false, java.util.Arrays.asList("default-src 'self'", "", "   ", ";"), false);
+
+        final String policy = handleAndCaptureHeader(handler, CSP_HEADER);
+
+        assertTrue(policy, policy.contains("default-src 'self'"));
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        final String lowerHaystack = haystack.toLowerCase(Locale.ROOT);
+        final String lowerNeedle = needle.toLowerCase(Locale.ROOT);
+        int count = 0;
+        int index = lowerHaystack.indexOf(lowerNeedle);
+        while (index >= 0) {
+            count++;
+            index = lowerHaystack.indexOf(lowerNeedle, index + lowerNeedle.length());
+        }
+        return count;
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/webprotection/CspDirective.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/webprotection/CspDirective.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.webprotection;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * A single Content Security Policy directive.
+ * <p>
+ * A trailing {@code ;} is optional and is discarded on parse. Directive names are case-insensitive
+ * per the CSP specification, so comparisons should use {@link #canonicalName()}; the name as typed
+ * by the operator is preserved in {@link #name()}.
+ * <p>
+ * Source-list values are not interpreted: everything after the first whitespace run is kept verbatim.
+ *
+ * @author GraviteeSource Team
+ */
+public record CspDirective(String name, String value) {
+
+    private static final Pattern VALID_NAME = Pattern.compile("^[a-z0-9-]+$");
+
+    /**
+     * Directives that carry no value at all, e.g. {@code upgrade-insecure-requests}.
+     */
+    private static final Set<String> NO_VALUE_DIRECTIVES = Set.of(
+            "upgrade-insecure-requests",
+            "block-all-mixed-content"
+    );
+
+    /**
+     * Directives whose value is optional, e.g. a bare {@code sandbox} is the most restrictive form.
+     */
+    private static final Set<String> OPTIONAL_VALUE_DIRECTIVES = Set.of(
+            "sandbox",
+            "trusted-types"
+    );
+
+    public static final String REPORT_URI = "report-uri";
+    public static final String REPORT_TO = "report-to";
+
+    /**
+     * Parses a stored directive entry.
+     *
+     * @return the parsed directive, or {@code null} if the entry is null, blank, or only a semicolon
+     */
+    public static CspDirective parse(String entry) {
+        if (entry == null) {
+            return null;
+        }
+        final String stripped = stripTrailingSemicolon(entry);
+        if (stripped.isEmpty()) {
+            return null;
+        }
+        final String[] parts = stripped.split("[ \t]+", 2);
+        return new CspDirective(parts[0], parts.length == 2 ? parts[1].trim() : "");
+    }
+
+    /**
+     * Trims the entry and discards a single trailing {@code ;}. Any remaining semicolon is an
+     * embedded one, which callers may reject.
+     */
+    public static String stripTrailingSemicolon(String entry) {
+        final String trimmed = entry.trim();
+        if (trimmed.endsWith(";")) {
+            return trimmed.substring(0, trimmed.length() - 1).trim();
+        }
+        return trimmed;
+    }
+
+    /**
+     * The directive name lowercased, for comparison and for keying the policy map.
+     */
+    public String canonicalName() {
+        return name.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Renders back to the {@code "name value"} storage form, without a trailing semicolon.
+     */
+    public String render() {
+        return value.isEmpty() ? name : name + " " + value;
+    }
+
+    public boolean hasValue() {
+        return !value.isEmpty();
+    }
+
+    /**
+     * Whether this directive is one of the report targets Vert.x requires in report-only mode.
+     */
+    public boolean isReportTarget() {
+        final String canonical = canonicalName();
+        return REPORT_URI.equals(canonical) || REPORT_TO.equals(canonical);
+    }
+
+    /**
+     * Whether a value carries a character that cannot be written to an HTTP header.
+     */
+    public static boolean hasIllegalHeaderCharacter(String value) {
+        return value != null && value.chars().anyMatch(c -> (c < 0x20 && c != '\t') || c == 0x7f);
+    }
+
+    public static boolean isValidName(String canonicalName) {
+        return canonicalName != null && VALID_NAME.matcher(canonicalName).matches();
+    }
+
+    /**
+     * Whether a value must be supplied. False for directives that take no value, and for those
+     * where it is optional.
+     */
+    public static boolean requiresValue(String canonicalName) {
+        return !NO_VALUE_DIRECTIVES.contains(canonicalName) && !OPTIONAL_VALUE_DIRECTIVES.contains(canonicalName);
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/webprotection/CspSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/webprotection/CspSettings.java
@@ -47,8 +47,12 @@ public class CspSettings {
             defaultValue = "true")
     private boolean scriptInlineNonce = true;
 
-    @Schema(description = "CSP directives, each in the form \"directive-name value;\".",
-            example = "[\"default-src 'self';\", \"script-src 'self';\"]")
+    @Schema(description = "CSP directives, one per entry, in the form \"directive-name value\". A trailing " +
+            "semicolon is optional. Directive names must be valid CSP tokens and must not repeat; values are " +
+            "not interpreted. Directives that take no value, such as \"upgrade-insecure-requests\", may be " +
+            "supplied on their own. When reportOnly is enabled, a \"report-uri\" or \"report-to\" directive " +
+            "is required.",
+            example = "[\"default-src 'self'\", \"script-src 'self'\", \"upgrade-insecure-requests\"]")
     private List<String> directives;
 
     public CspSettings() {

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/webprotection/CspDirectiveTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/webprotection/CspDirectiveTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.webprotection;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CspDirectiveTest {
+
+    @Test
+    public void shouldParseNameAndValue() {
+        final CspDirective directive = CspDirective.parse("default-src 'self'");
+
+        assertEquals("default-src", directive.name());
+        assertEquals("'self'", directive.value());
+    }
+
+    @Test
+    public void shouldParseWithOptionalTrailingSemicolon() {
+        assertEquals(CspDirective.parse("default-src 'self'"), CspDirective.parse("default-src 'self';"));
+    }
+
+    @Test
+    public void shouldKeepMultiTokenValueVerbatim() {
+        final CspDirective directive = CspDirective.parse("script-src 'self' https://cdn.example.com 'unsafe-inline'");
+
+        assertEquals("'self' https://cdn.example.com 'unsafe-inline'", directive.value());
+    }
+
+    @Test
+    public void shouldParseValuelessDirective() {
+        final CspDirective directive = CspDirective.parse("upgrade-insecure-requests");
+
+        assertEquals("upgrade-insecure-requests", directive.name());
+        assertEquals("", directive.value());
+        assertFalse(directive.hasValue());
+    }
+
+    @Test
+    public void shouldParseValuelessDirectiveWithTrailingSemicolon() {
+        final CspDirective directive = CspDirective.parse("upgrade-insecure-requests;");
+
+        assertEquals("upgrade-insecure-requests", directive.name());
+        assertEquals("", directive.value());
+    }
+
+    @Test
+    public void shouldCollapseExtraWhitespace() {
+        final CspDirective directive = CspDirective.parse("  default-src\t  'self'  ");
+
+        assertEquals("default-src", directive.name());
+        assertEquals("'self'", directive.value());
+    }
+
+    @Test
+    public void shouldReturnNullForBlankEntries() {
+        assertNull(CspDirective.parse(null));
+        assertNull(CspDirective.parse(""));
+        assertNull(CspDirective.parse("   "));
+        assertNull(CspDirective.parse(";"));
+    }
+
+    @Test
+    public void shouldPreserveNameCasingButCanonicaliseForComparison() {
+        final CspDirective directive = CspDirective.parse("Script-Src 'self'");
+
+        assertEquals("Script-Src", directive.name());
+        assertEquals("script-src", directive.canonicalName());
+    }
+
+    @Test
+    public void shouldRenderBackToStorageForm() {
+        assertEquals("default-src 'self'", CspDirective.parse("default-src 'self';").render());
+        assertEquals("upgrade-insecure-requests", CspDirective.parse("upgrade-insecure-requests").render());
+    }
+
+    @Test
+    public void shouldRoundTripThroughParseAndRender() {
+        final String entry = "script-src 'self' https://cdn.example.com";
+
+        assertEquals(entry, CspDirective.parse(CspDirective.parse(entry).render()).render());
+    }
+
+    @Test
+    public void shouldStripOnlyOneTrailingSemicolon() {
+        assertEquals("default-src 'self'", CspDirective.stripTrailingSemicolon("default-src 'self';"));
+        assertEquals("default-src 'self'; script-src 'self'",
+                CspDirective.stripTrailingSemicolon("default-src 'self'; script-src 'self';"));
+    }
+
+    @Test
+    public void shouldIdentifyReportTargets() {
+        assertTrue(CspDirective.parse("report-uri /csp-reports").isReportTarget());
+        assertTrue(CspDirective.parse("Report-To csp-endpoint").isReportTarget());
+        assertFalse(CspDirective.parse("default-src 'self'").isReportTarget());
+    }
+
+    @Test
+    public void shouldValidateNameSyntax() {
+        assertTrue(CspDirective.isValidName("default-src"));
+        assertTrue(CspDirective.isValidName("require-trusted-types-for"));
+        assertFalse(CspDirective.isValidName("script_src"));
+        assertFalse(CspDirective.isValidName("Script-Src"));
+        assertFalse(CspDirective.isValidName("default src"));
+        assertFalse(CspDirective.isValidName(""));
+        assertFalse(CspDirective.isValidName(null));
+    }
+
+    @Test
+    public void shouldRejectCharactersNettyForbidsInAHeaderValue() {
+        // Everything below 0x20 except tab, plus DEL.
+        for (int code = 0; code < 0x20; code++) {
+            if (code == '\t') {
+                continue;
+            }
+            assertTrue("0x%02x should be rejected".formatted(code),
+                    CspDirective.hasIllegalHeaderCharacter("'self'" + (char) code));
+        }
+        assertTrue(CspDirective.hasIllegalHeaderCharacter("'self'" + (char) 0x7f));
+    }
+
+    @Test
+    public void shouldRejectCarriageReturnAndLineFeed() {
+        assertTrue(CspDirective.hasIllegalHeaderCharacter("'self'" + (char) 0x0a + " more"));
+        assertTrue(CspDirective.hasIllegalHeaderCharacter("'self'" + (char) 0x0d + (char) 0x0a + " more"));
+    }
+
+    @Test
+    public void shouldAllowTabAndOrdinaryValueCharacters() {
+        assertFalse(CspDirective.hasIllegalHeaderCharacter("'self'" + (char) 0x09 + "https://cdn.example.com"));
+        assertFalse(CspDirective.hasIllegalHeaderCharacter("'self' https://cdn.example.com data:"));
+        assertFalse(CspDirective.hasIllegalHeaderCharacter("https://caf\u00e9.example.com"));
+        assertFalse(CspDirective.hasIllegalHeaderCharacter(""));
+        assertFalse(CspDirective.hasIllegalHeaderCharacter(null));
+    }
+
+    @Test
+    public void shouldNotRequireValueForValuelessDirectives() {
+        assertFalse(CspDirective.requiresValue("upgrade-insecure-requests"));
+        assertFalse(CspDirective.requiresValue("block-all-mixed-content"));
+        assertFalse(CspDirective.requiresValue("sandbox"));
+        assertFalse(CspDirective.requiresValue("trusted-types"));
+        assertTrue(CspDirective.requiresValue("default-src"));
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/domain/DomainValidatorImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/domain/DomainValidatorImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.am.service.exception.InvalidDomainException;
 import io.gravitee.am.service.validators.dynamicparams.ClientRegistrationSettingsValidator;
 import io.gravitee.am.service.validators.path.PathValidator;
 import io.gravitee.am.service.validators.virtualhost.VirtualHostValidator;
+import io.gravitee.am.service.validators.webprotection.CspSettingsValidator;
 import io.reactivex.rxjava3.core.Completable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -44,14 +45,17 @@ public class DomainValidatorImpl implements DomainValidator {
     private final PathValidator pathValidator;
     private final VirtualHostValidator virtualHostValidator;
     private final ClientRegistrationSettingsValidator clientRegistrationSettingsValidator;
+    private final CspSettingsValidator cspSettingsValidator;
 
     @Autowired
     public DomainValidatorImpl(PathValidator pathValidator,
                                VirtualHostValidator virtualHostValidator,
-                               ClientRegistrationSettingsValidator clientRegistrationSettingsValidator ){
+                               ClientRegistrationSettingsValidator clientRegistrationSettingsValidator,
+                               CspSettingsValidator cspSettingsValidator){
         this.pathValidator = pathValidator;
         this.virtualHostValidator = virtualHostValidator;
         this.clientRegistrationSettingsValidator = clientRegistrationSettingsValidator;
+        this.cspSettingsValidator = cspSettingsValidator;
     }
 
     @Override
@@ -114,6 +118,7 @@ public class DomainValidatorImpl implements DomainValidator {
         }
 
         chain.add(validateCertificateBasedAuthSettings(domain));
+        chain.add(validateCspSettings(domain));
 
         return Completable.merge(chain);
     }
@@ -139,6 +144,13 @@ public class DomainValidatorImpl implements DomainValidator {
         }
 
         return Completable.complete();
+    }
+
+    private Completable validateCspSettings(Domain domain) {
+        if (domain.getWebProtectionSettings() == null || domain.getWebProtectionSettings().getCsp() == null) {
+            return Completable.complete();
+        }
+        return cspSettingsValidator.validate(domain.getWebProtectionSettings().getCsp());
     }
 
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/webprotection/CspSettingsValidator.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/webprotection/CspSettingsValidator.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.validators.webprotection;
+
+import io.gravitee.am.model.webprotection.CspSettings;
+import io.gravitee.am.service.validators.Validator;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * Validates domain-level {@link CspSettings} so that an invalid policy cannot be persisted and then
+ * fail at request time on the gateway.
+ *
+ * @author GraviteeSource Team
+ */
+public interface CspSettingsValidator extends Validator<CspSettings, Completable> {
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/webprotection/CspSettingsValidatorImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/webprotection/CspSettingsValidatorImpl.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.validators.webprotection;
+
+import io.gravitee.am.model.webprotection.CspDirective;
+import io.gravitee.am.model.webprotection.CspSettings;
+import io.gravitee.am.model.webprotection.WebProtectionResolution;
+import io.gravitee.am.model.webprotection.WebProtectionSettingsResolver;
+import io.gravitee.am.service.exception.InvalidDomainException;
+import io.reactivex.rxjava3.core.Completable;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Service-layer validator for {@link CspSettings}.
+ * <p>
+ * Only the shape of the directive list is validated: names must be syntactically valid CSP tokens and
+ * must not repeat, values must be present where the directive requires one, and report-only mode must
+ * name a report target. Source-list grammar ({@code 'self'}, hosts, nonces, hashes) is deliberately
+ * not interpreted.
+ * <p>
+ * Directive names are compared case-insensitively per the CSP specification, but the operator's input
+ * is never rewritten — the gateway parser canonicalizes when it builds the policy map.
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+public class CspSettingsValidatorImpl implements CspSettingsValidator {
+
+    @Override
+    public Completable validate(CspSettings settings) {
+        if (WebProtectionSettingsResolver.resolve(settings) != WebProtectionResolution.ENABLED) {
+            return Completable.complete();
+        }
+
+        final List<String> entries = settings.getDirectives();
+        if (entries == null || entries.isEmpty()) {
+            return error("At least one CSP directive is required when CSP is enabled");
+        }
+
+        final Set<String> seenNames = new HashSet<>();
+        boolean hasReportTarget = false;
+
+        for (String entry : entries) {
+            final Completable failure = validateEntry(entry, seenNames);
+            if (failure != null) {
+                return failure;
+            }
+            final CspDirective directive = CspDirective.parse(entry);
+            hasReportTarget |= directive.isReportTarget() && directive.hasValue();
+        }
+
+        if (settings.isReportOnly() && !hasReportTarget) {
+            return error("Report-only mode requires a 'report-uri' or 'report-to' directive with a value, " +
+                    "otherwise the login page cannot be served");
+        }
+
+        return Completable.complete();
+    }
+
+    /**
+     * @return a failed {@link Completable} describing the problem, or {@code null} when the entry is valid
+     */
+    private Completable validateEntry(String entry, Set<String> seenNames) {
+        final CspDirective directive = CspDirective.parse(entry);
+        if (directive == null) {
+            return error("CSP directives must not be blank");
+        }
+
+        if (CspDirective.stripTrailingSemicolon(entry).contains(";")) {
+            return error("CSP directive '%s' must not contain ';', configure one directive per entry"
+                    .formatted(directive.name()));
+        }
+
+        final String canonicalName = directive.canonicalName();
+        if (!CspDirective.isValidName(canonicalName)) {
+            return error("'%s' is not a valid CSP directive name, names may contain only letters, digits and hyphens"
+                    .formatted(directive.name()));
+        }
+
+        if (CspDirective.hasIllegalHeaderCharacter(directive.value())) {
+            return error("CSP directive '%s' must not contain control characters".formatted(directive.name()));
+        }
+
+        if (CspDirective.requiresValue(canonicalName) && !directive.hasValue()) {
+            return error("CSP directive '%s' requires a value".formatted(directive.name()));
+        }
+
+        if (!seenNames.add(canonicalName)) {
+            return error("CSP directive '%s' is configured more than once".formatted(directive.name()));
+        }
+
+        return null;
+    }
+
+    private Completable error(String message) {
+        return Completable.error(new InvalidDomainException(message));
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/CspSettingsValidatorTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/CspSettingsValidatorTest.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.validators;
+
+import io.gravitee.am.model.webprotection.CspSettings;
+import io.gravitee.am.service.exception.InvalidDomainException;
+import io.gravitee.am.service.validators.webprotection.CspSettingsValidator;
+import io.gravitee.am.service.validators.webprotection.CspSettingsValidatorImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CspSettingsValidatorTest {
+
+    private CspSettingsValidator validator;
+
+    @Before
+    public void before() {
+        validator = new CspSettingsValidatorImpl();
+    }
+
+    private static CspSettings enabled(List<String> directives) {
+        final CspSettings settings = new CspSettings();
+        settings.setInherited(false);
+        settings.setEnabled(true);
+        settings.setDirectives(directives);
+        return settings;
+    }
+
+    private void assertRejected(CspSettings settings, String expectedMessageFragment) {
+        final AtomicReference<Throwable> captured = new AtomicReference<>();
+
+        validator.validate(settings)
+                .doOnError(captured::set)
+                .test()
+                .assertError(InvalidDomainException.class);
+
+        final Throwable error = captured.get();
+        assertNotNull("expected validation to fail", error);
+        assertTrue("expected message to contain '" + expectedMessageFragment + "' but was: " + error.getMessage(),
+                error.getMessage().contains(expectedMessageFragment));
+    }
+
+    // --- settings that carry no policy of their own -------------------------------------------------
+
+    @Test
+    public void shouldAcceptNullSettings() {
+        validator.validate(null).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptInheritedSettingsWithoutDirectives() {
+        final CspSettings settings = new CspSettings();
+        settings.setInherited(true);
+
+        validator.validate(settings).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptExplicitlyDisabledSettingsWithoutDirectives() {
+        final CspSettings settings = new CspSettings();
+        settings.setInherited(false);
+        settings.setEnabled(false);
+
+        validator.validate(settings).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptLegacySettingsThatInheritWhenDisabled() {
+        // inherited == null is the legacy shape: enabled == false means inherit
+        final CspSettings settings = new CspSettings();
+        settings.setEnabled(false);
+
+        validator.validate(settings).test().assertNoErrors();
+    }
+
+    // --- valid policies -----------------------------------------------------------------------------
+
+    @Test
+    public void shouldAcceptSimpleDirectives() {
+        validator.validate(enabled(List.of("default-src 'self'", "script-src 'self' https://cdn.example.com")))
+                .test()
+                .assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptTrailingSemicolons() {
+        validator.validate(enabled(List.of("default-src 'self';", "script-src 'self';")))
+                .test()
+                .assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptDirectivesThatTakeNoValue() {
+        validator.validate(enabled(List.of("default-src 'self'", "upgrade-insecure-requests", "block-all-mixed-content")))
+                .test()
+                .assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptBareSandbox() {
+        validator.validate(enabled(List.of("default-src 'self'", "sandbox"))).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptUnknownButSyntacticallyValidDirectiveName() {
+        validator.validate(enabled(List.of("some-future-directive 'self'"))).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptMixedCaseDirectiveName() {
+        validator.validate(enabled(List.of("Default-Src 'self'"))).test().assertNoErrors();
+    }
+
+    // --- rejections ---------------------------------------------------------------------------------
+
+    @Test
+    public void shouldRejectEmptyDirectiveList() {
+        assertRejected(enabled(List.of()), "At least one CSP directive");
+    }
+
+    @Test
+    public void shouldRejectNullDirectiveList() {
+        assertRejected(enabled(null), "At least one CSP directive");
+    }
+
+    @Test
+    public void shouldRejectBlankEntry() {
+        assertRejected(enabled(Arrays.asList("default-src 'self'", "   ")), "must not be blank");
+    }
+
+    @Test
+    public void shouldRejectInvalidDirectiveName() {
+        assertRejected(enabled(List.of("script_src 'self'")), "'script_src' is not a valid CSP directive name");
+    }
+
+    @Test
+    public void shouldRejectMissingValue() {
+        assertRejected(enabled(List.of("default-src")), "'default-src' requires a value");
+    }
+
+    @Test
+    public void shouldRejectDuplicateDirectiveNames() {
+        assertRejected(enabled(List.of("default-src 'self'", "default-src 'none'")), "configured more than once");
+    }
+
+    @Test
+    public void shouldRejectDuplicatesDifferingOnlyByCase() {
+        assertRejected(enabled(List.of("script-src 'self'", "Script-Src 'none'")), "configured more than once");
+    }
+
+    @Test
+    public void shouldRejectEmbeddedSemicolon() {
+        assertRejected(enabled(List.of("default-src 'self'; script-src 'self'")), "must not contain ';'");
+    }
+
+    @Test
+    public void shouldRejectEmbeddedSemicolonEvenWithTrailingSemicolon() {
+        assertRejected(enabled(List.of("default-src 'self'; script-src 'self';")), "must not contain ';'");
+    }
+
+    @Test
+    public void shouldRejectControlCharactersInAValue() {
+        assertRejected(enabled(List.of("default-src 'self'" + (char) 0x01 + "https://cdn.example.com")),
+                "must not contain control characters");
+    }
+
+    @Test
+    public void shouldRejectLineFeedInAValue() {
+        // Would otherwise fold into the header rather than fail, per Netty's obs-fold handling.
+        assertRejected(enabled(List.of("default-src 'self'" + (char) 0x0a + " more")), "must not contain control characters");
+    }
+
+    @Test
+    public void shouldRejectDeleteCharacterInAValue() {
+        assertRejected(enabled(List.of("default-src 'self'" + (char) 0x7f)), "must not contain control characters");
+    }
+
+    @Test
+    public void shouldAcceptTabInAValue() {
+        validator.validate(enabled(List.of("default-src 'self'" + (char) 0x09 + "https://cdn.example.com")))
+                .test()
+                .assertNoErrors();
+    }
+
+    // --- report-only --------------------------------------------------------------------------------
+
+    @Test
+    public void shouldRejectReportOnlyWithoutReportTarget() {
+        final CspSettings settings = enabled(List.of("default-src 'self'"));
+        settings.setReportOnly(true);
+
+        assertRejected(settings, "Report-only mode requires a 'report-uri' or 'report-to' directive");
+    }
+
+    @Test
+    public void shouldRejectReportOnlyWhenReportTargetHasNoValue() {
+        final CspSettings settings = enabled(List.of("default-src 'self'", "report-uri"));
+        settings.setReportOnly(true);
+
+        assertRejected(settings, "'report-uri' requires a value");
+    }
+
+    @Test
+    public void shouldAcceptReportOnlyWithReportUri() {
+        final CspSettings settings = enabled(List.of("default-src 'self'", "report-uri /csp-reports"));
+        settings.setReportOnly(true);
+
+        validator.validate(settings).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptReportOnlyWithReportTo() {
+        final CspSettings settings = enabled(List.of("default-src 'self'", "report-to csp-endpoint"));
+        settings.setReportOnly(true);
+
+        validator.validate(settings).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldAcceptReportOnlyWithMixedCaseReportTarget() {
+        final CspSettings settings = enabled(List.of("default-src 'self'", "Report-URI /csp-reports"));
+        settings.setReportOnly(true);
+
+        validator.validate(settings).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldNotRequireReportTargetWhenNotReportOnly() {
+        validator.validate(enabled(List.of("default-src 'self'"))).test().assertNoErrors();
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/DomainValidatorTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/DomainValidatorTest.java
@@ -18,6 +18,8 @@ package io.gravitee.am.service.validators;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.webprotection.CspSettings;
+import io.gravitee.am.model.webprotection.WebProtectionSettings;
 import io.gravitee.am.service.ApplicationService;
 import io.gravitee.am.service.exception.InvalidDomainException;
 import io.gravitee.am.service.validators.domain.DomainValidator;
@@ -25,6 +27,8 @@ import io.gravitee.am.service.validators.domain.DomainValidatorImpl;
 import io.gravitee.am.service.validators.dynamicparams.ClientRegistrationSettingsValidator;
 import io.gravitee.am.service.validators.path.PathValidatorImpl;
 import io.gravitee.am.service.validators.virtualhost.VirtualHostValidatorImpl;
+import io.gravitee.am.service.validators.webprotection.CspSettingsValidator;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +39,9 @@ import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -44,6 +51,7 @@ import static org.mockito.Mockito.when;
 public class DomainValidatorTest {
 
     private DomainValidator domainValidator;
+    private CspSettingsValidator cspSettingsValidator;
 
     @Before
     public void before(){
@@ -53,7 +61,8 @@ public class DomainValidatorTest {
         when(applicationService.findByDomain(Mockito.anyString())).thenReturn(Single.just(Set.of()));
         ClientRegistrationSettingsValidator clientRegistrationSettingsValidator = new ClientRegistrationSettingsValidator(applicationService);
 
-        domainValidator = new DomainValidatorImpl(pathValidator, new VirtualHostValidatorImpl(pathValidator), clientRegistrationSettingsValidator);
+        cspSettingsValidator = Mockito.mock(CspSettingsValidator.class);
+        domainValidator = new DomainValidatorImpl(pathValidator, new VirtualHostValidatorImpl(pathValidator), clientRegistrationSettingsValidator, cspSettingsValidator);
     }
 
     @Test
@@ -193,6 +202,65 @@ public class DomainValidatorTest {
         domain.setLoginSettings(loginSettings);
 
         domainValidator.validate(domain, emptyList()).test().assertNoErrors();
+    }
+
+    @Test
+    public void validate_noCspSettings_doesNotCallCspValidator() {
+        domainValidator.validate(getValidDomain(), emptyList()).test().assertNoErrors();
+
+        verify(cspSettingsValidator, never()).validate(any());
+    }
+
+    @Test
+    public void validate_nullCspSettings_doesNotCallCspValidator() {
+        Domain domain = getValidDomain();
+        domain.setWebProtectionSettings(new WebProtectionSettings());
+
+        domainValidator.validate(domain, emptyList()).test().assertNoErrors();
+
+        verify(cspSettingsValidator, never()).validate(any());
+    }
+
+    @Test
+    public void validate_cspSettings_callsCspValidator() {
+        CspSettings cspSettings = new CspSettings();
+        Domain domain = domainWithCsp(cspSettings);
+        when(cspSettingsValidator.validate(cspSettings)).thenReturn(Completable.complete());
+
+        domainValidator.validate(domain, emptyList()).test().assertNoErrors();
+
+        verify(cspSettingsValidator).validate(cspSettings);
+    }
+
+    @Test
+    public void validate_cspSettingsError_surfacesValidatorMessage() {
+        assertCspErrorPropagates(new InvalidDomainException("duplicate directive"), InvalidDomainException.class, "duplicate directive");
+    }
+
+    @Test
+    public void validate_cspSettingsUnexpectedError_isNotDisguisedAsAValidationFailure() {
+        // An unexpected validator fault is a bug, not bad input, so it must not become a 400.
+        assertCspErrorPropagates(new IllegalStateException("validator failed"), IllegalStateException.class, "validator failed");
+    }
+
+    private void assertCspErrorPropagates(Throwable validatorError, Class<? extends Throwable> expectedType, String expectedMessage) {
+        CspSettings cspSettings = new CspSettings();
+        Domain domain = domainWithCsp(cspSettings);
+        when(cspSettingsValidator.validate(cspSettings)).thenReturn(Completable.error(validatorError));
+
+        domainValidator.validate(domain, emptyList()).test()
+                .assertError(expectedType)
+                .assertError(throwable -> expectedMessage.equals(throwable.getMessage()));
+
+        verify(cspSettingsValidator).validate(cspSettings);
+    }
+
+    private Domain domainWithCsp(CspSettings cspSettings) {
+        Domain domain = getValidDomain();
+        WebProtectionSettings webProtectionSettings = new WebProtectionSettings();
+        webProtectionSettings.setCsp(cspSettings);
+        domain.setWebProtectionSettings(webProtectionSettings);
+        return domain;
     }
 
     private Domain getValidDomain() {

--- a/gravitee-am-test/specs/management/domain/csp.jest.spec.ts
+++ b/gravitee-am-test/specs/management/domain/csp.jest.spec.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as faker from 'faker';
+import { afterAll, beforeAll, expect } from '@jest/globals';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createDomain, safeDeleteDomain, patchDomain, startDomain } from '@management-commands/domain-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { setup } from '../../test-fixture';
+
+let accessToken;
+let domain;
+
+setup(200000);
+
+beforeAll(async () => {
+  accessToken = await requestAdminAccessToken();
+  const createdDomain = await createDomain(accessToken, uniqueName('csp-test', true), faker.company.catchPhraseDescriptor());
+  expect(createdDomain).toBeDefined();
+  expect(createdDomain.id).toBeDefined();
+
+  const startedDomain = await startDomain(createdDomain.id, accessToken);
+  expect(startedDomain).toBeDefined();
+  domain = startedDomain;
+});
+
+afterAll(async () => {
+  if (domain?.id) {
+    await safeDeleteDomain(domain.id, accessToken);
+  }
+});
+
+const patchCsp = (csp: Record<string, unknown>) =>
+  patchDomain(domain.id, accessToken, {
+    path: `${domain.path}`,
+    vhostMode: false,
+    vhosts: [],
+    webProtectionSettings: {
+      csp: {
+        inherited: false,
+        enabled: true,
+        ...csp,
+      },
+    },
+  });
+
+/**
+ * Patches and expects a 400, returning the server-supplied message so the test can assert it is
+ * actually readable.
+ */
+const expectCspRejected = async (csp: Record<string, unknown>): Promise<string> => {
+  let rejection: any;
+  try {
+    await patchCsp(csp);
+  } catch (error) {
+    rejection = error;
+  }
+
+  expect(rejection).toBeDefined();
+  expect(rejection.response?.status).toBe(400);
+
+  const raw = String(rejection.message ?? '');
+  const bodyStart = raw.indexOf('body=');
+  expect(bodyStart).toBeGreaterThanOrEqual(0);
+
+  const body = JSON.parse(raw.slice(bodyStart + 'body='.length));
+  expect(typeof body.message).toBe('string');
+  return body.message;
+};
+
+describe('CSP settings validation', () => {
+  describe('accepted policies', () => {
+    it('should accept a simple directive list', async () => {
+      const patched = await patchCsp({ directives: ["default-src 'self'", "script-src 'self' https://cdn.example.com"] });
+
+      expect(patched.webProtectionSettings.csp.directives).toContain("default-src 'self'");
+    });
+
+    it('should accept trailing semicolons without altering validity', async () => {
+      const patched = await patchCsp({ directives: ["default-src 'self';", "script-src 'self';"] });
+
+      expect(patched.webProtectionSettings.csp.directives).toHaveLength(2);
+    });
+
+    it('should accept directives that take no value', async () => {
+      const patched = await patchCsp({ directives: ["default-src 'self'", 'upgrade-insecure-requests'] });
+
+      expect(patched.webProtectionSettings.csp.directives).toContain('upgrade-insecure-requests');
+    });
+
+    it('should accept an unknown but syntactically valid directive name', async () => {
+      // The known-name list is a Console concern; the API must not block a directive CSP adds later.
+      const patched = await patchCsp({ directives: ["some-future-directive 'self'"] });
+
+      expect(patched.webProtectionSettings.csp.directives).toContain("some-future-directive 'self'");
+    });
+
+    it('should persist the operator casing verbatim', async () => {
+      const patched = await patchCsp({ directives: ["Default-Src 'self'"] });
+
+      expect(patched.webProtectionSettings.csp.directives).toContain("Default-Src 'self'");
+    });
+
+    it('should accept report-only with a report-uri', async () => {
+      const patched = await patchCsp({
+        reportOnly: true,
+        directives: ["default-src 'self'", 'report-uri /csp-reports'],
+      });
+
+      expect(patched.webProtectionSettings.csp.reportOnly).toBe(true);
+    });
+
+    it('should accept report-only with a report-to', async () => {
+      const patched = await patchCsp({
+        reportOnly: true,
+        directives: ["default-src 'self'", 'report-to csp-endpoint'],
+      });
+
+      expect(patched.webProtectionSettings.csp.reportOnly).toBe(true);
+    });
+
+    it('should not validate directives when CSP is inherited', async () => {
+      const patched = await patchDomain(domain.id, accessToken, {
+        path: `${domain.path}`,
+        vhostMode: false,
+        vhosts: [],
+        webProtectionSettings: {
+          csp: { inherited: true, enabled: false, directives: ['this is not valid'] },
+        },
+      });
+
+      expect(patched.webProtectionSettings.csp.inherited).toBe(true);
+    });
+  });
+
+  describe('rejected policies', () => {
+    it('should reject an unknown-shaped directive name', async () => {
+      const message = await expectCspRejected({ directives: ["script_src 'self'"] });
+
+      expect(message).toContain('script_src');
+      expect(message).toContain('not a valid CSP directive name');
+    });
+
+    it('should reject a directive with no value', async () => {
+      const message = await expectCspRejected({ directives: ['default-src'] });
+
+      expect(message).toContain('requires a value');
+    });
+
+    it('should reject duplicate directive names', async () => {
+      const message = await expectCspRejected({ directives: ["default-src 'self'", "default-src 'none'"] });
+
+      expect(message).toContain('more than once');
+    });
+
+    it('should reject duplicates differing only by case', async () => {
+      const message = await expectCspRejected({ directives: ["script-src 'self'", "Script-Src 'none'"] });
+
+      expect(message).toContain('more than once');
+    });
+
+    it('should reject several directives packed into one entry', async () => {
+      const message = await expectCspRejected({ directives: ["default-src 'self'; script-src 'self'"] });
+
+      expect(message).toContain(';');
+    });
+
+    it('should reject an empty directive list when CSP is enabled', async () => {
+      const message = await expectCspRejected({ directives: [] });
+
+      expect(message).toContain('At least one CSP directive');
+    });
+
+    it('should reject report-only without a report target', async () => {
+      const message = await expectCspRejected({ reportOnly: true, directives: ["default-src 'self'"] });
+
+      expect(message).toContain('report-uri');
+      expect(message).toContain('report-to');
+    });
+  });
+});

--- a/gravitee-am-ui/src/app/domain/settings/web-protection/csp-directives.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/web-protection/csp-directives.spec.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  allowsValue,
+  analyzeCspDirectives,
+  CSP_DIRECTIVE_NAME_PATTERN,
+  CSP_DIRECTIVE_VALUE_PATTERN,
+  CspDirectiveRow,
+  parseCspDirective,
+  parseCspDirectives,
+  requiresValue,
+  serializeCspDirective,
+  serializeCspDirectives,
+} from './csp-directives';
+
+const rows = (...entries: [string, string][]): CspDirectiveRow[] => entries.map(([name, value]) => ({ name, value }));
+
+describe('csp-directives', () => {
+  describe('parsing', () => {
+    it('splits a name and value on the first whitespace', () => {
+      expect(parseCspDirective("default-src 'self'")).toEqual({ name: 'default-src', value: "'self'" });
+    });
+
+    it('keeps a multi-token source list verbatim', () => {
+      expect(parseCspDirective("script-src 'self' https://cdn.example.com")).toEqual({
+        name: 'script-src',
+        value: "'self' https://cdn.example.com",
+      });
+    });
+
+    it('treats a trailing semicolon as optional', () => {
+      expect(parseCspDirective("default-src 'self';")).toEqual(parseCspDirective("default-src 'self'"));
+    });
+
+    it('keeps an optional trailing semicolon out of the value', () => {
+      const row = parseCspDirective("default-src 'self';");
+
+      expect(row.value).toBe("'self'");
+      expect(new RegExp(`^${CSP_DIRECTIVE_VALUE_PATTERN}$`).test(row.value)).toBe(true);
+    });
+
+    it('keeps an optional trailing semicolon out of a valueless directive name', () => {
+      const row = parseCspDirective('upgrade-insecure-requests;');
+
+      expect(row).toEqual({ name: 'upgrade-insecure-requests', value: '' });
+      expect(new RegExp(`^${CSP_DIRECTIVE_NAME_PATTERN}$`).test(row.name)).toBe(true);
+    });
+
+    it('parses a directive that takes no value', () => {
+      expect(parseCspDirective('upgrade-insecure-requests')).toEqual({ name: 'upgrade-insecure-requests', value: '' });
+    });
+
+    it('preserves the casing the operator typed', () => {
+      expect(parseCspDirective("Script-Src 'self'").name).toBe('Script-Src');
+    });
+
+    it('still produces a row for an entry that does not parse cleanly, so it can be fixed', () => {
+      expect(parseCspDirective('this is not valid')).toEqual({ name: 'this', value: 'is not valid' });
+    });
+  });
+
+  describe('serialising', () => {
+    it('renders name and value without a trailing semicolon', () => {
+      expect(serializeCspDirective({ name: 'default-src', value: "'self'" })).toBe("default-src 'self'");
+    });
+
+    it('renders a valueless directive as the name alone', () => {
+      expect(serializeCspDirective({ name: 'upgrade-insecure-requests', value: '' })).toBe('upgrade-insecure-requests');
+    });
+
+    it('round-trips a stored list', () => {
+      const stored = ["default-src 'self'", "script-src 'self' https://cdn.example.com", 'upgrade-insecure-requests'];
+
+      expect(serializeCspDirectives(parseCspDirectives(stored))).toEqual(stored);
+    });
+
+    it('normalizes a trailing semicolon out on round-trip', () => {
+      expect(serializeCspDirectives(parseCspDirectives(["default-src 'self';"]))).toEqual(["default-src 'self'"]);
+    });
+  });
+
+  describe('analysis', () => {
+    const analyze = (directives: CspDirectiveRow[], reportOnly = false) => analyzeCspDirectives(directives, reportOnly);
+
+    it('reports nothing for a clean policy', () => {
+      const analysis = analyze(rows(['default-src', "'self'"], ['script-src', "'self'"]));
+
+      expect(analysis.formErrors).toEqual([]);
+      expect(analysis.hasBlockingIssue).toBe(false);
+      expect(analysis.rows.every((row) => !row.duplicate && !row.unknownName)).toBe(true);
+    });
+
+    it('flags every duplicate after the first', () => {
+      const analysis = analyze(rows(['default-src', "'self'"], ['default-src', "'none'"], ['default-src', "'*'"]));
+
+      expect(analysis.rows.map((row) => row.duplicate)).toEqual([false, true, true]);
+      expect(analysis.hasBlockingIssue).toBe(true);
+    });
+
+    it('treats names differing only by case as duplicates', () => {
+      const analysis = analyze(rows(['script-src', "'self'"], ['Script-Src', "'none'"]));
+
+      expect(analysis.rows.map((row) => row.duplicate)).toEqual([false, true]);
+    });
+
+    it('does not flag empty names as duplicates of each other', () => {
+      const analysis = analyze(rows(['', ''], ['', '']));
+
+      expect(analysis.rows.map((row) => row.duplicate)).toEqual([false, false]);
+    });
+
+    it('flags an unrecognized name without blocking the save', () => {
+      const analysis = analyze(rows(['some-future-directive', "'self'"]));
+
+      expect(analysis.rows[0].unknownName).toBe(true);
+      expect(analysis.hasBlockingIssue).toBe(false);
+    });
+
+    it('does not flag known names, whatever their casing', () => {
+      const analysis = analyze(rows(['default-src', "'self'"], ['Script-Src', "'self'"]));
+
+      expect(analysis.rows.map((row) => row.unknownName)).toEqual([false, false]);
+    });
+
+    it('does not flag a syntactically invalid name as unrecognized, since the field already errors', () => {
+      expect(analyze(rows(['script_src', "'self'"])).rows[0].unknownName).toBe(false);
+    });
+
+    it('requires at least one directive', () => {
+      const analysis = analyze([]);
+
+      expect(analysis.formErrors[0]).toContain('at least one directive');
+      expect(analysis.hasBlockingIssue).toBe(true);
+    });
+
+    it('requires a report target in report only mode', () => {
+      const analysis = analyze(rows(['default-src', "'self'"]), true);
+
+      expect(analysis.formErrors[0]).toContain('Report only needs');
+      expect(analysis.hasBlockingIssue).toBe(true);
+    });
+
+    it('accepts report only with a report-uri', () => {
+      expect(analyze(rows(['default-src', "'self'"], ['report-uri', '/csp-reports']), true).formErrors).toEqual([]);
+    });
+
+    it('accepts report only with a report-to', () => {
+      expect(analyze(rows(['default-src', "'self'"], ['report-to', 'csp-endpoint']), true).formErrors).toEqual([]);
+    });
+
+    it('ignores a report target that has no value', () => {
+      expect(analyze(rows(['default-src', "'self'"], ['report-uri', '']), true).formErrors.length).toBeGreaterThan(0);
+    });
+
+    it('notes that report-to alone is not delivered by AM', () => {
+      expect(analyze(rows(['report-to', 'csp-endpoint'])).rows[0].reportToNeedsEndpoint).toBe(true);
+    });
+
+    it('drops that note once report-uri is configured too', () => {
+      const analysis = analyze(rows(['report-to', 'csp-endpoint'], ['report-uri', '/csp-reports']));
+
+      expect(analysis.rows[0].reportToNeedsEndpoint).toBe(false);
+    });
+  });
+
+  describe('value pattern', () => {
+    const valuePattern = new RegExp(`^${CSP_DIRECTIVE_VALUE_PATTERN}$`);
+
+    it('accepts ordinary source lists', () => {
+      expect(valuePattern.test("'self' https://cdn.example.com data:")).toBe(true);
+    });
+
+    it('accepts a tab', () => {
+      expect(valuePattern.test(`'self'${String.fromCharCode(0x09)}https://cdn.example.com`)).toBe(true);
+    });
+
+    it('rejects a semicolon', () => {
+      expect(valuePattern.test("'self'; script-src 'self'")).toBe(false);
+    });
+
+    it('rejects every control character except tab', () => {
+      for (let code = 0; code < 0x20; code++) {
+        if (code === 0x09) {
+          continue;
+        }
+        expect(valuePattern.test(`'self'${String.fromCharCode(code)}x`)).toBe(false);
+      }
+      expect(valuePattern.test(`'self'${String.fromCharCode(0x7f)}x`)).toBe(false);
+    });
+
+    it('accepts non-ascii characters, which headers permit', () => {
+      expect(valuePattern.test('https://café.example.com')).toBe(true);
+    });
+  });
+
+  describe('value expectations', () => {
+    it('allows a value for ordinary directives', () => {
+      expect(allowsValue('default-src')).toBe(true);
+      expect(requiresValue('default-src')).toBe(true);
+    });
+
+    it('blocks a value for directives that take none', () => {
+      expect(allowsValue('upgrade-insecure-requests')).toBe(false);
+      expect(allowsValue('block-all-mixed-content')).toBe(false);
+      expect(requiresValue('upgrade-insecure-requests')).toBe(false);
+    });
+
+    it('allows but does not require a value for optional-value directives', () => {
+      expect(allowsValue('sandbox')).toBe(true);
+      expect(requiresValue('sandbox')).toBe(false);
+      expect(allowsValue('trusted-types')).toBe(true);
+      expect(requiresValue('trusted-types')).toBe(false);
+    });
+
+    it('ignores casing', () => {
+      expect(allowsValue('Upgrade-Insecure-Requests')).toBe(false);
+    });
+  });
+});

--- a/gravitee-am-ui/src/app/domain/settings/web-protection/csp-directives.ts
+++ b/gravitee-am-ui/src/app/domain/settings/web-protection/csp-directives.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * CSP directive editing helpers.
+ *
+ * Per-field rules (name required, name characters, value required, no semicolons) are expressed as
+ * native validators on the template. These mirror the service-layer CspSettingsValidator.
+ */
+
+export interface CspDirectiveRow {
+  name: string;
+  value: string;
+}
+
+/** Per-row advisory state, indexed alongside the rows themselves. */
+export interface CspRowIssue {
+  /** True for every occurrence after the first with the same (case-insensitive) name. */
+  duplicate: boolean;
+  /** Syntactically fine, but not a directive we know about. */
+  unknownName: boolean;
+  /** report-to is configured but AM sends no Reporting-Endpoints header. */
+  reportToNeedsEndpoint: boolean;
+}
+
+export interface CspAnalysis {
+  rows: CspRowIssue[];
+  /** Problems that belong to the policy rather than to any one field. */
+  formErrors: string[];
+  /** True when the policy would be rejected for a reason no field-level validator catches. */
+  hasBlockingIssue: boolean;
+}
+
+/** Directives that carry no value at all. */
+export const CSP_NO_VALUE_DIRECTIVES: string[] = ['upgrade-insecure-requests', 'block-all-mixed-content'];
+
+/** Directives whose value is optional — a bare `sandbox` is the most restrictive form. */
+export const CSP_OPTIONAL_VALUE_DIRECTIVES: string[] = ['sandbox', 'trusted-types'];
+
+export const CSP_REPORT_URI = 'report-uri';
+export const CSP_REPORT_TO = 'report-to';
+
+/** Rejects the characters the API rejects, and doubles as the no-semicolon rule for names. */
+export const CSP_DIRECTIVE_NAME_PATTERN = '[A-Za-z0-9-]+';
+
+/**
+ * Values are kept verbatim, so only characters that cannot survive the round trip are forbidden.
+ */
+export const CSP_DIRECTIVE_VALUE_PATTERN = '[^;\\x00-\\x08\\x0a-\\x1f\\x7f]*';
+
+/** Known directive names, used for autocomplete and the unrecognized-name hint. */
+export const CSP_DIRECTIVE_NAMES: string[] = [
+  'base-uri',
+  'block-all-mixed-content',
+  'child-src',
+  'connect-src',
+  'default-src',
+  'fenced-frame-src',
+  'font-src',
+  'form-action',
+  'frame-ancestors',
+  'frame-src',
+  'img-src',
+  'manifest-src',
+  'media-src',
+  'object-src',
+  'report-to',
+  'report-uri',
+  'require-trusted-types-for',
+  'sandbox',
+  'script-src',
+  'script-src-attr',
+  'script-src-elem',
+  'style-src',
+  'style-src-attr',
+  'style-src-elem',
+  'trusted-types',
+  'upgrade-insecure-requests',
+  'worker-src',
+];
+
+const canonical = (name: string): string => (name ?? '').trim().toLowerCase();
+
+/** Trims and discards a single trailing `;`, which is optional in the API. */
+function stripTrailingSemicolon(entry: string): string {
+  const trimmed = (entry ?? '').trim();
+  return trimmed.endsWith(';') ? trimmed.slice(0, -1).trim() : trimmed;
+}
+
+/**
+ * Parses a stored `"name value"` entry into an editable row.
+ *
+ * Never returns null: an entry that does not parse cleanly still becomes a row so the operator can
+ * see and fix it rather than having it silently disappear.
+ */
+export function parseCspDirective(entry: string): CspDirectiveRow {
+  const stripped = stripTrailingSemicolon(entry);
+  const separator = stripped.search(/[ \t]/);
+  if (separator < 0) {
+    return { name: stripped, value: '' };
+  }
+  return { name: stripped.slice(0, separator), value: stripped.slice(separator + 1).trim() };
+}
+
+/** Renders a row back to the storage form, without a trailing semicolon. */
+export function serializeCspDirective(row: CspDirectiveRow): string {
+  const name = (row.name ?? '').trim();
+  const value = (row.value ?? '').trim();
+  return value ? `${name} ${value}` : name;
+}
+
+export function parseCspDirectives(entries: string[]): CspDirectiveRow[] {
+  return (entries ?? []).map(parseCspDirective);
+}
+
+export function serializeCspDirectives(rows: CspDirectiveRow[]): string[] {
+  return (rows ?? []).map(serializeCspDirective);
+}
+
+/** False only for directives that take no value at all — those get a disabled value field. */
+export function allowsValue(name: string): boolean {
+  return !CSP_NO_VALUE_DIRECTIVES.includes(canonical(name));
+}
+
+/** True when a value must be supplied. Optional-value directives are neither required nor blocked. */
+export function requiresValue(name: string): boolean {
+  const key = canonical(name);
+  return !CSP_NO_VALUE_DIRECTIVES.includes(key) && !CSP_OPTIONAL_VALUE_DIRECTIVES.includes(key);
+}
+
+export function isKnownDirective(name: string): boolean {
+  return CSP_DIRECTIVE_NAMES.includes(canonical(name));
+}
+
+const isSyntacticallyValidName = (name: string): boolean => new RegExp(`^${CSP_DIRECTIVE_NAME_PATTERN}$`).test(name ?? '');
+
+/**
+ * Works out everything the per-field validators cannot: duplicate names, whether the policy has a
+ * usable shape, and the advisory hints.
+ */
+export function analyzeCspDirectives(rows: CspDirectiveRow[], reportOnly: boolean): CspAnalysis {
+  const directives = rows ?? [];
+  const names = directives.map((row) => canonical(row.name));
+  const hasReportTo = directives.some((row) => canonical(row.name) === CSP_REPORT_TO && (row.value ?? '').trim());
+  const hasReportUri = directives.some((row) => canonical(row.name) === CSP_REPORT_URI && (row.value ?? '').trim());
+
+  const issues: CspRowIssue[] = directives.map((row, index) => {
+    const key = names[index];
+    return {
+      duplicate: key.length > 0 && names.indexOf(key) !== index,
+      unknownName: key.length > 0 && isSyntacticallyValidName(row.name) && !isKnownDirective(key),
+      reportToNeedsEndpoint: key === CSP_REPORT_TO && !hasReportUri,
+    };
+  });
+
+  const formErrors: string[] = [];
+  if (directives.length === 0) {
+    formErrors.push('Add at least one directive, or turn off Enable CSP.');
+  }
+  if (reportOnly && !hasReportTo && !hasReportUri) {
+    formErrors.push(`Report only needs a "${CSP_REPORT_URI}" or "${CSP_REPORT_TO}" directive with a value.`);
+  }
+
+  return {
+    rows: issues,
+    formErrors,
+    hasBlockingIssue: formErrors.length > 0 || issues.some((issue) => issue.duplicate),
+  };
+}

--- a/gravitee-am-ui/src/app/domain/settings/web-protection/web-protection.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/web-protection/web-protection.component.html
@@ -178,7 +178,7 @@
                 <mat-slide-toggle
                   [(ngModel)]="domain.webProtectionSettings.csp.reportOnly"
                   name="cspReportOnly"
-                  (ngModelChange)="updateFormState()"
+                  (ngModelChange)="directiveChanged()"
                   [disabled]="readonly"
                 >
                   Report only
@@ -198,31 +198,84 @@
                 <mat-hint style="font-size: 75%">Include a nonce in the script-src directive for inline scripts.</mat-hint>
               </div>
 
-              <mat-form-field appearance="outline" floatLabel="always">
-                <mat-label>Directives</mat-label>
-                <mat-chip-grid #directives aria-label="cspDirectives" [disabled]="readonly">
-                  <mat-chip-row
-                    *ngFor="let directive of domain.webProtectionSettings.csp.directives"
-                    [removable]="!readonly"
-                    (removed)="removeDirective(directive)"
-                  >
-                    {{ directive }}
-                    <mat-icon matChipRemove>cancel</mat-icon>
-                  </mat-chip-row>
-                  <input
-                    matInput
-                    type="text"
-                    placeholder="default-src 'self';"
-                    name="cspDirective"
-                    [matChipInputFor]="directives"
-                    (keydown.enter)="addDirective($event)"
-                    [value]="directiveValue || ''"
-                    (input)="directiveValue = $any($event.target).value"
-                    [disabled]="readonly"
-                  />
-                </mat-chip-grid>
-                <mat-hint>Each directive must follow the format "directive-name value;". Press Enter to add.</mat-hint>
-              </mat-form-field>
+              <div class="directives-actions">
+                <span>Directives</span>
+                <button (click)="addDirective(); $event.preventDefault()" mat-button *hasPermission="['domain_settings_update']">
+                  <mat-icon>add_circle_outline</mat-icon>
+                </button>
+              </div>
+
+              <ng-container *ngFor="let directive of cspDirectives; let i = index; trackBy: trackByIndex">
+                <div fxLayout="row" fxLayoutAlign="start start" class="directive-row">
+                  <div class="directive-remove">
+                    <button (click)="removeDirective(i); $event.preventDefault()" mat-button *hasPermission="['domain_settings_update']">
+                      <mat-icon>remove_circle_outline</mat-icon>
+                    </button>
+                  </div>
+
+                  <mat-form-field appearance="outline" floatLabel="always" class="form-field" fxFlex="40">
+                    <mat-label>Name</mat-label>
+                    <input
+                      matInput
+                      type="text"
+                      placeholder="default-src"
+                      [name]="'cspDirectiveName' + i"
+                      [(ngModel)]="directive.name"
+                      (ngModelChange)="directiveChanged(directive)"
+                      required
+                      [pattern]="cspNamePattern"
+                      [readonly]="readonly"
+                      [errorStateMatcher]="duplicateErrorStateMatcher(i)"
+                      [matAutocomplete]="directiveName"
+                      #directiveNameModel="ngModel"
+                    />
+                    <mat-icon
+                      matSuffix
+                      class="directive-hint-icon"
+                      *ngIf="isUnknownDirective(i)"
+                      matTooltip="This is not a directive we recognize. It will be saved as entered so check spelling."
+                      >warning_outline</mat-icon
+                    >
+                    <mat-autocomplete #directiveName="matAutocomplete">
+                      <mat-option *ngFor="let name of filteredDirectiveNames(directive)" [value]="name">{{ name }}</mat-option>
+                    </mat-autocomplete>
+                    <mat-error *ngIf="directiveNameModel.errors?.required">Enter a directive name</mat-error>
+                    <mat-error *ngIf="directiveNameModel.errors?.pattern">Use letters, digits and hyphens only</mat-error>
+                    <mat-error *ngIf="!directiveNameModel.errors && isDuplicateDirective(i)"
+                      >This directive is already configured</mat-error
+                    >
+                  </mat-form-field>
+
+                  <mat-form-field appearance="outline" floatLabel="always" class="form-field" fxFlex>
+                    <mat-label>Value</mat-label>
+                    <input
+                      matInput
+                      type="text"
+                      [placeholder]="isDirectiveValueAllowed(directive) ? '\'self\' https://cdn.example.com' : 'No value required'"
+                      [name]="'cspDirectiveValue' + i"
+                      [(ngModel)]="directive.value"
+                      (ngModelChange)="directiveChanged()"
+                      [required]="isDirectiveValueRequired(directive)"
+                      [pattern]="cspValuePattern"
+                      [disabled]="readonly || !isDirectiveValueAllowed(directive)"
+                      #directiveValueModel="ngModel"
+                    />
+                    <mat-icon
+                      matSuffix
+                      class="directive-hint-icon"
+                      *ngIf="needsReportingEndpoint(i)"
+                      matTooltip="report-to needs a Reporting-Endpoints header, which AM does not send. Add report-uri as well, or have a proxy supply the header."
+                      >info_outline</mat-icon
+                    >
+                    <mat-error *ngIf="directiveValueModel.errors?.required">Enter a value</mat-error>
+                    <mat-error *ngIf="directiveValueModel.errors?.pattern"
+                      >Use one directive per row, without ";" or control characters</mat-error
+                    >
+                  </mat-form-field>
+                </div>
+              </ng-container>
+
+              <p class="directive-form-error" *ngFor="let error of cspFormErrors">{{ error }}</p>
             </ng-container>
           </ng-container>
         </div>
@@ -311,7 +364,7 @@
         </div>
 
         <div *hasPermission="['domain_settings_update']">
-          <button mat-raised-button color="primary" [disabled]="!domainForm.valid || !formChanged" type="submit">SAVE</button>
+          <button mat-raised-button color="primary" [disabled]="!domainForm.valid || !formChanged || cspInvalid" type="submit">SAVE</button>
         </div>
       </form>
     </div>
@@ -321,9 +374,26 @@
         <p>Configure HTTP security headers and CORS for your security domain.</p>
         <p>Changes take effect without restarting the system.</p>
         <p>
-          By default, each setting follows the platform configuration. Turn off inherit to customise or disable a protection for this
+          By default, each setting follows the platform configuration. Turn off inherit to customize or disable a protection for this
           security domain only.
         </p>
+        <h4>CSP directives</h4>
+        <p>CSP directive values are saved exactly as you type them, so quoting matters:</p>
+        <ul>
+          <li>
+            Keywords and tokens need single quotes — <code>'self'</code>, <code>'none'</code>, <code>'unsafe-inline'</code>,
+            <code>'strict-dynamic'</code>, as well as nonces or hashes.
+          </li>
+          <li>
+            URLs, hostnames, schemes and paths must be unquoted — <code>https://cdn.example.com</code>, <code>*.example.com</code>,
+            <code>data:</code>, <code>/csp-reports</code>.
+          </li>
+          <li>Separate multiple sources with spaces, for example <code>'self' https://cdn.example.com data:</code>.</li>
+          <li>
+            Use one directive per row and leave semicolons out — they are added for you. A few directives, such as
+            <code>upgrade-insecure-requests</code>, take no value at all.
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/gravitee-am-ui/src/app/domain/settings/web-protection/web-protection.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/web-protection/web-protection.component.scss
@@ -1,1 +1,52 @@
-/* Empty: inherits shared page layout styles */
+.directives-actions {
+  span {
+    padding-right: 10px;
+    color: grey;
+  }
+
+  height: 30px;
+  margin-bottom: 15px;
+}
+
+.directive-row {
+  .directive-remove {
+    display: flex;
+    height: var(--mat-form-field-container-height, 56px);
+    align-items: center;
+    margin-top: 0.45em;
+  }
+
+  .mat-mdc-icon-button {
+    width: 25px;
+    height: 25px;
+  }
+}
+
+.form-field {
+  padding-left: 12px;
+}
+
+mat-icon {
+  color: grey;
+}
+
+.directive-hint-icon {
+  color: grey;
+}
+
+.directive-form-error {
+  margin: 0 0 8px;
+  color: var(--mat-sys-error, #b3261e);
+  font-family: Roboto, 'Helvetica Neue Light', sans-serif;
+  font-size: 75%;
+}
+
+.gv-page-description-content {
+  code {
+    font-size: 90%;
+  }
+
+  ul {
+    padding-left: 18px;
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/web-protection/web-protection.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/web-protection/web-protection.component.spec.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+
+import { AuthService } from '../../../services/auth.service';
+import { DomainService } from '../../../services/domain.service';
+import { SnackbarService } from '../../../services/snackbar.service';
+import { DomainStoreService } from '../../../stores/domain.store';
+
+jest.mock('@gravitee/ui-components/src/lib/utils', () => ({
+  deepClone: (obj: any) => {
+    if (obj) {
+      return JSON.parse(JSON.stringify(obj));
+    }
+    return obj;
+  },
+}));
+
+import { DomainSettingsWebProtectionComponent } from './web-protection.component';
+
+const domainWithCsp = (csp: Record<string, unknown>) => ({
+  id: 'domain-id',
+  name: 'my-domain',
+  webProtectionSettings: {
+    csp: { inherited: false, enabled: true, reportOnly: false, scriptInlineNonce: true, ...csp },
+  },
+});
+
+describe('DomainSettingsWebProtectionComponent', () => {
+  let component: DomainSettingsWebProtectionComponent;
+  let fixture: ComponentFixture<DomainSettingsWebProtectionComponent>;
+  let domainService: { patchWebProtectionSettings: jest.Mock; notify: jest.Mock };
+  let domainStore: DomainStoreService;
+
+  const initWith = (domain: unknown) => {
+    domainStore.set(domain);
+    fixture = TestBed.createComponent(DomainSettingsWebProtectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    domainService = {
+      patchWebProtectionSettings: jest.fn().mockImplementation((id, domain) => of(domain)),
+      notify: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [FormsModule, MatAutocompleteModule, NoopAnimationsModule],
+      declarations: [DomainSettingsWebProtectionComponent],
+      providers: [
+        DomainStoreService,
+        { provide: DomainService, useValue: domainService },
+        { provide: SnackbarService, useValue: { open: jest.fn() } },
+        { provide: AuthService, useValue: { hasPermissions: () => true } },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+      teardown: { destroyAfterEach: false },
+    }).compileComponents();
+
+    domainStore = TestBed.inject(DomainStoreService);
+  });
+
+  it('renders without error for a domain that overrides CSP', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    expect(component.cspDirectives).toEqual([{ name: 'default-src', value: "'self'" }]);
+    expect(component.cspFormErrors).toEqual([]);
+  });
+
+  it('loads stored directives into editable rows', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self';", 'upgrade-insecure-requests'] }));
+
+    expect(component.cspDirectives).toEqual([
+      { name: 'default-src', value: "'self'" },
+      { name: 'upgrade-insecure-requests', value: '' },
+    ]);
+  });
+
+  it('shows an invalid stored entry rather than dropping it, leaving the field to flag it', () => {
+    initWith(domainWithCsp({ directives: ['script_src oops'] }));
+
+    expect(component.cspDirectives).toEqual([{ name: 'script_src', value: 'oops' }]);
+  });
+
+  it('accepts a loosely-typed entry the API would also accept, hinting rather than blocking', () => {
+    // "this is not valid" parses to the name "this", which is syntactically legal CSP.
+    initWith(domainWithCsp({ directives: ['this is not valid'] }));
+
+    expect(component.cspDirectives).toEqual([{ name: 'this', value: 'is not valid' }]);
+    expect(component.isUnknownDirective(0)).toBe(true);
+    expect(component.cspInvalid).toBe(false);
+  });
+
+  it('serializes rows back to the stored string form on save', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    component.cspDirectives = [
+      { name: 'default-src', value: "'self'" },
+      { name: 'upgrade-insecure-requests', value: '' },
+    ];
+    component.update();
+
+    const patched = domainService.patchWebProtectionSettings.mock.calls[0][1];
+    expect(patched.webProtectionSettings.csp.directives).toEqual(["default-src 'self'", 'upgrade-insecure-requests']);
+  });
+
+  it('adds and removes rows', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    component.addDirective();
+    expect(component.cspDirectives).toHaveLength(2);
+    expect(component.formChanged).toBe(true);
+
+    component.removeDirective(0);
+    expect(component.cspDirectives).toEqual([{ name: '', value: '' }]);
+  });
+
+  it('flags every duplicate name after the first and blocks the save', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'", "Default-Src 'none'"] }));
+
+    expect(component.isDuplicateDirective(0)).toBe(false);
+    expect(component.isDuplicateDirective(1)).toBe(true);
+    expect(component.cspInvalid).toBe(true);
+  });
+
+  it('marks a stored duplicate as an error before the field is touched', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'", "default-src 'none'"] }));
+
+    const matcher = component.duplicateErrorStateMatcher(1);
+
+    expect(matcher.isErrorState(null, null)).toBe(true);
+  });
+
+  it('does not put an untouched, non-duplicate field into an error state', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    const matcher = component.duplicateErrorStateMatcher(0);
+
+    expect(matcher.isErrorState(null, null)).toBe(false);
+  });
+
+  it('blocks the save when report only has no report target', () => {
+    initWith(domainWithCsp({ reportOnly: true, directives: ["default-src 'self'"] }));
+
+    expect(component.cspInvalid).toBe(true);
+    expect(component.cspFormErrors[0]).toContain('Report only needs');
+  });
+
+  it('blocks the save when CSP is enabled with no directives', () => {
+    initWith(domainWithCsp({ directives: [] }));
+
+    expect(component.cspInvalid).toBe(true);
+    expect(component.cspFormErrors[0]).toContain('at least one directive');
+  });
+
+  it('does not validate directives while CSP is inherited', () => {
+    initWith({
+      id: 'domain-id',
+      name: 'my-domain',
+      webProtectionSettings: { csp: { inherited: true, enabled: false, directives: ['this is not valid'] } },
+    });
+
+    expect(component.cspFormErrors).toEqual([]);
+    expect(component.cspInvalid).toBe(false);
+  });
+
+  it('does not validate directives while CSP is disabled for the domain', () => {
+    initWith(domainWithCsp({ enabled: false, directives: [] }));
+
+    expect(component.cspFormErrors).toEqual([]);
+  });
+
+  it('flags an unrecognized directive name without blocking the save', () => {
+    initWith(domainWithCsp({ directives: ["some-future-directive 'self'"] }));
+
+    expect(component.isUnknownDirective(0)).toBe(true);
+    expect(component.cspInvalid).toBe(false);
+  });
+
+  it('notes when report-to is configured without report-uri', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'", 'report-to csp-endpoint'] }));
+
+    expect(component.needsReportingEndpoint(1)).toBe(true);
+  });
+
+  it('only requires a value for directives that take one', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    expect(component.isDirectiveValueRequired({ name: 'default-src', value: '' })).toBe(true);
+    expect(component.isDirectiveValueRequired({ name: 'upgrade-insecure-requests', value: '' })).toBe(false);
+  });
+
+  it('disables the value field for a directive that takes no value', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    expect(component.isDirectiveValueAllowed({ name: 'default-src', value: '' })).toBe(true);
+    expect(component.isDirectiveValueAllowed({ name: 'upgrade-insecure-requests', value: '' })).toBe(false);
+    expect(component.isDirectiveValueAllowed({ name: 'sandbox', value: '' })).toBe(true);
+  });
+
+  it('clears a leftover value when the row switches to a valueless directive', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    const row = component.cspDirectives[0];
+    row.name = 'upgrade-insecure-requests';
+    component.directiveChanged(row);
+
+    expect(row.value).toBe('');
+  });
+
+  it('keeps the value when the row switches to a directive that allows one', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    const row = component.cspDirectives[0];
+    row.name = 'script-src';
+    component.directiveChanged(row);
+
+    expect(row.value).toBe("'self'");
+  });
+
+  it('narrows autocomplete options to what has been typed', () => {
+    initWith(domainWithCsp({ directives: ["default-src 'self'"] }));
+
+    expect(component.filteredDirectiveNames({ name: 'script', value: '' })).toContain('script-src');
+    expect(component.filteredDirectiveNames({ name: 'script', value: '' })).not.toContain('default-src');
+    expect(component.filteredDirectiveNames({ name: '', value: '' }).length).toBeGreaterThan(0);
+  });
+});

--- a/gravitee-am-ui/src/app/domain/settings/web-protection/web-protection.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/web-protection/web-protection.component.ts
@@ -14,12 +14,27 @@
  * limitations under the License.
  */
 import { Component, OnInit } from '@angular/core';
+import { AbstractControl } from '@angular/forms';
+import { ErrorStateMatcher } from '@angular/material/core';
 import { deepClone } from '@gravitee/ui-components/src/lib/utils';
 
 import { DomainService } from '../../../services/domain.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { AuthService } from '../../../services/auth.service';
 import { DomainStoreService } from '../../../stores/domain.store';
+
+import {
+  allowsValue,
+  analyzeCspDirectives,
+  CSP_DIRECTIVE_NAME_PATTERN,
+  CSP_DIRECTIVE_NAMES,
+  CSP_DIRECTIVE_VALUE_PATTERN,
+  CspAnalysis,
+  CspDirectiveRow,
+  parseCspDirectives,
+  requiresValue,
+  serializeCspDirectives,
+} from './csp-directives';
 
 @Component({
   selector: 'app-domain-web-protection',
@@ -35,7 +50,12 @@ export class DomainSettingsWebProtectionComponent implements OnInit {
   xframeActions: string[] = ['DENY', 'SAMEORIGIN'];
   headerValue: string;
   originValue: string;
-  directiveValue: string;
+  cspDirectives: CspDirectiveRow[] = [];
+  cspAnalysis: CspAnalysis = { rows: [], formErrors: [], hasBlockingIssue: false };
+  readonly cspDirectiveNames = CSP_DIRECTIVE_NAMES;
+  readonly cspNamePattern = CSP_DIRECTIVE_NAME_PATTERN;
+  readonly cspValuePattern = CSP_DIRECTIVE_VALUE_PATTERN;
+  private readonly duplicateMatchers = new Map<number, ErrorStateMatcher>();
 
   private readonly defaultCorsConfiguration = {
     inherited: true,
@@ -114,6 +134,9 @@ export class DomainSettingsWebProtectionComponent implements OnInit {
     if (this.domain.corsSettings.maxAge === 0) {
       this.domain.corsSettings.maxAge = null;
     }
+
+    this.cspDirectives = parseCspDirectives(this.domain.webProtectionSettings.csp.directives);
+    this.revalidateCsp();
   }
 
   private normalizeInherited(settings: { inherited?: boolean; enabled?: boolean }): void {
@@ -124,6 +147,7 @@ export class DomainSettingsWebProtectionComponent implements OnInit {
 
   update(): void {
     this.flushPendingChipValues();
+    this.domain.webProtectionSettings.csp.directives = serializeCspDirectives(this.cspDirectives);
     this.domainService.patchWebProtectionSettings(this.domain.id, this.domain).subscribe((response) => {
       this.domain = response;
       this.domainStore.set(response);
@@ -144,6 +168,7 @@ export class DomainSettingsWebProtectionComponent implements OnInit {
       settings.enabled = false;
     }
     this.formChanged = true;
+    this.revalidateCsp();
   }
 
   enableCorsSettings(event: any): void {
@@ -228,6 +253,7 @@ export class DomainSettingsWebProtectionComponent implements OnInit {
   enableCspSettings(event: any): void {
     this.domain.webProtectionSettings.csp.enabled = event.checked;
     this.formChanged = true;
+    this.revalidateCsp();
   }
 
   isCspSettingsEnabled(): boolean {
@@ -236,32 +262,96 @@ export class DomainSettingsWebProtectionComponent implements OnInit {
 
   addDirective(event?: Event): void {
     event?.preventDefault();
-    this.addDirectiveValue();
+    this.cspDirectives = [...this.cspDirectives, { name: '', value: '' }];
+    this.formChanged = true;
+    this.revalidateCsp();
   }
 
-  private addDirectiveValue(): void {
-    const value = this.directiveValue?.trim();
-    if (!value) {
+  removeDirective(index: number): void {
+    this.cspDirectives = this.cspDirectives.filter((_, i) => i !== index);
+    this.formChanged = true;
+    this.revalidateCsp();
+  }
+
+  directiveChanged(row?: CspDirectiveRow): void {
+    // Switching to a directive that takes no value would otherwise leave the old value behind and
+    // serialize it back out, e.g. "upgrade-insecure-requests 'self'".
+    if (row && !allowsValue(row.name)) {
+      row.value = '';
+    }
+    this.formChanged = true;
+    this.revalidateCsp();
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  /**
+   * Autocomplete options for a row, narrowed by whatever has been typed so far. Free text is still
+   * accepted — the list is a convenience, not a whitelist.
+   */
+  filteredDirectiveNames(row: CspDirectiveRow): string[] {
+    const typed = (row?.name ?? '').trim().toLowerCase();
+    if (!typed) {
+      return this.cspDirectiveNames;
+    }
+    return this.cspDirectiveNames.filter((name) => name.includes(typed));
+  }
+
+  isDirectiveValueRequired(row: CspDirectiveRow): boolean {
+    return requiresValue(row?.name);
+  }
+
+  isDirectiveValueAllowed(row: CspDirectiveRow): boolean {
+    return allowsValue(row?.name);
+  }
+
+  isDuplicateDirective(index: number): boolean {
+    return this.cspAnalysis.rows[index]?.duplicate === true;
+  }
+
+  isUnknownDirective(index: number): boolean {
+    return this.cspAnalysis.rows[index]?.unknownName === true;
+  }
+
+  needsReportingEndpoint(index: number): boolean {
+    return this.cspAnalysis.rows[index]?.reportToNeedsEndpoint === true;
+  }
+
+  get cspFormErrors(): string[] {
+    return this.cspAnalysis.formErrors;
+  }
+
+  /**
+   * Duplicates are the one rule a single field cannot detect, so the error state is supplied rather
+   * than derived from the control. Stored duplicates are flagged immediately instead of waiting for
+   * the operator to touch the field.
+   */
+  duplicateErrorStateMatcher(index: number): ErrorStateMatcher {
+    if (!this.duplicateMatchers.has(index)) {
+      this.duplicateMatchers.set(index, {
+        isErrorState: (control: AbstractControl | null): boolean =>
+          this.isDuplicateDirective(index) || (!!control && control.invalid && (control.dirty || control.touched)),
+      });
+    }
+    return this.duplicateMatchers.get(index);
+  }
+
+  /**
+   * Cross-row rules (duplicates, report targets, at least one directive) cannot be expressed with
+   * template-driven validators, so they are recomputed here and block the save separately.
+   */
+  private revalidateCsp(): void {
+    if (this.isInherited(this.domain.webProtectionSettings?.csp) || !this.isCspSettingsEnabled()) {
+      this.cspAnalysis = { rows: [], formErrors: [], hasBlockingIssue: false };
       return;
     }
-    const directives = this.domain.webProtectionSettings.csp.directives;
-    if (!directives.some((el) => el === value)) {
-      directives.push(value);
-      this.domain.webProtectionSettings.csp.directives = [...directives];
-      this.formChanged = true;
-      this.directiveValue = '';
-    } else {
-      this.snackbarService.open(`Error : Directive "${value}" already exists`);
-    }
+    this.cspAnalysis = analyzeCspDirectives(this.cspDirectives, this.domain.webProtectionSettings?.csp?.reportOnly);
   }
 
-  removeDirective(directive: string): void {
-    const directives = this.domain.webProtectionSettings.csp.directives;
-    const index = directives.indexOf(directive);
-    if (index > -1) {
-      directives.splice(index, 1);
-      this.formChanged = true;
-    }
+  get cspInvalid(): boolean {
+    return this.cspAnalysis.hasBlockingIssue;
   }
 
   enableXFrameSettings(event: any): void {
@@ -292,9 +382,6 @@ export class DomainSettingsWebProtectionComponent implements OnInit {
     }
     if (this.headerValue?.trim()) {
       this.addHeaderValue();
-    }
-    if (this.directiveValue?.trim()) {
-      this.addDirectiveValue();
     }
   }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7386](https://gravitee.atlassian.net/browse/AM-7386)

## :pencil2: A description of the changes proposed in the pull request
Enhance validation and UX of domain-level CSP configuration:
- Replace chip input with a structured Name/Value list editor for domain-level CSP directives.
- Validate format of directive names and values in UI and mAPI/aAPI (known directives are used for autocompletion in the UI only).
- Fix runtime gateway issues:
  - HTTP 500 Vert.x error when reportOnly is enabled with no `report-uri`/`report-to` directive.
  - Mixed-case script-src defeating the nonce lookup.
  - Valueless directives (like `upgrade-insecure-requests`) being silently dropped.

## :memo: Test scenarios 
See [AM-7368](https://gravitee.atlassian.net/browse/AM-7368)

## :computer: Add screenshots for UI

### Before
<img width="1919" height="752" alt="image" src="https://github.com/user-attachments/assets/8c5e168e-567a-467f-bad4-f55a83cb1f19" />

### After
<img width="1917" height="884" alt="image" src="https://github.com/user-attachments/assets/bc68e0a7-7699-4256-92bb-a0ab34161cc2" />

## :books: Any other comments that will help with documentation
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7386]: https://gravitee.atlassian.net/browse/AM-7386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-7368]: https://gravitee.atlassian.net/browse/AM-7368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ