### PR TITLE
fix(console): keep the factor screens usable without DOMAIN_RESOURCE

### DIFF
--- a/gravitee-am-test/specs/management/permissions/fixtures/permission-sweep-tables.ts
+++ b/gravitee-am-test/specs/management/permissions/fixtures/permission-sweep-tables.ts
@@ -69,15 +69,12 @@ export const EXCLUDED_ROUTES: Record<string, string> = {
 /**
  * Additional exclusions that apply only when a test *grants* the documented permission and expects
  * to be admitted. They are deliberately not in the shared table above: a caller who holds nothing
- * is still correctly refused on both routes, so the negative sweep must keep covering them.
+ * is still correctly refused on that route, so the negative sweep must keep covering it.
  */
 export const SUFFICIENCY_ONLY_EXCLUDED: Record<string, string> = {
   // INSTALLATION is only relevant to the PLATFORM tier, so it cannot be granted by an
   // organization-assignable role and this technique cannot reach it.
   '/platform/installation': 'PLATFORM-tier permission, not grantable at organization level',
-  // Guarded by DOMAIN_FACTOR instead of DOMAIN_RESOURCE, so the documented permission does not
-  // open it. Re-include once AM-7478 is fixed — asserting today's behaviour would enshrine it.
-  '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/resources': 'AM-7478: guarded by the wrong permission',
 };
 
 /** The permission a route really enforces, preferring a confirmed override over the spec. */

--- a/gravitee-am-ui/src/app/app-routing.module.ts
+++ b/gravitee-am-ui/src/app/app-routing.module.ts
@@ -165,6 +165,7 @@ import { ResourceCreationComponent } from './domain/settings/resources/creation/
 import { ResourceComponent } from './domain/settings/resources/resource/resource.component';
 import { ResourceResolver } from './resolvers/resource.resolver';
 import { ResourcesResolver } from './resolvers/resources.resolver';
+import { FactorResourcesResolver } from './resolvers/factor-resources.resolver';
 import { NotFoundComponent } from './not-found/not-found.component';
 import { EntrypointsComponent } from './settings/management/entrypoints/entrypoints.component';
 import { EntrypointCreationComponent } from './settings/management/entrypoints/creation/entrypoint-creation.component';
@@ -2124,7 +2125,7 @@ export const routes: Routes = [
                             canActivate: [AuthGuard],
                             resolve: {
                               factorPlugins: FactorPluginsResolver,
-                              resources: ResourcesResolver,
+                              resources: FactorResourcesResolver,
                               resourcePlugins: ResourcePluginsResolver,
                             },
                             data: {
@@ -2140,7 +2141,7 @@ export const routes: Routes = [
                             resolve: {
                               factor: FactorResolver,
                               factorPlugins: FactorPluginsResolver,
-                              resources: ResourcesResolver,
+                              resources: FactorResourcesResolver,
                               resourcePlugins: ResourcePluginsResolver,
                             },
                             data: {

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -338,6 +338,7 @@ import { FactorFormComponent } from './domain/settings/factors/factor/form/form.
 import { FactorResolver } from './resolvers/factor.resolver';
 import { EnrolledFactorsResolver } from './resolvers/enrolled-factors.resolver';
 import { ResourcesResolver } from './resolvers/resources.resolver';
+import { FactorResourcesResolver } from './resolvers/factor-resources.resolver';
 import { ResourcePluginsResolver } from './resolvers/resource-plugins.resolver';
 import { ResourceService } from './services/resource.service';
 import { ResourceComponent } from './domain/settings/resources/resource/resource.component';
@@ -974,6 +975,7 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     EnrolledFactorsResolver,
     ResourceService,
     ResourcesResolver,
+    FactorResourcesResolver,
     ResourcePluginsResolver,
     ResourceResolver,
     AuthGuard,

--- a/gravitee-am-ui/src/app/resolvers/factor-resources.resolver.ts
+++ b/gravitee-am-ui/src/app/resolvers/factor-resources.resolver.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { Observable } from 'rxjs';
+
+import { ResourceService } from '../services/resource.service';
+
+@Injectable()
+export class FactorResourcesResolver {
+  constructor(private resourceService: ResourceService) {}
+
+  resolve(route: ActivatedRouteSnapshot): Observable<any[]> {
+    const domainId = route.parent.data['domain'].id;
+    return this.resourceService.findByDomainWhenPermitted(domainId);
+  }
+}

--- a/gravitee-am-ui/src/app/services/resource.service.spec.ts
+++ b/gravitee-am-ui/src/app/services/resource.service.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpErrorResponse, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+
+import { AppConfig } from '../../config/app.config';
+
+import { ResourceService } from './resource.service';
+
+describe('ResourceService', () => {
+  let httpTestingController: HttpTestingController;
+  let resourceService: ResourceService;
+
+  const domainId = 'domain-1234';
+  const resourcesUrl = `${AppConfig.settings.domainBaseURL}${domainId}/resources`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      teardown: { destroyAfterEach: false },
+      imports: [],
+      providers: [ResourceService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+    });
+
+    httpTestingController = TestBed.get(HttpTestingController);
+    resourceService = TestBed.get(ResourceService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('findByDomainWhenPermitted', () => {
+    it('returns the resources when the user is permitted', (done) => {
+      const resources = [{ id: 'resource-1', name: 'my-smtp', type: 'smtp-am-resource' }];
+
+      resourceService.findByDomainWhenPermitted(domainId).subscribe((result) => {
+        expect(result).toEqual(resources);
+        done();
+      });
+
+      httpTestingController.expectOne({ method: 'GET', url: resourcesUrl }).flush(resources);
+    });
+
+    it('returns an empty list when the user lacks DOMAIN_RESOURCE[LIST]', (done) => {
+      resourceService.findByDomainWhenPermitted(domainId).subscribe((result) => {
+        expect(result).toEqual([]);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({ method: 'GET', url: resourcesUrl })
+        .flush({ message: 'Permission denied' }, { status: 403, statusText: 'Forbidden' });
+    });
+
+    it('propagates errors other than 403', (done) => {
+      resourceService.findByDomainWhenPermitted(domainId).subscribe({
+        next: () => done.fail('expected the error to propagate'),
+        error: (error: unknown) => {
+          expect(error).toBeInstanceOf(HttpErrorResponse);
+          expect((error as HttpErrorResponse).status).toEqual(500);
+          done();
+        },
+      });
+
+      httpTestingController
+        .expectOne({ method: 'GET', url: resourcesUrl })
+        .flush({ message: 'Server error' }, { status: 500, statusText: 'Internal Server Error' });
+    });
+  });
+});

--- a/gravitee-am-ui/src/app/services/resource.service.spec.ts
+++ b/gravitee-am-ui/src/app/services/resource.service.spec.ts
@@ -15,9 +15,10 @@
  */
 import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { HttpErrorResponse, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 import { AppConfig } from '../../config/app.config';
+import { SKIP_ERROR_SNACKBAR } from '../interceptors/http-request.interceptor';
 
 import { ResourceService } from './resource.service';
 
@@ -61,19 +62,18 @@ describe('ResourceService', () => {
         done();
       });
 
-      httpTestingController
-        .expectOne({ method: 'GET', url: resourcesUrl })
-        .flush({ message: 'Permission denied' }, { status: 403, statusText: 'Forbidden' });
+      const req = httpTestingController.expectOne({ method: 'GET', url: resourcesUrl });
+      expect(req.request.context.get(SKIP_ERROR_SNACKBAR)).toBe(true);
+      req.flush({ message: 'Permission denied' }, { status: 403, statusText: 'Forbidden' });
     });
 
-    it('propagates errors other than 403', (done) => {
+    it('returns an empty list when the request fails for any other reason', (done) => {
       resourceService.findByDomainWhenPermitted(domainId).subscribe({
-        next: () => done.fail('expected the error to propagate'),
-        error: (error: unknown) => {
-          expect(error).toBeInstanceOf(HttpErrorResponse);
-          expect((error as HttpErrorResponse).status).toEqual(500);
+        next: (result) => {
+          expect(result).toEqual([]);
           done();
         },
+        error: (error: unknown) => done(error),
       });
 
       httpTestingController

--- a/gravitee-am-ui/src/app/services/resource.service.ts
+++ b/gravitee-am-ui/src/app/services/resource.service.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpContext, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import { AppConfig } from '../../config/app.config';
+import { SKIP_ERROR_SNACKBAR } from '../interceptors/http-request.interceptor';
 
 @Injectable()
 export class ResourceService {
@@ -27,6 +29,18 @@ export class ResourceService {
 
   findByDomain(domainId): Observable<any> {
     return this.http.get<any>(this.resourcesURL + domainId + '/resources');
+  }
+
+  // The factor screens render without the resource list, so a user who lacks
+  // DOMAIN_RESOURCE[LIST] gets an empty list rather than a failed route.
+  findByDomainWhenPermitted(domainId): Observable<any[]> {
+    return this.http
+      .get<any[]>(this.resourcesURL + domainId + '/resources', {
+        context: new HttpContext().set(SKIP_ERROR_SNACKBAR, true),
+      })
+      .pipe(
+        catchError((error: unknown) => (error instanceof HttpErrorResponse && error.status === 403 ? of([]) : throwError(() => error))),
+      );
   }
 
   get(domainId, id): Observable<any> {

--- a/gravitee-am-ui/src/app/services/resource.service.ts
+++ b/gravitee-am-ui/src/app/services/resource.service.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpContext, HttpErrorResponse } from '@angular/common/http';
-import { Observable, of, throwError } from 'rxjs';
+import { HttpClient, HttpContext } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 import { AppConfig } from '../../config/app.config';
@@ -31,16 +31,15 @@ export class ResourceService {
     return this.http.get<any>(this.resourcesURL + domainId + '/resources');
   }
 
-  // The factor screens render without the resource list, so a user who lacks
-  // DOMAIN_RESOURCE[LIST] gets an empty list rather than a failed route.
+  // The factor screens render without the resource list, so a failed lookup
+  // (typically a user without DOMAIN_RESOURCE[LIST]) gives an empty list
+  // rather than a cancelled route with no message behind it.
   findByDomainWhenPermitted(domainId): Observable<any[]> {
     return this.http
       .get<any[]>(this.resourcesURL + domainId + '/resources', {
         context: new HttpContext().set(SKIP_ERROR_SNACKBAR, true),
       })
-      .pipe(
-        catchError((error: unknown) => (error instanceof HttpErrorResponse && error.status === 403 ? of([]) : throwError(() => error))),
-      );
+      .pipe(catchError(() => of([])));
   }
 
   get(domainId, id): Observable<any> {


### PR DESCRIPTION
## :id: Reference related issue.

https://gravitee.atlassian.net/browse/AM-7478

## :pencil2: A description of the changes proposed in the pull request

Follow-up to #8424. That PR moved the resources listing endpoint onto `DOMAIN_RESOURCE[LIST]` and merged before these two parts went up.

The Console reaches that endpoint from the factor screens, not only from the resources screen. `factors/new` and `factors/{factorId}` resolve the resource list, and a failed resolver stops the navigation. So a custom role that grants the factor permissions without `domain_resource_list` cannot open the factor screens at all on master today.

`ResourceService.findByDomainWhenPermitted` maps a 403 to an empty list and suppresses the error snackbar. Any other status still propagates. A new `FactorResourcesResolver` calls it, and the two factor routes use that resolver. Both factor components already disable the resource field when the list is empty, so the form works and the picker is simply unavailable.

The domain settings resources screen keeps `ResourcesResolver`. A 403 there means something is genuinely wrong, and it should still fail loudly.

The permission sweep from AM-7448 excluded this route while the guard was wrong. The exclusion comes out here, so the sufficiency test asserts that `domain_resource_list` alone opens the endpoint.

## :memo: Test scenarios

### Automated

From the repo root, with the local stack up:

```bash
npm --prefix gravitee-am-test run test -- specs/management/permissions/permission-sufficiency.jest.spec.ts specs/management/permissions/endpoint-permission-sweep.jest.spec.ts
```

99 tests, all green. The case to look for is `should admit domain_resource_list alone to /organizations/{organizationId}/environments/{environmentId}/domains/{domain}/resources`. This branch removes the exclusion that skipped it, so it fails against the old guard.

```bash
cd gravitee-am-ui && yarn test --test-path-pattern 'services/resource.service.spec.ts'
```

3 tests, all green: permitted, 403 gives an empty list, other errors propagate. Note the flag is kebab-case. `--testPathPattern` is rejected by the builder, and bare `npx jest` cannot run a spec at all because the jest preset comes from the Angular builder.

### Console, by hand

Walked end to end on a local stack. Build a role that can manage factors but cannot list
resources, then use the Console as a user holding it.

1. Get an admin token.

```bash
MGMT=http://localhost:8093/management
TOKEN=$(curl -s -u admin:adminadmin -X POST "$MGMT/auth/token" | jq -r .access_token)
```

2. Create the role, then set its permissions. Creation rejects a `permissions` property, so it is two calls.

```bash
ROLE=$(curl -s -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -X POST "$MGMT/organizations/DEFAULT/roles" \
  -d '{"name":"factor-admin-no-resources","assignableType":"ORGANIZATION"}' | jq -r .id)

curl -s -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -X PUT "$MGMT/organizations/DEFAULT/roles/$ROLE" \
  -d '{"name":"factor-admin-no-resources","permissions":["environment_list","environment_read","organization_tag_list","domain_list","domain_read","domain_settings_read","domain_factor_list","domain_factor_read","domain_factor_create"]}'
```

Every permission there earns its place. Without `environment_list` the Console renders an empty
shell and never reaches a domain. Without `organization_tag_list` the domain overview raises its
own "Access denied" toast, which muddies the check in step 6. `domain_resource_list` is the one
permission deliberately left out, and that omission is the whole test.

3. Create the user and give it the role.

```bash
USER=$(curl -s -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -X POST "$MGMT/organizations/DEFAULT/users" \
  -d '{"username":"factoradmin","password":"Password123!","firstName":"Factor","lastName":"Admin","email":"factoradmin@example.com","preRegistration":false}' | jq -r .id)

curl -s -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -X POST "$MGMT/organizations/DEFAULT/members" \
  -d "{\"memberId\":\"$USER\",\"memberType\":\"USER\",\"role\":\"$ROLE\"}"
```

4. Log in to the Console at `http://localhost:4200` as `factoradmin` / `Password123!`.

5. Open a domain, then Settings, then Security, then Multifactor Auth. Open an existing factor,
and separately click New.

6. Open the browser console. This is the check, and it is unambiguous:

```
GET .../domains/{domain}/resources  ->  403 (Forbidden)
```

The request fails, and the factor screen renders anyway, with no "Access denied" toast. That is
the fix: the 403 becomes an empty list, and the route proceeds. On master the same 403 rejects
the resolver and the router never leaves the page you were on.

7. Optional, to see the picker itself: the resource field only exists for factor plugins whose
schema has a `graviteeResource` widget, such as SMS and call factors. The MOCK factor has no
such field, so it proves the route but shows no picker. For the populated case, use an admin,
create a service resource whose plugin category matches the factor plugin, and reopen the
screen. The picker then lists it by name, which shows the read-only state above is the
permission and not an empty domain.

## :computer: Add screenshots for UI

Screenshot to follow: the factor form for a role without `domain_resource_list`, showing the disabled resource field.

## :books: Any other comments that will help with documentation

The upgrade note for AM-7478 says a missing `domain_resource_list` breaks the factor screens. Once this merges the factor screens degrade instead, so the note should say the resource picker is unavailable.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
