### PR TITLE
test: AM-7331 token exchange claim mapping test coverage

### DIFF
--- a/gravitee-am-test/specs/gateway/token-exchange/fixtures/token-exchange-fixture.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/fixtures/token-exchange-fixture.ts
@@ -32,6 +32,10 @@ import { TokenClaim } from '@management-models/TokenClaim';
 import { User } from '@management-models/User';
 import request from 'supertest';
 
+export const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
+export const ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
+export const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
+
 /**
  * OIDC configuration returned from well-known endpoint
  */
@@ -91,6 +95,12 @@ export interface TokenExchangeFixture {
 
   // Helper method to exchange token (impersonation/delegation)
   exchangeToken: (subjectToken: string, subjectTokenType: 'access_token' | 'refresh_token', actorToken?: string) => Promise<string>;
+
+  /**
+   * Exchange an access-token subject token and return the whole token response.
+   * `extraParams` is appended to the form body verbatim.
+   */
+  exchange: (subjectToken: string, extraParams?: string) => Promise<Record<string, any>>;
 }
 
 /**
@@ -341,6 +351,19 @@ export const setupTokenExchangeFixture = async (config: TokenExchangeFixtureConf
       return exchangedToken;
     };
 
+    const exchange = async (subjectToken: string, extraParams = ''): Promise<Record<string, any>> => {
+      const response = await performPost(
+        oidc.token_endpoint,
+        '',
+        `grant_type=${TOKEN_EXCHANGE_GRANT}&subject_token=${subjectToken}&subject_token_type=${ACCESS_TOKEN_TYPE}${extraParams}`,
+        {
+          'Content-type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${basicAuth}`,
+        },
+      ).expect(200);
+      return response.body;
+    };
+
     // Cleanup function
     const cleanup = async () => {
       if (domain?.id && accessToken) {
@@ -361,6 +384,7 @@ export const setupTokenExchangeFixture = async (config: TokenExchangeFixtureConf
       introspectToken,
       revokeToken,
       exchangeToken,
+      exchange,
       cleanup,
     };
   } catch (error) {

--- a/gravitee-am-test/specs/gateway/token-exchange/token-exchange-claim-mapper-el-precedence.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/token-exchange-claim-mapper-el-precedence.jest.spec.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { parseJwt } from '@api-fixtures/jwt';
+import { getApplication, patchApplication } from '@management-commands/application-management-commands';
+import { waitForDomainSync } from '@management-commands/domain-management-commands';
+import { retryUntil } from '@utils-commands/retry';
+import { TokenClaim } from '@management-models/TokenClaim';
+import { jira } from '@specs-utils/jira';
+import { setup } from '../../test-fixture';
+import {
+  ACCESS_TOKEN_TYPE,
+  ClaimMapping,
+  TOKEN_EXCHANGE_TEST,
+  TokenExchangeFixture,
+  setupTokenExchangeFixture,
+} from './fixtures/token-exchange-fixture';
+
+setup(300000);
+
+const SUBJECT_CLAIMS = "#context.attributes['token_exchange']['subject']['subject_token_claims']";
+const ACTOR_CLAIMS = "#context.attributes['token_exchange']['actor']['actor_token_claims']";
+
+const CONTESTED: ClaimMapping[] = [
+  { source: 'SUBJECT_TOKEN', sourceClaim: 'jti', tokenClaim: 'contested_subject' },
+  { source: 'ACTOR_TOKEN', sourceClaim: 'jti', tokenClaim: 'contested_actor' },
+];
+
+const shadowingClaims = (sourceClaim: string): TokenClaim[] => [
+  { claimName: 'contested_subject', claimValue: `{${SUBJECT_CLAIMS}['${sourceClaim}']}`, tokenType: 'ACCESS_TOKEN' },
+  { claimName: 'contested_actor', claimValue: `{${ACTOR_CLAIMS}['${sourceClaim}']}`, tokenType: 'ACCESS_TOKEN' },
+];
+
+/**
+ * The subject token keeps the fixture's default scopes; the actor token is issued narrower, and the
+ * exchange asks narrower still. All three differ, so a contested claim cannot pass by matching the
+ * wrong one of them.
+ */
+const SUBJECT_SCOPE = 'openid profile offline_access';
+const ACTOR_SCOPE = 'openid profile';
+const EXCHANGE_SCOPE = 'openid';
+
+const delegationConfig = {
+  allowImpersonation: true,
+  allowDelegation: true,
+  allowedActorTokenTypes: TOKEN_EXCHANGE_TEST.DEFAULT_ALLOWED_ACTOR_TOKEN_TYPES,
+  maxDelegationDepth: 3,
+};
+
+let applicationMapper: TokenExchangeFixture;
+let sameSource: TokenExchangeFixture;
+let domainMapper: TokenExchangeFixture;
+let removal: TokenExchangeFixture;
+let impersonation: TokenExchangeFixture;
+
+beforeAll(async () => {
+  applicationMapper = await setupTokenExchangeFixture({
+    domainNamePrefix: 'tx-el-shadow-app',
+    domainDescription: 'Custom claims shadow an application claims mapper',
+    clientName: 'tx-el-shadow-app-client',
+    ...delegationConfig,
+    claimMappings: CONTESTED,
+    tokenCustomClaims: shadowingClaims('scope'),
+  });
+
+  sameSource = await setupTokenExchangeFixture({
+    domainNamePrefix: 'tx-el-shadow-same',
+    domainDescription: 'Custom claims and mappers resolve the same source claim',
+    clientName: 'tx-el-shadow-same-client',
+    ...delegationConfig,
+    claimMappings: CONTESTED,
+    tokenCustomClaims: shadowingClaims('jti'),
+  });
+
+  domainMapper = await setupTokenExchangeFixture({
+    domainNamePrefix: 'tx-el-shadow-domain',
+    domainDescription: 'Custom claims shadow a mapper inherited from the domain',
+    clientName: 'tx-el-shadow-domain-client',
+    ...delegationConfig,
+    domainClaimMappings: CONTESTED,
+    tokenCustomClaims: shadowingClaims('scope'),
+  });
+
+  removal = await setupTokenExchangeFixture({
+    domainNamePrefix: 'tx-el-shadow-removal',
+    domainDescription: 'Mappers apply once the shadowing custom claims are removed',
+    clientName: 'tx-el-shadow-removal-client',
+    ...delegationConfig,
+    claimMappings: CONTESTED,
+    tokenCustomClaims: shadowingClaims('scope'),
+  });
+
+  // impersonation mode: the domain allows impersonation only, so no actor token ever reaches the
+  // exchange and the actor side of both mechanisms has nothing to resolve
+  impersonation = await setupTokenExchangeFixture({
+    domainNamePrefix: 'tx-el-shadow-impersonation',
+    domainDescription: 'Contested actor claim under impersonation',
+    clientName: 'tx-el-shadow-impersonation-client',
+    allowImpersonation: true,
+    allowDelegation: false,
+    claimMappings: CONTESTED,
+    tokenCustomClaims: shadowingClaims('scope'),
+  });
+});
+
+afterAll(async () => {
+  await applicationMapper?.cleanup();
+  await sameSource?.cleanup();
+  await domainMapper?.cleanup();
+  await removal?.cleanup();
+  await impersonation?.cleanup();
+});
+
+/** One delegation exchange, returning the issued payload alongside both source tokens. */
+const delegate = async (fixture: TokenExchangeFixture, extraParams = '') => {
+  const { accessToken: subjectToken } = await fixture.obtainSubjectToken();
+  const { accessToken: actorToken } = await fixture.obtainActorToken(encodeURIComponent(ACTOR_SCOPE));
+
+  const body = await fixture.exchange(subjectToken, `&actor_token=${actorToken}&actor_token_type=${ACCESS_TOKEN_TYPE}${extraParams}`);
+
+  return {
+    issued: parseJwt(body.access_token).payload,
+    subject: parseJwt(subjectToken).payload,
+    actor: parseJwt(actorToken).payload,
+  };
+};
+
+describe('Token Exchange custom claim shadowing a claims mapper', () => {
+  it(jira`should let custom claims shadow the mappers writing the same claims ${'AM-7558'}`, async () => {
+    const { issued, subject, actor } = await delegate(applicationMapper, `&scope=${EXCHANGE_SCOPE}`);
+
+    expect(issued['contested_subject']).toEqual(SUBJECT_SCOPE);
+    expect(issued['contested_subject']).toEqual(subject['scope']);
+    expect(issued['contested_subject']).not.toEqual(subject['jti']);
+
+    // the actor claim resolved the actor token, not the subject token
+    expect(issued['contested_actor']).toEqual(ACTOR_SCOPE);
+    expect(issued['contested_actor']).toEqual(actor['scope']);
+    expect(issued['contested_actor']).not.toEqual(actor['jti']);
+
+    // and both came from their source tokens, not from the scope asked for on the exchange
+    expect(issued['scope']).toEqual(EXCHANGE_SCOPE);
+  });
+
+  it(jira`should write each contested claim once when both sources resolve to the same value ${'AM-7558'}`, async () => {
+    const { issued, subject, actor } = await delegate(sameSource);
+
+    expect(issued['contested_subject']).toEqual(subject['jti']);
+    expect(issued['contested_actor']).toEqual(actor['jti']);
+
+    // neither writer may turn a claim into a list by appending to the other's value
+    expect(typeof issued['contested_subject']).toEqual('string');
+    expect(typeof issued['contested_actor']).toEqual('string');
+    expect(issued['contested_subject']).not.toEqual(issued['contested_actor']);
+  });
+
+  it(jira`should let custom claims shadow mappers inherited from the domain ${'AM-7558'}`, async () => {
+    const { issued, subject, actor } = await delegate(domainMapper, `&scope=${EXCHANGE_SCOPE}`);
+
+    expect(issued['contested_subject']).toEqual(SUBJECT_SCOPE);
+    expect(issued['contested_subject']).toEqual(subject['scope']);
+    expect(issued['contested_subject']).not.toEqual(subject['jti']);
+
+    expect(issued['contested_actor']).toEqual(ACTOR_SCOPE);
+    expect(issued['contested_actor']).toEqual(actor['scope']);
+    expect(issued['contested_actor']).not.toEqual(actor['jti']);
+  });
+
+  it(jira`should apply both mappers once the shadowing custom claims are removed ${'AM-7558'}`, async () => {
+    const { domain, application, accessToken: adminToken } = removal;
+
+    await patchApplication(domain.id, adminToken, { settings: { oauth: { tokenCustomClaims: [] } } }, application.id);
+
+    // guard: the patch must leave the mappers in place, or the assertions below would prove nothing
+    const reread = await getApplication(domain.id, adminToken, application.id);
+    expect(reread.settings.oauth.tokenExchangeOAuthSettings.claimMappings).toHaveLength(2);
+
+    await waitForDomainSync(domain.id);
+
+    // the gateway applies the change on its next sync, so the mapped values take a moment to surface
+    const { issued, subject, actor } = await retryUntil(
+      () => delegate(removal),
+      (result) => result.issued['contested_subject'] === result.subject['jti'],
+      { timeoutMillis: 20000, intervalMillis: 1000 },
+    );
+
+    expect(issued['contested_subject']).toEqual(subject['jti']);
+    expect(issued['contested_actor']).toEqual(actor['jti']);
+  });
+
+  it(jira`should not write the contested actor claim in impersonation mode ${'AM-7558'}`, async () => {
+    const { accessToken: subjectToken } = await impersonation.obtainSubjectToken();
+
+    const body = await impersonation.exchange(subjectToken);
+    const issued = parseJwt(body.access_token).payload;
+    const subject = parseJwt(subjectToken).payload;
+
+    // the subject side is unaffected: the custom claim still shadows its mapper
+    expect(issued['contested_subject']).toEqual(SUBJECT_SCOPE);
+    expect(issued['contested_subject']).toEqual(subject['scope']);
+
+    // with no actor token, neither the custom claim nor the mapper writes the actor claim -
+    // an unresolvable EL does not hand the claim back to the mapper
+    expect(issued).not.toHaveProperty('contested_actor');
+  });
+});

--- a/gravitee-am-test/specs/gateway/token-exchange/token-exchange-claim-mappings.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/token-exchange-claim-mappings.jest.spec.ts
@@ -15,16 +15,19 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import { performPost } from '@gateway-commands/oauth-oidc-commands';
 import { parseJwt } from '@api-fixtures/jwt';
+import { jira } from '@specs-utils/jira';
 import { setup } from '../../test-fixture';
-import { ClaimMapping, setupTokenExchangeFixture, TokenExchangeFixture, TOKEN_EXCHANGE_TEST } from './fixtures/token-exchange-fixture';
+import {
+  ACCESS_TOKEN_TYPE,
+  ClaimMapping,
+  ID_TOKEN_TYPE,
+  TOKEN_EXCHANGE_TEST,
+  TokenExchangeFixture,
+  setupTokenExchangeFixture,
+} from './fixtures/token-exchange-fixture';
 
 setup(180000);
-
-const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
-const ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
-const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
 
 // jti is used as the source claim because it is always present and its value differs between the
 // subject token and the token the exchange issues. That difference is what proves the mapper read
@@ -84,25 +87,12 @@ afterAll(async () => {
   }
 });
 
-const exchange = async (fixture: TokenExchangeFixture, subjectToken: string, extraParams = ''): Promise<Record<string, any>> => {
-  const response = await performPost(
-    fixture.oidc.token_endpoint,
-    '',
-    `grant_type=${TOKEN_EXCHANGE_GRANT}&subject_token=${subjectToken}&subject_token_type=${ACCESS_TOKEN_TYPE}${extraParams}`,
-    {
-      'Content-type': 'application/x-www-form-urlencoded',
-      Authorization: `Basic ${fixture.basicAuth}`,
-    },
-  ).expect(200);
-  return response.body;
-};
-
 describe.each(PLACEMENTS)('Token Exchange claims mapper on the %s (RFC 8693)', (placement) => {
-  it('should copy a subject token claim onto the exchanged access token', async () => {
+  it(jira`should copy a subject token claim onto the exchanged access token ${'AM-7539'}`, async () => {
     const fixture = fixtures[placement].main;
     const { accessToken: subjectToken } = await fixture.obtainSubjectToken();
 
-    const body = await exchange(fixture, subjectToken);
+    const body = await fixture.exchange(subjectToken);
     const exchanged = parseJwt(body.access_token);
 
     expect(exchanged.payload['mapped_subject_jti']).toEqual(parseJwt(subjectToken).payload['jti']);
@@ -113,7 +103,7 @@ describe.each(PLACEMENTS)('Token Exchange claims mapper on the %s (RFC 8693)', (
     const fixture = fixtures[placement].main;
     const { accessToken: subjectToken } = await fixture.obtainSubjectToken();
 
-    const body = await exchange(fixture, subjectToken);
+    const body = await fixture.exchange(subjectToken);
 
     expect(body.access_token).toBeDefined();
     expect(parseJwt(body.access_token).payload).not.toHaveProperty('never_appears');
@@ -123,7 +113,7 @@ describe.each(PLACEMENTS)('Token Exchange claims mapper on the %s (RFC 8693)', (
     const fixture = fixtures[placement].main;
     const { accessToken: subjectToken } = await fixture.obtainSubjectToken();
 
-    const body = await exchange(fixture, subjectToken);
+    const body = await fixture.exchange(subjectToken);
 
     expect(parseJwt(body.access_token).payload).not.toHaveProperty('mapped_actor_jti');
   });
@@ -133,7 +123,7 @@ describe.each(PLACEMENTS)('Token Exchange claims mapper on the %s (RFC 8693)', (
     const { accessToken: subjectToken } = await fixture.obtainSubjectToken();
     const { accessToken: actorToken } = await fixture.obtainActorToken();
 
-    const body = await exchange(fixture, subjectToken, `&actor_token=${actorToken}&actor_token_type=${ACCESS_TOKEN_TYPE}`);
+    const body = await fixture.exchange(subjectToken, `&actor_token=${actorToken}&actor_token_type=${ACCESS_TOKEN_TYPE}`);
     const exchanged = parseJwt(body.access_token);
 
     expect(exchanged.payload['mapped_subject_jti']).toEqual(parseJwt(subjectToken).payload['jti']);
@@ -145,7 +135,7 @@ describe.each(PLACEMENTS)('Token Exchange claims mapper on the %s (RFC 8693)', (
     const fixture = fixtures[placement].main;
     const { accessToken: subjectToken } = await fixture.obtainSubjectToken();
 
-    const body = await exchange(fixture, subjectToken, `&requested_token_type=${ID_TOKEN_TYPE}`);
+    const body = await fixture.exchange(subjectToken, `&requested_token_type=${ID_TOKEN_TYPE}`);
     const issued = parseJwt(body.access_token);
 
     expect(body.issued_token_type).toEqual(ID_TOKEN_TYPE);
@@ -156,7 +146,7 @@ describe.each(PLACEMENTS)('Token Exchange claims mapper on the %s (RFC 8693)', (
     const fixture = fixtures[placement].precedence;
     const { accessToken: subjectToken } = await fixture.obtainSubjectToken();
 
-    const body = await exchange(fixture, subjectToken);
+    const body = await fixture.exchange(subjectToken);
     const exchanged = parseJwt(body.access_token);
 
     expect(exchanged.payload['contested_claim']).toEqual('from-custom-claim');
@@ -188,7 +178,7 @@ describe('Token Exchange claims mapper inheritance', () => {
   it('should not apply the domain mapper to an application that overrides without one', async () => {
     const { accessToken: subjectToken } = await overrideFixture.obtainSubjectToken();
 
-    const body = await exchange(overrideFixture, subjectToken);
+    const body = await overrideFixture.exchange(subjectToken);
 
     expect(body.access_token).toBeDefined();
     expect(parseJwt(body.access_token).payload).not.toHaveProperty('mapped_subject_jti');

--- a/gravitee-am-test/specs/gateway/token-exchange/token-exchange-invalid.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/token-exchange-invalid.jest.spec.ts
@@ -16,17 +16,46 @@
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { parseJwt } from '@api-fixtures/jwt';
 import { setup } from '../../test-fixture';
 import {
+  ACCESS_TOKEN_TYPE,
+  ClaimMapping,
   setupTokenExchangeFixture,
-  TokenExchangeFixture,
+  TOKEN_EXCHANGE_GRANT,
   TOKEN_EXCHANGE_TEST,
+  TokenExchangeFixture,
 } from './fixtures/token-exchange-fixture';
+import { setupTrustedIssuerFixture, TrustedIssuerFixture } from './fixtures/trusted-issuer-fixture';
 
-setup(120000);
+setup(240000);
+
+const JWT_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:jwt';
+
+const SUBJECT_MAPPING: ClaimMapping[] = [{ source: 'SUBJECT_TOKEN', sourceClaim: 'jti', tokenClaim: 'mapped_subject_jti' }];
+const EXTERNAL_MAPPING: ClaimMapping[] = [{ source: 'SUBJECT_TOKEN', sourceClaim: 'claim_id', tokenClaim: 'business_claim_id' }];
+
+const FORGED_JTI = 'forged-jti-value';
+
+const encode = (value: object): string => Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+const decodeSegment = (segment: string): Record<string, any> => JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
+
+/** Rewrite one payload claim, keeping the original header and the original signature. */
+const forgeClaim = (token: string, claim: string, value: unknown): string => {
+  const [header, payload, signature] = token.split('.');
+  return `${header}.${encode({ ...decodeSegment(payload), [claim]: value })}.${signature}`;
+};
+
+/** Strip the signature entirely and declare the token unsigned. */
+const unsign = (token: string): string => {
+  const [header, payload] = token.split('.');
+  return `${encode({ ...decodeSegment(header), alg: 'none' })}.${payload}.`;
+};
 
 let defaultFixture: TokenExchangeFixture;
 let delegationFixture: TokenExchangeFixture;
+let mapperFixture: TokenExchangeFixture;
+let externalFixture: TrustedIssuerFixture;
 
 beforeAll(async () => {
   // Setup default fixture with all token types allowed (impersonation only by default)
@@ -42,6 +71,21 @@ beforeAll(async () => {
     allowedActorTokenTypes: TOKEN_EXCHANGE_TEST.DEFAULT_ALLOWED_ACTOR_TOKEN_TYPES,
     maxDelegationDepth: 3,
   });
+
+  // a domain that sources a claim from the subject token, so a refused token can be shown to
+  // contribute nothing
+  mapperFixture = await setupTokenExchangeFixture({
+    domainNamePrefix: 'token-exchange-mapper',
+    domainDescription: 'Token exchange sourcing a claim from the subject token',
+    clientName: 'token-exchange-mapper-client',
+    allowImpersonation: true,
+    allowDelegation: false,
+    claimMappings: SUBJECT_MAPPING,
+  });
+
+  // the externally signed case, where the expiry of someone else's JWT is the only thing between
+  // their claims and the issued token
+  externalFixture = await setupTrustedIssuerFixture({ claimMappings: EXTERNAL_MAPPING });
 });
 
 afterAll(async () => {
@@ -51,7 +95,26 @@ afterAll(async () => {
   if (delegationFixture) {
     await delegationFixture.cleanup();
   }
+  await mapperFixture?.cleanup();
+  await externalFixture?.cleanup();
 });
+
+/** Raw exchange that asserts nothing, so each test can inspect the status itself. */
+const rawExchange = (fixture: TokenExchangeFixture, subjectToken: string, extraParams = '') =>
+  performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=${TOKEN_EXCHANGE_GRANT}&subject_token=${subjectToken}&subject_token_type=${ACCESS_TOKEN_TYPE}${extraParams}`,
+    { 'Content-type': 'application/x-www-form-urlencoded', Authorization: `Basic ${fixture.basicAuth}` },
+  );
+
+const exchangeExternalJwt = (externalJwt: string) =>
+  performPost(
+    externalFixture.oidc.token_endpoint,
+    '',
+    `grant_type=${TOKEN_EXCHANGE_GRANT}&subject_token=${encodeURIComponent(externalJwt)}&subject_token_type=${JWT_TOKEN_TYPE}`,
+    { 'Content-type': 'application/x-www-form-urlencoded', Authorization: `Basic ${externalFixture.basicAuth}` },
+  );
 
 describe('Token Exchange with invalid tokens', () => {
   it('should reject a subject token with a tampered signature', async () => {
@@ -92,10 +155,10 @@ describe('Token Exchange with invalid tokens', () => {
       oidc.token_endpoint,
       '',
       `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` +
-      `&subject_token=${subjectToken}` +
-      `&subject_token_type=urn:ietf:params:oauth:token-type:access_token` +
-      `&actor_token=${tamperedActorToken}` +
-      `&actor_token_type=urn:ietf:params:oauth:token-type:access_token`,
+        `&subject_token=${subjectToken}` +
+        `&subject_token_type=urn:ietf:params:oauth:token-type:access_token` +
+        `&actor_token=${tamperedActorToken}` +
+        `&actor_token_type=urn:ietf:params:oauth:token-type:access_token`,
       {
         'Content-type': 'application/x-www-form-urlencoded',
         Authorization: `Basic ${basicAuth}`,
@@ -105,5 +168,75 @@ describe('Token Exchange with invalid tokens', () => {
     // Then: invalid_request with a generic description.
     expect(response.body.error).toBe('invalid_request');
     expect(response.body.error_description).toBe('The presented token is invalid');
+  });
+
+  it('should refuse a subject token whose mapped claim was edited after signing', async () => {
+    const { accessToken: subjectToken } = await mapperFixture.obtainSubjectToken();
+
+    const genuine = await mapperFixture.exchange(subjectToken);
+    expect(parseJwt(genuine.access_token).payload['mapped_subject_jti']).toEqual(parseJwt(subjectToken).payload['jti']);
+
+    // unlike the tampered-signature cases above, this carries the ORIGINAL signature - correct
+    // length and encoding - so it reaches the cryptographic comparison rather than failing on shape
+    const forged = forgeClaim(subjectToken, 'jti', FORGED_JTI);
+    expect(parseJwt(forged).payload['jti']).toEqual(FORGED_JTI);
+    expect(forged.split('.')[2]).toEqual(subjectToken.split('.')[2]);
+
+    const response = await rawExchange(mapperFixture, forged).expect(400);
+
+    expect(response.body.error).toEqual('invalid_request');
+    expect(response.body.error_description).toEqual('The presented token is invalid');
+    expect(response.body).not.toHaveProperty('access_token');
+  });
+
+  it('should refuse an unsigned subject token declaring alg none', async () => {
+    const { accessToken: subjectToken } = await mapperFixture.obtainSubjectToken();
+
+    const genuine = await mapperFixture.exchange(subjectToken);
+    expect(parseJwt(genuine.access_token).payload['mapped_subject_jti']).toEqual(parseJwt(subjectToken).payload['jti']);
+
+    const unsigned = unsign(forgeClaim(subjectToken, 'jti', FORGED_JTI));
+    expect(parseJwt(unsigned).header['alg']).toEqual('none');
+    expect(parseJwt(unsigned).payload['jti']).toEqual(FORGED_JTI);
+
+    const response = await rawExchange(mapperFixture, unsigned).expect(400);
+
+    expect(response.body.error).toEqual('invalid_request');
+    expect(response.body).not.toHaveProperty('access_token');
+  });
+
+  it('should refuse a subject token minted by another domain', async () => {
+    const { accessToken: ownToken } = await mapperFixture.obtainSubjectToken();
+    const { accessToken: foreignToken } = await defaultFixture.obtainSubjectToken();
+
+    const genuine = await mapperFixture.exchange(ownToken);
+    expect(parseJwt(genuine.access_token).payload['mapped_subject_jti']).toEqual(parseJwt(ownToken).payload['jti']);
+
+    // correctly signed, but by another domain's certificate: a valid signature is not enough,
+    // it has to be valid under the trust anchor of the domain being asked
+    const response = await rawExchange(mapperFixture, foreignToken).expect(400);
+
+    expect(response.body.error).toEqual('invalid_request');
+    expect(response.body).not.toHaveProperty('access_token');
+  });
+
+  it('should refuse an expired subject token that is correctly signed', async () => {
+    const claims = { sub: 'external-user-123', scope: 'external:read', iss: externalFixture.externalIssuer, claim_id: 'EXTERNAL-42' };
+
+    const genuine = await exchangeExternalJwt(externalFixture.signExternalJwt(claims)).expect(200);
+    expect(parseJwt(genuine.body.access_token).payload['business_claim_id']).toEqual('EXTERNAL-42');
+
+    // the same issuer, the same key, the same claim - only the lifetime has passed
+    const expired = externalFixture.signExternalJwt(claims, { expiresInSeconds: -60 });
+    expect(parseJwt(expired).payload['exp']).toBeLessThan(Math.floor(Date.now() / 1000));
+
+    const response = await exchangeExternalJwt(expired).expect(400);
+
+    expect(response.body.error).toEqual('invalid_request');
+    // the refusal is indistinguishable from a signature failure by message alone - the trusted
+    // issuer resolver's nimbus claims verifier rejects the expiry before AM's temporal check
+    // can raise its more specific "has expired".
+    expect(response.body.error_description).toEqual('The presented token is invalid');
+    expect(response.body).not.toHaveProperty('access_token');
   });
 });

--- a/gravitee-am-test/specs/gateway/token-exchange/token-exchange-jwt-bearer-subject.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/token-exchange-jwt-bearer-subject.jest.spec.ts
@@ -16,6 +16,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { parseJwt } from '@api-fixtures/jwt';
+import { jira } from '@specs-utils/jira';
 import { setup } from '../../test-fixture';
 import {
   ASSERTION_CLAIM,
@@ -45,7 +46,7 @@ afterAll(async () => {
  * request, so the propagated value cannot come from static configuration.
  */
 describe('Token Exchange over a JWT Bearer subject token (RFC 8693)', () => {
-  it('should propagate an assertion claim through the JWT Bearer grant and the exchange', async () => {
+  it(jira`should propagate an assertion claim through the JWT Bearer grant and the exchange ${'AM-7539'}`, async () => {
     const claimValue = 'AGENT-101';
 
     const subjectToken = await fixture.obtainSubjectToken(claimValue);

--- a/gravitee-am-test/specs/gateway/token-exchange/token-exchange-subject-claims.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/token-exchange-subject-claims.jest.spec.ts
@@ -15,16 +15,18 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import { performPost } from '@gateway-commands/oauth-oidc-commands';
 import { parseJwt } from '@api-fixtures/jwt';
+import { jira } from '@specs-utils/jira';
 import { setup } from '../../test-fixture';
-import { setupTokenExchangeFixture, TokenExchangeFixture, TOKEN_EXCHANGE_TEST } from './fixtures/token-exchange-fixture';
+import {
+  ACCESS_TOKEN_TYPE,
+  ID_TOKEN_TYPE,
+  TOKEN_EXCHANGE_TEST,
+  TokenExchangeFixture,
+  setupTokenExchangeFixture,
+} from './fixtures/token-exchange-fixture';
 
 setup(120000);
-
-const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
-const ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
-const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
 
 const SUBJECT_CLAIMS = "#context.attributes['token_exchange']['subject']['subject_token_claims']";
 const ACTOR_CLAIMS = "#context.attributes['token_exchange']['actor']['actor_token_claims']";
@@ -71,29 +73,12 @@ afterAll(async () => {
   }
 });
 
-const exchange = async (
-  fixture: TokenExchangeFixture,
-  subjectToken: string,
-  extraParams = '',
-): Promise<Record<string, any>> => {
-  const response = await performPost(
-    fixture.oidc.token_endpoint,
-    '',
-    `grant_type=${TOKEN_EXCHANGE_GRANT}&subject_token=${subjectToken}&subject_token_type=${ACCESS_TOKEN_TYPE}${extraParams}`,
-    {
-      'Content-type': 'application/x-www-form-urlencoded',
-      Authorization: `Basic ${fixture.basicAuth}`,
-    },
-  ).expect(200);
-  return response.body;
-};
-
 describe('Token Exchange subject token claims in EL (RFC 8693)', () => {
-  it('should copy a subject token claim onto the exchanged access token', async () => {
+  it(jira`should copy a subject token claim onto the exchanged access token ${'AM-7539'}`, async () => {
     const { obtainSubjectToken } = impersonationFixture;
     const { accessToken: subjectToken } = await obtainSubjectToken();
 
-    const body = await exchange(impersonationFixture, subjectToken);
+    const body = await impersonationFixture.exchange(subjectToken);
     const exchanged = parseJwt(body.access_token);
     const subject = parseJwt(subjectToken);
 
@@ -102,11 +87,11 @@ describe('Token Exchange subject token claims in EL (RFC 8693)', () => {
     expect(exchanged.payload['tx_subject_jti']).not.toEqual(exchanged.payload['jti']);
   });
 
-  it('should expose the subject token scope, not the scope requested on the exchange', async () => {
+  it(jira`should expose the subject token scope, not the scope requested on the exchange ${'AM-7539'}`, async () => {
     const { obtainSubjectToken } = impersonationFixture;
     const { accessToken: subjectToken } = await obtainSubjectToken('openid%20profile%20offline_access');
 
-    const body = await exchange(impersonationFixture, subjectToken, '&scope=openid');
+    const body = await impersonationFixture.exchange(subjectToken, '&scope=openid');
     const exchanged = parseJwt(body.access_token);
 
     const subjectScope = String(exchanged.payload['tx_subject_scope']).split(' ').sort();
@@ -118,7 +103,7 @@ describe('Token Exchange subject token claims in EL (RFC 8693)', () => {
     const { obtainSubjectToken } = impersonationFixture;
     const { accessToken: subjectToken } = await obtainSubjectToken();
 
-    const body = await exchange(impersonationFixture, subjectToken);
+    const body = await impersonationFixture.exchange(subjectToken);
     const exchanged = parseJwt(body.access_token);
 
     expect(body.access_token).toBeDefined();
@@ -129,7 +114,7 @@ describe('Token Exchange subject token claims in EL (RFC 8693)', () => {
     const { obtainSubjectToken } = impersonationFixture;
     const { accessToken: subjectToken } = await obtainSubjectToken();
 
-    const body = await exchange(impersonationFixture, subjectToken, `&requested_token_type=${ID_TOKEN_TYPE}`);
+    const body = await impersonationFixture.exchange(subjectToken, `&requested_token_type=${ID_TOKEN_TYPE}`);
     const issued = parseJwt(body.access_token);
     const subject = parseJwt(subjectToken);
 
@@ -142,11 +127,7 @@ describe('Token Exchange subject token claims in EL (RFC 8693)', () => {
     const { accessToken: subjectToken } = await obtainSubjectToken();
     const { accessToken: actorToken } = await obtainActorToken();
 
-    const body = await exchange(
-      delegationFixture,
-      subjectToken,
-      `&actor_token=${actorToken}&actor_token_type=${ACCESS_TOKEN_TYPE}`,
-    );
+    const body = await delegationFixture.exchange(subjectToken, `&actor_token=${actorToken}&actor_token_type=${ACCESS_TOKEN_TYPE}`);
     const exchanged = parseJwt(body.access_token);
 
     expect(exchanged.payload['tx_subject_jti']).toEqual(parseJwt(subjectToken).payload['jti']);

--- a/gravitee-am-test/specs/management/domain/token-exchange-claim-mappings-validation.jest.spec.ts
+++ b/gravitee-am-test/specs/management/domain/token-exchange-claim-mappings-validation.jest.spec.ts
@@ -21,6 +21,7 @@ import { getDomainManagerUrl } from '@management-commands/service/utils';
 import { uniqueName } from '@utils-commands/misc';
 import { Application } from '@management-models/Application';
 import { Domain } from '@management-models/Domain';
+import { jira } from '@specs-utils/jira';
 import request from 'supertest';
 import { setup } from '../../test-fixture';
 import { patchDomainRaw } from '../../gateway/token-exchange/fixtures/trusted-issuer-fixture';
@@ -105,7 +106,7 @@ afterAll(async () => {
 });
 
 describe('Token exchange claims mapper validation - application level', () => {
-  it.each(RESERVED_CLAIMS)('should refuse a mapping onto the reserved claim "%s"', async (reserved) => {
+  it.each(RESERVED_CLAIMS)(jira`should refuse a mapping onto the reserved claim "%s" ${'AM-7541'}`, async (reserved) => {
     const response = await patchApplicationRaw(
       domain.id,
       application.id,
@@ -116,7 +117,7 @@ describe('Token exchange claims mapper validation - application level', () => {
     expect(response.body.message).toEqual(`Invalid token exchange claim mappings: [${reserved}]`);
   });
 
-  it('should name every reserved claim it refuses', async () => {
+  it(jira`should name every reserved claim it refuses ${'AM-7541'}`, async () => {
     const response = await patchApplicationRaw(
       domain.id,
       application.id,
@@ -147,7 +148,7 @@ describe('Token exchange claims mapper validation - application level', () => {
     expect(response.body.message).toEqual('Duplicate token exchange claim mappings: [business_claim_id]');
   });
 
-  it('should accept an ordinary target claim and store the mapping', async () => {
+  it(jira`should accept an ordinary target claim and store the mapping ${'AM-7541'}`, async () => {
     const mapping = { source: 'SUBJECT_TOKEN', sourceClaim: 'claim_id', tokenClaim: 'business_claim_id' };
 
     const response = await patchApplicationRaw(domain.id, application.id, accessToken, applicationSettings([mapping])).expect(200);
@@ -159,7 +160,7 @@ describe('Token exchange claims mapper validation - application level', () => {
 });
 
 describe('Token exchange claims mapper validation - domain level', () => {
-  it.each(RESERVED_CLAIMS)('should refuse a domain mapping onto the reserved claim "%s"', async (reserved) => {
+  it.each(RESERVED_CLAIMS)(jira`should refuse a domain mapping onto the reserved claim "%s" ${'AM-7541'}`, async (reserved) => {
     const response = await patchDomainRaw(
       domain.id,
       accessToken,
@@ -182,7 +183,7 @@ describe('Token exchange claims mapper validation - domain level', () => {
     expect(response.body.message).toEqual('Duplicate token exchange claim mappings: [agent_email]');
   });
 
-  it('should accept an ordinary target claim on the domain defaults', async () => {
+  it(jira`should accept an ordinary target claim on the domain defaults ${'AM-7541'}`, async () => {
     const response = await patchDomainRaw(
       domain.id,
       accessToken,


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7331](https://gravitee.atlassian.net/browse/AM-7331)

## :pencil2: A description of the changes proposed in the pull request
Broaden test coverage of token exchange flow with
- `subject_token` and `actor_token` claim mapping with shadowing custom claims
- forged token claims shown to be unreachable by the exchanged token

Add references from automated jest tests to their Jest test case counterparts. (These references are output to the `test_key` and `issue` properties in the run's JUnit XML for future tracking.)

## :memo: Test scenarios 
n/a

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7331]: https://gravitee.atlassian.net/browse/AM-7331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ