### PR TITLE
test: healthy and expired certificates on the certificates page (AM-2220)

### DIFF
--- a/gravitee-am-test/playwright/tests/security/certificates/certificate-expiry-states.spec.ts
+++ b/gravitee-am-test/playwright/tests/security/certificates/certificate-expiry-states.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createCertificate } from '@management-commands/certificate-management-commands';
+import { waitForDomainSync } from '@management-commands/domain-management-commands';
+import { expect, test } from '../../../fixtures/base.fixture';
+import { DomainCertificatesPage } from '../../../pages/domain-certificates.page';
+import { linkJira } from '../../../utils/jira';
+import { uniqueTestName } from '../../../utils/fixture-helpers';
+import { alreadyExpired, validForDays } from '../../../utils/pkcs12-certificate-with-validity';
+
+/**
+ * AM-2220 / UC-AM69 — how the certificates page distinguishes certificates by expiry.
+ *
+ * A near-expiry certificate being flagged was already covered, but nothing showed a healthy one
+ * going unflagged, so a Console that put a warning on every row would have passed. Both are
+ * created in the same domain and read from the same page, so only the expiry date differs.
+ *
+ * The status is decided server-side in `CertificateEntity.determineStatus` against a configurable
+ * threshold; a certificate lasting ten years and one lasting a day sit either side of it whatever
+ * that threshold is set to.
+ */
+test.describe('Certificate expiry states (AM-2220)', () => {
+  test('AM-2220: a near-expiry certificate is flagged and a healthy one is not', async ({ page, testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-2220');
+
+    const healthyName = uniqueTestName('pw-healthy-cert');
+    const nearExpiryName = uniqueTestName('pw-near-expiry-cert');
+
+    await createCertificate(testDomain.id, adminToken, validForDays(healthyName, 3650));
+    await createCertificate(testDomain.id, adminToken, validForDays(nearExpiryName, 1));
+    await waitForDomainSync(testDomain.id);
+
+    const certPage = new DomainCertificatesPage(page);
+    await certPage.navigateTo(testDomain.id);
+
+    const nearExpiryWarning = certPage.certificateRow(nearExpiryName).locator('mat-icon.warning');
+    await expect(nearExpiryWarning).toBeVisible();
+    // The tooltip carries the remaining life, so the warning says how urgent it is rather than
+    // only that something is wrong.
+    await expect(nearExpiryWarning).toHaveAttribute('aria-describedby', /.+/);
+
+    // The half that was missing: without it, a page that flagged every row would still pass.
+    await expect(certPage.certificateRow(healthyName).locator('mat-icon.warning')).toHaveCount(0);
+  });
+
+  test('AM-2220: a certificate that has already expired is refused on upload', async ({ testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-2220');
+
+    // The ticket asks what is shown for an expired certificate. Nothing is: one cannot be put
+    // into a domain in the first place. Only a certificate that expires while installed reaches
+    // that state, which a test cannot wait for.
+    let status: number | undefined;
+    let message = '';
+    try {
+      await createCertificate(testDomain.id, adminToken, alreadyExpired(uniqueTestName('pw-expired-cert')));
+    } catch (e: any) {
+      status = e?.response?.status;
+      message = e?.message ?? '';
+    }
+
+    expect(status).toEqual(400);
+    expect(message).toContain('already expired');
+  });
+});

--- a/gravitee-am-test/playwright/tests/security/certificates/certificate-expiry-states.spec.ts
+++ b/gravitee-am-test/playwright/tests/security/certificates/certificate-expiry-states.spec.ts
@@ -53,7 +53,11 @@ test.describe('Certificate expiry states (AM-2220)', () => {
     await expect(nearExpiryWarning).toHaveAttribute('aria-describedby', /.+/);
 
     // The half that was missing: without it, a page that flagged every row would still pass.
-    await expect(certPage.certificateRow(healthyName).locator('mat-icon.warning')).toHaveCount(0);
+    // The row is asserted present first — "no warning icon" is otherwise equally true of a row
+    // that has not rendered, which is the case this is here to rule out.
+    const healthyRow = certPage.certificateRow(healthyName);
+    await expect(healthyRow).toBeVisible();
+    await expect(healthyRow.locator('mat-icon.warning')).toHaveCount(0);
   });
 
   test('AM-2220: a certificate that has already expired is refused on upload', async ({ testDomain, adminToken }, testInfo) => {

--- a/gravitee-am-test/playwright/utils/pkcs12-certificate-with-validity.ts
+++ b/gravitee-am-test/playwright/utils/pkcs12-certificate-with-validity.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import forge from 'node-forge';
+
+import type { NewCertificate } from '@management-models/NewCertificate';
+
+const PKCS12_PASSWORD = 'changeme';
+/**
+ * The alias has to differ per certificate: AM refuses a second certificate carrying an alias
+ * already used in the domain ("A certificate with alias [x] already exists in this domain"), and
+ * these tests deliberately put several in one domain.
+ */
+const aliasFor = (displayName: string) => `alias-${displayName}`.slice(0, 60);
+
+/**
+ * Build a pkcs12 certificate whose validity window is given explicitly, so a certificate that has
+ * already expired can be created as easily as one that has not.
+ *
+ * Built with node-forge rather than by shelling out to OpenSSL. `openssl req` refuses a
+ * non-positive `-days`, and its `-not_before`/`-not_after` options only arrived in OpenSSL 3.5 —
+ * newer than the image CI runs on. Doing it in JavaScript keeps every validity window available
+ * on any machine.
+ */
+export function buildPkcs12CertificateWithValidity(displayName: string, notBefore: Date, notAfter: Date): NewCertificate {
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '01' + forge.util.bytesToHex(forge.random.getBytesSync(8));
+  cert.validity.notBefore = notBefore;
+  cert.validity.notAfter = notAfter;
+
+  const attrs = [{ name: 'commonName', value: 'am-playwright-validity.test' }];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+
+  const p12Asn1 = forge.pkcs12.toPkcs12Asn1(keys.privateKey, [cert], PKCS12_PASSWORD, {
+    friendlyName: aliasFor(displayName),
+    algorithm: '3des',
+  });
+  const contentB64 = forge.util.encode64(forge.asn1.toDer(p12Asn1).getBytes());
+
+  const fileMeta = JSON.stringify({
+    name: `${displayName}.p12`,
+    type: 'application/x-pkcs12',
+    size: new TextEncoder().encode(contentB64).length,
+    content: contentB64,
+  });
+
+  return {
+    name: displayName,
+    type: 'pkcs12-am-certificate',
+    configuration: JSON.stringify({
+      storepass: PKCS12_PASSWORD,
+      alias: aliasFor(displayName),
+      keypass: PKCS12_PASSWORD,
+      algorithm: 'RS256',
+      use: ['sig', 'enc'],
+      content: fileMeta,
+    }),
+  };
+}
+
+/** Convenience: a certificate valid from now until `days` from now. */
+export const validForDays = (displayName: string, days: number): NewCertificate =>
+  buildPkcs12CertificateWithValidity(displayName, new Date(), new Date(Date.now() + days * 24 * 3600 * 1000));
+
+/** Convenience: a certificate whose validity window has already passed. */
+export const alreadyExpired = (displayName: string): NewCertificate =>
+  buildPkcs12CertificateWithValidity(displayName, new Date(Date.now() - 30 * 24 * 3600 * 1000), new Date(Date.now() - 24 * 3600 * 1000));


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2220](https://gravitee.atlassian.net/browse/AM-2220)

## :pencil2: A description of the changes proposed in the pull request
A near-expiry certificate being flagged was already covered, but nothing showed a healthy one going unflagged — a Console that put a warning on every row would have passed.

- A near-expiry certificate is flagged, and its warning carries the tooltip saying how long is left
- A healthy certificate in the same domain is not flagged
- An already-expired certificate is refused on upload

Both certificates are created in the same domain and read from the same page, so only the expiry date differs. Two new files; nothing existing changed, including the original test in `certificate-expiry-warning.spec.ts`.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**The ticket's third scenario cannot happen as written.** It assumed an expired certificate could be uploaded and its display inspected. AM refuses it: `400 — "The certificate you uploaded has already expired. Please select a different certificate to upload."` Only a certificate that expires while installed reaches that state, which a test cannot wait for, so the refusal is what is pinned down instead. A valid certificate uploads to the same domain in the test above, so the refusal is about the expiry rather than the upload.

**Certificates are built with node-forge** rather than by shelling out to OpenSSL. `openssl req` refuses a non-positive `-days`, and `-not_before`/`-not_after` only arrived in OpenSSL 3.5 — newer than the image CI runs on. Building them in JavaScript keeps every validity window available on any machine.

**Aliases are derived per certificate.** AM rejects a second certificate reusing an alias already in the domain (`409 — "A certificate with alias [test] already exists"`), and these tests deliberately put several in one domain.

Not covered, and worth its own ticket: the expiry notification shown against the bell in the Console, and the expiry email. The email notifier ships disabled, runs on a daily cron, and uses thresholds of 20, 15, 10, 5 and 1 days — testing it means enabling the notifier and overriding the schedule rather than asserting on a page.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2220]: https://gravitee.atlassian.net/browse/AM-2220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ