### PR TITLE
fix: guard service resource listing with DOMAIN_RESOURCE permission

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ServiceResourcesResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ServiceResourcesResource.java
@@ -95,11 +95,11 @@ public class ServiceResourcesResource extends AbstractResource {
             @PathParam("domain") String domain,
             @Suspended final AsyncResponse response) {
 
-        checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_FACTOR, Acl.LIST)
+        checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_RESOURCE, Acl.LIST)
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                         .flatMapPublisher(___ -> resourceService.findByDomain(domain))
-                        .map(this::filterFactorInfos)
+                        .map(this::filterServiceResourceInfos)
                         .toList())
                 .subscribe(response::resume, response::resume);
     }
@@ -144,7 +144,7 @@ public class ServiceResourcesResource extends AbstractResource {
         return resourceContext.getResource(ServiceResourceResource.class);
     }
 
-    private ServiceResource filterFactorInfos(ServiceResource resource) {
+    private ServiceResource filterServiceResourceInfos(ServiceResource resource) {
         ServiceResource filteredResource = new ServiceResource();
         filteredResource.setId(resource.getId());
         filteredResource.setName(resource.getName());

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/JerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/JerseySpringTest.java
@@ -52,6 +52,7 @@ import io.gravitee.am.management.service.PermissionService;
 import io.gravitee.am.management.service.PolicyPluginService;
 import io.gravitee.am.management.service.ReporterServiceProxy;
 import io.gravitee.am.management.service.ResourcePluginService;
+import io.gravitee.am.management.service.ServiceResourceServiceProxy;
 import io.gravitee.am.management.service.RevokeTokenManagementService;
 import io.gravitee.am.management.service.TagService;
 import io.gravitee.am.management.service.dataplane.CredentialManagementService;
@@ -95,6 +96,7 @@ import io.gravitee.am.service.validators.email.UserEmail;
 import io.gravitee.am.service.validators.email.UserEmailConstraintValidator;
 import io.gravitee.am.service.validators.email.resource.EmailTemplateValidator;
 import io.gravitee.am.service.validators.flow.FlowValidator;
+import io.gravitee.am.service.validators.resource.ResourceValidator;
 import io.gravitee.am.service.validators.plugincfg.PluginJsonFormValidator;
 import io.gravitee.am.service.validators.user.UserValidator;
 import io.gravitee.node.api.license.LicenseManager;
@@ -267,6 +269,9 @@ public abstract class JerseySpringTest {
 
     @Autowired
     protected ResourcePluginService resourcePluginService;
+
+    @Autowired
+    protected ServiceResourceServiceProxy serviceResourceServiceProxy;
 
     @Autowired
     protected BotDetectionPluginService botDetectionPluginService;
@@ -606,6 +611,18 @@ public abstract class JerseySpringTest {
         @Bean
         public ResourcePluginService resourcePluginService() {
             return mock(ResourcePluginService.class);
+        }
+
+        @Bean
+        public ServiceResourceServiceProxy serviceResourceServiceProxy() {
+            return mock(ServiceResourceServiceProxy.class);
+        }
+
+        @Bean
+        public ResourceValidator resourceValidator() {
+            ResourceValidator mock = mock(ResourceValidator.class);
+            when(mock.validate(Mockito.any())).thenReturn(Completable.complete());
+            return mock;
         }
 
         @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ServiceResourcesResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/ServiceResourcesResourceTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.resources.organizations.environments.domains;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
+import io.gravitee.am.management.service.permissions.PermissionAcls;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.Membership;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.model.resource.ServiceResource;
+import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+public class ServiceResourcesResourceTest extends JerseySpringTest {
+
+    private static final String DOMAIN_ID = "domain-1";
+
+    @Test
+    public void shouldList() {
+        final ServiceResource serviceResource = new ServiceResource();
+        serviceResource.setId("resource-1");
+        serviceResource.setName("my-smtp");
+        serviceResource.setType("smtp-am-resource");
+        serviceResource.setConfiguration("{\"password\":\"secret\"}");
+
+        doReturn(Maybe.just(domain())).when(domainService).findById(DOMAIN_ID);
+        doReturn(Flowable.just(serviceResource)).when(serviceResourceServiceProxy).findByDomain(DOMAIN_ID);
+
+        final Response response = listResources();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        final List<Map<String, Object>> resources = response.readEntity(List.class);
+        assertEquals(1, resources.size());
+        assertEquals(Map.of("id", "resource-1", "name", "my-smtp", "type", "smtp-am-resource"), resources.get(0));
+    }
+
+    @Test
+    public void shouldListWithDomainResourcePermission() {
+        doReturn(Maybe.just(domain())).when(domainService).findById(DOMAIN_ID);
+        doReturn(Flowable.empty()).when(serviceResourceServiceProxy).findByDomain(DOMAIN_ID);
+
+        listResources();
+
+        final ArgumentCaptor<PermissionAcls> captor = ArgumentCaptor.forClass(PermissionAcls.class);
+        verify(permissionService, atLeastOnce()).hasPermission(any(User.class), captor.capture());
+
+        final List<PermissionAcls> checked = captor.getAllValues();
+        assertTrue("DOMAIN_RESOURCE[LIST] should open the endpoint",
+                checked.stream().anyMatch(acls -> acls.match(granted(Permission.DOMAIN_RESOURCE))));
+        assertFalse("DOMAIN_FACTOR[LIST] should not open the endpoint",
+                checked.stream().anyMatch(acls -> acls.match(granted(Permission.DOMAIN_FACTOR))));
+    }
+
+    private Response listResources() {
+        return target("domains").path(DOMAIN_ID).path("resources").request().get();
+    }
+
+    private Domain domain() {
+        final Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        return domain;
+    }
+
+    private Map<Membership, Map<Permission, Set<Acl>>> granted(Permission permission) {
+        final Membership membership = new Membership();
+        membership.setReferenceType(ReferenceType.DOMAIN);
+        membership.setReferenceId(DOMAIN_ID);
+        return Map.of(membership, Map.of(permission, Set.of(Acl.LIST)));
+    }
+}


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7478

## :pencil2: A description of the changes proposed in the pull request

Listing the service resources of a domain checked `DOMAIN_FACTOR[LIST]`. It now checks `DOMAIN_RESOURCE[LIST]`, which is what the OpenAPI description says and what the other four operations on the same resources already use.

Two things get fixed by that:

- An admin who grants `DOMAIN_RESOURCE[LIST]` can list the resources. Before, the call gave a 403.
- A user who only has `DOMAIN_FACTOR[LIST]` cannot list them any more. Service resources describe SMTP and HTTP integrations, so that crossed a boundary the admin thought they had set.

The list method was copied from the factors resource, so I renamed its mapper from `filterFactorInfos` to `filterServiceResourceInfos`. The Jersey test harness gained mock beans for `ServiceResourceServiceProxy` and `ResourceValidator`, because the resource autowires both and no test reached it before.

## :warning: Upgrade note

Technically a breaking change, but the old behaviour was the bug. It goes in the release notes rather than on the commit.

`GET /management/organizations/{org}/environments/{env}/domains/{domain}/resources` now requires `DOMAIN_RESOURCE[LIST]`. It accepted `DOMAIN_FACTOR[LIST]` before.

Who this affects: anyone with a custom role that grants the factor permissions but not `domain_resource_list`. The built-in roles are safe. `DefaultRole` only has OWNER and USER at each level, so they carry both permissions or neither.

What breaks for them:

- The Management API call returns 403.
- The Console factor screens fail to open. `factors/new` and `factors/{factorId}` resolve `ResourcesResolver`, which calls this endpoint, and a failed resolver stops the navigation.

Upgrade step: add `domain_resource_list` to any custom role that manages factors.

The Console part gets handled in this PR. The factor screens must tolerate a 403 from the resource list and show an empty resource picker, so a missing `domain_resource_list` degrades the factor form instead of blocking the route.

## :memo: Test scenarios

Unit coverage in the branch, all green. The new permission test fails against the old guard.

`gravitee-am-test/specs/management/permissions/permission-sufficiency.jest.spec.ts` excludes this route with a reference to the ticket. That spec is not on master yet. Whoever merges AM-7448 should drop the exclusion.

## :computer: Add screenshots for UI

No UI changes yet. The factor screen fix lands in this PR and needs a screenshot of the factor form with an empty resource picker.

## :books: Any other comments that will help with documentation

The release notes need the upgrade note above.

`release/helpers/changelog-helper.mjs` builds the notes from the Jira issues of the version, and it keeps only `Public Bug`, `Public Security`, `Public Improvement` and `Story`. AM-7478 is a `Private Bug`, so it does not reach the notes as it stands.

The OpenAPI description already documented `DOMAIN_RESOURCE[LIST]`, so the spec needs no change. The permission has carried `DOMAIN_FACTOR` since the file's first commit.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
