### PR TITLE
test: a remembered device stops being trusted (AM-2218)

### DIFF
--- a/gravitee-am-test/specs/gateway/mfa/mfa-remember-device.spec.ts
+++ b/gravitee-am-test/specs/gateway/mfa/mfa-remember-device.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { performDelete, performGet, getWellKnownOpenIdConfiguration } from '@gateway-commands/oauth-oidc-commands';
+import { waitFor } from '@management-commands/domain-management-commands';
+import { getDomainManagerUrl } from '@management-commands/service/utils';
+import { Domain, initClient, initDomain, enableDomain, removeDomain, TestSuiteContext } from './fixture/mfa-setup-fixture';
+import { processLoginFromContext, processMfaEndToEnd } from './fixture/mfa-flow-fixture';
+import { setup } from '../../test-fixture';
+
+setup(300000);
+
+/**
+ * AM-2218 / UC-AM45 — a remembered device stops being trusted.
+ *
+ * Every test remembers a device and confirms the challenge is skipped before doing anything else,
+ * so a later challenge means the trust ended rather than remember-device never having worked.
+ */
+const EXPIRATION_SECONDS = 10;
+
+/** Long enough past `expiresAt` that a slow gateway cannot make the result ambiguous. */
+const WAIT_PAST_EXPIRY_MS = (EXPIRATION_SECONDS + 3) * 1000;
+
+const domain = {
+  admin: { username: 'admin', password: 'adminadmin' },
+  domain: { domainHrid: 'mfa-remember-device-am2218' },
+} as Domain;
+
+function rememberDeviceSettings(dom: Domain) {
+  return {
+    factors: [],
+    settings: {
+      mfa: {
+        factor: {
+          defaultFactorId: dom.domain.factors[0].id,
+          applicationFactors: [dom.domain.factors[0], dom.domain.factors[1]],
+        },
+        stepUpAuthenticationRule: '',
+        stepUpAuthentication: { active: false, stepUpAuthenticationRule: '' },
+        adaptiveAuthenticationRule: '',
+        rememberDevice: {
+          active: true,
+          skipRememberDevice: false,
+          expirationTimeSeconds: EXPIRATION_SECONDS,
+          deviceIdentifierId: dom.domain.devices[0].id,
+        },
+        enrollment: { forceEnrollment: false },
+        enroll: { active: false, enrollmentSkipActive: false, forceEnrollment: false, type: 'required' },
+        challenge: { active: true, challengeRule: '', type: 'required' },
+      },
+    },
+  };
+}
+
+let client: any;
+let authorizationEndpoint: string;
+
+const adminHeaders = () => ({ Authorization: `Bearer ${domain.admin.accessToken}` });
+const userDevicesUrl = (userId: string) => `${getDomainManagerUrl(domain.domain.domainId)}/users/${userId}/devices`;
+
+const findUserId = async (username: string) => {
+  const res = await performGet(`${getDomainManagerUrl(domain.domain.domainId)}/users?q=${username}`, '', adminHeaders());
+  const id = res.body?.data?.[0]?.id;
+  if (!id) {
+    throw new Error(`No user found for ${username}`);
+  }
+  return id;
+};
+
+/** The devices shown against the user, which is where a remembered device appears. */
+const listDevices = async (userId: string) => {
+  const res = await performGet(userDevicesUrl(userId), '', adminHeaders()).expect(200);
+  return res.body;
+};
+
+/** Signs in on `deviceId` and reports whether the challenge was skipped. */
+const signInOn = async (ctx: TestSuiteContext, deviceId: string) => {
+  const response = await processLoginFromContext(ctx, true, deviceId);
+  const location = response.headers['location'];
+  expect(location).toBeDefined();
+  return { response, location, skippedChallenge: location.includes('code=') };
+};
+
+/** Remembers `deviceId` for a user and returns their id once the device is trusted. */
+const rememberDeviceFor = async (userIndex: number, deviceId: string) => {
+  const ctx = new TestSuiteContext(domain, client, domain.domain.users[userIndex], authorizationEndpoint);
+  ctx.session = await processMfaEndToEnd(ctx, true, deviceId);
+  const userId = await findUserId(ctx.user.username);
+
+  // The anchor for everything below: this device is trusted right now.
+  const first = await signInOn(ctx, deviceId);
+  expect(first.skippedChallenge).toBe(true);
+
+  return { ctx, userId };
+};
+
+beforeAll(async () => {
+  await initDomain(domain, 3);
+  client = await initClient(domain, 'remember-device', rememberDeviceSettings(domain));
+  await enableDomain(domain);
+  await waitFor(3000);
+  const oidc = await getWellKnownOpenIdConfiguration(domain.domain.domainHrid).expect(200);
+  authorizationEndpoint = oidc.body.authorization_endpoint;
+});
+
+afterAll(async () => {
+  await removeDomain(domain);
+});
+
+describe('Remember device stops being trusted', () => {
+  it(jira`the device is challenged again once the remembered period passes ${'AM-2218'}`, async () => {
+    const { ctx, userId } = await rememberDeviceFor(0, 'am2218-device-expiry');
+
+    const [device] = await listDevices(userId);
+    expect(device.deviceId).toEqual('am2218-device-expiry');
+    // The period is what decides the trust, so it is read back rather than assumed.
+    expect(device.expiresAt - device.createdAt).toEqual(EXPIRATION_SECONDS * 1000);
+
+    await waitFor(WAIT_PAST_EXPIRY_MS);
+
+    const afterExpiry = await signInOn(ctx, 'am2218-device-expiry');
+    expect(afterExpiry.skippedChallenge).toBe(false);
+    expect(afterExpiry.location).toContain('/mfa/challenge');
+
+    // The record is removed once it lapses rather than left behind unused.
+    expect(await listDevices(userId)).toEqual([]);
+  });
+
+  it(jira`another device is still challenged ${'AM-2218'}`, async () => {
+    const { ctx, userId } = await rememberDeviceFor(1, 'am2218-device-known');
+
+    const other = await signInOn(ctx, 'am2218-device-other');
+    expect(other.skippedChallenge).toBe(false);
+    expect(other.location).toContain('/mfa/challenge');
+
+    // Being challenged did not add the second device to the trusted ones.
+    const devices = await listDevices(userId);
+    expect(devices.map((d) => d.deviceId)).toEqual(['am2218-device-known']);
+  });
+
+  it(jira`deleting the remembered device challenges the user again ${'AM-2218'}`, async () => {
+    const { ctx, userId } = await rememberDeviceFor(2, 'am2218-device-deleted');
+
+    const [device] = await listDevices(userId);
+    await performDelete(`${userDevicesUrl(userId)}/${device.id}`, '', adminHeaders()).expect(204);
+    expect(await listDevices(userId)).toEqual([]);
+
+    const afterDelete = await signInOn(ctx, 'am2218-device-deleted');
+    expect(afterDelete.skippedChallenge).toBe(false);
+    expect(afterDelete.location).toContain('/mfa/challenge');
+
+    // The user can trust the device again, so removing it is not a one-way door.
+    const challengePage = await performGet(afterDelete.location, '', {
+      Cookie: afterDelete.response.headers['set-cookie'],
+    }).expect(200);
+    expect(challengePage.text).toContain('name="rememberDeviceConsent"');
+  });
+});

--- a/gravitee-am-test/specs/gateway/mfa/mfa-remember-device.spec.ts
+++ b/gravitee-am-test/specs/gateway/mfa/mfa-remember-device.spec.ts
@@ -15,8 +15,8 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { jira } from '@specs-utils/jira';
-import { performDelete, performGet, getWellKnownOpenIdConfiguration } from '@gateway-commands/oauth-oidc-commands';
-import { waitFor } from '@management-commands/domain-management-commands';
+import { performDelete, performGet } from '@gateway-commands/oauth-oidc-commands';
+import { waitFor, waitForOidcReady } from '@management-commands/domain-management-commands';
 import { getDomainManagerUrl } from '@management-commands/service/utils';
 import { Domain, initClient, initDomain, enableDomain, removeDomain, TestSuiteContext } from './fixture/mfa-setup-fixture';
 import { processLoginFromContext, processMfaEndToEnd } from './fixture/mfa-flow-fixture';
@@ -30,10 +30,14 @@ setup(300000);
  * Every test remembers a device and confirms the challenge is skipped before doing anything else,
  * so a later challenge means the trust ended rather than remember-device never having worked.
  */
-const EXPIRATION_SECONDS = 10;
+const EXPIRATION_SECONDS = 5;
 
-/** Long enough past `expiresAt` that a slow gateway cannot make the result ambiguous. */
-const WAIT_PAST_EXPIRY_MS = (EXPIRATION_SECONDS + 3) * 1000;
+/**
+ * Margin added to the device's own `expiresAt` before signing in again. Trust ends the moment that
+ * timestamp passes — every device read filters on `gte(expiresAt, now)` — so this covers request
+ * latency and clock skew rather than waiting for anything to run.
+ */
+const GRACE_PAST_EXPIRY_MS = 500;
 
 const domain = {
   admin: { username: 'admin', password: 'adminadmin' },
@@ -112,8 +116,7 @@ beforeAll(async () => {
   await initDomain(domain, 3);
   client = await initClient(domain, 'remember-device', rememberDeviceSettings(domain));
   await enableDomain(domain);
-  await waitFor(3000);
-  const oidc = await getWellKnownOpenIdConfiguration(domain.domain.domainHrid).expect(200);
+  const oidc = await waitForOidcReady(domain.domain.domainHrid);
   authorizationEndpoint = oidc.body.authorization_endpoint;
 });
 
@@ -130,13 +133,19 @@ describe('Remember device stops being trusted', () => {
     // The period is what decides the trust, so it is read back rather than assumed.
     expect(device.expiresAt - device.createdAt).toEqual(EXPIRATION_SECONDS * 1000);
 
-    await waitFor(WAIT_PAST_EXPIRY_MS);
+    // Waiting on the record's own expiry rather than a fixed period, so the test only sleeps for
+    // what is left of the window. Asserting there is something left also keeps the failure clear
+    // if the sign-in above ever overran the window on a slow run.
+    const remainingMs = device.expiresAt - Date.now();
+    expect(remainingMs).toBeGreaterThan(0);
+    await waitFor(remainingMs + GRACE_PAST_EXPIRY_MS);
 
     const afterExpiry = await signInOn(ctx, 'am2218-device-expiry');
     expect(afterExpiry.skippedChallenge).toBe(false);
     expect(afterExpiry.location).toContain('/mfa/challenge');
 
-    // The record is removed once it lapses rather than left behind unused.
+    // A lapsed device also stops being listed. The row itself lingers until Mongo's TTL monitor
+    // removes it, so this is the read filter rather than a deletion.
     expect(await listDevices(userId)).toEqual([]);
   });
 


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2218](https://gravitee.atlassian.net/browse/AM-2218)

## :pencil2: A description of the changes proposed in the pull request
A remembered device skipping the challenge is well covered. Nothing covered the trust ever ending — a device remembered forever, or trusted on a machine it was never granted on, would have gone unnoticed.

- The device is challenged again once the remembered period passes
- Another device is still challenged
- Deleting the remembered device challenges the user again

One new file. Nothing existing is modified — the shared MFA fixtures are imported only, and `mfa-challange-required.spec.ts` was run alongside these to confirm it still passes.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**The tests read the device off the user's profile, not just the redirect.** `GET .../users/{user}/devices` is what backs the Devices list in the Console, and no test had used it before. That turns "were they challenged?" into something checkable at the source:

- the entry's `expiresAt - createdAt` equals the configured period exactly, so the window is asserted rather than assumed
- once it lapses the entry is **removed**, not left behind unused
- being challenged on a second device does not quietly add it to the trusted list
- after deletion the challenge page offers `name="rememberDeviceConsent"` again, so revoking a device is not a one-way door

**Every test remembers a device and confirms the challenge is skipped first.** Without that anchor, a "challenged" result would pass equally well if remember-device were broken outright.

**One scenario the ticket lists is already covered.** It names "turning the setting off" as a gap, but `specs/gateway/mfa/mfa-challange-required.spec.ts` already has *"When Challenge REQUIRED and factor enrolled and no session issued using MFA and RememberDevice disabled → should Challenge"*. The ticket's analysis looked only at the Playwright tests. Left alone here rather than duplicated, and noted on the ticket.

**The expiry test waits ~13s.** `expirationTimeSeconds` is set to 10 for the test application; there is no way to fast-forward the window.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2218]: https://gravitee.atlassian.net/browse/AM-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ