### PR TITLE
feat: add name-filtered cookie tracing to diagnose remember-device co…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/web/WebConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/spring/web/WebConfiguration.java
@@ -29,6 +29,7 @@ import io.gravitee.am.gateway.handler.common.vertx.web.handler.XFrameHandlerFact
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.XSSHandlerFactory;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.AuthenticationFlowHandlerImpl;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.CookieHandler;
+import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.CookieTracer;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.CookieSessionHandler;
 import io.gravitee.am.gateway.handler.common.vertx.web.handler.impl.PolicyChainHandlerImpl;
 import io.gravitee.am.model.Domain;
@@ -74,8 +75,9 @@ public class WebConfiguration {
 
     @Bean
     public CookieHandler cookieHandler(@Value("${http.cookie.secure:false}") boolean cookieSecure,
-                                       @Value("${http.cookie.sameSite:Lax}") String sameSite) {
-        return new CookieHandler(cookieSecure, CookieSameSite.valueOf(sameSite.toUpperCase()));
+                                       @Value("${http.cookie.sameSite:Lax}") String sameSite,
+                                       @Value("${http.cookie.trace.names:}") String tracedCookieNames) {
+        return new CookieHandler(cookieSecure, CookieSameSite.valueOf(sameSite.toUpperCase()), new CookieTracer(tracedCookieNames));
     }
 
     @Bean

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CookieHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CookieHandler.java
@@ -36,14 +36,18 @@ public class CookieHandler implements Handler<RoutingContext> {
     private static final String X_FORWARDED_PREFIX = "X-Forwarded-Prefix";
     private final boolean cookieSecure;
     private final CookieSameSite sameSite;
+    private final CookieTracer cookieTracer;
 
-    public CookieHandler(boolean cookieSecure, CookieSameSite sameSite) {
+    public CookieHandler(boolean cookieSecure, CookieSameSite sameSite, CookieTracer cookieTracer) {
         this.cookieSecure = cookieSecure;
         this.sameSite = sameSite;
+        this.cookieTracer = cookieTracer;
     }
 
     @Override
     public void handle(RoutingContext context) {
+
+        cookieTracer.traceRequest(context);
 
         context.addHeadersEndHandler(v -> {
             // save the cookies
@@ -51,6 +55,7 @@ public class CookieHandler implements Handler<RoutingContext> {
             for (Cookie cookie: cookies.values()) {
                 if (cookie instanceof ServerCookie && ((ServerCookie) cookie).isChanged()) {
                     finalizeCookie(context, (ServerCookie) cookie);
+                    cookieTracer.traceResponse(context, (ServerCookie) cookie);
                 }
             }
         });

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CookieTracer.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CookieTracer.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl;
+
+import io.vertx.core.http.Cookie;
+import io.vertx.core.http.impl.ServerCookie;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Traces the lifecycle of a restricted set of cookies, identified by name.
+ *
+ * @author GraviteeSource Team
+ */
+public class CookieTracer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("io.gravitee.am.cookie.trace");
+
+    private final Set<String> tracedNames;
+
+    public CookieTracer(String names) {
+        this.tracedNames = names == null || names.isBlank()
+                ? Set.of()
+                : Arrays.stream(names.split(","))
+                        .map(String::trim)
+                        .filter(name -> !name.isEmpty())
+                        .collect(Collectors.toUnmodifiableSet());
+    }
+
+    public boolean isActive() {
+        return !tracedNames.isEmpty() && LOGGER.isDebugEnabled();
+    }
+
+    public void traceRequest(RoutingContext context) {
+        if (!isActive()) {
+            return;
+        }
+        final var path = context.request().path();
+        final var cookies = context.getDelegate().cookieMap();
+        for (String name : tracedNames) {
+            final Cookie cookie = cookies.get(name);
+            if (cookie != null) {
+                LOGGER.debug("[{}] request carries cookie '{}' {}", path, name, describe(cookie));
+            } else {
+                LOGGER.debug("[{}] request does not carry cookie '{}'", path, name);
+            }
+        }
+    }
+
+    public void traceResponse(RoutingContext context, ServerCookie cookie) {
+        if (!isActive() || !tracedNames.contains(cookie.getName())) {
+            return;
+        }
+        final var path = context.request().path();
+        if (cookie.getMaxAge() == 0) {
+            LOGGER.debug("[{}] sending DELETION of cookie '{}', Max-Age=0 {}", path, cookie.getName(), describe(cookie));
+        } else {
+            LOGGER.debug("[{}] sending cookie '{}', Max-Age={} {}", path, cookie.getName(), cookie.getMaxAge(), describe(cookie));
+        }
+    }
+
+    public void traceRemoval(RoutingContext context, String name, boolean invalidated, String reason) {
+        if (!isActive() || !tracedNames.contains(name)) {
+            return;
+        }
+        final var path = context.request().path();
+        if (invalidated) {
+            LOGGER.debug("[{}] removeCookie('{}') invalidated the cookie, a Max-Age=0 will be sent, reason: {}", path, name, reason);
+        } else {
+            LOGGER.debug("[{}] removeCookie('{}') was a no-op, the cookie was absent from the jar, no Set-Cookie will be sent, reason: {}", path, name, reason);
+        }
+    }
+
+    private static String describe(Cookie cookie) {
+        return "[value=" + fingerprint(cookie.getValue())
+                + ", path=" + cookie.getPath()
+                + ", domain=" + cookie.getDomain()
+                + ", secure=" + cookie.isSecure()
+                + ", httpOnly=" + cookie.isHttpOnly()
+                + ", sameSite=" + cookie.getSameSite()
+                + ", fromUserAgent=" + (cookie instanceof ServerCookie serverCookie && serverCookie.isFromUserAgent())
+                + "]";
+    }
+
+    private static String fingerprint(String value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value.isEmpty()) {
+            return "empty";
+        }
+        return "length:" + value.length() + "/hash:" + Integer.toHexString(value.hashCode());
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CookieTracerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CookieTracerTest.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.gateway.handler.common.vertx.web.handler.impl;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.vertx.core.http.Cookie;
+import io.vertx.core.http.CookieSameSite;
+import io.vertx.core.http.impl.CookieImpl;
+import io.vertx.core.http.impl.ServerCookie;
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CookieTracerTest {
+
+    private static final String TRACE_LOGGER = "io.gravitee.am.cookie.trace";
+    private static final String PATH = "/my-domain/oauth/authorize";
+    private static final String TRACED = "GRAVITEE_IO_REMEMBER_DEVICE";
+    private static final String OTHER = "GRAVITEE_IO_AM_SESSION";
+
+    private ch.qos.logback.classic.Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+    private Level previousLevel;
+
+    @BeforeEach
+    void setUp() {
+        logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(TRACE_LOGGER);
+        previousLevel = logger.getLevel();
+        logger.setLevel(Level.DEBUG);
+        logger.setAdditive(false);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+        appender.stop();
+        logger.setLevel(previousLevel);
+        logger.setAdditive(true);
+    }
+
+    @Test
+    void shouldNotBeActiveWhenNamesAreNull() {
+        assertThat(new CookieTracer(null).isActive()).isFalse();
+    }
+
+    @Test
+    void shouldNotBeActiveWhenNamesAreBlank() {
+        assertThat(new CookieTracer("  ").isActive()).isFalse();
+        assertThat(new CookieTracer(" , ,, ").isActive()).isFalse();
+    }
+
+    @Test
+    void shouldNotBeActiveWhenDebugIsDisabled() {
+        logger.setLevel(Level.INFO);
+        assertThat(new CookieTracer(TRACED).isActive()).isFalse();
+    }
+
+    @Test
+    void shouldBeActiveWhenNamesAreConfiguredAndDebugIsEnabled() {
+        assertThat(new CookieTracer(TRACED).isActive()).isTrue();
+    }
+
+    @Test
+    void shouldTraceCookieCarriedByRequest() {
+        new CookieTracer(TRACED).traceRequest(context(cookie(TRACED, "abcdef")));
+
+        assertThat(messages()).singleElement().asString()
+                .startsWith("[" + PATH + "] request carries cookie '" + TRACED + "'")
+                .contains("path=null", "domain=null", "secure=false", "httpOnly=false", "sameSite=null", "fromUserAgent=false");
+    }
+
+    @Test
+    void shouldTraceCookieMissingFromRequest() {
+        new CookieTracer(TRACED).traceRequest(context(cookie(OTHER, "abcdef")));
+
+        assertThat(messages()).containsExactly("[" + PATH + "] request does not carry cookie '" + TRACED + "'");
+    }
+
+    @Test
+    void shouldTraceEveryConfiguredNameAndIgnoreBlankOnes() {
+        new CookieTracer(" " + TRACED + " , ,other-cookie ").traceRequest(context(cookie(TRACED, "abcdef")));
+
+        assertThat(messages()).hasSize(2)
+                .anySatisfy(message -> assertThat(message).contains("request carries cookie '" + TRACED + "'"))
+                .anySatisfy(message -> assertThat(message).contains("request does not carry cookie 'other-cookie'"));
+    }
+
+    @Test
+    void shouldNotTraceRequestWhenInactive() {
+        new CookieTracer("").traceRequest(context(cookie(TRACED, "abcdef")));
+
+        assertThat(messages()).isEmpty();
+    }
+
+    @Test
+    void shouldNotLogTheCookieValue() {
+        new CookieTracer(TRACED).traceRequest(context(cookie(TRACED, "super-secret")));
+
+        assertThat(messages()).singleElement().asString()
+                .contains("value=length:12/hash:" + Integer.toHexString("super-secret".hashCode()))
+                .doesNotContain("super-secret");
+    }
+
+    @Test
+    void shouldReportEmptyCookieValue() {
+        new CookieTracer(TRACED).traceRequest(context(cookie(TRACED, "")));
+
+        assertThat(messages()).singleElement().asString().contains("value=empty");
+    }
+
+    @Test
+    void shouldReportCookieComingFromUserAgent() {
+        ServerCookie cookie = mock(ServerCookie.class);
+        when(cookie.getName()).thenReturn(TRACED);
+        when(cookie.getValue()).thenReturn(null);
+        when(cookie.isFromUserAgent()).thenReturn(true);
+
+        new CookieTracer(TRACED).traceRequest(context(cookie));
+
+        assertThat(messages()).singleElement().asString().contains("value=null", "fromUserAgent=true");
+    }
+
+    @Test
+    void shouldTraceCookieSentInResponse() {
+        ServerCookie cookie = (ServerCookie) cookie(TRACED, "abcdef").setMaxAge(3600).setPath("/my-domain").setSecure(true).setHttpOnly(true).setSameSite(CookieSameSite.LAX);
+
+        new CookieTracer(TRACED).traceResponse(context(), cookie);
+
+        assertThat(messages()).singleElement().asString()
+                .startsWith("[" + PATH + "] sending cookie '" + TRACED + "', Max-Age=3600")
+                .contains("path=/my-domain", "secure=true", "httpOnly=true", "sameSite=Lax");
+    }
+
+    @Test
+    void shouldTraceCookieDeletionWhenMaxAgeIsZero() {
+        ServerCookie cookie = (ServerCookie) cookie(TRACED, "abcdef").setMaxAge(0);
+
+        new CookieTracer(TRACED).traceResponse(context(), cookie);
+
+        assertThat(messages()).singleElement().asString()
+                .startsWith("[" + PATH + "] sending DELETION of cookie '" + TRACED + "', Max-Age=0");
+    }
+
+    @Test
+    void shouldNotTraceResponseCookieWithUntracedName() {
+        new CookieTracer(TRACED).traceResponse(context(), (ServerCookie) cookie(OTHER, "abcdef").setMaxAge(3600));
+
+        assertThat(messages()).isEmpty();
+    }
+
+    @Test
+    void shouldTraceInvalidatingRemoval() {
+        new CookieTracer(TRACED).traceRemoval(context(), TRACED, true, "logout");
+
+        assertThat(messages()).singleElement().asString()
+                .isEqualTo("[" + PATH + "] removeCookie('" + TRACED + "') invalidated the cookie, a Max-Age=0 will be sent, reason: logout");
+    }
+
+    @Test
+    void shouldTraceNoOpRemoval() {
+        new CookieTracer(TRACED).traceRemoval(context(), TRACED, false, "logout");
+
+        assertThat(messages()).singleElement().asString()
+                .isEqualTo("[" + PATH + "] removeCookie('" + TRACED + "') was a no-op, the cookie was absent from the jar, no Set-Cookie will be sent, reason: logout");
+    }
+
+    @Test
+    void shouldNotTraceRemovalOfUntracedName() {
+        new CookieTracer(TRACED).traceRemoval(context(), OTHER, true, "logout");
+
+        assertThat(messages()).isEmpty();
+    }
+
+    private List<String> messages() {
+        return appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+    }
+
+    private static Cookie cookie(String name, String value) {
+        return new CookieImpl(name, value);
+    }
+
+    private static RoutingContext context(Cookie... cookies) {
+        RoutingContext context = mock(RoutingContext.class);
+        io.vertx.ext.web.RoutingContext delegate = mock(io.vertx.ext.web.RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        Map<String, Cookie> cookieMap = Arrays.stream(cookies).collect(Collectors.toMap(Cookie::getName, Function.identity()));
+        when(context.getDelegate()).thenReturn(delegate);
+        when(context.request()).thenReturn(request);
+        when(request.path()).thenReturn(PATH);
+        when(delegate.cookieMap()).thenReturn(cookieMap);
+        return context;
+    }
+}

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/DeviceIdentifierHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/root/resources/handler/rememberdevice/DeviceIdentifierHandler.java
@@ -114,20 +114,30 @@ public class DeviceIdentifierHandler implements Handler<RoutingContext> {
     }
 
     private Maybe<String> extractDeviceId(RoutingContext routingContext, Client client) {
-        var deviceId = routingContext.request().getParam(DEVICE_ID);
         final var deviceIdCookie = routingContext.request().getCookie(rememberDeviceCookiName);
-        if (deviceIdentifierManager.useCookieBasedDeviceIdentifier(client) && deviceIdCookie != null) {
+        final var cookieBasedDeviceIdentifier = deviceIdentifierManager.useCookieBasedDeviceIdentifier(client);
+        log.debug("Remember device cookie '{}' lookup for clientID '{}': cookieBasedDeviceIdentifier={}, cookiePresent={}",
+                rememberDeviceCookiName, client.getClientId(), cookieBasedDeviceIdentifier, deviceIdCookie != null);
+        if (cookieBasedDeviceIdentifier && deviceIdCookie != null) {
             return jwtService.decodeAndVerify(deviceIdCookie.getValue(), client, JWTService.TokenType.SESSION)
                     .map(JWT::getJti)
                     .toMaybe()
                     .onErrorResumeNext((err) -> {
                         log.debug("Remember device cookie validation fails for clientID '{}', fallback to the new deviceId", client.getClientId(), err);
                         // validation fail, remove the cookie to force new generation.
-                        routingContext.response().removeCookie(rememberDeviceCookiName);
-                        return isNullOrEmpty(deviceId) ? Maybe.empty() : Maybe.just(deviceId);
+                        final var removedCookie = routingContext.response().removeCookie(rememberDeviceCookiName);
+                        log.debug("Remember device cookie '{}' removal for clientID '{}': {}",
+                                rememberDeviceCookiName, client.getClientId(),
+                                removedCookie != null ? "invalidated, Max-Age=0 will be sent" : "no-op, cookie absent from the jar");
+                        return extractDeviceId(routingContext);
                     });
         } else {
-            return isNullOrEmpty(deviceId) ? Maybe.empty() : Maybe.just(deviceId);
+            return extractDeviceId(routingContext);
         }
+    }
+
+    private Maybe<String> extractDeviceId(RoutingContext routingContext) {
+        var deviceId = routingContext.request().getParam(DEVICE_ID);
+        return isNullOrEmpty(deviceId) ? Maybe.empty() : Maybe.just(deviceId);
     }
 }


### PR DESCRIPTION
    <logger name="io.gravitee.am.gateway.handler.root.resources.handler.rememberdevice" level="DEBUG" />
    <logger name="io.gravitee.am.cookie.trace" level="DEBUG" />

```
http:
  cookie:
    trace:
      names: GRAVITEE_IO_REMEMBER_DEVICE
```
