### PR TITLE
feat: trusted domains become the only source of trust (AM-7372)

### DIFF
--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -2606,13 +2606,17 @@ components:
           $ref: "#/components/schemas/TokenExchangeOAuthSettings"
         trustedIssuers:
           type: array
-          description: "External issuers whose JWTs may be accepted as subject or\
-            \ actor tokens. When unset, only domain-issued tokens are accepted."
+          deprecated: true
+          description: "Deprecated: use the trusted-domains API instead. External\
+            \ issuers whose JWTs may be accepted as subject or actor tokens. A projection\
+            \ over the security domain's token-exchange trusted domains; a write replaces\
+            \ the list, so an omitted issuer is no longer trusted."
           items:
             $ref: "#/components/schemas/TrustedIssuer"
       title: Token exchange settings
     TrustedIssuer:
       type: object
+      deprecated: true
       description: "An external token issuer whose JWTs are accepted as subject or\
         \ actor tokens during token exchange, validated with the configured key material."
       properties:

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -18306,8 +18306,11 @@ components:
           $ref: "#/components/schemas/TokenExchangeOAuthSettings"
         trustedIssuers:
           type: array
-          description: "External issuers whose JWTs may be accepted as subject or\
-            \ actor tokens. When unset, only domain-issued tokens are accepted."
+          deprecated: true
+          description: "Deprecated: use the trusted-domains API instead. External\
+            \ issuers whose JWTs may be accepted as subject or actor tokens. A projection\
+            \ over the security domain's token-exchange trusted domains; a write replaces\
+            \ the list, so an omitted issuer is no longer trusted."
           items:
             $ref: "#/components/schemas/TrustedIssuer"
       title: Token exchange settings
@@ -18421,6 +18424,7 @@ components:
       title: Trusted domain key material
     TrustedIssuer:
       type: object
+      deprecated: true
       description: "An external token issuer whose JWTs are accepted as subject or\
         \ actor tokens during token exchange, validated with the configured key material."
       properties:

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidator.java
@@ -128,7 +128,7 @@ public class SpiffeClientAssertionValidator implements ClientAssertionValidator 
                         return Maybe.error(new InvalidClientException("Client missing SPIFFE settings"));
                     }
                     return Maybe.fromOptional(trustDomainManager.findBySpiffeTrustDomain(spiffe.getTrustDomain()))
-                            .switchIfEmpty(Maybe.error(new InvalidClientException("Trust domain not registered")))
+                            .switchIfEmpty(Maybe.error(() -> new InvalidClientException("Trust domain not registered")))
                             .flatMap(td -> {
                                 String fail = new SpiffeJwtSvidValidator(settings)
                                         .validate(signedJWT, td, spiffe, tokenEndpoint);

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/TrustedIssuerResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/TrustedIssuerResolver.java
@@ -16,7 +16,7 @@
 package io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange;
 
 import com.nimbusds.jwt.JWTClaimsSet;
-import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.TrustDomain;
 import io.reactivex.rxjava3.core.Single;
 
 /**
@@ -27,14 +27,14 @@ import io.reactivex.rxjava3.core.Single;
 public interface TrustedIssuerResolver {
 
     /**
-     * Resolve the issuer's key material and verify the JWT signature.
+     * Resolve the trusted domain's key material and verify the JWT signature.
      *
      * @param rawToken the raw JWT string
-     * @param trustedIssuer the trusted issuer configuration
+     * @param trustedDomain the token-exchange trusted domain vouching for the token's issuer
      * @return the verified JWT claims set; the returned Single fails with a SecurityException when
-     *         the token cannot be verified against the issuer's keys, and with an unchecked
-     *         exception when the issuer's key material is unusable or its JWKS URL is refused by
-     *         the security domain's retrieval policy
+     *         the token cannot be verified against the trusted domain's keys, and with an unchecked
+     *         exception when its key material is unusable or its JWKS URL is refused by the
+     *         security domain's retrieval policy
      */
-    Single<JWTClaimsSet> resolve(String rawToken, TrustedIssuer trustedIssuer);
+    Single<JWTClaimsSet> resolve(String rawToken, TrustDomain trustedDomain);
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/ValidatedToken.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/ValidatedToken.java
@@ -15,8 +15,9 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange;
 
-import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.TrustDomain;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Singular;
 
@@ -33,6 +34,7 @@ import java.util.*;
  */
 @Builder
 @Getter
+@EqualsAndHashCode
 public class ValidatedToken {
 
     /**
@@ -98,17 +100,18 @@ public class ValidatedToken {
     private final Set<String> domainParentJtis;
 
     /**
-     * The trusted issuer config used to validate this token when it was validated via an external issuer.
-     * Null when validated with the domain certificate. Used for scope mapping and user binding (EL context and criteria).
+     * The token-exchange trusted domain used to validate this token when it was validated via an
+     * external issuer. Null when validated with the domain certificate. Used for scope mapping and
+     * user binding (EL context and criteria).
      */
-    private final TrustedIssuer trustedIssuer;
+    private final TrustDomain trustedDomain;
 
     /**
      * Whether this token was validated via a trusted external issuer (not the domain certificate).
-     * Derived from {@link #trustedIssuer} for convenience.
+     * Derived from {@link #trustedDomain} for convenience.
      */
     public boolean isTrustedIssuerValidated() {
-        return trustedIssuer != null;
+        return trustedDomain != null;
     }
 
     /**
@@ -135,20 +138,8 @@ public class ValidatedToken {
                 .clientId(clientId)
                 .tokenType(tokenType)
                 .domain(domain)
-                .trustedIssuer(trustedIssuer)
+                .trustedDomain(trustedDomain)
                 .domainParentJtis(parentJtis)
                 .build();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
-        ValidatedToken that = (ValidatedToken) o;
-        return Objects.equals(subject, that.subject) && Objects.equals(issuer, that.issuer) && Objects.equals(claims, that.claims) && Objects.equals(scopes, that.scopes) && Objects.equals(expiration, that.expiration) && Objects.equals(issuedAt, that.issuedAt) && Objects.equals(notBefore, that.notBefore) && Objects.equals(tokenId, that.tokenId) && Objects.equals(audience, that.audience) && Objects.equals(clientId, that.clientId) && Objects.equals(tokenType, that.tokenType) && Objects.equals(domain, that.domain) && Objects.equals(domainParentJtis, that.domainParentJtis) && Objects.equals(trustedIssuer, that.trustedIssuer);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(subject, issuer, claims, scopes, expiration, issuedAt, notBefore, tokenId, audience, clientId, tokenType, domain, domainParentJtis, trustedIssuer);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenValidationUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenValidationUtils.java
@@ -19,7 +19,7 @@ import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.TrustDomain;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -74,7 +74,7 @@ final class TokenValidationUtils {
                                                long exp, long iat, long nbf,
                                                Set<String> scopes, List<String> audience,
                                                String tokenType, Domain domain,
-                                               TrustedIssuer trustedIssuer) {
+                                               TrustDomain trustedDomain) {
         return ValidatedToken.builder()
                 .subject(Objects.toString(claims.get(Claims.SUB), null))
                 .issuer(Objects.toString(claims.get(Claims.ISS), null))
@@ -89,7 +89,7 @@ final class TokenValidationUtils {
                 .tokenType(tokenType)
                 .domain(domain.getId())
                 .domain(Objects.toString(claims.get(Claims.DOMAIN), null))
-                .trustedIssuer(trustedIssuer)
+                .trustedDomain(trustedDomain)
                 .domainParentJtis(Set.of())
                 .build();
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerResolverImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerResolverImpl.java
@@ -21,13 +21,9 @@ import com.nimbusds.jwt.SignedJWT;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TrustedIssuerResolver;
 import io.gravitee.am.gateway.handler.oidc.service.jws.JWSService;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
-import io.gravitee.am.model.KeyResolutionMethod;
-import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.jose.JWK;
 import io.gravitee.am.model.oidc.JWKSet;
-import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.oidc.TrustDomain;
-import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 
@@ -53,12 +49,6 @@ public class TrustedIssuerResolverImpl implements TrustedIssuerResolver {
 
     private static final String SIGNATURE_USE = "sig";
 
-    /**
-     * Namespaces the cache key so an inline trusted issuer cannot collide with a stored trusted
-     * domain. Transitional: trusted issuers become trusted-domain entities of their own later.
-     */
-    private static final String CACHE_KEY_PREFIX = "trusted-issuer:";
-
     private final TrustDomainKeyService trustDomainKeyService;
     private final JWSService jwsService;
 
@@ -68,39 +58,33 @@ public class TrustedIssuerResolverImpl implements TrustedIssuerResolver {
     }
 
     @Override
-    public Single<JWTClaimsSet> resolve(String rawToken, TrustedIssuer trustedIssuer) {
+    public Single<JWTClaimsSet> resolve(String rawToken, TrustDomain trustedDomain) {
         final SignedJWT signedJWT;
         try {
             signedJWT = SignedJWT.parse(rawToken);
         } catch (ParseException e) {
-            return Single.error(malformed(trustedIssuer));
+            return Single.error(malformed(trustedDomain));
         }
         JWSAlgorithm algorithm = signedJWT.getHeader().getAlgorithm();
         if (!SUPPORTED_ALGORITHMS.contains(algorithm)) {
             return Single.error(new SecurityException(
-                    "Unsupported signature algorithm " + algorithm + " for trusted issuer: " + trustedIssuer.getIssuer()));
+                    "Unsupported signature algorithm " + algorithm + " for trusted issuer: " + trustedDomain.getIssuer()));
         }
-        final TrustDomain trustDomain;
-        try {
-            trustDomain = asTrustDomain(trustedIssuer);
-        } catch (IllegalArgumentException e) {
-            return Single.error(e);
-        }
-        return verify(signedJWT, trustDomain, trustedIssuer);
+        return verify(signedJWT, trustedDomain);
     }
 
-    private Single<JWTClaimsSet> verify(SignedJWT signedJWT, TrustDomain trustDomain, TrustedIssuer trustedIssuer) {
+    private Single<JWTClaimsSet> verify(SignedJWT signedJWT, TrustDomain trustedDomain) {
         String kid = signedJWT.getHeader().getKeyID();
         Maybe<Boolean> verified = kid == null || kid.isBlank()
-                ? trustDomainKeyService.getKeys(trustDomain).map(jwks -> anyKeyVerifies(signedJWT, jwks))
-                : trustDomainKeyService.getKey(trustDomain, kid).map(jwk -> isValidSignature(signedJWT, jwk));
+                ? trustDomainKeyService.getKeys(trustedDomain).map(jwks -> anyKeyVerifies(signedJWT, jwks))
+                : trustDomainKeyService.getKey(trustedDomain, kid).map(jwk -> isValidSignature(signedJWT, jwk));
         return verified
                 .switchIfEmpty(Single.error(() -> new SecurityException(
-                        "No signing key available for trusted issuer: " + trustedIssuer.getIssuer())))
+                        "No signing key available for trusted issuer: " + trustedDomain.getIssuer())))
                 .flatMap(valid -> valid
-                        ? claimsOf(signedJWT, trustedIssuer)
+                        ? claimsOf(signedJWT, trustedDomain)
                         : Single.error(new SecurityException(
-                                "JWT signature verification failed for trusted issuer: " + trustedIssuer.getIssuer())));
+                                "JWT signature verification failed for trusted issuer: " + trustedDomain.getIssuer())));
     }
 
     private boolean anyKeyVerifies(SignedJWT signedJWT, JWKSet jwks) {
@@ -122,37 +106,15 @@ public class TrustedIssuerResolverImpl implements TrustedIssuerResolver {
         }
     }
 
-    private static Single<JWTClaimsSet> claimsOf(SignedJWT signedJWT, TrustedIssuer trustedIssuer) {
+    private static Single<JWTClaimsSet> claimsOf(SignedJWT signedJWT, TrustDomain trustedDomain) {
         try {
             return Single.just(signedJWT.getJWTClaimsSet());
         } catch (ParseException e) {
-            return Single.error(malformed(trustedIssuer));
+            return Single.error(malformed(trustedDomain));
         }
     }
 
-    private static SecurityException malformed(TrustedIssuer trustedIssuer) {
-        return new SecurityException("Malformed JWT from trusted issuer: " + trustedIssuer.getIssuer());
-    }
-
-    private static TrustDomain asTrustDomain(TrustedIssuer trustedIssuer) {
-        KeyResolutionMethod method = trustedIssuer.getKeyResolutionMethod();
-        if (method == null) {
-            throw new IllegalArgumentException("Unsupported key resolution method: null");
-        }
-        TrustDomainKeyMaterial keyMaterial = switch (method) {
-            case JWKS_URL -> TrustDomainKeyMaterial.builder()
-                    .source(KeyMaterialSource.JWKS_URL)
-                    .jwksUrl(trustedIssuer.getJwksUri())
-                    .build();
-            case PEM -> TrustDomainKeyMaterial.builder()
-                    .source(KeyMaterialSource.PEM)
-                    .certificate(trustedIssuer.getCertificate())
-                    .build();
-        };
-        return TrustDomain.builder()
-                .id(CACHE_KEY_PREFIX + trustedIssuer.getIssuer())
-                .name(trustedIssuer.getIssuer())
-                .keyMaterial(keyMaterial)
-                .build();
+    private static SecurityException malformed(TrustDomain trustedDomain) {
+        return new SecurityException("Malformed JWT from trusted issuer: " + trustedDomain.getIssuer());
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidator.java
@@ -23,10 +23,11 @@ import io.gravitee.am.gateway.handler.oauth2.exception.TokenVerificationExceptio
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenValidator;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TrustedIssuerResolver;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.TokenExchangeSettings;
-import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.model.oidc.TrustDomain;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
@@ -34,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
@@ -57,17 +59,20 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
 
     private final TokenValidator delegate;
     private final TrustedIssuerResolver trustedIssuerResolver;
+    private final TrustDomainManager trustDomainManager;
     private final JWTService jwtService;
     private final JWTService.TokenType jwtTokenType;
     private final String supportedTokenType;
 
     public TrustedIssuerTokenValidator(TokenValidator delegate,
                                        TrustedIssuerResolver trustedIssuerResolver,
+                                       TrustDomainManager trustDomainManager,
                                        JWTService jwtService,
                                        JWTService.TokenType jwtTokenType,
                                        String supportedTokenType) {
         this.delegate = delegate;
         this.trustedIssuerResolver = trustedIssuerResolver;
+        this.trustDomainManager = trustDomainManager;
         this.jwtService = jwtService;
         this.jwtTokenType = jwtTokenType;
         this.supportedTokenType = supportedTokenType;
@@ -82,16 +87,16 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
     public Single<ValidatedToken> validate(String token, TokenExchangeSettings settings, Domain domain, Client client) {
         return delegate.validate(token, settings, domain, client)
                 .onErrorResumeNext(error -> {
-                    if (error instanceof TokenVerificationException && hasTrustedIssuers(settings)) {
+                    if (error instanceof TokenVerificationException && trustDomainManager.hasTokenExchangeTrust()) {
                         log.debug("Domain cert validation failed, trying trusted issuers: {}",
                                 error.getMessage());
-                        return validateWithTrustedIssuer(token, settings, domain);
+                        return validateWithTrustedIssuer(token, domain);
                     }
                     return Single.error(error);
                 });
     }
 
-    private Single<ValidatedToken> validateWithTrustedIssuer(String token, TokenExchangeSettings settings, Domain domain) {
+    private Single<ValidatedToken> validateWithTrustedIssuer(String token, Domain domain) {
         return jwtService.decode(token, jwtTokenType)
                 .flatMap(jwt -> {
                     String issuer = jwt.getIss();
@@ -99,14 +104,14 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
                         return Single.error(new InvalidRequestException("JWT missing 'iss' claim"));
                     }
 
-                    TrustedIssuer matchingIssuer = findTrustedIssuer(settings, issuer);
-                    if (matchingIssuer == null) {
-                        return Single.error(new InvalidRequestException("Untrusted issuer: " + issuer));
+                    TrustDomain trustedDomain = trustDomainManager.findByIssuer(issuer).orElse(null);
+                    if (trustedDomain == null) {
+                        return Single.error(untrusted(issuer));
                     }
 
-                    return trustedIssuerResolver.resolve(token, matchingIssuer)
+                    return trustedIssuerResolver.resolve(token, trustedDomain)
                             .subscribeOn(Schedulers.io())
-                            .map(claimsSet -> buildValidatedToken(claimsSet, domain, matchingIssuer));
+                            .map(claimsSet -> buildValidatedToken(claimsSet, domain, trustedDomain));
                 })
                 .onErrorResumeNext(error -> {
                     if (error instanceof InvalidRequestException) {
@@ -117,8 +122,12 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
                 });
     }
 
+    private InvalidRequestException untrusted(String issuer) {
+        return new InvalidRequestException("Untrusted issuer: " + issuer);
+    }
+
     private ValidatedToken buildValidatedToken(JWTClaimsSet claimsSet, Domain domain,
-                                               TrustedIssuer matchingIssuer) {
+                                               TrustDomain trustedDomain) {
         long exp = claimsSet.getExpirationTime() != null ? claimsSet.getExpirationTime().getTime() / 1000 : 0;
         long iat = claimsSet.getIssueTime() != null ? claimsSet.getIssueTime().getTime() / 1000 : 0;
         long nbf = claimsSet.getNotBeforeTime() != null ? claimsSet.getNotBeforeTime().getTime() / 1000 : 0;
@@ -126,17 +135,17 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
         TokenValidationUtils.validateTemporalClaims(exp, nbf, supportedTokenType);
 
         Map<String, Object> claims = new HashMap<>(claimsSet.getClaims());
-        Set<String> scopes = applyScopeMapping(TokenValidationUtils.parseScopes(claims.get(Claims.SCOPE)), matchingIssuer);
+        Set<String> scopes = applyScopeMapping(TokenValidationUtils.parseScopes(claims.get(Claims.SCOPE)), trustedDomain);
         List<String> audience = TokenValidationUtils.parseAudience(claims.get(Claims.AUD));
 
         return TokenValidationUtils.buildValidatedToken(claims,
                 exp, iat, nbf,
                 scopes, audience,
-                supportedTokenType, domain, matchingIssuer);
+                supportedTokenType, domain, trustedDomain);
     }
 
-    private Set<String> applyScopeMapping(Set<String> originalScopes, TrustedIssuer issuer) {
-        Map<String, String> mappings = issuer.getScopeMappings();
+    private Set<String> applyScopeMapping(Set<String> originalScopes, TrustDomain trustedDomain) {
+        Map<String, String> mappings = trustedDomain.getScopeMappings();
         if (mappings == null || mappings.isEmpty()) {
             return originalScopes;
         }
@@ -144,15 +153,5 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
                 .map(mappings::get)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
-    }
-
-    private static boolean hasTrustedIssuers(TokenExchangeSettings settings) {
-        return settings != null
-                && settings.getTrustedIssuers() != null
-                && !settings.getTrustedIssuers().isEmpty();
-    }
-
-    private static TrustedIssuer findTrustedIssuer(TokenExchangeSettings settings, String issuer) {
-        return settings.getMapOfTrustedIssuers().get(issuer);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolver.java
@@ -20,9 +20,9 @@ import io.gravitee.am.gateway.handler.common.jwt.SubjectManager;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenExchangeUserResolver;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
 import io.gravitee.am.gateway.handler.common.user.UserGatewayService;
-import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.UserBindingCriterion;
+import io.gravitee.am.model.oidc.TrustDomain;
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
 import io.gravitee.el.TemplateContext;
 import io.gravitee.el.TemplateEngine;
@@ -53,11 +53,11 @@ public class TrustedIssuerUserResolver implements TokenExchangeUserResolver {
 
     @Override
     public Maybe<User> resolve(ValidatedToken subjectToken) {
-        TrustedIssuer trustedIssuer = subjectToken.getTrustedIssuer();
-        if (trustedIssuer == null || !trustedIssuer.isUserBindingEnabled()) {
+        TrustDomain trustedDomain = subjectToken.getTrustedDomain();
+        if (trustedDomain == null || !trustedDomain.isUserBindingEnabled()) {
             return Maybe.empty();
         }
-        List<UserBindingCriterion> criteria = trustedIssuer.getUserBindingCriteria();
+        List<UserBindingCriterion> criteria = trustedDomain.getUserBindingCriteria();
         if (criteria == null || criteria.isEmpty()) {
             return Maybe.empty();
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/spring/OAuth2Configuration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/spring/OAuth2Configuration.java
@@ -50,6 +50,7 @@ import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenEx
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TokenExchangeUserResolver;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.impl.*;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.TrustedIssuerResolver;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
 import io.gravitee.am.gateway.handler.oidc.service.jws.JWSService;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
 import io.gravitee.am.gateway.handler.oauth2.service.validation.ResourceValidationService;
@@ -124,11 +125,13 @@ public class OAuth2Configuration implements ProtocolConfiguration {
     }
 
     @Bean
-    public TokenValidator jwtTokenValidator(JWTService jwtService, TrustedIssuerResolver trustedIssuerResolver) {
+    public TokenValidator jwtTokenValidator(JWTService jwtService,
+                                            TrustedIssuerResolver trustedIssuerResolver,
+                                            TrustDomainManager trustDomainManager) {
         DefaultTokenValidator domainValidator = new DefaultTokenValidator(
                 jwtService, JWTService.TokenType.JWT, TokenType.JWT);
         return new TrustedIssuerTokenValidator(
-                domainValidator, trustedIssuerResolver, jwtService,
+                domainValidator, trustedIssuerResolver, trustDomainManager, jwtService,
                 JWTService.TokenType.JWT, TokenType.JWT);
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManager.java
@@ -38,4 +38,8 @@ public interface TrustDomainManager extends Service {
      */
     Optional<TrustDomain> findByIssuer(String issuer);
 
+    /**
+     * Whether the security domain vouches for any external issuer.
+     */
+    boolean hasTokenExchangeTrust();
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainManagerImpl.java
@@ -120,6 +120,10 @@ public class TrustDomainManagerImpl extends AbstractService implements TrustDoma
         return issuer == null ? Optional.empty() : Optional.ofNullable(byIssuer.get(issuer));
     }
 
+    @Override
+    public boolean hasTokenExchangeTrust() {
+        return !byIssuer.isEmpty();
+    }
 
     private void reload(String trustDomainId) {
         log.info("Loading trusted domain {} for domain {}", trustDomainId, domain.getName());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
@@ -32,7 +32,7 @@ import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.Validat
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.KeyResolutionMethod;
 import io.gravitee.am.model.TokenExchangeSettings;
-import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.TrustDomain;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.application.ApplicationScopeSettings;
@@ -1712,7 +1712,7 @@ public class TokenExchangeServiceImplTest {
         tokenRequest.setClientId("client-id");
         tokenRequest.setParameters(buildParameters(TokenType.JWT, TokenType.ACCESS_TOKEN));
 
-        Domain domain = domainWithTrustedIssuerBinding(externalIssuer, criteria);
+        Domain domain = domainWithTokenExchangeEnabled();
         Client client = new Client();
         client.setClientId("client-id");
 
@@ -1737,7 +1737,7 @@ public class TokenExchangeServiceImplTest {
         tokenRequest.setClientId("client-id");
         tokenRequest.setParameters(buildParameters(TokenType.JWT, TokenType.ACCESS_TOKEN));
 
-        Domain domain = domainWithTrustedIssuerBinding(externalIssuer, criteria);
+        Domain domain = domainWithTokenExchangeEnabled();
         Client client = new Client();
         client.setClientId("client-id");
 
@@ -1764,7 +1764,7 @@ public class TokenExchangeServiceImplTest {
         tokenRequest.setClientId("client-id");
         tokenRequest.setParameters(buildParameters(TokenType.JWT, TokenType.ACCESS_TOKEN));
 
-        Domain domain = domainWithTrustedIssuerBinding(externalIssuer, criteria);
+        Domain domain = domainWithTokenExchangeEnabled();
         Client client = new Client();
         client.setClientId("client-id");
 
@@ -1785,7 +1785,7 @@ public class TokenExchangeServiceImplTest {
         tokenRequest.setParameters(buildParameters(TokenType.JWT, TokenType.ACCESS_TOKEN));
 
         // Trusted issuer without user binding enabled
-        Domain domain = domainWithTrustedIssuer(externalIssuer, false);
+        Domain domain = domainWithTokenExchangeEnabled();
         Client client = new Client();
         client.setClientId("client-id");
 
@@ -1832,7 +1832,7 @@ public class TokenExchangeServiceImplTest {
         tokenRequest.setClientId("client-id");
         tokenRequest.setParameters(buildParameters(TokenType.JWT, TokenType.ACCESS_TOKEN));
 
-        Domain domain = domainWithTrustedIssuerBinding(externalIssuer, criteria);
+        Domain domain = domainWithTokenExchangeEnabled();
         Client client = new Client();
         client.setClientId("client-id");
 
@@ -1861,7 +1861,7 @@ public class TokenExchangeServiceImplTest {
         tokenRequest.setClientId("client-id");
         tokenRequest.setParameters(buildParameters(TokenType.JWT, TokenType.ACCESS_TOKEN));
 
-        Domain domain = domainWithTrustedIssuerBinding(externalIssuer, criteria);
+        Domain domain = domainWithTokenExchangeEnabled();
         Client client = new Client();
         client.setClientId("client-id");
 
@@ -1884,7 +1884,7 @@ public class TokenExchangeServiceImplTest {
         tokenRequest.setClientId("client-id");
         tokenRequest.setParameters(buildParameters(TokenType.JWT, TokenType.ACCESS_TOKEN));
 
-        Domain domain = domainWithTrustedIssuerBinding(externalIssuer, criteria);
+        Domain domain = domainWithTokenExchangeEnabled();
         Client client = new Client();
         client.setClientId("client-id");
 
@@ -2686,12 +2686,13 @@ public class TokenExchangeServiceImplTest {
 
     private TokenValidator trustedIssuerValidator(String issuer, Map<String, Object> additionalClaims,
                                                   List<UserBindingCriterion> bindingCriteria) {
-        TrustedIssuer ti = new TrustedIssuer();
-        ti.setIssuer(issuer);
+        TrustDomain.TrustDomainBuilder trustedDomainBuilder = TrustDomain.builder()
+                .name(issuer)
+                .issuer(issuer);
         if (bindingCriteria != null) {
-            ti.setUserBindingEnabled(true);
-            ti.setUserBindingCriteria(bindingCriteria);
+            trustedDomainBuilder.userBindingEnabled(true).userBindingCriteria(bindingCriteria);
         }
+        TrustDomain trustedDomain = trustedDomainBuilder.build();
         return new TokenValidator() {
             @Override
             public Single<ValidatedToken> validate(String token, TokenExchangeSettings settings, Domain domain, Client client) {
@@ -2703,7 +2704,7 @@ public class TokenExchangeServiceImplTest {
                         .scopes(Set.of("openid"))
                         .expiration(Date.from(Instant.now().plusSeconds(60)))
                         .tokenType(TokenType.JWT)
-                        .trustedIssuer(ti)
+                        .trustedDomain(trustedDomain)
                         .build());
             }
 
@@ -2714,39 +2715,10 @@ public class TokenExchangeServiceImplTest {
         };
     }
 
-    private Domain domainWithTrustedIssuerBinding(String issuerUrl, List<UserBindingCriterion> bindingCriteria) {
-        TrustedIssuer trustedIssuer = new TrustedIssuer();
-        trustedIssuer.setIssuer(issuerUrl);
-        trustedIssuer.setKeyResolutionMethod(KeyResolutionMethod.JWKS_URL);
-        trustedIssuer.setJwksUri(issuerUrl + "/.well-known/jwks.json");
-        trustedIssuer.setUserBindingEnabled(true);
-        trustedIssuer.setUserBindingCriteria(bindingCriteria);
-
+    private Domain domainWithTokenExchangeEnabled() {
         TokenExchangeSettings settings = new TokenExchangeSettings();
         settings.setEnabled(true);
         settings.setAllowedSubjectTokenTypes(List.of(TokenType.JWT, TokenType.ACCESS_TOKEN));
-        settings.setTrustedIssuers(List.of(trustedIssuer));
-
-        Domain domain = new Domain();
-        domain.setId("domain-id");
-        domain.setTokenExchangeSettings(settings);
-        return domain;
-    }
-
-    private Domain domainWithTrustedIssuer(String issuerUrl, boolean bindingEnabled) {
-        TrustedIssuer trustedIssuer = new TrustedIssuer();
-        trustedIssuer.setIssuer(issuerUrl);
-        trustedIssuer.setKeyResolutionMethod(KeyResolutionMethod.JWKS_URL);
-        trustedIssuer.setJwksUri(issuerUrl + "/.well-known/jwks.json");
-        trustedIssuer.setUserBindingEnabled(bindingEnabled);
-        if (bindingEnabled) {
-            trustedIssuer.setUserBindingCriteria(List.of(criterion("email", "{#token['email']}")));
-        }
-
-        TokenExchangeSettings settings = new TokenExchangeSettings();
-        settings.setEnabled(true);
-        settings.setAllowedSubjectTokenTypes(List.of(TokenType.JWT, TokenType.ACCESS_TOKEN));
-        settings.setTrustedIssuers(List.of(trustedIssuer));
 
         Domain domain = new Domain();
         domain.setId("domain-id");

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenValidationUtilsTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenValidationUtilsTest.java
@@ -19,7 +19,7 @@ import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.TrustDomain;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -193,8 +193,9 @@ public class TokenValidationUtilsTest {
     public void buildValidatedToken_withTrustedIssuer() {
         Domain domain = mock(Domain.class);
 
-        TrustedIssuer ti = new TrustedIssuer();
-        ti.setIssuer("https://external.example.com");
+        TrustDomain trustedDomain = TrustDomain.builder()
+                .issuer("https://external.example.com")
+                .build();
 
         Map<String, Object> claims = new HashMap<>();
         claims.put(Claims.SUB, "ext-user");
@@ -202,7 +203,7 @@ public class TokenValidationUtilsTest {
         ValidatedToken result = TokenValidationUtils.buildValidatedToken(
                 claims, 0, 0, 0,
                 Set.of(), List.of(),
-                "jwt", domain, ti);
+                "jwt", domain, trustedDomain);
 
         assertTrue(result.isTrustedIssuerValidated());
         assertEquals("ext-user", result.getSubject());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerResolverImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerResolverImplTest.java
@@ -27,10 +27,12 @@ import io.gravitee.am.certificate.api.X509CertUtils;
 import io.gravitee.am.gateway.handler.oidc.service.jws.impl.JWSServiceImpl;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.impl.TrustDomainKeyServiceImpl;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.KeyResolutionMethod;
-import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.oidc.JWKSet;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.KeyRetrievalSettings;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.service.jwk.JWKSetFetcher;
 import io.gravitee.am.service.jwk.JWKSetFetcher.JWKSetFetchResponse;
 import io.gravitee.am.service.utils.jwk.converter.JWKConverter;
@@ -164,13 +166,11 @@ class TrustedIssuerResolverImplTest {
     }
 
     @Test
-    void shouldFailWhenTheKeyResolutionMethodIsMissing() throws Exception {
-        TrustedIssuer issuer = new TrustedIssuer();
-        issuer.setIssuer(ISSUER);
+    void shouldFailWhenTheKeyMaterialIsMissing() throws Exception {
         String jwt = signJwt(trustedPrivateKey, "user-123", null);
 
-        resolver().resolve(jwt, issuer).test()
-                .assertError(IllegalArgumentException.class);
+        resolver().resolve(jwt, trustedDomain(null)).test()
+                .assertError(SecurityException.class);
     }
 
     @Test
@@ -233,7 +233,7 @@ class TrustedIssuerResolverImplTest {
         when(jwkSetFetcher.getKeys(JWKS_URL, DEFAULT_MAX_RESPONSE_SIZE_BYTES))
                 .thenReturn(Maybe.just(new JWKSetFetchResponse(jwks("kid-1"), null)));
         TrustedIssuerResolverImpl resolver = resolver();
-        TrustedIssuer issuer = jwksIssuer(JWKS_URL);
+        TrustDomain issuer = jwksIssuer(JWKS_URL);
 
         resolver.resolve(signJwt(trustedPrivateKey, "user-1", "kid-1"), issuer).test().assertNoErrors();
         resolver.resolve(signJwt(trustedPrivateKey, "user-2", "kid-1"), issuer).test().assertNoErrors();
@@ -248,7 +248,7 @@ class TrustedIssuerResolverImplTest {
                 .thenReturn(Maybe.just(new JWKSetFetchResponse(jwks("kid-1"), null)))
                 .thenReturn(Maybe.error(new RuntimeException("upstream down")));
         TrustedIssuerResolverImpl resolver = resolver();
-        TrustedIssuer issuer = jwksIssuer(JWKS_URL);
+        TrustDomain issuer = jwksIssuer(JWKS_URL);
 
         resolver.resolve(signJwt(trustedPrivateKey, "user-1", "kid-1"), issuer).test().assertNoErrors();
         resolver.resolve(signJwt(trustedPrivateKey, "user-2", "kid-1"), issuer).test()
@@ -264,7 +264,7 @@ class TrustedIssuerResolverImplTest {
                 .thenReturn(Maybe.just(new JWKSetFetchResponse(jwks("kid-1"), null)))
                 .thenReturn(Maybe.just(new JWKSetFetchResponse(jwks("kid-2"), null)));
         TrustedIssuerResolverImpl resolver = resolver();
-        TrustedIssuer issuer = jwksIssuer(JWKS_URL);
+        TrustDomain issuer = jwksIssuer(JWKS_URL);
 
         resolver.resolve(signJwt(trustedPrivateKey, "user-1", "kid-1"), issuer).test().assertNoErrors();
         resolver.resolve(signJwt(trustedPrivateKey, "user-2", "kid-2"), issuer).test()
@@ -313,20 +313,27 @@ class TrustedIssuerResolverImplTest {
         return new TrustedIssuerResolverImpl(new TrustDomainKeyServiceImpl(jwkSetFetcher, domain), new JWSServiceImpl());
     }
 
-    private static TrustedIssuer pemIssuer(String certificate) {
-        TrustedIssuer issuer = new TrustedIssuer();
-        issuer.setIssuer(ISSUER);
-        issuer.setKeyResolutionMethod(KeyResolutionMethod.PEM);
-        issuer.setCertificate(certificate);
-        return issuer;
+    private static TrustDomain pemIssuer(String certificate) {
+        return trustedDomain(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.PEM)
+                .certificate(certificate)
+                .build());
     }
 
-    private static TrustedIssuer jwksIssuer(String jwksUri) {
-        TrustedIssuer issuer = new TrustedIssuer();
-        issuer.setIssuer(ISSUER);
-        issuer.setKeyResolutionMethod(KeyResolutionMethod.JWKS_URL);
-        issuer.setJwksUri(jwksUri);
-        return issuer;
+    private static TrustDomain jwksIssuer(String jwksUri) {
+        return trustedDomain(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.JWKS_URL)
+                .jwksUrl(jwksUri)
+                .build());
+    }
+
+    private static TrustDomain trustedDomain(TrustDomainKeyMaterial keyMaterial) {
+        return TrustDomain.builder()
+                .id("trust-domain-1")
+                .name("trusted.example.com")
+                .keyMaterial(keyMaterial)
+                .issuer(ISSUER)
+                .build();
     }
 
     private static JWKSet jwks(String kid) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidatorTest.java
@@ -27,7 +27,10 @@ import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.Validat
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.KeyResolutionMethod;
 import io.gravitee.am.model.TokenExchangeSettings;
-import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.model.oidc.Client;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -43,6 +46,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -64,6 +68,9 @@ public class TrustedIssuerTokenValidatorTest {
     private TrustedIssuerResolver trustedIssuerResolver;
 
     @Mock
+    private TrustDomainManager trustDomainManager;
+
+    @Mock
     private TokenExchangeSettings settings;
 
     @Mock
@@ -77,6 +84,7 @@ public class TrustedIssuerTokenValidatorTest {
     private static final String TOKEN = "test.jwt.token";
     private static final String DOMAIN_ID = "domain-123";
     private static final String TOKEN_TYPE_URN = "urn:ietf:params:oauth:token-type:test";
+    private static final String EXTERNAL_ISSUER = "https://external-idp.example.com";
 
     @Before
     public void setUp() {
@@ -84,7 +92,7 @@ public class TrustedIssuerTokenValidatorTest {
         DefaultTokenValidator delegate = new DefaultTokenValidator(
                 jwtService, JWTService.TokenType.ACCESS_TOKEN, TOKEN_TYPE_URN);
         validator = new TrustedIssuerTokenValidator(
-                delegate, trustedIssuerResolver, jwtService,
+                delegate, trustedIssuerResolver, trustDomainManager, jwtService,
                 JWTService.TokenType.ACCESS_TOKEN, TOKEN_TYPE_URN);
     }
 
@@ -161,8 +169,7 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testUnknownIssuer_reportsUntrustedIssuer() {
-        TrustedIssuer ti = createTrustedIssuer();
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
 
         // Delegate fails with TokenVerificationException
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
@@ -185,8 +192,7 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testBlankIssClaim_reportsJwtMissingIss() {
-        TrustedIssuer ti = createTrustedIssuer();
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -205,13 +211,33 @@ public class TrustedIssuerTokenValidatorTest {
         );
     }
 
+    @Test
+    public void testIssuerMatchingOnlyASpiffeTrustDomain_isUntrusted() {
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
+        when(trustDomainManager.findByIssuer("am.local")).thenReturn(Optional.empty());
+
+        when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
+                .thenReturn(Single.error(new JOSEException("Invalid signature")));
+
+        JWT decodedJwt = new JWT();
+        decodedJwt.setIss("am.local");
+        when(jwtService.decode(eq(TOKEN), eq(JWTService.TokenType.ACCESS_TOKEN)))
+                .thenReturn(Single.just(decodedJwt));
+
+        TestObserver<ValidatedToken> testObserver = validator.validate(TOKEN, settings, domain, client).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+
+        testObserver.assertError(InvalidRequestException.class);
+        testObserver.assertError(error -> error.getMessage().equals("Untrusted issuer: am.local"));
+    }
+
     // --- Trusted issuer validation ---
 
     @Test
     public void testTrustedIssuer_success() throws Exception {
-        TrustedIssuer ti = createTrustedIssuer();
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
-        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
+        TrustDomain ti = createTrustedDomain();
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
+        when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -250,9 +276,9 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_signatureVerificationFails() throws Exception {
-        TrustedIssuer ti = createTrustedIssuer();
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
-        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
+        TrustDomain ti = createTrustedDomain();
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
+        when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -276,10 +302,10 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_scopeMapping() throws Exception {
-        TrustedIssuer ti = createTrustedIssuer();
+        TrustDomain ti = createTrustedDomain();
         ti.setScopeMappings(Map.of("ext:read", "domain:read", "ext:write", "domain:write"));
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
-        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
+        when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -314,9 +340,9 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_noScopeMapping_passThrough() throws Exception {
-        TrustedIssuer ti = createTrustedIssuer();
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
-        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
+        TrustDomain ti = createTrustedDomain();
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
+        when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -349,9 +375,9 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_allFieldsCopied() throws Exception {
-        TrustedIssuer ti = createTrustedIssuer();
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
-        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
+        TrustDomain ti = createTrustedDomain();
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
+        when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -401,9 +427,9 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_expiredToken() throws Exception {
-        TrustedIssuer ti = createTrustedIssuer();
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
-        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
+        TrustDomain ti = createTrustedDomain();
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
+        when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -433,9 +459,9 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_nullTimestamps() throws Exception {
-        TrustedIssuer ti = createTrustedIssuer();
-        when(settings.getTrustedIssuers()).thenReturn(List.of(ti));
-        when(settings.getMapOfTrustedIssuers()).thenReturn(Map.of(ti.getIssuer(), ti));
+        TrustDomain ti = createTrustedDomain();
+        when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
+        when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
         when(jwtService.decodeAndVerify(eq(TOKEN), ArgumentMatchers.<Maybe<String>>any(), eq(JWTService.TokenType.ACCESS_TOKEN)))
                 .thenReturn(Single.error(new JOSEException("Invalid signature")));
@@ -466,12 +492,16 @@ public class TrustedIssuerTokenValidatorTest {
 
     // --- Helpers ---
 
-    private TrustedIssuer createTrustedIssuer() {
-        TrustedIssuer ti = new TrustedIssuer();
-        ti.setIssuer("https://external-idp.example.com");
-        ti.setKeyResolutionMethod(KeyResolutionMethod.PEM);
-        ti.setCertificate("some-pem");
-        return ti;
+    private TrustDomain createTrustedDomain() {
+        return TrustDomain.builder()
+                .id("trust-domain-1")
+                .name("external-idp.example.com")
+                .keyMaterial(TrustDomainKeyMaterial.builder()
+                        .source(KeyMaterialSource.PEM)
+                        .certificate("some-pem")
+                        .build())
+                .issuer(EXTERNAL_ISSUER)
+                .build();
     }
 
     private JWT createValidJWT() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolverTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolverTest.java
@@ -18,7 +18,7 @@ package io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.impl;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
 import io.gravitee.am.gateway.handler.common.user.UserGatewayService;
-import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.TrustDomain;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.reactivex.rxjava3.core.Single;
@@ -40,6 +40,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class TrustedIssuerUserResolverTest {
 
+    private static final String ISSUER = "https://issuer.example.com";
+
     @Mock
     private UserGatewayService userGatewayService;
 
@@ -50,18 +52,17 @@ class TrustedIssuerUserResolverTest {
         resolver = new TrustedIssuerUserResolver(userGatewayService);
     }
 
-    private ValidatedToken subjectTokenWith(TrustedIssuer trusted) {
+    private ValidatedToken subjectTokenWith(TrustDomain trustedDomain) {
         return ValidatedToken.builder()
                 .subject("sub-1")
                 .claims(Map.of("email", "user@example.com", "preferred_username", "joe"))
-                .trustedIssuer(trusted)
+                .trustedDomain(trustedDomain)
                 .build();
     }
 
     @Test
     void resolve_returnsEmptyWhenUserBindingDisabled() {
-        TrustedIssuer trusted = new TrustedIssuer();
-        trusted.setUserBindingEnabled(false);
+        TrustDomain trusted = TrustDomain.builder().issuer(ISSUER).userBindingEnabled(false).build();
 
         User result = resolver.resolve(subjectTokenWith(trusted)).blockingGet();
 
@@ -69,7 +70,7 @@ class TrustedIssuerUserResolverTest {
     }
 
     @Test
-    void resolve_returnsEmptyWhenTrustedIssuerNull() {
+    void resolve_returnsEmptyWhenTrustedDomainNull() {
         User result = resolver.resolve(subjectTokenWith(null)).blockingGet();
 
         assertThat(result).isNull();
@@ -77,9 +78,9 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_returnsEmptyWhenNoCriteria() {
-        TrustedIssuer trusted = new TrustedIssuer();
-        trusted.setUserBindingEnabled(true);
-        trusted.setUserBindingCriteria(Collections.emptyList());
+        TrustDomain trusted = TrustDomain.builder()
+                .issuer(ISSUER)
+                .userBindingEnabled(true).userBindingCriteria(Collections.emptyList()).build();
 
         User result = resolver.resolve(subjectTokenWith(trusted)).blockingGet();
 
@@ -88,12 +89,12 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_throwsWhenZeroUsersMatch() {
-        TrustedIssuer trusted = new TrustedIssuer();
-        trusted.setUserBindingEnabled(true);
+        TrustDomain.TrustDomainBuilder trustedBuilder =
+                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
         UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        trusted.setUserBindingCriteria(List.of(c));
+        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
 
         when(userGatewayService.findByCriteria(any())).thenReturn(Single.just(List.of()));
 
@@ -104,12 +105,12 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_returnsUserWhenOneMatch() {
-        TrustedIssuer trusted = new TrustedIssuer();
-        trusted.setUserBindingEnabled(true);
+        TrustDomain.TrustDomainBuilder trustedBuilder =
+                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
         UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        trusted.setUserBindingCriteria(List.of(c));
+        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
 
         User domainUser = new User();
         domainUser.setId("domain-user-id");
@@ -123,12 +124,12 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_throwsWhenMultipleUsersMatch() {
-        TrustedIssuer trusted = new TrustedIssuer();
-        trusted.setUserBindingEnabled(true);
+        TrustDomain.TrustDomainBuilder trustedBuilder =
+                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
         UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        trusted.setUserBindingCriteria(List.of(c));
+        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
 
         User u1 = new User();
         User u2 = new User();
@@ -142,17 +143,17 @@ class TrustedIssuerUserResolverTest {
     @Test
     void resolve_throwsWhenNullClaims() {
         // T3: ValidatedToken with null claims should produce InvalidRequestException
-        TrustedIssuer trusted = new TrustedIssuer();
-        trusted.setUserBindingEnabled(true);
+        TrustDomain.TrustDomainBuilder trustedBuilder =
+                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
         UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        trusted.setUserBindingCriteria(List.of(c));
+        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
 
         ValidatedToken noClaims = ValidatedToken.builder()
                 .subject("sub-1")
                 .claims(null)
-                .trustedIssuer(trusted)
+                .trustedDomain(trusted)
                 .build();
 
         assertThatThrownBy(() -> resolver.resolve(noClaims).blockingGet())
@@ -163,17 +164,17 @@ class TrustedIssuerUserResolverTest {
     @Test
     void resolve_throwsWhenExpressionEvaluatesToWhitespace() {
         // T4: EL expression evaluating to whitespace should produce InvalidRequestException
-        TrustedIssuer trusted = new TrustedIssuer();
-        trusted.setUserBindingEnabled(true);
+        TrustDomain.TrustDomainBuilder trustedBuilder =
+                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
         UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        trusted.setUserBindingCriteria(List.of(c));
+        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
 
         ValidatedToken whitespaceToken = ValidatedToken.builder()
                 .subject("sub-1")
                 .claims(Map.of("email", "   "))
-                .trustedIssuer(trusted)
+                .trustedDomain(trusted)
                 .build();
 
         assertThatThrownBy(() -> resolver.resolve(whitespaceToken).blockingGet())
@@ -183,12 +184,12 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_throwsWhenExpressionEvaluatesToNull() {
-        TrustedIssuer trusted = new TrustedIssuer();
-        trusted.setUserBindingEnabled(true);
+        TrustDomain.TrustDomainBuilder trustedBuilder =
+                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
         UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['nonexistent']}");
-        trusted.setUserBindingCriteria(List.of(c));
+        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
 
         assertThatThrownBy(() -> resolver.resolve(subjectTokenWith(trusted)).blockingGet())
                 .isInstanceOf(InvalidRequestException.class)

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainResource.java
@@ -19,6 +19,7 @@ import io.gravitee.am.common.utils.GraviteeContext;
 import io.gravitee.am.management.handlers.automation.mapper.AutomationDomainMapper;
 import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.trustdomain.TrustedIssuerProjection;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.permissions.Permission;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,6 +53,9 @@ public class DomainResource extends AbstractAutomationResource {
     @Autowired
     private DomainService domainService;
 
+    @Autowired
+    private TrustedIssuerProjection trustedIssuerProjection;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "automationGetDomain", summary = "Get a domain",
@@ -70,6 +74,7 @@ public class DomainResource extends AbstractAutomationResource {
         final AutomationRef domainRef = AutomationRef.parse(domainKey);
         checkAnyPermission(principal, organizationId, environmentId, Permission.DOMAIN, Acl.READ)
                 .andThen(resolver.resolveDomain(environmentId, domainRef))
+                .flatMap(trustedIssuerProjection::project)
                 .map(AutomationDomainMapper::toAutomationDomain)
                 .subscribe(response::resume, response::resume);
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DomainsResource.java
@@ -19,11 +19,14 @@ import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.handlers.automation.mapper.AutomationDomainMapper;
 import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.trustdomain.TrustedIssuerProjection;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.exception.InvalidParameterException;
@@ -53,6 +56,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Stuart Clark
@@ -66,6 +70,9 @@ public class DomainsResource extends AbstractAutomationResource {
 
     @Autowired
     private DomainService domainService;
+
+    @Autowired
+    private TrustedIssuerProjection trustedIssuerProjection;
 
     @Autowired
     private IdentityProviderService identityProviderService;
@@ -87,6 +94,7 @@ public class DomainsResource extends AbstractAutomationResource {
                 .andThen(domainService.findAllByEnvironment(organizationId, environmentId)
                         .filter(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API))
                         .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()))
+                        .concatMapSingle(trustedIssuerProjection::project)
                         .map(AutomationDomainMapper::toAutomationDomain)
                         .toList())
                 .subscribe(response::resume, response::resume);
@@ -181,9 +189,21 @@ public class DomainsResource extends AbstractAutomationResource {
         return automationIdentityProviders(domain.getId())
                 .flatMap(idps -> {
                     AutomationDomainMapper.applyTo(definition, domain, idps);
-                    return domainService.update(domain.getId(), domain, false);
+                    return trustedIssuerProjection.apply(domain, declaredTrustedIssuers(definition), principal)
+                            .andThen(Single.defer(() -> domainService.update(domain.getId(), domain, false)));
                 })
+                .flatMap(trustedIssuerProjection::project)
                 .map(AutomationDomainMapper::toAutomationDomain);
+    }
+
+    /**
+     * The definition declares the whole desired state, so trusted issuers it omits are no longer
+     * trusted — unlike the management API's partial patch, where an absent list is left alone.
+     */
+    private static List<TrustedIssuer> declaredTrustedIssuers(AutomationDomain definition) {
+        return Optional.ofNullable(definition.getTokenExchangeSettings())
+                .map(TokenExchangeSettings::getTrustedIssuers)
+                .orElse(List.of());
     }
 
     private Single<List<IdentityProvider>> automationIdentityProviders(String domainId) {

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
@@ -25,6 +25,8 @@ import io.gravitee.am.management.handlers.automation.resource.AutomationResource
 import io.gravitee.am.management.handlers.management.api.mapper.ObjectMapperResolver;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.trustdomain.TrustedIssuerProjection;
+import io.gravitee.am.service.TrustDomainService;
 import io.gravitee.am.management.service.IdentityProviderManager;
 import io.gravitee.am.management.service.PermissionService;
 import io.gravitee.am.management.service.ReporterPluginService;
@@ -36,6 +38,7 @@ import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.ReporterService;
 import io.gravitee.am.service.idp.SystemClusterIdpPolicy;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.client.Entity;
@@ -116,6 +119,9 @@ public abstract class AutomationJerseySpringTest {
     @Autowired
     protected PluginConfigurationValidationService validationService;
 
+    @Autowired
+    protected TrustDomainService trustDomainService;
+
     @BeforeEach
     public void init() {
         // The service mocks are Spring singletons shared across the cached context, so clear any
@@ -123,6 +129,8 @@ public abstract class AutomationJerseySpringTest {
         // (e.g. "delete was never called") scoped to the test at hand.
         clearInvocations(permissionService, domainService, certificateService, identityProviderService,
                 defaultIdentityProviderService, reporterService);
+        reset(trustDomainService);
+        when(trustDomainService.findByReference(any(), any())).thenReturn(Flowable.empty());
         // Fully reset the validation mocks (not just their invocations): tests add throwing/erroring stubs
         // to exercise rejection paths, and those would otherwise leak across the shared singleton context.
         reset(reporterPluginService, identityProviderManager, validationService);
@@ -153,6 +161,16 @@ public abstract class AutomationJerseySpringTest {
         @Bean
         public DomainService domainService() {
             return mock(DomainService.class);
+        }
+
+        @Bean
+        public TrustDomainService trustDomainService() {
+            return mock(TrustDomainService.class);
+        }
+
+        @Bean
+        public TrustedIssuerProjection trustedIssuerProjection() {
+            return new TrustedIssuerProjection(trustDomainService());
         }
 
         @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
@@ -18,13 +18,20 @@ package io.gravitee.am.management.handlers.automation.resource;
 import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
 import io.gravitee.am.management.handlers.automation.model.AutomationDomain;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.KeyResolutionMethod;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.service.model.NewTrustDomain;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.ReferenceType;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 
@@ -33,6 +40,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -128,6 +136,52 @@ class DomainsResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(200, response.getStatus());
         assertEquals("customer-auth", readEntity(response, AutomationDomain.class).getAutomationKey());
+    }
+
+    @Test
+    void put_declares_trusted_issuers_as_token_exchange_trusted_domains() {
+        String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
+        Domain existing = domain(domainId, "customer-auth");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(existing));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+        when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(existing));
+        when(trustDomainService.create(eq(existing), any(NewTrustDomain.class), any()))
+                .thenReturn(Single.just(new TrustDomain()));
+
+        AutomationDomain in = definition("customer-auth");
+        TokenExchangeSettings tokenExchange = new TokenExchangeSettings();
+        TrustedIssuer trustedIssuer = new TrustedIssuer();
+        trustedIssuer.setIssuer("https://issuer.example.com");
+        trustedIssuer.setKeyResolutionMethod(KeyResolutionMethod.JWKS_URL);
+        trustedIssuer.setJwksUri("https://issuer.example.com/keys");
+        tokenExchange.setTrustedIssuers(List.of(trustedIssuer));
+        in.setTokenExchangeSettings(tokenExchange);
+
+        assertEquals(200, put(domainsTarget(), in).getStatus());
+
+        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
+        verify(trustDomainService).create(eq(existing), captor.capture(), any());
+        assertEquals("https://issuer.example.com", captor.getValue().getIssuer());
+    }
+
+    @Test
+    void put_omitting_trusted_issuers_stops_trusting_them() {
+        String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
+        Domain existing = domain(domainId, "customer-auth");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(existing));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+        when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(existing));
+        when(trustDomainService.findByReference(ReferenceType.DOMAIN, domainId)).thenReturn(Flowable.just(
+                TrustDomain.builder()
+                        .id("td-1")
+                        .name("https-issuer.example.com")
+                        .issuer("https://issuer.example.com")
+                        .build()));
+        when(trustDomainService.delete(eq(existing), anyString(), any())).thenReturn(Completable.complete());
+
+        assertEquals(200, put(domainsTarget(), definition("customer-auth")).getStatus());
+
+        verify(trustDomainService).delete(eq(existing), eq("td-1"), any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/AbstractDomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/AbstractDomainResource.java
@@ -21,6 +21,7 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.trustdomain.TrustedIssuerProjection;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -39,6 +40,9 @@ public class AbstractDomainResource extends AbstractResource {
 
     @Autowired
     protected DomainService domainService;
+
+    @Autowired
+    protected TrustedIssuerProjection trustedIssuerProjection;
 
     @Context
     protected ResourceContext resourceContext;

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainResource.java
@@ -87,8 +87,9 @@ public class DomainResource extends AbstractDomainResource {
         checkAnyPermission(organizationId, environmentId, domainId, Permission.DOMAIN, Acl.READ)
                 .andThen(domainService.findById(domainId)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId)))
-                        .flatMapSingle(domain -> findAllPermissions(authenticatedUser, organizationId, environmentId, domainId)
-                                .map(userPermissions -> filterDomainInfos(domain, userPermissions))))
+                        .flatMapSingle(domain -> trustedIssuerProjection.project(domain)
+                                .flatMap(projected -> findAllPermissions(authenticatedUser, organizationId, environmentId, domainId)
+                                        .map(userPermissions -> filterDomainInfos(projected, userPermissions)))))
                 .subscribe(response::resume, response::resume);
     }
 
@@ -216,6 +217,7 @@ public class DomainResource extends AbstractDomainResource {
 
         checkAnyPermission(organizationId, environmentId, domainId, Permission.DOMAIN_SETTINGS, Acl.UPDATE)
                 .andThen(domainService.updateCertificateSettings(new GraviteeContext(organizationId, environmentId, domainId), domainId, certificateSettings, authenticatedUser)
+                        .flatMap(trustedIssuerProjection::project)
                         .flatMap(domain -> findAllPermissions(authenticatedUser, organizationId, environmentId, domainId)
                                 .map(userPermissions -> filterDomainInfos(domain, userPermissions))))
                 .subscribe(response::resume, response::resume);
@@ -374,6 +376,7 @@ public class DomainResource extends AbstractDomainResource {
                     .map(permission -> checkAnyPermission(organizationId, environmentId, domainId, permission, Acl.UPDATE)).collect(Collectors.toList()))
                     .andThen(checkVhostCloudModeChange(domainId, patchDomain))
                     .andThen(Single.defer(() -> domainService.patch(new GraviteeContext(organizationId, environmentId, domainId), domainId, patchDomain, authenticatedUser)
+                            .flatMap(trustedIssuerProjection::project)
                             .flatMap(domain -> findAllPermissions(authenticatedUser, organizationId, environmentId, domainId)
                                     .map(userPermissions -> filterDomainInfos(domain, userPermissions)))))
                     .subscribe(response::resume, response::resume);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainsResource.java
@@ -187,9 +187,9 @@ public class DomainsResource extends AbstractDomainResource {
         domainService.findByHrid(environmentId, hrid)
                 .flatMap(domain ->
                         checkAnyPermission(authenticatedUser, organizationId, environmentId, domain.getId(), Permission.DOMAIN, Acl.READ)
-                                .andThen(Single.defer(() ->
-                                        findAllPermissions(authenticatedUser, organizationId, environmentId, domain.getId())
-                                                .map(userPermissions -> filterDomainInfos(domain, userPermissions))))
+                                .andThen(Single.defer(() -> trustedIssuerProjection.project(domain)
+                                        .flatMap(projected -> findAllPermissions(authenticatedUser, organizationId, environmentId, domain.getId())
+                                                .map(userPermissions -> filterDomainInfos(projected, userPermissions)))))
                 ).subscribe(response::resume, response::resume);
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/JerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/JerseySpringTest.java
@@ -32,6 +32,7 @@ import io.gravitee.am.management.service.AuthenticationDeviceNotifierPluginServi
 import io.gravitee.am.management.service.AuthorizationEngineManager;
 import io.gravitee.am.management.service.AuthorizationEnginePluginService;
 import io.gravitee.am.management.service.AuthorizationEngineServiceProxy;
+import io.gravitee.am.management.service.trustdomain.TrustedIssuerProjection;
 import io.gravitee.am.service.TrustDomainService;
 import io.gravitee.am.management.service.BotDetectionPluginService;
 import io.gravitee.am.management.service.BotDetectionServiceProxy;
@@ -41,6 +42,10 @@ import io.gravitee.am.management.service.DefaultIdentityProviderService;
 import io.gravitee.am.management.service.DeviceIdentifierPluginService;
 import io.gravitee.am.management.service.DomainGroupService;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.Membership;
+import io.gravitee.am.model.Acl;
 import io.gravitee.am.management.service.EmailManager;
 import io.gravitee.am.management.service.ExtensionGrantPluginService;
 import io.gravitee.am.management.service.FactorPluginService;
@@ -102,6 +107,7 @@ import io.gravitee.am.service.validators.plugincfg.PluginJsonFormValidator;
 import io.gravitee.am.service.validators.user.UserValidator;
 import io.gravitee.node.api.license.LicenseManager;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.annotation.Priority;
 import jakarta.servlet.http.HttpServletRequest;
@@ -131,9 +137,14 @@ import javax.inject.Named;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -343,9 +354,25 @@ public abstract class JerseySpringTest {
     @Autowired
     protected LicenseManager licenseManager;
 
+    /**
+     * Answers permission checks against a principal holding only these permissions on the given
+     * security domain, so the real matching logic decides rather than a blanket true or false.
+     */
+    protected void grantOnly(String domainId, Permission... permissions) {
+        Membership membership = new Membership();
+        membership.setReferenceType(ReferenceType.DOMAIN);
+        membership.setReferenceId(domainId);
+        Map<Permission, Set<Acl>> held = Arrays.stream(permissions)
+                .collect(Collectors.toMap(Function.identity(), permission -> Set.of(Acl.values())));
+        Map<Membership, Map<Permission, Set<Acl>>> byMembership = Map.of(membership, held);
+        doAnswer(invocation -> Single.just(invocation.<PermissionAcls>getArgument(1).match(byMembership)))
+                .when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+    }
+
     @BeforeEach
     public void init() {
         when(permissionService.hasPermission(any(User.class), any(PermissionAcls.class))).thenReturn(Single.just(true));
+        Mockito.lenient().when(trustDomainService.findByReference(any(), any())).thenReturn(Flowable.empty());
     }
 
     @Configuration
@@ -732,6 +759,11 @@ public abstract class JerseySpringTest {
         @Bean
         public TrustDomainService trustDomainService() {
             return mock(TrustDomainService.class);
+        }
+
+        @Bean
+        public TrustedIssuerProjection trustedIssuerProjection() {
+            return new TrustedIssuerProjection(trustDomainService());
         }
 
         @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
@@ -23,16 +23,23 @@ import io.gravitee.am.management.service.permissions.PermissionAcls;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.CertificateSettings;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.KeyResolutionMethod;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.login.LoginSettings;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.oidc.OIDCSettings;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.model.scim.SCIMSettings;
 import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.model.PatchDomain;
 import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.core.Response;
@@ -42,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -98,6 +106,80 @@ public class DomainResourceTest extends JerseySpringTest {
         assertEquals(mockDomain.getTags(), domain.getTags());
         assertNotNull(domain.getCertificateSettings());
         assertEquals("fallback-cert-id", domain.getCertificateSettings().getFallbackCertificate());
+    }
+
+    @Test
+    public void shouldAssembleDeprecatedTrustedIssuersFromTrustedDomains() {
+        final Domain mockDomain = buildDomainMock();
+
+        doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+        doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(mockDomain.getId());
+        doReturn(Flowable.just(
+                tokenExchangeTrustDomain("td-1", "issuer.example.com", "https://issuer.example.com"),
+                spiffeTrustDomain("td-2", "am.local")))
+                .when(trustDomainService).findByReference(ReferenceType.DOMAIN, mockDomain.getId());
+
+        final Response response = target("domains").path(mockDomain.getId()).request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        final Domain domain = readEntity(response, Domain.class);
+        final List<TrustedIssuer> trustedIssuers = domain.getTokenExchangeSettings().getTrustedIssuers();
+        assertEquals(1, trustedIssuers.size());
+        assertEquals("https://issuer.example.com", trustedIssuers.get(0).getIssuer());
+        assertEquals(KeyResolutionMethod.JWKS_URL, trustedIssuers.get(0).getKeyResolutionMethod());
+        assertEquals("https://issuer.example.com/keys", trustedIssuers.get(0).getJwksUri());
+    }
+
+    @Test
+    public void shouldReportNoTrustedIssuersWhenNoTokenExchangeTrustedDomainExists() {
+        final Domain mockDomain = buildDomainMock();
+        mockDomain.getTokenExchangeSettings().setTrustedIssuers(List.of(new TrustedIssuer()));
+
+        doReturn(Single.just(true)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+        doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
+        doReturn(Maybe.just(mockDomain)).when(domainService).findById(mockDomain.getId());
+        doReturn(Flowable.just(spiffeTrustDomain("td-2", "am.local")))
+                .when(trustDomainService).findByReference(ReferenceType.DOMAIN, mockDomain.getId());
+
+        final Response response = target("domains").path(mockDomain.getId()).request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        assertNull(readEntity(response, Domain.class).getTokenExchangeSettings().getTrustedIssuers());
+    }
+
+    @Test
+    public void shouldAcceptTheDeprecatedTrustedIssuerWriteWithoutTheTrustedDomainPermission() {
+        final Domain mockDomain = buildDomainMock();
+        PatchDomain patchDomain = new PatchDomain();
+        TokenExchangeSettings tokenExchangeSettings = new TokenExchangeSettings();
+        tokenExchangeSettings.setEnabled(true);
+        tokenExchangeSettings.setTrustedIssuers(List.of(new TrustedIssuer()));
+        patchDomain.setTokenExchangeSettings(Optional.of(tokenExchangeSettings));
+
+        grantOnly(mockDomain.getId(), Permission.DOMAIN_SETTINGS);
+        doReturn(Single.just(Permission.allPermissionAcls(ReferenceType.DOMAIN))).when(permissionService).findAllPermissions(any(User.class), any(ReferenceType.class), anyString());
+        doReturn(Single.just(mockDomain)).when(domainService).patch(any(GraviteeContext.class), eq(mockDomain.getId()), any(PatchDomain.class), any(User.class));
+
+        final Response response = put(target("domains").path(mockDomain.getId()), patchDomain);
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+    }
+
+    private static TrustDomain tokenExchangeTrustDomain(String id, String name, String issuer) {
+        return TrustDomain.builder()
+                .id(id)
+                .name(name)
+                .keyMaterial(TrustDomainKeyMaterial.builder()
+                        .source(KeyMaterialSource.JWKS_URL)
+                        .jwksUrl(issuer + "/keys")
+                        .build())
+                .issuer(issuer)
+                .build();
+    }
+
+    private static TrustDomain spiffeTrustDomain(String id, String name) {
+        return TrustDomain.builder().id(id).name(name).spiffeTrustDomain(name).build();
     }
 
     @Test
@@ -410,6 +492,7 @@ public class DomainResourceTest extends JerseySpringTest {
         mockDomain.setLoginSettings(new LoginSettings());
         mockDomain.setAccountSettings(new AccountSettings());
         mockDomain.setTags(Collections.singleton("tag"));
+        mockDomain.setTokenExchangeSettings(new TokenExchangeSettings());
         CertificateSettings certificateSettings = new CertificateSettings();
         certificateSettings.setFallbackCertificate("fallback-cert-id");
         mockDomain.setCertificateSettings(certificateSettings);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainsResourceTest.java
@@ -356,4 +356,28 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
         verify(trustDomainService, never()).create(any(), any(), any());
     }
+
+    @Test
+    public void shouldRejectListWhenOnlyTheDeprecatedPermissionsAreHeld() {
+        grantOnly(DOMAIN_ID, Permission.DOMAIN_SETTINGS, Permission.DOMAIN_OPENID);
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request().get();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).findByReference(any(), any());
+    }
+
+    @Test
+    public void shouldRejectCreateWhenOnlyTheDeprecatedPermissionsAreHeld() {
+        grantOnly(DOMAIN_ID, Permission.DOMAIN_SETTINGS, Permission.DOMAIN_OPENID);
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
+                .post(Entity.json(Map.of(
+                        "name", "issuer.example.org",
+                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"),
+                        "issuer", "https://issuer.example.org")));
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).create(any(), any(), any());
+    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DomainServiceImpl.java
@@ -29,6 +29,7 @@ import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.trustdomain.TrustedIssuerProjection;
 import io.gravitee.am.model.Application;
 import io.gravitee.am.model.CertificateSettings;
 import io.gravitee.am.model.CorsSettings;
@@ -40,6 +41,8 @@ import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Membership;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.common.event.Event;
@@ -135,6 +138,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -298,6 +302,9 @@ public class DomainServiceImpl implements DomainService {
     private AuthorizationEngineService authorizationEngineService;
     @Autowired
     private CimdClientStateService cimdClientStateService;
+
+    @Autowired
+    private TrustedIssuerProjection trustedIssuerProjection;
 
     @Override
     public Maybe<Domain> findById(String id) {
@@ -628,6 +635,7 @@ public class DomainServiceImpl implements DomainService {
                     toPatch.setUpdatedAt(new Date());
                     return validateDomain(toPatch)
                             .andThen(validateCertificateSettings(toPatch))
+                            .andThen(trustedIssuerProjection.apply(toPatch, writtenTrustedIssuers(patchDomain), principal))
                             .andThen(Single.defer(() -> domainRepository.update(toPatch)))
                             // create event for sync process
                             .flatMap(domain1 -> {
@@ -669,6 +677,17 @@ public class DomainServiceImpl implements DomainService {
                     log.error("An error occurred while trying to patch a domain", ex);
                     return Single.error(new TechnicalManagementException("An error occurred while trying to patch a domain", ex));
                 });
+    }
+
+    /**
+     * The trusted issuers the caller wrote through the deprecated inline field, or null when the
+     * field was not part of the patch and the trusted domains are therefore left alone.
+     */
+    private static List<TrustedIssuer> writtenTrustedIssuers(PatchDomain patchDomain) {
+        return Optional.ofNullable(patchDomain.getTokenExchangeSettings())
+                .flatMap(Function.identity())
+                .map(TokenExchangeSettings::getTrustedIssuers)
+                .orElse(null);
     }
 
     private boolean needOrganizationAudit(Domain oldDomain, Domain toPatch) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgrader.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.service.impl.upgrades;
 
 import io.gravitee.am.common.scope.ManagementRepositoryScope;
 import io.gravitee.am.management.service.DomainService;
+import io.gravitee.am.management.service.trustdomain.TrustedIssuerNaming;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.KeyResolutionMethod;
 import io.gravitee.am.model.ReferenceType;
@@ -37,29 +38,22 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Date;
-import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import static io.gravitee.am.management.service.impl.upgrades.UpgraderOrder.DOMAIN_TRUSTED_ISSUER_UPGRADER;
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toSet;
 
 /**
  * Gives every trusted issuer declared inside a security domain's token-exchange settings a trusted
- * domain of its own. The inline declarations are left in place and stay authoritative; this upgrader
- * only makes the entities exist, so the migration can be proven before anything reads them.
+ * domain of its own, then re-saves the security domain so no stored domain keeps a vestigial inline
+ * list. A security domain holding an issuer that could not be migrated keeps its list untouched, so
+ * a later run can still see what it declared.
  *
  * <p>Entities are written straight to the repository rather than through
  * {@code TrustDomainService}: that service applies the SSRF guard the inline shape never had, so an
@@ -67,6 +61,10 @@ import static java.util.stream.Collectors.toSet;
  * the upgrade rather than migrate. It does bypass the length bound that service enforces, so an
  * inline issuer too long to store is left inline and warned about rather than failing the upgrade
  * of every other security domain.
+ *
+ * <p>Runs before every upgrader that rewrites a security domain. The storage layer no longer
+ * persists the inline declarations, so any earlier domain write erases the issuers this upgrader
+ * reads and the migration silently finds nothing left to do.
  *
  * @author GraviteeSource Team
  */
@@ -78,11 +76,6 @@ public class DomainTrustedIssuerUpgrader extends SystemTaskUpgrader {
     private static final String TASK_ID = "trusted_issuer_trust_domain_migration";
     private static final String UPGRADE_NOT_SUCCESSFUL_ERROR_MESSAGE =
             "Trusted issuers can't be migrated to trusted domains, other instance may process them or an upgrader has failed previously";
-
-    private static final int MAX_NAME_LENGTH = 255;
-    private static final int DIGEST_LENGTH = 8;
-    private static final Pattern OUTSIDE_LABEL = Pattern.compile("[^a-z0-9.-]+");
-    private static final Pattern LABEL_EDGES = Pattern.compile("(?:^[.-]+)|(?:[.-]+$)");
 
     private final DomainService domainService;
     private final TrustDomainRepository trustDomainRepository;
@@ -136,27 +129,39 @@ public class DomainTrustedIssuerUpgrader extends SystemTaskUpgrader {
         // names are unique across every trusted domain, so a derived name may not collide with a
         // trusted domain that only serves SPIFFE either
         Set<String> takenNames = existing.stream().map(TrustDomain::getName).collect(toSet());
-        Map<String, String> derivedNames = deriveNames(issuers, takenNames);
+        Map<String, String> derivedNames = TrustedIssuerNaming.deriveNames(
+                issuers.stream().map(TrustedIssuer::getIssuer).filter(issuer -> !alreadyVouchedFor.contains(issuer)).toList(),
+                takenNames);
 
         return Flowable.fromIterable(issuers)
                 .filter(issuer -> !alreadyVouchedFor.contains(issuer.getIssuer()))
-                .concatMapCompletable(issuer ->
-                        migrateIssuer(domain, issuer, derivedNames.get(issuer.getIssuer()), takenNames));
+                .concatMapSingle(issuer ->
+                        migrateIssuer(domain, issuer, derivedNames.get(issuer.getIssuer()), takenNames))
+                .reduce(true, (allMigrated, migrated) -> allMigrated && migrated)
+                .flatMapCompletable(allMigrated -> allMigrated ? purgeInlineIssuers(domain) : Completable.complete());
     }
 
-    private Completable migrateIssuer(Domain domain, TrustedIssuer issuer, String name, Set<String> takenNames) {
+    private Single<Boolean> migrateIssuer(Domain domain, TrustedIssuer issuer, String name, Set<String> takenNames) {
         if (issuer.getIssuer().length() > TrustDomain.ISSUER_MAX_LENGTH) {
             log.warn("Trusted issuer {} of domain {} is left inline: a trusted domain bounds its issuer at {} characters",
                     issuer.getIssuer(), domain.getId(), TrustDomain.ISSUER_MAX_LENGTH);
-            return Completable.complete();
+            return Single.just(false);
         }
         if (takenNames.contains(name)) {
             log.warn("Trusted issuer {} of domain {} is left inline: a trusted domain already holds its derived name {}",
                     issuer.getIssuer(), domain.getId(), name);
-            return Completable.complete();
+            return Single.just(false);
         }
         log.debug("Migrating trusted issuer {} of domain {} to trusted domain {}", issuer.getIssuer(), domain.getId(), name);
-        return trustDomainRepository.create(asTrustDomain(domain, issuer, name)).ignoreElement();
+        return trustDomainRepository.create(asTrustDomain(domain, issuer, name)).map(created -> true);
+    }
+
+    /**
+     * Drops the stored inline declarations now that the entities are authoritative. The storage
+     * layer no longer persists them, so re-saving the security domain is all it takes.
+     */
+    private Completable purgeInlineIssuers(Domain domain) {
+        return domainService.update(domain.getId(), domain).ignoreElement();
     }
 
     private static TrustDomain asTrustDomain(Domain domain, TrustedIssuer issuer, String name) {
@@ -203,48 +208,6 @@ public class DomainTrustedIssuerUpgrader extends SystemTaskUpgrader {
                 .filter(issuer -> issuer != null && StringUtils.hasText(issuer.getIssuer()))
                 .forEach(issuer -> byIssuer.putIfAbsent(issuer.getIssuer(), issuer));
         return List.copyOf(byIssuer.values());
-    }
-
-    private static Map<String, String> deriveNames(List<TrustedIssuer> issuers, Set<String> takenNames) {
-        Map<String, Long> occurrences = issuers.stream()
-                .collect(groupingBy(issuer -> slugOf(issuer.getIssuer()), counting()));
-        Map<String, String> names = new LinkedHashMap<>();
-        issuers.forEach(issuer -> {
-            String slug = slugOf(issuer.getIssuer());
-            boolean ambiguous = slug.isEmpty() || occurrences.get(slug) > 1 || takenNames.contains(slug);
-            names.put(issuer.getIssuer(), ambiguous ? disambiguate(issuer.getIssuer(), slug) : slug);
-        });
-        return names;
-    }
-
-    private static String slugOf(String issuer) {
-        return slugOf(issuer, MAX_NAME_LENGTH);
-    }
-
-    private static String slugOf(String issuer, int maxLength) {
-        String slug = trimEdges(OUTSIDE_LABEL.matcher(issuer.toLowerCase(Locale.ROOT)).replaceAll("-"));
-        return slug.length() > maxLength ? trimEdges(slug.substring(0, maxLength)) : slug;
-    }
-
-    private static String trimEdges(String slug) {
-        return LABEL_EDGES.matcher(slug).replaceAll("");
-    }
-
-    private static String disambiguate(String issuer, String slug) {
-        String digest = digestOf(issuer);
-        if (slug.isEmpty()) {
-            return digest;
-        }
-        return slugOf(issuer, MAX_NAME_LENGTH - digest.length() - 1) + "-" + digest;
-    }
-
-    private static String digestOf(String issuer) {
-        try {
-            byte[] digest = MessageDigest.getInstance("SHA-256").digest(issuer.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(digest).substring(0, DIGEST_LENGTH);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 is required to name a migrated trusted domain", e);
-        }
     }
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/UpgraderOrder.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/UpgraderOrder.java
@@ -31,6 +31,7 @@ public final class UpgraderOrder {
     public static final int DOMAIN_REPORTER_UPGRADER = 8;
     public static final int POLICY_FLOW_UPGRADER = 9;
     public static final int APPLICATION_SCOPE_SETTINGS_UPGRADER = 10;
+    public static final int DOMAIN_TRUSTED_ISSUER_UPGRADER = 11;
     public static final int APPLICATION_IDENTITY_PROVIDER_UPGRADER = 13;
     public static final int SYSTEM_CERTIFICATE_UPGRADER = 14;
     public static final int APPLICATION_FACTOR_UPGRADER = 15;
@@ -42,7 +43,6 @@ public final class UpgraderOrder {
     public static final int EMAIL_CONFIGURATION_UPGRADER = 21;
     public static final int ORGANIZATION_STANDARD_ROLE_UPGRADER = 22;
     public static final int DOMAIN_KEY_RETRIEVAL_SETTINGS_UPGRADER = 23;
-    public static final int DOMAIN_TRUSTED_ISSUER_UPGRADER = 24;
 
     private UpgraderOrder() {
         throw new UnsupportedOperationException("utility class, don't instantiate");

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerNaming.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerNaming.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.trustdomain;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+
+public final class TrustedIssuerNaming {
+
+    private static final int MAX_NAME_LENGTH = 255;
+    private static final int DIGEST_LENGTH = 8;
+    private static final Pattern OUTSIDE_LABEL = Pattern.compile("[^a-z0-9.-]+");
+    private static final Pattern LABEL_EDGES = Pattern.compile("(?:^[.-]+)|(?:[.-]+$)");
+
+    private TrustedIssuerNaming() {
+        throw new UnsupportedOperationException("utility class, don't instantiate");
+    }
+
+    /**
+     * Derives the trusted-domain name each issuer URL maps to, keyed by issuer URL. Derivation is
+     * deterministic and order-independent, so identical configuration yields identical names in
+     * every environment; an issuer whose slug would collide with another issuer's or with an
+     * already taken name carries a digest of its URL.
+     */
+    public static Map<String, String> deriveNames(Collection<String> issuers, Set<String> takenNames) {
+        Map<String, Long> occurrences = issuers.stream()
+                .collect(groupingBy(TrustedIssuerNaming::slugOf, counting()));
+        Map<String, String> names = new LinkedHashMap<>();
+        issuers.forEach(issuer -> {
+            String slug = slugOf(issuer);
+            boolean ambiguous = slug.isEmpty() || occurrences.get(slug) > 1 || takenNames.contains(slug);
+            names.put(issuer, ambiguous ? disambiguate(issuer, slug) : slug);
+        });
+        return names;
+    }
+
+    private static String slugOf(String issuer) {
+        return slugOf(issuer, MAX_NAME_LENGTH);
+    }
+
+    private static String slugOf(String issuer, int maxLength) {
+        String slug = trimEdges(OUTSIDE_LABEL.matcher(issuer.toLowerCase(Locale.ROOT)).replaceAll("-"));
+        return slug.length() > maxLength ? trimEdges(slug.substring(0, maxLength)) : slug;
+    }
+
+    private static String trimEdges(String slug) {
+        return LABEL_EDGES.matcher(slug).replaceAll("");
+    }
+
+    private static String disambiguate(String issuer, String slug) {
+        String digest = digestOf(issuer);
+        if (slug.isEmpty()) {
+            return digest;
+        }
+        return slugOf(issuer, MAX_NAME_LENGTH - digest.length() - 1) + "-" + digest;
+    }
+
+    private static String digestOf(String issuer) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(issuer.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest).substring(0, DIGEST_LENGTH);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required to name a migrated trusted domain", e);
+        }
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerProjection.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerProjection.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.trustdomain;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.KeyResolutionMethod;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
+import io.gravitee.am.service.TrustDomainService;
+import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Backs the deprecated inline trusted-issuer list of a security domain's token-exchange settings
+ * with the trusted domains that vouch for an issuer, which are the only place external trust is
+ * stored.
+ */
+@Component
+public class TrustedIssuerProjection {
+
+    private final TrustDomainService trustDomainService;
+
+    public TrustedIssuerProjection(TrustDomainService trustDomainService) {
+        this.trustDomainService = trustDomainService;
+    }
+
+    /**
+     * Assembles the deprecated inline list onto the given security domain from its token-exchange
+     * trusted domains. A trusted domain whose key material is an inline JWK set has no inline
+     * representation and is reported without a key-resolution method.
+     */
+    public Single<Domain> project(Domain domain) {
+        return tokenExchangeTrustDomains(domain.getId())
+                .map(trustDomains -> {
+                    if (trustDomains.isEmpty() && domain.getTokenExchangeSettings() == null) {
+                        return domain;
+                    }
+                    if (domain.getTokenExchangeSettings() == null) {
+                        domain.setTokenExchangeSettings(new TokenExchangeSettings());
+                    }
+                    domain.getTokenExchangeSettings().setTrustedIssuers(
+                            trustDomains.isEmpty() ? null : trustDomains.stream().map(TrustedIssuerProjection::asTrustedIssuer).toList());
+                    return domain;
+                });
+    }
+
+    /**
+     * Translates a written inline list into trusted-domain creates, updates and deletes. The list
+     * replaces what the security domain trusts, so an issuer absent from it is deleted. A null
+     * list means the deprecated field was not written and leaves the trusted domains alone.
+     */
+    public Completable apply(Domain domain, List<TrustedIssuer> written, User principal) {
+        if (written == null) {
+            return Completable.complete();
+        }
+        return tokenExchangeTrustDomains(domain.getId())
+                .flatMapCompletable(existing -> replace(domain, existing, written, principal));
+    }
+
+    private Completable replace(Domain domain, List<TrustDomain> existing, List<TrustedIssuer> written, User principal) {
+        Map<String, TrustDomain> byIssuer = new LinkedHashMap<>();
+        existing.forEach(trustDomain -> byIssuer.put(trustDomain.getIssuer(), trustDomain));
+
+        List<TrustedIssuer> declared = written.stream()
+                .filter(issuer -> issuer != null && issuer.getIssuer() != null && !issuer.getIssuer().isBlank())
+                .toList();
+        Set<String> declaredIssuers = declared.stream().map(TrustedIssuer::getIssuer).collect(toSet());
+        Map<String, String> derivedNames = TrustedIssuerNaming.deriveNames(
+                declared.stream().map(TrustedIssuer::getIssuer).filter(issuer -> !byIssuer.containsKey(issuer)).toList(),
+                existing.stream().map(TrustDomain::getName).collect(toSet()));
+
+        Completable upserts = Flowable.fromIterable(declared)
+                .concatMapCompletable(issuer -> {
+                    TrustDomain match = byIssuer.get(issuer.getIssuer());
+                    return match != null
+                            ? trustDomainService.update(domain, match.getId(), asUpdate(issuer, match), principal).ignoreElement()
+                            : trustDomainService.create(domain, asNew(issuer, derivedNames.get(issuer.getIssuer())), principal).ignoreElement();
+                });
+        Completable deletions = Flowable.fromIterable(existing)
+                .filter(trustDomain -> !declaredIssuers.contains(trustDomain.getIssuer()))
+                .concatMapCompletable(trustDomain -> trustDomainService.delete(domain, trustDomain.getId(), principal));
+
+        return upserts.andThen(deletions);
+    }
+
+    private Single<List<TrustDomain>> tokenExchangeTrustDomains(String domainId) {
+        return trustDomainService.findByReference(ReferenceType.DOMAIN, domainId)
+                .filter(TrustDomain::trustsTokenExchange)
+                .toList();
+    }
+
+    private static TrustedIssuer asTrustedIssuer(TrustDomain trustDomain) {
+        TrustedIssuer trustedIssuer = new TrustedIssuer();
+        trustedIssuer.setIssuer(trustDomain.getIssuer());
+        trustedIssuer.setScopeMappings(trustDomain.getScopeMappings());
+        trustedIssuer.setUserBindingEnabled(trustDomain.isUserBindingEnabled());
+        trustedIssuer.setUserBindingCriteria(trustDomain.getUserBindingCriteria());
+        TrustDomainKeyMaterial keyMaterial = trustDomain.getKeyMaterial();
+        if (keyMaterial != null && keyMaterial.getSource() == KeyMaterialSource.JWKS_URL) {
+            trustedIssuer.setKeyResolutionMethod(KeyResolutionMethod.JWKS_URL);
+            trustedIssuer.setJwksUri(keyMaterial.getJwksUrl());
+        } else if (keyMaterial != null && keyMaterial.getSource() == KeyMaterialSource.PEM) {
+            trustedIssuer.setKeyResolutionMethod(KeyResolutionMethod.PEM);
+            trustedIssuer.setCertificate(keyMaterial.getCertificate());
+        }
+        return trustedIssuer;
+    }
+
+    private static NewTrustDomain asNew(TrustedIssuer issuer, String name) {
+        NewTrustDomain newTrustDomain = new NewTrustDomain();
+        newTrustDomain.setName(name);
+        newTrustDomain.setIssuer(issuer.getIssuer());
+        newTrustDomain.setKeyMaterial(keyMaterialOf(issuer));
+        newTrustDomain.setScopeMappings(issuer.getScopeMappings());
+        newTrustDomain.setUserBindingEnabled(issuer.isUserBindingEnabled());
+        newTrustDomain.setUserBindingCriteria(issuer.getUserBindingCriteria());
+        return newTrustDomain;
+    }
+
+    private static UpdateTrustDomain asUpdate(TrustedIssuer issuer, TrustDomain existing) {
+        UpdateTrustDomain updateTrustDomain = new UpdateTrustDomain();
+        updateTrustDomain.setDescription(existing.getDescription());
+        updateTrustDomain.setIssuer(issuer.getIssuer());
+        updateTrustDomain.setSpiffeTrustDomain(existing.getSpiffeTrustDomain());
+        updateTrustDomain.setKeyMaterial(keyMaterialOf(issuer));
+        updateTrustDomain.setScopeMappings(issuer.getScopeMappings());
+        updateTrustDomain.setUserBindingEnabled(issuer.isUserBindingEnabled());
+        updateTrustDomain.setUserBindingCriteria(issuer.getUserBindingCriteria());
+        return updateTrustDomain;
+    }
+
+    private static TrustDomainKeyMaterial keyMaterialOf(TrustedIssuer issuer) {
+        KeyResolutionMethod method = issuer.getKeyResolutionMethod();
+        if (method == null) {
+            return null;
+        }
+        return switch (method) {
+            case JWKS_URL -> TrustDomainKeyMaterial.builder()
+                    .source(KeyMaterialSource.JWKS_URL)
+                    .jwksUrl(issuer.getJwksUri())
+                    .build();
+            case PEM -> TrustDomainKeyMaterial.builder()
+                    .source(KeyMaterialSource.PEM)
+                    .certificate(issuer.getCertificate())
+                    .build();
+        };
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -23,6 +23,7 @@ import io.gravitee.am.identityprovider.api.DefaultUser;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
 import io.gravitee.am.management.service.DomainGroupService;
 import io.gravitee.am.management.service.ManagementUserService;
+import io.gravitee.am.management.service.trustdomain.TrustedIssuerProjection;
 import io.gravitee.am.management.service.dataplane.UMAResourceManagementService;
 import io.gravitee.am.management.service.dataplane.CredentialManagementService;
 import io.gravitee.am.management.service.dataplane.DeviceManagementService;
@@ -212,6 +213,9 @@ public class DomainServiceTest {
 
     @Mock
     private EntryPointManager entryPointManager;
+
+    @Mock
+    private TrustedIssuerProjection trustedIssuerProjection;
 
     @Mock
     private DataPlaneRegistry dataPlaneRegistry;
@@ -410,6 +414,11 @@ public class DomainServiceTest {
     @BeforeEach
     void stubNoLinkedDataPlanes() {
         Mockito.lenient().when(dataPlaneDefinitionService.findByEnvironmentId(anyString())).thenReturn(Flowable.empty());
+    }
+
+    @BeforeEach
+    void stubTrustedIssuerProjectionDefaults() {
+        Mockito.lenient().when(trustedIssuerProjection.apply(any(Domain.class), any(), any())).thenReturn(Completable.complete());
     }
 
     /**

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgraderTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgraderTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -216,6 +217,7 @@ class DomainTrustedIssuerUpgraderTest {
         Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
 
         initializeSystemTask();
+        stubDomainUpdate();
         when(domainService.listAll()).thenReturn(Flowable.just(domain));
         when(trustDomainRepository.findByReference(ReferenceType.DOMAIN, DOMAIN_ID))
                 .thenReturn(Flowable.just(alreadyMigrated("https://issuer.example.com")));
@@ -249,7 +251,8 @@ class DomainTrustedIssuerUpgraderTest {
 
     @Test
     void shouldLeaveIssuerInlineWhenEveryDerivedNameIsAlreadyHeld() {
-        Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
+        TrustedIssuer issuer = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
+        Domain domain = domainWith(issuer);
 
         initializeSystemTask();
         when(domainService.listAll()).thenReturn(Flowable.just(domain));
@@ -259,6 +262,8 @@ class DomainTrustedIssuerUpgraderTest {
         assertTrue(upgrader.upgrade());
 
         verify(trustDomainRepository, never()).create(any());
+        verify(domainService, never()).update(any(), any());
+        assertSame(issuer, domain.getTokenExchangeSettings().getTrustedIssuers().get(0));
     }
 
     @Test
@@ -285,14 +290,18 @@ class DomainTrustedIssuerUpgraderTest {
     }
 
     @Test
-    void shouldLeaveInlineTrustedIssuersInPlace() {
-        TrustedIssuer issuer = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
-        Domain domain = domainWith(issuer);
+    void shouldRunBeforeEveryUpgraderRewritingADomain() {
+        assertTrue(upgrader.getOrder() < UpgraderOrder.DOMAIN_DATA_PLANE_UPGRADER);
+        assertTrue(upgrader.getOrder() < UpgraderOrder.DOMAIN_KEY_RETRIEVAL_SETTINGS_UPGRADER);
+    }
+
+    @Test
+    void shouldDropInlineTrustedIssuersOnceMigrated() {
+        Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
 
         migrate(domain);
 
-        assertSame(issuer, domain.getTokenExchangeSettings().getTrustedIssuers().get(0));
-        verify(domainService, never()).update(any(), any());
+        verify(domainService).update(DOMAIN_ID, domain);
     }
 
     @Test
@@ -326,6 +335,7 @@ class DomainTrustedIssuerUpgraderTest {
 
     private List<TrustDomain> migrateAll(Domain... domains) {
         initializeSystemTask();
+        stubDomainUpdate();
         when(domainService.listAll()).thenReturn(Flowable.fromArray(domains));
         when(trustDomainRepository.findByReference(any(), any())).thenReturn(Flowable.empty());
         return captureCreated();
@@ -333,6 +343,7 @@ class DomainTrustedIssuerUpgraderTest {
 
     private List<TrustDomain> migrate(Domain domain, TrustDomain... existing) {
         initializeSystemTask();
+        stubDomainUpdate();
         when(domainService.listAll()).thenReturn(Flowable.just(domain));
         when(trustDomainRepository.findByReference(ReferenceType.DOMAIN, DOMAIN_ID))
                 .thenReturn(Flowable.fromArray(existing));
@@ -346,6 +357,10 @@ class DomainTrustedIssuerUpgraderTest {
         assertTrue(upgrader.upgrade());
 
         return captor.getAllValues();
+    }
+
+    private void stubDomainUpdate() {
+        lenient().when(domainService.update(anyString(), any(Domain.class))).thenAnswer(i -> Single.just(i.getArgument(1)));
     }
 
     private void initializeSystemTask() {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerProjectionTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerProjectionTest.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.service.trustdomain;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.KeyResolutionMethod;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
+import io.gravitee.am.model.UserBindingCriterion;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
+import io.gravitee.am.service.TrustDomainService;
+import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrustedIssuerProjectionTest {
+
+    private static final String DOMAIN_ID = "domain-id";
+    private static final String ISSUER = "https://issuer.example.com";
+
+    @Mock
+    private TrustDomainService trustDomainService;
+
+    @Mock
+    private User principal;
+
+    private TrustedIssuerProjection projection;
+
+    @BeforeEach
+    void setUp() {
+        projection = new TrustedIssuerProjection(trustDomainService);
+    }
+
+    @Test
+    void shouldAssembleTheInlineListFromTokenExchangeTrustedDomains() {
+        Domain domain = domain();
+        stubExisting(tokenExchange("td-1", "https-issuer.example.com", ISSUER), spiffe("td-2", "am.local"));
+
+        Domain projected = projection.project(domain).blockingGet();
+
+        List<TrustedIssuer> trustedIssuers = projected.getTokenExchangeSettings().getTrustedIssuers();
+        assertEquals(1, trustedIssuers.size());
+        assertEquals(ISSUER, trustedIssuers.get(0).getIssuer());
+        assertEquals(KeyResolutionMethod.JWKS_URL, trustedIssuers.get(0).getKeyResolutionMethod());
+        assertEquals(ISSUER + "/keys", trustedIssuers.get(0).getJwksUri());
+        assertEquals(Map.of("ext:read", "read"), trustedIssuers.get(0).getScopeMappings());
+        assertTrue(trustedIssuers.get(0).isUserBindingEnabled());
+        assertEquals("email", trustedIssuers.get(0).getUserBindingCriteria().get(0).getAttribute());
+    }
+
+    @Test
+    void shouldReportNoInlineListWhenNothingIsTrusted() {
+        Domain domain = domain();
+        domain.getTokenExchangeSettings().setTrustedIssuers(List.of(new TrustedIssuer()));
+        stubExisting(spiffe("td-2", "am.local"));
+
+        Domain projected = projection.project(domain).blockingGet();
+
+        assertNull(projected.getTokenExchangeSettings().getTrustedIssuers());
+    }
+
+    @Test
+    void shouldCreateATrustedDomainForAWrittenIssuer() {
+        Domain domain = domain();
+        stubExisting();
+        when(trustDomainService.create(eq(domain), any(NewTrustDomain.class), any()))
+                .thenReturn(Single.just(new TrustDomain()));
+
+        projection.apply(domain, List.of(jwksIssuer(ISSUER)), principal).blockingAwait();
+
+        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
+        verify(trustDomainService).create(eq(domain), captor.capture(), eq(principal));
+        assertEquals("https-issuer.example.com", captor.getValue().getName());
+        assertEquals(ISSUER, captor.getValue().getIssuer());
+        assertEquals(KeyMaterialSource.JWKS_URL, captor.getValue().getKeyMaterial().getSource());
+        assertEquals(ISSUER + "/keys", captor.getValue().getKeyMaterial().getJwksUrl());
+    }
+
+    @Test
+    void shouldAmendTheTrustedDomainAlreadyVouchingForAWrittenIssuer() {
+        Domain domain = domain();
+        stubExisting(tokenExchange("td-1", "https-issuer.example.com", ISSUER));
+        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustDomain.class), any()))
+                .thenReturn(Single.just(new TrustDomain()));
+
+        TrustedIssuer written = jwksIssuer(ISSUER);
+        written.setScopeMappings(Map.of("ext:write", "write"));
+        projection.apply(domain, List.of(written), principal).blockingAwait();
+
+        ArgumentCaptor<UpdateTrustDomain> captor = ArgumentCaptor.forClass(UpdateTrustDomain.class);
+        verify(trustDomainService).update(eq(domain), eq("td-1"), captor.capture(), eq(principal));
+        assertEquals(Map.of("ext:write", "write"), captor.getValue().getScopeMappings());
+        verify(trustDomainService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    void shouldDeleteTheTrustedDomainOfAnIssuerOmittedFromTheWrittenList() {
+        Domain domain = domain();
+        stubExisting(tokenExchange("td-1", "https-issuer.example.com", ISSUER),
+                tokenExchange("td-2", "https-other.example.com", "https://other.example.com"));
+        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustDomain.class), any()))
+                .thenReturn(Single.just(new TrustDomain()));
+        when(trustDomainService.delete(eq(domain), anyString(), any())).thenReturn(Completable.complete());
+
+        projection.apply(domain, List.of(jwksIssuer(ISSUER)), principal).blockingAwait();
+
+        verify(trustDomainService).delete(domain, "td-2", principal);
+        verify(trustDomainService, never()).delete(domain, "td-1", principal);
+    }
+
+    @Test
+    void shouldDisambiguateAWrittenIssuerWhoseDerivedNameIsAlreadyHeld() {
+        Domain domain = domain();
+        stubExisting(tokenExchange("td-1", "https-issuer.example.com", ISSUER));
+        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustDomain.class), any()))
+                .thenReturn(Single.just(new TrustDomain()));
+        when(trustDomainService.create(eq(domain), any(NewTrustDomain.class), any()))
+                .thenReturn(Single.just(new TrustDomain()));
+
+        projection.apply(domain, List.of(jwksIssuer(ISSUER), jwksIssuer(ISSUER + "/")), principal).blockingAwait();
+
+        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
+        verify(trustDomainService).create(eq(domain), captor.capture(), eq(principal));
+        assertNotEquals("https-issuer.example.com", captor.getValue().getName());
+        assertTrue(captor.getValue().getName().startsWith("https-issuer.example.com-"));
+    }
+
+    @Test
+    void shouldDeleteEveryTrustedDomainWhenTheWrittenListIsEmpty() {
+        Domain domain = domain();
+        stubExisting(tokenExchange("td-1", "https-issuer.example.com", ISSUER));
+        when(trustDomainService.delete(eq(domain), anyString(), any())).thenReturn(Completable.complete());
+
+        projection.apply(domain, List.of(), principal).blockingAwait();
+
+        verify(trustDomainService).delete(domain, "td-1", principal);
+    }
+
+    @Test
+    void shouldLeaveTrustedDomainsAloneWhenTheDeprecatedFieldWasNotWritten() {
+        Domain domain = domain();
+
+        projection.apply(domain, null, principal).blockingAwait();
+
+        verify(trustDomainService, never()).findByReference(any(), any());
+        verify(trustDomainService, never()).create(any(), any(), any());
+        verify(trustDomainService, never()).delete(any(), any(), any());
+    }
+
+    private void stubExisting(TrustDomain... trustDomains) {
+        when(trustDomainService.findByReference(ReferenceType.DOMAIN, DOMAIN_ID))
+                .thenReturn(Flowable.fromArray(trustDomains));
+    }
+
+    private static Domain domain() {
+        Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        domain.setTokenExchangeSettings(new TokenExchangeSettings());
+        return domain;
+    }
+
+    private static TrustedIssuer jwksIssuer(String issuer) {
+        TrustedIssuer trustedIssuer = new TrustedIssuer();
+        trustedIssuer.setIssuer(issuer);
+        trustedIssuer.setKeyResolutionMethod(KeyResolutionMethod.JWKS_URL);
+        trustedIssuer.setJwksUri(issuer + "/keys");
+        return trustedIssuer;
+    }
+
+    private static TrustDomain tokenExchange(String id, String name, String issuer) {
+        UserBindingCriterion criterion = new UserBindingCriterion();
+        criterion.setAttribute("email");
+        criterion.setExpression("{#token.email}");
+        return TrustDomain.builder()
+                .id(id)
+                .name(name)
+                .keyMaterial(TrustDomainKeyMaterial.builder()
+                        .source(KeyMaterialSource.JWKS_URL)
+                        .jwksUrl(issuer + "/keys")
+                        .build())
+                .issuer(issuer)
+                .scopeMappings(Map.of("ext:read", "read"))
+                .userBindingEnabled(true)
+                .userBindingCriteria(List.of(criterion))
+                .build();
+    }
+
+    private static TrustDomain spiffe(String id, String name) {
+        return TrustDomain.builder().id(id).name(name).spiffeTrustDomain(name).build();
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/TokenExchangeSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/TokenExchangeSettings.java
@@ -15,19 +15,13 @@
  */
 package io.gravitee.am.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.am.model.application.TokenExchangeOAuthSettings;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static io.gravitee.am.common.oauth2.TokenType.ACCESS_TOKEN;
 import static io.gravitee.am.common.oauth2.TokenType.ID_TOKEN;
@@ -95,16 +89,17 @@ public class TokenExchangeSettings {
             "1–100.", defaultValue = "25")
     private int maxDelegationDepth = DEFAULT_MAX_DELEGATION_DEPTH;
 
-    @Schema(description = "External issuers whose JWTs may be accepted as subject or actor tokens. When unset, " +
-            "only domain-issued tokens are accepted.")
-    private List<TrustedIssuer> trustedIssuers;
-
     /**
-     * Map representation of the TrustedIssuer list to each the lookup
+     * @deprecated superseded by token-exchange trusted domains. Neither stored nor read here: a
+     * projection over the trusted domains of the security domain, assembled on read and translated
+     * into trusted-domain creates, updates and deletes on write.
      */
-    @Setter(AccessLevel.NONE)
-    @JsonIgnore
-    private Map<String, TrustedIssuer> mapOfTrustedIssuers = Map.of();
+    @Deprecated
+    @Schema(deprecated = true, description = "Deprecated: use the trusted-domains API instead. External " +
+            "issuers whose JWTs may be accepted as subject or actor tokens. A projection over the security " +
+            "domain's token-exchange trusted domains; a write replaces the list, so an omitted issuer is " +
+            "no longer trusted.")
+    private List<TrustedIssuer> trustedIssuers;
 
     @Schema(description = "Domain-level default token-exchange OAuth settings, such as scope handling. " +
             "Applications can inherit or override these. When unset, system defaults apply.")
@@ -114,6 +109,18 @@ public class TokenExchangeSettings {
         this.allowedSubjectTokenTypes = new ArrayList<>(List.of(ACCESS_TOKEN, REFRESH_TOKEN, ID_TOKEN, JWT));
         this.allowedRequestedTokenTypes = new ArrayList<>(DEFAULT_ALLOWED_REQUESTED_TOKEN_TYPES);
         this.allowedActorTokenTypes = new ArrayList<>(List.of(ACCESS_TOKEN, ID_TOKEN, JWT));
+    }
+
+    public TokenExchangeSettings(TokenExchangeSettings other) {
+        this.enabled = other.enabled;
+        this.allowedSubjectTokenTypes = other.allowedSubjectTokenTypes;
+        this.allowedRequestedTokenTypes = other.allowedRequestedTokenTypes;
+        this.allowImpersonation = other.allowImpersonation;
+        this.allowedActorTokenTypes = other.allowedActorTokenTypes;
+        this.allowDelegation = other.allowDelegation;
+        this.maxDelegationDepth = other.maxDelegationDepth;
+        this.trustedIssuers = other.trustedIssuers;
+        this.tokenExchangeOAuthSettings = other.tokenExchangeOAuthSettings;
     }
 
     /**
@@ -135,18 +142,5 @@ public class TokenExchangeSettings {
      */
     public void setMaxDelegationDepth(int maxDelegationDepth) {
         this.maxDelegationDepth = Math.max(MIN_MAX_DELEGATION_DEPTH, Math.min(MAX_MAX_DELEGATION_DEPTH, maxDelegationDepth));
-    }
-
-    public void setTrustedIssuers(List<TrustedIssuer> trustedIssuers) {
-        this.trustedIssuers = trustedIssuers;
-        if (trustedIssuers != null) {
-            this.mapOfTrustedIssuers = trustedIssuers.stream()
-                    // make sure the issuer has value to avoid "null" in the map
-                    .filter(ti -> StringUtils.hasText(ti.getIssuer()))
-                    // in case of two issuer definitions keep the first one.
-                    .collect(Collectors.toMap(TrustedIssuer::getIssuer, Function.identity(), (issuer1, issuer2) -> issuer1));
-        } else {
-            this.mapOfTrustedIssuers = Map.of();
-        }
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/TrustedIssuer.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/TrustedIssuer.java
@@ -27,13 +27,17 @@ import java.util.Map;
  * Defines an external issuer whose JWTs can be accepted as subject/actor tokens
  * when validated with the configured key material (JWKS URL or PEM certificate).
  *
+ * @deprecated superseded by token-exchange trusted domains; this shape is only the projection
+ * over them that the deprecated domain-level API still speaks.
  * @see TokenExchangeSettings#getTrustedIssuers()
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc8693">RFC 8693 - OAuth 2.0 Token Exchange</a>
  * @author GraviteeSource Team
  */
+@Deprecated
 @Getter
 @Setter
-@Schema(title = "Trusted issuer", description = "An external token issuer whose JWTs are accepted as subject or " +
+@Schema(title = "Trusted issuer", deprecated = true,
+        description = "An external token issuer whose JWTs are accepted as subject or " +
         "actor tokens during token exchange, validated with the configured key material.")
 public class TrustedIssuer {
 

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/mapper/TokenExchangeSettingsConverter.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/mapper/TokenExchangeSettingsConverter.java
@@ -24,13 +24,26 @@ public class TokenExchangeSettingsConverter extends DozerConverter<TokenExchange
         super(TokenExchangeSettings.class, String.class);
     }
 
+    /**
+     * Trusted issuers are deliberately dropped: they live as token-exchange trusted domains and the
+     * inline list is only a projection over them.
+     */
     @Override
     public String convertTo(TokenExchangeSettings tokenExchangeSettings, String s) {
-        return JSONMapper.toJson(tokenExchangeSettings);
+        return JSONMapper.toJson(withoutTrustedIssuers(tokenExchangeSettings));
     }
 
     @Override
     public TokenExchangeSettings convertFrom(String s, TokenExchangeSettings tokenExchangeSettings) {
         return JSONMapper.toBean(s, TokenExchangeSettings.class);
+    }
+
+    private static TokenExchangeSettings withoutTrustedIssuers(TokenExchangeSettings settings) {
+        if (settings == null || settings.getTrustedIssuers() == null) {
+            return settings;
+        }
+        TokenExchangeSettings copy = new TokenExchangeSettings(settings);
+        copy.setTrustedIssuers(null);
+        return copy;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/TokenExchangeSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/TokenExchangeSettingsMongo.java
@@ -35,6 +35,11 @@ public class TokenExchangeSettingsMongo {
     private List<String> allowedActorTokenTypes;
     private boolean allowDelegation;
     private Integer maxDelegationDepth;
+    /**
+     * @deprecated read only, so that the migration to token-exchange trusted domains can still see
+     * what a security domain declared before the cutover. Never written back.
+     */
+    @Deprecated
     private List<TrustedIssuerMongo> trustedIssuers;
     private TokenExchangeOAuthSettingsMongo tokenExchangeOAuthSettings;
 
@@ -138,7 +143,8 @@ public class TokenExchangeSettingsMongo {
     }
 
     /**
-     * Convert domain model to MongoDB representation.
+     * Convert domain model to MongoDB representation. Trusted issuers are deliberately dropped:
+     * they live as token-exchange trusted domains and the inline list is only a projection.
      */
     public static TokenExchangeSettingsMongo convert(TokenExchangeSettings settings) {
         if (settings == null) {
@@ -152,11 +158,6 @@ public class TokenExchangeSettingsMongo {
         mongo.setAllowedActorTokenTypes(settings.getAllowedActorTokenTypes());
         mongo.setAllowDelegation(settings.isAllowDelegation());
         mongo.setMaxDelegationDepth(settings.getMaxDelegationDepth());
-        if (settings.getTrustedIssuers() != null) {
-            mongo.setTrustedIssuers(settings.getTrustedIssuers().stream()
-                    .map(TrustedIssuerMongo::convert)
-                    .toList());
-        }
         mongo.setTokenExchangeOAuthSettings(TokenExchangeOAuthSettingsMongo.convert(settings.getTokenExchangeOAuthSettings()));
         return mongo;
     }

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DomainRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DomainRepositoryTest.java
@@ -20,7 +20,10 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.DomainVersion;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.SAMLSettings;
+import io.gravitee.am.model.KeyResolutionMethod;
 import io.gravitee.am.model.SelfServiceAccountManagementSettings;
+import io.gravitee.am.model.TokenExchangeSettings;
+import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.VirtualHost;
 import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.login.LoginSettings;
@@ -90,6 +93,28 @@ public class DomainRepositoryTest extends AbstractManagementTest {
                 domain1.getTags().equals(domain2.getTags()) &&
                 domain1.getIdentities().equals(domain2.getIdentities()) &&
                 domain1.getLoginSettings().getResetPasswordOnExpiration().equals(domain2.getLoginSettings().getResetPasswordOnExpiration());
+    }
+
+    @Test
+    public void shouldNotPersistInlineTrustedIssuers() {
+        Domain domain = initDomain();
+        TokenExchangeSettings tokenExchange = new TokenExchangeSettings();
+        tokenExchange.setEnabled(true);
+        TrustedIssuer trustedIssuer = new TrustedIssuer();
+        trustedIssuer.setIssuer("https://issuer.example.com");
+        trustedIssuer.setKeyResolutionMethod(KeyResolutionMethod.JWKS_URL);
+        trustedIssuer.setJwksUri("https://issuer.example.com/.well-known/jwks.json");
+        tokenExchange.setTrustedIssuers(List.of(trustedIssuer));
+        domain.setTokenExchangeSettings(tokenExchange);
+
+        Domain created = domainRepository.create(domain).blockingGet();
+
+        TestObserver<Domain> testObserver = domainRepository.findById(created.getId()).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertValue(d -> d.getTokenExchangeSettings() != null && d.getTokenExchangeSettings().isEnabled());
+        testObserver.assertValue(d -> d.getTokenExchangeSettings().getTrustedIssuers() == null);
     }
 
     private Domain initDomain() {

--- a/gravitee-am-test/specs/gateway/token-exchange/trusted-issuers.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/trusted-issuers.jest.spec.ts
@@ -17,19 +17,45 @@ import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { performPost } from '@gateway-commands/oauth-oidc-commands';
 import { parseJwt } from '@api-fixtures/jwt';
 import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
-import { waitForOidcReady } from '@management-commands/domain-management-commands';
+import { getDomain, waitForOidcReady } from '@management-commands/domain-management-commands';
+import { listTrustDomains } from '@management-commands/trust-domain-management-commands';
+import { TrustDomain } from '@management-models/TrustDomain';
 import { setup } from '../../test-fixture';
-import {
-  setupTrustedIssuerFixture,
-  TrustedIssuerFixture,
-  patchDomainRaw,
-} from './fixtures/trusted-issuer-fixture';
+import { setupTrustedIssuerFixture, TrustedIssuerFixture, patchDomainRaw } from './fixtures/trusted-issuer-fixture';
 import { signJwtForTrustedIssuer } from './fixtures/trusted-issuer-jwt-helper';
 import { TOKEN_EXCHANGE_TEST } from './fixtures/token-exchange-fixture';
 
-setup();
+setup(120000);
 
 let fixture: TrustedIssuerFixture;
+
+const baselineTrustedIssuer = () => ({
+  issuer: fixture.externalIssuer,
+  keyResolutionMethod: 'PEM',
+  certificate: fixture.trustedKey.certificatePem,
+  scopeMappings: { 'external:read': 'openid', 'external:profile': 'profile' },
+});
+
+const writeTrustedIssuers = async (trustedIssuers: Array<Record<string, unknown>>) => {
+  const { domain, accessToken } = fixture;
+  await waitForSyncAfter(domain.id, () =>
+    patchDomainRaw(domain.id, accessToken, {
+      tokenExchangeSettings: {
+        enabled: true,
+        allowedSubjectTokenTypes: TOKEN_EXCHANGE_TEST.DEFAULT_ALLOWED_SUBJECT_TOKEN_TYPES,
+        allowedRequestedTokenTypes: TOKEN_EXCHANGE_TEST.DEFAULT_ALLOWED_REQUESTED_TOKEN_TYPES,
+        allowImpersonation: true,
+        allowDelegation: true,
+        allowedActorTokenTypes: TOKEN_EXCHANGE_TEST.DEFAULT_ALLOWED_ACTOR_TOKEN_TYPES,
+        maxDelegationDepth: 3,
+        trustedIssuers,
+      },
+    }).expect(200),
+  );
+  await waitForOidcReady(domain.hrid);
+};
+
+const restoreBaseline = () => writeTrustedIssuers([baselineTrustedIssuer()]);
 
 beforeAll(async () => {
   fixture = await setupTrustedIssuerFixture();
@@ -323,44 +349,29 @@ describe('Trusted Issuers - Domain-issued tokens (no regression)', () => {
 });
 
 describe('Trusted Issuers - User Binding', () => {
-  // Helper to build the trusted issuer config with user binding settings
-  const buildTrustedIssuerConfig = (
-    userBindingEnabled: boolean,
-    userBindingCriteria?: Array<{ attribute: string; expression: string }>,
-  ) => ({
-    tokenExchangeSettings: {
-      enabled: true,
-      allowedSubjectTokenTypes: TOKEN_EXCHANGE_TEST.DEFAULT_ALLOWED_SUBJECT_TOKEN_TYPES,
-      allowedRequestedTokenTypes: TOKEN_EXCHANGE_TEST.DEFAULT_ALLOWED_REQUESTED_TOKEN_TYPES,
-      allowImpersonation: true,
-      allowDelegation: true,
-      allowedActorTokenTypes: TOKEN_EXCHANGE_TEST.DEFAULT_ALLOWED_ACTOR_TOKEN_TYPES,
-      maxDelegationDepth: 3,
-      trustedIssuers: [
-        {
-          issuer: fixture.externalIssuer,
-          keyResolutionMethod: 'PEM',
-          certificate: fixture.trustedKey.certificatePem,
-          scopeMappings: { 'external:read': 'openid', 'external:profile': 'profile' },
-          userBindingEnabled,
-          ...(userBindingCriteria?.length && { userBindingCriteria }),
-        },
-      ],
-    },
+  const EMAIL_BINDING_CRITERIA = [{ attribute: 'emails.value', expression: "{#token['email']}" }];
+
+  const writeUserBinding = (userBindingEnabled: boolean, userBindingCriteria?: Array<{ attribute: string; expression: string }>) =>
+    writeTrustedIssuers([
+      {
+        ...baselineTrustedIssuer(),
+        userBindingEnabled,
+        ...(userBindingCriteria?.length && { userBindingCriteria }),
+      },
+    ]);
+
+  afterAll(async () => {
+    await restoreBaseline();
   });
 
   it('should use domain user when user binding is enabled and email matches', async () => {
-    const { domain, accessToken, oidc, basicAuth, externalIssuer, user } = fixture;
+    const { oidc, basicAuth, externalIssuer, user } = fixture;
 
     // Discover the domain user's actual sub by parsing a domain-issued token
     const domainTokens = await fixture.obtainSubjectToken('openid');
-    const domainUserSub = (parseJwt(domainTokens.accessToken).payload['sub'] as string);
+    const domainUserSub = parseJwt(domainTokens.accessToken).payload['sub'] as string;
 
-    // Patch domain to enable user binding with email -> email mapping
-    await waitForSyncAfter(domain.id, () =>
-      patchDomainRaw(domain.id, accessToken, buildTrustedIssuerConfig(true, [{ attribute: 'emails.value', expression: "{#token['email']}" }])).expect(200),
-    );
-    await waitForOidcReady(domain.hrid);
+    await writeUserBinding(true, EMAIL_BINDING_CRITERIA);
 
     // Sign external JWT with matching email (from fixture user created by buildCreateAndTestUser)
     const externalJwt = fixture.signExternalJwt({
@@ -392,7 +403,8 @@ describe('Trusted Issuers - User Binding', () => {
   it('should reject when user binding is enabled but no matching domain user found', async () => {
     const { oidc, basicAuth, externalIssuer } = fixture;
 
-    // Domain is already patched with user binding enabled from the previous test
+    await writeUserBinding(true, EMAIL_BINDING_CRITERIA);
+
     const externalJwt = fixture.signExternalJwt({
       sub: 'external-user-no-match',
       email: 'nonexistent@example.com',
@@ -417,13 +429,9 @@ describe('Trusted Issuers - User Binding', () => {
   });
 
   it('should use synthetic user when user binding is disabled', async () => {
-    const { domain, accessToken, oidc, basicAuth, externalIssuer } = fixture;
+    const { oidc, basicAuth, externalIssuer } = fixture;
 
-    // Restore config with user binding disabled
-    await waitForSyncAfter(domain.id, () =>
-      patchDomainRaw(domain.id, accessToken, buildTrustedIssuerConfig(false)).expect(200),
-    );
-    await waitForOidcReady(domain.hrid);
+    await writeUserBinding(false);
 
     const externalJwt = fixture.signExternalJwt({
       sub: 'external-user-synthetic',
@@ -448,5 +456,93 @@ describe('Trusted Issuers - User Binding', () => {
     expect(response.body.access_token).toBeDefined();
     const decoded = parseJwt(response.body.access_token);
     expect(decoded.payload['sub']).toBe('external-user-synthetic');
+  });
+});
+
+describe('Trusted Issuers - Deprecated list is a projection over trusted domains', () => {
+  const REPLACEMENT_ISSUER = 'https://replacement-idp.example.com';
+
+  const replacementIssuer = () => ({
+    issuer: REPLACEMENT_ISSUER,
+    keyResolutionMethod: 'PEM',
+    certificate: fixture.untrustedKey.certificatePem,
+  });
+
+  const signReplacementJwt = () =>
+    signJwtForTrustedIssuer({
+      issuer: REPLACEMENT_ISSUER,
+      privateKeyPem: fixture.untrustedKey.privateKeyPem,
+      subject: 'external-user-456',
+      payload: { scope: 'openid' },
+    });
+
+  const trustedIssuerDomains = (trustDomains: TrustDomain[]) => trustDomains.filter((trustDomain) => trustDomain.issuer != null);
+
+  const exchangeExternalJwt = (externalJwt: string) => {
+    const { oidc, basicAuth } = fixture;
+    return performPost(
+      oidc.token_endpoint,
+      '',
+      `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` +
+        `&subject_token=${encodeURIComponent(externalJwt)}` +
+        `&subject_token_type=urn:ietf:params:oauth:token-type:jwt`,
+      {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${basicAuth}`,
+      },
+    );
+  };
+
+  afterAll(async () => {
+    await restoreBaseline();
+  });
+
+  it('should back a written issuer with a trusted domain carrying an issuer matcher', async () => {
+    const { domain, accessToken, externalIssuer } = fixture;
+
+    await writeTrustedIssuers([baselineTrustedIssuer()]);
+
+    const issuerDomains = trustedIssuerDomains(await listTrustDomains(domain.id, accessToken));
+    expect(issuerDomains).toHaveLength(1);
+    expect(issuerDomains[0].issuer).toBe(externalIssuer);
+    expect(issuerDomains[0].spiffeTrustDomain).toBeUndefined();
+    expect(issuerDomains[0].keyMaterial.source.toUpperCase()).toBe('PEM');
+
+    const projected = await getDomain(domain.id, accessToken);
+    expect(projected.tokenExchangeSettings.trustedIssuers).toHaveLength(1);
+    expect(projected.tokenExchangeSettings.trustedIssuers[0].issuer).toBe(externalIssuer);
+  });
+
+  it('should stop trusting an issuer omitted from a written list', async () => {
+    const { domain, accessToken, externalIssuer } = fixture;
+
+    await writeTrustedIssuers([baselineTrustedIssuer()]);
+    await writeTrustedIssuers([replacementIssuer()]);
+
+    expect(trustedIssuerDomains(await listTrustDomains(domain.id, accessToken))).toHaveLength(1);
+
+    const omittedIssuerJwt = fixture.signExternalJwt({
+      sub: 'external-user-123',
+      scope: 'external:read',
+      iss: externalIssuer,
+    });
+
+    const rejected = await exchangeExternalJwt(omittedIssuerJwt).expect(400);
+    expect(rejected.body.error).toBe('invalid_request');
+    expect(rejected.body.error_description).toContain(`Untrusted issuer: ${externalIssuer}`);
+
+    await exchangeExternalJwt(signReplacementJwt()).expect(200);
+  });
+
+  it('should stop trusting every issuer when an empty list is written', async () => {
+    const { domain, accessToken } = fixture;
+
+    await writeTrustedIssuers([replacementIssuer()]);
+    await writeTrustedIssuers([]);
+
+    expect(trustedIssuerDomains(await listTrustDomains(domain.id, accessToken))).toHaveLength(0);
+
+    const rejected = await exchangeExternalJwt(signReplacementJwt()).expect(400);
+    expect(rejected.body.error_description).toBe('The presented token is invalid');
   });
 });


### PR DESCRIPTION
The security domain stops persisting its inline trusted-issuer list on both
storage backends. The deprecated domain-level field becomes a projection over
the trusted domains carrying an issuer: reads assemble it, writes translate into
entity creates, updates and deletes, so an issuer omitted from a written list
stops being trusted. A write preserves the SPIFFE matcher of any domain it
touches, so a trusted domain serving both usages keeps both. The management API
keeps the permission it accepts today; the trusted-domains API requires the
trusted-domain permission.

The gateway resolves external subject and actor tokens by matching the issuer
against the resident trusted domains, and the derived issuer lookup on the
token-exchange settings is gone. Matchers are independent, so a single trusted
domain can serve JWT-SVID client assertions and token exchange over the same key
material.

The upgrader drops the inline declarations once every issuer it found is
represented as an entity, so no stored domain keeps a vestigial list.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>