### PR TITLE
test: step-up that does not apply leaves a session alone (AM-2209)

### DIFF
--- a/gravitee-am-test/specs/gateway/mfa/mfa-step-up-not-applied.spec.ts
+++ b/gravitee-am-test/specs/gateway/mfa/mfa-step-up-not-applied.spec.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { getWellKnownOpenIdConfiguration } from '@gateway-commands/oauth-oidc-commands';
+import { waitFor } from '@management-commands/domain-management-commands';
+import { Domain, initClient, initDomain, enableDomain, removeDomain, TestSuiteContext } from './fixture/mfa-setup-fixture';
+import { get, processLoginFromContext, processMfaEndToEnd } from './fixture/mfa-flow-fixture';
+import { setup } from '../../test-fixture';
+
+setup(300000);
+
+/**
+ * AM-2209 / UC-AM43 — step-up authentication that does not apply, for a user who already has a
+ * session.
+ *
+ * "Not challenged" is only worth asserting if something here is challenged, otherwise these tests
+ * would pass just as well with multi-factor authentication switched off altogether. The last test
+ * carries that weight: one session, two applications, opposite outcomes.
+ */
+const domain = {
+  admin: { username: 'admin', password: 'adminadmin' },
+  domain: { domainHrid: 'mfa-step-up-not-applied-am2209' },
+} as Domain;
+
+/** An application whose step-up rule is `rule`, or with step-up switched off when `active` is false. */
+const stepUpSettings = (dom: Domain, rule: string, active: boolean) => ({
+  factors: [],
+  settings: {
+    mfa: {
+      factor: {
+        defaultFactorId: dom.domain.factors[0].id,
+        applicationFactors: [dom.domain.factors[0]],
+      },
+      stepUpAuthenticationRule: rule,
+      stepUpAuthentication: { active, stepUpAuthenticationRule: rule },
+    },
+  },
+});
+
+let ruleDoesNotApplyCtx: TestSuiteContext;
+let stepUpOffCtx: TestSuiteContext;
+let ruleAppliesCtx: TestSuiteContext;
+
+/** Signs in from scratch and returns the session that sign-in established. */
+const signInAndKeepSession = async (ctx: TestSuiteContext) => {
+  const response = await processLoginFromContext(ctx);
+  expect(response.headers['location']).toContain('code=');
+  const cookie = response.headers['set-cookie'];
+  expect(cookie).toBeDefined();
+  return cookie;
+};
+
+/** Returns to an application carrying an existing session. */
+const returnToApplication = async (ctx: TestSuiteContext, cookie: any) => {
+  const response = await get(ctx.clientAuthUrl, 302, { Cookie: cookie });
+  const location = response.headers['location'];
+  expect(location).toBeDefined();
+  return { location, letThrough: location.includes('code=') };
+};
+
+beforeAll(async () => {
+  await initDomain(domain, 3);
+  const ruleDoesNotApply = await initClient(domain, 'step-up-rule-false', stepUpSettings(domain, '{{ false }}', true));
+  const stepUpOff = await initClient(domain, 'step-up-off', stepUpSettings(domain, '', false));
+  const ruleApplies = await initClient(domain, 'step-up-rule-true', stepUpSettings(domain, '{{ true }}', true));
+  await enableDomain(domain);
+  await waitFor(3000);
+
+  const oidc = await getWellKnownOpenIdConfiguration(domain.domain.domainHrid).expect(200);
+  const endpoint = oidc.body.authorization_endpoint;
+  ruleDoesNotApplyCtx = new TestSuiteContext(domain, ruleDoesNotApply, domain.domain.users[0], endpoint);
+  stepUpOffCtx = new TestSuiteContext(domain, stepUpOff, domain.domain.users[1], endpoint);
+  ruleAppliesCtx = new TestSuiteContext(domain, ruleApplies, domain.domain.users[2], endpoint);
+});
+
+afterAll(async () => {
+  await removeDomain(domain);
+});
+
+describe('Step-up authentication that does not apply', () => {
+  it(jira`an already signed-in user is not challenged when the rule does not apply ${'AM-2209'}`, async () => {
+    const session = await signInAndKeepSession(ruleDoesNotApplyCtx);
+
+    const again = await returnToApplication(ruleDoesNotApplyCtx, session);
+
+    expect(again.letThrough).toBe(true);
+    expect(again.location).not.toContain('/mfa/challenge');
+  });
+
+  it(jira`the same is true when step-up is switched off ${'AM-2209'}`, async () => {
+    const session = await signInAndKeepSession(stepUpOffCtx);
+
+    const again = await returnToApplication(stepUpOffCtx, session);
+
+    expect(again.letThrough).toBe(true);
+    expect(again.location).not.toContain('/mfa/challenge');
+  });
+
+  it(jira`a session one application challenges is let through where the rule does not apply ${'AM-2209'}`, async () => {
+    // This session has already answered a challenge on the application that asks for one.
+    const session = await processMfaEndToEnd(ruleAppliesCtx);
+
+    // Returning there asks again — so the session is genuinely subject to step-up.
+    const backWhereItApplies = await returnToApplication(ruleAppliesCtx, session.cookie);
+    expect(backWhereItApplies.letThrough).toBe(false);
+    expect(backWhereItApplies.location).toContain('/mfa/challenge');
+
+    // The same session, on an application whose rule does not apply, is let straight through.
+    const whereItDoesNot = await returnToApplication(ruleDoesNotApplyCtx, session.cookie);
+    expect(whereItDoesNot.letThrough).toBe(true);
+    expect(whereItDoesNot.location).not.toContain('/mfa/challenge');
+  });
+});

--- a/gravitee-am-test/specs/gateway/mfa/mfa-step-up-not-applied.spec.ts
+++ b/gravitee-am-test/specs/gateway/mfa/mfa-step-up-not-applied.spec.ts
@@ -15,8 +15,7 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { jira } from '@specs-utils/jira';
-import { getWellKnownOpenIdConfiguration } from '@gateway-commands/oauth-oidc-commands';
-import { waitFor } from '@management-commands/domain-management-commands';
+import { waitForOidcReady } from '@management-commands/domain-management-commands';
 import { Domain, initClient, initDomain, enableDomain, removeDomain, TestSuiteContext } from './fixture/mfa-setup-fixture';
 import { get, processLoginFromContext, processMfaEndToEnd } from './fixture/mfa-flow-fixture';
 import { setup } from '../../test-fixture';
@@ -28,8 +27,9 @@ setup(300000);
  * session.
  *
  * "Not challenged" is only worth asserting if something here is challenged, otherwise these tests
- * would pass just as well with multi-factor authentication switched off altogether. The last test
- * carries that weight: one session, two applications, opposite outcomes.
+ * would pass just as well with multi-factor authentication switched off altogether. The test
+ * covering one session across two applications carries that weight, by getting opposite outcomes
+ * from the same session.
  */
 const domain = {
   admin: { username: 'admin', password: 'adminadmin' },
@@ -78,9 +78,8 @@ beforeAll(async () => {
   const stepUpOff = await initClient(domain, 'step-up-off', stepUpSettings(domain, '', false));
   const ruleApplies = await initClient(domain, 'step-up-rule-true', stepUpSettings(domain, '{{ true }}', true));
   await enableDomain(domain);
-  await waitFor(3000);
 
-  const oidc = await getWellKnownOpenIdConfiguration(domain.domain.domainHrid).expect(200);
+  const oidc = await waitForOidcReady(domain.domain.domainHrid);
   const endpoint = oidc.body.authorization_endpoint;
   ruleDoesNotApplyCtx = new TestSuiteContext(domain, ruleDoesNotApply, domain.domain.users[0], endpoint);
   stepUpOffCtx = new TestSuiteContext(domain, stepUpOff, domain.domain.users[1], endpoint);
@@ -101,7 +100,7 @@ describe('Step-up authentication that does not apply', () => {
     expect(again.location).not.toContain('/mfa/challenge');
   });
 
-  it(jira`the same is true when step-up is switched off ${'AM-2209'}`, async () => {
+  it(jira`an already signed-in user is not challenged when step-up is switched off ${'AM-2209'}`, async () => {
     const session = await signInAndKeepSession(stepUpOffCtx);
 
     const again = await returnToApplication(stepUpOffCtx, session);


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2209](https://gravitee.atlassian.net/browse/AM-2209)

## :pencil2: A description of the changes proposed in the pull request
Step-up not applying is covered for a fresh sign-in. Nothing covered a user who already holds a session and returns — which is the situation this use case describes, and the one where step-up would misfire in practice.

- An already signed-in user is not challenged when the rule does not apply
- The same is true when step-up is switched off
- A session one application challenges is let through where the rule does not apply

One new file. Nothing existing is modified — the shared MFA fixtures are imported only, and `mfa-general.spec.ts` was run alongside these to confirm it still passes.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**"Not challenged" is only worth asserting if something is challenged.** The first two tests would pass equally well with multi-factor authentication switched off altogether, so the third carries that weight: one session is returned to the application whose rule applies — **challenged** — and then to the one where it does not — **let through**. Same session, opposite outcomes, so the rule is demonstrably doing the work.

**Already covered, so not repeated here.** The ticket's third scenario, a fresh sign-in not being challenged, already exists in `specs/gateway/mfa/mfa-general.spec.ts` as *"when stepUp=false"* and *"when stepUp is disabled"*. Those two are left alone rather than duplicated, and noted on the ticket.

**Tagging.** The ticket suggests linking those existing tests to AM-2209. That means editing a spec belonging to another area, so it has been left out of this PR and raised on the ticket instead.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2209]: https://gravitee.atlassian.net/browse/AM-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ