### PR TITLE
test: make the hidden login form test able to fail (AM-2169)

### DIFF
--- a/gravitee-am-test/playwright/tests/auth/login/login-flows-external-oidc.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/login/login-flows-external-oidc.spec.ts
@@ -67,15 +67,19 @@ test.describe('Hide login form with external IdP (AM-2169)', () => {
     linkJira(testInfo, 'AM-2169');
 
     const clientId = externalOidcBundle.clientApp.settings.oauth.clientId;
-    const providerLoginRe = new RegExp(`${externalOidcBundle.providerDomain.hrid}.*/login`, 'i');
-    const clientLoginRe = new RegExp(`${externalOidcBundle.clientDomain.hrid}/login`, 'i');
+
+    // Matched on the path alone rather than anywhere in the URL. The provider's authorize URL
+    // carries the client's own `/login/callback` inside its redirect_uri parameter, so a
+    // whole-URL match counts hops that never went near the client's login page.
+    const clientLoginPath = `/${externalOidcBundle.clientDomain.hrid}/login`;
+    const providerLoginPath = `/${externalOidcBundle.providerDomain.hrid}/login`;
 
     // LoginHideFormHandler sits on /login itself, so the browser does reach that URL — it is
-    // answered with a 302 rather than a rendered form. Recording the statuses is therefore how
+    // answered with a 302 rather than a rendered form. Recording the status is therefore how
     // "the form was hidden" is proved; the URL alone cannot show it.
     const clientLoginStatuses: number[] = [];
     page.on('response', (response) => {
-      if (clientLoginRe.test(response.url())) {
+      if (new URL(response.url()).pathname === clientLoginPath) {
         clientLoginStatuses.push(response.status());
       }
     });
@@ -84,12 +88,13 @@ test.describe('Hide login form with external IdP (AM-2169)', () => {
 
     // No fallback to clicking the provider button by hand: if the redirect does not happen, the
     // browser stays on a rendered login form and this fails, which is the point of the feature.
-    await page.waitForURL(providerLoginRe, { timeout: BRIEF_TIMEOUT * 6 });
+    await page.waitForURL((url) => url.pathname === providerLoginPath, { timeout: BRIEF_TIMEOUT * 6 });
 
-    expect(clientLoginStatuses.length).toBeGreaterThan(0);
-    expect(clientLoginStatuses.every((status) => status === 302)).toBe(true);
+    // The client's login page is reached exactly once, and answered with a redirect rather than
+    // a form. Asserting the whole array reports the statuses themselves when it fails.
+    expect(clientLoginStatuses).toEqual([302]);
     await expect(page.locator('#username')).toBeVisible();
-    expect(page.url()).toMatch(providerLoginRe);
+    expect(new URL(page.url()).pathname).toEqual(providerLoginPath);
 
     await submitLogin(page, externalOidcBundle.providerUser.username, externalOidcBundle.providerUser.password);
 
@@ -108,10 +113,10 @@ test.describe('Login form shown when hiding is off (AM-2169)', () => {
     linkJira(testInfo, 'AM-2169');
 
     const clientId = externalOidcBundle.clientApp.settings.oauth.clientId;
-    const clientLoginRe = new RegExp(`${externalOidcBundle.clientDomain.hrid}/login`, 'i');
+    const clientLoginPath = `/${externalOidcBundle.clientDomain.hrid}/login`;
 
     await page.goto(buildAuthorizeUrl(externalOidcBundle.clientGatewayUrl, clientId));
-    await page.waitForURL(clientLoginRe);
+    await page.waitForURL((url) => url.pathname === clientLoginPath);
 
     // The comparison that gives the test above its meaning: same domain, same single external
     // provider, only the setting differs — and here the form is served rather than redirected past.

--- a/gravitee-am-test/playwright/tests/auth/login/login-flows-external-oidc.spec.ts
+++ b/gravitee-am-test/playwright/tests/auth/login/login-flows-external-oidc.spec.ts
@@ -16,7 +16,7 @@
 import type { Page } from '@playwright/test';
 import { test, expect, buildAuthorizeUrl, submitLogin } from '../../../fixtures/login-flows-external-oidc.fixture';
 import { reachOAuthAuthorizationCallback } from '../../../utils/mfa-helpers';
-import { AUTH_CODE_FORMAT, MULTI_PHASE_TEST_TIMEOUT } from '../../../utils/test-constants';
+import { AUTH_CODE_FORMAT, BRIEF_TIMEOUT, MULTI_PHASE_TEST_TIMEOUT } from '../../../utils/test-constants';
 import { linkJira } from '../../../utils/jira';
 
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -67,20 +67,29 @@ test.describe('Hide login form with external IdP (AM-2169)', () => {
     linkJira(testInfo, 'AM-2169');
 
     const clientId = externalOidcBundle.clientApp.settings.oauth.clientId;
-
-    await page.goto(buildAuthorizeUrl(externalOidcBundle.clientGatewayUrl, clientId));
     const providerLoginRe = new RegExp(`${externalOidcBundle.providerDomain.hrid}.*/login`, 'i');
     const clientLoginRe = new RegExp(`${externalOidcBundle.clientDomain.hrid}/login`, 'i');
-    // Prefer LoginHideFormHandler auto-redirect (hideForm + single external IdP). If that is slow, or the gateway
-    // renders the standard login view first, use the social entry like AM-2207.
-    try {
-      await page.waitForURL(providerLoginRe);
-    } catch {
-      await page.waitForURL(clientLoginRe);
-      await clickClientOauth2GenericAmSocial(page);
-      await page.waitForURL(providerLoginRe);
-    }
-    expect(page.url()).not.toMatch(clientLoginRe);
+
+    // LoginHideFormHandler sits on /login itself, so the browser does reach that URL — it is
+    // answered with a 302 rather than a rendered form. Recording the statuses is therefore how
+    // "the form was hidden" is proved; the URL alone cannot show it.
+    const clientLoginStatuses: number[] = [];
+    page.on('response', (response) => {
+      if (clientLoginRe.test(response.url())) {
+        clientLoginStatuses.push(response.status());
+      }
+    });
+
+    await page.goto(buildAuthorizeUrl(externalOidcBundle.clientGatewayUrl, clientId));
+
+    // No fallback to clicking the provider button by hand: if the redirect does not happen, the
+    // browser stays on a rendered login form and this fails, which is the point of the feature.
+    await page.waitForURL(providerLoginRe, { timeout: BRIEF_TIMEOUT * 6 });
+
+    expect(clientLoginStatuses.length).toBeGreaterThan(0);
+    expect(clientLoginStatuses.every((status) => status === 302)).toBe(true);
+    await expect(page.locator('#username')).toBeVisible();
+    expect(page.url()).toMatch(providerLoginRe);
 
     await submitLogin(page, externalOidcBundle.providerUser.username, externalOidcBundle.providerUser.password);
 
@@ -88,5 +97,25 @@ test.describe('Hide login form with external IdP (AM-2169)', () => {
 
     const callbackUrl = new URL(page.url());
     expect(callbackUrl.searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
+  });
+});
+
+test.describe('Login form shown when hiding is off (AM-2169)', () => {
+  test.use({ hideLoginForm: false });
+  test.setTimeout(MULTI_PHASE_TEST_TIMEOUT * 2);
+
+  test('AM-2169: the same domain serves its own login form when the setting is off', async ({ page, externalOidcBundle }, testInfo) => {
+    linkJira(testInfo, 'AM-2169');
+
+    const clientId = externalOidcBundle.clientApp.settings.oauth.clientId;
+    const clientLoginRe = new RegExp(`${externalOidcBundle.clientDomain.hrid}/login`, 'i');
+
+    await page.goto(buildAuthorizeUrl(externalOidcBundle.clientGatewayUrl, clientId));
+    await page.waitForURL(clientLoginRe);
+
+    // The comparison that gives the test above its meaning: same domain, same single external
+    // provider, only the setting differs — and here the form is served rather than redirected past.
+    await expect(page.locator('#username')).toBeVisible();
+    await expect(page.locator('#password')).toBeVisible();
   });
 });


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2169](https://gravitee.atlassian.net/browse/AM-2169)

## :pencil2: A description of the changes proposed in the pull request
**This modifies an existing test** (`login-flows-external-oidc.spec.ts`, originally by @Fu Yu) rather than adding one, because the existing test could not fail on the behaviour it covers.

It fell back to doing the thing the feature is supposed to prevent:

```js
try {
  await page.waitForURL(providerLoginRe);         // redirect worked
} catch {
  await page.waitForURL(clientLoginRe);           // redirect did NOT work
  await clickClientOauth2GenericAmSocial(page);   // ...click the provider button by hand
  await page.waitForURL(providerLoginRe);
}
expect(page.url()).not.toMatch(clientLoginRe);    // passes either way
```

With "hide login form" broken, the catch branch ran, clicked through manually, and the final assertion still passed — indistinguishable from the ordinary external-provider test (AM-2207).

Changes:

- **Fallback removed.** If the redirect does not happen the browser stays on a rendered login form and the test fails.
- **Assert on the response, not the URL.** `LoginHideFormHandler` is a handler on `/login` itself and answers with a 302 instead of rendering the form, so the browser legitimately reaches that URL. Asserting "never visited `/login`" would fail against working software; the test records the response statuses for that URL and asserts they are redirects.
- **Added the setting-off comparison**, where the same domain serves its login form. Same single external provider either way, so only the setting differs.

`AM-2207`'s test in the same file is untouched.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
Not covered: more than one external provider. `LoginHideFormHandler` only redirects when `isHideFormEnabled && hasExactlyOneSocialProvider`, and this fixture deletes the default provider to get down to one, so that case needs a different setup.

Verified the fix does what it claims by running the corrected test with `hideLoginForm: false` — it fails on the redirect that never comes (`TimeoutError: page.waitForURL`), where the original passed. Suite is green: 4 passed.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2169]: https://gravitee.atlassian.net/browse/AM-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ