### PR TITLE
feat: trusted domains gain an issuer matcher, gateway residency and a migration (AM-7372)

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -8433,7 +8433,7 @@ paths:
           description: Invalid trust domain configuration
         "500":
           description: Internal server error
-      summary: Register a SPIFFE trust domain on the security domain
+      summary: Register a trust domain on the security domain
       tags:
       - trust-domain
       - domain
@@ -15856,6 +15856,10 @@ components:
           - STATIC_JWKS
         description:
           type: string
+        issuer:
+          type: string
+          maxLength: 512
+          minLength: 0
         jwksUrl:
           type: string
           deprecated: true
@@ -15869,12 +15873,22 @@ components:
         refreshIntervalSeconds:
           type: integer
           format: int32
+        scopeMappings:
+          type: object
+          additionalProperties:
+            type: string
         spiffeTrustDomain:
           type: string
           description: SPIFFE trust domain matched against the "sub" of a JWT-SVID.
-            Defaults to the name when not supplied.
+            Defaults to the name when no matcher is supplied.
           maxLength: 255
           minLength: 0
+        userBindingCriteria:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserBindingCriterion"
+        userBindingEnabled:
+          type: boolean
     NewUser:
       type: object
       properties:
@@ -18320,6 +18334,11 @@ components:
           type: string
         id:
           type: string
+        issuer:
+          type: string
+          description: Expected value of the "iss" claim in an external JWT. Required
+            to accept tokens during an RFC 8693 exchange.
+          example: https://sso.acme.com
         jwksUrl:
           type: string
           deprecated: true
@@ -18345,6 +18364,16 @@ components:
         refreshIntervalSeconds:
           type: integer
           format: int32
+        scopeMappings:
+          type: object
+          additionalProperties:
+            type: string
+            description: One-to-one mapping from external scope to domain scope. Unmapped
+              issuer scopes are dropped (fail-closed). Applies to tokens matched by
+              "issuer".
+          description: One-to-one mapping from external scope to domain scope. Unmapped
+            issuer scopes are dropped (fail-closed). Applies to tokens matched by
+            "issuer".
         spiffeTrustDomain:
           type: string
           description: "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID,\
@@ -18356,6 +18385,18 @@ components:
           type: integer
           format: int64
           description: Epoch timestamp in milliseconds.
+        userBindingCriteria:
+          type: array
+          description: Criteria used to locate a domain user when user binding is
+            enabled. All criteria are combined with AND.
+          items:
+            $ref: "#/components/schemas/UserBindingCriterion"
+        userBindingEnabled:
+          type: boolean
+          default: false
+          description: "Whether the external JWT subject is resolved to a single domain\
+            \ user using the user binding criteria. When false, a virtual user is\
+            \ built from the token claims only."
     TrustDomainKeyMaterial:
       type: object
       description: Where the trusted domain's signing keys come from. Exactly one
@@ -18853,6 +18894,10 @@ components:
           - STATIC_JWKS
         description:
           type: string
+        issuer:
+          type: string
+          maxLength: 512
+          minLength: 0
         jwksUrl:
           type: string
           deprecated: true
@@ -18867,12 +18912,23 @@ components:
         refreshIntervalSeconds:
           type: integer
           format: int32
+        scopeMappings:
+          type: object
+          additionalProperties:
+            type: string
         spiffeTrustDomain:
           type: string
           description: SPIFFE trust domain matched against the "sub" of a JWT-SVID.
-            Left unchanged when absent.
+            Supplying either matcher replaces both; supplying neither leaves them
+            unchanged.
           maxLength: 255
           minLength: 0
+        userBindingCriteria:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserBindingCriterion"
+        userBindingEnabled:
+          type: boolean
     UpdateUser:
       type: object
       properties:

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/event/Event.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/event/Event.java
@@ -62,6 +62,7 @@ public abstract class Event {
             case LICENSE -> LicenseEvent.actionOf(action);
             case ENTRYPOINT -> EntrypointEvent.actionOf(action);
             case DATA_PLANE -> DataPlaneEvent.actionOf(action);
+            case TRUST_DOMAIN -> TrustDomainEvent.actionOf(action);
             default -> null;
         };
     }

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/event/TrustDomainEvent.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/event/TrustDomainEvent.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.event;
+
+public enum TrustDomainEvent {
+    DEPLOY,
+    UPDATE,
+    UNDEPLOY;
+
+    public static TrustDomainEvent actionOf(Action action) {
+        return switch (action) {
+            case CREATE -> TrustDomainEvent.DEPLOY;
+            case UPDATE -> TrustDomainEvent.UPDATE;
+            case DELETE -> TrustDomainEvent.UNDEPLOY;
+            default -> null;
+        };
+    }
+}

--- a/gravitee-am-common/src/test/java/io/gravitee/am/common/event/TrustDomainEventTest.java
+++ b/gravitee-am-common/src/test/java/io/gravitee/am/common/event/TrustDomainEventTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.common.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author GraviteeSource Team
+ */
+class TrustDomainEventTest {
+
+    @Test
+    void shouldMapLifecycleActions() {
+        assertEquals(TrustDomainEvent.DEPLOY, TrustDomainEvent.actionOf(Action.CREATE));
+        assertEquals(TrustDomainEvent.UPDATE, TrustDomainEvent.actionOf(Action.UPDATE));
+        assertEquals(TrustDomainEvent.UNDEPLOY, TrustDomainEvent.actionOf(Action.DELETE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Action.class, names = {"BULK_CREATE", "BULK_UPDATE", "BULK_DELETE"})
+    void shouldIgnoreBulkActions(Action action) {
+        assertNull(TrustDomainEvent.actionOf(action));
+    }
+
+    @Test
+    void shouldResolveTrustDomainEvents() {
+        assertEquals(TrustDomainEvent.DEPLOY, Event.valueOf(Type.TRUST_DOMAIN, Action.CREATE));
+        assertEquals(TrustDomainEvent.UPDATE, Event.valueOf(Type.TRUST_DOMAIN, Action.UPDATE));
+        assertEquals(TrustDomainEvent.UNDEPLOY, Event.valueOf(Type.TRUST_DOMAIN, Action.DELETE));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidator.java
@@ -28,14 +28,13 @@ import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDProviderMetad
 import io.gravitee.am.gateway.handler.oidc.service.jws.JWSService;
 import io.gravitee.am.gateway.handler.oidc.service.spiffe.SpiffeJwtSvidValidator;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.application.AgentType;
 import io.gravitee.am.model.application.SpiffeApplicationSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
 import io.gravitee.am.model.oidc.TrustDomain;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
 import io.reactivex.rxjava3.core.Maybe;
 import lombok.CustomLog;
 
@@ -50,8 +49,8 @@ import static io.gravitee.am.gateway.handler.oauth2.service.assertion.impl.JwtAs
  * Validates a SPIFFE JWT-SVID carried as a {@code jwt-spiffe} client assertion.
  * The client is resolved either via {@code clientIdHint} (request {@code client_id})
  * or, when absent, by treating the SPIFFE URI in {@code sub} as the client_id
- * (CIMD-style). The trust domain is derived from the SPIFFE ID and the bundle
- * keys are fetched via {@link TrustDomainKeyService}.
+ * (CIMD-style). The trust domain is resolved from the {@link TrustDomainManager} and the
+ * bundle keys are fetched via {@link TrustDomainKeyService}.
  */
 @CustomLog
 public class SpiffeClientAssertionValidator implements ClientAssertionValidator {
@@ -61,20 +60,20 @@ public class SpiffeClientAssertionValidator implements ClientAssertionValidator 
     private final OpenIDDiscoveryService openIDDiscoveryService;
     private final Domain domain;
     private final TrustDomainKeyService trustDomainKeyService;
-    private final TrustDomainRepository trustDomainRepository;
+    private final TrustDomainManager trustDomainManager;
 
     public SpiffeClientAssertionValidator(ClientLookupService clientLookupService,
                                           JWSService jwsService,
                                           OpenIDDiscoveryService openIDDiscoveryService,
                                           Domain domain,
                                           TrustDomainKeyService trustDomainKeyService,
-                                          TrustDomainRepository trustDomainRepository) {
+                                          TrustDomainManager trustDomainManager) {
         this.clientLookupService = clientLookupService;
         this.jwsService = jwsService;
         this.openIDDiscoveryService = openIDDiscoveryService;
         this.domain = domain;
         this.trustDomainKeyService = trustDomainKeyService;
-        this.trustDomainRepository = trustDomainRepository;
+        this.trustDomainManager = trustDomainManager;
     }
 
     @Override
@@ -128,7 +127,7 @@ public class SpiffeClientAssertionValidator implements ClientAssertionValidator 
                     if (spiffe == null || spiffe.getTrustDomain() == null) {
                         return Maybe.error(new InvalidClientException("Client missing SPIFFE settings"));
                     }
-                    return trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, domain.getId(), spiffe.getTrustDomain())
+                    return Maybe.fromOptional(trustDomainManager.findBySpiffeTrustDomain(spiffe.getTrustDomain()))
                             .switchIfEmpty(Maybe.error(new InvalidClientException("Trust domain not registered")))
                             .flatMap(td -> {
                                 String fail = new SpiffeJwtSvidValidator(settings)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/OIDCProvider.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/OIDCProvider.java
@@ -33,6 +33,7 @@ import io.gravitee.am.gateway.handler.oauth2.resources.handler.ExceptionHandler;
 import io.gravitee.am.gateway.handler.oauth2.service.assertion.ClientAssertionService;
 import io.gravitee.am.gateway.handler.oauth2.service.granter.extensiongrant.ExtensionGrantManager;
 import io.gravitee.am.gateway.handler.oauth2.service.scope.ScopeManager;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
 import io.gravitee.am.gateway.handler.oidc.resources.endpoint.DynamicClientAccessEndpoint;
 import io.gravitee.am.gateway.handler.oidc.resources.endpoint.DynamicClientRegistrationEndpoint;
 import io.gravitee.am.gateway.handler.oidc.resources.endpoint.DynamicClientRegistrationTemplateEndpoint;
@@ -132,6 +133,9 @@ public class OIDCProvider extends AbstractProtocolProvider {
     private ScopeManager scopeManager;
 
     @Autowired
+    private TrustDomainManager trustDomainManager;
+
+    @Autowired
     private RequestObjectService requestObjectService;
 
     @Autowired
@@ -172,6 +176,7 @@ public class OIDCProvider extends AbstractProtocolProvider {
 
         extensionGrantManager.stop();
         scopeManager.stop();
+        trustDomainManager.stop();
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManager.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oidc.service.trustdomain;
+
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.common.service.Service;
+
+import java.util.Optional;
+
+/**
+ * Holds the security domain's trusted domains in memory and keeps them current from management
+ * events, so that resolving trust on a token request never reads the database.
+ *
+ * @author GraviteeSource Team
+ */
+public interface TrustDomainManager extends Service {
+
+    /**
+     * The trusted domain that vouches for this SPIFFE trust domain, if any.
+     */
+    Optional<TrustDomain> findBySpiffeTrustDomain(String spiffeTrustDomain);
+
+    /**
+     * The trusted domain that vouches for this issuer, if any.
+     */
+    Optional<TrustDomain> findByIssuer(String issuer);
+
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainManagerImpl.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oidc.service.trustdomain.impl;
+
+import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.event.TrustDomainEvent;
+import io.gravitee.am.common.event.Type;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.service.AbstractService;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import lombok.CustomLog;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@CustomLog
+public class TrustDomainManagerImpl extends AbstractService implements TrustDomainManager, InitializingBean, EventListener<TrustDomainEvent, Payload> {
+
+    private static final String PRELOAD_PLUGIN_ID = Type.TRUST_DOMAIN.name();
+
+    @Autowired
+    private Domain domain;
+
+    @Autowired
+    private EventManager eventManager;
+
+    @Autowired
+    private TrustDomainRepository trustDomainRepository;
+
+    @Autowired
+    private TrustDomainKeyService trustDomainKeyService;
+
+    @Autowired
+    private DomainReadinessService domainReadinessService;
+
+    private final ConcurrentMap<String, TrustDomain> byId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, TrustDomain> bySpiffeTrustDomain = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, TrustDomain> byIssuer = new ConcurrentHashMap<>();
+
+    @Override
+    public void afterPropertiesSet() {
+        log.info("Initializing trusted domains for domain {}", domain.getName());
+        domainReadinessService.initPluginSync(domain.getId(), PRELOAD_PLUGIN_ID, Type.TRUST_DOMAIN.name());
+        trustDomainRepository.findByReference(ReferenceType.DOMAIN, domain.getId())
+                .subscribeOn(Schedulers.io())
+                .subscribe(
+                        trustDomain -> {
+                            domainReadinessService.initPluginSync(domain.getId(), trustDomain.getId(), Type.TRUST_DOMAIN.name());
+                            index(trustDomain);
+                            log.info("Trusted domain {} loaded for domain {}", trustDomain.getName(), domain.getName());
+                            domainReadinessService.pluginLoaded(domain.getId(), trustDomain.getId());
+                        },
+                        error -> {
+                            log.error("An error has occurred when loading trusted domains for domain {}", domain.getName(), error);
+                            domainReadinessService.pluginInitFailed(domain.getId(), Type.TRUST_DOMAIN.name(), error.getMessage());
+                        },
+                        () -> {
+                            log.info("Trusted domains loaded for domain {}", domain.getName());
+                            domainReadinessService.pluginLoaded(domain.getId(), PRELOAD_PLUGIN_ID);
+                        });
+
+        log.info("Register event listener for trusted domain events for domain {}", domain.getName());
+        eventManager.subscribeForEvents(this, TrustDomainEvent.class, domain.getId());
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        log.info("Dispose event listener for trusted domain events for domain {}", domain.getName());
+        eventManager.unsubscribeForEvents(this, TrustDomainEvent.class, domain.getId());
+    }
+
+    @Override
+    public void onEvent(Event<TrustDomainEvent, Payload> event) {
+        log.debug("Receive trusted domain event {} for id {}", event.type(), event.content().getId());
+        if (event.content().getReferenceType() != ReferenceType.DOMAIN
+                || !domain.getId().equals(event.content().getReferenceId())) {
+            return;
+        }
+        final String trustDomainId = event.content().getId();
+        switch (event.type()) {
+            case DEPLOY, UPDATE -> reload(trustDomainId);
+            case UNDEPLOY -> unload(trustDomainId);
+        }
+    }
+
+    @Override
+    public Optional<TrustDomain> findBySpiffeTrustDomain(String spiffeTrustDomain) {
+        return spiffeTrustDomain == null ? Optional.empty() : Optional.ofNullable(bySpiffeTrustDomain.get(spiffeTrustDomain));
+    }
+
+    @Override
+    public Optional<TrustDomain> findByIssuer(String issuer) {
+        return issuer == null ? Optional.empty() : Optional.ofNullable(byIssuer.get(issuer));
+    }
+
+
+    private void reload(String trustDomainId) {
+        log.info("Loading trusted domain {} for domain {}", trustDomainId, domain.getName());
+        domainReadinessService.initPluginSync(domain.getId(), trustDomainId, Type.TRUST_DOMAIN.name());
+        trustDomainRepository.findById(trustDomainId)
+                .subscribeOn(Schedulers.io())
+                .subscribe(
+                        trustDomain -> {
+                            index(trustDomain);
+                            trustDomainKeyService.evict(trustDomainId);
+                            log.info("Trusted domain {} loaded for domain {}", trustDomain.getName(), domain.getName());
+                            domainReadinessService.pluginLoaded(domain.getId(), trustDomainId);
+                        },
+                        error -> {
+                            log.error("An error has occurred when loading trusted domain {} for domain {}", trustDomainId, domain.getName(), error);
+                            domainReadinessService.pluginFailed(domain.getId(), trustDomainId, error.getMessage());
+                        },
+                        () -> {
+                            log.warn("No trusted domain found with id {} for domain {}", trustDomainId, domain.getName());
+                            unload(trustDomainId);
+                        });
+    }
+
+    private void unload(String trustDomainId) {
+        TrustDomain removed = byId.remove(trustDomainId);
+        if (removed != null) {
+            unindex(removed);
+            log.info("Trusted domain {} has been removed for domain {}", removed.getName(), domain.getName());
+        }
+        trustDomainKeyService.evict(trustDomainId);
+        domainReadinessService.pluginRemoved(domain.getId(), trustDomainId);
+    }
+
+    private void index(TrustDomain trustDomain) {
+        TrustDomain previous = byId.put(trustDomain.getId(), trustDomain);
+        if (previous != null) {
+            unindex(previous);
+        }
+        Optional.ofNullable(trustDomain.getSpiffeTrustDomain())
+                .ifPresent(spiffeTrustDomain -> bySpiffeTrustDomain.put(spiffeTrustDomain, trustDomain));
+        Optional.ofNullable(trustDomain.getIssuer())
+                .ifPresent(issuer -> byIssuer.put(issuer, trustDomain));
+    }
+
+    private void unindex(TrustDomain trustDomain) {
+        Optional.ofNullable(trustDomain.getSpiffeTrustDomain())
+                .ifPresent(spiffeTrustDomain -> bySpiffeTrustDomain.remove(spiffeTrustDomain, trustDomain));
+        Optional.ofNullable(trustDomain.getIssuer())
+                .ifPresent(issuer -> byIssuer.remove(issuer, trustDomain));
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/spring/OIDCConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/spring/OIDCConfiguration.java
@@ -26,7 +26,6 @@ import io.gravitee.am.gateway.handler.oauth2.service.assertion.impl.SpiffeClient
 import io.gravitee.am.gateway.handler.oauth2.service.par.PushedAuthorizationRequestService;
 import io.gravitee.am.gateway.handler.oauth2.service.par.impl.PushedAuthorizationRequestServiceImpl;
 import io.gravitee.am.gateway.handler.oauth2.spring.OAuth2Configuration;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
 import io.gravitee.am.gateway.handler.oidc.service.clientregistration.ClientSecretService;
 import io.gravitee.am.gateway.handler.oidc.service.clientregistration.ClientService;
 import io.gravitee.am.gateway.handler.oidc.service.clientregistration.DynamicClientRegistrationService;
@@ -45,6 +44,8 @@ import io.gravitee.am.gateway.handler.oidc.service.jwk.JWKService;
 import io.gravitee.am.gateway.handler.oidc.service.jwk.impl.JWKServiceImpl;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.impl.TrustDomainKeyServiceImpl;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.impl.TrustDomainManagerImpl;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.service.jwk.JWKSetFetcher;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -111,6 +112,11 @@ public class OIDCConfiguration implements ProtocolConfiguration {
     }
 
     @Bean
+    public TrustDomainManager trustDomainManager() {
+        return new TrustDomainManagerImpl();
+    }
+
+    @Bean
     public JWSService jwsService() {
         return new JWSServiceImpl();
     }
@@ -149,7 +155,7 @@ public class OIDCConfiguration implements ProtocolConfiguration {
                                                                    OpenIDDiscoveryService openIDDiscoveryService,
                                                                    Domain domain,
                                                                    TrustDomainKeyService trustDomainKeyService,
-                                                                   TrustDomainRepository trustDomainRepository) {
-        return new SpiffeClientAssertionValidator(clientLookupService, jwsService, openIDDiscoveryService, domain, trustDomainKeyService, trustDomainRepository);
+                                                                   TrustDomainManager trustDomainManager) {
+        return new SpiffeClientAssertionValidator(clientLookupService, jwsService, openIDDiscoveryService, domain, trustDomainKeyService, trustDomainManager);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/ClientAssertionServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/ClientAssertionServiceTest.java
@@ -38,7 +38,7 @@ import io.gravitee.am.gateway.handler.oidc.service.jwk.JWKService;
 import io.gravitee.am.gateway.handler.oidc.service.jws.JWSService;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
 import io.gravitee.am.model.application.AgentType;
 import io.gravitee.am.model.jose.JWK;
 import io.gravitee.am.model.jose.RSAKey;
@@ -106,7 +106,7 @@ public class ClientAssertionServiceTest {
     private TrustDomainKeyService trustDomainKeyService;
 
     @Mock
-    private TrustDomainRepository trustDomainRepository;
+    private TrustDomainManager trustDomainManager;
 
     @Mock
     private io.gravitee.am.service.AuditService auditService;
@@ -120,7 +120,7 @@ public class ClientAssertionServiceTest {
         var agentJwtBearer = new AgentJwtBearerClientAssertionValidator(
                 clientLookupService, jwkService, jwsService, openIDDiscoveryService, domain);
         var spiffe = new SpiffeClientAssertionValidator(
-                clientLookupService, jwsService, openIDDiscoveryService, domain, trustDomainKeyService, trustDomainRepository);
+                clientLookupService, jwsService, openIDDiscoveryService, domain, trustDomainKeyService, trustDomainManager);
         clientAssertionService = new ClientAssertionServiceImpl(List.of(jwtBearer, agentJwtBearer, spiffe));
         lenient().when(clientLookupService.findByClientId(any())).thenReturn(Maybe.empty());
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidatorTest.java
@@ -31,7 +31,6 @@ import io.gravitee.am.gateway.handler.oidc.service.jws.impl.JWSServiceImpl;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.impl.TrustDomainKeyServiceImpl;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.application.AgentType;
 import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.application.SpiffeApplicationSettings;
@@ -42,7 +41,7 @@ import io.gravitee.am.model.oidc.SpiffeDomainSettings;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.oidc.TrustDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
 import io.gravitee.am.service.jwk.JWKSetFetcher;
 import io.reactivex.rxjava3.core.Maybe;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,6 +58,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -141,7 +141,7 @@ class SpiffeClientAssertionValidatorTest {
     @Mock
     private TrustDomainKeyService trustDomainKeyService;
     @Mock
-    private TrustDomainRepository trustDomainRepository;
+    private TrustDomainManager trustDomainManager;
     @Mock
     private OpenIDProviderMetadata discovery;
 
@@ -164,7 +164,7 @@ class SpiffeClientAssertionValidatorTest {
 
         validator = new SpiffeClientAssertionValidator(
                 clientLookupService, jwsService, openIDDiscoveryService, domain,
-                trustDomainKeyService, trustDomainRepository);
+                trustDomainKeyService, trustDomainManager);
     }
 
     /** Stubs required by every path that reaches {@code validateSpiffeAssertion} past the sub check. */
@@ -176,11 +176,6 @@ class SpiffeClientAssertionValidatorTest {
     /** Stubs required by every path that reaches the settings check. */
     private void stubDomainOidc() {
         when(domain.getOidc()).thenReturn(oidcSettings);
-    }
-
-    /** Stubs required by every path that reaches the trust-domain repository lookup. */
-    private void stubDomainId() {
-        when(domain.getId()).thenReturn(DOMAIN_ID);
     }
 
     @Test
@@ -272,11 +267,10 @@ class SpiffeClientAssertionValidatorTest {
     void rejects_whenTrustDomainNotRegistered() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Client client = clientWithSpiffeSettings();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.empty());
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.empty());
         String assertion = svid().serialize();
 
         validator.validate(assertion, BASE_PATH, null).test()
@@ -289,14 +283,13 @@ class SpiffeClientAssertionValidatorTest {
     void rejects_whenSvidValidatorFails() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Client client = clientWithSpiffeSettings();
         TrustDomain td = TrustDomain.builder()
                 .name(TRUST_DOMAIN_NAME)
                 .build();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         // aud mismatch — SVID validator returns non-null reason → InvalidClientException
         SignedJWT jwt = svidBuilder()
                 .audience("https://other.example/token")
@@ -313,12 +306,11 @@ class SpiffeClientAssertionValidatorTest {
     void rejects_whenKidMissing() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Client client = clientWithSpiffeSettings();
         TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         SignedJWT noKid = new SignedJWT(
                 new JWSHeader.Builder(JWSAlgorithm.RS256).build(),
                 validClaims().build());
@@ -333,12 +325,11 @@ class SpiffeClientAssertionValidatorTest {
     void rejects_whenBundleHasNoMatchingKey() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Client client = clientWithSpiffeSettings();
         TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         when(trustDomainKeyService.getKey(eq(td), eq(KID))).thenReturn(Maybe.empty());
 
         validator.validate(svid().serialize(), BASE_PATH, null).test()
@@ -350,14 +341,13 @@ class SpiffeClientAssertionValidatorTest {
     void rejects_whenSignatureInvalid() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Client client = clientWithSpiffeSettings();
         TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         when(trustDomainKeyService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
         when(jwsService.isValidSignature(any(), any())).thenReturn(false);
 
@@ -369,7 +359,6 @@ class SpiffeClientAssertionValidatorTest {
     void resolvesClient_viaClientIdHint_whenProvided() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         // sub is the SPIFFE URI but the form-level client_id should win as lookup id.
         Client client = clientWithSpiffeSettings();
         client.setClientId("hint-client-id");
@@ -378,8 +367,8 @@ class SpiffeClientAssertionValidatorTest {
         jwk.setKid(KID);
 
         when(clientLookupService.findByClientId("hint-client-id")).thenReturn(Maybe.just(client));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         when(trustDomainKeyService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
         when(jwsService.isValidSignature(any(), any())).thenReturn(true);
 
@@ -393,14 +382,13 @@ class SpiffeClientAssertionValidatorTest {
     void succeeds_onWellFormedSvid() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Client client = clientWithSpiffeSettings();
         TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         when(trustDomainKeyService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
         when(jwsService.isValidSignature(any(), any())).thenReturn(true);
 
@@ -413,7 +401,6 @@ class SpiffeClientAssertionValidatorTest {
     void synthesises_perInstanceAgentClient_forHostedDelegated_withPrefixSubject() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
 
         String parent = "spiffe://example.org/hotel-agent/";
         String instanceSpiffeId = parent + "instance-a";
@@ -434,8 +421,8 @@ class SpiffeClientAssertionValidatorTest {
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(blueprintClientId)).thenReturn(Maybe.just(blueprint));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         when(trustDomainKeyService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
         when(jwsService.isValidSignature(any(), any())).thenReturn(true);
 
@@ -451,7 +438,6 @@ class SpiffeClientAssertionValidatorTest {
     void synthesises_perInstanceAgentClient_forAutonomous_withPrefixSubject() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
 
         String parent = "spiffe://example.org/hotel-agent/";
         String instanceSpiffeId = parent + "instance-b";
@@ -472,8 +458,8 @@ class SpiffeClientAssertionValidatorTest {
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(blueprintClientId)).thenReturn(Maybe.just(blueprint));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         when(trustDomainKeyService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
         when(jwsService.isValidSignature(any(), any())).thenReturn(true);
 
@@ -486,14 +472,13 @@ class SpiffeClientAssertionValidatorTest {
     void doesNotSynthesise_forNonAgentClient_evenWithMatchingSvid() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Client client = clientWithSpiffeSettings(); // SERVICE-style, no appType=AGENT
         TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
         when(trustDomainKeyService.getKey(eq(td), eq(KID))).thenReturn(Maybe.just(jwk));
         when(jwsService.isValidSignature(any(), any())).thenReturn(true);
 
@@ -506,13 +491,12 @@ class SpiffeClientAssertionValidatorTest {
     void acceptsSvid_signedByPemKeyMaterial() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Domain realDomain = new Domain();
         realDomain.setId(DOMAIN_ID);
         realDomain.setOidc(oidcSettings);
         SpiffeClientAssertionValidator pemValidator = new SpiffeClientAssertionValidator(
                 clientLookupService, new JWSServiceImpl(), openIDDiscoveryService, domain,
-                new TrustDomainKeyServiceImpl(mock(JWKSetFetcher.class), realDomain), trustDomainRepository);
+                new TrustDomainKeyServiceImpl(mock(JWKSetFetcher.class), realDomain), trustDomainManager);
 
         TrustDomain td = TrustDomain.builder()
                 .id("td-pem")
@@ -523,8 +507,8 @@ class SpiffeClientAssertionValidatorTest {
                         .build())
                 .build();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(clientWithSpiffeSettings()));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
 
         String assertion = svidSignedBy(pemPrivateKey()).serialize();
 
@@ -537,13 +521,12 @@ class SpiffeClientAssertionValidatorTest {
     void rejectsSvid_notSignedByPemKeyMaterial() throws Exception {
         stubDiscovery();
         stubDomainOidc();
-        stubDomainId();
         Domain realDomain = new Domain();
         realDomain.setId(DOMAIN_ID);
         realDomain.setOidc(oidcSettings);
         SpiffeClientAssertionValidator pemValidator = new SpiffeClientAssertionValidator(
                 clientLookupService, new JWSServiceImpl(), openIDDiscoveryService, domain,
-                new TrustDomainKeyServiceImpl(mock(JWKSetFetcher.class), realDomain), trustDomainRepository);
+                new TrustDomainKeyServiceImpl(mock(JWKSetFetcher.class), realDomain), trustDomainManager);
 
         TrustDomain td = TrustDomain.builder()
                 .id("td-pem")
@@ -554,8 +537,8 @@ class SpiffeClientAssertionValidatorTest {
                         .build())
                 .build();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(clientWithSpiffeSettings()));
-        when(trustDomainRepository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, TRUST_DOMAIN_NAME))
-                .thenReturn(Maybe.just(td));
+        when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
+                .thenReturn(Optional.of(td));
 
         // signed by the per-test generated key, which the certificate does not carry
         String assertion = svidSignedBy(privateKey).serialize();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManagerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManagerImplTest.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.oidc.service.trustdomain;
+
+import io.gravitee.am.common.event.EventManager;
+import io.gravitee.am.common.event.TrustDomainEvent;
+import io.gravitee.am.common.event.Type;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.impl.TrustDomainManagerImpl;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.common.event.Payload;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.common.event.Event;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrustDomainManagerImplTest {
+
+    private static final String DOMAIN_ID = "domain-1";
+    private static final String PRELOAD_PLUGIN_ID = Type.TRUST_DOMAIN.name();
+
+    @InjectMocks
+    private final TrustDomainManagerImpl manager = new TrustDomainManagerImpl();
+
+    @Mock
+    private Domain domain;
+    @Mock
+    private TrustDomainRepository trustDomainRepository;
+    @Mock
+    private TrustDomainKeyService trustDomainKeyService;
+    @Mock
+    private DomainReadinessService domainReadinessService;
+    @Mock
+    private EventManager eventManager;
+    @Mock
+    private Payload payload;
+    @Mock
+    private Event<TrustDomainEvent, Payload> event;
+
+    @BeforeEach
+    void setUp() {
+        when(domain.getId()).thenReturn(DOMAIN_ID);
+        when(domain.getName()).thenReturn("domain-name");
+    }
+
+    private void stubEvent(TrustDomainEvent type, String trustDomainId) {
+        stubEvent(type, trustDomainId, ReferenceType.DOMAIN, DOMAIN_ID);
+    }
+
+    private void stubEvent(TrustDomainEvent type, String trustDomainId, ReferenceType referenceType, String referenceId) {
+        when(event.content()).thenReturn(payload);
+        when(event.type()).thenReturn(type);
+        when(payload.getId()).thenReturn(trustDomainId);
+        when(payload.getReferenceType()).thenReturn(referenceType);
+        when(payload.getReferenceId()).thenReturn(referenceId);
+    }
+
+    private static TrustDomain spiffe(String id, String name) {
+        return TrustDomain.builder().id(id).name(name).spiffeTrustDomain(name).build();
+    }
+
+    private static TrustDomain tokenExchange(String id, String name, String issuer) {
+        return TrustDomain.builder()
+                .id(id)
+                .name(name)
+                .issuer(issuer)
+                .build();
+    }
+
+    private void preload(TrustDomain... trustDomains) {
+        when(trustDomainRepository.findByReference(ReferenceType.DOMAIN, DOMAIN_ID)).thenReturn(Flowable.fromArray(trustDomains));
+        manager.afterPropertiesSet();
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(domainReadinessService).pluginLoaded(DOMAIN_ID, PRELOAD_PLUGIN_ID));
+    }
+
+    @Test
+    void shouldIndexEachMatcherUnderItsOwnLookup() {
+        preload(spiffe("td-1", "am.local"), tokenExchange("td-2", "issuer-name", "https://issuer.example.com"));
+
+        assertThat(manager.findBySpiffeTrustDomain("am.local").orElseThrow().getId()).isEqualTo("td-1");
+        assertThat(manager.findByIssuer("https://issuer.example.com").orElseThrow().getId()).isEqualTo("td-2");
+    }
+
+    @Test
+    void shouldNotResolveTokenExchangeTrustedDomainByName() {
+        preload(tokenExchange("td-2", "am.local", "https://issuer.example.com"));
+
+        assertThat(manager.findBySpiffeTrustDomain("am.local")).isEmpty();
+    }
+
+    @Test
+    void shouldIndexATrustedDomainThatServesBothUsagesUnderBothMatchers() {
+        TrustDomain both = TrustDomain.builder()
+                .id("td-3")
+                .name("acme-corp")
+                .spiffeTrustDomain("acme.org")
+                .issuer("https://sso.acme.com")
+                .build();
+        preload(both);
+
+        assertThat(manager.findBySpiffeTrustDomain("acme.org").orElseThrow().getId()).isEqualTo("td-3");
+        assertThat(manager.findByIssuer("https://sso.acme.com").orElseThrow().getId()).isEqualTo("td-3");
+    }
+
+    @Test
+    void shouldNotResolveSpiffeTrustedDomainByIssuer() {
+        preload(spiffe("td-1", "https://issuer.example.com"));
+
+        assertThat(manager.findByIssuer("https://issuer.example.com")).isEmpty();
+    }
+
+    @Test
+    void shouldReportInitialisationFailureWhenLoadFails() {
+        when(trustDomainRepository.findByReference(ReferenceType.DOMAIN, DOMAIN_ID))
+                .thenReturn(Flowable.error(new IllegalStateException("database down")));
+
+        manager.afterPropertiesSet();
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(domainReadinessService).pluginInitFailed(DOMAIN_ID, PRELOAD_PLUGIN_ID, "database down"));
+        verify(domainReadinessService, never()).pluginLoaded(DOMAIN_ID, PRELOAD_PLUGIN_ID);
+    }
+
+    @Test
+    void shouldIgnoreEventForAnotherSecurityDomain() {
+        preload(spiffe("td-1", "am.local"));
+        stubEvent(TrustDomainEvent.UNDEPLOY, "td-1", ReferenceType.DOMAIN, "another-domain");
+
+        manager.onEvent(event);
+
+        assertThat(manager.findBySpiffeTrustDomain("am.local")).isPresent();
+        verifyNoInteractions(trustDomainKeyService);
+    }
+
+    @Test
+    void shouldIgnoreEventForAnotherReferenceType() {
+        preload(spiffe("td-1", "am.local"));
+        when(event.content()).thenReturn(payload);
+        when(event.type()).thenReturn(TrustDomainEvent.UNDEPLOY);
+        when(payload.getId()).thenReturn("td-1");
+        when(payload.getReferenceType()).thenReturn(ReferenceType.ORGANIZATION);
+
+        manager.onEvent(event);
+
+        assertThat(manager.findBySpiffeTrustDomain("am.local")).isPresent();
+        verifyNoInteractions(trustDomainKeyService);
+    }
+
+    @Test
+    void shouldDropTrustedDomainWhenEventReferencesRemovedEntity() {
+        preload(spiffe("td-1", "am.local"));
+        stubEvent(TrustDomainEvent.UPDATE, "td-1");
+        when(trustDomainRepository.findById("td-1")).thenReturn(Maybe.empty());
+
+        manager.onEvent(event);
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(manager.findBySpiffeTrustDomain("am.local")).isEmpty());
+        verify(domainReadinessService).pluginRemoved(DOMAIN_ID, "td-1");
+    }
+
+    @Test
+    void shouldReportFailureWhenEventLoadFails() {
+        preload(spiffe("td-1", "am.local"));
+        stubEvent(TrustDomainEvent.UPDATE, "td-1");
+        when(trustDomainRepository.findById("td-1")).thenReturn(Maybe.error(new IllegalStateException("boom")));
+
+        manager.onEvent(event);
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(domainReadinessService).pluginFailed(DOMAIN_ID, "td-1", "boom"));
+    }
+
+    @Test
+    void shouldReindexAndEvictKeyMaterialWhenTrustedDomainIsRenamed() {
+        preload(spiffe("td-1", "am.local"));
+        stubEvent(TrustDomainEvent.UPDATE, "td-1");
+        when(trustDomainRepository.findById("td-1")).thenReturn(Maybe.just(spiffe("td-1", "am.renamed")));
+
+        manager.onEvent(event);
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(manager.findBySpiffeTrustDomain("am.renamed")).isPresent());
+        assertThat(manager.findBySpiffeTrustDomain("am.local")).isEmpty();
+        verify(trustDomainKeyService).evict("td-1");
+    }
+
+    @Test
+    void shouldRemoveTrustedDomainAndEvictKeyMaterialOnUndeploy() {
+        preload(spiffe("td-1", "am.local"), tokenExchange("td-2", "issuer-name", "https://issuer.example.com"));
+        stubEvent(TrustDomainEvent.UNDEPLOY, "td-2");
+
+        manager.onEvent(event);
+
+        assertThat(manager.findByIssuer("https://issuer.example.com")).isEmpty();
+        assertThat(manager.findBySpiffeTrustDomain("am.local")).isPresent();
+        verify(trustDomainKeyService).evict("td-2");
+        verify(domainReadinessService).pluginRemoved(DOMAIN_ID, "td-2");
+    }
+
+    @Test
+    void shouldTolerateUndeployOfUnknownTrustedDomain() {
+        preload(spiffe("td-1", "am.local"));
+        stubEvent(TrustDomainEvent.UNDEPLOY, "unknown");
+
+        manager.onEvent(event);
+
+        assertThat(manager.findBySpiffeTrustDomain("am.local")).isPresent();
+        verify(domainReadinessService).pluginRemoved(DOMAIN_ID, "unknown");
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainsResource.java
@@ -94,7 +94,7 @@ public class TrustDomainsResource extends AbstractResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             operationId = "createTrustDomain",
-            summary = "Register a SPIFFE trust domain on the security domain",
+            summary = "Register a trust domain on the security domain",
             description = "User must have the DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified domain " +
                     "or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified environment " +
                     "or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified organization")

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainResourceTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.resources.organizations.environments.domains;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
+import io.gravitee.am.management.service.permissions.PermissionAcls;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.UserBindingCriterion;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
+import io.gravitee.am.service.exception.TrustDomainIssuerAlreadyExistsException;
+import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class TrustDomainResourceTest extends JerseySpringTest {
+
+    private static final String DOMAIN_ID = "domain-id";
+    private static final String TRUST_DOMAIN_ID = "td-1";
+
+    @BeforeEach
+    public void resetTrustDomainService() {
+        reset(trustDomainService);
+    }
+
+    private Domain stubDomain() {
+        Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        doReturn(Maybe.just(domain)).when(domainService).findById(DOMAIN_ID);
+        return domain;
+    }
+
+    private static TrustDomain tokenExchangeTrustDomain() {
+        UserBindingCriterion criterion = new UserBindingCriterion();
+        criterion.setAttribute("emails.value");
+        criterion.setExpression("{#token['email']}");
+        return TrustDomain.builder()
+                .id(TRUST_DOMAIN_ID)
+                .referenceType(ReferenceType.DOMAIN)
+                .referenceId(DOMAIN_ID)
+                .name("issuer.example.org")
+                .keyMaterial(TrustDomainKeyMaterial.builder()
+                        .source(KeyMaterialSource.JWKS_URL)
+                        .jwksUrl("https://issuer.example.org/keys")
+                        .build())
+                .refreshIntervalSeconds(300)
+                .issuer("https://issuer.example.org")
+                .scopeMappings(Map.of("read", "domain:read"))
+                .userBindingEnabled(true)
+                .userBindingCriteria(List.of(criterion))
+                .build();
+    }
+
+    private jakarta.ws.rs.client.WebTarget trustDomainTarget() {
+        return target("domains").path(DOMAIN_ID).path("trust-domains").path(TRUST_DOMAIN_ID);
+    }
+
+    @Test
+    public void shouldReadTokenExchangeTrustedDomain() {
+        stubDomain();
+        doReturn(Maybe.just(tokenExchangeTrustDomain())).when(trustDomainService).findById(TRUST_DOMAIN_ID);
+
+        final Response response = trustDomainTarget().request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        Map<String, Object> body = response.readEntity(Map.class);
+        assertEquals("https://issuer.example.org", body.get("issuer"));
+        assertEquals(Map.of("read", "domain:read"), body.get("scopeMappings"));
+        assertEquals(Boolean.TRUE, body.get("userBindingEnabled"));
+        List<Map<String, Object>> criteria = (List<Map<String, Object>>) body.get("userBindingCriteria");
+        assertEquals("emails.value", criteria.get(0).get("attribute"));
+        assertEquals("{#token['email']}", criteria.get(0).get("expression"));
+    }
+
+    @Test
+    public void shouldReturnNotFound_whenTrustDomainBelongsToAnotherDomain() {
+        stubDomain();
+        TrustDomain other = tokenExchangeTrustDomain();
+        other.setReferenceId("another-domain");
+        doReturn(Maybe.just(other)).when(trustDomainService).findById(TRUST_DOMAIN_ID);
+
+        final Response response = trustDomainTarget().request().get();
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturnNotFound_whenTrustDomainIsUnknown() {
+        stubDomain();
+        doReturn(Maybe.empty()).when(trustDomainService).findById(TRUST_DOMAIN_ID);
+
+        final Response response = trustDomainTarget().request().get();
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void shouldUpdateTokenExchangeSettings() {
+        Domain domain = stubDomain();
+        doReturn(Single.just(tokenExchangeTrustDomain()))
+                .when(trustDomainService).update(eq(domain), eq(TRUST_DOMAIN_ID), any(UpdateTrustDomain.class), any());
+
+        final Response response = trustDomainTarget().request()
+                .put(Entity.json(Map.of(
+                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/v2/keys"),
+                        "issuer", "https://issuer.example.org/v2",
+                        "scopeMappings", Map.of("write", "domain:write"),
+                        "userBindingEnabled", true,
+                        "userBindingCriteria", List.of(Map.of(
+                                "attribute", "username",
+                                "expression", "{#token['sub']}")))));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        ArgumentCaptor<UpdateTrustDomain> captor = ArgumentCaptor.forClass(UpdateTrustDomain.class);
+        verify(trustDomainService).update(eq(domain), eq(TRUST_DOMAIN_ID), captor.capture(), any());
+        UpdateTrustDomain received = captor.getValue();
+        assertEquals("https://issuer.example.org/v2", received.getIssuer());
+        assertEquals(Map.of("write", "domain:write"), received.getScopeMappings());
+        assertTrue(received.getUserBindingEnabled());
+        assertEquals("username", received.getUserBindingCriteria().get(0).getAttribute());
+    }
+
+    @Test
+    public void shouldRejectUpdateIntroducingDuplicateIssuer() {
+        Domain domain = stubDomain();
+        doReturn(Single.error(new TrustDomainIssuerAlreadyExistsException("https://issuer.example.org")))
+                .when(trustDomainService).update(eq(domain), eq(TRUST_DOMAIN_ID), any(UpdateTrustDomain.class), any());
+
+        final Response response = trustDomainTarget().request()
+                .put(Entity.json(Map.of("issuer", "https://issuer.example.org")));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldDeleteTrustDomain() {
+        Domain domain = stubDomain();
+        doReturn(Completable.complete())
+                .when(trustDomainService).delete(eq(domain), eq(TRUST_DOMAIN_ID), any());
+
+        final Response response = trustDomainTarget().request().delete();
+
+        assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+        verify(trustDomainService).delete(eq(domain), eq(TRUST_DOMAIN_ID), any());
+    }
+
+    @Test
+    public void shouldRejectReadWithoutTrustDomainPermission() {
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = trustDomainTarget().request().get();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).findById(any());
+    }
+
+    @Test
+    public void shouldRejectUpdateWithoutTrustDomainPermission() {
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = trustDomainTarget().request()
+                .put(Entity.json(Map.of("issuer", "https://issuer.example.org")));
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).update(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldRejectDeleteWithoutTrustDomainPermission() {
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = trustDomainTarget().request().delete();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).delete(any(), any(), any());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainsResourceTest.java
@@ -18,6 +18,8 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.jose.RSAKey;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
@@ -26,6 +28,8 @@ import io.gravitee.am.model.oidc.TrustDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.service.exception.InvalidTrustDomainException;
 import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.management.service.permissions.PermissionAcls;
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.common.http.HttpStatusCode;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -42,6 +46,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -70,7 +75,7 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
         return domain;
     }
 
-    private static TrustDomain trustDomain(TrustDomainKeyMaterial keyMaterial) {
+    private static TrustDomain spiffeTrustDomain(TrustDomainKeyMaterial keyMaterial) {
         return TrustDomain.builder()
                 .id("td-1")
                 .referenceType(ReferenceType.DOMAIN)
@@ -83,9 +88,9 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
     }
 
     @Test
-    public void shouldExposeTheSpiffeMatcherAndKeyMaterial() {
+    public void shouldExposeMatchersAndKeyMaterial() {
         stubDomain();
-        doReturn(Flowable.just(trustDomain(TrustDomainKeyMaterial.builder()
+        doReturn(Flowable.just(spiffeTrustDomain(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://spire.example.org/keys")
                 .build())))
@@ -105,7 +110,7 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
     @Test
     public void shouldStillExposeDeprecatedBundleSource() {
         stubDomain();
-        doReturn(Flowable.just(trustDomain(TrustDomainKeyMaterial.builder()
+        doReturn(Flowable.just(spiffeTrustDomain(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://spire.example.org/keys")
                 .build())))
@@ -126,7 +131,7 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
                 .source(KeyMaterialSource.PEM)
                 .certificate(PEM_CERTIFICATE)
                 .build();
-        doReturn(Single.just(trustDomain(pem)))
+        doReturn(Single.just(spiffeTrustDomain(pem)))
                 .when(trustDomainService).create(eq(domain), any(NewTrustDomain.class), any());
 
         final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
@@ -150,7 +155,7 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
         key.setN("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86z");
         JWKSet jwkSet = new JWKSet();
         jwkSet.setKeys(List.of(key));
-        doReturn(Single.just(trustDomain(TrustDomainKeyMaterial.builder()
+        doReturn(Single.just(spiffeTrustDomain(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWK_SET)
                 .jwkSet(jwkSet)
                 .build())))
@@ -176,25 +181,20 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
     }
 
     @Test
-    public void shouldCreateWithAnExplicitSpiffeMatcher() {
+    public void shouldCreateWithAnIssuerMatcher() {
         Domain domain = stubDomain();
-        doReturn(Single.just(trustDomain(TrustDomainKeyMaterial.builder()
-                .source(KeyMaterialSource.JWKS_URL)
-                .jwksUrl("https://issuer.example.org/keys")
-                .build())))
+        doReturn(Single.just(tokenExchangeTrustDomain()))
                 .when(trustDomainService).create(eq(domain), any(NewTrustDomain.class), any());
 
         final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
                 .post(Entity.json(Map.of(
-                        "name", "acme-corp",
-                        "spiffeTrustDomain", "example.org",
+                        "name", "example.org",
+                        "issuer", "https://issuer.example.org",
                         "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"))));
 
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
-        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
-        verify(trustDomainService).create(eq(domain), captor.capture(), any());
-        assertEquals("example.org", captor.getValue().getSpiffeTrustDomain());
         Map<String, Object> body = response.readEntity(Map.class);
+        assertEquals("https://issuer.example.org", body.get("issuer"));
         assertEquals("jwks_url", body.get("bundleSource"));
     }
 
@@ -253,7 +253,7 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
     @Test
     public void shouldStillAcceptDeprecatedBundleSourceInput() {
         Domain domain = stubDomain();
-        doReturn(Single.just(trustDomain(TrustDomainKeyMaterial.builder()
+        doReturn(Single.just(spiffeTrustDomain(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://spire.example.org/keys")
                 .build())))
@@ -271,5 +271,89 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
         assertNull(captor.getValue().getKeyMaterial());
         assertEquals(SpiffeBundleSource.JWKS_URL, captor.getValue().getBundleSource());
         assertEquals("https://spire.example.org/keys", captor.getValue().getJwksUrl());
+    }
+
+    private static TrustDomain tokenExchangeTrustDomain() {
+        UserBindingCriterion criterion = new UserBindingCriterion();
+        criterion.setAttribute("emails.value");
+        criterion.setExpression("{#token['email']}");
+        TrustDomain td = spiffeTrustDomain(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.JWKS_URL)
+                .jwksUrl("https://issuer.example.org/keys")
+                .build());
+        td.setSpiffeTrustDomain(null);
+        td.setIssuer("https://issuer.example.org");
+        td.setScopeMappings(Map.of("read", "domain:read"));
+        td.setUserBindingEnabled(true);
+        td.setUserBindingCriteria(List.of(criterion));
+        return td;
+    }
+
+    @Test
+    public void shouldCreateTokenExchangeTrustedDomainWithScopeMappingsAndUserBinding() {
+        Domain domain = stubDomain();
+        doReturn(Single.just(tokenExchangeTrustDomain()))
+                .when(trustDomainService).create(eq(domain), any(NewTrustDomain.class), any());
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
+                .post(Entity.json(Map.of(
+                        "name", "issuer.example.org",
+                        "issuer", "https://issuer.example.org",
+                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"),
+                        "scopeMappings", Map.of("read", "domain:read"),
+                        "userBindingEnabled", true,
+                        "userBindingCriteria", List.of(Map.of(
+                                "attribute", "emails.value",
+                                "expression", "{#token['email']}")))));
+
+        assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
+        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
+        verify(trustDomainService).create(eq(domain), captor.capture(), any());
+        NewTrustDomain received = captor.getValue();
+        assertEquals("https://issuer.example.org", received.getIssuer());
+        assertEquals(Map.of("read", "domain:read"), received.getScopeMappings());
+        assertTrue(received.isUserBindingEnabled());
+        assertEquals(1, received.getUserBindingCriteria().size());
+        assertEquals("emails.value", received.getUserBindingCriteria().get(0).getAttribute());
+        assertEquals("{#token['email']}", received.getUserBindingCriteria().get(0).getExpression());
+    }
+
+    @Test
+    public void shouldExposeTokenExchangeSettingsInList() {
+        stubDomain();
+        doReturn(Flowable.just(tokenExchangeTrustDomain()))
+                .when(trustDomainService).findByReference(ReferenceType.DOMAIN, DOMAIN_ID);
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        List<Map<String, Object>> body = response.readEntity(List.class);
+        assertEquals("https://issuer.example.org", body.get(0).get("issuer"));
+        assertEquals(Map.of("read", "domain:read"), body.get(0).get("scopeMappings"));
+        assertEquals(Boolean.TRUE, body.get(0).get("userBindingEnabled"));
+    }
+
+    @Test
+    public void shouldRejectListWithoutTrustDomainPermission() {
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request().get();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).findByReference(any(), any());
+    }
+
+    @Test
+    public void shouldRejectCreateWithoutTrustDomainPermission() {
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
+                .post(Entity.json(Map.of(
+                        "name", "issuer.example.org",
+                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"),
+                        "issuer", "https://issuer.example.org")));
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).create(any(), any(), any());
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgrader.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.upgrades;
+
+import io.gravitee.am.common.scope.ManagementRepositoryScope;
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.KeyResolutionMethod;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.SystemTask;
+import io.gravitee.am.model.SystemTaskStatus;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
+import io.gravitee.am.repository.management.api.SystemTaskRepository;
+import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static io.gravitee.am.management.service.impl.upgrades.UpgraderOrder.DOMAIN_TRUSTED_ISSUER_UPGRADER;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Gives every trusted issuer declared inside a security domain's token-exchange settings a trusted
+ * domain of its own. The inline declarations are left in place and stay authoritative; this upgrader
+ * only makes the entities exist, so the migration can be proven before anything reads them.
+ *
+ * <p>Entities are written straight to the repository rather than through
+ * {@code TrustDomainService}: that service applies the SSRF guard the inline shape never had, so an
+ * issuer whose JWKS URL resolves to a private address — legal when it was configured — would fail
+ * the upgrade rather than migrate. It does bypass the length bound that service enforces, so an
+ * inline issuer too long to store is left inline and warned about rather than failing the upgrade
+ * of every other security domain.
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+@ManagementRepositoryScope
+@CustomLog
+public class DomainTrustedIssuerUpgrader extends SystemTaskUpgrader {
+
+    private static final String TASK_ID = "trusted_issuer_trust_domain_migration";
+    private static final String UPGRADE_NOT_SUCCESSFUL_ERROR_MESSAGE =
+            "Trusted issuers can't be migrated to trusted domains, other instance may process them or an upgrader has failed previously";
+
+    private static final int MAX_NAME_LENGTH = 255;
+    private static final int DIGEST_LENGTH = 8;
+    private static final Pattern OUTSIDE_LABEL = Pattern.compile("[^a-z0-9.-]+");
+    private static final Pattern LABEL_EDGES = Pattern.compile("(?:^[.-]+)|(?:[.-]+$)");
+
+    private final DomainService domainService;
+    private final TrustDomainRepository trustDomainRepository;
+
+    public DomainTrustedIssuerUpgrader(@Lazy SystemTaskRepository systemTaskRepository,
+                                       DomainService domainService,
+                                       @Lazy TrustDomainRepository trustDomainRepository) {
+        super(systemTaskRepository);
+        this.domainService = domainService;
+        this.trustDomainRepository = trustDomainRepository;
+    }
+
+    @Override
+    protected Single<Boolean> processUpgrade(String instanceOperationId, SystemTask task, String previousOperationId) {
+        return updateSystemTask(task, SystemTaskStatus.ONGOING, previousOperationId)
+                .flatMap(ongoing -> {
+                    if (!ongoing.getOperationId().equals(instanceOperationId)) {
+                        return Single.error(new IllegalStateException("Task " + getTaskId() + " already processed by another instance : trigger a retry"));
+                    }
+                    return migrateDomains(ongoing)
+                            .andThen(Single.just(true))
+                            .onErrorResumeNext(err -> {
+                                log.error("Unable to migrate trusted issuers (task: {}): {}", TASK_ID, err.getMessage());
+                                return Single.just(false);
+                            });
+                });
+    }
+
+    private Completable migrateDomains(SystemTask task) {
+        return domainService.listAll()
+                .concatMapCompletable(this::migrateDomain)
+                .doOnError(err -> updateSystemTask(task, SystemTaskStatus.FAILURE, task.getOperationId()).subscribe())
+                .andThen(updateSystemTask(task, SystemTaskStatus.SUCCESS, task.getOperationId()).ignoreElement());
+    }
+
+    private Completable migrateDomain(Domain domain) {
+        List<TrustedIssuer> issuers = declaredIssuers(domain);
+        if (issuers.isEmpty()) {
+            return Completable.complete();
+        }
+        return trustDomainRepository.findByReference(ReferenceType.DOMAIN, domain.getId())
+                .toList()
+                .flatMapCompletable(existing -> migrateIssuers(domain, issuers, existing));
+    }
+
+    private Completable migrateIssuers(Domain domain, List<TrustedIssuer> issuers, List<TrustDomain> existing) {
+        Set<String> alreadyVouchedFor = existing.stream()
+                .map(TrustDomain::getIssuer)
+                .filter(Objects::nonNull)
+                .collect(toSet());
+        // names are unique across every trusted domain, so a derived name may not collide with a
+        // trusted domain that only serves SPIFFE either
+        Set<String> takenNames = existing.stream().map(TrustDomain::getName).collect(toSet());
+        Map<String, String> derivedNames = deriveNames(issuers, takenNames);
+
+        return Flowable.fromIterable(issuers)
+                .filter(issuer -> !alreadyVouchedFor.contains(issuer.getIssuer()))
+                .concatMapCompletable(issuer ->
+                        migrateIssuer(domain, issuer, derivedNames.get(issuer.getIssuer()), takenNames));
+    }
+
+    private Completable migrateIssuer(Domain domain, TrustedIssuer issuer, String name, Set<String> takenNames) {
+        if (issuer.getIssuer().length() > TrustDomain.ISSUER_MAX_LENGTH) {
+            log.warn("Trusted issuer {} of domain {} is left inline: a trusted domain bounds its issuer at {} characters",
+                    issuer.getIssuer(), domain.getId(), TrustDomain.ISSUER_MAX_LENGTH);
+            return Completable.complete();
+        }
+        if (takenNames.contains(name)) {
+            log.warn("Trusted issuer {} of domain {} is left inline: a trusted domain already holds its derived name {}",
+                    issuer.getIssuer(), domain.getId(), name);
+            return Completable.complete();
+        }
+        log.debug("Migrating trusted issuer {} of domain {} to trusted domain {}", issuer.getIssuer(), domain.getId(), name);
+        return trustDomainRepository.create(asTrustDomain(domain, issuer, name)).ignoreElement();
+    }
+
+    private static TrustDomain asTrustDomain(Domain domain, TrustedIssuer issuer, String name) {
+        Date now = Date.from(Instant.now());
+        return TrustDomain.builder()
+                .referenceType(ReferenceType.DOMAIN)
+                .referenceId(domain.getId())
+                .name(name)
+                .issuer(issuer.getIssuer())
+                .keyMaterial(keyMaterialOf(issuer))
+                .refreshIntervalSeconds(TrustDomain.DEFAULT_REFRESH_INTERVAL_SECONDS)
+                .scopeMappings(issuer.getScopeMappings())
+                .userBindingEnabled(issuer.isUserBindingEnabled())
+                .userBindingCriteria(issuer.getUserBindingCriteria())
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+
+    private static TrustDomainKeyMaterial keyMaterialOf(TrustedIssuer issuer) {
+        KeyResolutionMethod method = issuer.getKeyResolutionMethod();
+        if (method == null) {
+            return null;
+        }
+        return switch (method) {
+            case JWKS_URL -> TrustDomainKeyMaterial.builder()
+                    .source(KeyMaterialSource.JWKS_URL)
+                    .jwksUrl(issuer.getJwksUri())
+                    .build();
+            case PEM -> TrustDomainKeyMaterial.builder()
+                    .source(KeyMaterialSource.PEM)
+                    .certificate(issuer.getCertificate())
+                    .build();
+        };
+    }
+
+    private static List<TrustedIssuer> declaredIssuers(Domain domain) {
+        TokenExchangeSettings settings = domain.getTokenExchangeSettings();
+        if (settings == null || settings.getTrustedIssuers() == null) {
+            return List.of();
+        }
+        Map<String, TrustedIssuer> byIssuer = new LinkedHashMap<>();
+        settings.getTrustedIssuers().stream()
+                .filter(issuer -> issuer != null && StringUtils.hasText(issuer.getIssuer()))
+                .forEach(issuer -> byIssuer.putIfAbsent(issuer.getIssuer(), issuer));
+        return List.copyOf(byIssuer.values());
+    }
+
+    private static Map<String, String> deriveNames(List<TrustedIssuer> issuers, Set<String> takenNames) {
+        Map<String, Long> occurrences = issuers.stream()
+                .collect(groupingBy(issuer -> slugOf(issuer.getIssuer()), counting()));
+        Map<String, String> names = new LinkedHashMap<>();
+        issuers.forEach(issuer -> {
+            String slug = slugOf(issuer.getIssuer());
+            boolean ambiguous = slug.isEmpty() || occurrences.get(slug) > 1 || takenNames.contains(slug);
+            names.put(issuer.getIssuer(), ambiguous ? disambiguate(issuer.getIssuer(), slug) : slug);
+        });
+        return names;
+    }
+
+    private static String slugOf(String issuer) {
+        return slugOf(issuer, MAX_NAME_LENGTH);
+    }
+
+    private static String slugOf(String issuer, int maxLength) {
+        String slug = trimEdges(OUTSIDE_LABEL.matcher(issuer.toLowerCase(Locale.ROOT)).replaceAll("-"));
+        return slug.length() > maxLength ? trimEdges(slug.substring(0, maxLength)) : slug;
+    }
+
+    private static String trimEdges(String slug) {
+        return LABEL_EDGES.matcher(slug).replaceAll("");
+    }
+
+    private static String disambiguate(String issuer, String slug) {
+        String digest = digestOf(issuer);
+        if (slug.isEmpty()) {
+            return digest;
+        }
+        return slugOf(issuer, MAX_NAME_LENGTH - digest.length() - 1) + "-" + digest;
+    }
+
+    private static String digestOf(String issuer) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(issuer.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest).substring(0, DIGEST_LENGTH);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required to name a migrated trusted domain", e);
+        }
+    }
+
+    @Override
+    protected IllegalStateException getIllegalStateException() {
+        return new IllegalStateException(UPGRADE_NOT_SUCCESSFUL_ERROR_MESSAGE);
+    }
+
+    @Override
+    protected String getTaskId() {
+        return TASK_ID;
+    }
+
+    @Override
+    public int getOrder() {
+        return DOMAIN_TRUSTED_ISSUER_UPGRADER;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/UpgraderOrder.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/UpgraderOrder.java
@@ -42,6 +42,7 @@ public final class UpgraderOrder {
     public static final int EMAIL_CONFIGURATION_UPGRADER = 21;
     public static final int ORGANIZATION_STANDARD_ROLE_UPGRADER = 22;
     public static final int DOMAIN_KEY_RETRIEVAL_SETTINGS_UPGRADER = 23;
+    public static final int DOMAIN_TRUSTED_ISSUER_UPGRADER = 24;
 
     private UpgraderOrder() {
         throw new UnsupportedOperationException("utility class, don't instantiate");

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgraderTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgraderTest.java
@@ -1,0 +1,414 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.impl.upgrades;
+
+import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.KeyResolutionMethod;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.SystemTask;
+import io.gravitee.am.model.SystemTaskStatus;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.UserBindingCriterion;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
+import io.gravitee.am.repository.management.api.SystemTaskRepository;
+import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DomainTrustedIssuerUpgraderTest {
+
+    private static final String DOMAIN_ID = "domain-id";
+
+    @Mock
+    private SystemTaskRepository systemTaskRepository;
+
+    @Mock
+    private DomainService domainService;
+
+    @Mock
+    private TrustDomainRepository trustDomainRepository;
+
+    @InjectMocks
+    private DomainTrustedIssuerUpgrader upgrader;
+
+    @Test
+    void shouldMigrateTrustedIssuerToTokenExchangeTrustedDomain() {
+        TrustedIssuer issuer = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
+
+        TrustDomain migrated = migrateOne(domainWith(issuer));
+
+        assertEquals(ReferenceType.DOMAIN, migrated.getReferenceType());
+        assertEquals(DOMAIN_ID, migrated.getReferenceId());
+        assertEquals("https://issuer.example.com", migrated.getIssuer());
+        assertEquals(KeyMaterialSource.JWKS_URL, migrated.getKeyMaterial().getSource());
+        assertEquals("https://issuer.example.com/jwks", migrated.getKeyMaterial().getJwksUrl());
+        assertEquals(TrustDomain.DEFAULT_REFRESH_INTERVAL_SECONDS, migrated.getRefreshIntervalSeconds());
+        assertNull(migrated.getAllowedAlgorithms());
+    }
+
+    @Test
+    void shouldCarryScopeMappingsAndUserBindingConfiguration() {
+        TrustedIssuer issuer = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
+        issuer.setScopeMappings(Map.of("ext:read", "read"));
+        issuer.setUserBindingEnabled(true);
+        issuer.setUserBindingCriteria(List.of(criterion("email", "{#token.email}")));
+
+        TrustDomain migrated = migrateOne(domainWith(issuer));
+
+        assertEquals(Map.of("ext:read", "read"), migrated.getScopeMappings());
+        assertTrue(migrated.isUserBindingEnabled());
+        assertEquals(1, migrated.getUserBindingCriteria().size());
+        assertEquals("email", migrated.getUserBindingCriteria().get(0).getAttribute());
+        assertEquals("{#token.email}", migrated.getUserBindingCriteria().get(0).getExpression());
+    }
+
+    @Test
+    void shouldCarryPemCertificate() {
+        TrustedIssuer issuer = new TrustedIssuer();
+        issuer.setIssuer("https://issuer.example.com");
+        issuer.setKeyResolutionMethod(KeyResolutionMethod.PEM);
+        issuer.setCertificate("-----BEGIN CERTIFICATE-----\nMII\n-----END CERTIFICATE-----");
+
+        TrustDomainKeyMaterial keyMaterial = migrateOne(domainWith(issuer)).getKeyMaterial();
+
+        assertEquals(KeyMaterialSource.PEM, keyMaterial.getSource());
+        assertEquals("-----BEGIN CERTIFICATE-----\nMII\n-----END CERTIFICATE-----", keyMaterial.getCertificate());
+        assertNull(keyMaterial.getJwksUrl());
+    }
+
+    @Test
+    void shouldDeriveNameFromSlugifiedIssuerUrl() {
+        TrustedIssuer issuer = jwksIssuer("https://Issuer.Example.com/realms/Trusted_One", "https://issuer.example.com/jwks");
+
+        assertEquals("https-issuer.example.com-realms-trusted-one", migrateOne(domainWith(issuer)).getName());
+    }
+
+    @Test
+    void shouldDeriveDistinctNamesForIssuersSharingHostButDifferentPath() {
+        List<TrustDomain> migrated = migrate(domainWith(
+                jwksIssuer("https://issuer.example.com/realms/one", "https://issuer.example.com/one/jwks"),
+                jwksIssuer("https://issuer.example.com/realms/two", "https://issuer.example.com/two/jwks")));
+
+        assertEquals("https-issuer.example.com-realms-one", migrated.get(0).getName());
+        assertEquals("https-issuer.example.com-realms-two", migrated.get(1).getName());
+    }
+
+    @Test
+    void shouldDeriveSameNamesWhateverTheDeclarationOrder() {
+        TrustedIssuer one = jwksIssuer("https://issuer.example.com/a-b", "https://issuer.example.com/jwks");
+        TrustedIssuer two = jwksIssuer("https://issuer.example.com/a/b", "https://issuer.example.com/jwks");
+        Domain forward = domainWith(one, two);
+        Domain backward = domainWith(two, one);
+        backward.setId("other-domain-id");
+
+        List<TrustDomain> migrated = migrateAll(forward, backward);
+
+        assertEquals(namesOf(migrated, DOMAIN_ID), namesOf(migrated, "other-domain-id"));
+    }
+
+    @Test
+    void shouldDisambiguateIssuersSlugifyingToTheSameName() {
+        List<TrustDomain> migrated = migrate(domainWith(
+                jwksIssuer("https://issuer.example.com/a-b", "https://issuer.example.com/jwks"),
+                jwksIssuer("https://issuer.example.com/a/b", "https://issuer.example.com/jwks")));
+
+        assertEquals("https-issuer.example.com-a-b-22504d54", migrated.get(0).getName());
+        assertEquals("https-issuer.example.com-a-b-9d44d822", migrated.get(1).getName());
+    }
+
+    @Test
+    void shouldTruncateDerivedNameToStorageLimit() {
+        String longPath = "p".repeat(400);
+        TrustedIssuer issuer = jwksIssuer("https://issuer.example.com/" + longPath, "https://issuer.example.com/jwks");
+
+        assertEquals(255, migrateOne(domainWith(issuer)).getName().length());
+    }
+
+    @Test
+    void shouldSkipTrustedIssuerWithoutIssuer() {
+        TrustedIssuer blank = jwksIssuer(" ", "https://issuer.example.com/jwks");
+        TrustedIssuer valid = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
+
+        List<TrustDomain> migrated = migrate(domainWith(blank, valid));
+
+        assertEquals(1, migrated.size());
+        assertEquals("https://issuer.example.com", migrated.get(0).getIssuer());
+    }
+
+    @Test
+    void shouldLeaveIssuerInlineWhenItIsTooLongToStore() {
+        TrustedIssuer tooLong = jwksIssuer("https://issuer.example.com/" + "a".repeat(TrustDomain.ISSUER_MAX_LENGTH), "https://issuer.example.com/jwks");
+        TrustedIssuer valid = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
+
+        List<TrustDomain> migrated = migrate(domainWith(tooLong, valid));
+
+        assertEquals(1, migrated.size());
+        assertEquals("https://issuer.example.com", migrated.get(0).getIssuer());
+    }
+
+    @Test
+    void shouldMigrateIssuerSittingExactlyOnTheStorageLimit() {
+        String issuer = "https://issuer.example.com/" + "a".repeat(TrustDomain.ISSUER_MAX_LENGTH - "https://issuer.example.com/".length());
+
+        assertEquals(issuer, migrateOne(domainWith(jwksIssuer(issuer, "https://issuer.example.com/jwks"))).getIssuer());
+    }
+
+    @Test
+    void shouldLeaveSpiffeTrustDomainsUntouched() {
+        Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
+        TrustDomain spiffe = TrustDomain.builder()
+                .id("spiffe-id")
+                .referenceType(ReferenceType.DOMAIN)
+                .referenceId(DOMAIN_ID)
+                .name("spiffe-label")
+                .spiffeTrustDomain("issuer.example.com")
+                .build();
+
+        List<TrustDomain> migrated = migrate(domain, spiffe);
+
+        assertEquals(1, migrated.size());
+        assertEquals("https://issuer.example.com", migrated.get(0).getIssuer());
+        verify(trustDomainRepository, never()).update(any());
+        verify(trustDomainRepository, never()).delete(any());
+    }
+
+    @Test
+    void shouldNotMigrateIssuerAlreadyCarriedByTrustedDomain() {
+        Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
+
+        initializeSystemTask();
+        when(domainService.listAll()).thenReturn(Flowable.just(domain));
+        when(trustDomainRepository.findByReference(ReferenceType.DOMAIN, DOMAIN_ID))
+                .thenReturn(Flowable.just(alreadyMigrated("https://issuer.example.com")));
+
+        assertTrue(upgrader.upgrade());
+
+        verify(trustDomainRepository, never()).create(any());
+        verify(trustDomainRepository, never()).update(any());
+    }
+
+    @Test
+    void shouldMigrateOnlyIssuersMissingFromStorage() {
+        Domain domain = domainWith(
+                jwksIssuer("https://one.example.com", "https://one.example.com/jwks"),
+                jwksIssuer("https://two.example.com", "https://two.example.com/jwks"));
+
+        List<TrustDomain> migrated = migrate(domain, alreadyMigrated("https://one.example.com"));
+
+        assertEquals(1, migrated.size());
+        assertEquals("https://two.example.com", migrated.get(0).getIssuer());
+    }
+
+    @Test
+    void shouldDisambiguateWhenTheDerivedNameIsAlreadyHeld() {
+        Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
+
+        TrustDomain migrated = migrateOne(domain, squatter("https-issuer.example.com"));
+
+        assertEquals("https-issuer.example.com-605ec2f1", migrated.getName());
+    }
+
+    @Test
+    void shouldLeaveIssuerInlineWhenEveryDerivedNameIsAlreadyHeld() {
+        Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
+
+        initializeSystemTask();
+        when(domainService.listAll()).thenReturn(Flowable.just(domain));
+        when(trustDomainRepository.findByReference(ReferenceType.DOMAIN, DOMAIN_ID)).thenReturn(Flowable.just(
+                squatter("https-issuer.example.com"), squatter("https-issuer.example.com-605ec2f1")));
+
+        assertTrue(upgrader.upgrade());
+
+        verify(trustDomainRepository, never()).create(any());
+    }
+
+    @Test
+    void shouldNotRunTwiceOnceTheMigrationHasSucceeded() {
+        SystemTask done = new SystemTask();
+        done.setStatus(SystemTaskStatus.SUCCESS.name());
+        when(systemTaskRepository.findById(anyString())).thenReturn(Maybe.just(done));
+
+        assertTrue(upgrader.upgrade());
+
+        verify(systemTaskRepository, times(1)).findById(anyString());
+        verify(domainService, never()).listAll();
+    }
+
+    @Test
+    void shouldMigrateIssuerDeclaringNoKeyResolutionMethod() {
+        TrustedIssuer issuer = new TrustedIssuer();
+        issuer.setIssuer("https://issuer.example.com");
+
+        TrustDomain migrated = migrateOne(domainWith(issuer));
+
+        assertEquals("https://issuer.example.com", migrated.getIssuer());
+        assertNull(migrated.getKeyMaterial());
+    }
+
+    @Test
+    void shouldLeaveInlineTrustedIssuersInPlace() {
+        TrustedIssuer issuer = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
+        Domain domain = domainWith(issuer);
+
+        migrate(domain);
+
+        assertSame(issuer, domain.getTokenExchangeSettings().getTrustedIssuers().get(0));
+        verify(domainService, never()).update(any(), any());
+    }
+
+    @Test
+    void shouldHandleDomainWithoutTrustedIssuers() {
+        Domain domain = domainWith();
+        initializeSystemTask();
+        when(domainService.listAll()).thenReturn(Flowable.just(domain));
+
+        assertTrue(upgrader.upgrade());
+
+        verify(trustDomainRepository, never()).create(any());
+    }
+
+    @Test
+    void shouldHandleDomainWithoutTokenExchangeSettings() {
+        Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        initializeSystemTask();
+        when(domainService.listAll()).thenReturn(Flowable.just(domain));
+
+        assertTrue(upgrader.upgrade());
+
+        verify(trustDomainRepository, never()).create(any());
+    }
+
+    private TrustDomain migrateOne(Domain domain, TrustDomain... existing) {
+        List<TrustDomain> migrated = migrate(domain, existing);
+        assertEquals(1, migrated.size());
+        return migrated.get(0);
+    }
+
+    private List<TrustDomain> migrateAll(Domain... domains) {
+        initializeSystemTask();
+        when(domainService.listAll()).thenReturn(Flowable.fromArray(domains));
+        when(trustDomainRepository.findByReference(any(), any())).thenReturn(Flowable.empty());
+        return captureCreated();
+    }
+
+    private List<TrustDomain> migrate(Domain domain, TrustDomain... existing) {
+        initializeSystemTask();
+        when(domainService.listAll()).thenReturn(Flowable.just(domain));
+        when(trustDomainRepository.findByReference(ReferenceType.DOMAIN, DOMAIN_ID))
+                .thenReturn(Flowable.fromArray(existing));
+        return captureCreated();
+    }
+
+    private List<TrustDomain> captureCreated() {
+        ArgumentCaptor<TrustDomain> captor = ArgumentCaptor.forClass(TrustDomain.class);
+        when(trustDomainRepository.create(captor.capture())).thenAnswer(i -> Single.just(i.getArgument(0)));
+
+        assertTrue(upgrader.upgrade());
+
+        return captor.getAllValues();
+    }
+
+    private void initializeSystemTask() {
+        when(systemTaskRepository.findById(anyString())).thenReturn(Maybe.empty());
+        SystemTask task = new SystemTask();
+        task.setStatus(SystemTaskStatus.INITIALIZED.name());
+        when(systemTaskRepository.create(any())).thenReturn(Single.just(task));
+        when(systemTaskRepository.updateIf(any(), anyString())).thenAnswer(args -> {
+            SystemTask updated = args.getArgument(0);
+            updated.setOperationId(args.getArgument(1));
+            return Single.just(updated);
+        });
+    }
+
+    private static List<String> namesOf(List<TrustDomain> migrated, String referenceId) {
+        return migrated.stream()
+                .filter(trustDomain -> referenceId.equals(trustDomain.getReferenceId()))
+                .map(TrustDomain::getName)
+                .sorted()
+                .toList();
+    }
+
+    private static TrustDomain squatter(String name) {
+        return TrustDomain.builder()
+                .id("squatter-" + name)
+                .referenceType(ReferenceType.DOMAIN)
+                .referenceId(DOMAIN_ID)
+                .name(name)
+                .issuer("https://other.example.com")
+                .build();
+    }
+
+    private static TrustDomain alreadyMigrated(String issuer) {
+        return TrustDomain.builder()
+                .id("existing-" + issuer)
+                .referenceType(ReferenceType.DOMAIN)
+                .referenceId(DOMAIN_ID)
+                .name("already-migrated")
+                .issuer(issuer)
+                .build();
+    }
+
+    private static TrustedIssuer jwksIssuer(String issuer, String jwksUri) {
+        TrustedIssuer trustedIssuer = new TrustedIssuer();
+        trustedIssuer.setIssuer(issuer);
+        trustedIssuer.setKeyResolutionMethod(KeyResolutionMethod.JWKS_URL);
+        trustedIssuer.setJwksUri(jwksUri);
+        return trustedIssuer;
+    }
+
+    private static UserBindingCriterion criterion(String attribute, String expression) {
+        UserBindingCriterion criterion = new UserBindingCriterion();
+        criterion.setAttribute(attribute);
+        criterion.setExpression(expression);
+        return criterion;
+    }
+
+    private static Domain domainWith(TrustedIssuer... issuers) {
+        TokenExchangeSettings settings = new TokenExchangeSettings();
+        settings.setTrustedIssuers(List.of(issuers));
+        Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        domain.setTokenExchangeSettings(settings);
+        return domain;
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TrustDomain.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TrustDomain.java
@@ -17,6 +17,7 @@ package io.gravitee.am.model.oidc;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.UserBindingCriterion;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,14 +25,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * External authority an AM domain trusts, and the key material used to verify what it vouches for.
  *
  * <p>A trusted domain declares how tokens are recognised as coming from it: {@code spiffeTrustDomain}
- * matches the trust domain of a JWT-SVID presented as a client assertion.
+ * matches the trust domain of a JWT-SVID presented as a client assertion, {@code issuer} matches the
+ * {@code iss} claim of an external token presented during an RFC 8693 exchange. At least one is
+ * required, and setting both lets one authority serve both usages on shared key material.
  *
  * @author GraviteeSource Team
  */
@@ -47,6 +53,8 @@ public class TrustDomain {
     public static final int NAME_MAX_LENGTH = 255;
 
     public static final int SPIFFE_TRUST_DOMAIN_MAX_LENGTH = 255;
+
+    public static final int ISSUER_MAX_LENGTH = 512;
 
     private String id;
     private String referenceId;
@@ -71,6 +79,15 @@ public class TrustDomain {
             example = "acme.org")
     private String spiffeTrustDomain;
 
+    /**
+     * Value of the {@code iss} claim this authority vouches for, matched against external subject and
+     * actor tokens. Null when this authority is not trusted for token exchange.
+     */
+    @Schema(description = "Expected value of the \"iss\" claim in an external JWT. Required to accept "
+            + "tokens during an RFC 8693 exchange.",
+            example = "https://sso.acme.com")
+    private String issuer;
+
     private TrustDomainKeyMaterial keyMaterial;
 
     private int refreshIntervalSeconds = DEFAULT_REFRESH_INTERVAL_SECONDS;
@@ -79,6 +96,19 @@ public class TrustDomain {
      * Optional override of {@link SpiffeDomainSettings#getDefaultAllowedAlgorithms()}.
      */
     private List<String> allowedAlgorithms;
+
+    @Schema(description = "One-to-one mapping from external scope to domain scope. Unmapped issuer scopes "
+            + "are dropped (fail-closed). Applies to tokens matched by \"issuer\".")
+    private Map<String, String> scopeMappings;
+
+    @Schema(description = "Whether the external JWT subject is resolved to a single domain user using the "
+            + "user binding criteria. When false, a virtual user is built from the token claims only.",
+            defaultValue = "false")
+    private boolean userBindingEnabled;
+
+    @Schema(description = "Criteria used to locate a domain user when user binding is enabled. All criteria "
+            + "are combined with AND.")
+    private List<UserBindingCriterion> userBindingCriteria;
 
     @Schema(type = "java.lang.Long")
     private Date createdAt;
@@ -93,9 +123,13 @@ public class TrustDomain {
         this.name = other.name;
         this.description = other.description;
         this.spiffeTrustDomain = other.spiffeTrustDomain;
+        this.issuer = other.issuer;
         this.keyMaterial = other.keyMaterial != null ? new TrustDomainKeyMaterial(other.keyMaterial) : null;
         this.refreshIntervalSeconds = other.refreshIntervalSeconds;
         this.allowedAlgorithms = other.allowedAlgorithms;
+        this.scopeMappings = other.scopeMappings != null ? new LinkedHashMap<>(other.scopeMappings) : null;
+        this.userBindingEnabled = other.userBindingEnabled;
+        this.userBindingCriteria = other.userBindingCriteria != null ? new ArrayList<>(other.userBindingCriteria) : null;
         this.createdAt = other.createdAt;
         this.updatedAt = other.updatedAt;
     }
@@ -105,6 +139,13 @@ public class TrustDomain {
      */
     public boolean trustsSpiffe() {
         return spiffeTrustDomain != null;
+    }
+
+    /**
+     * Whether this authority is trusted for RFC 8693 token exchange.
+     */
+    public boolean trustsTokenExchange() {
+        return issuer != null;
     }
 
     /**

--- a/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/DomainReadinessService.java
+++ b/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/DomainReadinessService.java
@@ -79,6 +79,14 @@ public interface DomainReadinessService {
     void pluginUnloaded(String domainId, String pluginId);
 
     /**
+     * Remove a plugin from matching and record that a change was applied, so the domain's
+     * last-sync timestamp advances as it does for a load.
+     * @param domainId Domain ID.
+     * @param pluginId Plugin ID.
+     */
+    void pluginRemoved(String domainId, String pluginId);
+
+    /**
      * Update the status of a domain.
      * @param domainId Domain ID.
      * @param status Domain Status.

--- a/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/DomainReadinessServiceImpl.java
+++ b/gravitee-am-monitoring/src/main/java/io/gravitee/am/monitoring/DomainReadinessServiceImpl.java
@@ -151,6 +151,21 @@ public class DomainReadinessServiceImpl implements DomainReadinessService {
     }
 
     @Override
+    public void pluginRemoved(String domainId, String pluginId) {
+        if (domainId == null) {
+            log.warn("Received pluginRemoved for null domainId. Plugin: {}", pluginId);
+            return;
+        }
+
+        pluginUnloaded(domainId, pluginId);
+
+        DomainState domainState = domainStates.get(domainId);
+        if (domainState != null) {
+            domainState.setLastSync(System.currentTimeMillis());
+        }
+    }
+
+    @Override
     public void updateDomainStatus(String domainId, DomainState.Status status) {
         if (domainId == null) {
             log.warn("Received updateDomainStatus for null domainId. Status: {}", status);

--- a/gravitee-am-monitoring/src/test/java/io/gravitee/am/monitoring/DomainReadinessServiceImplTest.java
+++ b/gravitee-am-monitoring/src/test/java/io/gravitee/am/monitoring/DomainReadinessServiceImplTest.java
@@ -95,6 +95,7 @@ public class DomainReadinessServiceImplTest {
         domainReadinessService.pluginFailed(null, "plugin", "error");
         domainReadinessService.pluginUnlicensed(null, "plugin", "feature required");
         domainReadinessService.pluginUnloaded(null, "plugin");
+        domainReadinessService.pluginRemoved(null, "plugin");
         domainReadinessService.updateDomainStatus(null, DomainState.Status.DEPLOYED);
         domainReadinessService.removeDomain(null);
         
@@ -161,6 +162,23 @@ public class DomainReadinessServiceImplTest {
         // Ensure graceful handling if domain state is null
         domainReadinessService.pluginUnloaded("new-domain", "plugin-X");
         assertNotNull(domainReadinessService.getDomainState("new-domain"));
+    }
+
+    @Test
+    public void shouldAdvanceLastSyncWhenPluginIsRemoved() {
+        String domainId = "domain-removed";
+        String pluginId = "plugin-1";
+
+        domainReadinessService.initPluginSync(domainId, pluginId, "TRUST_DOMAIN");
+        domainReadinessService.pluginLoaded(domainId, pluginId);
+        long lastSyncBefore = domainReadinessService.getDomainState(domainId).getLastSync().get();
+
+        domainReadinessService.pluginRemoved(domainId, pluginId);
+
+        DomainState state = domainReadinessService.getDomainState(domainId);
+        assertEquals(0, state.getCreationState().size());
+        assertTrue(state.getLastSync().get() >= lastSyncBefore);
+        assertTrue(state.isSynchronized());
     }
 
     @Test

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/TrustDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/TrustDomainRepository.java
@@ -38,4 +38,10 @@ public interface TrustDomainRepository extends CrudRepository<TrustDomain, Strin
      * absent on trusted domains that are not trusted for SPIFFE.
      */
     Maybe<TrustDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain);
+
+    /**
+     * Finds the trusted domain vouching for an issuer. Unique per reference, and absent on trusted
+     * domains that are not trusted for token exchange.
+     */
+    Maybe<TrustDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer);
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcTrustDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcTrustDomainRepository.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.common.utils.RandomString;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.jose.JWKModule;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
 import io.gravitee.am.model.oidc.TrustDomain;
@@ -37,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 
 import static reactor.adapter.rxjava.RxJava3Adapter.monoToSingle;
 
@@ -45,6 +47,9 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
 
     private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JWKModule());
     private static final TypeReference<List<String>> STRING_LIST = new TypeReference<>() {};
+    private static final TypeReference<Map<String, String>> STRING_MAP = new TypeReference<>() {};
+    private static final TypeReference<List<UserBindingCriterion>> CRITERION_LIST = new TypeReference<>() {};
+    private static final TypeReference<TrustDomainKeyMaterial> KEY_MATERIAL = new TypeReference<>() {};
 
     @Autowired
     private SpringTrustDomainRepository repository;
@@ -105,6 +110,14 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
                 .observeOn(Schedulers.computation());
     }
 
+    @Override
+    public Maybe<TrustDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer) {
+        LOGGER.debug("findByIssuer({}, {}, {})", referenceType, referenceId, issuer);
+        return repository.findByIssuer(referenceType.name(), referenceId, issuer)
+                .map(this::toEntity)
+                .observeOn(Schedulers.computation());
+    }
+
     private TrustDomain toEntity(JdbcTrustDomain entity) {
         if (entity == null) {
             return null;
@@ -113,12 +126,16 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
         td.setId(entity.getId());
         td.setReferenceId(entity.getReferenceId());
         td.setReferenceType(entity.getReferenceType() != null ? ReferenceType.valueOf(entity.getReferenceType()) : null);
-        td.setSpiffeTrustDomain(readSpiffeTrustDomain(entity));
         td.setName(entity.getName());
         td.setDescription(entity.getDescription());
+        td.setSpiffeTrustDomain(readSpiffeTrustDomain(entity));
+        td.setIssuer(entity.getIssuer());
         td.setKeyMaterial(readKeyMaterial(entity));
         td.setRefreshIntervalSeconds(entity.getRefreshIntervalSeconds());
-        td.setAllowedAlgorithms(parseAlgorithms(entity.getAllowedAlgorithms()));
+        td.setAllowedAlgorithms(parseJson(entity.getAllowedAlgorithms(), STRING_LIST, "allowed algorithms"));
+        td.setScopeMappings(parseJson(entity.getScopeMappings(), STRING_MAP, "scope mappings"));
+        td.setUserBindingEnabled(Boolean.TRUE.equals(entity.getUserBindingEnabled()));
+        td.setUserBindingCriteria(parseJson(entity.getUserBindingCriteria(), CRITERION_LIST, "user binding criteria"));
         td.setCreatedAt(toDate(entity.getCreatedAt()));
         td.setUpdatedAt(toDate(entity.getUpdatedAt()));
         return td;
@@ -132,23 +149,19 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
         entity.setId(td.getId());
         entity.setReferenceId(td.getReferenceId());
         entity.setReferenceType(td.getReferenceType() != null ? td.getReferenceType().name() : null);
-        entity.setSpiffeTrustDomain(td.getSpiffeTrustDomain());
         entity.setName(td.getName());
         entity.setDescription(td.getDescription());
-        entity.setKeyMaterial(serializeKeyMaterial(td.getKeyMaterial()));
+        entity.setSpiffeTrustDomain(td.getSpiffeTrustDomain());
+        entity.setIssuer(td.getIssuer());
+        entity.setKeyMaterial(serializeJson(td.getKeyMaterial(), "key material"));
         entity.setRefreshIntervalSeconds(td.getRefreshIntervalSeconds());
-        entity.setAllowedAlgorithms(serializeAlgorithms(td.getAllowedAlgorithms()));
+        entity.setAllowedAlgorithms(serializeJson(td.getAllowedAlgorithms(), "allowed algorithms"));
+        entity.setScopeMappings(serializeJson(td.getScopeMappings(), "scope mappings"));
+        entity.setUserBindingEnabled(td.isUserBindingEnabled());
+        entity.setUserBindingCriteria(serializeJson(td.getUserBindingCriteria(), "user binding criteria"));
         entity.setCreatedAt(toLocalDateTime(td.getCreatedAt()));
         entity.setUpdatedAt(toLocalDateTime(td.getUpdatedAt()));
         return entity;
-    }
-
-    /**
-     * Reads the SPIFFE matcher, falling back to the name for trust domains stored while the name was
-     * the matcher.
-     */
-    static String readSpiffeTrustDomain(JdbcTrustDomain entity) {
-        return entity.getSpiffeTrustDomain() != null ? entity.getSpiffeTrustDomain() : entity.getName();
     }
 
     /**
@@ -157,47 +170,43 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
      */
     static TrustDomainKeyMaterial readKeyMaterial(JdbcTrustDomain entity) {
         if (entity.getKeyMaterial() != null && !entity.getKeyMaterial().isBlank()) {
-            try {
-                return MAPPER.readValue(entity.getKeyMaterial(), TrustDomainKeyMaterial.class);
-            } catch (JsonProcessingException e) {
-                throw new IllegalStateException("Failed to parse trust domain key material", e);
-            }
+            return parseJson(entity.getKeyMaterial(), KEY_MATERIAL, "key material");
         }
         return TrustDomainKeyMaterial.fromBundleSource(
                 entity.getBundleSource() != null ? SpiffeBundleSource.valueOf(entity.getBundleSource()) : null,
                 entity.getJwksUrl());
     }
 
-    private static String serializeKeyMaterial(TrustDomainKeyMaterial keyMaterial) {
-        if (keyMaterial == null) {
-            return null;
+    /**
+     * Reads the SPIFFE matcher, falling back to the name for trust domains stored while the name was
+     * the matcher. Rows that carry an issuer were written by the migration and are not SPIFFE.
+     */
+    static String readSpiffeTrustDomain(JdbcTrustDomain entity) {
+        if (entity.getSpiffeTrustDomain() != null) {
+            return entity.getSpiffeTrustDomain();
         }
-        try {
-            return MAPPER.writeValueAsString(keyMaterial);
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Failed to serialize trust domain key material", e);
-        }
+        return entity.getIssuer() == null ? entity.getName() : null;
     }
 
-    private static String serializeAlgorithms(List<String> algorithms) {
-        if (algorithms == null) {
-            return null;
-        }
-        try {
-            return MAPPER.writeValueAsString(algorithms);
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Failed to serialize allowed algorithms", e);
-        }
-    }
-
-    private static List<String> parseAlgorithms(String json) {
+    private static <T> T parseJson(String json, TypeReference<T> type, String what) {
         if (json == null || json.isBlank()) {
             return null;
         }
         try {
-            return MAPPER.readValue(json, STRING_LIST);
+            return MAPPER.readValue(json, type);
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Failed to parse allowed algorithms", e);
+            throw new IllegalStateException("Failed to parse trust domain " + what, e);
+        }
+    }
+
+    private static String serializeJson(Object value, String what) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize trust domain " + what, e);
         }
     }
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcTrustDomain.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcTrustDomain.java
@@ -35,9 +35,6 @@ public class JdbcTrustDomain {
 
     private String name;
 
-    @Column("spiffe_trust_domain")
-    private String spiffeTrustDomain;
-
     private String description;
 
     /**
@@ -68,6 +65,20 @@ public class JdbcTrustDomain {
     @Column("allowed_algorithms")
     private String allowedAlgorithms;
 
+    @Column("spiffe_trust_domain")
+    private String spiffeTrustDomain;
+
+    private String issuer;
+
+    @Column("scope_mappings")
+    private String scopeMappings;
+
+    @Column("user_binding_enabled")
+    private Boolean userBindingEnabled;
+
+    @Column("user_binding_criteria")
+    private String userBindingCriteria;
+
     @Column("created_at")
     private LocalDateTime createdAt;
 
@@ -96,14 +107,6 @@ public class JdbcTrustDomain {
 
     public void setReferenceType(String referenceType) {
         this.referenceType = referenceType;
-    }
-
-    public String getSpiffeTrustDomain() {
-        return spiffeTrustDomain;
-    }
-
-    public void setSpiffeTrustDomain(String spiffeTrustDomain) {
-        this.spiffeTrustDomain = spiffeTrustDomain;
     }
 
     public String getKeyMaterial() {
@@ -176,5 +179,45 @@ public class JdbcTrustDomain {
 
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public String getScopeMappings() {
+        return scopeMappings;
+    }
+
+    public void setScopeMappings(String scopeMappings) {
+        this.scopeMappings = scopeMappings;
+    }
+
+    public Boolean getUserBindingEnabled() {
+        return userBindingEnabled;
+    }
+
+    public void setUserBindingEnabled(Boolean userBindingEnabled) {
+        this.userBindingEnabled = userBindingEnabled;
+    }
+
+    public String getUserBindingCriteria() {
+        return userBindingCriteria;
+    }
+
+    public void setUserBindingCriteria(String userBindingCriteria) {
+        this.userBindingCriteria = userBindingCriteria;
+    }
+
+    public String getSpiffeTrustDomain() {
+        return spiffeTrustDomain;
+    }
+
+    public void setSpiffeTrustDomain(String spiffeTrustDomain) {
+        this.spiffeTrustDomain = spiffeTrustDomain;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringTrustDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringTrustDomainRepository.java
@@ -36,4 +36,9 @@ public interface SpringTrustDomainRepository extends RxJava3CrudRepository<JdbcT
     Maybe<JdbcTrustDomain> findBySpiffeTrustDomain(@Param("refType") String refType,
                                                    @Param("refId") String refId,
                                                    @Param("spiffeTrustDomain") String spiffeTrustDomain);
+
+    @Query("select * from trust_domains where reference_type = :refType and reference_id = :refId and issuer = :issuer")
+    Maybe<JdbcTrustDomain> findByIssuer(@Param("refType") String refType,
+                                        @Param("refId") String refId,
+                                        @Param("issuer") String issuer);
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-trust-domains-token-exchange.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-trust-domains-token-exchange.yml
@@ -1,0 +1,65 @@
+databaseChangeLog:
+  # A trusted domain that vouches for an issuer declares it here, along with the scopes it may grant
+  # and how its subjects bind to domain users. These columns stay null on trusted domains that only
+  # match SPIFFE.
+  - changeSet:
+      id: 4.13.0-trust-domains-token-exchange
+      author: GraviteeSource Team
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: trust_domains
+                columnName: issuer
+      changes:
+        - addColumn:
+            tableName: trust_domains
+            columns:
+              - column: { name: issuer, type: nvarchar(512), constraints: { nullable: true } }
+              - column: { name: scope_mappings, type: clob, constraints: { nullable: true } }
+              - column: { name: user_binding_enabled, type: boolean, constraints: { nullable: true } }
+              - column: { name: user_binding_criteria, type: clob, constraints: { nullable: true } }
+
+  # An issuer is vouched for by at most one trusted domain per security domain. SPIFFE rows leave
+  # issuer null, and PostgreSQL / MySQL / MariaDB treat nulls as distinct in a unique index.
+  # The index key is (64 + 64 + 512) chars; at utf8mb4 that is 2560 bytes, inside InnoDB's 3072-byte
+  # limit, which is what bounds the issuer column width.
+  - changeSet:
+      id: 4.13.0-trust-domains-issuer-unique
+      author: GraviteeSource Team
+      dbms: postgresql, mysql, mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: trust_domains
+                indexName: idx_trust_domains_ref_issuer
+      changes:
+        - createIndex:
+            columns:
+              - column: { name: reference_type }
+              - column: { name: reference_id }
+              - column: { name: issuer }
+            indexName: idx_trust_domains_ref_issuer
+            tableName: trust_domains
+            unique: true
+
+  # SQL Server treats nulls as equal in a unique index, so the same constraint has to be filtered
+  # down to the rows that actually carry an issuer. SQL Server refuses to build a filtered index
+  # unless QUOTED_IDENTIFIER is ON, so the batch sets it rather than trusting the connection.
+  - changeSet:
+      id: 4.13.0-trust-domains-issuer-unique-mssql
+      author: GraviteeSource Team
+      dbms: mssql
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: trust_domains
+                indexName: idx_trust_domains_ref_issuer
+      changes:
+        - sql:
+            splitStatements: false
+            sql: |
+              SET QUOTED_IDENTIFIER ON;
+              CREATE UNIQUE INDEX idx_trust_domains_ref_issuer ON trust_domains (reference_type, reference_id, issuer) WHERE issuer IS NOT NULL;

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
@@ -243,3 +243,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_13_0/4.13.0-trust-domains-key-material-and-matcher.yml
   - include:
       - file: liquibase/changelogs/v4_13_0/4.13.0-domains-add-key-retrieval-settings-column.yml
+  - include:
+      - file: liquibase/changelogs/v4_13_0/4.13.0-trust-domains-token-exchange.yml

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/management/api/JdbcTrustDomainLegacyMappingTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/management/api/JdbcTrustDomainLegacyMappingTest.java
@@ -37,6 +37,15 @@ public class JdbcTrustDomainLegacyMappingTest {
     }
 
     @Test
+    public void shouldNotReadAMigratedIssuerRowAsSpiffe() {
+        JdbcTrustDomain migrated = new JdbcTrustDomain();
+        migrated.setName("issuer.example");
+        migrated.setIssuer("https://issuer.example/realm");
+
+        assertNull(JdbcTrustDomainRepository.readSpiffeTrustDomain(migrated));
+    }
+
+    @Test
     public void shouldPreferTheStoredMatcherOverTheName() {
         JdbcTrustDomain row = new JdbcTrustDomain();
         row.setName("acme-corp");

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoTrustDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoTrustDomainRepository.java
@@ -30,6 +30,7 @@ import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.repository.management.api.TrustDomainRepository;
 import io.gravitee.am.repository.mongodb.management.internal.model.TrustDomainKeyMaterialMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.TrustDomainMongo;
+import io.gravitee.am.repository.mongodb.management.internal.model.UserBindingCriterionMongo;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -61,6 +62,7 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
     private static final String COLLECTION_NAME = "trust_domains";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_SPIFFE_TRUST_DOMAIN = "spiffeTrustDomain";
+    private static final String FIELD_ISSUER = "issuer";
 
     private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JWKModule());
 
@@ -75,7 +77,10 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
                 new IndexOptions().name("rt1ri1n1").unique(true),
                 new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_SPIFFE_TRUST_DOMAIN, 1),
                 new IndexOptions().name("rt1ri1std1").unique(true)
-                        .partialFilterExpression(exists(FIELD_SPIFFE_TRUST_DOMAIN, true))
+                        .partialFilterExpression(exists(FIELD_SPIFFE_TRUST_DOMAIN, true)),
+                new Document(FIELD_REFERENCE_TYPE, 1).append(FIELD_REFERENCE_ID, 1).append(FIELD_ISSUER, 1),
+                new IndexOptions().name("rt1ri1i1").unique(true)
+                        .partialFilterExpression(exists(FIELD_ISSUER, true))
         ));
         if (ensureIndexOnStart) {
             stampSpiffeTrustDomainOnLegacyDocuments().subscribe();
@@ -89,7 +94,7 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
      */
     private Completable stampSpiffeTrustDomainOnLegacyDocuments() {
         return Completable.fromPublisher(collection.updateMany(
-                        exists(FIELD_SPIFFE_TRUST_DOMAIN, false),
+                        and(exists(FIELD_SPIFFE_TRUST_DOMAIN, false), exists(FIELD_ISSUER, false)),
                         List.of(new Document("$set", new Document(FIELD_SPIFFE_TRUST_DOMAIN, "$" + FIELD_NAME)))))
                 .doOnError(error -> log.warn("Unable to stamp the SPIFFE trust domain on legacy trust domains", error));
     }
@@ -147,6 +152,11 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
         return findByField(referenceType, referenceId, FIELD_SPIFFE_TRUST_DOMAIN, spiffeTrustDomain);
     }
 
+    @Override
+    public Maybe<TrustDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer) {
+        return findByField(referenceType, referenceId, FIELD_ISSUER, issuer);
+    }
+
     private Maybe<TrustDomain> findByField(ReferenceType referenceType, String referenceId, String field, String value) {
         return Observable.fromPublisher(collection.find(and(
                         eq(FIELD_REFERENCE_TYPE, referenceType.name()),
@@ -165,12 +175,16 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
         td.setId(doc.getId());
         td.setReferenceId(doc.getReferenceId());
         td.setReferenceType(doc.getReferenceType() != null ? ReferenceType.valueOf(doc.getReferenceType()) : null);
-        td.setSpiffeTrustDomain(readSpiffeTrustDomain(doc));
         td.setName(doc.getName());
         td.setDescription(doc.getDescription());
+        td.setSpiffeTrustDomain(readSpiffeTrustDomain(doc));
+        td.setIssuer(doc.getIssuer());
         td.setKeyMaterial(readKeyMaterial(doc));
         td.setRefreshIntervalSeconds(doc.getRefreshIntervalSeconds());
         td.setAllowedAlgorithms(doc.getAllowedAlgorithms());
+        td.setScopeMappings(doc.getScopeMappings());
+        td.setUserBindingEnabled(Boolean.TRUE.equals(doc.getUserBindingEnabled()));
+        td.setUserBindingCriteria(UserBindingCriterionMongo.toModelList(doc.getUserBindingCriteria()));
         td.setCreatedAt(doc.getCreatedAt());
         td.setUpdatedAt(doc.getUpdatedAt());
         return td;
@@ -184,12 +198,16 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
         doc.setId(td.getId());
         doc.setReferenceId(td.getReferenceId());
         doc.setReferenceType(td.getReferenceType() != null ? td.getReferenceType().name() : null);
-        doc.setSpiffeTrustDomain(td.getSpiffeTrustDomain());
         doc.setName(td.getName());
         doc.setDescription(td.getDescription());
+        doc.setSpiffeTrustDomain(td.getSpiffeTrustDomain());
+        doc.setIssuer(td.getIssuer());
         doc.setKeyMaterial(toMongo(td.getKeyMaterial()));
         doc.setRefreshIntervalSeconds(td.getRefreshIntervalSeconds());
         doc.setAllowedAlgorithms(td.getAllowedAlgorithms());
+        doc.setScopeMappings(td.getScopeMappings());
+        doc.setUserBindingEnabled(td.isUserBindingEnabled());
+        doc.setUserBindingCriteria(UserBindingCriterionMongo.fromModelList(td.getUserBindingCriteria()));
         doc.setCreatedAt(td.getCreatedAt());
         doc.setUpdatedAt(td.getUpdatedAt());
         return doc;
@@ -197,10 +215,13 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
 
     /**
      * Reads the SPIFFE matcher, falling back to the name for trust domains stored while the name was
-     * the matcher.
+     * the matcher. Documents that carry an issuer were written by the migration and are not SPIFFE.
      */
     static String readSpiffeTrustDomain(TrustDomainMongo doc) {
-        return doc.getSpiffeTrustDomain() != null ? doc.getSpiffeTrustDomain() : doc.getName();
+        if (doc.getSpiffeTrustDomain() != null) {
+            return doc.getSpiffeTrustDomain();
+        }
+        return doc.getIssuer() == null ? doc.getName() : null;
     }
 
     /**

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/TrustDomainMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/TrustDomainMongo.java
@@ -19,6 +19,7 @@ import io.gravitee.am.repository.mongodb.common.model.Auditable;
 import org.bson.codecs.pojo.annotations.BsonId;
 
 import java.util.List;
+import java.util.Map;
 
 public class TrustDomainMongo extends Auditable {
 
@@ -27,7 +28,6 @@ public class TrustDomainMongo extends Auditable {
 
     private String referenceId;
     private String referenceType;
-    private String spiffeTrustDomain;
     private String name;
     private String description;
     private TrustDomainKeyMaterialMongo keyMaterial;
@@ -44,6 +44,11 @@ public class TrustDomainMongo extends Auditable {
     private String jwksUrl;
     private int refreshIntervalSeconds;
     private List<String> allowedAlgorithms;
+    private String spiffeTrustDomain;
+    private String issuer;
+    private Map<String, String> scopeMappings;
+    private Boolean userBindingEnabled;
+    private List<UserBindingCriterionMongo> userBindingCriteria;
 
     public String getId() {
         return id;
@@ -67,14 +72,6 @@ public class TrustDomainMongo extends Auditable {
 
     public void setReferenceType(String referenceType) {
         this.referenceType = referenceType;
-    }
-
-    public String getSpiffeTrustDomain() {
-        return spiffeTrustDomain;
-    }
-
-    public void setSpiffeTrustDomain(String spiffeTrustDomain) {
-        this.spiffeTrustDomain = spiffeTrustDomain;
     }
 
     public TrustDomainKeyMaterialMongo getKeyMaterial() {
@@ -131,5 +128,45 @@ public class TrustDomainMongo extends Auditable {
 
     public void setAllowedAlgorithms(List<String> allowedAlgorithms) {
         this.allowedAlgorithms = allowedAlgorithms;
+    }
+
+    public String getSpiffeTrustDomain() {
+        return spiffeTrustDomain;
+    }
+
+    public void setSpiffeTrustDomain(String spiffeTrustDomain) {
+        this.spiffeTrustDomain = spiffeTrustDomain;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public Map<String, String> getScopeMappings() {
+        return scopeMappings;
+    }
+
+    public void setScopeMappings(Map<String, String> scopeMappings) {
+        this.scopeMappings = scopeMappings;
+    }
+
+    public Boolean getUserBindingEnabled() {
+        return userBindingEnabled;
+    }
+
+    public void setUserBindingEnabled(Boolean userBindingEnabled) {
+        this.userBindingEnabled = userBindingEnabled;
+    }
+
+    public List<UserBindingCriterionMongo> getUserBindingCriteria() {
+        return userBindingCriteria;
+    }
+
+    public void setUserBindingCriteria(List<UserBindingCriterionMongo> userBindingCriteria) {
+        this.userBindingCriteria = userBindingCriteria;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/management/MongoTrustDomainLegacyMappingTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/management/MongoTrustDomainLegacyMappingTest.java
@@ -38,6 +38,15 @@ public class MongoTrustDomainLegacyMappingTest {
     }
 
     @Test
+    public void shouldNotReadAMigratedIssuerDocumentAsSpiffe() {
+        TrustDomainMongo migrated = new TrustDomainMongo();
+        migrated.setName("issuer.example");
+        migrated.setIssuer("https://issuer.example/realm");
+
+        assertNull(MongoTrustDomainRepository.readSpiffeTrustDomain(migrated));
+    }
+
+    @Test
     public void shouldPreferTheStoredMatcherOverTheName() {
         TrustDomainMongo doc = new TrustDomainMongo();
         doc.setName("acme-corp");

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/TrustDomainRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/TrustDomainRepositoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.repository.management.api;
 
+import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.jose.RSAKey;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
@@ -26,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.gravitee.am.model.ReferenceType.DOMAIN;
@@ -161,6 +163,35 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
     }
 
     @Test
+    public void shouldNotFindBySpiffeTrustDomain_whenTrustedForTokenExchangeOnly() {
+        String referenceId = randomUUID().toString();
+        repository.create(buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm")).blockingGet();
+
+        var observer = repository.findBySpiffeTrustDomain(DOMAIN, referenceId, "issuer.example").test();
+        observer.awaitDone(5, TimeUnit.SECONDS);
+        observer.assertComplete();
+        observer.assertNoValues();
+        observer.assertNoErrors();
+    }
+
+    @Test
+    public void shouldServeBothUsagesFromOneTrustedDomain() {
+        String referenceId = randomUUID().toString();
+        TrustDomain both = buildTrustDomain(referenceId, "acme-corp");
+        both.setSpiffeTrustDomain("acme.org");
+        both.setIssuer("https://sso.acme.com");
+        var created = repository.create(both).blockingGet();
+
+        var bySpiffe = repository.findBySpiffeTrustDomain(DOMAIN, referenceId, "acme.org").test();
+        bySpiffe.awaitDone(10, TimeUnit.SECONDS);
+        bySpiffe.assertValue(found -> found.getId().equals(created.getId()));
+
+        var byIssuer = repository.findByIssuer(DOMAIN, referenceId, "https://sso.acme.com").test();
+        byIssuer.awaitDone(10, TimeUnit.SECONDS);
+        byIssuer.assertValue(found -> found.getId().equals(created.getId()));
+    }
+
+    @Test
     public void shouldRejectDuplicateSpiffeTrustDomain() {
         String referenceId = randomUUID().toString();
         repository.create(buildTrustDomain(referenceId, "example.org")).blockingGet();
@@ -265,5 +296,107 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
         findObserver.assertComplete();
         findObserver.assertNoValues();
         findObserver.assertNoErrors();
+    }
+
+    private TrustDomain buildTokenExchangeTrustDomain(String referenceId, String issuer) {
+        TrustDomain td = buildTrustDomain(referenceId, "issuer.example");
+        td.setSpiffeTrustDomain(null);
+        td.setAllowedAlgorithms(null);
+        UserBindingCriterion criterion = new UserBindingCriterion();
+        criterion.setAttribute("emails.value");
+        criterion.setExpression("{#token['email']}");
+        td.setIssuer(issuer);
+        td.setScopeMappings(Map.of("read", "domain:read"));
+        td.setUserBindingEnabled(true);
+        td.setUserBindingCriteria(List.of(criterion));
+        return td;
+    }
+
+    @Test
+    public void shouldRoundTripTokenExchangeSettings() {
+        String referenceId = randomUUID().toString();
+        var created = repository.create(buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm")).blockingGet();
+
+        var observer = repository.findById(created.getId()).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertNoErrors();
+        observer.assertValue(found -> found.getSpiffeTrustDomain() == null);
+        observer.assertValue(found -> "https://issuer.example/realm".equals(found.getIssuer()));
+        observer.assertValue(found -> Map.of("read", "domain:read").equals(found.getScopeMappings()));
+        observer.assertValue(found -> found.isUserBindingEnabled());
+        observer.assertValue(found -> found.getUserBindingCriteria().size() == 1);
+        observer.assertValue(found -> "emails.value".equals(found.getUserBindingCriteria().get(0).getAttribute()));
+        observer.assertValue(found -> "{#token['email']}".equals(found.getUserBindingCriteria().get(0).getExpression()));
+    }
+
+    @Test
+    public void shouldFindByIssuer() {
+        String referenceId = randomUUID().toString();
+        var created = repository.create(buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm")).blockingGet();
+
+        var observer = repository.findByIssuer(DOMAIN, referenceId, "https://issuer.example/realm").test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertComplete();
+        observer.assertNoErrors();
+        observer.assertValue(found -> found.getId().equals(created.getId()));
+    }
+
+    @Test
+    public void shouldNotFindByIssuer_whenReferenceDiffers() {
+        String referenceId = randomUUID().toString();
+        repository.create(buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm")).blockingGet();
+
+        var observer = repository.findByIssuer(DOMAIN, randomUUID().toString(), "https://issuer.example/realm").test();
+        observer.awaitDone(5, TimeUnit.SECONDS);
+        observer.assertComplete();
+        observer.assertNoValues();
+        observer.assertNoErrors();
+    }
+
+    @Test
+    public void shouldRejectDuplicateIssuerWithinReference() {
+        String referenceId = randomUUID().toString();
+        repository.create(buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm")).blockingGet();
+
+        TrustDomain duplicate = buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm");
+        duplicate.setName("other.example");
+        var observer = repository.create(duplicate).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertError(Throwable.class);
+
+        var stored = repository.findByReference(DOMAIN, referenceId).toList().test();
+        stored.awaitDone(10, TimeUnit.SECONDS);
+        stored.assertValue(list -> list.size() == 1);
+    }
+
+    @Test
+    public void shouldAllowManySpiffeTrustDomainsWithoutIssuer() {
+        String referenceId = randomUUID().toString();
+        repository.create(buildTrustDomain(referenceId, "first.example")).blockingGet();
+        repository.create(buildTrustDomain(referenceId, "second.example")).blockingGet();
+
+        var stored = repository.findByReference(DOMAIN, referenceId).toList().test();
+        stored.awaitDone(10, TimeUnit.SECONDS);
+        stored.assertNoErrors();
+        stored.assertValue(list -> list.size() == 2);
+    }
+
+    @Test
+    public void shouldUpdateIssuer() {
+        String referenceId = randomUUID().toString();
+        var created = repository.create(buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm")).blockingGet();
+
+        TrustDomain toUpdate = new TrustDomain(created);
+        toUpdate.setIssuer("https://issuer.example/realm-v2");
+        toUpdate.setUpdatedAt(new Date());
+        repository.update(toUpdate).blockingGet();
+
+        var observer = repository.findByIssuer(DOMAIN, referenceId, "https://issuer.example/realm-v2").test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+        observer.assertValue(found -> found.getId().equals(created.getId()));
+
+        var stale = repository.findByIssuer(DOMAIN, referenceId, "https://issuer.example/realm").test();
+        stale.awaitDone(5, TimeUnit.SECONDS);
+        stale.assertNoValues();
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/TrustDomainIssuerAlreadyExistsException.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/exception/TrustDomainIssuerAlreadyExistsException.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.exception;
+
+import io.gravitee.common.http.HttpStatusCode;
+
+public class TrustDomainIssuerAlreadyExistsException extends AbstractManagementException {
+
+    private final String issuer;
+
+    public TrustDomainIssuerAlreadyExistsException(String issuer) {
+        this.issuer = issuer;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "A trusted domain vouching for issuer [" + issuer + "] already exists for this domain.";
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/TrustDomainServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/TrustDomainServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.KeyRetrievalSettings;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.common.event.Event;
 import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.model.oidc.JWKSet;
@@ -37,6 +38,7 @@ import io.gravitee.am.service.TrustDomainService;
 import io.gravitee.am.service.exception.InvalidTrustDomainException;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.exception.TrustDomainAlreadyExistsException;
+import io.gravitee.am.service.exception.TrustDomainIssuerAlreadyExistsException;
 import io.gravitee.am.service.exception.TrustDomainNotFoundException;
 import io.gravitee.am.service.exception.TrustDomainSpiffeAlreadyExistsException;
 import io.gravitee.am.service.model.NewTrustDomain;
@@ -67,7 +69,6 @@ import lombok.CustomLog;
 @Component
 @CustomLog
 public class TrustDomainServiceImpl implements TrustDomainService {
-
 
     /**
      * SPIFFE trust domains are case-insensitive DNS-style host labels per the
@@ -116,11 +117,14 @@ public class TrustDomainServiceImpl implements TrustDomainService {
         td.setReferenceId(domain.getId());
         td.setName(trimToNull(input.getName()));
         td.setDescription(input.getDescription());
-        applySpiffeTrustDomain(td, input.getSpiffeTrustDomain());
+        applyMatchers(td, input.getSpiffeTrustDomain(), input.getIssuer());
         td.setKeyMaterial(resolveKeyMaterial(input.getKeyMaterial(), input.getBundleSource(), input.getJwksUrl()));
         td.setRefreshIntervalSeconds(Optional.ofNullable(input.getRefreshIntervalSeconds())
                 .orElse(TrustDomain.DEFAULT_REFRESH_INTERVAL_SECONDS));
         td.setAllowedAlgorithms(input.getAllowedAlgorithms());
+        td.setScopeMappings(input.getScopeMappings());
+        td.setUserBindingEnabled(input.isUserBindingEnabled());
+        td.setUserBindingCriteria(input.getUserBindingCriteria());
         Date now = new Date();
         td.setCreatedAt(now);
         td.setUpdatedAt(now);
@@ -162,8 +166,8 @@ public class TrustDomainServiceImpl implements TrustDomainService {
                         updated.setName(trimToNull(input.getName()));
                     }
                     updated.setDescription(input.getDescription());
-                    if (input.getSpiffeTrustDomain() != null) {
-                        applySpiffeTrustDomain(updated, input.getSpiffeTrustDomain());
+                    if (input.getSpiffeTrustDomain() != null || input.getIssuer() != null) {
+                        applyMatchers(updated, input.getSpiffeTrustDomain(), input.getIssuer());
                     }
                     TrustDomainKeyMaterial keyMaterial =
                             resolveKeyMaterial(input.getKeyMaterial(), input.getBundleSource(), input.getJwksUrl());
@@ -175,6 +179,15 @@ public class TrustDomainServiceImpl implements TrustDomainService {
                     }
                     if (input.getAllowedAlgorithms() != null) {
                         updated.setAllowedAlgorithms(input.getAllowedAlgorithms());
+                    }
+                    if (input.getScopeMappings() != null) {
+                        updated.setScopeMappings(input.getScopeMappings());
+                    }
+                    if (input.getUserBindingEnabled() != null) {
+                        updated.setUserBindingEnabled(input.getUserBindingEnabled());
+                    }
+                    if (input.getUserBindingCriteria() != null) {
+                        updated.setUserBindingCriteria(input.getUserBindingCriteria());
                     }
                     updated.setUpdatedAt(new Date());
                     updatedRef.set(updated);
@@ -244,43 +257,25 @@ public class TrustDomainServiceImpl implements TrustDomainService {
                 });
     }
 
-    private Completable publish(Domain domain, TrustDomain trustDomain, Action action) {
-        Event event = new Event(TRUST_DOMAIN, new Payload(trustDomain.getId(), trustDomain.getReferenceType(), trustDomain.getReferenceId(), action));
-        return eventService.create(event, domain).ignoreElement();
-    }
-
     /**
-     * Maps the deprecated bundle-source input onto the shared key-material shape. The deprecated
-     * fields are ignored whenever key material is supplied directly; a bare {@code jwksUrl} means
-     * the JWKS-URL source, as it did before the bundle source became explicit.
+     * Sets the matchers a trusted domain is recognised by. A payload that declares neither is written
+     * against the SPIFFE-only API that preceded the issuer matcher, and means the name.
      */
-    private static TrustDomainKeyMaterial resolveKeyMaterial(TrustDomainKeyMaterial keyMaterial,
-                                                             SpiffeBundleSource bundleSource,
-                                                             String jwksUrl) {
-        if (keyMaterial != null) {
-            return keyMaterial;
-        }
-        if (bundleSource == null && jwksUrl == null) {
-            return null;
-        }
-        return TrustDomainKeyMaterial.fromBundleSource(
-                bundleSource != null ? bundleSource : SpiffeBundleSource.JWKS_URL, jwksUrl);
-    }
-
-    /**
-     * Sets the SPIFFE trust domain this authority issues IDs for. A payload that does not declare one
-     * is written against the API that preceded the matcher, and means the name.
-     */
-    private static void applySpiffeTrustDomain(TrustDomain td, String spiffeTrustDomain) {
-        String spiffe = spiffeTrustDomain == null ? td.getName() : trimToNull(spiffeTrustDomain);
+    private static void applyMatchers(TrustDomain td, String spiffeTrustDomain, String issuer) {
+        String spiffe = spiffeTrustDomain == null && issuer == null
+                ? td.getName()
+                : trimToNull(spiffeTrustDomain);
         td.setSpiffeTrustDomain(spiffe != null ? spiffe.toLowerCase(Locale.ROOT) : null);
+        td.setIssuer(trimToNull(issuer));
     }
 
     private Completable rejectDuplicates(Domain domain, TrustDomain td, TrustDomain beforeUpdate) {
         return rejectDuplicate(domain, td, beforeUpdate, TrustDomain::getName,
                 repository::findByName, TrustDomainAlreadyExistsException::new)
                 .andThen(rejectDuplicate(domain, td, beforeUpdate, TrustDomain::getSpiffeTrustDomain,
-                        repository::findBySpiffeTrustDomain, TrustDomainSpiffeAlreadyExistsException::new));
+                        repository::findBySpiffeTrustDomain, TrustDomainSpiffeAlreadyExistsException::new))
+                .andThen(rejectDuplicate(domain, td, beforeUpdate, TrustDomain::getIssuer,
+                        repository::findByIssuer, TrustDomainIssuerAlreadyExistsException::new));
     }
 
     private Completable rejectDuplicate(Domain domain,
@@ -305,6 +300,29 @@ public class TrustDomainServiceImpl implements TrustDomainService {
         Maybe<TrustDomain> find(ReferenceType referenceType, String referenceId, String value);
     }
 
+    private Completable publish(Domain domain, TrustDomain trustDomain, Action action) {
+        Event event = new Event(TRUST_DOMAIN, new Payload(trustDomain.getId(), trustDomain.getReferenceType(), trustDomain.getReferenceId(), action));
+        return eventService.create(event, domain).ignoreElement();
+    }
+
+    /**
+     * Maps the deprecated bundle-source input onto the shared key-material shape. The deprecated
+     * fields are ignored whenever key material is supplied directly; a bare {@code jwksUrl} means
+     * the JWKS-URL source, as it did before the bundle source became explicit.
+     */
+    private static TrustDomainKeyMaterial resolveKeyMaterial(TrustDomainKeyMaterial keyMaterial,
+                                                             SpiffeBundleSource bundleSource,
+                                                             String jwksUrl) {
+        if (keyMaterial != null) {
+            return keyMaterial;
+        }
+        if (bundleSource == null && jwksUrl == null) {
+            return null;
+        }
+        return TrustDomainKeyMaterial.fromBundleSource(
+                bundleSource != null ? bundleSource : SpiffeBundleSource.JWKS_URL, jwksUrl);
+    }
+
     private static String trimToNull(String value) {
         if (value == null) {
             return null;
@@ -320,23 +338,19 @@ public class TrustDomainServiceImpl implements TrustDomainService {
         KeyRetrievalSettings settings = Optional.ofNullable(domain.getKeyRetrievalSettings())
                 .orElseGet(KeyRetrievalSettings::defaultSettings);
 
-        if (!spiffeSettings.isEnabled()) {
-            return Completable.error(new InvalidTrustDomainException(
-                    "SPIFFE workload identity is disabled for this domain. Enable it in domain settings before registering a SPIFFE trust domain."));
-        }
         if (td.getName() == null) {
             return Completable.error(new InvalidTrustDomainException("name is required"));
         }
         if (td.getName().length() > TrustDomain.NAME_MAX_LENGTH) {
             return Completable.error(new InvalidTrustDomainException("name must be at most " + TrustDomain.NAME_MAX_LENGTH + " characters"));
         }
-        if (td.getSpiffeTrustDomain() == null || !SPIFFE_TRUST_DOMAIN_PATTERN.matcher(td.getSpiffeTrustDomain()).matches()) {
-            return Completable.error(new InvalidTrustDomainException(
-                    "spiffeTrustDomain must be a DNS-style label (lowercase letters, digits, '.' or '-')"));
+        Optional<String> matcherError = validateMatchers(td, spiffeSettings);
+        if (matcherError.isPresent()) {
+            return Completable.error(new InvalidTrustDomainException(matcherError.get()));
         }
-        if (td.getSpiffeTrustDomain().length() > TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH) {
-            return Completable.error(new InvalidTrustDomainException(
-                    "spiffeTrustDomain must be at most " + TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH + " characters"));
+        Optional<String> userBindingError = validateUserBinding(td);
+        if (userBindingError.isPresent()) {
+            return Completable.error(new InvalidTrustDomainException(userBindingError.get()));
         }
         Optional<String> keyMaterialError = validateKeyMaterial(td.getKeyMaterial(), settings);
         if (keyMaterialError.isPresent()) {
@@ -355,6 +369,51 @@ public class TrustDomainServiceImpl implements TrustDomainService {
             }
         }
         return Completable.complete();
+    }
+
+    private Optional<String> validateMatchers(TrustDomain td, SpiffeDomainSettings spiffeSettings) {
+        if (!td.trustsSpiffe() && !td.trustsTokenExchange()) {
+            return Optional.of("a trusted domain must declare spiffeTrustDomain, issuer, or both");
+        }
+        if (td.trustsSpiffe()) {
+            if (!spiffeSettings.isEnabled()) {
+                return Optional.of("SPIFFE workload identity is disabled for this domain. Enable it in domain settings before registering a SPIFFE trust domain.");
+            }
+            if (!SPIFFE_TRUST_DOMAIN_PATTERN.matcher(td.getSpiffeTrustDomain()).matches()) {
+                return Optional.of("spiffeTrustDomain must be a DNS-style label (lowercase letters, digits, '.' or '-')");
+            }
+            if (td.getSpiffeTrustDomain().length() > TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH) {
+                return Optional.of("spiffeTrustDomain must be at most " + TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH + " characters");
+            }
+        }
+        if (td.trustsTokenExchange() && td.getIssuer().length() > TrustDomain.ISSUER_MAX_LENGTH) {
+            return Optional.of("issuer must be at most " + TrustDomain.ISSUER_MAX_LENGTH + " characters");
+        }
+        if (!td.trustsTokenExchange()) {
+            if (td.getScopeMappings() != null && !td.getScopeMappings().isEmpty()) {
+                return Optional.of("scopeMappings requires an issuer");
+            }
+            if (td.isUserBindingEnabled()) {
+                return Optional.of("userBindingEnabled requires an issuer");
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> validateUserBinding(TrustDomain td) {
+        if (!td.isUserBindingEnabled()) {
+            return Optional.empty();
+        }
+        List<UserBindingCriterion> criteria = td.getUserBindingCriteria();
+        if (criteria == null || criteria.isEmpty()) {
+            return Optional.of("userBindingCriteria must not be empty when user binding is enabled");
+        }
+        boolean incomplete = criteria.stream().anyMatch(c -> c == null
+                || c.getAttribute() == null || c.getAttribute().isBlank()
+                || c.getExpression() == null || c.getExpression().isBlank());
+        return incomplete
+                ? Optional.of("userBindingCriteria entries must have a non-blank attribute and expression")
+                : Optional.empty();
     }
 
     private Optional<String> validateKeyMaterial(TrustDomainKeyMaterial keyMaterial, KeyRetrievalSettings settings) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewTrustDomain.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewTrustDomain.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service.model;
 
+import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
 import io.gravitee.am.model.oidc.TrustDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
@@ -22,26 +23,21 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
+import java.util.Map;
 
 public class NewTrustDomain {
     private String name;
     private String description;
     private String spiffeTrustDomain;
+    private String issuer;
     private TrustDomainKeyMaterial keyMaterial;
     private SpiffeBundleSource bundleSource;
     private String jwksUrl;
     private Integer refreshIntervalSeconds;
     private List<String> allowedAlgorithms;
-
-    /**
-     * SPIFFE trust domain this authority issues IDs for. Defaults to {@code name} when not supplied,
-     * so a payload written against the API that preceded the matcher keeps its meaning.
-     */
-    @Schema(description = "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID. Defaults to the "
-            + "name when not supplied.")
-    @Size(max = TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH, message = "SPIFFE trust domain must be at most {max} characters")
-    public String getSpiffeTrustDomain() { return spiffeTrustDomain; }
-    public void setSpiffeTrustDomain(String spiffeTrustDomain) { this.spiffeTrustDomain = spiffeTrustDomain; }
+    private Map<String, String> scopeMappings;
+    private boolean userBindingEnabled;
+    private List<UserBindingCriterion> userBindingCriteria;
 
     @Size(max = TrustDomain.NAME_MAX_LENGTH, message = "Name must be at most {max} characters")
     public String getName() { return name; }
@@ -49,6 +45,20 @@ public class NewTrustDomain {
 
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
+
+    /**
+     * SPIFFE trust domain this authority issues IDs for. Defaults to {@code name} when neither matcher
+     * is supplied, so a payload written against the SPIFFE-only API keeps its meaning.
+     */
+    @Schema(description = "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID. Defaults to the "
+            + "name when no matcher is supplied.")
+    @Size(max = TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH, message = "SPIFFE trust domain must be at most {max} characters")
+    public String getSpiffeTrustDomain() { return spiffeTrustDomain; }
+    public void setSpiffeTrustDomain(String spiffeTrustDomain) { this.spiffeTrustDomain = spiffeTrustDomain; }
+
+    @Size(max = TrustDomain.ISSUER_MAX_LENGTH, message = "Issuer must be at most {max} characters")
+    public String getIssuer() { return issuer; }
+    public void setIssuer(String issuer) { this.issuer = issuer; }
 
     public TrustDomainKeyMaterial getKeyMaterial() { return keyMaterial; }
     public void setKeyMaterial(TrustDomainKeyMaterial keyMaterial) { this.keyMaterial = keyMaterial; }
@@ -74,4 +84,13 @@ public class NewTrustDomain {
 
     public List<String> getAllowedAlgorithms() { return allowedAlgorithms; }
     public void setAllowedAlgorithms(List<String> allowedAlgorithms) { this.allowedAlgorithms = allowedAlgorithms; }
+
+    public Map<String, String> getScopeMappings() { return scopeMappings; }
+    public void setScopeMappings(Map<String, String> scopeMappings) { this.scopeMappings = scopeMappings; }
+
+    public boolean isUserBindingEnabled() { return userBindingEnabled; }
+    public void setUserBindingEnabled(boolean userBindingEnabled) { this.userBindingEnabled = userBindingEnabled; }
+
+    public List<UserBindingCriterion> getUserBindingCriteria() { return userBindingCriteria; }
+    public void setUserBindingCriteria(List<UserBindingCriterion> userBindingCriteria) { this.userBindingCriteria = userBindingCriteria; }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateTrustDomain.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateTrustDomain.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.service.model;
 
+import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
 import io.gravitee.am.model.oidc.TrustDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
@@ -22,30 +23,43 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
+import java.util.Map;
 
 public class UpdateTrustDomain {
     private String name;
     private String description;
     private String spiffeTrustDomain;
+    private String issuer;
     private TrustDomainKeyMaterial keyMaterial;
     private SpiffeBundleSource bundleSource;
     private String jwksUrl;
     private Integer refreshIntervalSeconds;
     private List<String> allowedAlgorithms;
+    private Map<String, String> scopeMappings;
+    private Boolean userBindingEnabled;
+    private List<UserBindingCriterion> userBindingCriteria;
 
     @Schema(description = "New label for the trusted domain. Left unchanged when absent.")
     @Size(max = TrustDomain.NAME_MAX_LENGTH, message = "Name must be at most {max} characters")
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
 
-    @Schema(description = "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID. Left unchanged "
-            + "when absent.")
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    /**
+     * SPIFFE trust domain this authority issues IDs for. Declaring either matcher replaces both, so
+     * omitting one clears it; omitting both leaves the trusted domain's usages untouched.
+     */
+    @Schema(description = "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID. Supplying either "
+            + "matcher replaces both; supplying neither leaves them unchanged.")
     @Size(max = TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH, message = "SPIFFE trust domain must be at most {max} characters")
     public String getSpiffeTrustDomain() { return spiffeTrustDomain; }
     public void setSpiffeTrustDomain(String spiffeTrustDomain) { this.spiffeTrustDomain = spiffeTrustDomain; }
 
-    public String getDescription() { return description; }
-    public void setDescription(String description) { this.description = description; }
+    @Size(max = TrustDomain.ISSUER_MAX_LENGTH, message = "Issuer must be at most {max} characters")
+    public String getIssuer() { return issuer; }
+    public void setIssuer(String issuer) { this.issuer = issuer; }
 
     public TrustDomainKeyMaterial getKeyMaterial() { return keyMaterial; }
     public void setKeyMaterial(TrustDomainKeyMaterial keyMaterial) { this.keyMaterial = keyMaterial; }
@@ -71,4 +85,13 @@ public class UpdateTrustDomain {
 
     public List<String> getAllowedAlgorithms() { return allowedAlgorithms; }
     public void setAllowedAlgorithms(List<String> allowedAlgorithms) { this.allowedAlgorithms = allowedAlgorithms; }
+
+    public Map<String, String> getScopeMappings() { return scopeMappings; }
+    public void setScopeMappings(Map<String, String> scopeMappings) { this.scopeMappings = scopeMappings; }
+
+    public Boolean getUserBindingEnabled() { return userBindingEnabled; }
+    public void setUserBindingEnabled(Boolean userBindingEnabled) { this.userBindingEnabled = userBindingEnabled; }
+
+    public List<UserBindingCriterion> getUserBindingCriteria() { return userBindingCriteria; }
+    public void setUserBindingCriteria(List<UserBindingCriterion> userBindingCriteria) { this.userBindingCriteria = userBindingCriteria; }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/TrustDomainServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/TrustDomainServiceImplTest.java
@@ -15,8 +15,15 @@
  */
 package io.gravitee.am.service.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.common.audit.EventType;
+import io.gravitee.am.common.audit.Status;
+import io.gravitee.am.identityprovider.api.DefaultUser;
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.reporter.api.audit.model.Audit;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.jose.RSAKey;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
@@ -31,6 +38,7 @@ import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.exception.InvalidTrustDomainException;
 import io.gravitee.am.service.exception.TrustDomainAlreadyExistsException;
+import io.gravitee.am.service.exception.TrustDomainIssuerAlreadyExistsException;
 import io.gravitee.am.service.exception.TrustDomainNotFoundException;
 import io.gravitee.am.service.exception.TrustDomainSpiffeAlreadyExistsException;
 import io.gravitee.am.service.model.NewTrustDomain;
@@ -48,8 +56,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -116,11 +127,9 @@ public class TrustDomainServiceImplTest {
         domain.setOidc(oidc);
         domain.setKeyRetrievalSettings(keyRetrievalSettings);
 
-        // create() builds the post-validate chain eagerly via andThen(...); the repository
-        // call inside that chain therefore runs even on validation-failure paths. Default
-        // to an empty result so the call doesn't NPE before validate's error propagates.
         lenient().when(repository.findByName(any(), any(), any())).thenReturn(Maybe.empty());
         lenient().when(repository.findBySpiffeTrustDomain(any(), any(), any())).thenReturn(Maybe.empty());
+        lenient().when(repository.findByIssuer(any(), any(), any())).thenReturn(Maybe.empty());
     }
 
     @Test
@@ -219,13 +228,14 @@ public class TrustDomainServiceImplTest {
     }
 
     @Test
-    public void shouldDefaultSpiffeTrustDomainToName_whenNotProvided() {
+    public void shouldDefaultSpiffeTrustDomainToName_whenNoMatcherProvided() {
         NewTrustDomain input = validInput();
         stubRepoForCreate();
 
         service.create(domain, input, null).test()
                 .assertNoErrors()
-                .assertValue(created -> "example.org".equals(created.getSpiffeTrustDomain()));
+                .assertValue(created -> "example.org".equals(created.getSpiffeTrustDomain()))
+                .assertValue(created -> created.getIssuer() == null);
     }
 
     @Test
@@ -242,12 +252,39 @@ public class TrustDomainServiceImplTest {
     }
 
     @Test
+    public void shouldCreateTokenExchangeTrustedDomain_whenSpiffeDisabled() {
+        spiffeSettings.setEnabled(false);
+        stubRepoForCreate();
+        stubNoIssuerConflict();
+
+        service.create(domain, tokenExchangeInput(), null).test()
+                .assertNoErrors()
+                .assertValue(created -> "https://issuer.example.com".equals(created.getIssuer()))
+                .assertValue(created -> created.getSpiffeTrustDomain() == null);
+    }
+
+    @Test
+    public void shouldServeBothUsagesFromOneTrustedDomain() {
+        stubRepoForCreate();
+        stubNoIssuerConflict();
+        NewTrustDomain input = tokenExchangeInput();
+        input.setName("acme-corp");
+        input.setSpiffeTrustDomain("acme.org");
+
+        service.create(domain, input, null).test()
+                .assertNoErrors()
+                .assertValue(created -> "acme.org".equals(created.getSpiffeTrustDomain()))
+                .assertValue(created -> "https://issuer.example.com".equals(created.getIssuer()));
+    }
+
+    @Test
     public void shouldCheckDuplicateNameAcrossEveryTrustedDomain() {
         stubRepoForCreate();
+        stubNoIssuerConflict();
 
-        service.create(domain, validInput(), null).test().assertNoErrors();
+        service.create(domain, tokenExchangeInput(), null).test().assertNoErrors();
 
-        verify(repository).findByName(ReferenceType.DOMAIN, DOMAIN_ID, "example.org");
+        verify(repository).findByName(ReferenceType.DOMAIN, DOMAIN_ID, "issuer.example.com");
     }
 
     @Test
@@ -516,6 +553,22 @@ public class TrustDomainServiceImplTest {
     }
 
     private void stubExistingTrustDomainForUpdate() {
+        stubExistingSpiffeTrustDomain();
+        when(repository.update(any())).thenAnswer(inv -> Single.just(inv.getArgument(0)));
+        when(eventService.create(any(), any())).thenReturn(Single.just(new io.gravitee.am.model.common.event.Event()));
+    }
+
+    private void stubExistingSpiffeTrustDomain() {
+        when(repository.findById("td-1")).thenReturn(Maybe.just(spiffeEntity()));
+    }
+
+    private void stubExistingSpiffeTrustDomainForUpdate() {
+        when(repository.findById("td-1")).thenReturn(Maybe.just(spiffeEntity()));
+        when(repository.update(any())).thenAnswer(inv -> Single.just(inv.getArgument(0)));
+        when(eventService.create(any(), any())).thenReturn(Single.just(new io.gravitee.am.model.common.event.Event()));
+    }
+
+    private static TrustDomain spiffeEntity() {
         TrustDomain existing = new TrustDomain();
         existing.setId("td-1");
         existing.setReferenceType(ReferenceType.DOMAIN);
@@ -527,9 +580,7 @@ public class TrustDomainServiceImplTest {
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://example.com/keys")
                 .build());
-        when(repository.findById("td-1")).thenReturn(Maybe.just(existing));
-        when(repository.update(any())).thenAnswer(inv -> Single.just(inv.getArgument(0)));
-        when(eventService.create(any(), any())).thenReturn(Single.just(new io.gravitee.am.model.common.event.Event()));
+        return existing;
     }
 
     private static JWKSet inlineJwkSet() {
@@ -634,5 +685,310 @@ public class TrustDomainServiceImplTest {
         service.delete(domain, "td-1", null).test().assertNoErrors();
 
         verify(auditService).report(any(TrustDomainAuditBuilder.class));
+    }
+
+    @Test
+    public void shouldCreateTokenExchangeTrustedDomain() {
+        stubRepoForCreate();
+        stubNoIssuerConflict();
+
+        service.create(domain, tokenExchangeInput(), null).test()
+                .assertNoErrors()
+                .assertValue(created -> "https://issuer.example.com".equals(created.getIssuer()));
+    }
+
+    @Test
+    public void shouldRoundTripScopeMappingsAndUserBinding() {
+        stubRepoForCreate();
+        stubNoIssuerConflict();
+        NewTrustDomain input = tokenExchangeInput();
+        input.setUserBindingEnabled(true);
+        input.setUserBindingCriteria(List.of(criterion("emails.value", "{#token['email']}")));
+
+        service.create(domain, input, null).test()
+                .assertNoErrors()
+                .assertValue(created -> Map.of("read", "domain:read").equals(created.getScopeMappings()))
+                .assertValue(created -> created.isUserBindingEnabled())
+                .assertValue(created -> created.getUserBindingCriteria().size() == 1)
+                .assertValue(created -> "emails.value".equals(created.getUserBindingCriteria().get(0).getAttribute()));
+    }
+
+    @Test
+    public void shouldAuditTokenExchangeCreateAgainstThePrincipal() {
+        stubRepoForCreate();
+        stubNoIssuerConflict();
+
+        service.create(domain, tokenExchangeInput(), principal()).test().assertNoErrors();
+
+        verifyAudit(EventType.TRUST_DOMAIN_CREATED);
+    }
+
+    @Test
+    public void shouldAuditTokenExchangeUpdateAgainstThePrincipal() {
+        stubExistingTokenExchangeForUpdate();
+
+        UpdateTrustDomain input = new UpdateTrustDomain();
+        input.setDescription("amended");
+
+        service.update(domain, "td-1", input, principal()).test().assertNoErrors();
+
+        verifyAudit(EventType.TRUST_DOMAIN_UPDATED);
+    }
+
+    @Test
+    public void shouldAllowAlgorithmsOnATokenExchangeTrustedDomain() {
+        stubRepoForCreate();
+        stubNoIssuerConflict();
+        NewTrustDomain input = tokenExchangeInput();
+        input.setAllowedAlgorithms(List.of("RS256"));
+
+        service.create(domain, input, null).test()
+                .assertNoErrors()
+                .assertValue(created -> List.of("RS256").equals(created.getAllowedAlgorithms()));
+    }
+
+    @Test
+    public void shouldRejectTrustedDomainWithoutAnyMatcher() {
+        NewTrustDomain input = tokenExchangeInput();
+        input.setIssuer("  ");
+
+        service.create(domain, input, null).test()
+                .assertError(InvalidTrustDomainException.class)
+                .assertError(err -> err.getMessage().contains("must declare spiffeTrustDomain, issuer, or both"));
+    }
+
+    @Test
+    public void shouldRejectAnIssuerLongerThanTheColumn() {
+        NewTrustDomain input = tokenExchangeInput();
+        input.setIssuer("https://issuer.example.com/" + "a".repeat(TrustDomain.ISSUER_MAX_LENGTH));
+
+        service.create(domain, input, null).test()
+                .assertError(InvalidTrustDomainException.class)
+                .assertError(err -> err.getMessage().contains("issuer must be at most 512 characters"));
+    }
+
+    @Test
+    public void shouldAcceptAnIssuerOnlyTrustedDomainWithoutASpiffeTrustDomain() {
+        NewTrustDomain input = tokenExchangeInput();
+        stubRepoForCreate();
+
+        service.create(domain, input, null).test().assertNoErrors();
+    }
+
+    @Test
+    public void shouldRejectScopeMappingsWithoutAnIssuer() {
+        NewTrustDomain input = validInput();
+        input.setScopeMappings(Map.of("read", "domain:read"));
+
+        service.create(domain, input, null).test()
+                .assertError(InvalidTrustDomainException.class)
+                .assertError(err -> err.getMessage().contains("scopeMappings requires an issuer"));
+    }
+
+    @Test
+    public void shouldRejectUserBindingWithoutAnIssuer() {
+        NewTrustDomain input = validInput();
+        input.setUserBindingEnabled(true);
+
+        service.create(domain, input, null).test()
+                .assertError(InvalidTrustDomainException.class)
+                .assertError(err -> err.getMessage().contains("userBindingEnabled requires an issuer"));
+    }
+
+    @Test
+    public void shouldRejectUserBindingWithoutCriteria() {
+        NewTrustDomain input = tokenExchangeInput();
+        input.setUserBindingEnabled(true);
+
+        service.create(domain, input, null).test()
+                .assertError(InvalidTrustDomainException.class)
+                .assertError(err -> err.getMessage().contains("userBindingCriteria"));
+    }
+
+    @Test
+    public void shouldRejectUserBindingCriterionWithBlankAttribute() {
+        NewTrustDomain input = tokenExchangeInput();
+        input.setUserBindingEnabled(true);
+        input.setUserBindingCriteria(List.of(criterion(" ", "{#token['email']}")));
+
+        service.create(domain, input, null).test()
+                .assertError(InvalidTrustDomainException.class)
+                .assertError(err -> err.getMessage().contains("non-blank attribute and expression"));
+    }
+
+    @Test
+    public void shouldRejectDuplicateIssuerInSameDomain() {
+        when(repository.findByIssuer(ReferenceType.DOMAIN, DOMAIN_ID, "https://issuer.example.com"))
+                .thenReturn(Maybe.just(new TrustDomain()));
+
+        service.create(domain, tokenExchangeInput(), null).test()
+                .assertError(TrustDomainIssuerAlreadyExistsException.class);
+        verify(repository, never()).create(any());
+    }
+
+    @Test
+    public void shouldAuditDuplicateIssuerRejection() {
+        when(repository.findByIssuer(any(), any(), any())).thenReturn(Maybe.just(new TrustDomain()));
+
+        service.create(domain, tokenExchangeInput(), null).test()
+                .assertError(TrustDomainIssuerAlreadyExistsException.class);
+
+        verify(auditService).report(any(TrustDomainAuditBuilder.class));
+    }
+
+    @Test
+    public void shouldNotCheckIssuerUniquenessForSpiffeTrustedDomain() {
+        stubRepoForCreate();
+
+        service.create(domain, validInput(), null).test().assertNoErrors();
+
+        verify(repository, never()).findByIssuer(any(), any(), any());
+    }
+
+    @Test
+    public void shouldUpdateTokenExchangeSettings() {
+        stubExistingTokenExchangeForUpdate();
+        stubNoIssuerConflict();
+
+        UpdateTrustDomain input = new UpdateTrustDomain();
+        input.setIssuer("https://issuer.example.com/v2");
+        input.setScopeMappings(Map.of("write", "domain:write"));
+
+        service.update(domain, "td-1", input, null).test()
+                .assertNoErrors()
+                .assertValue(saved -> "https://issuer.example.com/v2".equals(saved.getIssuer()))
+                .assertValue(saved -> Map.of("write", "domain:write").equals(saved.getScopeMappings()));
+    }
+
+    @Test
+    public void shouldKeepTokenExchangeSettingsWhenUpdateCarriesNone() {
+        stubExistingTokenExchangeForUpdate();
+
+        service.update(domain, "td-1", new UpdateTrustDomain(), null).test()
+                .assertNoErrors()
+                .assertValue(saved -> "https://issuer.example.com".equals(saved.getIssuer()));
+        verify(repository, never()).findByIssuer(any(), any(), any());
+    }
+
+    @Test
+    public void shouldRejectUpdateIntroducingDuplicateIssuer() {
+        stubExistingTokenExchange();
+        TrustDomain other = new TrustDomain();
+        other.setId("td-2");
+        when(repository.findByIssuer(ReferenceType.DOMAIN, DOMAIN_ID, "https://issuer.example.com/v2"))
+                .thenReturn(Maybe.just(other));
+
+        UpdateTrustDomain input = new UpdateTrustDomain();
+        input.setIssuer("https://issuer.example.com/v2");
+
+        service.update(domain, "td-1", input, null).test()
+                .assertError(TrustDomainIssuerAlreadyExistsException.class);
+        verify(repository, never()).update(any());
+    }
+
+    @Test
+    public void shouldAllowUpdateKeepingItsOwnIssuer() {
+        stubExistingTokenExchangeForUpdate();
+
+        UpdateTrustDomain input = new UpdateTrustDomain();
+        input.setIssuer("https://issuer.example.com");
+        input.setScopeMappings(Map.of("write", "domain:write"));
+
+        service.update(domain, "td-1", input, null).test().assertNoErrors();
+        verify(repository, never()).findByIssuer(any(), any(), any());
+    }
+
+    @Test
+    public void shouldAddATokenExchangeBindingToASpiffeTrustedDomain() {
+        stubExistingSpiffeTrustDomainForUpdate();
+        stubNoIssuerConflict();
+
+        UpdateTrustDomain input = new UpdateTrustDomain();
+        input.setSpiffeTrustDomain("example.org");
+        input.setIssuer("https://issuer.example.com");
+
+        service.update(domain, "td-1", input, null).test()
+                .assertNoErrors()
+                .assertValue(saved -> "example.org".equals(saved.getSpiffeTrustDomain()))
+                .assertValue(saved -> "https://issuer.example.com".equals(saved.getIssuer()));
+    }
+
+    @Test
+    public void shouldDeleteTokenExchangeTrustedDomain() {
+        when(repository.findById("td-1")).thenReturn(Maybe.just(tokenExchangeEntity()));
+        when(repository.delete("td-1")).thenReturn(Completable.complete());
+        when(eventService.create(any(), any())).thenReturn(Single.just(new io.gravitee.am.model.common.event.Event()));
+
+        service.delete(domain, "td-1", principal()).test().assertNoErrors();
+
+        verifyAudit(EventType.TRUST_DOMAIN_DELETED);
+    }
+
+    private static User principal() {
+        DefaultUser user = new DefaultUser("admin");
+        user.setId("principal-1");
+        return user;
+    }
+
+    private void verifyAudit(String eventType) {
+        verify(auditService).report(argThat(builder -> {
+            Audit audit = builder.build(new ObjectMapper());
+            assertEquals(ReferenceType.DOMAIN, audit.getReferenceType());
+            assertEquals(DOMAIN_ID, audit.getReferenceId());
+            assertEquals("principal-1", audit.getActor().getId());
+            assertEquals(eventType, audit.getType());
+            assertEquals(Status.SUCCESS, audit.getOutcome().getStatus());
+            return true;
+        }));
+    }
+
+    private NewTrustDomain tokenExchangeInput() {
+        NewTrustDomain input = new NewTrustDomain();
+        input.setName("issuer.example.com");
+        input.setKeyMaterial(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.JWKS_URL)
+                .jwksUrl("https://example.com/issuer/keys")
+                .build());
+        input.setRefreshIntervalSeconds(60);
+        input.setIssuer("https://issuer.example.com");
+        input.setScopeMappings(Map.of("read", "domain:read"));
+        return input;
+    }
+
+    private static TrustDomain tokenExchangeEntity() {
+        TrustDomain td = new TrustDomain();
+        td.setId("td-1");
+        td.setReferenceType(ReferenceType.DOMAIN);
+        td.setReferenceId(DOMAIN_ID);
+        td.setName("issuer.example.com");
+        td.setRefreshIntervalSeconds(60);
+        td.setKeyMaterial(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.JWKS_URL)
+                .jwksUrl("https://example.com/issuer/keys")
+                .build());
+        td.setIssuer("https://issuer.example.com");
+        td.setScopeMappings(Map.of("read", "domain:read"));
+        return td;
+    }
+
+    private void stubExistingTokenExchangeForUpdate() {
+        when(repository.findById("td-1")).thenReturn(Maybe.just(tokenExchangeEntity()));
+        when(repository.update(any())).thenAnswer(inv -> Single.just(inv.getArgument(0)));
+        when(eventService.create(any(), any())).thenReturn(Single.just(new io.gravitee.am.model.common.event.Event()));
+    }
+
+    private void stubExistingTokenExchange() {
+        when(repository.findById("td-1")).thenReturn(Maybe.just(tokenExchangeEntity()));
+    }
+
+    private void stubNoIssuerConflict() {
+        lenient().when(repository.findByIssuer(any(), any(), any())).thenReturn(Maybe.empty());
+    }
+
+    private static UserBindingCriterion criterion(String attribute, String expression) {
+        UserBindingCriterion criterion = new UserBindingCriterion();
+        criterion.setAttribute(attribute);
+        criterion.setExpression(expression);
+        return criterion;
     }
 }

--- a/gravitee-am-test/api/commands/management/service/utils.ts
+++ b/gravitee-am-test/api/commands/management/service/utils.ts
@@ -35,6 +35,7 @@ import { PasswordPolicyApi } from '@management-apis/PasswordPolicyApi';
 import { ExtensionGrantApi } from '@management-apis/ExtensionGrantApi';
 import { BotDetectionApi } from '@management-apis/BotDetectionApi';
 import { ProtectedResourceApi } from '@management-apis/ProtectedResourceApi';
+import { TrustDomainApi } from '@management-apis/TrustDomainApi';
 import { DefaultApi } from '@management-apis/DefaultApi';
 import { AlertsApi } from '@management-apis/AlertsApi';
 import { NotifierApi } from '@management-apis/NotifierApi';
@@ -74,6 +75,10 @@ export function getEntrypointsApi(accessToken) {
 
 export function getProtectedResourcesApi(accessToken) {
   return new ProtectedResourceApi(createAccessTokenConfig(accessToken));
+}
+
+export function getTrustDomainApi(accessToken) {
+  return new TrustDomainApi(createAccessTokenConfig(accessToken));
 }
 
 export function getAuthenticationDeviceNotifierApi(accessToken) {

--- a/gravitee-am-test/api/commands/management/trust-domain-management-commands.ts
+++ b/gravitee-am-test/api/commands/management/trust-domain-management-commands.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getTrustDomainApi } from './service/utils';
+import { NewTrustDomain } from '@management-models/NewTrustDomain';
+import { UpdateTrustDomain } from '@management-models/UpdateTrustDomain';
+import { TrustDomain } from '@management-models/TrustDomain';
+
+export const createTrustDomain = (domainId: string, accessToken: string, body: NewTrustDomain): Promise<TrustDomain> =>
+  getTrustDomainApi(accessToken).createTrustDomain({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    newTrustDomain: body,
+  });
+
+export const updateTrustDomain = (
+  domainId: string,
+  accessToken: string,
+  trustDomainId: string,
+  body: UpdateTrustDomain,
+): Promise<TrustDomain> =>
+  getTrustDomainApi(accessToken).updateTrustDomain({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    trustDomainId: trustDomainId,
+    updateTrustDomain: body,
+  });
+
+export const getTrustDomain = (domainId: string, accessToken: string, trustDomainId: string): Promise<TrustDomain> =>
+  getTrustDomainApi(accessToken).getTrustDomain({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    trustDomainId: trustDomainId,
+  });
+
+export const listTrustDomains = (domainId: string, accessToken: string): Promise<Array<TrustDomain>> =>
+  getTrustDomainApi(accessToken).listTrustDomains({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+  });
+
+export const deleteTrustDomain = (domainId: string, accessToken: string, trustDomainId: string): Promise<void> =>
+  getTrustDomainApi(accessToken).deleteTrustDomain({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    trustDomainId: trustDomainId,
+  });

--- a/gravitee-am-test/api/management/models/NewTrustDomain.ts
+++ b/gravitee-am-test/api/management/models/NewTrustDomain.ts
@@ -26,6 +26,13 @@
 /* tslint:disable */
 /* eslint-disable */
 import { mapValues } from '../runtime';
+import type { UserBindingCriterion } from './UserBindingCriterion';
+import {
+  UserBindingCriterionFromJSON,
+  UserBindingCriterionFromJSONTyped,
+  UserBindingCriterionToJSON,
+  UserBindingCriterionToJSONTyped,
+} from './UserBindingCriterion';
 import type { TrustDomainKeyMaterial } from './TrustDomainKeyMaterial';
 import {
   TrustDomainKeyMaterialFromJSON,
@@ -60,6 +67,12 @@ export interface NewTrustDomain {
    */
   description?: string;
   /**
+   *
+   * @type {string}
+   * @memberof NewTrustDomain
+   */
+  issuer?: string;
+  /**
    * Use keyMaterial.jwksUrl instead.
    * @type {string}
    * @memberof NewTrustDomain
@@ -85,11 +98,29 @@ export interface NewTrustDomain {
    */
   refreshIntervalSeconds?: number;
   /**
-   * SPIFFE trust domain matched against the "sub" of a JWT-SVID. Defaults to the name when not supplied.
+   *
+   * @type {{ [key: string]: string; }}
+   * @memberof NewTrustDomain
+   */
+  scopeMappings?: { [key: string]: string };
+  /**
+   * SPIFFE trust domain matched against the "sub" of a JWT-SVID. Defaults to the name when no matcher is supplied.
    * @type {string}
    * @memberof NewTrustDomain
    */
   spiffeTrustDomain?: string;
+  /**
+   *
+   * @type {Array<UserBindingCriterion>}
+   * @memberof NewTrustDomain
+   */
+  userBindingCriteria?: Array<UserBindingCriterion>;
+  /**
+   *
+   * @type {boolean}
+   * @memberof NewTrustDomain
+   */
+  userBindingEnabled?: boolean;
 }
 
 /**
@@ -120,11 +151,16 @@ export function NewTrustDomainFromJSONTyped(json: any, ignoreDiscriminator: bool
     allowedAlgorithms: json['allowedAlgorithms'] == null ? undefined : json['allowedAlgorithms'],
     bundleSource: json['bundleSource'] == null ? undefined : json['bundleSource'],
     description: json['description'] == null ? undefined : json['description'],
+    issuer: json['issuer'] == null ? undefined : json['issuer'],
     jwksUrl: json['jwksUrl'] == null ? undefined : json['jwksUrl'],
     keyMaterial: json['keyMaterial'] == null ? undefined : TrustDomainKeyMaterialFromJSON(json['keyMaterial']),
     name: json['name'] == null ? undefined : json['name'],
     refreshIntervalSeconds: json['refreshIntervalSeconds'] == null ? undefined : json['refreshIntervalSeconds'],
+    scopeMappings: json['scopeMappings'] == null ? undefined : json['scopeMappings'],
     spiffeTrustDomain: json['spiffeTrustDomain'] == null ? undefined : json['spiffeTrustDomain'],
+    userBindingCriteria:
+      json['userBindingCriteria'] == null ? undefined : (json['userBindingCriteria'] as Array<any>).map(UserBindingCriterionFromJSON),
+    userBindingEnabled: json['userBindingEnabled'] == null ? undefined : json['userBindingEnabled'],
   };
 }
 
@@ -141,10 +177,15 @@ export function NewTrustDomainToJSONTyped(value?: NewTrustDomain | null, ignoreD
     allowedAlgorithms: value['allowedAlgorithms'],
     bundleSource: value['bundleSource'],
     description: value['description'],
+    issuer: value['issuer'],
     jwksUrl: value['jwksUrl'],
     keyMaterial: TrustDomainKeyMaterialToJSON(value['keyMaterial']),
     name: value['name'],
     refreshIntervalSeconds: value['refreshIntervalSeconds'],
+    scopeMappings: value['scopeMappings'],
     spiffeTrustDomain: value['spiffeTrustDomain'],
+    userBindingCriteria:
+      value['userBindingCriteria'] == null ? undefined : (value['userBindingCriteria'] as Array<any>).map(UserBindingCriterionToJSON),
+    userBindingEnabled: value['userBindingEnabled'],
   };
 }

--- a/gravitee-am-test/api/management/models/TrustDomain.ts
+++ b/gravitee-am-test/api/management/models/TrustDomain.ts
@@ -28,6 +28,13 @@
 import { mapValues } from '../runtime';
 import type { JWKSet } from './JWKSet';
 import { JWKSetFromJSON, JWKSetFromJSONTyped, JWKSetToJSON, JWKSetToJSONTyped } from './JWKSet';
+import type { UserBindingCriterion } from './UserBindingCriterion';
+import {
+  UserBindingCriterionFromJSON,
+  UserBindingCriterionFromJSONTyped,
+  UserBindingCriterionToJSON,
+  UserBindingCriterionToJSONTyped,
+} from './UserBindingCriterion';
 import type { TrustDomainKeyMaterial } from './TrustDomainKeyMaterial';
 import {
   TrustDomainKeyMaterialFromJSON,
@@ -74,6 +81,12 @@ export interface TrustDomain {
    */
   id?: string;
   /**
+   * Expected value of the "iss" claim in an external JWT. Required to accept tokens during an RFC 8693 exchange.
+   * @type {string}
+   * @memberof TrustDomain
+   */
+  issuer?: string;
+  /**
    * Use keyMaterial.jwksUrl instead.
    * @type {string}
    * @memberof TrustDomain
@@ -111,6 +124,12 @@ export interface TrustDomain {
    */
   refreshIntervalSeconds?: number;
   /**
+   * One-to-one mapping from external scope to domain scope. Unmapped issuer scopes are dropped (fail-closed). Applies to tokens matched by "issuer".
+   * @type {{ [key: string]: string; }}
+   * @memberof TrustDomain
+   */
+  scopeMappings?: { [key: string]: string };
+  /**
    * SPIFFE trust domain matched against the "sub" of a JWT-SVID, without the "spiffe://" scheme. Required to accept SPIFFE client assertions.
    * @type {string}
    * @memberof TrustDomain
@@ -128,6 +147,18 @@ export interface TrustDomain {
    * @memberof TrustDomain
    */
   updatedAt?: number;
+  /**
+   * Criteria used to locate a domain user when user binding is enabled. All criteria are combined with AND.
+   * @type {Array<UserBindingCriterion>}
+   * @memberof TrustDomain
+   */
+  userBindingCriteria?: Array<UserBindingCriterion>;
+  /**
+   * Whether the external JWT subject is resolved to a single domain user using the user binding criteria. When false, a virtual user is built from the token claims only.
+   * @type {boolean}
+   * @memberof TrustDomain
+   */
+  userBindingEnabled?: boolean;
 }
 
 /**
@@ -173,15 +204,20 @@ export function TrustDomainFromJSONTyped(json: any, ignoreDiscriminator: boolean
     createdAt: json['createdAt'] == null ? undefined : json['createdAt'],
     description: json['description'] == null ? undefined : json['description'],
     id: json['id'] == null ? undefined : json['id'],
+    issuer: json['issuer'] == null ? undefined : json['issuer'],
     jwksUrl: json['jwksUrl'] == null ? undefined : json['jwksUrl'],
     keyMaterial: json['keyMaterial'] == null ? undefined : TrustDomainKeyMaterialFromJSON(json['keyMaterial']),
     name: json['name'] == null ? undefined : json['name'],
     referenceId: json['referenceId'] == null ? undefined : json['referenceId'],
     referenceType: json['referenceType'] == null ? undefined : json['referenceType'],
     refreshIntervalSeconds: json['refreshIntervalSeconds'] == null ? undefined : json['refreshIntervalSeconds'],
+    scopeMappings: json['scopeMappings'] == null ? undefined : json['scopeMappings'],
     spiffeTrustDomain: json['spiffeTrustDomain'] == null ? undefined : json['spiffeTrustDomain'],
     staticJwks: json['staticJwks'] == null ? undefined : JWKSetFromJSON(json['staticJwks']),
     updatedAt: json['updatedAt'] == null ? undefined : json['updatedAt'],
+    userBindingCriteria:
+      json['userBindingCriteria'] == null ? undefined : (json['userBindingCriteria'] as Array<any>).map(UserBindingCriterionFromJSON),
+    userBindingEnabled: json['userBindingEnabled'] == null ? undefined : json['userBindingEnabled'],
   };
 }
 
@@ -200,14 +236,19 @@ export function TrustDomainToJSONTyped(value?: TrustDomain | null, ignoreDiscrim
     createdAt: value['createdAt'],
     description: value['description'],
     id: value['id'],
+    issuer: value['issuer'],
     jwksUrl: value['jwksUrl'],
     keyMaterial: TrustDomainKeyMaterialToJSON(value['keyMaterial']),
     name: value['name'],
     referenceId: value['referenceId'],
     referenceType: value['referenceType'],
     refreshIntervalSeconds: value['refreshIntervalSeconds'],
+    scopeMappings: value['scopeMappings'],
     spiffeTrustDomain: value['spiffeTrustDomain'],
     staticJwks: JWKSetToJSON(value['staticJwks']),
     updatedAt: value['updatedAt'],
+    userBindingCriteria:
+      value['userBindingCriteria'] == null ? undefined : (value['userBindingCriteria'] as Array<any>).map(UserBindingCriterionToJSON),
+    userBindingEnabled: value['userBindingEnabled'],
   };
 }

--- a/gravitee-am-test/api/management/models/UpdateTrustDomain.ts
+++ b/gravitee-am-test/api/management/models/UpdateTrustDomain.ts
@@ -26,6 +26,13 @@
 /* tslint:disable */
 /* eslint-disable */
 import { mapValues } from '../runtime';
+import type { UserBindingCriterion } from './UserBindingCriterion';
+import {
+  UserBindingCriterionFromJSON,
+  UserBindingCriterionFromJSONTyped,
+  UserBindingCriterionToJSON,
+  UserBindingCriterionToJSONTyped,
+} from './UserBindingCriterion';
 import type { TrustDomainKeyMaterial } from './TrustDomainKeyMaterial';
 import {
   TrustDomainKeyMaterialFromJSON,
@@ -60,6 +67,12 @@ export interface UpdateTrustDomain {
    */
   description?: string;
   /**
+   *
+   * @type {string}
+   * @memberof UpdateTrustDomain
+   */
+  issuer?: string;
+  /**
    * Use keyMaterial.jwksUrl instead.
    * @type {string}
    * @memberof UpdateTrustDomain
@@ -85,11 +98,29 @@ export interface UpdateTrustDomain {
    */
   refreshIntervalSeconds?: number;
   /**
-   * SPIFFE trust domain matched against the "sub" of a JWT-SVID. Left unchanged when absent.
+   *
+   * @type {{ [key: string]: string; }}
+   * @memberof UpdateTrustDomain
+   */
+  scopeMappings?: { [key: string]: string };
+  /**
+   * SPIFFE trust domain matched against the "sub" of a JWT-SVID. Supplying either matcher replaces both; supplying neither leaves them unchanged.
    * @type {string}
    * @memberof UpdateTrustDomain
    */
   spiffeTrustDomain?: string;
+  /**
+   *
+   * @type {Array<UserBindingCriterion>}
+   * @memberof UpdateTrustDomain
+   */
+  userBindingCriteria?: Array<UserBindingCriterion>;
+  /**
+   *
+   * @type {boolean}
+   * @memberof UpdateTrustDomain
+   */
+  userBindingEnabled?: boolean;
 }
 
 /**
@@ -120,11 +151,16 @@ export function UpdateTrustDomainFromJSONTyped(json: any, ignoreDiscriminator: b
     allowedAlgorithms: json['allowedAlgorithms'] == null ? undefined : json['allowedAlgorithms'],
     bundleSource: json['bundleSource'] == null ? undefined : json['bundleSource'],
     description: json['description'] == null ? undefined : json['description'],
+    issuer: json['issuer'] == null ? undefined : json['issuer'],
     jwksUrl: json['jwksUrl'] == null ? undefined : json['jwksUrl'],
     keyMaterial: json['keyMaterial'] == null ? undefined : TrustDomainKeyMaterialFromJSON(json['keyMaterial']),
     name: json['name'] == null ? undefined : json['name'],
     refreshIntervalSeconds: json['refreshIntervalSeconds'] == null ? undefined : json['refreshIntervalSeconds'],
+    scopeMappings: json['scopeMappings'] == null ? undefined : json['scopeMappings'],
     spiffeTrustDomain: json['spiffeTrustDomain'] == null ? undefined : json['spiffeTrustDomain'],
+    userBindingCriteria:
+      json['userBindingCriteria'] == null ? undefined : (json['userBindingCriteria'] as Array<any>).map(UserBindingCriterionFromJSON),
+    userBindingEnabled: json['userBindingEnabled'] == null ? undefined : json['userBindingEnabled'],
   };
 }
 
@@ -141,10 +177,15 @@ export function UpdateTrustDomainToJSONTyped(value?: UpdateTrustDomain | null, i
     allowedAlgorithms: value['allowedAlgorithms'],
     bundleSource: value['bundleSource'],
     description: value['description'],
+    issuer: value['issuer'],
     jwksUrl: value['jwksUrl'],
     keyMaterial: TrustDomainKeyMaterialToJSON(value['keyMaterial']),
     name: value['name'],
     refreshIntervalSeconds: value['refreshIntervalSeconds'],
+    scopeMappings: value['scopeMappings'],
     spiffeTrustDomain: value['spiffeTrustDomain'],
+    userBindingCriteria:
+      value['userBindingCriteria'] == null ? undefined : (value['userBindingCriteria'] as Array<any>).map(UserBindingCriterionToJSON),
+    userBindingEnabled: value['userBindingEnabled'],
   };
 }

--- a/gravitee-am-test/api/management/models/index.ts
+++ b/gravitee-am-test/api/management/models/index.ts
@@ -210,7 +210,6 @@ export * from './ProtectedResourceSecret';
 export * from './Reference';
 export * from './RememberDeviceSettings';
 export * from './Reporter';
-export * from './ReporterAttributeMapping';
 export * from './ResetPasswordSettings';
 export * from './Resource';
 export * from './ResourceEntity';

--- a/gravitee-am-test/specs/gateway/blueprint-agents/fixtures/spiffe-prefix-fixture.ts
+++ b/gravitee-am-test/specs/gateway/blueprint-agents/fixtures/spiffe-prefix-fixture.ts
@@ -26,6 +26,8 @@ import {
 } from '@management-commands/domain-management-commands';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { uniqueName } from '@utils-commands/misc';
+import { deleteTrustDomain } from '@management-commands/trust-domain-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
 import { Fixture } from '../../../test-fixture';
 
 const ORG_ID = process.env.AM_DEF_ORG_ID;
@@ -47,6 +49,8 @@ export interface SpiffePrefixFixture extends Fixture {
   prefixSubject: string;
   /** Fetch a JWT-SVID from the local SPIRE agent for the given SPIFFE ID + audience. */
   fetchSvid: (spiffeId: string, audience: string) => string;
+  /** Revokes the trust domain and waits for the gateway to apply the removal. */
+  revokeTrustDomain: () => Promise<void>;
   cleanUp: () => Promise<void>;
 }
 
@@ -96,6 +100,7 @@ export const setupSpiffePrefixFixture = async (): Promise<SpiffePrefixFixture> =
     if (!trustDomainResp.ok) {
       throw new Error(`Failed to register trust domain: ${trustDomainResp.status} ${await trustDomainResp.text()}`);
     }
+    const trustDomainId = (await trustDomainResp.json()).id;
 
     // 3. Create the blueprint agent application.
     const createAppResp = await fetch(managementUrl(`/domains/${domain.id}/applications`), {
@@ -146,6 +151,7 @@ export const setupSpiffePrefixFixture = async (): Promise<SpiffePrefixFixture> =
       blueprintAppId: blueprintApp.id,
       prefixSubject,
       fetchSvid: (spiffeId, audience) => fetchSvidFromSpireAgent(spiffeId, audience),
+      revokeTrustDomain: () => waitForSyncAfter(domain.id, () => deleteTrustDomain(domain.id, accessToken, trustDomainId)),
       cleanUp: async () => {
         if (domain?.id && accessToken) {
           await safeDeleteDomain(domain.id, accessToken);

--- a/gravitee-am-test/specs/gateway/blueprint-agents/spiffe-prefix-assertion.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/blueprint-agents/spiffe-prefix-assertion.jest.spec.ts
@@ -24,6 +24,11 @@ setup(120000);
 const JWT_SPIFFE_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-spiffe';
 const JWT_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
+// Bootstrapped by SPIRE under the fixture's PREFIX (spiffe://am.local/agent/test/).
+const IN_PREFIX_INSTANCE = 'spiffe://am.local/agent/test/sample';
+// Provisioned but outside that prefix — the negative case.
+const OUT_OF_PREFIX_INSTANCE = 'spiffe://am.local/agent/billing';
+
 /**
  * GMA-329 — SPIFFE per-instance agent identity.
  *
@@ -53,40 +58,47 @@ describeIfSpire('Blueprint Agent — SPIFFE PREFIX subject matching', () => {
     await fixture?.cleanUp();
   });
 
-  function postClientAssertion(assertion: string) {
+  function postClientAssertion(agent: SpiffePrefixFixture, instanceId: string) {
+    const assertion = agent.fetchSvid(instanceId, agent.oidc.token_endpoint);
     // Pin the client_id to our blueprint so client lookup resolves to it; otherwise
     // the validator falls back to looking the client up by the SVID's `sub`, which
     // would mask the PREFIX-mismatch path in the negative case below.
     const body =
       `grant_type=client_credentials` +
-      `&client_id=${encodeURIComponent(fixture.clientId)}` +
+      `&client_id=${encodeURIComponent(agent.clientId)}` +
       `&client_assertion_type=${encodeURIComponent(JWT_SPIFFE_ASSERTION_TYPE)}` +
       `&client_assertion=${encodeURIComponent(assertion)}`;
-    return performPost(fixture.oidc.token_endpoint, '', body, {
+    return performPost(agent.oidc.token_endpoint, '', body, {
       'Content-type': 'application/x-www-form-urlencoded',
     });
   }
 
   it('mints a per-instance token when the SVID is under the configured subject prefix', async () => {
-    const instanceId = 'spiffe://am.local/agent/test/sample';
-    const svid = fixture.fetchSvid(instanceId, fixture.oidc.token_endpoint);
-
-    const response = await postClientAssertion(svid).expect(200);
+    const response = await postClientAssertion(fixture, IN_PREFIX_INSTANCE).expect(200);
 
     expect(response.body.access_token).toMatch(JWT_FORMAT);
     expect(response.body.token_type).toEqual('bearer');
 
     const decoded = decodeJwt(response.body.access_token);
-    expect(decoded.sub).toEqual(instanceId);
+    expect(decoded.sub).toEqual(IN_PREFIX_INSTANCE);
     expect(decoded.act).toBeDefined();
     expect((decoded.act as any).sub).toEqual(fixture.clientId);
   });
 
   it('rejects SVIDs whose sub falls outside the configured subject prefix', async () => {
-    // Provisioned but unrelated to fixture.prefixSubject (spiffe://am.local/agent/test/).
-    const outOfPrefix = 'spiffe://am.local/agent/billing';
-    const svid = fixture.fetchSvid(outOfPrefix, fixture.oidc.token_endpoint);
+    await postClientAssertion(fixture, OUT_OF_PREFIX_INSTANCE).expect(401);
+  });
 
-    await postClientAssertion(svid).expect(401);
+  it('stops accepting SVIDs once the trust domain is revoked', async () => {
+    const revocable = await setupSpiffePrefixFixture();
+    try {
+      await postClientAssertion(revocable, IN_PREFIX_INSTANCE).expect(200);
+
+      await revocable.revokeTrustDomain();
+
+      await postClientAssertion(revocable, IN_PREFIX_INSTANCE).expect(401);
+    } finally {
+      await revocable.cleanUp();
+    }
   });
 });

--- a/gravitee-am-test/specs/gateway/trusted-domains/fixtures/trusted-domain-sync-fixture.ts
+++ b/gravitee-am-test/specs/gateway/trusted-domains/fixtures/trusted-domain-sync-fixture.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { patchDomain, safeDeleteDomain, setupDomainForTest } from '@management-commands/domain-management-commands';
+import { Domain } from '@management-models/Domain';
+import { TrustDomain } from '@management-models/TrustDomain';
+import { uniqueName } from '@utils-commands/misc';
+import { createTrustDomain, deleteTrustDomain, updateTrustDomain } from '@management-commands/trust-domain-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { Fixture } from '../../../test-fixture';
+
+export const TRUSTED_DOMAIN_SYNC_TEST = {
+  DOMAIN_NAME_PREFIX: 'trusted-domain-sync',
+  SPIFFE_JWKS_URL: 'https://spire.example.com/keys',
+  SPIFFE_AMENDED_JWKS_URL: 'https://spire.example.com/rotated-keys',
+  TOKEN_EXCHANGE_JWKS_URL: 'https://issuer.example.com/.well-known/jwks.json',
+  BOTH_JWKS_URL: 'https://sso.acme.com/.well-known/jwks.json',
+  AMENDED_REFRESH_INTERVAL_SECONDS: 600,
+} as const;
+
+const distinctLabel = (prefix: string) => uniqueName(prefix, true).toLowerCase();
+
+/** Body of a trusted domain matching SPIFFE only, named so it collides with no other test's. */
+export const spiffeTrustDomainBody = () => {
+  const label = distinctLabel('spiffe-sync');
+  return {
+    name: label,
+    spiffeTrustDomain: `${label}.local`,
+    keyMaterial: { source: 'JWKS_URL', jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.SPIFFE_JWKS_URL },
+  };
+};
+
+/** Body of a trusted domain vouching for an issuer only, named so it collides with no other test's. */
+export const issuerTrustDomainBody = () => {
+  const label = distinctLabel('issuer-sync');
+  return {
+    name: label,
+    issuer: `https://${label}.example.com`,
+    keyMaterial: { source: 'JWKS_URL', jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.TOKEN_EXCHANGE_JWKS_URL },
+  };
+};
+
+/** Body of a trusted domain serving both usages over the same key material. */
+export const bothUsagesTrustDomainBody = () => {
+  const label = distinctLabel('both-sync');
+  return {
+    name: label,
+    spiffeTrustDomain: `${label}.local`,
+    issuer: `https://${label}.example.com`,
+    keyMaterial: { source: 'JWKS_URL', jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.BOTH_JWKS_URL },
+  };
+};
+
+export interface TrustedDomainSyncFixture extends Fixture {
+  domain: Domain;
+  accessToken: string;
+  /** Registers a trusted domain and waits for the gateway to apply the change. */
+  registerAndSync: (body: object) => Promise<TrustDomain>;
+  /** Amends a trusted domain and waits for the gateway to apply the change. */
+  amendAndSync: (trustDomainId: string, body: object) => Promise<TrustDomain>;
+  /** Removes a trusted domain and waits for the gateway to apply the change. */
+  removeAndSync: (trustDomainId: string) => Promise<void>;
+}
+
+export const setupTrustedDomainSyncFixture = async (): Promise<TrustedDomainSyncFixture> => {
+  let domain: Domain | null = null;
+  let accessToken: string | null = null;
+
+  try {
+    accessToken = await requestAdminAccessToken();
+    const domainResult = await setupDomainForTest(uniqueName(TRUSTED_DOMAIN_SYNC_TEST.DOMAIN_NAME_PREFIX, true), {
+      accessToken,
+      waitForStart: true,
+    });
+    domain = domainResult.domain;
+
+    await patchDomain(domain.id, accessToken, {
+      oidc: {
+        workloadIdentitySettings: { enabled: true },
+      },
+      keyRetrievalSettings: { allowPrivateIpAddress: true, allowUnsecuredHttpUri: true },
+    });
+
+    const token = accessToken;
+    const domainId = domain.id;
+
+    return {
+      domain,
+      accessToken,
+      registerAndSync: (body) => waitForSyncAfter(domainId, () => createTrustDomain(domainId, token, body)),
+      amendAndSync: (trustDomainId, body) => waitForSyncAfter(domainId, () => updateTrustDomain(domainId, token, trustDomainId, body)),
+      removeAndSync: (trustDomainId) => waitForSyncAfter(domainId, () => deleteTrustDomain(domainId, token, trustDomainId)),
+      cleanUp: async () => {
+        await safeDeleteDomain(domainId, token);
+      },
+    };
+  } catch (error) {
+    if (domain?.id && accessToken) {
+      try {
+        await safeDeleteDomain(domain.id, accessToken);
+      } catch (cleanupError) {
+        console.error('Failed to cleanup after setup failure:', cleanupError);
+      }
+    }
+    throw error;
+  }
+};

--- a/gravitee-am-test/specs/gateway/trusted-domains/trusted-domain-sync.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/trusted-domains/trusted-domain-sync.jest.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { listTrustDomains } from '@management-commands/trust-domain-management-commands';
+import { getDomainState } from '@gateway-commands/monitoring-commands';
+import { setup } from '../../test-fixture';
+import {
+  bothUsagesTrustDomainBody,
+  issuerTrustDomainBody,
+  setupTrustedDomainSyncFixture,
+  spiffeTrustDomainBody,
+  TRUSTED_DOMAIN_SYNC_TEST,
+  TrustedDomainSyncFixture,
+} from './fixtures/trusted-domain-sync-fixture';
+
+setup(120000);
+
+let fixture: TrustedDomainSyncFixture;
+
+beforeAll(async () => {
+  fixture = await setupTrustedDomainSyncFixture();
+});
+
+afterAll(async () => {
+  await fixture?.cleanUp();
+});
+
+describe('Trusted domain changes reach the gateway', () => {
+  it('should synchronise the gateway when a SPIFFE trusted domain is registered', async () => {
+    const body = spiffeTrustDomainBody();
+
+    const created = await fixture.registerAndSync(body);
+
+    expect(created.name).toEqual(body.name);
+    expect(created.spiffeTrustDomain).toEqual(body.spiffeTrustDomain);
+  });
+
+  it('should synchronise the gateway when a trusted-issuer trusted domain is registered', async () => {
+    const body = issuerTrustDomainBody();
+
+    const created = await fixture.registerAndSync(body);
+
+    expect(created.issuer).toEqual(body.issuer);
+  });
+
+  it('should synchronise the gateway when one trusted domain serves both usages', async () => {
+    const body = bothUsagesTrustDomainBody();
+
+    const created = await fixture.registerAndSync(body);
+
+    expect(created.spiffeTrustDomain).toEqual(body.spiffeTrustDomain);
+    expect(created.issuer).toEqual(body.issuer);
+  });
+
+  it('should synchronise the gateway when a trusted domain is amended', async () => {
+    const registered = await fixture.registerAndSync(spiffeTrustDomainBody());
+
+    const amended = await fixture.amendAndSync(registered.id, {
+      keyMaterial: { source: 'JWKS_URL', jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.SPIFFE_AMENDED_JWKS_URL },
+      refreshIntervalSeconds: TRUSTED_DOMAIN_SYNC_TEST.AMENDED_REFRESH_INTERVAL_SECONDS,
+    });
+
+    expect(amended.keyMaterial.jwksUrl).toEqual(TRUSTED_DOMAIN_SYNC_TEST.SPIFFE_AMENDED_JWKS_URL);
+    expect(amended.refreshIntervalSeconds).toEqual(TRUSTED_DOMAIN_SYNC_TEST.AMENDED_REFRESH_INTERVAL_SECONDS);
+  });
+
+  it('should synchronise the gateway when a trusted domain is removed', async () => {
+    const kept = await fixture.registerAndSync(spiffeTrustDomainBody());
+    const removed = await fixture.registerAndSync(issuerTrustDomainBody());
+
+    await fixture.removeAndSync(removed.id);
+
+    const remaining = (await listTrustDomains(fixture.domain.id, fixture.accessToken)).map((trustDomain) => trustDomain.id);
+    expect(remaining).toContain(kept.id);
+    expect(remaining).not.toContain(removed.id);
+  });
+
+  it('should report the domain as stable and synchronised once a change has been applied', async () => {
+    await fixture.registerAndSync(spiffeTrustDomainBody());
+
+    const state = await getDomainState(fixture.domain.id);
+
+    expect(state.stable).toBe(true);
+    expect(state.synchronized).toBe(true);
+  });
+});


### PR DESCRIPTION
A trusted domain gains a second matcher alongside the SPIFFE one: the issuer it
vouches for, matched against the "iss" claim of an external token during an RFC
8693 exchange. It sits flat beside spiffeTrustDomain rather than in a block of
its own, together with the scope mappings and user binding that govern what an
accepted token becomes. A trusted domain must declare at least one matcher, and
declaring both lets one authority serve both usages over the same key material —
there is no kind to choose between them. Scope mappings and user binding are the
only settings tied to a usage: they need an issuer, because nothing else
consumes them.

Trusted domains are created, read, listed, amended and removed through the
trusted-domains API under the trusted-domain permission, each with its own audit
record.

An issuer is vouched for by at most one trusted domain per security domain. The
service rejects a duplicate before writing, and every backend carries the
constraint: a partial unique index on MongoDB, since a sparse one would admit
every issuerless SPIFFE document and collide; a plain unique index on
PostgreSQL, MySQL and MariaDB, which treat nulls as distinct; and a filtered one
on SQL Server, which does not. The issuer column is bounded at 512 characters so
the index key stays inside InnoDB's 3072-byte limit at utf8mb4.

Registering, amending or removing a trusted domain now takes effect at the
gateway promptly and without restarting the security domain's reactor, and
validating a SPIFFE client assertion no longer costs a database round trip. The
gateway's event-type resolution had no case for TRUST_DOMAIN, so every
trust-domain event the management API published resolved to no type and was
silently discarded; the gateway compensated by reading from the database on
every token request. A trusted-domain event and its resolution case close that
gap.

A trusted-domain manager holds all of a security domain's trusted domains in
memory, following the established manager pattern rather than a lazy cache:
trusted domains are bounded configuration, so full residency is cheap and the
database leaves the token request path. It keeps one lookup per matcher — by
SPIFFE trust domain and by issuer — so a trusted domain declaring both is
reachable through either, and one declaring a single matcher is simply absent
from the other lookup. Amending re-indexes under the new matchers and evicts
cached key material, so a corrected JWKS URL takes effect promptly; removal
takes effect immediately rather than after a cache lifetime.

Readiness is reported per trusted domain, plus one marker registered before the
preload starts, so a security domain reports as synchronised only once its
trusted domains are loaded rather than while the load is still in flight. A load
failure is reported as an initialisation failure and leaves the domain unstable
rather than passing silently. Removal now advances the domain's last-sync
timestamp as a load does: the readiness service could only report a plugin
unloaded, which drops it from matching without recording that anything happened,
so a deletion was invisible to the sync barrier integration tests wait on.
Every applied change is therefore waitable, and the tests wait on it instead of
polling for side effects. An event referencing an entity that no longer exists
drops it from residency; one belonging to another security domain, or to another
reference type, is ignored.

On upgrade, every trusted issuer declared inside a security domain's
token-exchange settings gains a trusted domain of its own, carrying its issuer,
key material, scope mappings and user-binding configuration. Migrated entities
are named from the slugified full issuer URL, so the same configuration migrates
to the same names in every environment and two issuers sharing a host but
differing in path stay distinct. Where two issuers would slugify alike, both —
never just the one declared second — carry a digest of their issuer, keeping the
outcome free of declaration order; a derived name an existing trusted domain
already holds is disambiguated the same way rather than dropped, since a skipped
issuer would silently stop being trusted at cutover. Entities are written
straight to the repository rather than through TrustDomainService, because that
service applies the SSRF guard the inline shape never had, so an issuer
resolving to a private address — legal when it was configured — would fail the
upgrade instead of migrating. The migration creates rows under a unique index,
so it runs behind a system task like the password-policy migration rather than
the plain async upgrader: two management-api instances booting together would
otherwise race. Re-running neither duplicates nor overwrites.

The inline declarations are deliberately left in place and stay authoritative;
nothing reads the new entities for token exchange yet, so both the entities and
the migration can be proven before anything depends on them. The token-exchange
path still reads its inline trusted issuers; moving it onto the manager is the
cutover that follows.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>