### PR TITLE
test: an application with no client authentication method set (AM-2232)

### DIFF
--- a/gravitee-am-test/specs/gateway/token-auth-methods/arbitrary-auth-method.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/arbitrary-auth-method.jest.spec.ts
@@ -36,8 +36,9 @@ setup(200000);
  * Assertion-based methods are deliberately not covered here. An unset application refuses
  * client_secret_jwt even though `ClientAssertionAuthProvider.canHandle` carries the same
  * empty-method branch as basic and post — the identical assertion is accepted once the method is
- * set explicitly. That looks like a defect rather than intended behaviour, so it is raised
- * separately instead of being written down here as expected.
+ * set explicitly. That looks like a defect rather than intended behaviour, so it is tracked as
+ * AM-7591 instead of being written down here as expected. Add the assertion cases to this file
+ * once that is resolved.
  */
 let fixture: ArbitraryAuthMethodFixture;
 

--- a/gravitee-am-test/specs/gateway/token-auth-methods/arbitrary-auth-method.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/arbitrary-auth-method.jest.spec.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import jwt from 'jsonwebtoken';
-import crypto from 'crypto';
 import { jira } from '@specs-utils/jira';
 import { JWT_FORMAT } from '@specs-utils/jwt-format';
 import { performPost } from '@gateway-commands/oauth-oidc-commands';
@@ -34,6 +32,12 @@ setup(200000);
  * empty and the matching credentials are present.
  *
  * The two applications live in one domain, so the comparison differs only in that setting.
+ *
+ * Assertion-based methods are deliberately not covered here. An unset application refuses
+ * client_secret_jwt even though `ClientAssertionAuthProvider.canHandle` carries the same
+ * empty-method branch as basic and post — the identical assertion is accepted once the method is
+ * set explicitly. That looks like a defect rather than intended behaviour, so it is raised
+ * separately instead of being written down here as expected.
  */
 let fixture: ArbitraryAuthMethodFixture;
 
@@ -65,30 +69,6 @@ const withRequestBody = (app: AuthMethodApp) =>
     FORM,
   );
 
-/** A signed assertion — client_secret_jwt. */
-const withSignedAssertion = (app: AuthMethodApp) => {
-  const assertion = jwt.sign(
-    {
-      iss: app.clientId,
-      sub: app.clientId,
-      aud: fixture.oidc.token_endpoint,
-      jti: crypto.randomBytes(16).toString('hex'),
-      exp: Math.floor(Date.now() / 1000) + 300,
-    },
-    app.clientSecret,
-    { algorithm: 'HS256' },
-  );
-
-  return performPost(
-    fixture.oidc.token_endpoint,
-    '',
-    `grant_type=client_credentials&client_assertion_type=${encodeURIComponent(
-      'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-    )}&client_assertion=${encodeURIComponent(assertion)}`,
-    FORM,
-  );
-};
-
 describe('An application with no authentication method set', () => {
   it(jira`is stored with an empty method rather than a default ${'AM-2232'}`, async () => {
     // Anchors the rest of the file. Omitting the field on create is not the same thing: the
@@ -109,16 +89,6 @@ describe('An application with no authentication method set', () => {
 
     expect(response.status).toEqual(200);
     expect(response.body.access_token).toMatch(JWT_FORMAT);
-  });
-
-  it(jira`refuses a signed assertion ${'AM-2232'}`, async () => {
-    const response = await withSignedAssertion(fixture.unsetApp);
-
-    // The arbitrary option covers the secret-based methods only. An assertion is handled by a
-    // different provider, which requires the method to be set explicitly — so leaving it unset
-    // does not make an application accept client_secret_jwt.
-    expect(response.status).toEqual(401);
-    expect(response.body.error).toEqual('invalid_client');
   });
 });
 

--- a/gravitee-am-test/specs/gateway/token-auth-methods/arbitrary-auth-method.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/arbitrary-auth-method.jest.spec.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
+import { jira } from '@specs-utils/jira';
+import { JWT_FORMAT } from '@specs-utils/jwt-format';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { getBase64BasicAuth } from '@gateway-commands/utils';
+import { setup } from '../../test-fixture';
+import { ArbitraryAuthMethodFixture, AuthMethodApp, setupArbitraryAuthMethodFixture } from './fixtures/arbitrary-auth-method-fixture';
+
+setup(200000);
+
+/**
+ * AM-2232 / UC-AM58 — an application left without a fixed client authentication method.
+ *
+ * Every method is covered elsewhere with that method fixed on the application. What was untested
+ * is the arbitrary option itself: one application, no method set, accepting whichever the incoming
+ * request uses. `ClientBasicAuthProvider.canHandle` allows it when the stored method is null or
+ * empty and the matching credentials are present.
+ *
+ * The two applications live in one domain, so the comparison differs only in that setting.
+ */
+let fixture: ArbitraryAuthMethodFixture;
+
+beforeAll(async () => {
+  fixture = await setupArbitraryAuthMethodFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+const FORM = { 'Content-type': 'application/x-www-form-urlencoded' };
+
+/** Credentials in the Authorization header — client_secret_basic. */
+const withAuthorizationHeader = (app: AuthMethodApp) =>
+  performPost(fixture.oidc.token_endpoint, '', 'grant_type=client_credentials', {
+    ...FORM,
+    Authorization: 'Basic ' + getBase64BasicAuth(app.clientId, app.clientSecret),
+  });
+
+/** Credentials in the request body — client_secret_post. */
+const withRequestBody = (app: AuthMethodApp) =>
+  performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=client_credentials&client_id=${encodeURIComponent(app.clientId)}&client_secret=${encodeURIComponent(app.clientSecret)}`,
+    FORM,
+  );
+
+/** A signed assertion — client_secret_jwt. */
+const withSignedAssertion = (app: AuthMethodApp) => {
+  const assertion = jwt.sign(
+    {
+      iss: app.clientId,
+      sub: app.clientId,
+      aud: fixture.oidc.token_endpoint,
+      jti: crypto.randomBytes(16).toString('hex'),
+      exp: Math.floor(Date.now() / 1000) + 300,
+    },
+    app.clientSecret,
+    { algorithm: 'HS256' },
+  );
+
+  return performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=client_credentials&client_assertion_type=${encodeURIComponent(
+      'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+    )}&client_assertion=${encodeURIComponent(assertion)}`,
+    FORM,
+  );
+};
+
+describe('An application with no authentication method set', () => {
+  it(jira`is stored with an empty method rather than a default ${'AM-2232'}`, async () => {
+    // Anchors the rest of the file. Omitting the field on create is not the same thing: the
+    // management API then stores client_secret_basic, and the application would be fixed to one
+    // method while appearing unset — every test below would pass against the wrong subject.
+    expect(fixture.unsetAppStoredMethod).toEqual('');
+  });
+
+  it(jira`accepts credentials in the authorization header ${'AM-2232'}`, async () => {
+    const response = await withAuthorizationHeader(fixture.unsetApp);
+
+    expect(response.status).toEqual(200);
+    expect(response.body.access_token).toMatch(JWT_FORMAT);
+  });
+
+  it(jira`also accepts credentials in the request body ${'AM-2232'}`, async () => {
+    const response = await withRequestBody(fixture.unsetApp);
+
+    expect(response.status).toEqual(200);
+    expect(response.body.access_token).toMatch(JWT_FORMAT);
+  });
+
+  it(jira`refuses a signed assertion ${'AM-2232'}`, async () => {
+    const response = await withSignedAssertion(fixture.unsetApp);
+
+    // The arbitrary option covers the secret-based methods only. An assertion is handled by a
+    // different provider, which requires the method to be set explicitly — so leaving it unset
+    // does not make an application accept client_secret_jwt.
+    expect(response.status).toEqual(401);
+    expect(response.body.error).toEqual('invalid_client');
+  });
+});
+
+describe('An application fixed to one authentication method', () => {
+  it(jira`accepts its own method ${'AM-2232'}`, async () => {
+    const response = await withAuthorizationHeader(fixture.fixedApp);
+
+    expect(response.status).toEqual(200);
+    expect(response.body.access_token).toMatch(JWT_FORMAT);
+  });
+
+  it(jira`refuses a different one ${'AM-2232'}`, async () => {
+    const response = await withRequestBody(fixture.fixedApp);
+
+    // The same request the unset application accepts above. Same domain, same identity provider,
+    // same credentials — only the setting differs, which is what makes the option meaningful.
+    expect(response.status).toEqual(401);
+    expect(response.body.error).toEqual('invalid_client');
+  });
+});

--- a/gravitee-am-test/specs/gateway/token-auth-methods/fixtures/arbitrary-auth-method-fixture.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/fixtures/arbitrary-auth-method-fixture.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Domain } from '@management-models/Domain';
+import {
+  createDomain,
+  DomainOidcConfig,
+  patchDomain,
+  safeDeleteDomain,
+  startDomain,
+  waitForDomainStart,
+} from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createIdp, deleteIdp } from '@management-commands/idp-management-commands';
+import { createApplication, updateApplication } from '@management-commands/application-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+export interface AuthMethodApp {
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface ArbitraryAuthMethodFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  /** No token endpoint authentication method set — the arbitrary case. */
+  unsetApp: AuthMethodApp;
+  /** Fixed to client_secret_basic, as the contrast. */
+  fixedApp: AuthMethodApp;
+  /** The method actually stored on the unset application, read back after creation. */
+  unsetAppStoredMethod: string | undefined;
+}
+
+/**
+ * Both applications live in one domain so the comparison is like for like: same gateway, same
+ * identity provider, differing only in whether a token endpoint authentication method is set.
+ */
+export const setupArbitraryAuthMethodFixture = async (): Promise<ArbitraryAuthMethodFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  let domain: Domain | null = null;
+
+  try {
+    domain = await createDomain(accessToken, uniqueName('arbitrary-auth', true), 'AM-2232 arbitrary client authentication method');
+
+    await patchDomain(domain.id, accessToken, {
+      oidc: {
+        clientRegistrationSettings: { allowLocalhostRedirectUri: true, allowHttpSchemeRedirectUri: true },
+      },
+    });
+
+    await deleteIdp(domain.id, accessToken, 'default-idp-' + domain.id);
+    const idp = await createIdp(domain.id, accessToken, {
+      external: false,
+      type: 'inline-am-idp',
+      domainWhitelist: [],
+      configuration: JSON.stringify({
+        users: [{ firstname: 'Token', lastname: 'User', username: uniqueName('arb-user', true), password: '#CoMpL3X-P@SsW0Rd' }],
+      }),
+      name: 'arbitrary-auth-idp',
+    });
+
+    const buildApp = async (label: string, tokenEndpointAuthMethod?: string) => {
+      const created = await createApplication(domain!.id, accessToken, {
+        name: uniqueName(label, true),
+        type: 'WEB',
+        redirectUris: ['http://localhost:4000/'],
+      });
+
+      const oauth: Record<string, any> = {
+        redirectUris: ['http://localhost:4000/'],
+        grantTypes: ['client_credentials'],
+      };
+      // Sent as an empty string for the arbitrary case. Omitting the field entirely is not the
+      // same thing: the management API then stores client_secret_basic, and the application ends
+      // up fixed to one method rather than accepting any.
+      oauth.tokenEndpointAuthMethod = tokenEndpointAuthMethod ?? '';
+
+      const updated = await updateApplication(
+        domain!.id,
+        accessToken,
+        { settings: { oauth }, identityProviders: [{ identity: idp.id, priority: 0 }] },
+        created.id,
+      );
+
+      return {
+        clientId: updated.settings.oauth.clientId,
+        clientSecret: created.settings.oauth.clientSecret,
+        storedMethod: updated.settings.oauth.tokenEndpointAuthMethod,
+      };
+    };
+
+    const unset = await buildApp('arb-unset-app');
+    const fixed = await buildApp('arb-fixed-app', 'client_secret_basic');
+
+    const startedDomain = await startDomain(domain.id, accessToken);
+    const started = await waitForDomainStart(startedDomain);
+
+    return {
+      accessToken,
+      domain,
+      oidc: started.oidcConfig,
+      unsetApp: { clientId: unset.clientId, clientSecret: unset.clientSecret },
+      fixedApp: { clientId: fixed.clientId, clientSecret: fixed.clientSecret },
+      unsetAppStoredMethod: unset.storedMethod,
+      cleanUp: async () => {
+        if (domain?.id) {
+          await safeDeleteDomain(domain.id, accessToken);
+        }
+      },
+    };
+  } catch (error) {
+    if (domain?.id) {
+      try {
+        await safeDeleteDomain(domain.id, accessToken);
+      } catch (e) {
+        console.error('Cleanup failed:', e);
+      }
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2232](https://gravitee.atlassian.net/browse/AM-2232)

## :pencil2: A description of the changes proposed in the pull request
Every client authentication method is covered elsewhere with that method fixed on the application. The arbitrary option itself was untested: one application, no method set, accepting whichever method the incoming request uses.

- An unset application accepts credentials in the authorization header, and in the request body
- A fixed application accepts its own method and refuses a different one

Both applications live in one domain, so the comparison differs only in that setting.

Two new files; nothing existing changed.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
The ticket asked for the assertion behaviour to be confirmed against a running gateway before expectations were agreed. It was, and it looks like a defect: **an unset application refuses `client_secret_jwt`** even though `ClientAssertionAuthProvider.canHandle` carries the same empty-method branch as the basic and post providers, which both work.

Isolated to a single variable — the identical assertion request is accepted by a second application in the same domain whose method is set to `client_secret_jwt`, and refused when the method is empty. Raised as **AM-7591**. That case is deliberately left out of this suite rather than asserting the current behaviour as expected; it should be added once the bug is resolved.

One trap worth knowing, which is why the first test exists: **omitting `tokenEndpointAuthMethod` does not create an unset application** — the management API stores `client_secret_basic`. The first probe of this work did exactly that, and every method behaved as though fixed. The application has to be sent an explicit empty string. That first test asserts the stored method is `""`, so the rest of the file cannot silently run against the wrong subject.

Not covered: `private_key_jwt` against an unset application, which needs a registered key pair; and mTLS, whose existing tests need the `gateway-mtls` container.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2232]: https://gravitee.atlassian.net/browse/AM-2232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ