### PR TITLE
feat: store access_token and refresh_token in one batch

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenManager.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.token;
 
+import io.gravitee.am.repository.oauth2.model.AccessToken;
+import io.gravitee.am.repository.oauth2.model.RefreshToken;
 import io.gravitee.common.service.Service;
 import io.reactivex.rxjava3.core.Completable;
 
@@ -24,7 +26,14 @@ import io.reactivex.rxjava3.core.Completable;
  */
 public interface TokenManager extends Service {
 
-    Completable storeAccessToken(io.gravitee.am.repository.oauth2.model.AccessToken accessToken);
-
-    Completable storeRefreshToken(io.gravitee.am.repository.oauth2.model.RefreshToken refreshToken);
+    /**
+     * Store an access token and, when provided, its refresh token in a single write.
+     * <p>
+     * The write is not atomic on every backend: on error one of the tokens may already be stored.
+     *
+     * @param accessToken the access token to store
+     * @param refreshToken the refresh token to store, may be null
+     * @return acknowledge of the operation
+     */
+    Completable storeTokens(AccessToken accessToken, RefreshToken refreshToken);
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenManagerImpl.java
@@ -17,7 +17,6 @@ package io.gravitee.am.gateway.handler.oauth2.service.token.impl;
 
 import io.gravitee.am.gateway.handler.oauth2.service.token.TokenManager;
 import io.gravitee.am.repository.oauth2.api.BackwardCompatibleTokenRepository;
-import io.gravitee.am.repository.oauth2.api.TokenRepository;
 import io.gravitee.am.repository.oauth2.model.AccessToken;
 import io.gravitee.am.repository.oauth2.model.RefreshToken;
 import io.gravitee.common.service.AbstractService;
@@ -41,12 +40,7 @@ public class TokenManagerImpl extends AbstractService implements TokenManager {
     }
 
     @Override
-    public Completable storeAccessToken(AccessToken accessToken) {
-        return tokenRepository.create(accessToken).ignoreElement();
-    }
-
-    @Override
-    public Completable storeRefreshToken(RefreshToken refreshToken) {
-        return tokenRepository.create(refreshToken).ignoreElement();
+    public Completable storeTokens(AccessToken accessToken, RefreshToken refreshToken) {
+        return tokenRepository.create(accessToken, refreshToken);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -330,13 +330,9 @@ public class TokenServiceImpl implements TokenService {
     }
 
     private Completable storeTokens(JWT accessToken, JWT refreshToken, OAuth2Request oAuth2Request, User user) {
-        // store access token
-        final Completable persistAccessToken = tokenManager.storeAccessToken(convert(accessToken, refreshToken, oAuth2Request, user));
-        // store refresh token (if exists)
-        if (refreshToken != null) {
-            return persistAccessToken.andThen(tokenManager.storeRefreshToken(convert(refreshToken, user, oAuth2Request)));
-        }
-        return persistAccessToken;
+        return tokenManager.storeTokens(
+                convert(accessToken, refreshToken, oAuth2Request, user),
+                refreshToken != null ? convert(refreshToken, user, oAuth2Request) : null);
     }
 
     private io.gravitee.am.repository.oauth2.model.AccessToken convert(JWT token, JWT refreshToken, OAuth2Request oAuth2Request, User user) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/TokenServiceTest.java
@@ -82,6 +82,7 @@ import java.util.concurrent.TimeUnit;
 import static io.gravitee.am.gateway.handler.dummies.TestCertificateInfoFactory.createTestCertificateInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
@@ -154,15 +155,97 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
 
         expectTokenCreatedAuditLog();
+    }
+
+    @Test
+    public void shouldStoreAccessAndRefreshTokenInSingleBatch() {
+        OAuth2Request oAuth2Request = new OAuth2Request();
+        oAuth2Request.setSupportRefreshToken(true);
+
+        Client client = new Client();
+        client.setClientId("my-client-id");
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+
+        ArgumentCaptor<io.gravitee.am.repository.oauth2.model.AccessToken> accessTokenCaptor =
+                ArgumentCaptor.forClass(io.gravitee.am.repository.oauth2.model.AccessToken.class);
+        ArgumentCaptor<io.gravitee.am.repository.oauth2.model.RefreshToken> refreshTokenCaptor =
+                ArgumentCaptor.forClass(io.gravitee.am.repository.oauth2.model.RefreshToken.class);
+
+        when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
+        when(executionContextFactory.create(any())).thenReturn(executionContext);
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
+
+        TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(tokenManager, times(1)).storeTokens(accessTokenCaptor.capture(), refreshTokenCaptor.capture());
+        assertNotNull(refreshTokenCaptor.getValue());
+        assertEquals(refreshTokenCaptor.getValue().getToken(), accessTokenCaptor.getValue().getRefreshToken());
+
+        expectTokenCreatedAuditLog();
+    }
+
+    @Test
+    public void shouldStoreAccessTokenWithoutRefreshTokenWhenNotSupported() {
+        OAuth2Request oAuth2Request = new OAuth2Request();
+
+        Client client = new Client();
+        client.setClientId("my-client-id");
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+
+        ArgumentCaptor<io.gravitee.am.repository.oauth2.model.RefreshToken> refreshTokenCaptor =
+                ArgumentCaptor.forClass(io.gravitee.am.repository.oauth2.model.RefreshToken.class);
+
+        when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
+        when(executionContextFactory.create(any())).thenReturn(executionContext);
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
+
+        TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        verify(tokenManager, times(1)).storeTokens(any(), refreshTokenCaptor.capture());
+        assertNull(refreshTokenCaptor.getValue());
+
+        expectTokenCreatedAuditLog();
+    }
+
+    @Test
+    public void shouldNotReturnTokenWhenBatchStoreFails() {
+        OAuth2Request oAuth2Request = new OAuth2Request();
+        oAuth2Request.setSupportRefreshToken(true);
+
+        Client client = new Client();
+        client.setClientId("my-client-id");
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+
+        when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
+        when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
+        when(executionContextFactory.create(any())).thenReturn(executionContext);
+        doReturn(Completable.error(new TechnicalException("batch insert failed"))).when(tokenManager).storeTokens(any(), any());
+
+        TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
+        testObserver.assertError(TechnicalException.class);
+        testObserver.assertNoValues();
+
+        verify(tokenManager, times(1)).storeTokens(any(), any());
+
+        expectTokenCreatedFailedAuditLog();
     }
 
     @Test
@@ -180,13 +263,13 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenAnswer(ans -> Single.just(ans.getArgument(0)));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValue(token -> token.getAdditionalInformation().containsKey("key"));
 
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
 
         expectTokenCreatedAuditLog();
@@ -209,14 +292,14 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenAnswer(ans -> Single.just(ans.getArgument(0)));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
         testObserver.assertValue(token -> token.getAdditionalInformation().isEmpty());
 
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
         verify(subjectManager).updateJWT(any(), any());
 
@@ -239,14 +322,14 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenAnswer(ans -> Single.just(ans.getArgument(0)));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
         testObserver.assertValue(token -> token.getAdditionalInformation().isEmpty());
 
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
 
         expectTokenCreatedAuditLog();
@@ -267,12 +350,12 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
 
         ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
@@ -302,12 +385,12 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(accessToken));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
 
         expectTokenCreatedAuditLog();
@@ -335,12 +418,12 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
         verify(jwtService).encodeJwt(argThat(jwt -> jwt.get(Claims.AUD) instanceof List
                 && jwt.getAud().equals(((List) jwt.get(Claims.AUD)).get(0))
@@ -362,13 +445,13 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(any(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.error(new TechnicalException())).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.error(new TechnicalException())).when(tokenManager).storeTokens(any(), any());
 
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.awaitDone(10, TimeUnit.SECONDS);
         testObserver.assertError(TechnicalException.class);
 
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
 
         expectTokenCreatedFailedAuditLog();
@@ -388,14 +471,14 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(jwtCaptor.capture(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
         testObserver.assertNoErrors();
 
         JWT jwt = jwtCaptor.getValue();
         assertTrue(jwt != null && jwt.get("permissions") != null);
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
 
         expectTokenCreatedAuditLog();
@@ -430,7 +513,7 @@ public class TokenServiceTest {
         when(jwtService.encodeJwt(jwtCaptor.capture(), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("token-id")));
         when(executionContextFactory.create(any())).thenReturn(executionContext);
-        doReturn(Completable.complete()).when(tokenManager).storeAccessToken(any());
+        doReturn(Completable.complete()).when(tokenManager).storeTokens(any(), any());
 
         TestObserver<Token> testObserver = tokenService.create(oAuth2Request, client, null).test();
         testObserver.assertComplete();
@@ -440,7 +523,7 @@ public class TokenServiceTest {
         assertNotNull(jwt);
         assertTrue(jwt.get("iss") != null && "https://custom-iss".equals(jwt.get("iss")));
         assertTrue(jwt.get("aud") != null && "my-api".equals(jwt.get("aud")));
-        verify(tokenManager, times(1)).storeAccessToken(any());
+        verify(tokenManager, times(1)).storeTokens(any(), any());
         verify(tokenRepository, never()).deleteByJti(anyString());
         verify(executionContext).setAttribute(eq(ConstantKeys.AUTH_FLOW_CONTEXT_ATTRIBUTES_KEY), any());
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImplTest.java
@@ -226,8 +226,7 @@ public class TokenServiceImplTest {
         when(openIDDiscoveryService.getIssuer(anyString())).thenReturn("https://auth.example.com");
         when(jwtService.encodeJwt(any(JWT.class), any(Client.class))).thenReturn(Single.just(sampleEncodedJwt()));
         when(tokenEnhancer.enhance(any(), any(), any(), any(), any())).thenReturn(Single.just(new AccessToken("access-token")));
-        when(tokenManager.storeAccessToken(any())).thenReturn(Completable.complete());
-        when(tokenManager.storeRefreshToken(any())).thenReturn(Completable.complete());
+        when(tokenManager.storeTokens(any(), any())).thenReturn(Completable.complete());
         when(executionContextFactory.create(any())).thenReturn(new SimpleExecutionContext(request, null));
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/oauth2/api/BackwardCompatibleTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/oauth2/api/BackwardCompatibleTokenRepository.java
@@ -55,6 +55,11 @@ public class BackwardCompatibleTokenRepository implements TokenRepository {
     }
 
     @Override
+    public Completable create(AccessToken accessToken, RefreshToken refreshToken) {
+        return tokenRepository.create(accessToken, refreshToken);
+    }
+
+    @Override
     public Observable<AccessToken> findAccessTokenByAuthorizationCode(String authorizationCode) {
         return tokenRepository.findAccessTokenByAuthorizationCode(authorizationCode)
                 .switchIfEmpty(maintainLegacyTokenRepositories ? accessTokenRepository.findByAuthorizationCode(authorizationCode) : Observable.empty());

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/oauth2/api/TokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/oauth2/api/TokenRepository.java
@@ -30,6 +30,19 @@ public interface TokenRepository extends ExpiredDataSweeper {
     Single<AccessToken> create(AccessToken accessToken);
     Observable<AccessToken> findAccessTokenByAuthorizationCode(String authorizationCode);
 
+    /**
+     * Store an access token and, when provided, its refresh token in a single write.
+     * <p>
+     * Not atomic on every backend: JDBC issues one statement so a failure stores neither token,
+     * while MongoDB stops at the failing document but keeps the ones already written. On error,
+     * callers must assume that one of the tokens may have been stored.
+     *
+     * @param accessToken the access token to store
+     * @param refreshToken the refresh token to store, may be null
+     * @return acknowledge of the operation
+     */
+    Completable create(AccessToken accessToken, RefreshToken refreshToken);
+
     Completable deleteByJti(String jti);
     Completable deleteByUserId(String userId);
     Completable deleteByDomainIdClientIdAndUserId(String domainId, String clientId, UserId userId);

--- a/gravitee-am-repository/gravitee-am-repository-api/src/test/java/io/gravitee/am/repository/oauth2/api/BackwardCompatibleTokenRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/test/java/io/gravitee/am/repository/oauth2/api/BackwardCompatibleTokenRepositoryTest.java
@@ -482,6 +482,29 @@ public class BackwardCompatibleTokenRepositoryTest {
         verify(tokenRepository).create(accessToken);
     }
 
+    // --- create(AccessToken, RefreshToken) ---
+
+    @Test
+    public void shouldDelegateBatchCreateToTokenRepository() {
+        AccessToken accessToken = new AccessToken();
+        RefreshToken refreshToken = new RefreshToken();
+        when(tokenRepository.create(accessToken, refreshToken)).thenReturn(Completable.complete());
+
+        BackwardCompatibleTokenRepository repository = new BackwardCompatibleTokenRepository(
+                tokenRepository,
+                accessTokenRepository,
+                refreshTokenRepository,
+                true);
+
+        TestObserver<Void> observer = repository.create(accessToken, refreshToken).test();
+        observer.assertComplete();
+        observer.assertNoErrors();
+
+        verify(tokenRepository).create(accessToken, refreshToken);
+        verify(accessTokenRepository, never()).create(any());
+        verify(refreshTokenRepository, never()).create(any());
+    }
+
     // --- purgeExpiredData ---
 
     @Test

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/oauth2/api/JdbcTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/oauth2/api/JdbcTokenRepository.java
@@ -31,8 +31,10 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.relational.core.query.Query;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.r2dbc.core.DatabaseClient;
 import org.springframework.stereotype.Repository;
 
@@ -40,6 +42,7 @@ import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,13 +54,40 @@ import static org.springframework.data.relational.core.query.Criteria.where;
 import static reactor.adapter.rxjava.RxJava3Adapter.*;
 
 @Repository
-public class JdbcTokenRepository extends AbstractJdbcRepository implements TokenRepository {
+public class JdbcTokenRepository extends AbstractJdbcRepository implements TokenRepository, InitializingBean {
 
     @Autowired
     private SpringTokenRepository spring;
 
     @Autowired
     private RetryOnConcurrencyFailureConfiguration retryOnConcurrencyFailureConfiguration;
+
+    private static final String ACCESS_TOKEN_PREFIX = "at_";
+    private static final String REFRESH_TOKEN_PREFIX = "rt_";
+
+    private static final List<FieldSpec<JdbcToken, ?>> TOKEN_FIELDS = List.of(
+            new FieldSpec<>("id", JdbcToken::getId, String.class),
+            new FieldSpec<>("domain", JdbcToken::getDomain, String.class),
+            new FieldSpec<>("client", JdbcToken::getClient, String.class),
+            new FieldSpec<>(SUBJECT, JdbcToken::getSubject, String.class),
+            new FieldSpec<>("token", JdbcToken::getToken, String.class),
+            new FieldSpec<>("created_at", JdbcToken::getCreatedAt, LocalDateTime.class),
+            new FieldSpec<>("expire_at", JdbcToken::getExpireAt, LocalDateTime.class),
+            new FieldSpec<>("authorization_code", JdbcToken::getAuthorizationCode, String.class),
+            new FieldSpec<>("refresh_token", JdbcToken::getRefreshToken, String.class),
+            new FieldSpec<>("type", JdbcToken::getType, String.class),
+            new FieldSpec<>("parent_jti_1", JdbcToken::getParentJti1, String.class),
+            new FieldSpec<>("parent_jti_2", JdbcToken::getParentJti2, String.class));
+
+    private static final List<FieldSpec<JdbcToken, ?>> ACCESS_TOKEN_FIELDS = prefixed(ACCESS_TOKEN_PREFIX);
+    private static final List<FieldSpec<JdbcToken, ?>> REFRESH_TOKEN_FIELDS = prefixed(REFRESH_TOKEN_PREFIX);
+
+    private String batchInsertStatement;
+
+    @Override
+    public void afterPropertiesSet() {
+        this.batchInsertStatement = createBatchInsertStatement();
+    }
 
     @Override
     public Maybe<RefreshToken> findRefreshTokenByJti(String jti) {
@@ -95,6 +125,48 @@ public class JdbcTokenRepository extends AbstractJdbcRepository implements Token
                 .map(this::toAccessToken)
                 .doOnError(error -> LOGGER.error("Unable to create accessToken with id {}", accessToken.getId(), error))
                 .observeOn(Schedulers.computation());
+    }
+
+    @Override
+    public Completable create(AccessToken accessToken, RefreshToken refreshToken) {
+        if (refreshToken == null) {
+            return create(accessToken).ignoreElement();
+        }
+        accessToken.setId(accessToken.getId() == null ? RandomString.generate() : accessToken.getId());
+        refreshToken.setId(refreshToken.getId() == null ? RandomString.generate() : refreshToken.getId());
+        LOGGER.debug("Create accessToken with id {} and refreshToken with id {}", accessToken.getId(), refreshToken.getId());
+
+        DatabaseClient.GenericExecuteSpec spec = getTemplate().getDatabaseClient().sql(batchInsertStatement);
+        spec = addQuotedFields(spec, ACCESS_TOKEN_FIELDS, toJdbcEntity(accessToken));
+        spec = addQuotedFields(spec, REFRESH_TOKEN_FIELDS, toJdbcEntity(refreshToken));
+
+        return monoToCompletable(spec.fetch().rowsUpdated())
+                .doOnError(error -> LOGGER.error("Unable to create accessToken with id {} and refreshToken with id {}",
+                        accessToken.getId(), refreshToken.getId(), error))
+                .observeOn(Schedulers.computation());
+    }
+
+    private String createBatchInsertStatement() {
+        String columns = TOKEN_FIELDS.stream()
+                .map(FieldSpec::columnName)
+                .map(SqlIdentifier::quoted)
+                .map(databaseDialectHelper::toSql)
+                .collect(Collectors.joining(","));
+        return "INSERT INTO tokens (" + columns + ") VALUES ("
+                + bindMarkers(ACCESS_TOKEN_FIELDS) + "),("
+                + bindMarkers(REFRESH_TOKEN_FIELDS) + ")";
+    }
+
+    private static String bindMarkers(List<FieldSpec<JdbcToken, ?>> fields) {
+        return fields.stream().map(field -> ":" + field.columnName()).collect(Collectors.joining(","));
+    }
+
+    private static List<FieldSpec<JdbcToken, ?>> prefixed(String prefix) {
+        return TOKEN_FIELDS.stream().<FieldSpec<JdbcToken, ?>>map(field -> withPrefix(prefix, field)).toList();
+    }
+
+    private static <T> FieldSpec<JdbcToken, T> withPrefix(String prefix, FieldSpec<JdbcToken, T> field) {
+        return new FieldSpec<>(prefix + field.columnName(), field.valueGetter(), field.valueType());
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/oauth2/api/TokenRepositoryBatchCreateTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/oauth2/api/TokenRepositoryBatchCreateTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.oauth2.api;
+
+import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.repository.oauth2.AbstractOAuthTest;
+import io.gravitee.am.repository.oauth2.model.AccessToken;
+import io.gravitee.am.repository.oauth2.model.RefreshToken;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * The batch insert is a single multi-values INSERT statement, so a constraint violation on any row
+ * rolls back the whole statement. Two sequential inserts would leave the access token behind.
+ *
+ * @author GraviteeSource Team
+ */
+public class TokenRepositoryBatchCreateTest extends AbstractOAuthTest {
+
+    private static final long TIMEOUT_SECONDS = 10;
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
+    private R2dbcEntityTemplate template;
+
+    @Test
+    public void shouldNotStoreAccessTokenWhenRefreshTokenRowFails() {
+        String suffix = shortSuffix();
+        String domain = "domain-" + suffix;
+
+        AccessToken existingToken = newAccessToken("existing-at-" + suffix, domain);
+        tokenRepository.create(existingToken).ignoreElement().blockingAwait();
+
+        AccessToken accessToken = newAccessToken("batch-at-" + suffix, domain);
+        RefreshToken refreshToken = newRefreshToken("batch-rt-" + suffix, domain);
+        refreshToken.setId(existingToken.getId());
+
+        TestObserver<Void> observer = tokenRepository.create(accessToken, refreshToken).test();
+        observer.awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertError(Throwable.class);
+
+        assertNull(tokenRepository.findAccessTokenByJti(accessToken.getToken()).blockingGet());
+        assertNull(tokenRepository.findRefreshTokenByJti(refreshToken.getToken()).blockingGet());
+        assertNotNull(tokenRepository.findAccessTokenByJti(existingToken.getToken()).blockingGet());
+        assertEquals(1L, countTokens(domain));
+    }
+
+    @Test
+    public void shouldNotStoreRefreshTokenWhenAccessTokenRowFails() {
+        String suffix = shortSuffix();
+        String domain = "domain-" + suffix;
+
+        AccessToken existingToken = newAccessToken("existing-at-" + suffix, domain);
+        tokenRepository.create(existingToken).ignoreElement().blockingAwait();
+
+        AccessToken accessToken = newAccessToken("batch-at-" + suffix, domain);
+        accessToken.setId(existingToken.getId());
+        RefreshToken refreshToken = newRefreshToken("batch-rt-" + suffix, domain);
+
+        TestObserver<Void> observer = tokenRepository.create(accessToken, refreshToken).test();
+        observer.awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertError(Throwable.class);
+
+        assertNull(tokenRepository.findAccessTokenByJti(accessToken.getToken()).blockingGet());
+        assertNull(tokenRepository.findRefreshTokenByJti(refreshToken.getToken()).blockingGet());
+        assertEquals(1L, countTokens(domain));
+    }
+
+    private AccessToken newAccessToken(String token, String domain) {
+        AccessToken accessToken = new AccessToken();
+        accessToken.setId(RandomString.generate());
+        accessToken.setToken(token);
+        accessToken.setDomain(domain);
+        accessToken.setAllParentJtis(new HashSet<>());
+        return accessToken;
+    }
+
+    private RefreshToken newRefreshToken(String token, String domain) {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setId(RandomString.generate());
+        refreshToken.setToken(token);
+        refreshToken.setDomain(domain);
+        refreshToken.setAllParentJtis(new HashSet<>());
+        return refreshToken;
+    }
+
+    private long countTokens(String domain) {
+        Long count = template.getDatabaseClient()
+                .sql("SELECT COUNT(*) FROM tokens WHERE domain = '" + domain + "'")
+                .map(row -> ((Number) row.get(0)).longValue())
+                .one()
+                .block();
+        return count == null ? 0L : count;
+    }
+
+    private String shortSuffix() {
+        return RandomString.generate().substring(0, 8);
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoTokenRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/oauth2/MongoTokenRepository.java
@@ -96,6 +96,20 @@ public class MongoTokenRepository extends AbstractOAuth2MongoRepository implemen
     }
 
     @Override
+    public Completable create(AccessToken accessToken, RefreshToken refreshToken) {
+        if (refreshToken == null) {
+            return create(accessToken).ignoreElement();
+        }
+        if (refreshToken.getId() == null) {
+            refreshToken.setId(RandomString.generate());
+        }
+
+        return Completable
+                .fromPublisher(tokenCollection.insertMany(List.of(convert(accessToken), convert(refreshToken))))
+                .observeOn(Schedulers.computation());
+    }
+
+    @Override
     public Maybe<AccessToken> findAccessTokenByJti(String token) {
         return Observable
                 .fromPublisher(tokenCollection.find(and(

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/oauth2/MongoTokenRepositoryBatchTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/oauth2/MongoTokenRepositoryBatchTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.oauth2;
+
+import com.mongodb.client.result.InsertManyResult;
+import com.mongodb.client.result.InsertOneResult;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import io.gravitee.am.repository.mongodb.oauth2.internal.model.TokenMongo;
+import io.gravitee.am.repository.oauth2.api.TokenRepository.TokenType;
+import io.gravitee.am.repository.oauth2.model.AccessToken;
+import io.gravitee.am.repository.oauth2.model.RefreshToken;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards the single round-trip: reverting to two insertOne calls would keep the behaviour tests green
+ * but lose what the batch buys on MongoDB, which does not roll back an ordered insertMany.
+ *
+ * @author GraviteeSource Team
+ */
+public class MongoTokenRepositoryBatchTest {
+
+    private static final long TIMEOUT_SECONDS = 10;
+
+    private MongoCollection<TokenMongo> tokenCollection;
+    private MongoTokenRepository repository;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void before() {
+        tokenCollection = mock(MongoCollection.class);
+        repository = new MongoTokenRepository();
+        ReflectionTestUtils.setField(repository, "tokenCollection", tokenCollection);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldInsertBothTokensInSingleCall() {
+        when(tokenCollection.insertMany(anyList())).thenReturn(Flowable.just(InsertManyResult.unacknowledged()));
+
+        AccessToken accessToken = newAccessToken();
+        RefreshToken refreshToken = newRefreshToken();
+
+        TestObserver<Void> observer = repository.create(accessToken, refreshToken).test();
+        observer.awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertComplete();
+        observer.assertNoErrors();
+
+        ArgumentCaptor<List<TokenMongo>> captor = ArgumentCaptor.forClass(List.class);
+        verify(tokenCollection, times(1)).insertMany(captor.capture());
+        verify(tokenCollection, never()).insertOne(any());
+
+        List<TokenMongo> inserted = captor.getValue();
+        assertEquals(2, inserted.size());
+        assertEquals(TokenType.ACCESS_TOKEN, inserted.get(0).getType());
+        assertEquals(accessToken.getToken(), inserted.get(0).getJti());
+        assertEquals(TokenType.REFRESH_TOKEN, inserted.get(1).getType());
+        assertEquals(refreshToken.getToken(), inserted.get(1).getJti());
+    }
+
+    @Test
+    public void shouldNotInsertManyWhenRefreshTokenIsNull() {
+        when(tokenCollection.insertOne(any())).thenReturn(Flowable.just(InsertOneResult.unacknowledged()));
+
+        TestObserver<Void> observer = repository.create(newAccessToken(), null).test();
+        observer.awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertComplete();
+
+        verify(tokenCollection, times(1)).insertOne(any());
+        verify(tokenCollection, never()).insertMany(anyList());
+    }
+
+    private AccessToken newAccessToken() {
+        AccessToken accessToken = new AccessToken();
+        accessToken.setId("at-id");
+        accessToken.setToken("at-jti");
+        return accessToken;
+    }
+
+    private RefreshToken newRefreshToken() {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setId("rt-id");
+        refreshToken.setToken("rt-jti");
+        return refreshToken;
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/oauth2/api/TokenRepositoryBatchCreateTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/oauth2/api/TokenRepositoryBatchCreateTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.oauth2.api;
+
+import io.gravitee.am.common.utils.RandomString;
+import io.gravitee.am.repository.oauth2.AbstractOAuthTest;
+import io.gravitee.am.repository.oauth2.model.AccessToken;
+import io.gravitee.am.repository.oauth2.model.RefreshToken;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * The batch insert relies on an ordered insertMany, which is not a transaction: MongoDB stops at the
+ * failing document but keeps the ones already written. Unlike the JDBC batch, it gives a single
+ * round-trip, not all-or-nothing. Standalone deployments cannot provide the latter.
+ *
+ * @author GraviteeSource Team
+ */
+public class TokenRepositoryBatchCreateTest extends AbstractOAuthTest {
+
+    private static final long TIMEOUT_SECONDS = 10;
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Test
+    public void shouldKeepAccessTokenWhenRefreshTokenDocumentFails() {
+        String suffix = shortSuffix();
+        String domain = "domain-" + suffix;
+
+        AccessToken existingToken = newAccessToken("existing-at-" + suffix, domain);
+        tokenRepository.create(existingToken).ignoreElement().blockingAwait();
+
+        AccessToken accessToken = newAccessToken("batch-at-" + suffix, domain);
+        RefreshToken refreshToken = newRefreshToken("batch-rt-" + suffix, domain);
+        refreshToken.setId(existingToken.getId());
+
+        TestObserver<Void> observer = tokenRepository.create(accessToken, refreshToken).test();
+        observer.awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertError(Throwable.class);
+
+        assertNotNull(tokenRepository.findAccessTokenByJti(accessToken.getToken()).blockingGet());
+        assertNull(tokenRepository.findRefreshTokenByJti(refreshToken.getToken()).blockingGet());
+    }
+
+    @Test
+    public void shouldNotStoreRefreshTokenWhenAccessTokenDocumentFails() {
+        String suffix = shortSuffix();
+        String domain = "domain-" + suffix;
+
+        AccessToken existingToken = newAccessToken("existing-at-" + suffix, domain);
+        tokenRepository.create(existingToken).ignoreElement().blockingAwait();
+
+        AccessToken accessToken = newAccessToken("batch-at-" + suffix, domain);
+        accessToken.setId(existingToken.getId());
+        RefreshToken refreshToken = newRefreshToken("batch-rt-" + suffix, domain);
+
+        TestObserver<Void> observer = tokenRepository.create(accessToken, refreshToken).test();
+        observer.awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertError(Throwable.class);
+
+        assertNull(tokenRepository.findAccessTokenByJti(accessToken.getToken()).blockingGet());
+        assertNull(tokenRepository.findRefreshTokenByJti(refreshToken.getToken()).blockingGet());
+    }
+
+    private AccessToken newAccessToken(String token, String domain) {
+        AccessToken accessToken = new AccessToken();
+        accessToken.setId(RandomString.generate());
+        accessToken.setToken(token);
+        accessToken.setDomain(domain);
+        accessToken.setAllParentJtis(new HashSet<>());
+        return accessToken;
+    }
+
+    private RefreshToken newRefreshToken(String token, String domain) {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setId(RandomString.generate());
+        refreshToken.setToken(token);
+        refreshToken.setDomain(domain);
+        refreshToken.setAllParentJtis(new HashSet<>());
+        return refreshToken;
+    }
+
+    private String shortSuffix() {
+        return RandomString.generate().substring(0, 8);
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/oauth2/api/TokenRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/oauth2/api/TokenRepositoryTest.java
@@ -25,9 +25,11 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Date;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -75,6 +77,74 @@ public class TokenRepositoryTest extends AbstractOAuthTest {
         refreshObserver.assertComplete();
         refreshObserver.assertValueCount(1);
         refreshObserver.assertNoErrors();
+    }
+
+    @Test
+    public void shouldBatchCreateAccessAndRefreshTokens() {
+        String suffix = shortSuffix();
+        Date createdAt = new Date();
+        Date expireAt = new Date(createdAt.getTime() + TimeUnit.DAYS.toMillis(1));
+
+        AccessToken accessToken = newAccessToken("batch-at-" + suffix, "domain-id", "client-id", "user-id", "parent-jti-" + suffix);
+        accessToken.setAuthorizationCode("batch-code-" + suffix);
+        accessToken.setRefreshToken("batch-rt-" + suffix);
+        accessToken.setCreatedAt(createdAt);
+        accessToken.setExpireAt(expireAt);
+
+        RefreshToken refreshToken = newRefreshToken("batch-rt-" + suffix, "domain-id", "client-id", "user-id", "parent-jti-" + suffix);
+        refreshToken.setCreatedAt(createdAt);
+        refreshToken.setExpireAt(expireAt);
+
+        tokenRepository.create(accessToken, refreshToken).blockingAwait();
+
+        AccessToken storedAccessToken = tokenRepository.findAccessTokenByJti(accessToken.getToken()).blockingGet();
+        assertNotNull(storedAccessToken);
+        assertEquals(accessToken.getId(), storedAccessToken.getId());
+        assertEquals("domain-id", storedAccessToken.getDomain());
+        assertEquals("client-id", storedAccessToken.getClient());
+        assertEquals("user-id", storedAccessToken.getSubject());
+        assertEquals(accessToken.getAuthorizationCode(), storedAccessToken.getAuthorizationCode());
+        assertEquals(refreshToken.getToken(), storedAccessToken.getRefreshToken());
+        assertEquals(createdAt.getTime(), storedAccessToken.getCreatedAt().getTime());
+        assertEquals(expireAt.getTime(), storedAccessToken.getExpireAt().getTime());
+
+        RefreshToken storedRefreshToken = tokenRepository.findRefreshTokenByJti(refreshToken.getToken()).blockingGet();
+        assertNotNull(storedRefreshToken);
+        assertEquals(refreshToken.getId(), storedRefreshToken.getId());
+        assertEquals("domain-id", storedRefreshToken.getDomain());
+        assertEquals("client-id", storedRefreshToken.getClient());
+        assertEquals("user-id", storedRefreshToken.getSubject());
+        assertEquals(createdAt.getTime(), storedRefreshToken.getCreatedAt().getTime());
+        assertEquals(expireAt.getTime(), storedRefreshToken.getExpireAt().getTime());
+
+        assertNull(tokenRepository.findRefreshTokenByJti(accessToken.getToken()).blockingGet());
+        assertNull(tokenRepository.findAccessTokenByJti(refreshToken.getToken()).blockingGet());
+    }
+
+    @Test
+    public void shouldBatchCreateAccessTokenOnlyWhenRefreshTokenIsNull() {
+        String suffix = shortSuffix();
+        AccessToken accessToken = newAccessToken("batch-single-at-" + suffix, null, null, null);
+
+        tokenRepository.create(accessToken, null).blockingAwait();
+
+        assertNotNull(tokenRepository.findAccessTokenByJti(accessToken.getToken()).blockingGet());
+    }
+
+    @Test
+    public void shouldDeleteBatchCreatedTokensByParentJti() {
+        String suffix = shortSuffix();
+        AccessToken parent = newAccessToken("batch-parent-" + suffix, null, null, null);
+        AccessToken accessToken = newAccessToken("batch-child-at-" + suffix, null, null, null, parent.getToken());
+        RefreshToken refreshToken = newRefreshToken("batch-child-rt-" + suffix, null, null, null, parent.getToken());
+
+        tokenRepository.create(parent).ignoreElement()
+                .andThen(tokenRepository.create(accessToken, refreshToken))
+                .andThen(tokenRepository.deleteByJti(parent.getToken()))
+                .blockingAwait();
+
+        assertNull(tokenRepository.findAccessTokenByJti(accessToken.getToken()).blockingGet());
+        assertNull(tokenRepository.findRefreshTokenByJti(refreshToken.getToken()).blockingGet());
     }
 
     @Test


### PR DESCRIPTION
to test: 
1. mongo and jdbc 
2. ensure querry/command by enabling driver's logs
3. create an app with refresh_token grant_flow and obtain user's token (password or auth_code grant_flow) - two tokens should appear in tokens collection/table