### PR TITLE
feat: AM-7265 allow default mongo IDPs to use data plane

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -396,7 +396,7 @@ repositories:
   # specify which scope is used as reference
   # to initialize the IdentityProviders with the "use system cluster"
   # option enabled (only management and gateway scopes are allowed as value)
-  system-cluster: management
+  system-cluster: gateway
   # Management repository is used to store global configuration such as domains, clients, ...
   # This is the default configuration using MongoDB (single server)
   # For more information about MongoDB configuration, please have a look to:

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
@@ -97,7 +97,14 @@ public abstract class MongoAbstractProvider implements InitializingBean {
             final var provider = this.dataPlaneRegistry.getProviderById(this.identityProviderEntity.getDataPlaneId());
             // make sure the DataPlane plugin is a Mongo one
             if (provider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)) {
-                return provider.getClientWrapper();
+                final ClientWrapper<MongoClient> clientWrapper = provider.getClientWrapper();
+                // Only a domain's default identity provider follows the data plane's database: it has no
+                // connection settings of its own to honor. A user-configured provider keeps the database
+                // from its own form to preserve historical behavior.
+                if (this.identityProviderEntity.isSystem()) {
+                    this.configuration.setDatabase(clientWrapper.getDatabaseName());
+                }
+                return clientWrapper;
             }
         }
 

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProviderTest.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.identityprovider.mongo;
+
+import io.gravitee.am.dataplane.api.DataPlaneProvider;
+import io.gravitee.am.model.IdentityProvider;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.repository.provider.ClientWrapper;
+import io.gravitee.am.repository.provider.ConnectionProvider;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers how a Mongo identity provider picks the cluster it talks to, in particular the data plane
+ * branch a domain's default identity provider relies on.
+ *
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MongoAbstractProviderTest {
+
+    private static final String DATA_PLANE_ID = "dp1";
+
+    /** Concrete class for connection wiring tests. */
+    private static class TestMongoProvider extends MongoAbstractProvider {
+    }
+
+    @Mock
+    private ConnectionProvider commonConnectionProvider;
+
+    @Mock
+    private DataPlaneRegistry dataPlaneRegistry;
+
+    @Mock
+    private DataPlaneProvider dataPlaneProvider;
+
+    @Mock
+    private ClientWrapper dataPlaneClientWrapper;
+
+    @Mock
+    private ClientWrapper commonClientWrapper;
+
+    private final MockEnvironment environment = new MockEnvironment();
+    private final MongoIdentityProviderConfiguration configuration = new MongoIdentityProviderConfiguration();
+    private final IdentityProvider identityProviderEntity = new IdentityProvider();
+
+    private TestMongoProvider provider;
+
+    @Before
+    public void setUp() {
+        provider = new TestMongoProvider();
+        ReflectionTestUtils.setField(provider, "commonConnectionProvider", commonConnectionProvider);
+        ReflectionTestUtils.setField(provider, "dataPlaneRegistry", dataPlaneRegistry);
+        ReflectionTestUtils.setField(provider, "identityProviderEntity", identityProviderEntity);
+        ReflectionTestUtils.setField(provider, "configuration", configuration);
+        ReflectionTestUtils.setField(provider, "environment", environment);
+
+        identityProviderEntity.setSystem(true);
+        identityProviderEntity.setDataPlaneId(DATA_PLANE_ID);
+    }
+
+    @Test
+    public void systemProviderBoundToTheSystemCluster_usesTheDataPlaneClient() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+        configuration.setUseSystemCluster(true);
+        when(dataPlaneRegistry.getProviderById(DATA_PLANE_ID)).thenReturn(dataPlaneProvider);
+        when(dataPlaneProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+        when(dataPlaneProvider.getClientWrapper()).thenReturn(dataPlaneClientWrapper);
+
+        provider.afterPropertiesSet();
+
+        Assert.assertSame(dataPlaneClientWrapper, ReflectionTestUtils.getField(provider, "clientWrapper"));
+        verify(commonConnectionProvider, never()).getClientWrapper();
+    }
+
+    @Test
+    public void systemProviderBoundToTheSystemCluster_readsTheDataPlaneDatabase() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+        configuration.setUseSystemCluster(true);
+        // the value the management API persisted, which must not be used against the data plane cluster
+        configuration.setDatabase("management-db");
+        when(dataPlaneRegistry.getProviderById(DATA_PLANE_ID)).thenReturn(dataPlaneProvider);
+        when(dataPlaneProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+        when(dataPlaneProvider.getClientWrapper()).thenReturn(dataPlaneClientWrapper);
+        when(dataPlaneClientWrapper.getDatabaseName()).thenReturn("data-plane-db");
+
+        provider.afterPropertiesSet();
+
+        // client and database both come from the data plane, so they cannot disagree
+        Assert.assertEquals("data-plane-db", configuration.getDatabase());
+    }
+
+    @Test
+    public void nonSystemProviderOnTheDataPlane_keepsItsConfiguredDatabase() {
+        // a user-configured provider owns its connection settings: opting into the system cluster must
+        // not silently repoint it at another database
+        environment.setProperty("repositories.system-cluster", "gateway");
+        identityProviderEntity.setSystem(false);
+        configuration.setUseSystemCluster(true);
+        configuration.setDatabase("my-own-db");
+        when(dataPlaneRegistry.getProviderById(DATA_PLANE_ID)).thenReturn(dataPlaneProvider);
+        when(dataPlaneProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+        when(dataPlaneProvider.getClientWrapper()).thenReturn(dataPlaneClientWrapper);
+
+        provider.afterPropertiesSet();
+
+        Assert.assertSame(dataPlaneClientWrapper, ReflectionTestUtils.getField(provider, "clientWrapper"));
+        Assert.assertEquals("my-own-db", configuration.getDatabase());
+    }
+
+    @Test
+    public void unboundSystemProvider_keepsItsConfiguredDatabase() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+        configuration.setUseSystemCluster(false);
+        configuration.setDatabase("management-db");
+        when(commonConnectionProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+        when(commonConnectionProvider.getClientWrapper()).thenReturn(commonClientWrapper);
+
+        provider.afterPropertiesSet();
+
+        Assert.assertEquals("management-db", configuration.getDatabase());
+    }
+
+    @Test
+    public void systemProviderNotBoundToTheSystemCluster_usesTheManagementClient() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+        configuration.setUseSystemCluster(false);
+        when(commonConnectionProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+        when(commonConnectionProvider.getClientWrapper()).thenReturn(commonClientWrapper);
+
+        provider.afterPropertiesSet();
+
+        Assert.assertSame(commonClientWrapper, ReflectionTestUtils.getField(provider, "clientWrapper"));
+        verify(dataPlaneRegistry, never()).getProviderById(DATA_PLANE_ID);
+    }
+
+    @Test
+    public void systemProviderOnTheManagementScope_usesTheManagementClient() {
+        // the flag alone is not enough: gravitee.yml still has to select the gateway scope
+        configuration.setUseSystemCluster(true);
+        when(commonConnectionProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+        when(commonConnectionProvider.getClientWrapper()).thenReturn(commonClientWrapper);
+
+        provider.afterPropertiesSet();
+
+        Assert.assertSame(commonClientWrapper, ReflectionTestUtils.getField(provider, "clientWrapper"));
+        verify(dataPlaneRegistry, never()).getProviderById(DATA_PLANE_ID);
+    }
+
+    @Test
+    public void systemProviderWithoutDataPlane_usesTheManagementClient() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+        configuration.setUseSystemCluster(true);
+        identityProviderEntity.setDataPlaneId(null);
+        when(commonConnectionProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+        when(commonConnectionProvider.getClientWrapper()).thenReturn(commonClientWrapper);
+
+        provider.afterPropertiesSet();
+
+        Assert.assertSame(commonClientWrapper, ReflectionTestUtils.getField(provider, "clientWrapper"));
+    }
+
+    @Test
+    public void invalidSystemClusterScope_isRejected() {
+        environment.setProperty("repositories.system-cluster", "oauth2");
+        lenient().when(commonConnectionProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+
+        IllegalStateException error = Assert.assertThrows(IllegalStateException.class, () -> provider.afterPropertiesSet());
+        Assert.assertTrue(error.getMessage().contains("repositories.system-cluster"));
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DefaultIdentityProviderService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/DefaultIdentityProviderService.java
@@ -32,5 +32,14 @@ public interface DefaultIdentityProviderService {
      */
     Single<IdentityProvider> create(Domain domain, String automationKey, User principal);
 
+    /**
+     * Build the configuration of a domain's default identity provider.
+     */
     Map<String, Object> createProviderConfiguration(String referenceId, NewIdentityProvider identityProvider);
+
+    /**
+     * Rebuild the configuration of an existing default identity provider, preserving the repository
+     * scope and password encoder setting it was originally created with.
+     */
+    Map<String, Object> refreshProviderConfiguration(IdentityProvider identityProvider);
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
@@ -55,6 +55,11 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
     private static final String DEFAULT_JDBC_IDP_TYPE = "jdbc-am-idp";
     private static final int TABLE_NAME_MAX_LENGTH = 50;
     public static final String PASSWORD = "password";
+    public static final String USE_SYSTEM_CLUSTER = "useSystemCluster";
+    private static final String PASSWORD_ENCODER = "passwordEncoder";
+    private static final String PASSWORD_ENCODER_OPTIONS = "passwordEncoderOptions";
+
+    static final String SYSTEM_CLUSTER_PROPERTY = "repositories.system-cluster";
 
     private static final Set<String> SUPPORTED_PASSWORD_ENCODER = Set.of("BCrypt", "PBKDF2-SHA1", "PBKDF2-SHA256", "PBKDF2-SHA512", "SHA-256", "SHA-384", "SHA-512", "SHA-256+MD5");
     private static final Map<String, String> PBKDF2_PASSWORD_ENCODER_MAP = Map.of(
@@ -110,6 +115,50 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
 
     @Override
     public Map<String, Object> createProviderConfiguration(String referenceId, NewIdentityProvider identityProvider) {
+        return buildProviderConfiguration(referenceId, identityProvider, boundToSystemClusterByConfiguration());
+    }
+
+    @Override
+    public Map<String, Object> refreshProviderConfiguration(IdentityProvider identityProvider) {
+        final Map<String, Object> existingConfig = readConfiguration(identityProvider);
+        // Preserve existing binding setting. The identity provider and its users cannot be moved to another cluster.
+        final boolean boundToSystemCluster = Boolean.TRUE.equals(existingConfig.get(USE_SYSTEM_CLUSTER));
+
+        final Map<String, Object> configMap = buildProviderConfiguration(identityProvider.getReferenceId(), null, boundToSystemCluster);
+
+        // Password encoder settings are owned by the provider, not by gravitee.yml.
+        configMap.put(PASSWORD_ENCODER, existingConfig.get(PASSWORD_ENCODER));
+        configMap.put(PASSWORD_ENCODER_OPTIONS, existingConfig.get(PASSWORD_ENCODER_OPTIONS));
+        return configMap;
+    }
+
+    private Map<String, Object> readConfiguration(IdentityProvider identityProvider) {
+        try {
+            return objectMapper.readValue(identityProvider.getConfiguration(), Map.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Unable to read the default idp configuration for domain '" + identityProvider.getReferenceId() + "'", e);
+        }
+    }
+
+    private boolean boundToSystemClusterByConfiguration() {
+        return useMongoRepositories() && systemClusterScope() == Scope.GATEWAY;
+    }
+
+    private Scope systemClusterScope() {
+        final String value = environment.getProperty(SYSTEM_CLUSTER_PROPERTY, Scope.MANAGEMENT.getName());
+        final Scope scope;
+        try {
+            scope = Scope.fromName(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid '" + SYSTEM_CLUSTER_PROPERTY + "' value '" + value + "', only 'management' or 'gateway' are accepted", e);
+        }
+        if (scope != Scope.MANAGEMENT && scope != Scope.GATEWAY) {
+            throw new IllegalStateException("Invalid '" + SYSTEM_CLUSTER_PROPERTY + "' value '" + value + "', only 'management' or 'gateway' are accepted");
+        }
+        return scope;
+    }
+
+    private Map<String, Object> buildProviderConfiguration(String referenceId, NewIdentityProvider identityProvider, boolean boundToSystemCluster) {
         final Map<String, Object> configMap = new LinkedHashMap<>();
 
         final String encoder = environment.getProperty("domains.identities.default.passwordEncoder.algorithm", "BCrypt");
@@ -150,7 +199,8 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
             configMap.put("findUserByEmailQuery", "{email: ?}");
             configMap.put("usernameField", "username");
             configMap.put("passwordField", PASSWORD);
-            configMap.put("passwordEncoder", parsePasswordEncoder(encoder));
+            configMap.put(PASSWORD_ENCODER, parsePasswordEncoder(encoder));
+            configMap.put(USE_SYSTEM_CLUSTER, boundToSystemCluster);
             updatePasswordEncoderOptions(configMap, encoder);
 
         } else if (useJdbcRepositories()) {
@@ -182,7 +232,7 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
             configMap.put("identifierAttribute", "id");
             configMap.put("usernameAttribute", "username");
             configMap.put("passwordAttribute", PASSWORD);
-            configMap.put("passwordEncoder", parsePasswordEncoder(encoder));
+            configMap.put(PASSWORD_ENCODER, parsePasswordEncoder(encoder));
             jdbcSchema().ifPresent(schema -> configMap.put("options", List.of(Map.of("option", "currentSchema", "value", schema))));
             updatePasswordEncoderOptions(configMap, encoder);
         }
@@ -235,13 +285,13 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
     private void updatePasswordEncoderOptions(Map<String, Object> configMap, String encoder) {
         if ("bcrypt".equalsIgnoreCase(encoder)) {
             String rounds = environment.getProperty("domains.identities.default.passwordEncoder.properties.rounds", "10");
-            configMap.put("passwordEncoderOptions", new PasswordEncoderOptions(Integer.parseInt(rounds)));
+            configMap.put(PASSWORD_ENCODER_OPTIONS, new PasswordEncoderOptions(Integer.parseInt(rounds)));
         } else if (encoder.toLowerCase().startsWith("sha")) {
             String rounds = environment.getProperty("domains.identities.default.passwordEncoder.properties.rounds", "1");
-            configMap.put("passwordEncoderOptions", new PasswordEncoderOptions(Integer.parseInt(rounds)));
+            configMap.put(PASSWORD_ENCODER_OPTIONS, new PasswordEncoderOptions(Integer.parseInt(rounds)));
         } else if (encoder.toLowerCase().startsWith("pbkdf2")) {
             String rounds = environment.getProperty("domains.identities.default.passwordEncoder.properties.rounds", "600000");
-            configMap.put("passwordEncoderOptions", new PasswordEncoderOptions(Integer.parseInt(rounds)));
+            configMap.put(PASSWORD_ENCODER_OPTIONS, new PasswordEncoderOptions(Integer.parseInt(rounds)));
         }
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/system/upgraders/DefaultIdentityProviderUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/system/upgraders/DefaultIdentityProviderUpgrader.java
@@ -65,11 +65,8 @@ public class DefaultIdentityProviderUpgrader implements SystemUpgrader {
         updateIdentityProvider.setName(identityProvider.getName());
         updateIdentityProvider.setRoleMapper(identityProvider.getRoleMapper());
         updateIdentityProvider.setGroupMapper(identityProvider.getGroupMapper());
-        Map<String, Object> configMap = defaultIdentityProviderService.createProviderConfiguration(identityProvider.getReferenceId(), null);
+        Map<String, Object> configMap = defaultIdentityProviderService.refreshProviderConfiguration(identityProvider);
         try {
-            Map<String, Object> existingConfigMap = mapper.readValue(identityProvider.getConfiguration(), Map.class);
-            configMap.put("passwordEncoder", existingConfigMap.get("passwordEncoder"));
-            configMap.put("passwordEncoderOptions", existingConfigMap.get("passwordEncoderOptions"));
             updateIdentityProvider.setConfiguration(mapper.writeValueAsString(configMap));
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Unable to serialize the default idp configuration for domain '" + identityProvider.getReferenceId() + "'", e);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceTest.java
@@ -18,6 +18,9 @@ package io.gravitee.am.management.service.impl;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -211,5 +214,168 @@ public class DefaultIdentityProviderServiceTest {
 
         assertEquals("PBKDF2WithHmacSHA512", test.get("passwordEncoder"));
         assertEquals(600000, ((PasswordEncoderOptions) test.get("passwordEncoderOptions")).getRounds());
+    }
+
+    // --- repositories.system-cluster binding ---
+
+    @Test
+    public void managementScope_isNotBoundToTheSystemCluster() {
+        environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
+        environment.setProperty("repositories.management.mongodb.port", "27018");
+        environment.setProperty("repositories.management.mongodb.dbname", "mgmt-db");
+
+        Map<String, Object> config = cut.createProviderConfiguration("test", null);
+
+        assertEquals("mgmt-host", config.get("host"));
+        assertEquals(27018, config.get("port"));
+        assertEquals("mgmt-db", config.get("database"));
+        assertEquals("mongodb://mgmt-host:27018/?connectTimeoutMS=5000&socketTimeoutMS=5000", config.get("uri"));
+        assertEquals(false, config.get("useSystemCluster"));
+    }
+
+    @Test
+    public void mongoBackend_emitsTheFullProviderConfiguration() {
+        Map<String, Object> config = cut.createProviderConfiguration("test", null);
+
+        assertEquals("localhost", config.get("host"));
+        assertEquals(27017, config.get("port"));
+        assertEquals(false, config.get("enableCredentials"));
+        assertEquals("gravitee-am", config.get("database"));
+        assertEquals("idp_users_test", config.get("usersCollection"));
+        assertEquals("{username: ?}", config.get("findUserByUsernameQuery"));
+        assertEquals("{email: ?}", config.get("findUserByEmailQuery"));
+        assertEquals("username", config.get("usernameField"));
+        assertEquals("password", config.get("passwordField"));
+        assertEquals("BCrypt", config.get("passwordEncoder"));
+    }
+
+    @Test
+    public void gatewayScope_bindsTheProviderToTheSystemCluster() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+        environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
+        environment.setProperty("repositories.management.mongodb.dbname", "mgmt-db");
+
+        Map<String, Object> config = cut.createProviderConfiguration("test", null);
+
+        // the connection settings stay a fallback: the Mongo provider replaces both the client and the
+        // database with the data plane's when it honors this flag
+        assertEquals("mgmt-host", config.get("host"));
+        assertEquals("mgmt-db", config.get("database"));
+        assertEquals(true, config.get("useSystemCluster"));
+    }
+
+    @Test
+    public void invalidSystemClusterScope_isRejected() {
+        environment.setProperty("repositories.system-cluster", "oauth2");
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> cut.createProviderConfiguration("test", null));
+        assertTrue(error.getMessage().contains("oauth2"));
+    }
+
+    @Test
+    public void unknownSystemClusterScope_isRejected() {
+        environment.setProperty("repositories.system-cluster", "not-a-scope");
+
+        assertThrows(IllegalStateException.class, () -> cut.createProviderConfiguration("test", null));
+    }
+
+    @Test
+    public void jdbcBackend_emitsTheFullProviderConfiguration() {
+        environment.setProperty("repositories.management.type", "jdbc");
+
+        Map<String, Object> config = cut.createProviderConfiguration("test", null);
+
+        assertEquals("localhost", config.get("host"));
+        assertEquals(5432, config.get("port"));
+        assertEquals("gravitee_am", config.get("database"));
+        assertEquals("postgresql", config.get("protocol"));
+        assertEquals("idp_users_test", config.get("usersTable"));
+        assertEquals("postgres", config.get("user"));
+        assertEquals(true, config.get("autoProvisioning"));
+        assertEquals("SELECT * FROM idp_users_test WHERE username = %s", config.get("selectUserByUsernameQuery"));
+        assertEquals("SELECT * FROM idp_users_test WHERE email = %s", config.get("selectUserByEmailQuery"));
+        assertEquals("id", config.get("identifierAttribute"));
+        assertEquals("username", config.get("usernameAttribute"));
+        assertEquals("password", config.get("passwordAttribute"));
+        assertEquals("BCrypt", config.get("passwordEncoder"));
+    }
+
+    @Test
+    public void jdbcBackend_isNeverBoundToTheSystemCluster() {
+        environment.setProperty("repositories.management.type", "jdbc");
+        environment.setProperty("repositories.system-cluster", "gateway");
+        environment.setProperty("repositories.management.jdbc.host", "mgmt-jdbc");
+
+        Map<String, Object> config = cut.createProviderConfiguration("test", null);
+
+        assertEquals("mgmt-jdbc", config.get("host"));
+        assertFalse(config.containsKey("useSystemCluster"));
+    }
+
+    // --- refreshProviderConfiguration preserves the binding made at creation time ---
+
+    @Test
+    public void refresh_keepsAnExistingProviderUnboundEvenWhenGatewayIsConfigured() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+        environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
+
+        Map<String, Object> config = cut.refreshProviderConfiguration(
+                existingProvider("{\"host\":\"mgmt-host\",\"passwordEncoder\":\"BCrypt\"}"));
+
+        assertEquals("mgmt-host", config.get("host"));
+        assertEquals(false, config.get("useSystemCluster"));
+    }
+
+    @Test
+    public void refresh_keepsAnExplicitlyUnboundProviderUnbound() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+
+        Map<String, Object> config = cut.refreshProviderConfiguration(
+                existingProvider("{\"useSystemCluster\":false,\"passwordEncoder\":\"BCrypt\"}"));
+
+        assertEquals(false, config.get("useSystemCluster"));
+    }
+
+    @Test
+    public void refresh_keepsABoundProviderBound() {
+        environment.setProperty("repositories.system-cluster", "gateway");
+
+        Map<String, Object> config = cut.refreshProviderConfiguration(
+                existingProvider("{\"useSystemCluster\":true,\"passwordEncoder\":\"BCrypt\"}"));
+
+        assertEquals(true, config.get("useSystemCluster"));
+    }
+
+    @Test
+    public void refresh_keepsTheBindingWhenTheScopeIsMovedBackToManagement() {
+        environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
+
+        Map<String, Object> config = cut.refreshProviderConfiguration(
+                existingProvider("{\"useSystemCluster\":true,\"passwordEncoder\":\"BCrypt\"}"));
+
+        assertEquals("mgmt-host", config.get("host"));
+        assertEquals(true, config.get("useSystemCluster"));
+    }
+
+    @Test
+    public void refresh_preservesPasswordEncoderSettings() {
+        environment.setProperty("domains.identities.default.passwordEncoder.algorithm", "SHA-512");
+
+        Map<String, Object> config = cut.refreshProviderConfiguration(
+                existingProvider("{\"passwordEncoder\":\"BCrypt\",\"passwordEncoderOptions\":{\"rounds\":12}}"));
+
+        assertEquals("BCrypt", config.get("passwordEncoder"));
+        assertEquals(Map.of("rounds", 12), config.get("passwordEncoderOptions"));
+    }
+
+    private IdentityProvider existingProvider(String configuration) {
+        IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setId("default-idp-test");
+        identityProvider.setReferenceId("test");
+        identityProvider.setSystem(true);
+        identityProvider.setDataPlaneId("dp1");
+        identityProvider.setConfiguration(configuration);
+        return identityProvider;
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/system/upgraders/DefaultIdentityProviderUpgraderTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/system/upgraders/DefaultIdentityProviderUpgraderTest.java
@@ -28,7 +28,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -65,9 +64,12 @@ public class DefaultIdentityProviderUpgraderTest {
 
     @Test
     public void shouldUpdateDefaultIdp() throws Exception {
-        Map<String, Object> cfg = new HashMap<>(Map.of("new-config", "created"));
+        Map<String, Object> cfg = new LinkedHashMap<>();
+        cfg.put("new-config", "created");
+        cfg.put("passwordEncoder", "existing passwordEncoder");
+        cfg.put("passwordEncoderOptions", Map.of("options", "existing options"));
         when(identityProviderService.findAll()).thenReturn(Flowable.just(systemIdentityProvider));
-        when(defaultIdentityProviderService.createProviderConfiguration(anyString(), isNull())).thenReturn(cfg);
+        when(defaultIdentityProviderService.refreshProviderConfiguration(systemIdentityProvider)).thenReturn(cfg);
         when(identityProviderService.update(anyString(), anyString(), any(UpdateIdentityProvider.class), eq(true))).thenReturn(changeIdpConfig(true));
 
         TestObserver<Void> observer = defaultIdentityProviderUpgrader.upgrade().test();
@@ -75,13 +77,14 @@ public class DefaultIdentityProviderUpgraderTest {
         observer.assertNoErrors();
 
         verify(identityProviderService, times(1)).findAll();
+        verify(defaultIdentityProviderService, times(1)).refreshProviderConfiguration(systemIdentityProvider);
         verify(identityProviderService, times(1))
-                .update(anyString(),
-                        anyString(),
+                .update(eq("domain-id"),
+                        eq("test-idp-id"),
                         argThat(upIdp -> upIdp.getConfiguration().contains("\"new-config\"") && upIdp.getConfiguration().contains("\"created\"") &&
                                 // password encoder and linked options are immutable
                                 upIdp.getConfiguration().contains("\"existing passwordEncoder\"") && upIdp.getConfiguration().contains("\"existing options\"")),
-                        anyBoolean());
+                        eq(true));
     }
 
     @Test
@@ -94,6 +97,7 @@ public class DefaultIdentityProviderUpgraderTest {
         observer.assertNoErrors();
 
         verify(identityProviderService, times(1)).findAll();
+        verify(defaultIdentityProviderService, never()).refreshProviderConfiguration(any(IdentityProvider.class));
         verify(identityProviderService, never())
                 .update(anyString(), anyString(), any(UpdateIdentityProvider.class), anyBoolean());
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -418,6 +418,10 @@ user:
     maxRequestOperations: 1000
 
 repositories:
+  # specify which scope is used as reference
+  # to initialize the IdentityProviders with the "use system cluster"
+  # option enabled (only management and gateway scopes are allowed as value)
+  system-cluster: gateway
   # Management repository is used to store global configuration such as domains, clients, ...
   # This is the default configuration using MongoDB (single server)
   # For more information about MongoDB configuration, please have a look to:


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7265](https://gravitee.atlassian.net/browse/AM-7265)

## :pencil2: A description of the changes proposed in the pull request
When `repositories.system-cluster` is set to "gateway", sync domains' default mongo IDPs to their associated data planes. Historically default mongo IDPs always synced to the management repository settings.

New default mongo IDPs persist `useSystemCluster=true`, like non-system instances, when nodes configure `repositories.system-cluster` as "gateway"; existing IDPs are unaffected since they do not persist `useSystemCluster` at all and fall back to the existing management scope sync.

In the "use system cluster" mode, default IDPs use the database name configured for the data plane - so this is synced for default IDPs only. It's a latent inconsistency that non-system IDPs use the data plane's client but the database still defined on the form - but this behaviour is preserved.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7265]: https://gravitee.atlassian.net/browse/AM-7265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ