### PR TITLE
feat: AM-7553 evaluate reporter custom attribute mappings

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/audit/impl/GatewayAuditReporterManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/audit/impl/GatewayAuditReporterManager.java
@@ -36,6 +36,7 @@ import io.gravitee.am.plugins.reporter.core.ReporterProviderConfiguration;
 import io.gravitee.am.repository.management.api.ReporterRepository;
 import io.gravitee.am.service.EnvironmentService;
 import io.gravitee.am.service.PluginLicenseGate;
+import io.gravitee.am.service.reporter.attribute.AttributeMappingReporter;
 import io.gravitee.am.service.reporter.SystemReporterConfigResolver;
 import io.gravitee.am.service.reporter.impl.AuditReporterVerticle;
 import io.gravitee.am.service.reporter.vertx.EventBusReporterWrapper;
@@ -269,7 +270,8 @@ public class GatewayAuditReporterManager extends AbstractService<AuditReporterMa
         if (reporterProvider != null) {
             try {
                 log.info("Starting reporter: {}", reporter.getName());
-                io.gravitee.am.reporter.api.provider.Reporter eventBusReporter = new EventBusReporterWrapper(vertx, reporterProvider, Reference.domain(domain.getId()));
+                var mappedReporter = AttributeMappingReporter.decorate(reporterProvider, resolved.getAttributeMappings());
+                io.gravitee.am.reporter.api.provider.Reporter eventBusReporter = new EventBusReporterWrapper(vertx, mappedReporter, Reference.domain(domain.getId()));
                 eventBusReporter.start();
                 reporters.put(reporter.getId(), reporter);
                 reporterPlugins.put(reporter.getId(), eventBusReporter);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementAuditReporterManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ManagementAuditReporterManager.java
@@ -34,6 +34,7 @@ import io.gravitee.am.service.ReporterService;
 import io.gravitee.am.service.exception.EnvironmentNotFoundException;
 import io.gravitee.am.service.model.NewReporter;
 import io.gravitee.am.service.reporter.SystemReporterConfigResolver;
+import io.gravitee.am.service.reporter.attribute.AttributeMappingReporter;
 import io.gravitee.am.service.reporter.impl.AuditReporterVerticle;
 import io.gravitee.am.service.reporter.vertx.EventBusReporterWrapper;
 import io.gravitee.common.event.Event;
@@ -417,12 +418,13 @@ public class ManagementAuditReporterManager extends AbstractService<AuditReporte
         }
 
         private Reporter<?, ?> createWrapper(AuditReporter auditReporter, io.gravitee.am.model.Reporter reporterConfig) {
+            var mappedReporter = AttributeMappingReporter.decorate(auditReporter, reporterConfig.getAttributeMappings());
             if (additionalReferences.isEmpty()) {
-                return new EventBusReporterWrapper<>(vertx, auditReporter, reporterConfig.getReference());
+                return new EventBusReporterWrapper<>(vertx, mappedReporter, reporterConfig.getReference());
             }
             var allReferences = new ArrayList<>(additionalReferences);
             allReferences.add(0, reporterConfig.getReference());
-            return new EventBusReporterWrapper<>(vertx, auditReporter, allReferences);
+            return new EventBusReporterWrapper<>(vertx, mappedReporter, allReferences);
 
         }
     }

--- a/gravitee-am-reporter/gravitee-am-reporter-api/pom.xml
+++ b/gravitee-am-reporter/gravitee-am-reporter-api/pom.xml
@@ -48,6 +48,13 @@
             <artifactId>gravitee-secret-api</artifactId>
         </dependency>
 
+        <!-- Jackson annotations -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- RxJava -->
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>

--- a/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/audit/model/Audit.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/audit/model/Audit.java
@@ -15,10 +15,13 @@
  */
 package io.gravitee.am.reporter.api.audit.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.reporter.api.Reportable;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * Security Audit based on RFC 3881 - Security Audit and Access Accountability Message
@@ -85,6 +88,39 @@ public class Audit implements Reportable {
      * The date when the event was logged
      */
     private Instant timestamp;
+
+    /**
+     * Additional attributes the receiving reporter was configured to export, keyed by the operator's chosen name
+     */
+    @Schema(hidden = true)
+    private Map<String, Object> customAttributes;
+
+    /**
+     * The user and client behind the event, for reporters that resolve attribute mappings
+     */
+    @JsonIgnore
+    @Schema(hidden = true)
+    private transient AuditEnrichmentContext enrichmentContext;
+
+    public Audit() {
+    }
+
+    /**
+     * Copies the exported fields, sharing the nested objects
+     */
+    public Audit(Audit other) {
+        this.id = other.id;
+        this.transactionId = other.transactionId;
+        this.type = other.type;
+        this.referenceType = other.referenceType;
+        this.referenceId = other.referenceId;
+        this.accessPoint = other.accessPoint;
+        this.actor = other.actor;
+        this.target = other.target;
+        this.outcome = other.outcome;
+        this.timestamp = other.timestamp;
+        this.customAttributes = other.customAttributes;
+    }
 
     public String getId() {
         return id;
@@ -167,5 +203,26 @@ public class Audit implements Reportable {
 
     public void setOutcome(AuditOutcome outcome) {
         this.outcome = outcome;
+    }
+
+    @Schema(hidden = true)
+    public Map<String, Object> getCustomAttributes() {
+        return customAttributes;
+    }
+
+    public void setCustomAttributes(Map<String, Object> customAttributes) {
+        this.customAttributes = customAttributes;
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public AuditEnrichmentContext getEnrichmentContext() {
+        return enrichmentContext;
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public void setEnrichmentContext(AuditEnrichmentContext enrichmentContext) {
+        this.enrichmentContext = enrichmentContext;
     }
 }

--- a/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/audit/model/AuditEnrichmentContext.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-api/src/main/java/io/gravitee/am/reporter/api/audit/model/AuditEnrichmentContext.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.reporter.api.audit.model;
+
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.model.safe.ClientProperties;
+import io.gravitee.am.model.safe.UserProperties;
+
+/**
+ * Carries the user and client behind an {@link Audit}, for reporters that resolve attribute mappings.
+ *
+ * <p>Exposes them only as the sanitized {@link UserProperties} and {@link ClientProperties}
+ * projections; the raw models must not be exposed.
+ *
+ * @author GraviteeSource Team
+ */
+public class AuditEnrichmentContext {
+
+    private final User user;
+    private final Client client;
+
+    public AuditEnrichmentContext(User user, Client client) {
+        this.user = user;
+        this.client = client;
+    }
+
+    public UserProperties user() {
+        return user == null ? null : new UserProperties(user, false);
+    }
+
+    public ClientProperties client() {
+        return client == null ? null : new ClientProperties(client);
+    }
+}

--- a/gravitee-am-reporter/gravitee-am-reporter-file/src/main/java/io/gravitee/am/reporter/file/audit/AuditEntry.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-file/src/main/java/io/gravitee/am/reporter/file/audit/AuditEntry.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.reporter.file.audit;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.reporter.api.audit.model.AuditAccessPoint;
 import io.gravitee.am.reporter.api.audit.model.AuditEntity;
@@ -23,6 +24,7 @@ import lombok.Data;
 import lombok.Getter;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -94,6 +96,12 @@ public class AuditEntry implements ReportEntry {
     private String nodeId;
 
     private String nodeHostname;
+
+    /**
+     * The extra attributes this reporter was configured to export, keyed by the operator's chosen name
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Map<String, Object> customAttributes;
 
     /**
      * Indicates whether the event succeeded or failed

--- a/gravitee-am-reporter/gravitee-am-reporter-file/src/main/java/io/gravitee/am/reporter/file/audit/FileAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-file/src/main/java/io/gravitee/am/reporter/file/audit/FileAuditReporter.java
@@ -163,6 +163,8 @@ public class FileAuditReporter extends AbstractService<Reporter> implements Audi
             entry.setTarget(cloneOfTarget);
         }
 
+        entry.setCustomAttributes(audit.getCustomAttributes());
+
         // link event to the organization and to the environment
         entry.setOrganizationId(context.getOrganizationId());
         entry.setEnvironmentId(context.getEnvironmentId());

--- a/gravitee-am-reporter/gravitee-am-reporter-file/src/test/java/io/gravitee/am/reporter/file/formatter/CustomAttributesFormatterTest.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-file/src/test/java/io/gravitee/am/reporter/file/formatter/CustomAttributesFormatterTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.reporter.file.formatter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.common.audit.Status;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.reporter.api.audit.model.AuditOutcome;
+import io.gravitee.am.reporter.file.audit.AuditEntry;
+import io.gravitee.am.reporter.file.formatter.csv.AuditFormatter;
+import io.gravitee.am.reporter.file.formatter.json.JsonFormatter;
+import io.gravitee.am.reporter.file.formatter.msgpack.MsgPackFormatter;
+import org.junit.Test;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CustomAttributesFormatterTest {
+
+    private static AuditEntry entry(Map<String, Object> customAttributes) {
+        AuditEntry entry = new AuditEntry();
+        entry.setId("audit-1");
+        entry.setType("USER_LOGIN");
+        entry.setTransactionId("txn-1");
+        entry.setReferenceType(ReferenceType.DOMAIN);
+        entry.setReferenceId("domain-1");
+        entry.setTimestamp(Instant.now());
+        AuditOutcome outcome = new AuditOutcome();
+        outcome.setStatus(Status.SUCCESS);
+        entry.setOutcome(outcome);
+        entry.setCustomAttributes(customAttributes);
+        return entry;
+    }
+
+    @Test
+    public void jsonCarriesThem() {
+        String out = new JsonFormatter<AuditEntry>().format(entry(Map.of("employee_id", "E-4471"))).toString();
+
+        assertTrue(out, out.contains("\"customAttributes\":{\"employee_id\":\"E-4471\"}"));
+    }
+
+    @Test
+    public void jsonOmitsThemWhenThereAreNone() {
+        String out = new JsonFormatter<AuditEntry>().format(entry(null)).toString();
+
+        assertFalse(out, out.contains("customAttributes"));
+    }
+
+    @Test
+    public void messagePackCarriesThem() throws Exception {
+        var buffer = new MsgPackFormatter<AuditEntry>().format(entry(Map.of("employee_id", "E-4471")));
+
+        var decoded = new ObjectMapper(new MessagePackFactory()).readTree(buffer.getBytes());
+        assertEquals("E-4471", decoded.get("customAttributes").get("employee_id").asText());
+    }
+
+    /** Message pack sets no global null-inclusion policy, so the field carries its own. */
+    @Test
+    public void messagePackOmitsThemWhenThereAreNone() throws Exception {
+        var buffer = new MsgPackFormatter<AuditEntry>().format(entry(null));
+
+        var decoded = new ObjectMapper(new MessagePackFactory()).readTree(buffer.getBytes());
+        assertFalse(decoded.has("customAttributes"));
+    }
+
+    @Test
+    public void csvDoesNotCarryThem() {
+        String out = new AuditFormatter().format(entry(Map.of("employee_id", "E-4471"))).toString();
+
+        assertFalse(out, out.contains("employee_id"));
+    }
+}

--- a/gravitee-am-reporter/gravitee-am-reporter-kafka/src/main/java/io/gravitee/am/reporter/kafka/dto/AuditMessageValueDto.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-kafka/src/main/java/io/gravitee/am/reporter/kafka/dto/AuditMessageValueDto.java
@@ -22,8 +22,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 
 /**
@@ -54,6 +59,12 @@ public class AuditMessageValueDto {
     private String nodeHostname;
 
     /**
+     * The extra attributes this reporter was configured to export, keyed by the operator's chosen name;
+     * values that are not already strings are serialized as JSON
+     */
+    private Map<String, String> customAttributes;
+
+    /**
      * @deprecated moved into the {@link #outcome} field
      */
     @Deprecated(since = "4.5", forRemoval = true)
@@ -73,9 +84,28 @@ public class AuditMessageValueDto {
                 .actor(AuditEntityDto.from(audit.getActor()))
                 .target(AuditEntityDto.from(audit.getTarget()))
                 .outcome(AuditOutcomeDto.from(audit.getOutcome()))
+                .customAttributes(asStringValues(audit.getCustomAttributes()))
                 .context(context)
                 .node(node)
                 .build();
+    }
+
+    private static Map<String, String> asStringValues(Map<String, Object> customAttributes) {
+        if (customAttributes == null || customAttributes.isEmpty()) {
+            return null;
+        }
+        var mapper = new ObjectMapper();
+        return customAttributes.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> {
+                    if (e.getValue() instanceof String value) {
+                        return value;
+                    }
+                    try {
+                        return mapper.writeValueAsString(e.getValue());
+                    } catch (JsonProcessingException ex) {
+                        return "";
+                    }
+                }));
     }
 
     @SuppressWarnings("unused") // additional methods for @lombok.Builder

--- a/gravitee-am-reporter/gravitee-am-reporter-kafka/src/test/java/io/gravitee/am/reporter/kafka/dto/AuditMessageValueDtoMappingTest.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-kafka/src/test/java/io/gravitee/am/reporter/kafka/dto/AuditMessageValueDtoMappingTest.java
@@ -139,4 +139,44 @@ class AuditMessageValueDtoMappingTest {
             }
         };
     }
+
+    @org.junit.jupiter.api.Nested
+    class CustomAttributes {
+
+        private Audit auditWith(Map<String, Object> customAttributes) {
+            var audit = new Audit();
+            audit.setId("audit-1");
+            audit.setCustomAttributes(customAttributes);
+            return audit;
+        }
+
+        @Test
+        void areCarriedOntoTheRecord() {
+            var dto = AuditMessageValueDto.from(auditWith(Map.of("employee_id", "E-4471")), null, null);
+
+            assertThat(dto.getCustomAttributes()).isEqualTo(Map.of("employee_id", "E-4471"));
+        }
+
+        @Test
+        void nonStringValuesAreSerializedAsJson() {
+            var dto = AuditMessageValueDto.from(auditWith(Map.of("login_count", 12)), null, null);
+
+            assertThat(dto.getCustomAttributes()).isEqualTo(Map.of("login_count", "12"));
+        }
+
+        @Test
+        void aCollectionIsSerializedAsJson() {
+            var dto = AuditMessageValueDto.from(
+                    auditWith(Map.of("groups", java.util.List.of("admins", "platform"))), null, null);
+
+            assertThat(dto.getCustomAttributes()).isEqualTo(Map.of("groups", "[\"admins\",\"platform\"]"));
+        }
+
+        @Test
+        void areAbsentWhenNoneWereResolved() {
+            assertThat(AuditMessageValueDto.from(auditWith(null), null, null).getCustomAttributes()).isNull();
+            assertThat(AuditMessageValueDto.from(auditWith(Map.of()), null, null).getCustomAttributes()).isNull();
+        }
+    }
+
 }

--- a/gravitee-am-reporter/gravitee-am-reporter-tcp/src/main/java/io/gravitee/am/reporter/tcp/audit/AuditEntry.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-tcp/src/main/java/io/gravitee/am/reporter/tcp/audit/AuditEntry.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.reporter.tcp.audit;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.reporter.api.audit.model.AuditAccessPoint;
 import io.gravitee.am.reporter.api.audit.model.AuditEntity;
@@ -23,6 +24,7 @@ import io.gravitee.am.reporter.tcp.formatter.ReportEntry;
 import lombok.Data;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * Wire representation of an {@link io.gravitee.am.reporter.api.audit.model.Audit} event,
@@ -48,4 +50,11 @@ public class AuditEntry implements ReportEntry {
     private String organizationId;
     private String nodeId;
     private String nodeHostname;
+
+    /**
+     * The extra attributes this reporter was configured to export, keyed by the operator's chosen name
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Map<String, Object> customAttributes;
+
 }

--- a/gravitee-am-reporter/gravitee-am-reporter-tcp/src/main/java/io/gravitee/am/reporter/tcp/audit/TcpAuditReporter.java
+++ b/gravitee-am-reporter/gravitee-am-reporter-tcp/src/main/java/io/gravitee/am/reporter/tcp/audit/TcpAuditReporter.java
@@ -882,6 +882,8 @@ public class TcpAuditReporter extends AbstractService<Reporter> implements Audit
             entry.setTarget(copy);
         }
 
+        entry.setCustomAttributes(audit.getCustomAttributes());
+
         if (context != null) {
             entry.setOrganizationId(context.getOrganizationId());
             entry.setEnvironmentId(context.getEnvironmentId());

--- a/gravitee-am-service/pom.xml
+++ b/gravitee-am-service/pom.xml
@@ -62,6 +62,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Expression language -->
+        <dependency>
+            <groupId>io.gravitee.el</groupId>
+            <artifactId>gravitee-expression-language</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.gravitee.am.password.dictionary</groupId>
             <artifactId>gravitee-am-password-dictionary</artifactId>

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/attribute/AttributeMappingReporter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/attribute/AttributeMappingReporter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.reporter.attribute;
+
+import io.gravitee.am.common.analytics.Type;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.ReporterAttributeMapping;
+import io.gravitee.am.model.common.Page;
+import io.gravitee.am.reporter.api.Reportable;
+import io.gravitee.am.reporter.api.audit.model.Audit;
+import io.gravitee.am.reporter.api.provider.ReportableCriteria;
+import io.gravitee.am.reporter.api.provider.Reporter;
+import io.gravitee.common.component.Lifecycle;
+import lombok.CustomLog;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Applies one reporter's configured attribute mappings to each audit on its way to that reporter.
+ *
+ * <p>Wraps a single reporter provider, so reporters on the same reference each export only their own
+ * fields.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class AttributeMappingReporter<R extends Reportable, C extends ReportableCriteria> implements Reporter<R, C> {
+
+    private final Reporter<R, C> delegate;
+    private final List<ReporterAttributeMapping> mappings;
+    private final ReporterAttributeResolver resolver;
+
+    public static <R extends Reportable, C extends ReportableCriteria> Reporter<R, C> decorate(
+            Reporter<R, C> delegate, List<ReporterAttributeMapping> mappings) {
+        if (mappings == null || mappings.isEmpty()) {
+            return delegate;
+        }
+        return new AttributeMappingReporter<>(delegate, mappings);
+    }
+
+    public AttributeMappingReporter(Reporter<R, C> delegate, List<ReporterAttributeMapping> mappings) {
+        this(delegate, mappings, new ReporterAttributeResolver());
+    }
+
+    AttributeMappingReporter(Reporter<R, C> delegate, List<ReporterAttributeMapping> mappings, ReporterAttributeResolver resolver) {
+        this.delegate = delegate;
+        this.mappings = mappings;
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void report(io.gravitee.reporter.api.Reportable reportable) {
+        if (reportable instanceof Audit audit) {
+            Map<String, Object> resolved;
+            // Enrichment must never cost the event.
+            try {
+                resolved = resolver.resolve(mappings, audit);
+            } catch (Exception ex) {
+                log.warn("Unable to resolve attribute mappings for audit {}, reporting it unenriched", audit.getId(), ex);
+                delegate.report(reportable);
+                return;
+            }
+            if (!resolved.isEmpty()) {
+                // The event bus hands the same Audit instance to every reporter on the reference.
+                Audit enriched = new Audit(audit);
+                enriched.setCustomAttributes(resolved);
+                delegate.report(enriched);
+                return;
+            }
+        }
+        delegate.report(reportable);
+    }
+
+    @Override
+    public boolean canHandle(io.gravitee.reporter.api.Reportable reportable) {
+        return delegate.canHandle(reportable);
+    }
+
+    @Override
+    public Single<Page<R>> search(ReferenceType referenceType, String referenceId, C criteria, int page, int size) {
+        return delegate.search(referenceType, referenceId, criteria, page, size);
+    }
+
+    @Override
+    public Single<Map<Object, Object>> aggregate(ReferenceType referenceType, String referenceId, C criteria, Type analyticsType) {
+        return delegate.aggregate(referenceType, referenceId, criteria, analyticsType);
+    }
+
+    @Override
+    public Maybe<R> findById(ReferenceType referenceType, String referenceId, String id) {
+        return delegate.findById(referenceType, referenceId, id);
+    }
+
+    @Override
+    public boolean canSearch() {
+        return delegate.canSearch();
+    }
+
+    @Override
+    public Completable purgeExpiredData() {
+        return delegate.purgeExpiredData();
+    }
+
+    @Override
+    public Completable purgeExpiredData(Instant deadline) {
+        return delegate.purgeExpiredData(deadline);
+    }
+
+    @Override
+    public Lifecycle.State lifecycleState() {
+        return delegate.lifecycleState();
+    }
+
+    @Override
+    public Reporter<R, C> start() throws Exception {
+        delegate.start();
+        return this;
+    }
+
+    @Override
+    public Reporter<R, C> stop() throws Exception {
+        delegate.stop();
+        return this;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/attribute/EvaluableAuditContext.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/attribute/EvaluableAuditContext.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.reporter.attribute;
+
+import java.util.Map;
+
+/**
+ * Backs the {@code context} variable in reporter attribute mapping expressions.
+ *
+ * <p>Duplicated from the gateway's {@code EvaluableExecutionContext}.
+ *
+ * @author GraviteeSource Team
+ */
+public class EvaluableAuditContext {
+
+    private final Map<String, Object> attributes;
+
+    public EvaluableAuditContext(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/attribute/ReporterAttributeResolver.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/attribute/ReporterAttributeResolver.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.reporter.attribute;
+
+import io.gravitee.am.model.ReporterAttributeMapping;
+import io.gravitee.am.reporter.api.audit.model.Audit;
+import io.gravitee.am.reporter.api.audit.model.AuditAccessPoint;
+import io.gravitee.am.reporter.api.audit.model.AuditEnrichmentContext;
+import io.gravitee.el.TemplateEngine;
+import lombok.CustomLog;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Evaluates the attribute mappings configured on a reporter against one audit event, producing the extra
+ * fields that reporter exports.
+ *
+ * <p>Each mapping is evaluated in isolation, so one that fails to resolve does not affect the rest.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class ReporterAttributeResolver {
+
+    static final String CONTEXT_VARIABLE = "context";
+
+    static final String USER_KEY = "user";
+    static final String CLIENT_KEY = "client";
+    static final String REQUEST_KEY = "request";
+    static final String AUDIT_KEY = "audit";
+
+    /**
+     * @return the resolved attributes keyed by the operator's chosen export name, in declaration order
+     */
+    public Map<String, Object> resolve(List<ReporterAttributeMapping> mappings, Audit audit) {
+        if (mappings == null || mappings.isEmpty() || audit == null) {
+            return Map.of();
+        }
+
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable(CONTEXT_VARIABLE, new EvaluableAuditContext(attributesOf(audit)));
+
+        Map<String, Object> resolved = new LinkedHashMap<>();
+        for (ReporterAttributeMapping mapping : mappings) {
+            if (mapping == null || mapping.expression() == null || mapping.exportedName() == null) {
+                continue;
+            }
+            try {
+                Object value = engine.getValue(mapping.expression(), Object.class);
+                if (value != null) {
+                    resolved.put(mapping.exportedName(), value);
+                }
+            } catch (Exception ex) {
+                log.debug("Unable to resolve reporter attribute mapping '{}' for audit {}",
+                        mapping.expression(), audit.getId(), ex);
+            }
+        }
+        return resolved;
+    }
+
+    /**
+     * The attribute names an operator can address in a mapping expression.
+     */
+    private Map<String, Object> attributesOf(Audit audit) {
+        Map<String, Object> attributes = new HashMap<>();
+
+        AuditEnrichmentContext context = audit.getEnrichmentContext();
+        if (context != null) {
+            attributes.put(USER_KEY, project(context::user, audit));
+            attributes.put(CLIENT_KEY, project(context::client, audit));
+        }
+
+        AuditAccessPoint accessPoint = audit.getAccessPoint();
+        if (accessPoint != null) {
+            Map<String, Object> request = new HashMap<>();
+            request.put("ip", accessPoint.getIpAddress());
+            request.put("userAgent", accessPoint.getUserAgent());
+            attributes.put(REQUEST_KEY, request);
+        }
+
+        Map<String, Object> auditAttributes = new HashMap<>();
+        auditAttributes.put("id", audit.getId());
+        auditAttributes.put("type", audit.getType());
+        auditAttributes.put("transactionId", audit.getTransactionId());
+        if (audit.getOutcome() != null) {
+            auditAttributes.put("status", audit.getOutcome().getStatus());
+        }
+        attributes.put(AUDIT_KEY, auditAttributes);
+
+        return attributes;
+    }
+
+    /**
+     * Isolated so a projection that throws does not cost the mappings that never referenced it.
+     */
+    private static Object project(Supplier<?> projection, Audit audit) {
+        try {
+            return projection.get();
+        } catch (Exception ex) {
+            log.debug("Unable to project audit {} for attribute mapping", audit.getId(), ex);
+            return null;
+        }
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/AuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/AuditBuilder.java
@@ -34,6 +34,7 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.reporter.api.audit.model.Audit;
 import io.gravitee.am.reporter.api.audit.model.AuditAccessPoint;
+import io.gravitee.am.reporter.api.audit.model.AuditEnrichmentContext;
 import io.gravitee.am.reporter.api.audit.model.AuditEntity;
 import io.gravitee.am.reporter.api.audit.model.AuditOutcome;
 
@@ -85,6 +86,9 @@ public abstract class AuditBuilder<T extends AuditBuilder<T>> {
     protected Object oldValue;
     protected Object newValue;
 
+    protected io.gravitee.am.model.User capturedUser;
+    protected Client capturedClient;
+
     public static <T> T builder(Class<T> clazz) {
         try {
             return clazz.newInstance();
@@ -131,6 +135,7 @@ public abstract class AuditBuilder<T extends AuditBuilder<T>> {
             this.accessPointId = client.getId();
             this.accessPointAlternativeId = client.getClientId();
             this.accessPointName = client.getClientName();
+            this.capturedClient = client;
         }
         return (T) this;
     }
@@ -213,6 +218,13 @@ public abstract class AuditBuilder<T extends AuditBuilder<T>> {
         }
 
         return null;
+    }
+
+    /**
+     * Every builder method that receives an {@code io.gravitee.am.model.User} must call this.
+     */
+    protected void captureUser(io.gravitee.am.model.User user) {
+        this.capturedUser = user;
     }
 
     public String getType() {
@@ -316,6 +328,10 @@ public abstract class AuditBuilder<T extends AuditBuilder<T>> {
             result.setMessage(throwable.getMessage() + (throwable.getCause() != null ? ". Cause: " + throwable.getCause().getMessage() : ""));
         }
         audit.setOutcome(result);
+
+        if (capturedUser != null || capturedClient != null) {
+            audit.setEnrichmentContext(new AuditEnrichmentContext(capturedUser, capturedClient));
+        }
 
         return audit;
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/AuthenticationAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/AuthenticationAuditBuilder.java
@@ -52,6 +52,7 @@ public class AuthenticationAuditBuilder extends AuditBuilder<AuthenticationAudit
 
     public AuthenticationAuditBuilder user(User user) {
         if (user != null) {
+            captureUser(user);
             setActor(user.getId(), EntityType.USER, user.getUsername(), getDisplayName(user), user.getReferenceType(), user.getReferenceId(), user.getExternalId(), user.getSource());
         }
         return this;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/ClientTokenAuditBuilder.java
@@ -109,6 +109,7 @@ public class ClientTokenAuditBuilder extends GatewayAuditBuilder<ClientTokenAudi
 
     public ClientTokenAuditBuilder idTokenFor(User user) {
         if (user != null && user.getId() != null) {
+            captureUser(user);
             var userId = user.getId();
             tokenNewValue.put(TokenTypeHint.ID_TOKEN.name(), format("Delivered for sub '%s'", userId));
         }
@@ -130,6 +131,7 @@ public class ClientTokenAuditBuilder extends GatewayAuditBuilder<ClientTokenAudi
 
     public ClientTokenAuditBuilder tokenActor(User user) {
         if (user != null) {
+            captureUser(user);
             setActor(user.getId(), EntityType.USER, user.getUsername(), user.getDisplayName(), user.getReferenceType(), user.getReferenceId(), user.getExternalId(), user.getSource());
             if (ReferenceType.DOMAIN.equals(user.getReferenceType())) {
                 reference(Reference.domain(user.getReferenceId()));
@@ -141,6 +143,7 @@ public class ClientTokenAuditBuilder extends GatewayAuditBuilder<ClientTokenAudi
 
     public ClientTokenAuditBuilder tokenTarget(User user) {
         if (user != null) {
+            captureUser(user);
             setTarget(user.getId(), EntityType.USER, user.getUsername(), user.getDisplayName(), user.getReferenceType(), user.getReferenceId(), user.getExternalId(), user.getSource());
             if (ReferenceType.DOMAIN.equals(user.getReferenceType())) {
                 reference(Reference.domain(user.getReferenceId()));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/EmailAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/EmailAuditBuilder.java
@@ -46,6 +46,7 @@ public class EmailAuditBuilder extends AuditBuilder<EmailAuditBuilder> {
 
     public EmailAuditBuilder user(User user) {
         if (user != null) {
+            captureUser(user);
             setTarget(user.getId(), EntityType.USER, user.getUsername(), user.getDisplayName(), user.getReferenceType(), user.getReferenceId(), user.getExternalId(), user.getSource());
         }
         return this;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/MFAAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/MFAAuditBuilder.java
@@ -73,6 +73,7 @@ public class MFAAuditBuilder extends GatewayAuditBuilder<MFAAuditBuilder> {
 
     public MFAAuditBuilder user(User user) {
         if (user != null) {
+            captureUser(user);
             setActor(user.getId(), EntityType.USER, user.getUsername(), user.getDisplayName(), user.getReferenceType(), user.getReferenceId(), user.getExternalId(), user.getSource());
             if (user.getAdditionalInformation() != null) {
                 if (user.getAdditionalInformation().containsKey(Claims.IP_ADDRESS)) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/UserConsentAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/UserConsentAuditBuilder.java
@@ -40,6 +40,7 @@ public class UserConsentAuditBuilder extends ManagementAuditBuilder<UserConsentA
 
     public UserConsentAuditBuilder user(User user) {
         if (user != null) {
+            captureUser(user);
             setTarget(user.getId(), EntityType.USER, user.getUsername(), getDisplayName(user), user.getReferenceType(), user.getReferenceId(), user.getExternalId(), user.getSource());
         }
         return this;

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/gateway/VerifyAttemptAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/gateway/VerifyAttemptAuditBuilder.java
@@ -44,6 +44,7 @@ public class VerifyAttemptAuditBuilder extends GatewayAuditBuilder<VerifyAttempt
 
     public VerifyAttemptAuditBuilder user(User user) {
         if (user != null) {
+            captureUser(user);
             setActor(user.getId(), EntityType.USER, user.getUsername(), user.getDisplayName(), user.getReferenceType(), user.getReferenceId(), user.getExternalId(), user.getSource());
         }
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/management/UserAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/management/UserAuditBuilder.java
@@ -58,6 +58,7 @@ public class UserAuditBuilder extends ManagementAuditBuilder<UserAuditBuilder> {
 
     public UserAuditBuilder user(User user) {
         if (user != null && user.getReferenceId() != null && user.getReferenceType() != null) {
+            captureUser(user);
             if (isSensitiveEventType()) {
                 setNewValue(user);
             }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/reporter/ReporterAttributeMappingsValidator.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/validators/reporter/ReporterAttributeMappingsValidator.java
@@ -117,10 +117,8 @@ public class ReporterAttributeMappingsValidator implements Validator<List<Report
 
     private static boolean isValidExpression(String expression) {
         return expression != null
-                && expression.length() <= MAX_EXPRESSION_LENGTH
-                && expression.startsWith("{")
-                && expression.endsWith("}")
-                && expression.length() > 2;
+                && !expression.isBlank()
+                && expression.length() <= MAX_EXPRESSION_LENGTH;
     }
 
     private static boolean isValidExportedName(String exportedName) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ReporterServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ReporterServiceImplTest.java
@@ -142,7 +142,7 @@ class ReporterServiceImplTest {
             new ReporterAttributeMapping("{#context.attributes['user'].additionalInformation['sub']}", "user_sub");
     private static final ReporterAttributeMapping CLIENT_ID =
             new ReporterAttributeMapping("{#context.attributes['client'].clientId}", "client_id");
-    private static final ReporterAttributeMapping INVALID = new ReporterAttributeMapping("no braces", "user_sub");
+    private static final ReporterAttributeMapping INVALID = new ReporterAttributeMapping("   ", "user_sub");
 
     private Reporter systemReporter(List<ReporterAttributeMapping> attributeMappings, ManagedBy managedBy) {
         return Reporter.builder()

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/attribute/AttributeMappingReporterTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/attribute/AttributeMappingReporterTest.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.reporter.attribute;
+
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.ReporterAttributeMapping;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.reporter.api.audit.model.Audit;
+import io.gravitee.am.reporter.api.audit.model.AuditEnrichmentContext;
+import io.gravitee.am.reporter.api.provider.ReportableCriteria;
+import io.gravitee.am.reporter.api.provider.Reporter;
+import io.gravitee.reporter.api.Reportable;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author GraviteeSource Team
+ */
+class AttributeMappingReporterTest {
+
+    private static final String EMAIL_EXPRESSION = "{#context.attributes['user'].email}";
+    private static final String CLIENT_EXPRESSION = "{#context.attributes['client'].clientId}";
+
+    private static class CapturingReporter implements Reporter<Audit, ReportableCriteria> {
+        private final List<Reportable> reported = new ArrayList<>();
+
+        @Override
+        public void report(Reportable reportable) {
+            reported.add(reportable);
+        }
+
+        @Override
+        public io.reactivex.rxjava3.core.Single<io.gravitee.am.model.common.Page<Audit>> search(
+                ReferenceType referenceType, String referenceId, ReportableCriteria criteria, int page, int size) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public io.reactivex.rxjava3.core.Single<Map<Object, Object>> aggregate(
+                ReferenceType referenceType, String referenceId, ReportableCriteria criteria,
+                io.gravitee.am.common.analytics.Type analyticsType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public io.reactivex.rxjava3.core.Maybe<Audit> findById(ReferenceType referenceType, String referenceId, String id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean canSearch() {
+            return false;
+        }
+
+        @Override
+        public Reporter<Audit, ReportableCriteria> start() {
+            return this;
+        }
+
+        @Override
+        public Reporter<Audit, ReportableCriteria> stop() {
+            return this;
+        }
+
+        @Override
+        public io.gravitee.common.component.Lifecycle.State lifecycleState() {
+            return io.gravitee.common.component.Lifecycle.State.STARTED;
+        }
+
+        Audit onlyAudit() {
+            assertThat(reported).hasSize(1);
+            return (Audit) reported.get(0);
+        }
+    }
+
+    private static ReporterAttributeMapping mapping(String expression, String exportedName) {
+        return new ReporterAttributeMapping(expression, exportedName);
+    }
+
+    private static Audit auditWithContext() {
+        User user = new User();
+        user.setEmail("jsmith@example.com");
+        user.setAdditionalInformation(new HashMap<>(Map.of("sub", "external-sub")));
+
+        Client client = new Client();
+        client.setClientId("my-app");
+
+        Audit audit = new Audit();
+        audit.setId("audit-1");
+        audit.setType("USER_LOGIN");
+        audit.setEnrichmentContext(new AuditEnrichmentContext(user, client));
+        return audit;
+    }
+
+    @Nested
+    class NotWrappedWhenThereIsNothingToApply {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void decorateReturnsTheDelegateItself(List<ReporterAttributeMapping> mappings) {
+            var delegate = new CapturingReporter();
+
+            assertThat(AttributeMappingReporter.decorate(delegate, mappings)).isSameAs(delegate);
+        }
+    }
+
+    @Nested
+    class Enrichment {
+
+        @Test
+        void theReporterReceivesTheResolvedAttributes() {
+            var delegate = new CapturingReporter();
+            var reporter = AttributeMappingReporter.decorate(delegate,
+                    List.of(mapping(EMAIL_EXPRESSION, "user_email"), mapping(CLIENT_EXPRESSION, "application_id")));
+
+            reporter.report(auditWithContext());
+
+            assertThat(delegate.onlyAudit().getCustomAttributes()).containsOnly(
+                    Map.entry("user_email", "jsmith@example.com"),
+                    Map.entry("application_id", "my-app"));
+        }
+
+        @Test
+        void theRestOfTheAuditIsCarriedThrough() {
+            var delegate = new CapturingReporter();
+            var reporter = AttributeMappingReporter.decorate(delegate, List.of(mapping(EMAIL_EXPRESSION, "user_email")));
+            var original = auditWithContext();
+
+            reporter.report(original);
+
+            var delivered = delegate.onlyAudit();
+            assertThat(delivered.getId()).isEqualTo(original.getId());
+            assertThat(delivered.getType()).isEqualTo(original.getType());
+        }
+
+        @Test
+        void anAuditWithNothingResolvableIsPassedStraightThrough() {
+            var delegate = new CapturingReporter();
+            var reporter = AttributeMappingReporter.decorate(delegate,
+                    List.of(mapping("{#context.attributes['user'].additionalInformation['absent']}", "nope")));
+            var original = auditWithContext();
+
+            reporter.report(original);
+
+            assertThat(delegate.onlyAudit()).isSameAs(original);
+            assertThat(original.getCustomAttributes()).isNull();
+        }
+
+        @Test
+        void somethingThatIsNotAnAuditIsPassedStraightThrough() {
+            var delegate = new CapturingReporter();
+            var reporter = AttributeMappingReporter.decorate(delegate, List.of(mapping(EMAIL_EXPRESSION, "user_email")));
+            var other = mock(Reportable.class);
+
+            reporter.report(other);
+
+            assertThat(delegate.reported).containsExactly(other);
+        }
+    }
+
+    @Nested
+    class BrokenProjection {
+
+        /** A non-string {@code locale} with no preferredLanguage makes {@code new UserProperties(..)} throw. */
+        private Audit auditWithUnprojectableUser() {
+            User user = new User();
+            user.setEmail("jsmith@example.com");
+            Map<String, Object> additional = new HashMap<>();
+            additional.put("locale", Map.of("lang", "en"));
+            user.setAdditionalInformation(additional);
+
+            Client client = new Client();
+            client.setClientId("my-app");
+
+            Audit audit = new Audit();
+            audit.setId("audit-1");
+            audit.setType("USER_LOGIN");
+            audit.setEnrichmentContext(new AuditEnrichmentContext(user, client));
+            return audit;
+        }
+
+        @Test
+        void theEventStillReachesTheReporter() {
+            var delegate = new CapturingReporter();
+            var reporter = AttributeMappingReporter.decorate(delegate, List.of(mapping(CLIENT_EXPRESSION, "application_id")));
+
+            reporter.report(auditWithUnprojectableUser());
+
+            assertThat(delegate.reported).hasSize(1);
+        }
+
+        @Test
+        void mappingsThatDoNotTouchTheUserStillResolve() {
+            var delegate = new CapturingReporter();
+            var reporter = AttributeMappingReporter.decorate(delegate, List.of(mapping(CLIENT_EXPRESSION, "application_id")));
+
+            reporter.report(auditWithUnprojectableUser());
+
+            assertThat(delegate.onlyAudit().getCustomAttributes()).containsExactly(Map.entry("application_id", "my-app"));
+        }
+    }
+
+    @Nested
+    class PerReporterIsolation {
+
+        @Test
+        void twoReportersOverOneAuditEachSeeOnlyTheirOwnAttributes() {
+            var first = new CapturingReporter();
+            var second = new CapturingReporter();
+            var firstReporter = AttributeMappingReporter.decorate(first, List.of(mapping(EMAIL_EXPRESSION, "user_email")));
+            var secondReporter = AttributeMappingReporter.decorate(second, List.of(mapping(CLIENT_EXPRESSION, "application_id")));
+
+            var shared = auditWithContext();
+            firstReporter.report(shared);
+            secondReporter.report(shared);
+
+            assertThat(first.onlyAudit().getCustomAttributes()).containsOnlyKeys("user_email");
+            assertThat(second.onlyAudit().getCustomAttributes()).containsOnlyKeys("application_id");
+        }
+
+        @Test
+        void theSharedAuditIsNeverMutated() {
+            var delegate = new CapturingReporter();
+            var reporter = AttributeMappingReporter.decorate(delegate, List.of(mapping(EMAIL_EXPRESSION, "user_email")));
+            var shared = auditWithContext();
+
+            reporter.report(shared);
+
+            assertThat(shared.getCustomAttributes()).isNull();
+            assertThat(delegate.onlyAudit()).isNotSameAs(shared);
+        }
+
+        @Test
+        void aReporterWithoutMappingsIsUnaffectedByOneWithThem() {
+            var enriched = new CapturingReporter();
+            var plain = new CapturingReporter();
+            var enrichedReporter = AttributeMappingReporter.decorate(enriched, List.of(mapping(EMAIL_EXPRESSION, "user_email")));
+            var plainReporter = AttributeMappingReporter.decorate(plain, List.of());
+
+            var shared = auditWithContext();
+            enrichedReporter.report(shared);
+            plainReporter.report(shared);
+
+            assertThat(enriched.onlyAudit().getCustomAttributes()).containsOnlyKeys("user_email");
+            assertThat(plain.onlyAudit().getCustomAttributes()).isNull();
+        }
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/attribute/ReporterAttributeResolverTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/attribute/ReporterAttributeResolverTest.java
@@ -1,0 +1,407 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.reporter.attribute;
+
+import io.gravitee.am.common.audit.Status;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.ReporterAttributeMapping;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.reporter.api.audit.model.Audit;
+import io.gravitee.am.reporter.api.audit.model.AuditAccessPoint;
+import io.gravitee.am.reporter.api.audit.model.AuditEnrichmentContext;
+import io.gravitee.am.reporter.api.audit.model.AuditOutcome;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author GraviteeSource Team
+ */
+class ReporterAttributeResolverTest {
+
+    private final ReporterAttributeResolver resolver = new ReporterAttributeResolver();
+
+    private static ReporterAttributeMapping mapping(String expression, String exportedName) {
+        return new ReporterAttributeMapping(expression, exportedName);
+    }
+
+    private static User user() {
+        User user = new User();
+        user.setId("user-1");
+        user.setUsername("jsmith");
+        user.setEmail("jsmith@example.com");
+        user.setFirstName("Jane");
+        user.setReferenceType(ReferenceType.DOMAIN);
+        user.setReferenceId("domain-1");
+        user.setSource("ldap-idp");
+        Map<String, Object> additional = new HashMap<>();
+        additional.put("sub", "external-sub");
+        additional.put("employeeId", "E-4471");
+        additional.put("department", "Platform");
+        additional.put("loginCount", 12);
+        user.setAdditionalInformation(additional);
+        user.setPassword("s3cret");
+        return user;
+    }
+
+    private static Client client() {
+        Client client = new Client();
+        client.setId("client-internal-id");
+        client.setClientId("my-app");
+        client.setClientName("My Application");
+        return client;
+    }
+
+    /** An audit as it looks after AuditBuilder has captured the user and client behind the event. */
+    private static Audit audit() {
+        Audit audit = new Audit();
+        audit.setId("audit-1");
+        audit.setType("USER_LOGIN");
+        audit.setTransactionId("txn-1");
+
+        AuditAccessPoint accessPoint = new AuditAccessPoint();
+        accessPoint.setIpAddress("10.0.0.9");
+        accessPoint.setUserAgent("Mozilla/5.0");
+        audit.setAccessPoint(accessPoint);
+
+        AuditOutcome outcome = new AuditOutcome();
+        outcome.setStatus(Status.SUCCESS);
+        audit.setOutcome(outcome);
+
+        audit.setEnrichmentContext(new AuditEnrichmentContext(user(), client()));
+        return audit;
+    }
+
+    @Nested
+    class NothingToDo {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void noMappingsResolvesToNothing(List<ReporterAttributeMapping> mappings) {
+            assertThat(resolver.resolve(mappings, audit())).isEmpty();
+        }
+
+        @Test
+        void nullAuditResolvesToNothing() {
+            assertThat(resolver.resolve(List.of(mapping("{#context.attributes['user'].email}", "e")), null)).isEmpty();
+        }
+
+        @Test
+        void anAuditWithoutAnEnrichmentContextStillResolvesWhatItCan() {
+            Audit audit = audit();
+            audit.setEnrichmentContext(null);
+
+            var resolved = resolver.resolve(List.of(
+                    mapping("{#context.attributes['user'].email}", "user_email"),
+                    mapping("{#context.attributes['audit'].type}", "audit_type")), audit);
+
+            assertThat(resolved).containsExactly(Map.entry("audit_type", "USER_LOGIN"));
+        }
+    }
+
+    @Nested
+    class SupportedSources {
+
+        @Test
+        void resolvesATopLevelUserAttribute() {
+            var resolved = resolver.resolve(List.of(mapping("{#context.attributes['user'].email}", "user_email")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("user_email", "jsmith@example.com"));
+        }
+
+        @Test
+        void resolvesANestedCustomUserAttribute() {
+            var resolved = resolver.resolve(
+                    List.of(mapping("{#context.attributes['user'].additionalInformation['employeeId']}", "employee_id")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("employee_id", "E-4471"));
+        }
+
+        @Test
+        void resolvesAClientAttribute() {
+            var resolved = resolver.resolve(List.of(
+                    mapping("{#context.attributes['client'].clientId}", "application_id"),
+                    mapping("{#context.attributes['client'].name}", "application_name")), audit());
+
+            assertThat(resolved).containsOnly(
+                    Map.entry("application_id", "my-app"),
+                    Map.entry("application_name", "My Application"));
+        }
+
+        @Test
+        void resolvesTheRequestContext() {
+            var resolved = resolver.resolve(List.of(
+                    mapping("{#context.attributes['request'].ip}", "source_ip"),
+                    mapping("{#context.attributes['request'].userAgent}", "ua")), audit());
+
+            assertThat(resolved).containsOnly(
+                    Map.entry("source_ip", "10.0.0.9"),
+                    Map.entry("ua", "Mozilla/5.0"));
+        }
+
+        @Test
+        void resolvesTheAuditItself() {
+            var resolved = resolver.resolve(List.of(
+                    mapping("{#context.attributes['audit'].transactionId}", "txn"),
+                    mapping("{#context.attributes['audit'].status}", "result")), audit());
+
+            assertThat(resolved).containsOnly(
+                    Map.entry("txn", "txn-1"),
+                    Map.entry("result", Status.SUCCESS));
+        }
+
+        @Test
+        void theIdentityProviderIsReachableAsTheUserSource() {
+            var resolved = resolver.resolve(List.of(mapping("{#context.attributes['user'].source}", "idp")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("idp", "ldap-idp"));
+        }
+    }
+
+    @Nested
+    class Renaming {
+
+        @Test
+        void theValueIsExportedUnderTheConfiguredName() {
+            var resolved = resolver.resolve(
+                    List.of(mapping("{#context.attributes['user'].additionalInformation['department']}", "department_name")), audit());
+
+            assertThat(resolved).containsOnlyKeys("department_name");
+        }
+
+        @Test
+        void oneSourceCanBeExportedTwiceUnderDifferentNames() {
+            var resolved = resolver.resolve(List.of(
+                    mapping("{#context.attributes['user'].email}", "email"),
+                    mapping("{#context.attributes['user'].email}", "contact_email")), audit());
+
+            assertThat(resolved).containsOnly(
+                    Map.entry("email", "jsmith@example.com"),
+                    Map.entry("contact_email", "jsmith@example.com"));
+        }
+
+        @Test
+        void declarationOrderIsPreserved() {
+            var resolved = resolver.resolve(List.of(
+                    mapping("{#context.attributes['user'].username}", "a_username"),
+                    mapping("{#context.attributes['user'].email}", "b_email"),
+                    mapping("{#context.attributes['client'].clientId}", "c_client")), audit());
+
+            assertThat(resolved.keySet()).containsExactly("a_username", "b_email", "c_client");
+        }
+    }
+
+    @Nested
+    class NonStringValues {
+
+        @Test
+        void keepTheirNativeType() {
+            var resolved = resolver.resolve(
+                    List.of(mapping("{#context.attributes['user'].additionalInformation['loginCount']}", "login_count")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("login_count", 12));
+        }
+
+        @Test
+        void aCollectionResolvesAsACollection() {
+            User user = user();
+            user.setGroups(List.of("admins", "platform"));
+            Audit audit = audit();
+            audit.setEnrichmentContext(new AuditEnrichmentContext(user, client()));
+
+            var resolved = resolver.resolve(List.of(mapping("{#context.attributes['user'].groups}", "groups")), audit);
+
+            assertThat(resolved.get("groups")).isEqualTo(List.of("admins", "platform"));
+        }
+    }
+
+    @Nested
+    class NeverFailsTheEvent {
+
+        @Test
+        void aMissingAttributeIsOmittedRatherThanExportedAsNull() {
+            var resolved = resolver.resolve(
+                    List.of(mapping("{#context.attributes['user'].additionalInformation['nope']}", "missing")), audit());
+
+            assertThat(resolved).isEmpty();
+        }
+
+        @Test
+        void anUnknownRootKeyIsOmitted() {
+            var resolved = resolver.resolve(List.of(mapping("{#context.attributes['nope'].whatever}", "missing")), audit());
+
+            assertThat(resolved).isEmpty();
+        }
+
+        /** Navigating off an absent root throws, so the whole mapping is lost. */
+        @Test
+        void anAbsentRootTakesTheLiteralPartsWithIt() {
+            Audit audit = audit();
+            audit.setEnrichmentContext(null);
+
+            var resolved = resolver.resolve(
+                    List.of(mapping("EMPLOYEE#{#context.attributes['user'].additionalInformation['employeeId']}", "badge")), audit);
+
+            assertThat(resolved).isEmpty();
+        }
+
+        @Test
+        void safeNavigationKeepsTheLiteralPartsWhenTheRootIsAbsent() {
+            Audit audit = audit();
+            audit.setEnrichmentContext(null);
+
+            var resolved = resolver.resolve(List.of(mapping(
+                    "EMPLOYEE#{#context.attributes['user']?.additionalInformation?.get('employeeId')}", "badge")), audit);
+
+            assertThat(resolved).containsExactly(Map.entry("badge", "EMPLOYEE#"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "{#context.attributes['user'.email}",
+                "{#context.attributes['user'].email()}",
+                "{#1/0}"
+        })
+        void aMalformedExpressionIsOmitted(String expression) {
+            assertThat(resolver.resolve(List.of(mapping(expression, "broken")), audit())).isEmpty();
+        }
+
+        @Test
+        void oneBadExpressionDoesNotCostTheOthers() {
+            var resolved = resolver.resolve(List.of(
+                    mapping("{#context.attributes['user'].email}", "good_before"),
+                    mapping("{#context.attributes['user'.email}", "broken"),
+                    mapping("{#context.attributes['client'].clientId}", "good_after")), audit());
+
+            assertThat(resolved).containsOnly(
+                    Map.entry("good_before", "jsmith@example.com"),
+                    Map.entry("good_after", "my-app"));
+        }
+
+        @Test
+        void aMappingMissingEitherHalfIsSkipped() {
+            var resolved = resolver.resolve(java.util.Arrays.asList(
+                    null,
+                    mapping(null, "no_expression"),
+                    mapping("{#context.attributes['user'].email}", null),
+                    mapping("{#context.attributes['user'].username}", "fine")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("fine", "jsmith"));
+        }
+    }
+
+    /**
+     * The engine treats anything outside {@code {#...}} as template text.
+     */
+    @Nested
+    class TemplateText {
+
+        @Test
+        void interpolatesALiteralPrefix() {
+            var resolved = resolver.resolve(List.of(mapping(
+                    "tenant-{#context.attributes['user'].additionalInformation['department']}", "tenant")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("tenant", "tenant-Platform"));
+        }
+
+        @Test
+        void interpolatesALiteralSuffix() {
+            var resolved = resolver.resolve(List.of(mapping(
+                    "{#context.attributes['user'].additionalInformation['department']}-team", "team")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("team", "Platform-team"));
+        }
+
+        @Test
+        void exportsAPlainConstant() {
+            var resolved = resolver.resolve(List.of(mapping("production", "environment")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("environment", "production"));
+        }
+
+        @Test
+        void interpolatesLiteralTextBetweenTwoExpressions() {
+            var resolved = resolver.resolve(List.of(mapping(
+                    "{#context.attributes['user'].firstName} of {#context.attributes['user'].additionalInformation['department']}",
+                    "who")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("who", "Jane of Platform"));
+        }
+
+        @Test
+        void combinesTwoExpressionsInOneValue() {
+            var resolved = resolver.resolve(List.of(mapping(
+                    "{#context.attributes['user'].username}@{#context.attributes['client'].clientId}", "who")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("who", "jsmith@my-app"));
+        }
+
+        @Test
+        void aConstantIsExportedVerbatimBracesIncluded() {
+            var resolved = resolver.resolve(List.of(mapping("{prod}", "environment")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("environment", "{prod}"));
+        }
+
+        /** The engine renders a null leaf as empty text, so the literal parts survive. */
+        @Test
+        void aMissingLeafStillLeavesTheLiteralParts() {
+            var resolved = resolver.resolve(
+                    List.of(mapping("EMPLOYEE#{#context.attributes['user'].additionalInformation['absent']}", "badge")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("badge", "EMPLOYEE#"));
+        }
+
+        @Test
+        void anExpressionMissingItsHashIsExportedAsItsOwnText() {
+            var resolved = resolver.resolve(List.of(mapping("{context.attributes['user'].email}", "user_email")), audit());
+
+            assertThat(resolved).containsExactly(Map.entry("user_email", "{context.attributes['user'].email}"));
+        }
+    }
+
+    @Nested
+    class SensitiveValuesAreUnreachable {
+
+        @Test
+        void thePasswordIsNotExposedOnTheUserProjection() {
+            var resolved = resolver.resolve(List.of(mapping("{#context.attributes['user'].password}", "pwd")), audit());
+
+            assertThat(resolved).isEmpty();
+        }
+
+        @Test
+        void theClientSecretIsNotExposedOnTheClientProjection() {
+            Client client = client();
+            client.setClientSecret("super-secret");
+            Audit audit = audit();
+            audit.setEnrichmentContext(new AuditEnrichmentContext(user(), client));
+
+            var resolved = resolver.resolve(List.of(mapping("{#context.attributes['client'].clientSecret}", "secret")), audit);
+
+            assertThat(resolved).isEmpty();
+        }
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/AuditBuilderEnrichmentContextTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/reporter/builder/AuditBuilderEnrichmentContextTest.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.reporter.builder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.User;
+import io.gravitee.am.model.oidc.Client;
+import io.gravitee.am.service.reporter.builder.management.UserAuditBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.gravitee.am.common.audit.EventType.USER_LOGIN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author GraviteeSource Team
+ */
+class AuditBuilderEnrichmentContextTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static User user() {
+        User user = new User();
+        user.setId("user-1");
+        user.setUsername("jsmith");
+        user.setEmail("jsmith@example.com");
+        user.setReferenceType(ReferenceType.DOMAIN);
+        user.setReferenceId("domain-1");
+        Map<String, Object> additional = new HashMap<>();
+        additional.put("employeeId", "E-4471");
+        user.setAdditionalInformation(additional);
+        return user;
+    }
+
+    private static Client client() {
+        Client client = new Client();
+        client.setId("client-internal-id");
+        client.setClientId("my-app");
+        client.setClientName("My Application");
+        return client;
+    }
+
+    @Test
+    void capturesTheUserBehindALogin() {
+        var audit = AuditBuilder.builder(AuthenticationAuditBuilder.class)
+                .type(USER_LOGIN)
+                .user(user())
+                .build(objectMapper);
+
+        assertThat(audit.getEnrichmentContext()).isNotNull();
+        assertThat(audit.getEnrichmentContext().user().getEmail()).isEqualTo("jsmith@example.com");
+        assertThat(audit.getEnrichmentContext().user().getAdditionalInformation()).containsEntry("employeeId", "E-4471");
+    }
+
+    @Test
+    void capturesTheClientBehindALogin() {
+        var audit = AuditBuilder.builder(AuthenticationAuditBuilder.class)
+                .type(USER_LOGIN)
+                .client(client())
+                .build(objectMapper);
+
+        assertThat(audit.getEnrichmentContext()).isNotNull();
+        assertThat(audit.getEnrichmentContext().client().getClientId()).isEqualTo("my-app");
+        assertThat(audit.getEnrichmentContext().client().getClientName()).isEqualTo("My Application");
+    }
+
+    @Test
+    void capturesTheUserOnAManagementEvent() {
+        var audit = AuditBuilder.builder(UserAuditBuilder.class)
+                .type(USER_LOGIN)
+                .user(user())
+                .build(objectMapper);
+
+        assertThat(audit.getEnrichmentContext()).isNotNull();
+        assertThat(audit.getEnrichmentContext().user().getUsername()).isEqualTo("jsmith");
+    }
+
+    @Test
+    void thereIsNoContextWhenNeitherWasSupplied() {
+        var audit = AuditBuilder.builder(AuthenticationAuditBuilder.class)
+                .type(USER_LOGIN)
+                .build(objectMapper);
+
+        assertThat(audit.getEnrichmentContext()).isNull();
+    }
+
+    @Test
+    void capturesTheUserATokenIsIssuedFor() {
+        var audit = AuditBuilder.builder(ClientTokenAuditBuilder.class)
+                .tokenActor(client())
+                .tokenTarget(user())
+                .build(objectMapper);
+
+        assertThat(audit.getEnrichmentContext()).isNotNull();
+        assertThat(audit.getEnrichmentContext().user().getEmail()).isEqualTo("jsmith@example.com");
+        assertThat(audit.getEnrichmentContext().client().getClientId()).isEqualTo("my-app");
+    }
+
+    @Test
+    void capturesTheUserActingOnATokenEvent() {
+        var audit = AuditBuilder.builder(ClientTokenAuditBuilder.class)
+                .tokenActor(user())
+                .build(objectMapper);
+
+        assertThat(audit.getEnrichmentContext()).isNotNull();
+        assertThat(audit.getEnrichmentContext().user().getUsername()).isEqualTo("jsmith");
+    }
+
+    @Test
+    void capturesTheUserAnIdTokenIsMintedFor() {
+        var audit = AuditBuilder.builder(ClientTokenAuditBuilder.class)
+                .idTokenFor(user())
+                .build(objectMapper);
+
+        assertThat(audit.getEnrichmentContext()).isNotNull();
+        assertThat(audit.getEnrichmentContext().user().getUsername()).isEqualTo("jsmith");
+    }
+
+    @Test
+    void theCapturedUserIsTheSanitizedProjection() {
+        User user = user();
+        user.setPassword("s3cret");
+
+        var audit = AuditBuilder.builder(AuthenticationAuditBuilder.class)
+                .type(USER_LOGIN)
+                .user(user)
+                .build(objectMapper);
+
+        assertThat(audit.getEnrichmentContext().user())
+                .isInstanceOf(io.gravitee.am.model.safe.UserProperties.class);
+        assertThat(audit.getEnrichmentContext().user().getClass().getDeclaredFields())
+                .noneMatch(f -> f.getName().equals("password"));
+    }
+
+    @Test
+    void theFlattenedFieldsAreUnchanged() {
+        var audit = AuditBuilder.builder(AuthenticationAuditBuilder.class)
+                .type(USER_LOGIN)
+                .user(user())
+                .client(client())
+                .build(objectMapper);
+
+        assertThat(audit.getActor().getId()).isEqualTo("user-1");
+        assertThat(audit.getActor().getAlternativeId()).isEqualTo("jsmith");
+        assertThat(audit.getAccessPoint().getAlternativeId()).isEqualTo("my-app");
+        assertThat(audit.getCustomAttributes()).isNull();
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/reporter/ReporterAttributeMappingsValidatorTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/validators/reporter/ReporterAttributeMappingsValidatorTest.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static io.gravitee.am.service.validators.reporter.ReporterAttributeMappingsValidator.MAX_COUNT;
+import static io.gravitee.am.service.validators.reporter.ReporterAttributeMappingsValidator.MAX_EXPRESSION_LENGTH;
 
 /**
  * @author GraviteeSource Team
@@ -113,18 +114,22 @@ class ReporterAttributeMappingsValidatorTest {
         }
 
         @ParameterizedTest
-        @NullAndEmptySource
         @ValueSource(strings = {
-                "   ",                                  // whitespace only
-                "#context.attributes['user']",          // no braces at all
-                "{#context.attributes['user']",         // opening brace only
-                "#context.attributes['user']}",         // closing brace only
-                "{}",                                   // braces with nothing to evaluate
-                "{",                                    // a single brace satisfies neither end
-                " {#context.attributes['user']}",       // leading space: stored as-is, so rejected
-                "{#context.attributes['user']} "        // trailing space
+                "tenant-{#context.attributes['user'].id}",      // literal prefix, interpolated
+                "{#context.attributes['user'].id}-suffix",      // literal suffix, interpolated
+                "{#context.attributes['a']} of {#context.attributes['b']}", // literal between two
+                "production",                                   // a plain constant used as a static tag
+                "{}",                                           // template text, exported as-is
+                "{"                                             // template text, exported as-is
         })
-        void rejectsAnExpressionThatIsNotWrappedInBraces(String expression) {
+        void acceptsAnythingTheEngineWillTake(String expression) {
+            assertThat(validator.validate(List.of(mapping(expression, "user_sub"))).isInvalid()).isFalse();
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "\t", "\n"})
+        void rejectsAnExpressionWithNothingInIt(String expression) {
             var result = validator.validate(List.of(mapping(expression, "user_sub")));
 
             assertThat(result.isInvalid()).isTrue();
@@ -153,12 +158,14 @@ class ReporterAttributeMappingsValidatorTest {
 
         @Test
         void reportsEveryDistinctInvalidExpressionOnce() {
+            var tooLong = expressionOfLength(MAX_EXPRESSION_LENGTH + 1);
             var result = validator.validate(List.of(
-                    mapping("no braces", "first"),
-                    mapping("no braces", "second"),
-                    mapping("{unterminated", "third")));
+                    mapping("   ", "first"),
+                    mapping("   ", "second"),
+                    mapping(tooLong, "third")));
 
-            assertThat(result.invalidExpressions()).containsExactly("no braces", "{unterminated");
+            assertThat(result.invalidExpressions())
+                    .containsExactly("   ", tooLong.substring(0, 80) + "...");
         }
     }
 
@@ -277,7 +284,7 @@ class ReporterAttributeMappingsValidatorTest {
 
         @Test
         void expressionsAreDescribedBeforeNamesWhenBothAreInvalid() {
-            var result = validator.validate(List.of(mapping("no braces", "not a name")));
+            var result = validator.validate(List.of(mapping("   ", "not a name")));
 
             assertThat(result.invalidExpressions()).isNotEmpty();
             assertThat(result.invalidExportedNames()).isNotEmpty();

--- a/gravitee-am-test/specs/gateway/reporters/domain-reporter-attribute-mappings.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/reporters/domain-reporter-attribute-mappings.jest.spec.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { loginUserNameAndPassword } from '@gateway-commands/login-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { KafkaAuditPayload, waitForKafkaMessage } from '@utils-commands/kafka-consumer';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { applicationBase64Token } from '@gateway-commands/utils';
+import { DomainReporterGatewayFixture, setupDomainReporterGatewayFixture } from './fixture/domain-reporter-gateway-fixture';
+import { setup } from '../../test-fixture';
+
+setup(200000);
+
+let fixture: DomainReporterGatewayFixture;
+
+beforeAll(async () => {
+  fixture = await setupDomainReporterGatewayFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+/** Signs the fixture user in and returns the USER_LOGIN record the given topic received. */
+const loginAndAwaitLogin = (topic: string): Promise<KafkaAuditPayload> =>
+  waitForKafkaMessage(topic, { predicate: (msg) => msg.type === 'USER_LOGIN' }, () =>
+    loginUserNameAndPassword(
+      fixture.application.settings.oauth.clientId,
+      fixture.user,
+      fixture.user.password,
+      false,
+      fixture.openIdConfiguration,
+      fixture.domain,
+    ).then(() => {}),
+  );
+
+describe('Reporter attribute mappings - Domain Level Gateway', () => {
+  describe('Resolving the supported sources', () => {
+    it('should export a top-level user attribute', async () => {
+      const topic = uniqueName('mapping-user-attribute', true);
+      await fixture.addReporter(topic, [], [{ expression: "{#context.attributes['user'].email}", exportedName: 'user_email' }]);
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.customAttributes).toEqual({ user_email: fixture.user.email });
+    });
+
+    it('should export a nested custom user attribute under its configured name', async () => {
+      const topic = uniqueName('mapping-nested-attribute', true);
+      await fixture.addReporter(
+        topic,
+        [],
+        [{ expression: "{#context.attributes['user'].additionalInformation['employeeId']}", exportedName: 'employee_id' }],
+      );
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.customAttributes).toEqual({ employee_id: 'E-4471' });
+    });
+
+    it('should export a client attribute', async () => {
+      const topic = uniqueName('mapping-client-attribute', true);
+      await fixture.addReporter(topic, [], [{ expression: "{#context.attributes['client'].clientId}", exportedName: 'application_id' }]);
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.customAttributes).toEqual({ application_id: fixture.application.settings.oauth.clientId });
+    });
+
+    it('should export several mappings on one event', async () => {
+      const topic = uniqueName('mapping-several', true);
+      await fixture.addReporter(
+        topic,
+        [],
+        [
+          { expression: "{#context.attributes['user'].username}", exportedName: 'user_name' },
+          { expression: "{#context.attributes['user'].additionalInformation['department']}", exportedName: 'department_name' },
+          { expression: "{#context.attributes['client'].clientId}", exportedName: 'application_id' },
+        ],
+      );
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.customAttributes).toEqual({
+        user_name: fixture.user.username,
+        department_name: 'Platform',
+        application_id: fixture.application.settings.oauth.clientId,
+      });
+    });
+  });
+
+  describe('Template text', () => {
+    it('should interpolate a literal prefix and export a plain constant', async () => {
+      const topic = uniqueName('mapping-prefix-const', true);
+      await fixture.addReporter(
+        topic,
+        [],
+        [
+          {
+            expression: "tenant-{#context.attributes['user'].additionalInformation['department']}",
+            exportedName: 'tenant_tag',
+          },
+          { expression: 'production', exportedName: 'environment' },
+        ],
+      );
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.customAttributes).toEqual({ tenant_tag: 'tenant-Platform', environment: 'production' });
+    });
+
+    it('should interpolate literal text between two expressions', async () => {
+      const topic = uniqueName('mapping-interpolated', true);
+      await fixture.addReporter(
+        topic,
+        [],
+        [
+          {
+            expression: "{#context.attributes['user'].username} of {#context.attributes['user'].additionalInformation['department']}",
+            exportedName: 'who',
+          },
+        ],
+      );
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.customAttributes).toEqual({ who: `${fixture.user.username} of Platform` });
+    });
+  });
+
+  describe('Event coverage', () => {
+    it('should resolve user mappings on token events as well as login events', async () => {
+      const topic = uniqueName('mapping-token-event', true);
+      await fixture.addReporter(topic, [], [{ expression: "{#context.attributes['user'].username}", exportedName: 'user_name' }]);
+
+      const exchangeCodeForToken = async (): Promise<void> => {
+        const redirect = await loginUserNameAndPassword(
+          fixture.application.settings.oauth.clientId,
+          fixture.user,
+          fixture.user.password,
+          false,
+          fixture.openIdConfiguration,
+          fixture.domain,
+        );
+        const code = new URL(redirect.headers['location']).searchParams.get('code');
+        expect(code).toBeTruthy();
+
+        await performPost(
+          fixture.openIdConfiguration.token_endpoint,
+          '',
+          new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: fixture.application.settings.oauth.redirectUris[0],
+          }).toString(),
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${applicationBase64Token(fixture.application)}`,
+          },
+        ).expect(200);
+      };
+
+      const received = await waitForKafkaMessage(topic, { predicate: (msg) => msg.type === 'TOKEN_CREATED' }, exchangeCodeForToken);
+
+      expect(received.customAttributes).toEqual({ user_name: fixture.user.username });
+    });
+  });
+
+  describe('Never failing the event', () => {
+    it('should still deliver the event and omit the field when the attribute is missing', async () => {
+      const topic = uniqueName('mapping-missing-attribute', true);
+      await fixture.addReporter(
+        topic,
+        [],
+        [
+          { expression: "{#context.attributes['user'].additionalInformation['nowhereToBeFound']}", exportedName: 'absent' },
+          { expression: "{#context.attributes['user'].username}", exportedName: 'user_name' },
+        ],
+      );
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.type).toEqual('USER_LOGIN');
+      expect(received.customAttributes).toEqual({ user_name: fixture.user.username });
+    });
+
+    it('should still deliver the event and resolve the siblings when one expression is malformed', async () => {
+      const topic = uniqueName('mapping-malformed', true);
+      await fixture.addReporter(
+        topic,
+        [],
+        [
+          { expression: "{#context.attributes['user'.username}", exportedName: 'broken' },
+          { expression: "{#context.attributes['user'].email}", exportedName: 'user_email' },
+        ],
+      );
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.type).toEqual('USER_LOGIN');
+      expect(received.customAttributes).toEqual({ user_email: fixture.user.email });
+    });
+  });
+
+  describe('Backward compatibility', () => {
+    it('should leave the payload untouched when the reporter declares no mappings', async () => {
+      const topic = uniqueName('mapping-none-declared', true);
+      await fixture.addReporter(topic, []);
+
+      const received = await loginAndAwaitLogin(topic);
+
+      expect(received.type).toEqual('USER_LOGIN');
+      expect(received.referenceId).toEqual(fixture.domain.id);
+      expect(received.customAttributes).toBeUndefined();
+    });
+  });
+
+  describe('Per-reporter isolation', () => {
+    it('should give each reporter only its own attributes', async () => {
+      const userTopic = uniqueName('mapping-isolation-user', true);
+      const clientTopic = uniqueName('mapping-isolation-client', true);
+      const plainTopic = uniqueName('mapping-isolation-plain', true);
+
+      await fixture.addReporter(userTopic, [], [{ expression: "{#context.attributes['user'].email}", exportedName: 'user_email' }]);
+      await fixture.addReporter(
+        clientTopic,
+        [],
+        [{ expression: "{#context.attributes['client'].clientId}", exportedName: 'application_id' }],
+      );
+      await fixture.addReporter(plainTopic, []);
+
+      // One sign-in fans out to all three reporters on the domain.
+      const [fromUserTopic, fromClientTopic, fromPlainTopic] = await Promise.all([
+        waitForKafkaMessage(userTopic, { predicate: (msg) => msg.type === 'USER_LOGIN' }, () =>
+          loginUserNameAndPassword(
+            fixture.application.settings.oauth.clientId,
+            fixture.user,
+            fixture.user.password,
+            false,
+            fixture.openIdConfiguration,
+            fixture.domain,
+          ).then(() => {}),
+        ),
+        waitForKafkaMessage(clientTopic, { predicate: (msg) => msg.type === 'USER_LOGIN' }, () => Promise.resolve()),
+        waitForKafkaMessage(plainTopic, { predicate: (msg) => msg.type === 'USER_LOGIN' }, () => Promise.resolve()),
+      ]);
+
+      expect(fromUserTopic.customAttributes).toEqual({ user_email: fixture.user.email });
+      expect(fromClientTopic.customAttributes).toEqual({
+        application_id: fixture.application.settings.oauth.clientId,
+      });
+      expect(fromPlainTopic.customAttributes).toBeUndefined();
+    });
+  });
+});

--- a/gravitee-am-test/specs/gateway/reporters/fixture/domain-reporter-gateway-fixture.ts
+++ b/gravitee-am-test/specs/gateway/reporters/fixture/domain-reporter-gateway-fixture.ts
@@ -17,6 +17,7 @@
 import { Domain } from '@management-models/Domain';
 import { Application } from '@management-models/Application';
 import { Reporter } from '@management-models/Reporter';
+import { ReporterAttributeMapping } from '../../../management/reporters/fixtures/kafka-reporter-config-helper';
 import { DomainOidcConfig, safeDeleteDomain, setupDomainForTest } from '@management-commands/domain-management-commands';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { createUser } from '@management-commands/user-management-commands';
@@ -32,7 +33,7 @@ export interface DomainReporterGatewayFixture extends Fixture {
   application: Application;
   user: any & { password: string };
   openIdConfiguration: DomainOidcConfig;
-  addReporter(topicName: string, auditTypes?: string[]): Promise<Reporter>;
+  addReporter(topicName: string, auditTypes?: string[], attributeMappings?: ReporterAttributeMapping[]): Promise<Reporter>;
   addOAuthReporter(topicName: string, auditTypes?: string[]): Promise<Reporter>;
   cleanUp(): Promise<void>;
 }
@@ -82,12 +83,21 @@ export const setupDomainReporterGatewayFixture = async (): Promise<DomainReporte
     lastName: 'User',
     email: `${username}@test.com`,
     preRegistration: false,
+    // Nested source for attribute-mapping tests.
+    additionalInformation: {
+      employeeId: 'E-4471',
+      department: 'Platform',
+    },
   };
   await waitForSyncAfter(domain.id, () => createUser(domain.id, accessToken, user));
 
   const reporterIds: string[] = [];
 
-  const addReporter = async (topicName: string, auditTypes: string[] = []): Promise<Reporter> => {
+  const addReporter = async (
+    topicName: string,
+    auditTypes: string[] = [],
+    attributeMappings?: ReporterAttributeMapping[],
+  ): Promise<Reporter> => {
     const reporter = await waitForSyncAfter(domain.id, () =>
       createDomainReporter(domain.id, accessToken, {
         type: 'reporter-am-kafka',
@@ -99,6 +109,7 @@ export const setupDomainReporterGatewayFixture = async (): Promise<DomainReporte
           acks: '1',
           auditTypes,
         }),
+        ...(attributeMappings ? { attributeMappings } : {}),
       }),
     );
     reporterIds.push(reporter.id);

--- a/gravitee-am-test/specs/management/automation/domain-reporters.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/domain-reporters.jest.spec.ts
@@ -80,9 +80,7 @@ describe('Automation API - Reporters (resource under a domain)', () => {
 
     const response = await fixture.client.listReporters(fixture.domainKey);
     expect(response.status).toBe(200);
-    expect(response.body).toEqual([
-      expect.objectContaining({ key, attributeMappings: DEFAULT_REPORTER_ATTRIBUTE_MAPPINGS }),
-    ]);
+    expect(response.body).toEqual([expect.objectContaining({ key, attributeMappings: DEFAULT_REPORTER_ATTRIBUTE_MAPPINGS })]);
   });
 
   it('should update the reporter via a second PUT (idempotent)', async () => {
@@ -129,10 +127,7 @@ describe('Automation API - Reporters (resource under a domain)', () => {
   });
 
   it('should reject an invalid key pattern (400)', async () => {
-    const response = await fixture.client.putReporter(
-      fixture.domainKey,
-      buildAutomationReporterDef({ key: 'Invalid Key!' }),
-    );
+    const response = await fixture.client.putReporter(fixture.domainKey, buildAutomationReporterDef({ key: 'Invalid Key!' }));
     expect(response.status).toBe(400);
   });
 
@@ -174,9 +169,9 @@ describe('Automation API - Reporters - payload validation', () => {
     expect(response.status).toBe(400);
   });
 
-  it('should reject a mapping whose expression is not wrapped in braces (400)', async () => {
+  it('should reject a mapping whose expression is blank (400)', async () => {
     const { response } = await fixture.putNewReporter({
-      attributeMappings: [{ expression: "#context.attributes['user'].id", exportedName: 'user_id' }],
+      attributeMappings: [{ expression: '   ', exportedName: 'user_id' }],
     });
     expect(response.status).toBe(400);
   });
@@ -232,10 +227,7 @@ describe('Automation API - System reporter', () => {
     const { key } = await fixture.putNewSystemReporter();
 
     // the reporter was created with system:true; PUT it again as non-system -> rejected (immutable)
-    const response = await fixture.client.putReporter(
-      fixture.domainKey,
-      buildAutomationReporterDef({ key, system: false }),
-    );
+    const response = await fixture.client.putReporter(fixture.domainKey, buildAutomationReporterDef({ key, system: false }));
     expect(response.status).toBe(400);
   });
 

--- a/gravitee-am-test/specs/management/reporters/domain-reporter.jest.spec.ts
+++ b/gravitee-am-test/specs/management/reporters/domain-reporter.jest.spec.ts
@@ -195,16 +195,30 @@ describe('Domain Reporter Attribute Mapping Validation', () => {
     ).rejects.toMatchObject({ response: { status: 400 } });
   });
 
-  it('should reject an invalid expression (missing braces)', async () => {
-    await expect(
-      invalid([{ expression: "#context.attributes['user'].id", exportedName: 'user_id' }]),
-    ).rejects.toMatchObject({ response: { status: 400 } });
+  it('should reject a blank expression', async () => {
+    await expect(invalid([{ expression: '   ', exportedName: 'user_id' }])).rejects.toMatchObject({
+      response: { status: 400 },
+    });
+  });
+
+  it('should accept an expression with literal text around it, and a plain constant', async () => {
+    const reporter = await fixture.createReporter({
+      attributeMappings: [
+        { expression: "tenant-{#context.attributes['user'].id}", exportedName: 'tenant' },
+        { expression: 'production', exportedName: 'environment' },
+      ],
+    });
+
+    expect(reporter.attributeMappings).toEqual([
+      { expression: "tenant-{#context.attributes['user'].id}", exportedName: 'tenant' },
+      { expression: 'production', exportedName: 'environment' },
+    ]);
   });
 
   it('should reject an invalid exported name (too long)', async () => {
-    await expect(
-      invalid([{ expression: "{#context.attributes['user'].id}", exportedName: 'a'.repeat(65) }]),
-    ).rejects.toMatchObject({ response: { status: 400 } });
+    await expect(invalid([{ expression: "{#context.attributes['user'].id}", exportedName: 'a'.repeat(65) }])).rejects.toMatchObject({
+      response: { status: 400 },
+    });
   });
 });
 
@@ -218,9 +232,7 @@ describe('Domain System Reporter', () => {
         name: system.name,
         enabled: system.enabled,
         configuration: system.configuration ?? '{}',
-        attributeMappings: [
-          { expression: "{#context.attributes['user'].additionalInformation['sub']}", exportedName: 'user_sub' },
-        ],
+        attributeMappings: [{ expression: "{#context.attributes['user'].additionalInformation['sub']}", exportedName: 'user_sub' }],
       }),
     ).rejects.toMatchObject({ response: { status: 400 } });
   });

--- a/gravitee-am-test/specs/management/reporters/org-reporter.jest.spec.ts
+++ b/gravitee-am-test/specs/management/reporters/org-reporter.jest.spec.ts
@@ -273,9 +273,9 @@ describe('Org Reporter Attribute Mapping Validation', () => {
     ).rejects.toMatchObject({ response: { status: 400 } });
   });
 
-  it('should reject an expression that is not wrapped in braces', async () => {
-    await expect(
-      invalid([{ expression: "#context.attributes['user'].id", exportedName: 'user_id' }]),
-    ).rejects.toMatchObject({ response: { status: 400 } });
+  it('should reject a blank expression', async () => {
+    await expect(invalid([{ expression: '   ', exportedName: 'user_id' }])).rejects.toMatchObject({
+      response: { status: 400 },
+    });
   });
 });


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7553](https://gravitee.atlassian.net/browse/AM-7553)

## :pencil2: A description of the changes proposed in the pull request
Evaluate and produce `customAttributes` on audit events as they are built. The reporter types that support custom attributes mapping (Kafka, TCP and File) receive events containing the new property when mappings are configured and any mapping produces a value; data for existing reporters without mappings is unaffected.

Additionally, relax restriction on custom attribute mappings' `expression` fields - wrapping in `{}` is no longer required and any literal value as well as interpolated expressions is now supported and consistent with other usages of EL in AM.

Supported contexts are `user`, `client`, `request` and `audit` - example: `{#context.attributes['request'].ip}`. Availability of contextual data principally depends on the audit type. When an entire expression produces no value, the attribute is omitted from the audit data.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7553]: https://gravitee.atlassian.net/browse/AM-7553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ