### PR TITLE
fix: resolve msg() expressions in the MFA challenge email from name

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/email/impl/EmailServiceImpl.java
@@ -426,6 +426,12 @@ public class EmailServiceImpl implements EmailService {
                 .to(recipients.toArray(new String[recipients.size()]))
                 .build();
 
+        // compute email fromName
+        if (!Strings.isNullOrEmpty(emailTpl.getFromName())) {
+            final Template fromNameTemplate = new Template("fromName", new StringReader(emailTpl.getFromName()), freemarkerConfiguration);
+            email.setFromName(processTemplate(fromNameTemplate, params, preferredLanguage));
+        }
+
         // compute email subject
         final Template plainTextTemplate = new Template("subject", new StringReader(emailTpl.getSubject()), freemarkerConfiguration);
         email.setSubject(processTemplate(plainTextTemplate, params, preferredLanguage));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/email/EmailServiceImplTest.java
@@ -49,7 +49,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 
 import static freemarker.template.Configuration.AUTO_DETECT_NAMING_CONVENTION;
@@ -254,6 +256,45 @@ public class EmailServiceImplTest {
 
         io.gravitee.am.common.email.Email sentEmail = captor.getValue();
         assertThat(sentEmail.getFromName()).isEqualTo("domain-id-team");
+    }
+
+    @Test
+    public void createEmail_must_resolve_dynamic_fromName() throws Exception {
+        var emailService = instantiateEmailService(true);
+        emailServiceSpy = Mockito.spy(emailService);
+        MockitoAnnotations.openMocks(this);
+
+        final Email email = new Email();
+        email.setEnabled(true);
+        email.setFrom("noreply@gravitee.io");
+        email.setFromName("${msg('mfa.from-name')}");
+        email.setSubject("Verification Code");
+        email.setTemplate("mfa_challenge");
+        email.setContent("Your code");
+        email.setExpiresAfter(300);
+
+        when(freemarkerConfiguration.getIncompatibleImprovements()).thenReturn(DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+        when(freemarkerConfiguration.getNamingConvention()).thenReturn(AUTO_DETECT_NAMING_CONVENTION);
+        when(freemarkerConfiguration.getObjectWrapper()).thenReturn(new DefaultObjectWrapperBuilder(DEFAULT_INCOMPATIBLE_IMPROVEMENTS).build());
+        var templateMock = new freemarker.template.Template("content", new StringReader(email.getContent()), freemarkerConfiguration);
+        when(freemarkerConfiguration.getTemplate(eq(email.getTemplate() + ".html"))).thenReturn(templateMock);
+
+        final Properties dictionary = new Properties();
+        dictionary.setProperty("mfa.from-name", "Gravitee Security");
+        final DictionaryProvider mockDictionaryProvider = Mockito.mock(DictionaryProvider.class);
+        when(this.emailService.getDefaultDictionaryProvider()).thenReturn(mockDictionaryProvider);
+        when(mockDictionaryProvider.getDictionaryFor(any())).thenReturn(dictionary);
+        when(graviteeMessageResolver.getDynamicDictionaryProvider()).thenReturn(null);
+        when(emailManager.getEmail(anyString(), any(), anyInt())).thenReturn(email);
+
+        final Client client = new Client();
+        client.setId("client-id");
+        client.setClientId("client-id");
+
+        var wrapper = emailServiceSpy.createEmail(
+                Template.MFA_CHALLENGE, client, List.of("john.doe@gravitee.io"), new HashMap<>(), Locale.ENGLISH);
+
+        assertThat(wrapper.getEmail().getFromName()).isEqualTo("Gravitee Security");
     }
 
     private static EmailServiceImpl instantiateEmailService(boolean enabled) {


### PR DESCRIPTION
## :id: Reference related issue. 

https://gravitee.atlassian.net/browse/AM-7564

## :pencil2: A description of the changes proposed in the pull request

The From name of the MFA challenge email now goes through FreeMarker, so a `${msg('my.key')}` expression resolves against the domain text dictionary for the user's preferred locale.

`EmailServiceImpl.createEmail` passed the raw From name straight to the builder. The subject and the content in the same method were both processed. `EmailFactorProvider` is the only caller of that method, so the MFA challenge template was the only one affected.

The From address in the same method is still raw. AM-5997 left it raw in the sibling method too, and the console validates that field as an email address, so an expression there is unlikely. I'd rather keep this change to the reported behaviour.

## :memo: Test scenarios 

Unit coverage in the branch, all green. The new test fails on master and passes here. Manual steps to reproduce are in the Jira ticket.

## :computer: Add screenshots for UI

No UI changes.

## :books: Any other comments that will help with documentation

None.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes

@gravitee-io/am
