### PR TITLE
test: sign in to the Console as an admin defined in gravitee.yml (AM-2192)

### DIFF
--- a/docker/local-stack/dev/docker-compose.yml
+++ b/docker/local-stack/dev/docker-compose.yml
@@ -79,6 +79,18 @@ services:
       - GIO_MAX_MEM=512m
       - GRAVITEE_SERVICES_CORE_HTTP_HOST=0.0.0.0
       - GRAVITEE_HTTP_API_AUTOMATION_ENABLED=true
+      # AM-2192: a second administrator declared in the configuration file, alongside the
+      # default 'admin' shipped as users[0]. The inline provider is merged with the built-in
+      # Gravitee provider rather than replacing it, so 'admin:adminadmin' (and the healthcheck
+      # above) keeps working. Credentials must match ALT_ADMIN_* in playwright/utils/test-constants.ts.
+      # '$' is escaped as '$$' so Compose does not interpolate the BCrypt hash.
+      - GRAVITEE_SECURITY_PROVIDERS_0_ENABLED=true
+      - GRAVITEE_SECURITY_PROVIDERS_0_USERS_1_USERNAME=altadmin
+      # BCrypt hash of 'altadminaltadmin' — AM supports only the $2a$ prefix.
+      - GRAVITEE_SECURITY_PROVIDERS_0_USERS_1_PASSWORD=$$2a$$10$$52d0g.sIqu0Ut59IFTB8f.ld7px0p1Jl7cFPlYn8HK9BjDjUkVjha
+      - GRAVITEE_SECURITY_PROVIDERS_0_USERS_1_ROLE=ORGANIZATION_OWNER
+      - GRAVITEE_SECURITY_PROVIDERS_0_USERS_1_FIRSTNAME=Alternate
+      - GRAVITEE_SECURITY_PROVIDERS_0_USERS_1_LASTNAME=Administrator
 
   am-wait:
     image: curlimages/curl:8.10.1

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/IdentityProviderManagerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/IdentityProviderManagerTest.java
@@ -33,12 +33,14 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +67,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class IdentityProviderManagerTest {
     private static final String ADMIN_USERNAME = "admin";
+    private static final String ALT_ADMIN_USERNAME = "altadmin";
 
     @Spy
     private MockEnvironment environment = new MockEnvironment();
@@ -126,6 +129,53 @@ public class IdentityProviderManagerTest {
                 idp.getType().equals("gravitee-am-idp")));
         verify(idpPluginManager).create(eq("gravitee-am-idp"), any(), any());
 
+    }
+
+    /**
+     * AM-2192: the configuration file may declare more than one administrator. Existing
+     * coverage only ever exercised users[0], so a second entry reaching neither the provider
+     * configuration nor the role mapper would have gone unnoticed.
+     */
+    @Test
+    public void shouldRegisterSecondAdminDefinedInConfiguration() {
+        defineDefaultSecurityConfig(true);
+        doReturn(ALT_ADMIN_USERNAME).when(environment).getProperty("security.providers[0].users[1].username");
+        doReturn("altadminaltadmin").when(environment).getProperty("security.providers[0].users[1].password");
+        doReturn("ORGANIZATION_OWNER").when(environment).getProperty("security.providers[0].users[1].role");
+
+        Role primaryOwner = new Role();
+        primaryOwner.setId("primaryOwnerId");
+        primaryOwner.setName("ORGANIZATION_PRIMARY_OWNER");
+        Role owner = new Role();
+        owner.setId("ownerId");
+        owner.setName("ORGANIZATION_OWNER");
+
+        when(roleService.findRolesByName(any(), any(), any(), any())).thenReturn(Flowable.just(primaryOwner, owner));
+        when(idpPluginManager.create(eq("gravitee-am-idp"), any(), any())).thenReturn(Single.just(Optional.of(mock(UserProvider.class))));
+        when(idpPluginManager.create(eq("inline-am-idp"), any(), any())).thenReturn(Single.just(Optional.empty()));
+
+        cut.loadIdentityProviders().blockingAwait();
+
+        // the listener takes io.gravitee.am.model.IdentityProvider — qualified because this
+        // class imports the identityprovider.api type of the same name
+        ArgumentCaptor<io.gravitee.am.model.IdentityProvider> captor =
+                ArgumentCaptor.forClass(io.gravitee.am.model.IdentityProvider.class);
+        verify(listener, times(2)).registerAuthenticationProvider(captor.capture());
+
+        io.gravitee.am.model.IdentityProvider inline = captor.getAllValues().stream()
+                .filter(idp -> "inline-am-idp".equals(idp.getType()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("inline provider was not registered"));
+
+        assertTrue("default admin missing from provider configuration", inline.getConfiguration().contains(ADMIN_USERNAME));
+        assertTrue("second admin missing from provider configuration", inline.getConfiguration().contains(ALT_ADMIN_USERNAME));
+
+        assertTrue("no role mapped for the default admin", inline.getRoleMapper().containsKey("primaryOwnerId"));
+        assertTrue("no role mapped for the second admin", inline.getRoleMapper().containsKey("ownerId"));
+        assertTrue("second admin not mapped to ORGANIZATION_OWNER",
+                Arrays.asList(inline.getRoleMapper().get("ownerId")).contains("username=" + ALT_ADMIN_USERNAME));
+        assertTrue("default admin not mapped to ORGANIZATION_PRIMARY_OWNER",
+                Arrays.asList(inline.getRoleMapper().get("primaryOwnerId")).contains("username=" + ADMIN_USERNAME));
     }
 
     @Test

--- a/gravitee-am-test/playwright/pages/login.page.ts
+++ b/gravitee-am-test/playwright/pages/login.page.ts
@@ -58,6 +58,18 @@ export class LoginPage {
     await this.page.waitForURL(/.*(?:environments|dashboard|domains).*/i);
   }
 
+  /**
+   * Submit credentials without waiting for a redirect to the console.
+   * Use for sign-in attempts that are expected to be refused, where login()
+   * would block until its navigation timeout.
+   */
+  async submitCredentials(username: string, password: string): Promise<void> {
+    await this.usernameInput.waitFor({ state: 'visible' });
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+    await this.signInButton.click();
+  }
+
   async expectLoginFormVisible(): Promise<void> {
     await expect(this.usernameInput).toBeVisible();
     await expect(this.passwordInput).toBeVisible();

--- a/gravitee-am-test/playwright/pages/navbar.page.ts
+++ b/gravitee-am-test/playwright/pages/navbar.page.ts
@@ -95,4 +95,14 @@ export class NavbarPage extends BasePage {
     await this.row(name).hover();
     await this.menu.getByTestId(`domainDefaultToggle-${name}`).click();
   }
+
+  /**
+   * Assert which account the current session belongs to, read from the
+   * account menu's preferred_username. Distinguishes "a console is shown"
+   * from "this specific administrator is signed in".
+   */
+  async expectSignedInAs(username: string): Promise<void> {
+    await this.accountMenuTrigger.click();
+    await expect(this.accountMenu.locator('.userAccountInfo small')).toHaveText(username);
+  }
 }

--- a/gravitee-am-test/playwright/tests/auth/login/login-flows.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/login/login-flows.spec.ts
@@ -19,14 +19,7 @@ import { test as gatewayTest } from '../../../fixtures/login-flows-gateway.fixtu
 import { NavbarPage } from '../../../pages/navbar.page';
 import { linkJira } from '../../../utils/jira';
 import { buildAuthorizeUrl, submitLogin, reachOAuthAuthorizationCallback } from '../../../utils/mfa-helpers';
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  ALT_ADMIN_PASSWORD,
-  ALT_ADMIN_USERNAME,
-  AUTH_CODE_FORMAT,
-  UNCONFIGURED_ADMIN_USERNAME,
-} from '../../../utils/test-constants';
+import { ADMIN_PASSWORD, ADMIN_USERNAME, ALT_ADMIN_PASSWORD, ALT_ADMIN_USERNAME, AUTH_CODE_FORMAT } from '../../../utils/test-constants';
 
 consoleTest.describe('Console admin login (AM-2230)', () => {
   consoleTest.use({ storageState: { cookies: [], origins: [] } });
@@ -90,7 +83,7 @@ consoleTest.describe('Console alternate admin (AM-2192)', () => {
     linkJira(testInfo, 'AM-2192');
 
     await loginPage.goto();
-    await loginPage.submitCredentials(UNCONFIGURED_ADMIN_USERNAME, ALT_ADMIN_PASSWORD);
+    await loginPage.submitCredentials('ghostadmin', ALT_ADMIN_PASSWORD);
 
     // Asserting the error alone would also pass if the console were merely slow, so the
     // absence of the console shell is checked too.

--- a/gravitee-am-test/playwright/tests/auth/login/login-flows.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/login/login-flows.spec.ts
@@ -16,9 +16,17 @@
 import { expect } from '@playwright/test';
 import { test as consoleTest } from '../../../fixtures/base.fixture';
 import { test as gatewayTest } from '../../../fixtures/login-flows-gateway.fixture';
+import { NavbarPage } from '../../../pages/navbar.page';
 import { linkJira } from '../../../utils/jira';
 import { buildAuthorizeUrl, submitLogin, reachOAuthAuthorizationCallback } from '../../../utils/mfa-helpers';
-import { ADMIN_PASSWORD, AUTH_CODE_FORMAT } from '../../../utils/test-constants';
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  ALT_ADMIN_PASSWORD,
+  ALT_ADMIN_USERNAME,
+  AUTH_CODE_FORMAT,
+  UNCONFIGURED_ADMIN_USERNAME,
+} from '../../../utils/test-constants';
 
 consoleTest.describe('Console admin login (AM-2230)', () => {
   consoleTest.use({ storageState: { cookies: [], origins: [] } });
@@ -37,25 +45,58 @@ consoleTest.describe('Console admin login (AM-2230)', () => {
   });
 });
 
+/**
+ * AM-2192 — an administrator declared in the configuration file rather than the database.
+ *
+ * The account is provisioned as security.providers[0].users[1] by the management service in
+ * docker/local-stack/dev/docker-compose.yml. AM merges that inline provider with the built-in
+ * Gravitee provider instead of replacing it, so both administrators are expected to work.
+ */
 consoleTest.describe('Console alternate admin (AM-2192)', () => {
   consoleTest.use({ storageState: { cookies: [], origins: [] } });
 
-  consoleTest('AM-2192: login with non-default admin credentials when configured', async ({ loginPage, page }, testInfo) => {
+  consoleTest('AM-2192: an administrator added to the configuration file can sign in', async ({ loginPage, page }, testInfo) => {
     linkJira(testInfo, 'AM-2192');
 
-    // eslint-disable-next-line playwright/no-skipped-test -- optional stack configuration
-    consoleTest.skip(
-      !process.env.AM_ALT_ADMIN_USERNAME?.trim() || !process.env.AM_ALT_ADMIN_PASSWORD?.trim(),
-      'Set AM_ALT_ADMIN_USERNAME and AM_ALT_ADMIN_PASSWORD (user must exist for the Management API realm)',
-    );
-
-    const username = process.env.AM_ALT_ADMIN_USERNAME!.trim();
-    const password = process.env.AM_ALT_ADMIN_PASSWORD!.trim();
+    const username = process.env.AM_ALT_ADMIN_USERNAME?.trim() || ALT_ADMIN_USERNAME;
+    const password = process.env.AM_ALT_ADMIN_PASSWORD?.trim() || ALT_ADMIN_PASSWORD;
 
     await loginPage.goto();
     await loginPage.login(username, password);
 
     await expect(page.locator('.gio-side-nav').first()).toBeVisible();
+    await expect(page).toHaveURL(/(?:environments|dashboard|domains)/i);
+    // Prove the session belongs to the configuration-defined account, not the default admin.
+    await new NavbarPage(page).expectSignedInAs(username);
+  });
+
+  consoleTest('AM-2192: the default administrator still works alongside the added one', async ({ loginPage, page }, testInfo) => {
+    linkJira(testInfo, 'AM-2192');
+
+    // Regression guard: enabling the inline provider must not displace the database-backed
+    // 'admin' account that the rest of the suite (and the compose healthcheck) relies on.
+    const username = process.env.AM_ADMIN_USERNAME || ADMIN_USERNAME;
+    const password = process.env.AM_ADMIN_PASSWORD || ADMIN_PASSWORD;
+
+    await loginPage.goto();
+    await loginPage.login(username, password);
+
+    await expect(page.locator('.gio-side-nav').first()).toBeVisible();
+    await expect(page).toHaveURL(/(?:environments|dashboard|domains)/i);
+    await new NavbarPage(page).expectSignedInAs(username);
+  });
+
+  consoleTest('AM-2192: credentials not in the configuration file are refused', async ({ loginPage, page }, testInfo) => {
+    linkJira(testInfo, 'AM-2192');
+
+    await loginPage.goto();
+    await loginPage.submitCredentials(UNCONFIGURED_ADMIN_USERNAME, ALT_ADMIN_PASSWORD);
+
+    // Asserting the error alone would also pass if the console were merely slow, so the
+    // absence of the console shell is checked too.
+    await loginPage.expectError();
+    await expect(page).not.toHaveURL(/(?:environments|dashboard|domains)/i);
+    await expect(page.locator('.gio-side-nav')).toHaveCount(0);
   });
 });
 

--- a/gravitee-am-test/playwright/utils/test-constants.ts
+++ b/gravitee-am-test/playwright/utils/test-constants.ts
@@ -36,9 +36,6 @@ export const ADMIN_PASSWORD = 'adminadmin';
 export const ALT_ADMIN_USERNAME = 'altadmin';
 export const ALT_ADMIN_PASSWORD = 'altadminaltadmin';
 
-/** A username that is deliberately absent from the configuration file (AM-2192 negative case) */
-export const UNCONFIGURED_ADMIN_USERNAME = 'ghostadmin';
-
 /** Regex matching a valid JWT (three Base64url segments separated by dots) */
 export const JWT_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 

--- a/gravitee-am-test/playwright/utils/test-constants.ts
+++ b/gravitee-am-test/playwright/utils/test-constants.ts
@@ -26,6 +26,19 @@ export const ADMIN_USERNAME = 'admin';
 /** Default admin password */
 export const ADMIN_PASSWORD = 'adminadmin';
 
+/**
+ * AM-2192: a second administrator declared in the configuration file rather than the database.
+ * Provisioned as security.providers[0].users[1] by the management service in
+ * docker/local-stack/dev/docker-compose.yml — these must stay in step with that file.
+ * Deliberately a different password from ADMIN_PASSWORD, so a test signing in as this
+ * account cannot pass by accidentally authenticating as the default admin.
+ */
+export const ALT_ADMIN_USERNAME = 'altadmin';
+export const ALT_ADMIN_PASSWORD = 'altadminaltadmin';
+
+/** A username that is deliberately absent from the configuration file (AM-2192 negative case) */
+export const UNCONFIGURED_ADMIN_USERNAME = 'ghostadmin';
+
 /** Regex matching a valid JWT (three Base64url segments separated by dots) */
 export const JWT_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 


### PR DESCRIPTION
## Summary

The AM-2192 Console sign-in test never ran. It skipped unless `AM_ALT_ADMIN_USERNAME` and `AM_ALT_ADMIN_PASSWORD` were set, and nothing in the local stack or CI set them — `AM_ALT_ADMIN` appeared nowhere else in the repo. It reported as skipped, which looks green without having tested anything.

This provisions the administrator the test needs, removes the guard, and covers the three scenarios from the ticket.

## Changes

- Second administrator as `security.providers[0].users[1]` on the management service
- Credentials moved into `test-constants.ts`; skip guard deleted, so the test runs unconditionally
- Three scenarios: the configured admin signs in · the default admin still works alongside it · credentials absent from the configuration are refused
- Unit test for a second user in the configuration file — existing coverage only ever exercised `users[0]`

## On the shared compose change

`docker-compose.yml` is used by every suite, so worth stating explicitly: enabling the inline provider is *additive*. `loadIdentityProviders()` merges it with the built-in Gravitee provider rather than replacing it, so `admin:adminadmin` and the compose healthcheck are unaffected, and the provider is not persisted — `GET /organizations/DEFAULT/identities` is unchanged.

The BCrypt hash is written with `$$` in the compose file so Compose does not interpolate it away.

## Testing

All run locally against a Mongo local stack:

| Suite | Result |
|---|---|
| `login-flows.spec.ts` | 8 passed, **0 skipped** |
| `playwright/tests/auth/` | 39 passed |
| `IdentityProviderManagerTest` | 7 passed |
| Jest management (88 suites) | 1198 passed / 1215 |

The 17 Jest failures are confined to `ciba.jest.spec.ts` and `openfga.jest.spec.ts`, both of which need services absent from the local stack profile used here (OpenFGA refuses connection on `:8090`; no CIBA container). Neither touches security providers or admin authentication. The 1198 that passed all authenticate through `requestAdminAccessToken()`, which is direct confirmation at scale that the default admin is unaffected by the compose change.

Each new assertion was deliberately broken once to confirm it was live, then reverted. The sign-in scenarios assert the account shown in the navbar, so they distinguish "this admin is signed in" from "a console rendered" — the previous assertion would have passed for the default admin too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
