### PR TITLE
test: cover identity provider selection rules on the login path (AM-7546)

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandlerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/test/java/io/gravitee/am/gateway/handler/root/resources/handler/login/LoginSelectionRuleHandlerTest.java
@@ -100,4 +100,147 @@ public class LoginSelectionRuleHandlerTest extends RxWebTestBase {
                 },
                 302, "Found", null);
     }
+
+    /**
+     * The handler takes the first provider whose rule matches, and the client holds them ordered by
+     * priority. So when two tenants' rules both match a user, priority alone decides which tenant
+     * they reach — and getting that wrong looks like a successful login, not an error.
+     */
+    @Test
+    public void shouldRedirectToTheHighestPriorityIdP_whenSeveralSelectionRulesMatch() throws Exception {
+        // both providers whitelist the same domain, so both rules match the submitted username
+        var lowerPriority = applicationIdp("idp-priority-5", 5, WHITELISTED_DOMAIN_RULE);
+        var higherPriority = applicationIdp("idp-priority-1", 1, WHITELISTED_DOMAIN_RULE);
+
+        var client = new Client();
+        SortedSet<ApplicationIdentityProvider> applicationIdps = new TreeSet<>();
+        // added lower priority first, so a pass here cannot come from insertion order
+        applicationIdps.add(lowerPriority);
+        applicationIdps.add(higherPriority);
+        client.setIdentityProviders(applicationIdps);
+
+        seedRoutingContext(client,
+                List.of(socialProvider("idp-priority-5", "mail.com"), socialProvider("idp-priority-1", "mail.com")),
+                Map.of("idp-priority-5", "https://tenant-five.example.com/authorize",
+                        "idp-priority-1", "https://tenant-one.example.com/authorize"));
+
+        testRequest(
+                HttpMethod.POST,
+                "/login/identifier?username=john.doe@mail.com",
+                null,
+                resp -> assertEquals("https://tenant-one.example.com/authorize", resp.headers().get("location")),
+                302, "Found", null);
+    }
+
+    /**
+     * A user no rule matches must be left to the normal login flow rather than pushed at whichever
+     * provider happens to be configured first.
+     */
+    @Test
+    public void shouldNotRedirect_whenNoSelectionRuleMatches() throws Exception {
+        var client = new Client();
+        SortedSet<ApplicationIdentityProvider> applicationIdps = new TreeSet<>();
+        applicationIdps.add(applicationIdp("idp-1", 1, WHITELISTED_DOMAIN_RULE));
+        client.setIdentityProviders(applicationIdps);
+
+        // the provider only accepts another-mail.com, the user is on mail.com
+        seedRoutingContext(client,
+                List.of(socialProvider("idp-1", "another-mail.com")),
+                Map.of("idp-1", "https://another-mail.example.com/authorize"));
+
+        // reached only if the handler calls next() instead of redirecting
+        router.route(HttpMethod.POST, "/login/identifier")
+                .handler(rc -> rc.response().setStatusCode(200).end());
+
+        testRequest(
+                HttpMethod.POST,
+                "/login/identifier?username=john.doe@mail.com",
+                null,
+                resp -> assertNull("must not redirect a user no rule matched", resp.headers().get("location")),
+                200, "OK", null);
+    }
+
+    /**
+     * The username is handed to the external provider so the user is not asked for it twice. It has
+     * to survive encoding to do that — the handler carries a note that Azure AD turns a '+' into a
+     * space, so a username containing one is the case worth pinning down.
+     */
+    @Test
+    public void shouldPassUsernameAsEncodedLoginHint_onIdentifierFirstLogin() throws Exception {
+        seedIdentifierFirstRoute();
+
+        testRequest(
+                HttpMethod.POST,
+                "/login/identifier-first?username=john%2Btest@mail.com",
+                null,
+                resp -> assertEquals(
+                        "https://tenant-one.example.com/authorize?login_hint=john%2Btest%40mail.com",
+                        resp.headers().get("location")),
+                302, "Found", null);
+    }
+
+    @Test
+    public void shouldPassRememberMeHint_onIdentifierFirstLogin() throws Exception {
+        seedIdentifierFirstRoute();
+
+        testRequest(
+                HttpMethod.POST,
+                "/login/identifier-first?username=john.doe@mail.com&rememberMe=on",
+                null,
+                resp -> assertEquals(
+                        "https://tenant-one.example.com/authorize?login_hint=john.doe%40mail.com&remember_me_hint=on",
+                        resp.headers().get("location")),
+                302, "Found", null);
+    }
+
+    /** Matches a username whose domain is the one the identity provider whitelists. */
+    private static final String WHITELISTED_DOMAIN_RULE =
+            "{#request.params['username'][0] matches '.+@' + #identityProvider.domainWhitelist[0] + '$'}";
+
+    /**
+     * Mounts the handler in its identifier-first mode on a separate path, behind a single matching
+     * provider, so the login hint assertions have one unambiguous redirect target.
+     */
+    private void seedIdentifierFirstRoute() {
+        var client = new Client();
+        SortedSet<ApplicationIdentityProvider> applicationIdps = new TreeSet<>();
+        applicationIdps.add(applicationIdp("idp-1", 1, WHITELISTED_DOMAIN_RULE));
+        client.setIdentityProviders(applicationIdps);
+
+        seedRoutingContext(client,
+                List.of(socialProvider("idp-1", "mail.com")),
+                Map.of("idp-1", "https://tenant-one.example.com/authorize"));
+
+        router.route(HttpMethod.POST, "/login/identifier-first")
+                .handler(new LoginSelectionRuleHandler(true));
+    }
+
+    /** Seeds what LoginAuthenticationHandler would have put in the context before this handler runs. */
+    private void seedRoutingContext(Client client, List<IdentityProvider> socialProviders, Map<String, String> authorizeUrls) {
+        router.route()
+                .order(-1)
+                .handler(rc -> {
+                    rc.put(ConstantKeys.CLIENT_CONTEXT_KEY, client);
+                    rc.put(SOCIAL_PROVIDER_CONTEXT_KEY, socialProviders);
+                    rc.put(SOCIAL_AUTHORIZE_URL_CONTEXT_KEY, authorizeUrls);
+                    rc.put(SOCIAL_PROVIDER_MAP_CONTEXT_KEY,
+                            socialProviders.stream().collect(toMap(IdentityProvider::getId, identity())));
+                    rc.next();
+                });
+    }
+
+    private static ApplicationIdentityProvider applicationIdp(String identity, int priority, String selectionRule) {
+        var appIdp = new ApplicationIdentityProvider();
+        appIdp.setIdentity(identity);
+        appIdp.setPriority(priority);
+        appIdp.setSelectionRule(selectionRule);
+        return appIdp;
+    }
+
+    private static IdentityProvider socialProvider(String id, String whitelistedDomain) {
+        var identityProvider = new IdentityProvider();
+        identityProvider.setId(id);
+        identityProvider.setDomainWhitelist(List.of(whitelistedDomain));
+        return identityProvider;
+    }
 }

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/idp/ApplicationIdentityProviderTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/idp/ApplicationIdentityProviderTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.idp;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A client holds its identity providers in a sorted set, and the login path takes the first one
+ * whose selection rule matches. This ordering is therefore what decides which provider a user is
+ * routed to when more than one rule matches them, which on a multi-tenant domain means it decides
+ * which tenant they reach.
+ *
+ * @author GraviteeSource Team
+ */
+public class ApplicationIdentityProviderTest {
+
+    @Test
+    public void providersAreOrderedByAscendingPriorityWhicheverOrderTheyWereAddedIn() {
+        List<String> addedLowestFirst = identitiesOf(
+                provider("idp-first", 1),
+                provider("idp-second", 5),
+                provider("idp-third", 9));
+
+        List<String> addedHighestFirst = identitiesOf(
+                provider("idp-third", 9),
+                provider("idp-second", 5),
+                provider("idp-first", 1));
+
+        assertEquals("lowest priority value must be routed to first",
+                List.of("idp-first", "idp-second", "idp-third"), addedLowestFirst);
+
+        // Asserted from both directions on purpose. The comparator is the only thing that should
+        // decide the order here, so a result that tracked the order the providers were added in
+        // would mean routing depended on whatever order the store happened to return them.
+        assertEquals("ordering must come from priority, not from insertion order",
+                addedLowestFirst, addedHighestFirst);
+    }
+
+    private static ApplicationIdentityProvider provider(String identity, int priority) {
+        var appIdp = new ApplicationIdentityProvider();
+        appIdp.setIdentity(identity);
+        appIdp.setPriority(priority);
+        return appIdp;
+    }
+
+    private static List<String> identitiesOf(ApplicationIdentityProvider... providers) {
+        SortedSet<ApplicationIdentityProvider> sorted = new TreeSet<>();
+        for (ApplicationIdentityProvider provider : providers) {
+            sorted.add(provider);
+        }
+        return sorted.stream().map(ApplicationIdentityProvider::getIdentity).toList();
+    }
+}


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7546

## :pencil2: A description of the changes proposed in the pull request
Adds 5 tests over the identity provider selection rule decisions on the login path — 4 to LoginSelectionRuleHandlerTest and a new ApplicationIdentityProviderTest.

Covers which provider a user is routed to when more than one selection rule matches, that a user matching no rule falls through to normal login rather than being redirected, and that the username and remember-me preference reach the external provider correctly encoded on identifier-first login.

Driven by the Zendesk 17649 P1. These paths fail silently — wrong-tenant routing presents as a successful login, and a mangled login_hint makes the upstream provider re-prompt for a username the user already supplied. The plus sign in the login hint test is deliberate: the handler carries a note that Azure AD converts '+' to a space.

## :memo: Test scenarios 
NA

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA
