### PR TITLE
fix: AM-7515 reconcile and report mongo index creation

### DIFF
--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoUserRepository.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/main/java/io/gravitee/am/dataplane/mongodb/repository/MongoUserRepository.java
@@ -144,8 +144,9 @@ public class MongoUserRepository extends AbstractDataPlaneMongoRepository implem
         indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_LAST_NAME, 1), new IndexOptions().name("rt1ri1l1"));
         indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_EXTERNAL_ID, 1).append(FIELD_SOURCE, 1), new IndexOptions().name("rt1ri1ext1s1"));
         indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_IDENTITIES_USERNAME, 1).append(FIELD_IDENTITIES_PROVIDER_ID, 1), new IndexOptions().name("rt1ri1iu1ip1"));
-        super.createIndex(usersCollection, indexes);
-        createOrUpdateIndex();
+        indexes.put(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1).append(FIELD_SOURCE, 1),
+                new IndexOptions().name(INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE).unique(true));
+        createOrUpdateIndexes(indexes);
     }
 
     @Override
@@ -801,17 +802,16 @@ public class MongoUserRepository extends AbstractDataPlaneMongoRepository implem
                 }).collect(Collectors.toList());
     }
 
-    private void createOrUpdateIndex() {
+    /**
+     * Sweeps the index names retired by earlier versions, then declares the current set.
+     */
+    private void createOrUpdateIndexes(Map<Document, IndexOptions> indexes) {
         if (getEnsureIndexOnStart()) {
             MongoUtils.dropIndexes(usersCollection, UNUSED_INDEXES::contains)
-                    .doOnComplete(() -> {
-                        try {
-                            super.createIndex(usersCollection, Map.of(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1).append(FIELD_SOURCE, 1),
-                                    new IndexOptions().name(INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE).unique(true)));
-                        } catch (Exception e) {
-                            logger.error("An error has occurred while creating index {} with unique constraints", INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE, e);
-                        }
-                    })
+                    .doOnError(error -> logger.error("Unable to sweep the retired indexes of the users collection", error))
+                    // a sweep that failed must not stop the current indexes from being declared
+                    .onErrorComplete()
+                    .doOnComplete(() -> super.createIndex(usersCollection, indexes))
                     .subscribe();
         }
     }

--- a/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/test/java/io/gravitee/am/dataplane/mongodb/repository/DataPlaneIndexTest.java
+++ b/gravitee-am-dataplane/gravitee-am-dataplane-mongodb/src/test/java/io/gravitee/am/dataplane/mongodb/repository/DataPlaneIndexTest.java
@@ -143,6 +143,33 @@ public class DataPlaneIndexTest {
         assertLookupIndexes("scope_approvals", expected);
     }
 
+    @Test
+    public void theUserStoreCarriesItsUniqueIndex() throws Exception {
+        awaitIndex("users", "rt1ri1u1s1_unique");
+
+        Document index = indexesByName("users").get("rt1ri1u1s1_unique");
+        assertKeyEquals("users.rt1ri1u1s1_unique",
+                referenceTypeFirst().append("username", 1).append("source", 1),
+                index.get("key", Document.class));
+        assertEquals("users.rt1ri1u1s1_unique is no longer unique - duplicate users can now be stored",
+                Boolean.TRUE, index.getBoolean("unique"));
+    }
+
+    @Test
+    public void theUserStoreCarriesItsLookupIndexes() throws Exception {
+        Map<String, Document> expected = new LinkedHashMap<>();
+        expected.put("rt1ri1e1", referenceTypeFirst().append("email", 1));
+        expected.put("rt1ri1ae1", referenceTypeFirst().append("additionalInformation.email", 1));
+        expected.put("rt1ri1d1", referenceTypeFirst().append("displayName", 1));
+        expected.put("rt1ri1f1", referenceTypeFirst().append("firstName", 1));
+        expected.put("rt1ri1l1", referenceTypeFirst().append("lastName", 1));
+        expected.put("rt1ri1ext1s1", referenceTypeFirst().append("externalId", 1).append("source", 1));
+        expected.put("rt1ri1iu1ip1", referenceTypeFirst()
+                .append("identities.username", 1).append("identities.providerId", 1));
+
+        assertLookupIndexes("users", expected);
+    }
+
     // ---------------------------------------------------------------- helpers
 
     /** Asserts that a collection carries exactly the lookup indexes expected, keys compared in order. */

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/main/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporter.java
@@ -49,6 +49,7 @@ import io.gravitee.am.reporter.mongodb.audit.model.AuditAccessPointMongo;
 import io.gravitee.am.reporter.mongodb.audit.model.AuditEntityMongo;
 import io.gravitee.am.reporter.mongodb.audit.model.AuditMongo;
 import io.gravitee.am.reporter.mongodb.audit.model.AuditOutcomeMongo;
+import io.gravitee.am.repository.mongodb.common.MongoIndexManager;
 import io.gravitee.am.repository.mongodb.common.MongoUtils;
 import io.gravitee.am.repository.provider.ClientWrapper;
 import io.gravitee.am.repository.provider.ConnectionProvider;
@@ -404,12 +405,16 @@ public class MongoAuditReporter extends AbstractService<Reporter> implements Aud
         indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_TARGET_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_TARGET_ID_TIMESTAMP_NAME).background(true)));
         indexes.add(new IndexModel(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ACTOR_ID, 1).append(FIELD_TIMESTAMP, -1), new IndexOptions().name(INDEX_REFERENCE_ACTOR_ID_TIMESTAMP_NAME).background(true)));
 
-        Completable createNewIndexes = Completable.fromPublisher(reportableCollection.createIndexes(indexes))
-                .doOnComplete(() -> log.debug("{} Reporter indexes created", indexes.size()))
-                .doOnError(throwable -> log.error("An error has occurred during creation of indexes", throwable));
+        Completable createNewIndexes = MongoIndexManager.ensureIndexes(reportableCollection, indexes)
+                .doOnComplete(() -> log.debug("{} reporter indexes ensured for collection {}",
+                        indexes.size(), configuration.getReportableCollection()));
 
         // process indexes
         deleteOldIndexes
+                .doOnError(error -> log.error("Unable to sweep the retired indexes of collection {}",
+                        configuration.getReportableCollection(), error))
+                // a sweep that failed must not stop the current indexes from being declared
+                .onErrorComplete()
                 .andThen(createNewIndexes)
                 .subscribe();
     }

--- a/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/test/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporterIndexTest.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-mongodb/src/test/java/io/gravitee/am/reporter/mongodb/audit/MongoAuditReporterIndexTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 
 import static io.gravitee.am.reporter.mongodb.audit.constants.MongoAuditReporterConstants.FIELD_ACTOR;
@@ -66,6 +67,7 @@ import static io.gravitee.am.reporter.mongodb.audit.constants.MongoAuditReporter
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -217,6 +219,56 @@ public class MongoAuditReporterIndexTest {
                 names.contains(OLD_INDEX_REFERENCE_ACTOR_TARGET_TIMESTAMP_NAME_SHORT_NAME));
         assertTrue("indexes were created despite the repository switch being off",
                 CURRENT_INDEXES.stream().noneMatch(names::contains));
+    }
+
+    @Test
+    public void anIndexHoldingADeclaredNameWithAnOlderDefinitionIsRebuilt() throws Exception {
+        seedIndex(INDEX_REFERENCE_TIMESTAMP_NAME, new Document("a_previous_definition", 1));
+
+        startReporter(reporter -> {});
+
+        awaitIndexes(names -> names.containsAll(CURRENT_INDEXES),
+                "a stale definition on one declared name suppressed the whole index set");
+        assertKeyEquals(INDEX_REFERENCE_TIMESTAMP_NAME,
+                expectedKeys().get(INDEX_REFERENCE_TIMESTAMP_NAME),
+                indexesByName().get(INDEX_REFERENCE_TIMESTAMP_NAME).get("key", Document.class));
+    }
+
+    @Test
+    public void aForeignIndexOverADeclaredKeyCostsOnlyItsOwnDeclaration() throws Exception {
+        String incumbent = "legacy_actor_idx";
+        seedIndex(incumbent, expectedKeys().get(INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME));
+
+        startReporter(reporter -> {});
+
+        List<String> unaffected = CURRENT_INDEXES.stream()
+                .filter(name -> !name.equals(INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME))
+                .toList();
+        awaitIndexes(names -> names.containsAll(unaffected),
+                "a foreign index over one declared key suppressed the rest of the index set");
+
+        Set<String> names = indexNames();
+        assertTrue("an index the reporter did not name should have been left in place",
+                names.contains(incumbent));
+        assertFalse("the declared index should not have been created over an already covered key",
+                names.contains(INDEX_REFERENCE_ACTOR_TIMESTAMP_NAME));
+    }
+
+    @Test
+    public void noTwoIndexesAreDeclaredOverOneKey() throws Exception {
+        startReporter(reporter -> {});
+        awaitIndexes(names -> names.containsAll(CURRENT_INDEXES), "the current index set did not land");
+
+        Map<String, String> byKey = new HashMap<>();
+        for (Document index : indexesByName().values()) {
+            String key = index.get("key", Document.class).entrySet().stream()
+                    .map(entry -> entry.getKey() + ":" + entry.getValue())
+                    .collect(Collectors.joining(","));
+            String previous = byKey.put(key, index.getString("name"));
+            assertNull("indexes " + previous + " and " + index.getString("name")
+                    + " are both declared on " + key + " - MongoDB refuses both and the collection ends up unindexed",
+                    previous);
+        }
     }
 
     // ---------------------------------------------------------------- helpers

--- a/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/common/MongoIndexManager.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/common/MongoIndexManager.java
@@ -1,0 +1,366 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.common;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.model.IndexModel;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import lombok.CustomLog;
+import lombok.experimental.UtilityClass;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Applies a collection's declared indexes to MongoDB, and reconciles the collection with the
+ * declaration when they have drifted apart.
+ * <p>
+ * The rule this applies is that <em>AM owns its index names, not its index keys</em>. An index
+ * sitting on a name AM declares is AM's to replace, so it is dropped and rebuilt to match the
+ * declaration - this is what makes an upgrade that changes a definition converge. An index sitting
+ * on a key AM declares but under somebody else's name is left alone: its coverage is already there,
+ * and it may well have been created deliberately by an operator. What AM does not do is stay quiet
+ * about either case; see {@link MongoIndexReport}.
+ *
+ * @author GraviteeSource Team
+ */
+@UtilityClass
+@CustomLog
+public final class MongoIndexManager {
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    /** An index with this name already exists, holding a different definition. */
+    private static final int INDEX_KEY_SPECS_CONFLICT = 86;
+    /** An index over this key already exists, under a different name or with different options. */
+    private static final int INDEX_OPTIONS_CONFLICT = 85;
+    /** The index was already gone - another node dropped it first. */
+    private static final int INDEX_NOT_FOUND = 27;
+    /** MongoDB will not build this index at all - a malformed partial filter, too many indexes. */
+    private static final int CANNOT_CREATE_INDEX = 67;
+
+    private static final String ID_INDEX = "_id_";
+
+    /**
+     * Ensures {@code declared} is what {@code collection} carries.
+     * <p>
+     * The returned Completable always completes: a collection that could not be fully indexed is a
+     * degraded node, not a failed one. Callers that need to know what happened read {@link MongoIndexReport}.
+     */
+    public static Completable ensureIndexes(MongoCollection<?> collection, List<IndexModel> declared) {
+        final String collectionName = reportKey(collection);
+        if (declared.isEmpty()) {
+            return Completable.complete();
+        }
+        return createAll(collection, declared)
+                .doOnComplete(() -> {
+                    log.debug("{} indexes ensured for collection {}", declared.size(), collectionName);
+                    declared.forEach(model -> MongoIndexReport.ensured(collectionName, indexName(model)));
+                })
+                .onErrorResumeNext(error -> reconcile(collection, declared, error));
+    }
+
+    /**
+     * Attempt to create indexes the fast way: one round trip, no reads.
+     * A transient failure is retried, but a settled one is not.
+     */
+    private static Completable createAll(MongoCollection<?> collection, List<IndexModel> models) {
+        final String collectionName = reportKey(collection);
+        return Completable.fromPublisher(collection.createIndexes(models))
+                .retryWhen(errors -> errors
+                        .zipWith(Flowable.range(1, MAX_ATTEMPTS + 1), Attempt::new)
+                        .concatMap(attempt -> {
+                            if (attempt.spent() || isPermanent(attempt.error())) {
+                                return Flowable.<Long>error(attempt.error());
+                            }
+                            log.debug("Retrying index creation for collection {}, attempt={}/{}",
+                                    collectionName, attempt.number(), MAX_ATTEMPTS);
+                            return Flowable.timer(attempt.number(), TimeUnit.SECONDS);
+                        }));
+    }
+
+    /**
+     * Reads back what the collection actually carries and settles each declared index against it.
+     */
+    private static Completable reconcile(MongoCollection<?> collection, List<IndexModel> models, Throwable batchError) {
+        final String collectionName = reportKey(collection);
+        log.warn("Index creation failed for collection {} ({}). Reconciling its {} declared indexes one by one.",
+                collectionName, describe(batchError), models.size());
+        return listIndexes(collection)
+                .flatMapCompletable(existing -> Flowable.fromIterable(models)
+                        .concatMapCompletable(model -> reconcileOne(collection, model, existing)))
+                .onErrorResumeNext(error -> {
+                    log.error("Unable to reconcile the indexes of collection {}. Every query against it may fall back to a collection scan, and any TTL index it declares may be missing.",
+                            collectionName, error);
+                    models.forEach(model -> MongoIndexReport.failed(collectionName, indexName(model),
+                            "reconciliation could not run: " + describe(error)));
+                    return Completable.complete();
+                });
+    }
+
+    private static Completable reconcileOne(MongoCollection<?> collection, IndexModel model, List<Document> existing) {
+        final String collectionName = reportKey(collection);
+        final String name = indexName(model);
+
+        final Document underOurName = firstMatching(existing, index -> name.equals(index.getString("name")));
+        if (underOurName != null) {
+            return matches(underOurName, model)
+                    ? Completable.fromAction(() -> MongoIndexReport.ensured(collectionName, name))
+                    : rebuild(collection, model, existing, underOurName);
+        }
+
+        return createOne(collection, model)
+                .doOnComplete(() -> MongoIndexReport.ensured(collectionName, name))
+                .onErrorResumeNext(error -> errorCode(error) == INDEX_OPTIONS_CONFLICT
+                        ? Completable.fromAction(() -> reportShadowed(collectionName, model, existing))
+                        : reportFailure(collectionName, model, error));
+    }
+
+    /** AM owns this name, so the index under it is AM's to replace. */
+    private static Completable rebuild(MongoCollection<?> collection, IndexModel model, List<Document> existing, Document ours) {
+        final String collectionName = reportKey(collection);
+        final String name = indexName(model);
+        if (ID_INDEX.equals(name)) {
+            log.error("Index {} of collection {} does not match its declaration, but the id index cannot be replaced.", name, collectionName);
+            MongoIndexReport.failed(collectionName, name, "the id index cannot be replaced");
+            return Completable.complete();
+        }
+        final String detail = "replaced " + describe(ours) + " with " + describe(model);
+        log.warn("Index {} of collection {} no longer matches its declaration - dropping and rebuilding it ({}).",
+                name, collectionName, detail);
+        return dropIndex(collection, name)
+                .andThen(createOne(collection, model))
+                .doOnComplete(() -> MongoIndexReport.rebuilt(collectionName, name, detail))
+                .onErrorResumeNext(error -> errorCode(error) == INDEX_OPTIONS_CONFLICT
+                        ? Completable.fromAction(() -> reportShadowed(collectionName, model, existing))
+                        : reportFailure(collectionName, model, error));
+    }
+
+    /**
+     * MongoDB refused our index because another one already covers its key. Keep the incumbent -
+     * but if it cannot stand in for what the declaration asked for, something really is lost and
+     * this is a failure, not a note.
+     */
+    private static void reportShadowed(String collectionName, IndexModel model, List<Document> existing) {
+        final String name = indexName(model);
+        final String key = keyOf(model).toJson();
+        final Document incumbent = firstMatching(existing, index -> sameKey(index.get("key", Document.class), model));
+        final String incumbentName = incumbent != null ? incumbent.getString("name") : "another index";
+        final String missing = ttlLostTo(incumbent, model);
+
+        if (missing == null) {
+            log.warn("Index {} of collection {} was not created: {} already covers {}. Leaving the existing index in place.",
+                    name, collectionName, incumbentName, key);
+            MongoIndexReport.shadowed(collectionName, name, "covered by " + incumbentName);
+        } else {
+            log.error("Index {} of collection {} was not created: {} already covers {}, but {}. Leaving the existing index in place - drop {} to let AM create {}.",
+                    name, collectionName, incumbentName, key, missing, incumbentName, name);
+            MongoIndexReport.failed(collectionName, name, "shadowed by " + incumbentName + ": " + missing);
+        }
+    }
+
+    private static Completable reportFailure(String collectionName, IndexModel model, Throwable error) {
+        final String name = indexName(model);
+        log.error("Index {} of collection {} could not be created ({}). {}",
+                name, collectionName, describe(error), consequenceOf(model), error);
+        MongoIndexReport.failed(collectionName, name, describe(error));
+        return Completable.complete();
+    }
+
+    /** What the operator loses by this index being absent, in the terms they care about. */
+    private static String consequenceOf(IndexModel model) {
+        if (expireAfterSeconds(model.getOptions()) != null) {
+            return "Expired records of this collection will never be removed.";
+        }
+        if (model.getOptions().isUnique()) {
+            return "Duplicate records can now be stored in this collection.";
+        }
+        return "Queries on " + keyOf(model).toJson() + " will fall back to a collection scan.";
+    }
+
+    /** What the incumbent index does not cover of the declaration. */
+    private static String ttlLostTo(Document incumbent, IndexModel model) {
+        final Long declaredTtl = expireAfterSeconds(model.getOptions());
+        if (declaredTtl == null) {
+            return null;
+        }
+        if (incumbent == null) {
+            // created earlier in this same pass, so it is not in the snapshot we read has to read as lost
+            return "it cannot be confirmed to expire records, so expired records may never be removed";
+        }
+        return declaredTtl.equals(expireAfterSeconds(incumbent))
+                ? null
+                : "it does not expire records after " + declaredTtl + "s, so expired records will never be removed";
+    }
+
+    // --- declarations ---------------------------------------------------------------------------
+
+    private static String indexName(IndexModel model) {
+        final String declared = model.getOptions().getName();
+        return declared != null ? declared : defaultIndexName(keyOf(model));
+    }
+
+    /** The name MongoDB would generate for this key, so an unnamed declaration reconciles too. */
+    private static String defaultIndexName(BsonDocument key) {
+        return key.entrySet().stream()
+                .map(entry -> entry.getKey() + "_" + direction(entry.getValue()))
+                .collect(Collectors.joining("_"));
+    }
+
+    // --- comparison -----------------------------------------------------------------------------
+
+    private static boolean matches(Document existing, IndexModel model) {
+        final IndexOptions options = model.getOptions();
+        return sameKey(existing.get("key", Document.class), model)
+                && existing.getBoolean("unique", false) == options.isUnique()
+                && existing.getBoolean("sparse", false) == options.isSparse()
+                && Objects.equals(expireAfterSeconds(existing), expireAfterSeconds(options))
+                && Objects.equals(normalise(existing.get("partialFilterExpression", Document.class)),
+                                  normalise(options.getPartialFilterExpression()));
+    }
+
+    private static boolean sameKey(Document existingKey, IndexModel model) {
+        return existingKey != null && normalisedKey(normalise(existingKey)).equals(normalisedKey(keyOf(model)));
+    }
+
+    /** Renders a key so that {@code 1}, {@code 1L} and {@code 1.0} do not read as different indexes. */
+    private static List<String> normalisedKey(BsonDocument key) {
+        return key.entrySet().stream()
+                .map(entry -> entry.getKey() + '=' + direction(entry.getValue()))
+                .toList();
+    }
+
+    private static String direction(org.bson.BsonValue value) {
+        if (value.isNumber()) {
+            return String.valueOf(value.asNumber().longValue());
+        }
+        return value.isString() ? value.asString().getValue() : value.toString();
+    }
+
+    private static Long expireAfterSeconds(Document index) {
+        final Object value = index.get("expireAfterSeconds");
+        return value instanceof Number number ? number.longValue() : null;
+    }
+
+    private static Long expireAfterSeconds(IndexOptions options) {
+        return options.getExpireAfter(TimeUnit.SECONDS);
+    }
+
+    private static BsonDocument keyOf(IndexModel model) {
+        return normalise(model.getKeys());
+    }
+
+    private static BsonDocument normalise(Bson bson) {
+        return bson == null ? null : bson.toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry());
+    }
+
+    // --- mongo --------------------------------------------------------------------------------
+
+    private static String reportKey(MongoCollection<?> collection) {
+        return collection.getNamespace().getFullName();
+    }
+
+    private static Single<List<Document>> listIndexes(MongoCollection<?> collection) {
+        return Flowable.fromPublisher(collection.listIndexes()).toList();
+    }
+
+    private static Completable createOne(MongoCollection<?> collection, IndexModel model) {
+        return Completable.fromPublisher(collection.createIndex(model.getKeys(), model.getOptions()));
+    }
+
+    private static Completable dropIndex(MongoCollection<?> collection, String name) {
+        return Completable.fromPublisher(collection.dropIndex(name))
+                .onErrorResumeNext(error -> errorCode(error) == INDEX_NOT_FOUND
+                        // another node got there first, which is the outcome we wanted anyway
+                        ? Completable.complete()
+                        : Completable.error(error));
+    }
+
+    // --- plumbing -----------------------------------------------------------------------------
+
+    private static Document firstMatching(List<Document> indexes, Predicate<Document> predicate) {
+        return indexes.stream().filter(predicate).findFirst().orElse(null);
+    }
+
+    /**
+     * Whether waiting and asking again could possibly help. A conflict, a uniqueness violation in
+     * the data and an index the server will not build are all settled answers.
+     */
+    private static boolean isPermanent(Throwable error) {
+        final int code = errorCode(error);
+        return code == INDEX_KEY_SPECS_CONFLICT
+                || code == INDEX_OPTIONS_CONFLICT
+                || code == CANNOT_CREATE_INDEX
+                // the data already in the collection violates the uniqueness the declaration asks for
+                || ErrorCategory.fromErrorCode(code) == ErrorCategory.DUPLICATE_KEY;
+    }
+
+    private static int errorCode(Throwable error) {
+        for (Throwable candidate = error; candidate != null && candidate != candidate.getCause(); candidate = candidate.getCause()) {
+            if (candidate instanceof MongoCommandException mongoError) {
+                return mongoError.getErrorCode();
+            }
+        }
+        return -1;
+    }
+
+    private static String describe(Throwable error) {
+        for (Throwable candidate = error; candidate != null && candidate != candidate.getCause(); candidate = candidate.getCause()) {
+            if (candidate instanceof MongoCommandException mongoError) {
+                return mongoError.getErrorCodeName() + '/' + mongoError.getErrorCode();
+            }
+        }
+        return String.valueOf(error);
+    }
+
+    private static String describe(Document index) {
+        return "key=" + index.get("key") + optionSuffix(expireAfterSeconds(index), index.getBoolean("unique", false));
+    }
+
+    private static String describe(IndexModel model) {
+        return "key=" + keyOf(model).toJson()
+                + optionSuffix(expireAfterSeconds(model.getOptions()), model.getOptions().isUnique());
+    }
+
+    private static String optionSuffix(Long expireAfterSeconds, boolean unique) {
+        final StringBuilder suffix = new StringBuilder();
+        if (expireAfterSeconds != null) {
+            suffix.append(" expireAfterSeconds=").append(expireAfterSeconds);
+        }
+        if (unique) {
+            suffix.append(" unique=true");
+        }
+        return suffix.toString();
+    }
+
+    private record Attempt(Throwable error, int number) {
+        boolean spent() {
+            return number > MAX_ATTEMPTS;
+        }
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/common/MongoIndexReport.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/common/MongoIndexReport.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.common;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * What became of every index the MongoDB repositories declared.
+ *
+ * @author GraviteeSource Team
+ */
+public final class MongoIndexReport {
+
+    /**
+     * ENSURED - the index is in place.
+     * REBUILT - an index of the same name held a different definition and was replaced.
+     * SHADOWED - not created, because another index already covers its key with the same
+     * guarantees. Coverage is intact; only the name differs.
+     * FAILED - not created, and something is actually lost: a missing TTL, a missing uniqueness
+     * constraint, or an index MongoDB refused to build.
+     */
+    public enum Status {
+        ENSURED, REBUILT, SHADOWED, FAILED
+    }
+
+    public record IndexOutcome(String collection, String index, Status status, String detail) {
+        @Override
+        public String toString() {
+            return collection + '.' + index + ' ' + status + " (" + detail + ')';
+        }
+    }
+
+    private static final Map<String, IndexOutcome> OUTCOMES = new ConcurrentHashMap<>();
+
+    private MongoIndexReport() {
+    }
+
+    static void ensured(String collection, String index) {
+        record(new IndexOutcome(collection, index, Status.ENSURED, "in place"));
+    }
+
+    static void rebuilt(String collection, String index, String detail) {
+        record(new IndexOutcome(collection, index, Status.REBUILT, detail));
+    }
+
+    static void shadowed(String collection, String index, String detail) {
+        record(new IndexOutcome(collection, index, Status.SHADOWED, detail));
+    }
+
+    static void failed(String collection, String index, String detail) {
+        record(new IndexOutcome(collection, index, Status.FAILED, detail));
+    }
+
+    private static void record(IndexOutcome outcome) {
+        OUTCOMES.put(outcome.collection() + '.' + outcome.index(), outcome);
+    }
+
+    /** Every outcome recorded so far, ordered by collection then index. */
+    public static List<IndexOutcome> outcomes() {
+        return OUTCOMES.values().stream()
+                .sorted(Comparator.comparing(IndexOutcome::collection).thenComparing(IndexOutcome::index))
+                .toList();
+    }
+
+    public static List<IndexOutcome> outcomes(String collection) {
+        return outcomes().stream().filter(outcome -> outcome.collection().equals(collection)).toList();
+    }
+
+    /**
+     * The indexes that are missing something the declaration asked for. An empty list is the only
+     * healthy state; anything in here degrades queries, retention or uniqueness on that collection.
+     */
+    public static List<IndexOutcome> failures() {
+        return outcomes().stream().filter(outcome -> outcome.status() == Status.FAILED).toList();
+    }
+
+    public static void clear() {
+        OUTCOMES.clear();
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/common/MongoUtils.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/main/java/io/gravitee/am/repository/mongodb/common/MongoUtils.java
@@ -83,24 +83,20 @@ public final class MongoUtils {
                 );
     }
 
+    /**
+     * Declares the indexes {@code collection} should carry.
+     */
     public static void createIndex(MongoCollection<?> collection, Map<Document, IndexOptions> indexes, boolean ensure) {
         if (ensure) {
             var indexesModel = indexes.entrySet()
                     .stream()
                     .map(entry -> new IndexModel(entry.getKey(), entry.getValue().background(true)))
                     .toList();
-            Completable.fromPublisher(collection.createIndexes(indexesModel))
-                    .retryWhen(th -> th
-                            .zipWith(Flowable.range(1, 3), (error, attempt) -> attempt) // 3 attempts
-                            .flatMap(attempt -> {
-                                log.debug("Retrying index creation for {}, attempt={}/3", collection.getNamespace().getCollectionName(), attempt);
-                                return Flowable.timer(attempt, TimeUnit.SECONDS); // delayed backoff
-                            }))
+            MongoIndexManager.ensureIndexes(collection, indexesModel)
                     .subscribe(
-                            () -> log.debug("{} indexes created", collection.getNamespace().getCollectionName()),
+                            () -> log.debug("Indexes ensured for {}", collection.getNamespace().getCollectionName()),
                             throwable -> log.error("Error occurred during indexes creation for {}", collection.getNamespace().getCollectionName(), throwable)
                     );
-
         }
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/test/java/io/gravitee/am/repository/mongodb/common/MongoIndexManagerContractTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb-api/src/test/java/io/gravitee/am/repository/mongodb/common/MongoIndexManagerContractTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.mongodb.common;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.model.IndexModel;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.reactivestreams.client.ListIndexesPublisher;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import io.reactivex.rxjava3.core.Flowable;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class MongoIndexManagerContractTest {
+
+    private static final String COLLECTION = "unreadable";
+
+    @Before
+    public void resetReport() {
+        MongoIndexReport.clear();
+    }
+
+    @Test
+    public void everyDeclaredIndexIsReportedWhenTheCatalogCannotBeRead() {
+        MongoCollection<Document> collection = collectionThatCannotBeReconciled();
+
+        // completing at all is the assertion: an error here reaches callers that cannot handle one
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                        new IndexModel(new Document("token", 1), new IndexOptions().name("t1")),
+                        new IndexModel(new Document("subject", 1), new IndexOptions().name("s1"))))
+                .blockingAwait();
+
+        assertThat(MongoIndexReport.failures())
+                .extracting(MongoIndexReport.IndexOutcome::index)
+                .as("a reconciliation that could not run leaves every declared index unaccounted for")
+                .containsExactlyInAnyOrder("t1", "s1");
+    }
+
+    @Test
+    public void noDeclarationsIsNotAFailure() {
+        MongoCollection<Document> collection = collectionThatCannotBeReconciled();
+
+        MongoIndexManager.ensureIndexes(collection, List.of()).blockingAwait();
+
+        assertThat(MongoIndexReport.outcomes()).isEmpty();
+    }
+
+    /** Rejects the batch, then fails the catalog read that reconciliation depends on. */
+    @SuppressWarnings("unchecked")
+    private static MongoCollection<Document> collectionThatCannotBeReconciled() {
+        MongoCollection<Document> collection = mock(MongoCollection.class);
+        when(collection.getNamespace()).thenReturn(new MongoNamespace("test", COLLECTION));
+        when(collection.createIndexes(anyList())).thenReturn(Flowable.error(indexOptionsConflict()));
+
+        ListIndexesPublisher<Document> unreadable = mock(ListIndexesPublisher.class);
+        doAnswer(invocation -> {
+            // delegate so the subscriber still sees a well-formed onSubscribe/onError sequence
+            Flowable.<Document>error(new IllegalStateException("catalog unavailable"))
+                    .subscribe((Subscriber<Document>) invocation.getArgument(0));
+            return null;
+        }).when(unreadable).subscribe(any());
+        when(collection.listIndexes()).thenReturn(unreadable);
+        return collection;
+    }
+
+    /** A conflict rather than a transient error, so reconciliation is reached without a retry. */
+    private static MongoCommandException indexOptionsConflict() {
+        BsonDocument response = new BsonDocument("ok", new BsonInt32(0))
+                .append("code", new BsonInt32(85))
+                .append("codeName", new BsonString("IndexOptionsConflict"))
+                .append("errmsg", new BsonString("an index over this key already exists"));
+        return new MongoCommandException(response, new ServerAddress());
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoOrganizationUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoOrganizationUserRepository.java
@@ -652,14 +652,12 @@ public class MongoOrganizationUserRepository extends AbstractManagementMongoRepo
     private void createOrUpdateIndex() {
         if (ensureIndexOnStart) {
             dropIndexes(usersCollection, UNUSED_INDEXES::contains)
-                    .doOnComplete(() -> {
-                        try {
-                            super.createIndex(usersCollection, Map.of(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1).append(FIELD_SOURCE, 1),
-                                    new IndexOptions().name(INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE).unique(true)));
-                        } catch (Exception e) {
-                            log.error("An error has occurred while creating index {} with unique constraints", INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE, e);
-                        }
-                    })
+                    .doOnError(error -> log.error("Unable to sweep the retired indexes of the organization_users collection", error))
+                    // a sweep that failed must not stop the current indexes from being declared
+                    .onErrorComplete()
+                    .doOnComplete(() -> super.createIndex(usersCollection,
+                            Map.of(new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_USERNAME, 1).append(FIELD_SOURCE, 1),
+                                    new IndexOptions().name(INDEX_REFERENCE_TYPE_REFERENCE_ID_USERNAME_SOURCE_NAME_UNIQUE).unique(true))))
                     .subscribe();
         }
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/common/EnsureIndexOnStartResolutionTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/common/EnsureIndexOnStartResolutionTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.mongodb.common;
 
 import com.mongodb.client.model.IndexOptions;
+import com.mongodb.MongoNamespace;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 import io.gravitee.am.common.env.RepositoriesEnvironment;
@@ -207,6 +208,9 @@ public class EnsureIndexOnStartResolutionTest {
     private static MongoCollection<?> mockCollection() {
         MongoCollection<Document> collection = mock(MongoCollection.class);
         when(collection.createIndexes(any())).thenReturn(Flowable.empty());
+        // index creation names its collection in everything it logs and reports, so the mock has to
+        // carry a namespace the way a real collection always does
+        when(collection.getNamespace()).thenReturn(new MongoNamespace("test", "probe_collection"));
         return collection;
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/common/MongoIndexAssertions.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/common/MongoIndexAssertions.java
@@ -20,7 +20,10 @@ import io.reactivex.rxjava3.core.Flowable;
 import org.bson.Document;
 
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,6 +88,27 @@ public final class MongoIndexAssertions {
         assertThat(index.getBoolean("unique", false))
                 .as("index '%s' of '%s' is no longer unique - duplicates can now be stored", indexName, collection)
                 .isTrue();
+    }
+
+    /** Asserts that no two indexes of {@code collection} are built over the same key. */
+    public static void assertNoDuplicateIndexKeys(MongoDatabase database, String collection) {
+        Map<String, String> byKey = new LinkedHashMap<>();
+        for (Document index : listIndexes(database, collection)) {
+            String key = orderedKey(index);
+            String previous = byKey.putIfAbsent(key, index.getString("name"));
+            assertThat(previous)
+                    .as("indexes '%s' and '%s' of '%s' are both built on %s - MongoDB refuses both, and the collection ends up with no indexes at all",
+                            previous, index.getString("name"), collection, key)
+                    .isNull();
+        }
+    }
+
+    /** Keys as an ordered rendering: for a compound index the field order is the semantics. */
+    private static String orderedKey(Document index) {
+        Document key = index.get("key", Document.class);
+        return key.entrySet().stream()
+                .map(entry -> entry.getKey() + ":" + entry.getValue())
+                .collect(Collectors.joining(","));
     }
 
     private static Document awaitIndex(MongoDatabase database, String collection, String indexName, String consequence) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/common/MongoIndexLifecycleTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/common/MongoIndexLifecycleTest.java
@@ -15,14 +15,18 @@
  */
 package io.gravitee.am.repository.mongodb.common;
 
+import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 import io.gravitee.am.repository.mongodb.MongodbProvider;
+import io.gravitee.am.repository.mongodb.common.MongoIndexReport.Status;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.bson.Document;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -30,13 +34,15 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 /**
  * Covers what happens to indexes on the paths a clean start never exercises: restarting against a
- * collection that is already indexed, and removing indexes that a previous version left behind.
+ * collection that is already indexed, removing indexes that a previous version left behind, and
+ * reconciling a collection whose indexes have drifted away from what the repositories declare.
  * <p>
  * These are the paths an upgrade actually takes. {@link MongoUtils#dropIndexes} in particular is
  * destructive, carries its own retry and already-removed handling, and is used to sweep obsolete
@@ -64,6 +70,11 @@ public class MongoIndexLifecycleTest {
         if (provider != null) {
             provider.destroy();
         }
+    }
+
+    @Before
+    public void resetReport() {
+        MongoIndexReport.clear();
     }
 
     /**
@@ -166,10 +177,213 @@ public class MongoIndexLifecycleTest {
                 .containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "current");
     }
 
+    @Test
+    public void anIndexThatDriftedFromItsDeclarationIsRebuilt() {
+        MongoCollection<Document> collection = collection("stale_name");
+        seedIndex(collection, "e1", "old_expiry_field");
+
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                index("t1", new Document("token", 1)),
+                ttlIndex("e1", "expire_at"),
+                index("s1", new Document("subject", 1)))).blockingAwait();
+
+        assertThat(indexNames(collection))
+                .as("one conflicting index must not suppress the rest of the collection")
+                .containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "t1", "e1", "s1");
+
+        Document rebuilt = indexesByName(collection).get("e1");
+        assertThat(rebuilt.get("key")).isEqualTo(new Document("expire_at", 1));
+        assertThat(rebuilt.get("expireAfterSeconds"))
+                .as("the rebuilt index must expire records, or nothing ever removes them")
+                .isNotNull();
+        assertThat(statusOf(collection, "e1")).isEqualTo(Status.REBUILT);
+        assertThat(MongoIndexReport.failures()).isEmpty();
+    }
+
+    @Test
+    public void aForeignIndexHoldingADeclaredKeyIsLeftInPlace() {
+        MongoCollection<Document> collection = collection("foreign_key");
+        seedIndex(collection, "legacy_token_idx", "token");
+
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                index("t1", new Document("token", 1)),
+                index("s1", new Document("subject", 1)))).blockingAwait();
+
+        assertThat(indexNames(collection))
+                .containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "legacy_token_idx", "s1");
+        assertThat(statusOf(collection, "t1")).isEqualTo(Status.SHADOWED);
+        assertThat(statusOf(collection, "s1")).isEqualTo(Status.ENSURED);
+        assertThat(MongoIndexReport.failures())
+                .as("the key is covered, so nothing is actually lost")
+                .isEmpty();
+    }
+
+    @Test
+    public void aForeignIndexThatCannotExpireRecordsIsReportedAsAFailure() {
+        MongoCollection<Document> collection = collection("foreign_ttl");
+        seedIndex(collection, "operator_expiry", "expire_at");
+
+        MongoIndexManager.ensureIndexes(collection, List.of(ttlIndex("e1", "expire_at"))).blockingAwait();
+
+        assertThat(indexNames(collection)).containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "operator_expiry");
+        assertThat(statusOf(collection, "e1")).isEqualTo(Status.FAILED);
+        assertThat(MongoIndexReport.failures()).hasSize(1);
+        assertThat(MongoIndexReport.failures().get(0).detail())
+                .contains("expired records will never be removed");
+    }
+
+    @Test
+    public void anIndexMongoRefusesToBuildDoesNotSuppressTheOthers() {
+        MongoCollection<Document> collection = collection("unique_conflict");
+        insert(collection, new Document("username", "duplicate"), new Document("username", "duplicate"));
+
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                uniqueIndex("u1", new Document("username", 1)),
+                index("t1", new Document("token", 1)),
+                index("s1", new Document("subject", 1)))).blockingAwait();
+
+        assertThat(indexNames(collection))
+                .as("an index the server will not build must cost only itself")
+                .containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "t1", "s1");
+        assertThat(statusOf(collection, "u1")).isEqualTo(Status.FAILED);
+        assertThat(MongoIndexReport.failures()).hasSize(1);
+    }
+
+    /** The restart after the one that repaired the collection must be an ordinary no-op. */
+    @Test
+    public void reconciliationIsIdempotent() {
+        MongoCollection<Document> collection = collection("idempotent_reconcile");
+        seedIndex(collection, "e1", "old_expiry_field");
+        List<IndexModel> declared = List.of(index("t1", new Document("token", 1)), ttlIndex("e1", "expire_at"));
+
+        MongoIndexManager.ensureIndexes(collection, declared).blockingAwait();
+        List<String> afterRepair = indexNames(collection);
+
+        MongoIndexReport.clear();
+        MongoIndexManager.ensureIndexes(collection, declared).blockingAwait();
+
+        assertThat(indexNames(collection)).containsExactlyInAnyOrderElementsOf(afterRepair);
+        assertThat(MongoIndexReport.outcomes(collection.getNamespace().getFullName()))
+                .as("a settled collection must need no further repair")
+                .allMatch(outcome -> outcome.status() == Status.ENSURED);
+    }
+
+    /** Two nodes starting together reconcile the same collection; both must settle on the declaration. */
+    @Test
+    public void concurrentReconciliationsBothSettle() {
+        MongoCollection<Document> collection = collection("concurrent_reconcile");
+        seedIndex(collection, "e1", "old_expiry_field");
+        List<IndexModel> declared = List.of(index("t1", new Document("token", 1)), ttlIndex("e1", "expire_at"));
+
+        Completable.mergeArray(
+                MongoIndexManager.ensureIndexes(collection, declared).subscribeOn(Schedulers.io()),
+                MongoIndexManager.ensureIndexes(collection, declared).subscribeOn(Schedulers.io()))
+                .blockingAwait();
+
+        assertThat(indexNames(collection)).containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "t1", "e1");
+    }
+
+    @Test
+    public void twoDeclarationsOverOneKeyCostOnlyTheDuplicate() {
+        MongoCollection<Document> collection = collection("duplicate_declaration");
+
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                index("r1a1t_1", new Document("referenceType", 1).append("actor", 1)),
+                index("r1ai1t_1", new Document("referenceType", 1).append("actor", 1)),
+                index("t1", new Document("token", 1)))).blockingAwait();
+
+        assertThat(indexNames(collection))
+                .containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "r1a1t_1", "t1");
+        assertThat(statusOf(collection, "r1ai1t_1"))
+                .as("the key is covered by the first declaration, so nothing is lost by dropping the second")
+                .isEqualTo(Status.SHADOWED);
+    }
+
+    @Test
+    public void aUniqueDeclarationIsCreatedEvenWhereAPlainIndexCoversItsKey() {
+        MongoCollection<Document> collection = collection("unique_alongside_foreign");
+        seedIndex(collection, "operator_username", "username");
+        seedIndex(collection, "s1", "a_previous_field");
+
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                uniqueIndex("u1", new Document("username", 1)),
+                index("s1", new Document("subject", 1)))).blockingAwait();
+
+        assertThat(indexNames(collection))
+                .containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "operator_username", "u1", "s1");
+        assertThat(statusOf(collection, "u1")).isEqualTo(Status.ENSURED);
+        assertThat(MongoIndexReport.failures()).isEmpty();
+    }
+
+    @Test
+    public void anIndexThatStillMatchesItsDeclarationIsNotRebuilt() {
+        MongoCollection<Document> collection = collection("already_matching");
+        seedIndex(collection, ttlIndex("e1", "expire_at"));
+        seedIndex(collection, "s1", "a_previous_field");
+
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                ttlIndex("e1", "expire_at"),
+                index("s1", new Document("subject", 1)))).blockingAwait();
+
+        assertThat(statusOf(collection, "e1"))
+                .as("an index that already matches its declaration must be left alone")
+                .isEqualTo(Status.ENSURED);
+        assertThat(statusOf(collection, "s1")).isEqualTo(Status.REBUILT);
+        assertThat(indexNames(collection)).containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "e1", "s1");
+    }
+
+    @Test
+    public void anIndexThatCannotBeRebuiltIsReportedAndTakesTheOldOneWithIt() {
+        MongoCollection<Document> collection = collection("rebuild_failure");
+        insert(collection, new Document("username", "duplicate"), new Document("username", "duplicate"));
+        seedIndex(collection, "u1", "username");
+
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                uniqueIndex("u1", new Document("username", 1)),
+                index("t1", new Document("token", 1)))).blockingAwait();
+
+        assertThat(statusOf(collection, "u1")).isEqualTo(Status.FAILED);
+        assertThat(indexNames(collection))
+                .as("the failed rebuild costs its own index and nothing else")
+                .containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "t1");
+    }
+
+    @Test
+    public void aRebuildBlockedByAnEquivalentForeignIndexIsShadowedRatherThanFailed() {
+        MongoCollection<Document> collection = collection("rebuild_shadowed");
+        seedIndex(collection, "e1", "a_previous_field");
+        seedIndex(collection, ttlIndex("operator_expiry", "expire_at"));
+
+        MongoIndexManager.ensureIndexes(collection, List.of(ttlIndex("e1", "expire_at"))).blockingAwait();
+
+        assertThat(statusOf(collection, "e1"))
+                .as("retention is intact under another name, so nothing was lost")
+                .isEqualTo(Status.SHADOWED);
+        assertThat(MongoIndexReport.failures()).isEmpty();
+        assertThat(indexNames(collection)).containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "operator_expiry");
+    }
+
+    @Test
+    public void aTtlBlockedByAnIndexCreatedInTheSamePassIsNotReportedAsBenign() {
+        MongoCollection<Document> collection = collection("ttl_blocked_in_pass");
+
+        MongoIndexManager.ensureIndexes(collection, List.of(
+                index("x1", new Document("expire_at", 1)),
+                ttlIndex("e1", "expire_at"))).blockingAwait();
+
+        assertThat(indexNames(collection)).containsExactlyInAnyOrder(DEFAULT_ID_INDEX, "x1");
+        assertThat(statusOf(collection, "e1")).isEqualTo(Status.FAILED);
+        assertThat(MongoIndexReport.failures()).hasSize(1);
+    }
+
     // --- helpers ----------------------------------------------------------------------------
 
     private static MongoCollection<Document> collection(String name) {
         return database.getCollection(name, Document.class);
+    }
+
+    private static void seedIndex(MongoCollection<Document> collection, IndexModel model) {
+        Completable.fromPublisher(collection.createIndex(model.getKeys(), model.getOptions())).blockingAwait();
     }
 
     private static void seedIndex(MongoCollection<Document> collection, String indexName, String field) {
@@ -191,5 +405,35 @@ public class MongoIndexLifecycleTest {
                 .map(index -> index.getString("name"))
                 .toList()
                 .blockingGet();
+    }
+
+    private static IndexModel index(String name, Document key) {
+        return new IndexModel(key, new IndexOptions().name(name));
+    }
+
+    private static IndexModel uniqueIndex(String name, Document key) {
+        return new IndexModel(key, new IndexOptions().name(name).unique(true));
+    }
+
+    private static IndexModel ttlIndex(String name, String field) {
+        return new IndexModel(new Document(field, 1), new IndexOptions().name(name).expireAfter(0L, TimeUnit.SECONDS));
+    }
+
+    private static void insert(MongoCollection<Document> collection, Document... documents) {
+        Flowable.fromPublisher(collection.insertMany(List.of(documents))).blockingSubscribe();
+    }
+
+    private static Map<String, Document> indexesByName(MongoCollection<Document> collection) {
+        return Flowable.fromPublisher(collection.listIndexes())
+                .toMap(index -> index.getString("name"))
+                .blockingGet();
+    }
+
+    private static Status statusOf(MongoCollection<Document> collection, String indexName) {
+        return MongoIndexReport.outcomes(collection.getNamespace().getFullName()).stream()
+                .filter(outcome -> outcome.index().equals(indexName))
+                .map(MongoIndexReport.IndexOutcome::status)
+                .findFirst()
+                .orElse(null);
     }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7515](https://gravitee.atlassian.net/browse/AM-7515)

## :pencil2: A description of the changes proposed in the pull request
Add retry resilience, reconciliation and logging to mongo index creation. This hardens replacing indexes that can be replaced and describes those that cannot - chiefly to reconcile unexpected state during upgrades.

- Index creation mirrors `MongoUtils.dropIndexes` retry pattern, handling concurrent builds and transient failures.
- Only indexes defined in AM are updated.
- Logging:
  - DEBUG = nothing to do.
  - WARN = collection diverged, or an index was left/replaced on purpose.
  - ERROR = a declared guarantee is missing.

## :memo: Test scenarios 
See Jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7515]: https://gravitee.atlassian.net/browse/AM-7515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ