### PR TITLE
test: a translation used on the sign-in form (AM-2184)

### DIFF
--- a/gravitee-am-test/specs/gateway/i18n/fixtures/translation-fixture.ts
+++ b/gravitee-am-test/specs/gateway/i18n/fixtures/translation-fixture.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Domain } from '@management-models/Domain';
+import {
+  createDomain,
+  DomainOidcConfig,
+  safeDeleteDomain,
+  startDomain,
+  waitForDomainStart,
+} from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { getAllIdps } from '@management-commands/idp-management-commands';
+import { createApplication, updateApplication } from '@management-commands/application-management-commands';
+import { createDictionary, updateDictionaryEntries } from '@management-commands/dictionary-management-commands';
+import { getDomainApi } from '@management-commands/service/utils';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+export const REDIRECT_URI = 'https://callback';
+
+/** The language the translation is written for. Not English, so the fallback case is distinguishable. */
+export const TRANSLATED_LANGUAGE = 'fr';
+
+/** Recognisable wording, so a match cannot come from the shipped bundle by coincidence. */
+export const TRANSLATED_TITLE = 'AM-2184 translated sign-in title';
+export const TRANSLATED_BUTTON = 'AM-2184 translated sign-in button';
+
+/** A key of our own, not in any shipped bundle, rendered only because the template asks for it. */
+export const CUSTOM_KEY = 'login.extra.text';
+export const CUSTOM_WORDING = 'AM-2184 wording from a custom key';
+
+export interface TranslationFixture extends Fixture {
+  accessToken: string;
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  clientId: string;
+  /** Adds or replaces the entries on the domain's translation for TRANSLATED_LANGUAGE. */
+  setTranslationEntries: (entries: Record<string, string>) => Promise<void>;
+  /** True when the login form was overridden with a template referencing CUSTOM_KEY. */
+  templateReferencesCustomKey: boolean;
+}
+
+export const setupTranslationFixture = async (): Promise<TranslationFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  let domain: Domain | null = null;
+
+  try {
+    domain = await createDomain(accessToken, uniqueName('translation', true), 'AM-2184 a translation used on a form');
+
+    const idpSet = await getAllIdps(domain.id, accessToken);
+    const defaultIdp = idpSet.values().next().value;
+
+    const appName = uniqueName('translation-app', true);
+    const created = await createApplication(domain.id, accessToken, {
+      name: appName,
+      type: 'WEB',
+      clientId: appName,
+      clientSecret: uniqueName('translation-secret', true),
+      redirectUris: [REDIRECT_URI],
+    });
+
+    const app = await updateApplication(
+      domain.id,
+      accessToken,
+      {
+        settings: {
+          oauth: {
+            redirectUris: [REDIRECT_URI],
+            grantTypes: ['authorization_code'],
+            scopeSettings: [{ scope: 'openid', defaultScope: true }],
+          },
+        },
+        identityProviders: [{ identity: defaultIdp.id, priority: -1 }],
+      },
+      created.id,
+    );
+
+    const dictionary = await createDictionary(domain.id, accessToken, {
+      name: uniqueName('am2184-dictionary', true),
+      locale: TRANSLATED_LANGUAGE,
+    });
+
+    // A key of our own renders only if the template asks for it, so the domain's login form is
+    // replaced with one that does. Overriding a shipped key needs no template change; adding a
+    // new one does — that difference is what the custom-key test exists to show.
+    let templateReferencesCustomKey = false;
+    try {
+      const loginHtmlPath = join(
+        __dirname,
+        '../../../../../gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html',
+      );
+      const original = readFileSync(loginHtmlPath, 'utf-8');
+      const injected = original.replace('<body>', `<body><label id="am2184-extra" th:text="#{${CUSTOM_KEY}}"></label>`);
+
+      await getDomainApi(accessToken).createForm({
+        organizationId: process.env.AM_DEF_ORG_ID!,
+        environmentId: process.env.AM_DEF_ENV_ID!,
+        domain: domain.id,
+        newForm: { template: 'LOGIN' as any, content: injected, enabled: true },
+      });
+      templateReferencesCustomKey = true;
+    } catch (e) {
+      console.warn('Could not override the login form; the custom-key test will be skipped:', e);
+    }
+
+    await startDomain(domain.id, accessToken);
+    const started = await waitForDomainStart(domain);
+
+    // No waitForSyncAfter here: a dictionary update does not reliably advance the domain's
+    // lastSync, so waiting on it hangs. Callers poll the rendered page instead, which is both
+    // accurate and the thing under test.
+    const setTranslationEntries = async (entries: Record<string, string>) => {
+      await updateDictionaryEntries(domain!.id, accessToken, dictionary.id, entries);
+    };
+
+    return {
+      accessToken,
+      domain: started.domain,
+      oidc: started.oidcConfig,
+      clientId: app.settings.oauth.clientId,
+      setTranslationEntries,
+      templateReferencesCustomKey,
+      cleanUp: async () => {
+        if (domain?.id) {
+          await safeDeleteDomain(domain.id, accessToken);
+        }
+      },
+    };
+  } catch (error) {
+    if (domain?.id) {
+      try {
+        await safeDeleteDomain(domain.id, accessToken);
+      } catch (e) {
+        console.error('Cleanup failed:', e);
+      }
+    }
+    throw error;
+  }
+};

--- a/gravitee-am-test/specs/gateway/i18n/fixtures/translation-fixture.ts
+++ b/gravitee-am-test/specs/gateway/i18n/fixtures/translation-fixture.ts
@@ -52,8 +52,6 @@ export interface TranslationFixture extends Fixture {
   clientId: string;
   /** Adds or replaces the entries on the domain's translation for TRANSLATED_LANGUAGE. */
   setTranslationEntries: (entries: Record<string, string>) => Promise<void>;
-  /** True when the login form was overridden with a template referencing CUSTOM_KEY. */
-  templateReferencesCustomKey: boolean;
 }
 
 export const setupTranslationFixture = async (): Promise<TranslationFixture> => {
@@ -99,25 +97,25 @@ export const setupTranslationFixture = async (): Promise<TranslationFixture> => 
     // A key of our own renders only if the template asks for it, so the domain's login form is
     // replaced with one that does. Overriding a shipped key needs no template change; adding a
     // new one does — that difference is what the custom-key test exists to show.
-    let templateReferencesCustomKey = false;
-    try {
-      const loginHtmlPath = join(
-        __dirname,
-        '../../../../../gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html',
-      );
-      const original = readFileSync(loginHtmlPath, 'utf-8');
-      const injected = original.replace('<body>', `<body><label id="am2184-extra" th:text="#{${CUSTOM_KEY}}"></label>`);
-
-      await getDomainApi(accessToken).createForm({
-        organizationId: process.env.AM_DEF_ORG_ID!,
-        environmentId: process.env.AM_DEF_ENV_ID!,
-        domain: domain.id,
-        newForm: { template: 'LOGIN' as any, content: injected, enabled: true },
-      });
-      templateReferencesCustomKey = true;
-    } catch (e) {
-      console.warn('Could not override the login form; the custom-key test will be skipped:', e);
+    //
+    // Anything wrong here is a problem with the setup, not with the gateway, so it throws rather
+    // than leaving a test to fail as though the wording had not rendered.
+    const loginHtmlPath = join(
+      __dirname,
+      '../../../../../gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/login.html',
+    );
+    const original = readFileSync(loginHtmlPath, 'utf-8');
+    const injected = original.replace('<body>', `<body><label id="am2184-extra" th:text="#{${CUSTOM_KEY}}"></label>`);
+    if (injected === original) {
+      throw new Error(`No <body> found in ${loginHtmlPath}, so the custom key was never added to the template`);
     }
+
+    await getDomainApi(accessToken).createForm({
+      organizationId: process.env.AM_DEF_ORG_ID!,
+      environmentId: process.env.AM_DEF_ENV_ID!,
+      domain: domain.id,
+      newForm: { template: 'LOGIN' as any, content: injected, enabled: true },
+    });
 
     await startDomain(domain.id, accessToken);
     const started = await waitForDomainStart(domain);
@@ -135,7 +133,6 @@ export const setupTranslationFixture = async (): Promise<TranslationFixture> => 
       oidc: started.oidcConfig,
       clientId: app.settings.oauth.clientId,
       setTranslationEntries,
-      templateReferencesCustomKey,
       cleanUp: async () => {
         if (domain?.id) {
           await safeDeleteDomain(domain.id, accessToken);

--- a/gravitee-am-test/specs/gateway/i18n/translation-on-form.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/i18n/translation-on-form.jest.spec.ts
@@ -131,8 +131,6 @@ describe('A translation used on the sign-in form', () => {
   });
 
   it(jira`a key of its own is shown when the form's template asks for it ${'AM-2184'}`, async () => {
-    expect(fixture.templateReferencesCustomKey).toBe(true);
-
     // Overriding a shipped key needs no template change; a key of your own does. This domain's
     // login form was replaced with one referencing it, which is what makes the wording appear.
     await fixture.setTranslationEntries({ [TITLE_KEY]: TRANSLATED_TITLE, [CUSTOM_KEY]: CUSTOM_WORDING });

--- a/gravitee-am-test/specs/gateway/i18n/translation-on-form.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/i18n/translation-on-form.jest.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { performGet } from '@gateway-commands/oauth-oidc-commands';
+import { retryUntil } from '@utils-commands/retry';
+import { retryImmediatelyForThisFile, setup } from '../../test-fixture';
+import {
+  REDIRECT_URI,
+  TRANSLATED_BUTTON,
+  TRANSLATED_LANGUAGE,
+  TRANSLATED_TITLE,
+  TranslationFixture,
+  CUSTOM_KEY,
+  CUSTOM_WORDING,
+  setupTranslationFixture,
+} from './fixtures/translation-fixture';
+
+setup(200000);
+// Each test rewrites the translation's entries before loading the page, so they must not interleave.
+retryImmediatelyForThisFile();
+
+/**
+ * AM-2184 / UC-AM66 — a translation used on a form.
+ *
+ * Creating a translation and saving its entries is covered elsewhere, but nothing rendered a page,
+ * so a domain that stored translations and ignored them would have passed.
+ *
+ * `LocaleHandler` picks the language from the Accept-Language header and falls back to English,
+ * which is what lets the same page be asked for in two languages and compared.
+ */
+
+/** Shipped English wording, seen when the requested language has no bundle and no translation. */
+const ENGLISH_SUBMIT_BUTTON = 'Sign in';
+
+/**
+ * Shipped French wording. AM carries its own bundle per language, so an entry left out of a custom
+ * translation falls back to that bundle rather than to English — the page stays in the requested
+ * language and only the translated entries are replaced.
+ */
+const FRENCH_USERNAME_LABEL = 'Identifiant';
+
+/** The key the sign-in button actually uses — `login.button` is not a key and has no effect. */
+const BUTTON_KEY = 'login.button.submit';
+const TITLE_KEY = 'login.title';
+
+let fixture: TranslationFixture;
+
+beforeAll(async () => {
+  fixture = await setupTranslationFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+/** Loads the domain's sign-in page in the requested language and returns the rendered HTML. */
+const loadSignInPage = async (language: string): Promise<string> => {
+  const authorize = await performGet(
+    fixture.oidc.authorization_endpoint,
+    `?response_type=code&client_id=${fixture.clientId}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=openid`,
+    { 'Accept-Language': language },
+  );
+
+  const location = authorize.headers['location'];
+  expect(location).toBeDefined();
+
+  const url = new URL(location);
+  const page = await performGet(url.origin, url.pathname + url.search, { 'Accept-Language': language });
+  return page.text;
+};
+
+/** Loads the sign-in page until the gateway serves the wording just written, or gives up. */
+const signInPageShowing = (language: string, expected: string): Promise<string> =>
+  retryUntil(
+    () => loadSignInPage(language),
+    (html) => html.includes(expected),
+    {
+      timeoutMillis: 30000,
+      intervalMillis: 500,
+    },
+  );
+
+describe('A translation used on the sign-in form', () => {
+  it(jira`the page shows the custom wording in the translated language ${'AM-2184'}`, async () => {
+    await fixture.setTranslationEntries({ [TITLE_KEY]: TRANSLATED_TITLE, [BUTTON_KEY]: TRANSLATED_BUTTON });
+
+    const html = await signInPageShowing(TRANSLATED_LANGUAGE, TRANSLATED_TITLE);
+
+    expect(html).toContain(TRANSLATED_TITLE);
+    expect(html).toContain(TRANSLATED_BUTTON);
+  });
+
+  it(jira`another language falls back to the default wording ${'AM-2184'}`, async () => {
+    // Same domain and translation as above, only the requested language differs. Without this the
+    // test above could pass on a gateway that showed the custom wording to everyone.
+    const html = await loadSignInPage('de');
+
+    expect(html).not.toContain(TRANSLATED_TITLE);
+    expect(html).not.toContain(TRANSLATED_BUTTON);
+    expect(html).toContain(ENGLISH_SUBMIT_BUTTON);
+  });
+
+  it(jira`wording that was not translated keeps its default ${'AM-2184'}`, async () => {
+    // Only the title is translated this time; the username label is left out of the translation.
+    await fixture.setTranslationEntries({ [TITLE_KEY]: TRANSLATED_TITLE });
+
+    const html = await signInPageShowing(TRANSLATED_LANGUAGE, TRANSLATED_TITLE);
+
+    expect(html).toContain(TRANSLATED_TITLE);
+    // The untranslated entry falls back to the shipped French wording, not to English and not to
+    // the raw key — the rest of the form stays in the language that was asked for.
+    expect(html).toContain(FRENCH_USERNAME_LABEL);
+    expect(html).not.toContain(ENGLISH_SUBMIT_BUTTON);
+    expect(html).not.toContain(BUTTON_KEY);
+  });
+
+  it(jira`a key of its own is shown when the form's template asks for it ${'AM-2184'}`, async () => {
+    expect(fixture.templateReferencesCustomKey).toBe(true);
+
+    // Overriding a shipped key needs no template change; a key of your own does. This domain's
+    // login form was replaced with one referencing it, which is what makes the wording appear.
+    await fixture.setTranslationEntries({ [TITLE_KEY]: TRANSLATED_TITLE, [CUSTOM_KEY]: CUSTOM_WORDING });
+
+    const html = await signInPageShowing(TRANSLATED_LANGUAGE, CUSTOM_WORDING);
+
+    expect(html).toContain(CUSTOM_WORDING);
+    // The key itself is never rendered — a missing entry would leave the label empty instead.
+    expect(html).not.toContain(CUSTOM_KEY);
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2184](https://gravitee.atlassian.net/browse/AM-2184)

## :pencil2: A description of the changes proposed in the pull request
Creating a translation and saving its entries was already covered, but nothing rendered a page — a domain that stored translations and ignored them would have passed.

- The custom wording appears when the sign-in page is asked for in the translated language
- Another language falls back to the default wording
- An entry left out of the translation keeps its default
- A key of the domain's own is shown once the form's template asks for it

Two new files in a new `specs/gateway/i18n/` directory; nothing existing changed.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**An untranslated entry does not fall back to English.** AM ships its own bundle per language, so the page stays in the language that was asked for and only the translated entries are replaced — with a French translation covering just the title, the username label renders as `Identifiant`, not `Username`. The test asserts the French default and that the English wording is absent.

**Overriding a shipped key and adding a new one are different things.** A key of your own renders only if the template references it (`<label th:text="#{login.extra.text}"/>`), which is why that test replaces the domain's login form. Worth knowing: `login.button` is not a key — the sign-in button uses `login.button.submit`, and writing the wrong key fails silently.

**Sync.** The gateway is polled until it serves each write rather than waiting on the domain's `lastSync`, which a dictionary update does not reliably advance — waiting on it hung for the full 90 seconds.

Not covered: translations on other forms (registration, forgotten password, MFA), and translated wording in emails, which use a different templating mechanism and belong to their own ticket.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2184]: https://gravitee.atlassian.net/browse/AM-2184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ