### PR TITLE
test: identity provider selection rule edge cases (AM-2171)

### DIFF
--- a/gravitee-am-test/specs/gateway/login-flow/fixture/login-flow-inline-fixture.ts
+++ b/gravitee-am-test/specs/gateway/login-flow/fixture/login-flow-inline-fixture.ts
@@ -18,7 +18,8 @@ import { expect } from '@jest/globals';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { setupDomainForTest, safeDeleteDomain, DomainOidcConfig } from '@management-commands/domain-management-commands';
 import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
-import { initiateLoginFlow, login } from '@gateway-commands/login-commands';
+import { getHeaderLocation, initiateLoginFlow, login } from '@gateway-commands/login-commands';
+import { logoutUser, performGet, requestToken } from '@gateway-commands/oauth-oidc-commands';
 import { createIdp } from '@management-commands/idp-management-commands';
 import { createTestApp } from '@utils-commands/application-commands';
 import { getLastEmail } from '@utils-commands/email-commands';
@@ -248,4 +249,39 @@ export const setupInlineFixture = async (): Promise<LoginFlowInlineFixture> => {
       }
     },
   };
+};
+
+/**
+ * Sign in through `app` and return the profile of whichever identity provider answered.
+ *
+ * Both inline providers hold the same username with a different profile, so the returned
+ * `given_name` is what says which provider handled the sign-in — the basis of both the
+ * priority-order and selection-rule specs.
+ */
+export const signInAndReadProfile = async (
+  app: any,
+  openIdConfiguration: DomainOidcConfig,
+  username: string,
+  password: string,
+): Promise<Record<string, any>> => {
+  const clientId = app.settings.oauth.clientId;
+
+  const authResponse = await performGet(
+    openIdConfiguration.authorization_endpoint,
+    `?response_type=code&client_id=${clientId}&redirect_uri=${REDIRECT_URI}&scope=openid%20profile`,
+  ).expect(302);
+
+  const postLogin = await login(authResponse, username, clientId, password);
+  const loginResponse = await getHeaderLocation(postLogin);
+  expect(loginResponse.headers['location']).toContain(`${REDIRECT_URI}?code=`);
+
+  const tokenResponse = await requestToken(app, openIdConfiguration, loginResponse);
+  expect(tokenResponse.status).toBe(200);
+
+  const userInfo = await performGet(openIdConfiguration.userinfo_endpoint, '', {
+    Authorization: `Bearer ${tokenResponse.body.access_token}`,
+  }).expect(200);
+
+  await logoutUser(openIdConfiguration.end_session_endpoint, loginResponse);
+  return userInfo.body;
 };

--- a/gravitee-am-test/specs/gateway/login-flow/idp-priority-order.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/login-flow/idp-priority-order.jest.spec.ts
@@ -15,12 +15,10 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { jira } from '@specs-utils/jira';
-import { getHeaderLocation, login } from '@gateway-commands/login-commands';
-import { logoutUser, performGet, requestToken } from '@gateway-commands/oauth-oidc-commands';
 import { patchApplication } from '@management-commands/application-management-commands';
 import { updateIdp } from '@management-commands/idp-management-commands';
 import { retryImmediatelyForThisFile, setup } from '../../test-fixture';
-import { INLINE_USER, LoginFlowInlineFixture, REDIRECT_URI, setupInlineFixture } from './fixture/login-flow-inline-fixture';
+import { INLINE_USER, LoginFlowInlineFixture, setupInlineFixture, signInAndReadProfile } from './fixture/login-flow-inline-fixture';
 
 setup(200000);
 // The priorities are swapped once, between the two describes below, so order matters.
@@ -45,30 +43,6 @@ const IDP1_ONLY_USERNAME = 'only-in-idp1';
 const IDP1_ONLY_GIVEN_NAME = 'sole-holder';
 
 let fixture: LoginFlowInlineFixture;
-
-/** Signs in through the priority application and returns the profile the winning provider held. */
-const signInAndReadProfile = async (username: string, password: string): Promise<Record<string, any>> => {
-  const clientId = fixture.appIdpPriority.settings.oauth.clientId;
-
-  const authResponse = await performGet(
-    fixture.openIdConfiguration.authorization_endpoint,
-    `?response_type=code&client_id=${clientId}&redirect_uri=${REDIRECT_URI}&scope=openid%20profile`,
-  ).expect(302);
-
-  const postLogin = await login(authResponse, username, clientId, password);
-  const loginResponse = await getHeaderLocation(postLogin);
-  expect(loginResponse.headers['location']).toContain(`${REDIRECT_URI}?code=`);
-
-  const tokenResponse = await requestToken(fixture.appIdpPriority, fixture.openIdConfiguration, loginResponse);
-  expect(tokenResponse.status).toBe(200);
-
-  const userInfo = await performGet(fixture.openIdConfiguration.userinfo_endpoint, '', {
-    Authorization: `Bearer ${tokenResponse.body.access_token}`,
-  }).expect(200);
-
-  await logoutUser(fixture.openIdConfiguration.end_session_endpoint, loginResponse);
-  return userInfo.body;
-};
 
 beforeAll(async () => {
   fixture = await setupInlineFixture();
@@ -108,7 +82,7 @@ beforeAll(async () => {
   const deadline = Date.now() + 30_000;
   for (;;) {
     try {
-      await signInAndReadProfile(IDP1_ONLY_USERNAME, INLINE_USER.password);
+      await signInAndReadProfile(fixture.appIdpPriority, fixture.openIdConfiguration, IDP1_ONLY_USERNAME, INLINE_USER.password);
       break;
     } catch (e) {
       if (Date.now() > deadline) {
@@ -128,13 +102,23 @@ describe('Identity provider processing order (AM-2179)', () => {
   describe('with the shipped order', () => {
     it(jira`the higher priority provider answers for a username both hold ${'AM-2179'}`, async () => {
       // appIdpPriority ships as inmemoryIdp1=2, inmemoryIdp2=1, and the lower number wins.
-      const profile = await signInAndReadProfile(INLINE_USER.username, INLINE_USER.password);
+      const profile = await signInAndReadProfile(
+        fixture.appIdpPriority,
+        fixture.openIdConfiguration,
+        INLINE_USER.username,
+        INLINE_USER.password,
+      );
 
       expect(profile.given_name).toEqual(IDP2_GIVEN_NAME);
     });
 
     it(jira`a user held in only one provider signs in whatever the order ${'AM-2179'}`, async () => {
-      const profile = await signInAndReadProfile(IDP1_ONLY_USERNAME, INLINE_USER.password);
+      const profile = await signInAndReadProfile(
+        fixture.appIdpPriority,
+        fixture.openIdConfiguration,
+        IDP1_ONLY_USERNAME,
+        INLINE_USER.password,
+      );
 
       expect(profile.given_name).toEqual(IDP1_ONLY_GIVEN_NAME);
     });
@@ -158,7 +142,12 @@ describe('Identity provider processing order (AM-2179)', () => {
       // observable — who actually answers a sign-in — rather than waiting on a sync marker.
       const deadline = Date.now() + 30_000;
       for (;;) {
-        const profile = await signInAndReadProfile(INLINE_USER.username, INLINE_USER.password);
+        const profile = await signInAndReadProfile(
+          fixture.appIdpPriority,
+          fixture.openIdConfiguration,
+          INLINE_USER.username,
+          INLINE_USER.password,
+        );
         if (profile.given_name === IDP1_GIVEN_NAME) {
           return;
         }
@@ -169,7 +158,12 @@ describe('Identity provider processing order (AM-2179)', () => {
     });
 
     it(jira`swapping the order changes which provider answers ${'AM-2179'}`, async () => {
-      const profile = await signInAndReadProfile(INLINE_USER.username, INLINE_USER.password);
+      const profile = await signInAndReadProfile(
+        fixture.appIdpPriority,
+        fixture.openIdConfiguration,
+        INLINE_USER.username,
+        INLINE_USER.password,
+      );
 
       // The same username now resolves to the other provider's profile. The family name is
       // checked too, since the providers differ in both and one field alone could be coincidence.
@@ -178,7 +172,12 @@ describe('Identity provider processing order (AM-2179)', () => {
     });
 
     it(jira`the single-provider user is unaffected by the order ${'AM-2179'}`, async () => {
-      const profile = await signInAndReadProfile(IDP1_ONLY_USERNAME, INLINE_USER.password);
+      const profile = await signInAndReadProfile(
+        fixture.appIdpPriority,
+        fixture.openIdConfiguration,
+        IDP1_ONLY_USERNAME,
+        INLINE_USER.password,
+      );
 
       expect(profile.given_name).toEqual(IDP1_ONLY_GIVEN_NAME);
     });

--- a/gravitee-am-test/specs/gateway/login-flow/idp-selection-rules.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/login-flow/idp-selection-rules.jest.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { getHeaderLocation, login, loginUserNameAndPassword } from '@gateway-commands/login-commands';
+import { logoutUser, performGet, requestToken } from '@gateway-commands/oauth-oidc-commands';
+import { createTestApp } from '@utils-commands/application-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { setup } from '../../test-fixture';
+import { INLINE_USER, LoginFlowInlineFixture, REDIRECT_URI, setupInlineFixture } from './fixture/login-flow-inline-fixture';
+
+setup(200000);
+
+/**
+ * A selection rule that cannot be evaluated as a boolean. `selectionRuleMatches` catches the
+ * failure, logs a warning and returns false, so the provider is skipped rather than the sign-in
+ * failing outright. A typo in a rule therefore silently excludes a provider.
+ */
+const MALFORMED_RULE = "{#request.params['username'] matches";
+
+/** A well-formed rule that does not match the fixture user. */
+const NON_MATCHING_RULE = "{#request.params['username'] matches 'nobody'}";
+
+/** Profile held by inmemoryIdp2, which is how a test tells the two providers apart. */
+const IDP2_GIVEN_NAME = 'my-user-2';
+
+const APP_OAUTH_SETTINGS = {
+  redirectUris: [REDIRECT_URI],
+  grantTypes: ['authorization_code', 'client_credentials', 'password', 'refresh_token'],
+  // profile is needed so userinfo returns given_name.
+  scopeSettings: [{ scope: 'openid' }, { scope: 'profile' }],
+};
+
+let fixture: LoginFlowInlineFixture;
+let appMalformedWithFallback: any;
+let appMalformedOnly: any;
+let appUnruledAlongsideRuled: any;
+
+/**
+ * Both inline providers hold the same username with a different profile, so signing in and
+ * reading `given_name` back says which provider actually answered. In every application below
+ * the ruled provider carries the higher priority, so it would answer if its rule were ignored.
+ */
+const signInAndReadGivenName = async (app: any): Promise<string> => {
+  const clientId = app.settings.oauth.clientId;
+
+  const authResponse = await performGet(
+    fixture.openIdConfiguration.authorization_endpoint,
+    `?response_type=code&client_id=${clientId}&redirect_uri=${REDIRECT_URI}&scope=openid%20profile`,
+  ).expect(302);
+
+  const postLogin = await login(authResponse, INLINE_USER.username, clientId, INLINE_USER.password);
+  const loginResponse = await getHeaderLocation(postLogin);
+  expect(loginResponse.headers['location']).toContain(`${REDIRECT_URI}?code=`);
+
+  const tokenResponse = await requestToken(app, fixture.openIdConfiguration, loginResponse);
+  expect(tokenResponse.status).toBe(200);
+
+  const userInfo = await performGet(fixture.openIdConfiguration.userinfo_endpoint, '', {
+    Authorization: `Bearer ${tokenResponse.body.access_token}`,
+  }).expect(200);
+
+  await logoutUser(fixture.openIdConfiguration.end_session_endpoint, loginResponse);
+  return userInfo.body.given_name;
+};
+
+const buildApp = (name: string, identityProviders: any[]) =>
+  createTestApp(uniqueName(name, true), fixture.domain, fixture.accessToken, 'WEB', {
+    identityProviders: new Set(identityProviders),
+    settings: { oauth: APP_OAUTH_SETTINGS, advanced: { skipConsent: true } },
+  });
+
+beforeAll(async () => {
+  fixture = await setupInlineFixture();
+  expect(fixture.openIdConfiguration).toBeDefined();
+
+  appMalformedWithFallback = await buildApp('app-malformed-rule', [
+    { identity: fixture.inmemoryIdp1.id, selectionRule: MALFORMED_RULE, priority: 1 },
+    { identity: fixture.inmemoryIdp2.id, priority: 2 },
+  ]);
+
+  appUnruledAlongsideRuled = await buildApp('app-unruled-alongside-ruled', [
+    { identity: fixture.inmemoryIdp1.id, selectionRule: NON_MATCHING_RULE, priority: 1 },
+    { identity: fixture.inmemoryIdp2.id, priority: 2 },
+  ]);
+
+  // The last creation is wrapped so the gateway has picked up every application before any
+  // test runs, following the same pattern as the fixture itself.
+  appMalformedOnly = await waitForSyncAfter(fixture.domain.id, () =>
+    buildApp('app-malformed-only', [{ identity: fixture.inmemoryIdp1.id, selectionRule: MALFORMED_RULE, priority: 1 }]),
+  );
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('Identity provider selection rule - a rule that cannot be evaluated', () => {
+  it(jira`the provider carrying it is skipped rather than failing the sign-in ${'AM-2171'}`, async () => {
+    // Getting the other provider's profile back is what shows the broken rule excluded its
+    // provider — asserting only that sign-in succeeded would not.
+    expect(await signInAndReadGivenName(appMalformedWithFallback)).toEqual(IDP2_GIVEN_NAME);
+  });
+
+  it(jira`sign-in is refused when the broken rule leaves no provider ${'AM-2171'}`, async () => {
+    const loginResponse = await loginUserNameAndPassword(
+      appMalformedOnly.settings.oauth.clientId,
+      INLINE_USER,
+      INLINE_USER.password,
+      false,
+      fixture.openIdConfiguration,
+      fixture.domain,
+    );
+
+    // Refused the same way as a rule that simply does not match, rather than surfacing an
+    // internal error: the user exists in that provider and would sign in without the rule.
+    expect(loginResponse.headers['location']).toContain('error=login_failed&error_code=invalid_user');
+  });
+});
+
+describe('Identity provider selection rule - a provider carrying no rule', () => {
+  it(jira`takes part when the provider that has a rule does not match ${'AM-2171'}`, async () => {
+    // `selectionRuleMatches` returns true for a blank rule, which is what every provider without
+    // one relies on. The unruled provider has the lower priority, so a pass here can only mean
+    // the ruled provider was excluded rather than simply being beaten to it.
+    expect(await signInAndReadGivenName(appUnruledAlongsideRuled)).toEqual(IDP2_GIVEN_NAME);
+  });
+});

--- a/gravitee-am-test/specs/gateway/login-flow/idp-selection-rules.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/login-flow/idp-selection-rules.jest.spec.ts
@@ -15,13 +15,18 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { jira } from '@specs-utils/jira';
-import { getHeaderLocation, login, loginUserNameAndPassword } from '@gateway-commands/login-commands';
-import { logoutUser, performGet, requestToken } from '@gateway-commands/oauth-oidc-commands';
+import { loginUserNameAndPassword } from '@gateway-commands/login-commands';
 import { createTestApp } from '@utils-commands/application-commands';
 import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
 import { uniqueName } from '@utils-commands/misc';
 import { setup } from '../../test-fixture';
-import { INLINE_USER, LoginFlowInlineFixture, REDIRECT_URI, setupInlineFixture } from './fixture/login-flow-inline-fixture';
+import {
+  INLINE_USER,
+  LoginFlowInlineFixture,
+  REDIRECT_URI,
+  setupInlineFixture,
+  signInAndReadProfile,
+} from './fixture/login-flow-inline-fixture';
 
 setup(200000);
 
@@ -49,34 +54,6 @@ let fixture: LoginFlowInlineFixture;
 let appMalformedWithFallback: any;
 let appMalformedOnly: any;
 let appUnruledAlongsideRuled: any;
-
-/**
- * Both inline providers hold the same username with a different profile, so signing in and
- * reading `given_name` back says which provider actually answered. In every application below
- * the ruled provider carries the higher priority, so it would answer if its rule were ignored.
- */
-const signInAndReadGivenName = async (app: any): Promise<string> => {
-  const clientId = app.settings.oauth.clientId;
-
-  const authResponse = await performGet(
-    fixture.openIdConfiguration.authorization_endpoint,
-    `?response_type=code&client_id=${clientId}&redirect_uri=${REDIRECT_URI}&scope=openid%20profile`,
-  ).expect(302);
-
-  const postLogin = await login(authResponse, INLINE_USER.username, clientId, INLINE_USER.password);
-  const loginResponse = await getHeaderLocation(postLogin);
-  expect(loginResponse.headers['location']).toContain(`${REDIRECT_URI}?code=`);
-
-  const tokenResponse = await requestToken(app, fixture.openIdConfiguration, loginResponse);
-  expect(tokenResponse.status).toBe(200);
-
-  const userInfo = await performGet(fixture.openIdConfiguration.userinfo_endpoint, '', {
-    Authorization: `Bearer ${tokenResponse.body.access_token}`,
-  }).expect(200);
-
-  await logoutUser(fixture.openIdConfiguration.end_session_endpoint, loginResponse);
-  return userInfo.body.given_name;
-};
 
 const buildApp = (name: string, identityProviders: any[]) =>
   createTestApp(uniqueName(name, true), fixture.domain, fixture.accessToken, 'WEB', {
@@ -115,7 +92,13 @@ describe('Identity provider selection rule - a rule that cannot be evaluated', (
   it(jira`the provider carrying it is skipped rather than failing the sign-in ${'AM-2171'}`, async () => {
     // Getting the other provider's profile back is what shows the broken rule excluded its
     // provider — asserting only that sign-in succeeded would not.
-    expect(await signInAndReadGivenName(appMalformedWithFallback)).toEqual(IDP2_GIVEN_NAME);
+    const profile = await signInAndReadProfile(
+      appMalformedWithFallback,
+      fixture.openIdConfiguration,
+      INLINE_USER.username,
+      INLINE_USER.password,
+    );
+    expect(profile.given_name).toEqual(IDP2_GIVEN_NAME);
   });
 
   it(jira`sign-in is refused when the broken rule leaves no provider ${'AM-2171'}`, async () => {
@@ -139,6 +122,12 @@ describe('Identity provider selection rule - a provider carrying no rule', () =>
     // `selectionRuleMatches` returns true for a blank rule, which is what every provider without
     // one relies on. The unruled provider has the lower priority, so a pass here can only mean
     // the ruled provider was excluded rather than simply being beaten to it.
-    expect(await signInAndReadGivenName(appUnruledAlongsideRuled)).toEqual(IDP2_GIVEN_NAME);
+    const profile = await signInAndReadProfile(
+      appUnruledAlongsideRuled,
+      fixture.openIdConfiguration,
+      INLINE_USER.username,
+      INLINE_USER.password,
+    );
+    expect(profile.given_name).toEqual(IDP2_GIVEN_NAME);
   });
 });


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2171](https://gravitee.atlassian.net/browse/AM-2171)

## :pencil2: A description of the changes proposed in the pull request
Cover two gaps in identity provider selection rules. Routing a matching user to the right provider, and a user matching no rule at all, are already covered in `login-flow-inline.jest.spec.ts` and are not duplicated here.

- **A rule that cannot be evaluated.** `selectionRuleMatches` catches the failure, logs a warning and returns false, so the provider is skipped rather than the sign-in failing outright — a typo in a rule silently excludes a provider. Covered from both sides: with a second provider present the sign-in succeeds and returns *that* provider's profile, and when the broken rule is the only provider the sign-in is refused as `invalid_user` rather than surfacing an internal error.
- **A provider carrying no rule.** The existing fallback test asserts only that a code came back, and the fixture user exists in both providers, so it would pass with selection rules ignored entirely. The test here reads the profile back, and the ruled provider holds the higher priority, so a pass can only mean it was excluded rather than beaten to it.

No existing files changed. The weaker fallback test is left as it is, with this one alongside.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2171]: https://gravitee.atlassian.net/browse/AM-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ