### PR TITLE
test: several policies in one flow where one refuses or fails (AM-2198)

### DIFF
--- a/gravitee-am-test/specs/gateway/flows/fixture/refusing-policy-fixture.ts
+++ b/gravitee-am-test/specs/gateway/flows/fixture/refusing-policy-fixture.ts
@@ -27,7 +27,7 @@ import {
 } from '@management-commands/domain-management-commands';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { getAllIdps } from '@management-commands/idp-management-commands';
-import { createUser } from '@management-commands/user-management-commands';
+import { createUser, listUsers } from '@management-commands/user-management-commands';
 import { createApplication, updateApplication } from '@management-commands/application-management-commands';
 import { lookupFlowAndResetPolicies } from '@management-commands/flow-management-commands';
 import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
@@ -68,6 +68,24 @@ export const refusingPolicy = (status = '401') => ({
   }),
 });
 
+/**
+ * An Enrich User Profile policy writing a fixed value onto the signing-in user.
+ *
+ * Its effect is stored against the user rather than only reaching the token, so whether it ran
+ * can still be established after a sign-in that was refused and issued no token.
+ */
+export const enrichProfilePolicy = (key: string, value: string) => ({
+  name: 'Enrich User Profile',
+  policy: 'policy-am-enrich-profile',
+  description: '',
+  condition: '',
+  enabled: true,
+  configuration: JSON.stringify({
+    exitOnError: false,
+    properties: [{ claim: key, claimValue: value }],
+  }),
+});
+
 /** A Groovy policy whose script throws, for the runtime-failure case. */
 export const throwingPolicy = () => ({
   name: 'Groovy',
@@ -88,6 +106,8 @@ export interface RefusingPolicyFixture extends Fixture {
   user: typeof REFUSING_USER;
   /** Replace the policies on the domain's Login flow. Pass [] to clear them. */
   setLoginPolicies: (scope: 'pre' | 'post', policies: any[]) => Promise<void>;
+  /** The signing-in user's stored profile, for reading back what a policy wrote. */
+  readUserProfile: () => Promise<Record<string, any>>;
 }
 
 export const setupRefusingPolicyFixture = async (): Promise<RefusingPolicyFixture> => {
@@ -138,6 +158,14 @@ export const setupRefusingPolicyFixture = async (): Promise<RefusingPolicyFixtur
     await waitForSyncAfter(domain.id, () => updateDomainFlows(domain.id, accessToken, flows));
   };
 
+  const readUserProfile = async (): Promise<Record<string, any>> => {
+    const page = await listUsers(domain.id, accessToken, REFUSING_USER.username);
+    if (!page.totalCount || page.data.length === 0) {
+      throw new Error(`user ${REFUSING_USER.username} not found`);
+    }
+    return page.data[0].additionalInformation ?? {};
+  };
+
   return {
     accessToken,
     domain: started.domain,
@@ -145,6 +173,7 @@ export const setupRefusingPolicyFixture = async (): Promise<RefusingPolicyFixtur
     application,
     user: REFUSING_USER,
     setLoginPolicies,
+    readUserProfile,
     cleanUp: async () => {
       await safeDeleteDomain(domain.id, accessToken);
     },

--- a/gravitee-am-test/specs/gateway/flows/multiple-policies.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/flows/multiple-policies.jest.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+import { login } from '@gateway-commands/login-commands';
+import { retryImmediatelyForThisFile, setup } from '../../test-fixture';
+import {
+  REDIRECT_URI,
+  RefusingPolicyFixture,
+  enrichProfilePolicy,
+  refusingPolicy,
+  setupRefusingPolicyFixture,
+  throwingPolicy,
+} from './fixture/refusing-policy-fixture';
+
+setup(200000);
+// Each test rewrites the flow's policies before signing in, so they must not interleave.
+retryImmediatelyForThisFile();
+
+/**
+ * AM-2198 / UC-AM36 — several policies in one flow, where one of them refuses or fails.
+ *
+ * Policies running together, in order, and domain and application flows combining are all
+ * covered already. Every one of those tests ends with the sign-in succeeding, so nothing showed
+ * what a chain does when a member of it turns the user away or breaks.
+ *
+ * Enrich User Profile is used as the observable step: it writes to the user's stored profile
+ * rather than only to the token, so whether it ran can still be established after a sign-in that
+ * was refused and issued nothing. Each test writes its own key, since the profile accumulates.
+ */
+let fixture: RefusingPolicyFixture;
+
+beforeAll(async () => {
+  fixture = await setupRefusingPolicyFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+/** Signs in with valid credentials and returns where the gateway sent the user. */
+const signIn = async (): Promise<string> => {
+  const clientId = fixture.application.settings.oauth.clientId;
+
+  const authResponse = await performGet(
+    fixture.openIdConfiguration.authorization_endpoint,
+    `?response_type=code&client_id=${clientId}&redirect_uri=${REDIRECT_URI}&scope=openid`,
+  ).expect(302);
+
+  const postLogin = await login(authResponse, fixture.user.username, clientId, fixture.user.password);
+  expect(postLogin.headers['location']).toBeDefined();
+  return postLogin.headers['location'];
+};
+
+describe('Several policies in one flow', () => {
+  it(jira`all of them run when none refuses ${'AM-2198'}`, async () => {
+    await fixture.setLoginPolicies('post', [
+      enrichProfilePolicy('chain_first', 'first-ran'),
+      enrichProfilePolicy('chain_second', 'second-ran'),
+    ]);
+
+    const location = await signIn();
+    expect(location).toContain('/oauth/authorize');
+
+    // Anchors the two tests below: both policies in a chain do take effect, so a later absence
+    // means the chain stopped rather than the policy never having worked.
+    const profile = await fixture.readUserProfile();
+    expect(profile.chain_first).toEqual('first-ran');
+    expect(profile.chain_second).toEqual('second-ran');
+  });
+
+  it(jira`a refusing policy among others stops the sign-in ${'AM-2198'}`, async () => {
+    await fixture.setLoginPolicies('post', [enrichProfilePolicy('before_refusal', 'written-first'), refusingPolicy()]);
+
+    const location = await signIn();
+
+    expect(location).toContain('error=login_failed');
+    expect(location).toContain('error_code=REQUEST_VALIDATION_INVALID');
+    // Anchored so it matches only an authorization code, not response_type=code or error_code=.
+    expect(location).not.toMatch(/[?&]code=/);
+
+    // The policy that ran before the refusal keeps its effect: a refused sign-in still leaves
+    // what earlier policies wrote against the user.
+    expect((await fixture.readUserProfile()).before_refusal).toEqual('written-first');
+  });
+
+  it(jira`a policy failing partway stops the ones after it ${'AM-2198'}`, async () => {
+    await fixture.setLoginPolicies('post', [
+      enrichProfilePolicy('before_failure', 'ran-before'),
+      throwingPolicy(),
+      enrichProfilePolicy('after_failure', 'ran-after'),
+    ]);
+
+    const location = await signIn();
+    expect(location).toContain('error=login_failed');
+    expect(location).not.toMatch(/[?&]code=/);
+
+    const profile = await fixture.readUserProfile();
+    // The chain stops where it broke: what came before is kept, what came after never ran.
+    // The first test shows a second policy in a chain does otherwise take effect, so this is
+    // the failure halting it rather than the policy being misconfigured.
+    expect(profile.before_failure).toEqual('ran-before');
+    expect(profile).not.toHaveProperty('after_failure');
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2198](https://gravitee.atlassian.net/browse/AM-2198)

## :pencil2: A description of the changes proposed in the pull request
Policies running together, in order, and domain and application flows combining are covered already. Every one of those tests ends with the sign-in succeeding, so nothing showed what a chain does when a member of it turns the user away or breaks.

- A chain where every policy runs — the anchor for the two below
- A refusing policy among others stops the sign-in, and what the earlier policy wrote is kept
- A policy failing partway stops the ones after it from running

Enrich User Profile is the observable step, since it writes to the user's stored profile rather than only to the token — so whether it ran can still be established after a sign-in that issued nothing.

>⚠️ **Stacked on #8459 — that one merges first.**

This branch is based on `test/AM-2199-policy-refuses-signin`, not on master, so the shared fixture is added once by #8459 and only extended here (+30/-1, adding `enrichProfilePolicy` and `readUserProfile`). Merging this before #8459 would land a spec whose fixture is not on master.

One new file of its own; nothing existing changed.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
The ticket left two outcomes open. Both were determined by running them rather than assumed:

- a refused sign-in **still leaves** what earlier policies wrote against the user — a refusal is not a rollback
- a policy failing partway **stops** the policies after it from running

Not done, and tracked separately: `flow-policy.jest.spec.ts` carries the AM-2198 and AM-2199 keys but cannot exercise flows as written. It signs in with `grant_type=password`, which never reaches the login page, so Login-flow policies do not run for it — its fixture even defines a `groovy_claim` that never resolves. Confirmed by testing: adding the missing Enrich Auth Flow policy and moving the policies to the Root step both still gave `undefined`. Fixing it means moving that spec onto the authorization-code flow, which rewrites two tests that are not this ticket's, so it is left for a separate PR, tracked as **[AM-7590](https://gravitee.atlassian.net/browse/AM-7590)**. That deletion has to wait until this PR and #8459 have merged, since until then those two tests are the only ones on master carrying the AM-2198 and AM-2199 keys.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2198]: https://gravitee.atlassian.net/browse/AM-2198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



[AM-7590]: https://gravitee.atlassian.net/browse/AM-7590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ