### PR TITLE
fix: AM-7477 reject invalid permissions

### DIFF
--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
@@ -23,7 +23,9 @@ import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -157,28 +159,64 @@ public enum Permission {
         return flattenedPermissions;
     }
 
+    /**
+     * Rebuilds the permission/acl pairs from their flattened {@code <permission>_<acl>} form, as
+     * produced by {@link #flatten(Map)}.
+     *
+     * @param flatPermissions the flattened permissions, may be null
+     * @return the parsed permissions, empty if {@code flatPermissions} is null or empty
+     * @throws IllegalArgumentException if any entry is null, malformed, or names a permission or an
+     * acl that does not exist. Every offending entry is reported, and nothing is parsed.
+     */
     public static Map<Permission, Set<Acl>> unflatten(List<String> flatPermissions) {
 
         Map<Permission, Set<Acl>> permissions = new EnumMap<>(Permission.class);
 
-        if (flatPermissions != null) {
-            flatPermissions.stream().map(String::toUpperCase)
-                    .forEach(flatPermission -> {
-                        int i = flatPermission.lastIndexOf('_');
-                        Acl acl = Acl.valueOf(flatPermission.substring(i + 1));
-                        Permission permission = Permission.valueOf(flatPermission.substring(0, i));
+        if (flatPermissions == null) {
+            return permissions;
+        }
 
+        List<String> invalidPermissions = new ArrayList<>();
 
-                        if (permissions.containsKey(permission)) {
-                            permissions.get(permission).add(acl);
-                        } else {
-                            HashSet<Acl> acls = new HashSet<>();
-                            acls.add(acl);
-                            permissions.put(permission, acls);
-                        }
-                    });
+        for (String flatPermission : flatPermissions) {
+            parse(flatPermission).ifPresentOrElse(
+                    parsed -> permissions.computeIfAbsent(parsed.permission(), key -> new HashSet<>()).add(parsed.acl()),
+                    () -> invalidPermissions.add(flatPermission));
+        }
+
+        if (!invalidPermissions.isEmpty()) {
+            throw new IllegalArgumentException("Invalid permission(s): " + invalidPermissions);
         }
 
         return permissions;
+    }
+
+    private record PermissionAcl(Permission permission, Acl acl) {
+    }
+
+    private static Optional<PermissionAcl> parse(String flatPermission) {
+
+        if (flatPermission == null) {
+            return Optional.empty();
+        }
+
+        String candidate = flatPermission.toUpperCase(Locale.ROOT);
+        int separator = candidate.lastIndexOf('_');
+        if (separator < 1 || separator == candidate.length() - 1) {
+            return Optional.empty();
+        }
+
+        return resolve(Permission.class, candidate.substring(0, separator))
+                .flatMap(permission -> resolve(Acl.class, candidate.substring(separator + 1))
+                        .map(acl -> new PermissionAcl(permission, acl)));
+    }
+
+    private static <E extends Enum<E>> Optional<E> resolve(Class<E> type, String name) {
+
+        try {
+            return Optional.of(Enum.valueOf(type, name));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/gravitee-am-model/src/test/java/io/gravitee/am/model/permissions/PermissionTest.java
+++ b/gravitee-am-model/src/test/java/io/gravitee/am/model/permissions/PermissionTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.permissions;
+
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.ReferenceType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author GraviteeSource Team
+ */
+class PermissionTest {
+
+    @Nested
+    class Unflatten {
+
+        @Test
+        void shouldReturnEmptyPermissionsWhenListIsNull() {
+            assertThat(Permission.unflatten(null)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyPermissionsWhenListIsEmpty() {
+            assertThat(Permission.unflatten(List.of())).isEmpty();
+        }
+
+        @Test
+        void shouldGroupEveryAclUnderItsPermission() {
+            Map<Permission, Set<Acl>> permissions = Permission.unflatten(List.of("domain_read", "domain_update", "application_read"));
+
+            assertThat(permissions).containsOnly(
+                    Map.entry(Permission.DOMAIN, Set.of(Acl.READ, Acl.UPDATE)),
+                    Map.entry(Permission.APPLICATION, Set.of(Acl.READ)));
+        }
+
+        @Test
+        void shouldParsePermissionNameContainingUnderscores() {
+            Map<Permission, Set<Acl>> permissions = Permission.unflatten(List.of("organization_identity_provider_read"));
+
+            assertThat(permissions).containsOnly(Map.entry(Permission.ORGANIZATION_IDENTITY_PROVIDER, Set.of(Acl.READ)));
+        }
+
+        @Test
+        void shouldParseRegardlessOfCase() {
+            Map<Permission, Set<Acl>> permissions = Permission.unflatten(List.of("DOMAIN_READ", "domain_list", "Domain_Update"));
+
+            assertThat(permissions).containsOnly(Map.entry(Permission.DOMAIN, Set.of(Acl.READ, Acl.LIST, Acl.UPDATE)));
+        }
+
+        @Test
+        void shouldCollapseDuplicateEntries() {
+            Map<Permission, Set<Acl>> permissions = Permission.unflatten(List.of("domain_read", "domain_read"));
+
+            assertThat(permissions).containsOnly(Map.entry(Permission.DOMAIN, Set.of(Acl.READ)));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {
+                "",
+                " ",
+                "read",                 // no separator at all
+                "domain",               // permission with no acl
+                "_read",                // empty permission
+                "domain_",              // empty acl
+                "domain_foo",           // unknown acl
+                "foo_read",             // unknown permission
+                "domain_read_read",     // acl left in the permission half
+                " domain_read",         // untrimmed
+                "domain_read ",
+                "domain-read",          // wrong separator
+        })
+        void shouldRejectMalformedPermission(String flatPermission) {
+            List<String> flatPermissions = Collections.singletonList(flatPermission);
+
+            assertThatThrownBy(() -> Permission.unflatten(flatPermissions))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Invalid permission(s)")
+                    .hasMessageContaining(String.valueOf(flatPermission));
+        }
+
+        @Test
+        void shouldRejectTheWholeListWhenASingleEntryIsInvalid() {
+            List<String> flatPermissions = List.of("domain_read", "foo_read");
+
+            assertThatThrownBy(() -> Permission.unflatten(flatPermissions))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("foo_read")
+                    .hasMessageNotContaining("domain_read");
+        }
+
+        @Test
+        void shouldReportEveryInvalidEntry() {
+            List<String> flatPermissions = Arrays.asList("foo_read", "domain_foo", null);
+
+            assertThatThrownBy(() -> Permission.unflatten(flatPermissions))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("foo_read")
+                    .hasMessageContaining("domain_foo")
+                    .hasMessageContaining("null");
+        }
+    }
+
+    @Nested
+    class RoundTrip {
+
+        @Test
+        void shouldUnflattenWhatFlattenProduced() {
+            Map<Permission, Set<Acl>> permissions = Map.of(
+                    Permission.ORGANIZATION_IDENTITY_PROVIDER, Set.of(Acl.READ, Acl.LIST),
+                    Permission.DOMAIN, Acl.all());
+
+            assertThat(Permission.unflatten(Permission.flatten(permissions))).isEqualTo(permissions);
+        }
+
+        @Test
+        void shouldUnflattenEveryPermissionOfAReferenceType() {
+            Map<Permission, Set<Acl>> permissions = Permission.allPermissionAcls(ReferenceType.DOMAIN);
+
+            assertThat(Permission.unflatten(Permission.flatten(permissions))).isEqualTo(permissions);
+        }
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RoleServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RoleServiceImpl.java
@@ -37,6 +37,7 @@ import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.RoleService;
 import io.gravitee.am.service.exception.AbstractManagementException;
 import io.gravitee.am.service.exception.DefaultRoleUpdateException;
+import io.gravitee.am.service.exception.InvalidRoleException;
 import io.gravitee.am.service.exception.RoleAlreadyExistsException;
 import io.gravitee.am.service.exception.RoleNotFoundException;
 import io.gravitee.am.service.exception.SystemRoleDeleteException;
@@ -259,7 +260,7 @@ public class RoleServiceImpl implements RoleService {
                                 Role roleToUpdate = new Role(oldRole);
                                 roleToUpdate.setName(updateRole.getName());
                                 roleToUpdate.setDescription(updateRole.getDescription());
-                                roleToUpdate.setPermissionAcls(Permission.unflatten(updateRole.getPermissions()));
+                                roleToUpdate.setPermissionAcls(unflattenPermissions(updateRole.getPermissions()));
                                 roleToUpdate.setOauthScopes(updateRole.getOauthScopes());
                                 roleToUpdate.setUpdatedAt(new Date());
                                 return roleRepository.update(roleToUpdate)
@@ -286,6 +287,14 @@ public class RoleServiceImpl implements RoleService {
     public Single<Role> update(String domain, String id, UpdateRole updateRole, User principal) {
 
         return update(ReferenceType.DOMAIN, domain, id, updateRole, principal);
+    }
+
+    private static Map<Permission, Set<Acl>> unflattenPermissions(List<String> permissions) {
+        try {
+            return Permission.unflatten(permissions);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRoleException(e.getMessage());
+        }
     }
 
     @Override

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/RoleServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/RoleServiceTest.java
@@ -24,6 +24,7 @@ import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.repository.management.api.RoleRepository;
 import io.gravitee.am.service.exception.DefaultRoleUpdateException;
+import io.gravitee.am.service.exception.InvalidRoleException;
 import io.gravitee.am.service.exception.RoleAlreadyExistsException;
 import io.gravitee.am.service.exception.RoleNotFoundException;
 import io.gravitee.am.service.exception.SystemRoleDeleteException;
@@ -32,6 +33,7 @@ import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.RoleServiceImpl;
 import io.gravitee.am.service.model.NewRole;
 import io.gravitee.am.service.model.UpdateRole;
+import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -46,6 +48,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -258,6 +261,51 @@ public class RoleServiceTest {
         verify(roleRepository, times(1)).findById(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "my-role");
         verify(roleRepository, times(1)).findAll(ReferenceType.ORGANIZATION, ORGANIZATION_ID);
         verify(roleRepository, times(1)).update(any(Role.class));
+    }
+
+    @Test
+    public void shouldNotUpdate_unknownPermission() {
+        TestObserver<Role> testObserver = updateWithPermissions(Arrays.asList("domain_read", "domain_pillage", "kingdom_read"));
+
+        testObserver.assertNotComplete();
+        testObserver.assertError(InvalidRoleException.class);
+        testObserver.assertError(ex -> ((InvalidRoleException) ex).getHttpStatusCode() == HttpStatusCode.BAD_REQUEST_400);
+        testObserver.assertError(ex -> ex.getMessage().contains("domain_pillage") && ex.getMessage().contains("kingdom_read"));
+
+        verify(roleRepository, never()).update(any(Role.class));
+        verify(eventService, never()).create(any());
+    }
+
+    @Test
+    public void shouldNotUpdate_malformedPermission() {
+        TestObserver<Role> testObserver = updateWithPermissions(Collections.singletonList("read"));
+
+        testObserver.assertNotComplete();
+        testObserver.assertError(InvalidRoleException.class);
+        testObserver.assertError(ex -> ((InvalidRoleException) ex).getHttpStatusCode() == HttpStatusCode.BAD_REQUEST_400);
+
+        verify(roleRepository, never()).update(any(Role.class));
+        verify(eventService, never()).create(any());
+    }
+
+    private TestObserver<Role> updateWithPermissions(List<String> permissions) {
+        UpdateRole updateRole = new UpdateRole();
+        updateRole.setName("my-role-name");
+        updateRole.setPermissions(permissions);
+
+        Role role = new Role();
+        role.setId("my-role");
+        role.setName("my-role-name");
+        role.setReferenceType(ReferenceType.ORGANIZATION);
+        role.setReferenceId(ORGANIZATION_ID);
+
+        when(roleRepository.findById(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "my-role")).thenReturn(Maybe.just(role));
+        when(roleRepository.findAll(ReferenceType.ORGANIZATION, ORGANIZATION_ID)).thenReturn(Flowable.empty());
+
+        TestObserver<Role> testObserver = roleService.update(ReferenceType.ORGANIZATION, ORGANIZATION_ID, "my-role", updateRole, null).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        return testObserver;
     }
 
     @Test

--- a/gravitee-am-test/specs/management/permissions/custom-role-lifecycle.jest.spec.ts
+++ b/gravitee-am-test/specs/management/permissions/custom-role-lifecycle.jest.spec.ts
@@ -101,6 +101,49 @@ describe('Custom role lifecycle - permissions are not validated against the assi
   });
 });
 
+describe('Custom role lifecycle - malformed permissions are refused as client errors', () => {
+  it.each<[string, string[]]>([
+    ['an unknown acl', ['domain_pillage']],
+    ['an unknown permission', ['kingdom_read']],
+    ['no separator at all', ['read']],
+    ['an empty permission half', ['_read']],
+    ['an empty acl half', ['domain_']],
+    ['an empty string', ['']],
+    ['surrounding whitespace', [' domain_read']],
+    ['a valid permission alongside an invalid one', ['domain_read', 'domain_pillage']],
+  ])('should refuse %s with a 400', async (_label, permissions) => {
+    const role = await fixture.createRole('lifecycle-invalid');
+
+    await expect(updateOrganizationRole(fixture.adminToken, role.id, { name: role.name, permissions })).rejects.toMatchObject({
+      response: { status: 400 },
+      message: expect.stringContaining('Invalid permission(s)'),
+    });
+  });
+
+  it('should name every rejected entry, not just the first', async () => {
+    const role = await fixture.createRole('lifecycle-invalid-reported');
+
+    await expect(
+      updateOrganizationRole(fixture.adminToken, role.id, { name: role.name, permissions: ['domain_pillage', 'kingdom_read'] }),
+    ).rejects.toMatchObject({
+      response: { status: 400 },
+      message: expect.stringMatching(/domain_pillage.*kingdom_read/),
+    });
+  });
+
+  it('should leave the permissions already applied untouched after a refused update', async () => {
+    const role = await fixture.createRole('lifecycle-invalid-noop');
+    await updateOrganizationRole(fixture.adminToken, role.id, { name: role.name, permissions: ['domain_read'] });
+
+    await expect(
+      updateOrganizationRole(fixture.adminToken, role.id, { name: role.name, permissions: ['domain_update', 'domain_pillage'] }),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+
+    const reread = await getOrganizationRole(fixture.adminToken, role.id);
+    expect(reread.permissions).toEqual(['domain_read']);
+  });
+});
+
 describe('Custom role lifecycle - naming and deletion', () => {
   it('should refuse a second role with a name already in use', async () => {
     const role = await fixture.createRole('lifecycle-duplicate');


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7477](https://gravitee.atlassian.net/browse/AM-7477)

## :pencil2: A description of the changes proposed in the pull request
Validate and return 400 client error rather than 500 internal error when roles are updated in the API with invalid permissions.

Applying to master only to complement regression coverage enhancements. 

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7477]: https://gravitee.atlassian.net/browse/AM-7477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ