### PR TITLE
test: a required challenge after conditional enrolment with a skip rule (AM-2842)

### DIFF
--- a/gravitee-am-test/playwright/tests/mfa/mfa-conditional-skip-required-challenge.spec.ts
+++ b/gravitee-am-test/playwright/tests/mfa/mfa-conditional-skip-required-challenge.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/mfa-enrollment-matrix.fixture';
+import { linkJira } from '../../utils/jira';
+import { clearSessionOnly } from '../../utils/webauthn-helpers';
+import {
+  buildAuthorizeUrl,
+  completeMfaChallenge,
+  enrollMockFactor,
+  reachOAuthAuthorizationCallback,
+  skipMfaEnrollment,
+  submitLogin,
+} from '../../utils/mfa-helpers';
+import { API_USER_PASSWORD, AUTH_CODE_FORMAT, MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+
+/**
+ * AM-2842 — conditional enrolment with a skip rule, alongside a required challenge.
+ *
+ * The two tests are each other's control. Both applications are configured identically and both
+ * users sign in twice; the only difference is whether the first visit ended in enrolling or in
+ * skipping. One is then challenged and the other is not, so the challenge setting is shown to be
+ * live and the skip is shown to be what suppresses it.
+ *
+ * `MFAEnrollStep.conditional()` reaches the challenge through `userHasFactor -> continueFlow` when
+ * the user already holds a method. Skipping instead goes through `MFAEnrollPostEndpoint`, which
+ * marks the challenge complete for that authorisation leg at the same time as recording the skip.
+ */
+test.describe('Conditional enrolment with a skip rule and a required challenge (AM-2842)', () => {
+  test.use({
+    enrollActive: true,
+    enrollType: 'CONDITIONAL',
+    // Force is on so the skip control is decided by the skip rule rather than short-circuited.
+    enrollForce: true,
+    // The rule does not hold, so the user is asked to enrol...
+    enrollRule: '{{ false }}',
+    // ...but the skip rule does, so they are offered a way past it.
+    enrollSkipActive: true,
+    enrollSkipRule: '{{ true }}',
+    enrollSkipTimeSeconds: 3600,
+    challengeActive: true,
+    challengeType: 'REQUIRED',
+    challengeRule: '',
+  });
+  test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
+
+  const signIn = async (page, gatewayUrl: string, clientId: string, username: string) => {
+    await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
+    await page.waitForURL(/.*login.*/i);
+    await submitLogin(page, username, API_USER_PASSWORD);
+    await page.waitForURL(
+      (url) => /\/mfa\/(enroll|challenge)/i.test(url.href) || url.searchParams.has('code'),
+    );
+    return {
+      askedToEnrol: /\/mfa\/enroll/i.test(page.url()),
+      challenged: /\/mfa\/challenge/i.test(page.url()),
+    };
+  };
+
+  test('a user who enrolled is asked for a code on a later sign-in', async ({
+    page,
+    gatewayUrl,
+    matrixApp,
+    matrixUser,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-2842');
+
+    const clientId = matrixApp.settings.oauth.clientId;
+
+    // First visit: the skip is offered, but this user enrols instead.
+    const first = await signIn(page, gatewayUrl, clientId, matrixUser.username);
+    expect(first.askedToEnrol).toBe(true);
+    await enrollMockFactor(page);
+    // The verification the gateway always asks for straight after enrolling.
+    await completeMfaChallenge(page);
+    await reachOAuthAuthorizationCallback(page);
+
+    // Second visit: they hold a method now, so enrolment is behind them and the required
+    // challenge is what they meet.
+    await clearSessionOnly(page);
+    const second = await signIn(page, gatewayUrl, clientId, matrixUser.username);
+    expect(second.askedToEnrol).toBe(false);
+    expect(second.challenged).toBe(true);
+
+    await completeMfaChallenge(page);
+    await reachOAuthAuthorizationCallback(page);
+    expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
+  });
+
+  test('a user who skipped has no method, so the required challenge never applies', async ({
+    page,
+    gatewayUrl,
+    matrixApp,
+    matrixUser,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-2842');
+
+    const clientId = matrixApp.settings.oauth.clientId;
+
+    // Same application and the same required challenge as the test above — this user takes the
+    // skip rather than enrolling.
+    const first = await signIn(page, gatewayUrl, clientId, matrixUser.username);
+    expect(first.askedToEnrol).toBe(true);
+
+    // The skip rule holds, so the way past enrolment is offered even though the rule requiring
+    // enrolment did not. Asserted here rather than left to the helper.
+    await expect(page.locator('button[name="user_mfa_enrollment"][value="false"]')).toBeVisible();
+
+    await skipMfaEnrollment(page);
+    await reachOAuthAuthorizationCallback(page);
+    expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
+
+    // Second visit, still inside the skip window: no method to be challenged for, and the skip
+    // still standing, so they are asked for neither.
+    await clearSessionOnly(page);
+    const second = await signIn(page, gatewayUrl, clientId, matrixUser.username);
+    expect(second.askedToEnrol).toBe(false);
+    expect(second.challenged).toBe(false);
+    expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
+  });
+});

--- a/gravitee-am-test/playwright/tests/mfa/mfa-conditional-skip-required-challenge.spec.ts
+++ b/gravitee-am-test/playwright/tests/mfa/mfa-conditional-skip-required-challenge.spec.ts
@@ -18,17 +18,16 @@ import { test } from '../../fixtures/mfa-enrollment-matrix.fixture';
 import { linkJira } from '../../utils/jira';
 import { clearSessionOnly } from '../../utils/webauthn-helpers';
 import {
-  buildAuthorizeUrl,
   completeMfaChallenge,
   enrollMockFactor,
   reachOAuthAuthorizationCallback,
+  signInAndReportMfaStop,
   skipMfaEnrollment,
-  submitLogin,
 } from '../../utils/mfa-helpers';
-import { API_USER_PASSWORD, AUTH_CODE_FORMAT, MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
+import { AUTH_CODE_FORMAT, MULTI_PHASE_TEST_TIMEOUT } from '../../utils/test-constants';
 
 /**
- * AM-2842 — conditional enrolment with a skip rule, alongside a required challenge.
+ * AM-2842 — conditional enrollment with a skip rule, alongside a required challenge.
  *
  * The two tests are each other's control. Both applications are configured identically and both
  * users sign in twice; the only difference is whether the first visit ended in enrolling or in
@@ -39,13 +38,13 @@ import { API_USER_PASSWORD, AUTH_CODE_FORMAT, MULTI_PHASE_TEST_TIMEOUT } from '.
  * the user already holds a method. Skipping instead goes through `MFAEnrollPostEndpoint`, which
  * marks the challenge complete for that authorisation leg at the same time as recording the skip.
  */
-test.describe('Conditional enrolment with a skip rule and a required challenge (AM-2842)', () => {
+test.describe('Conditional enrollment with a skip rule and a required challenge (AM-2842)', () => {
   test.use({
     enrollActive: true,
     enrollType: 'CONDITIONAL',
     // Force is on so the skip control is decided by the skip rule rather than short-circuited.
     enrollForce: true,
-    // The rule does not hold, so the user is asked to enrol...
+    // The rule does not hold, so the user is asked to enroll...
     enrollRule: '{{ false }}',
     // ...but the skip rule does, so they are offered a way past it.
     enrollSkipActive: true,
@@ -57,42 +56,24 @@ test.describe('Conditional enrolment with a skip rule and a required challenge (
   });
   test.setTimeout(MULTI_PHASE_TEST_TIMEOUT);
 
-  const signIn = async (page, gatewayUrl: string, clientId: string, username: string) => {
-    await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
-    await page.waitForURL(/.*login.*/i);
-    await submitLogin(page, username, API_USER_PASSWORD);
-    await page.waitForURL(
-      (url) => /\/mfa\/(enroll|challenge)/i.test(url.href) || url.searchParams.has('code'),
-    );
-    return {
-      askedToEnrol: /\/mfa\/enroll/i.test(page.url()),
-      challenged: /\/mfa\/challenge/i.test(page.url()),
-    };
-  };
-
-  test('a user who enrolled is asked for a code on a later sign-in', async ({
-    page,
-    gatewayUrl,
-    matrixApp,
-    matrixUser,
-  }, testInfo) => {
+  test('a user who enrolled is asked for a code on a later sign-in', async ({ page, gatewayUrl, matrixApp, matrixUser }, testInfo) => {
     linkJira(testInfo, 'AM-2842');
 
     const clientId = matrixApp.settings.oauth.clientId;
 
     // First visit: the skip is offered, but this user enrols instead.
-    const first = await signIn(page, gatewayUrl, clientId, matrixUser.username);
-    expect(first.askedToEnrol).toBe(true);
+    const first = await signInAndReportMfaStop(page, gatewayUrl, clientId, matrixUser.username);
+    expect(first.askedToEnroll).toBe(true);
     await enrollMockFactor(page);
     // The verification the gateway always asks for straight after enrolling.
     await completeMfaChallenge(page);
     await reachOAuthAuthorizationCallback(page);
 
-    // Second visit: they hold a method now, so enrolment is behind them and the required
+    // Second visit: they hold a method now, so enrollment is behind them and the required
     // challenge is what they meet.
     await clearSessionOnly(page);
-    const second = await signIn(page, gatewayUrl, clientId, matrixUser.username);
-    expect(second.askedToEnrol).toBe(false);
+    const second = await signInAndReportMfaStop(page, gatewayUrl, clientId, matrixUser.username);
+    expect(second.askedToEnroll).toBe(false);
     expect(second.challenged).toBe(true);
 
     await completeMfaChallenge(page);
@@ -112,11 +93,11 @@ test.describe('Conditional enrolment with a skip rule and a required challenge (
 
     // Same application and the same required challenge as the test above — this user takes the
     // skip rather than enrolling.
-    const first = await signIn(page, gatewayUrl, clientId, matrixUser.username);
-    expect(first.askedToEnrol).toBe(true);
+    const first = await signInAndReportMfaStop(page, gatewayUrl, clientId, matrixUser.username);
+    expect(first.askedToEnroll).toBe(true);
 
-    // The skip rule holds, so the way past enrolment is offered even though the rule requiring
-    // enrolment did not. Asserted here rather than left to the helper.
+    // The skip rule holds, so the way past enrollment is offered even though the rule requiring
+    // enrollment did not. Asserted here rather than left to the helper.
     await expect(page.locator('button[name="user_mfa_enrollment"][value="false"]')).toBeVisible();
 
     await skipMfaEnrollment(page);
@@ -126,8 +107,8 @@ test.describe('Conditional enrolment with a skip rule and a required challenge (
     // Second visit, still inside the skip window: no method to be challenged for, and the skip
     // still standing, so they are asked for neither.
     await clearSessionOnly(page);
-    const second = await signIn(page, gatewayUrl, clientId, matrixUser.username);
-    expect(second.askedToEnrol).toBe(false);
+    const second = await signInAndReportMfaStop(page, gatewayUrl, clientId, matrixUser.username);
+    expect(second.askedToEnroll).toBe(false);
     expect(second.challenged).toBe(false);
     expect(new URL(page.url()).searchParams.get('code')).toMatch(AUTH_CODE_FORMAT);
   });

--- a/gravitee-am-test/playwright/utils/mfa-helpers.ts
+++ b/gravitee-am-test/playwright/utils/mfa-helpers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Page, expect } from '@playwright/test';
-import { AUTH_CODE_FORMAT, BRIEF_TIMEOUT, MOCK_MFA_CODE, MULTI_PHASE_TEST_TIMEOUT } from './test-constants';
+import { API_USER_PASSWORD, AUTH_CODE_FORMAT, BRIEF_TIMEOUT, MOCK_MFA_CODE, MULTI_PHASE_TEST_TIMEOUT } from './test-constants';
 import { reachOAuthAuthorizationCallback } from './oauth-callback-helpers';
 import { buildAuthorizeUrl } from './webauthn-helpers';
 
@@ -102,6 +102,28 @@ export async function skipMfaEnrollment(page: Page): Promise<void> {
     }),
     skipButton.click(),
   ]);
+}
+
+/**
+ * Signs in from the authorize endpoint and reports where the gateway stopped, rather than assuming
+ * which page comes next. Waits for whichever of enrollment, challenge or the callback arrives, so a
+ * test can assert on the one it expects and fail on the others by name instead of by timeout.
+ */
+export async function signInAndReportMfaStop(
+  page: Page,
+  gatewayUrl: string,
+  clientId: string,
+  username: string,
+  password: string = API_USER_PASSWORD,
+): Promise<{ askedToEnroll: boolean; challenged: boolean }> {
+  await page.goto(buildAuthorizeUrl(gatewayUrl, clientId));
+  await page.waitForURL(/.*login.*/i);
+  await submitLogin(page, username, password);
+  await page.waitForURL((url) => /\/mfa\/(enroll|challenge)/i.test(url.href) || url.searchParams.has('code'));
+  return {
+    askedToEnroll: /\/mfa\/enroll/i.test(page.url()),
+    challenged: /\/mfa\/challenge/i.test(page.url()),
+  };
 }
 
 /**


### PR DESCRIPTION
## :id: Reference related issue.
[AM-2842](https://gravitee.atlassian.net/browse/AM-2842)

## :pencil2: A description of the changes proposed in the pull request
The existing test sets conditional enrolment, a skip rule that holds and a required challenge — then enrols and answers the verification that always follows enrolment. Neither named setting influences the result: the skip is never used, and the required challenge is never reached on its own.

- A user who enrolled is asked for a code on a later sign-in
- A user who skipped has no method, so the required challenge never applies

One new file. Nothing existing is modified — the matrix fixture and MFA helpers are imported only, and `mfa-enrollment-matrix.spec.ts` was run alongside these (27 passing together) to confirm it still passes.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**The two tests are each other's control.** Same application, same required challenge, both users signing in twice — the only difference is whether the first visit ended in enrolling or skipping. One is then challenged and the other is not. Either test alone would show very little: "challenged" could be the post-enrolment verification rather than the configured challenge, and "not challenged" could mean the challenge was never configured at all.

**Two different routes through `MFAEnrollStep`.** A user holding a method reaches the challenge through `conditional() -> userHasFactor -> continueFlow`. A user who skipped goes through `MFAEnrollPostEndpoint`, which marks the challenge complete for that authorisation leg at the same moment it records the skip:

```java
// Skipping enrollment also skips MFA challenge for this authorisation leg
routingContext.session().put(ConstantKeys.MFA_ENROLLMENT_COMPLETED_KEY, true);
routingContext.session().put(ConstantKeys.MFA_CHALLENGE_COMPLETED_KEY, true);
```

That answers the third scenario, which the ticket records as unestablished: a user who skips is asked for neither, and it is deliberate rather than a side effect.

**`forceEnrollment` is on.** With it off, `MfaUtils.isCanSkip` short-circuits on `isNotForcedEnrollment` and the skip control appears whatever the skip rule says — so the rule would not be the thing under test. Same reasoning as PR #8474.

**Already covered elsewhere:** the skip control being offered under conditional enrolment is also asserted in #8474, with the challenge switched off. It is asserted here as well because this ticket's combination includes the required challenge, and that is the configuration its first scenario describes.

**Sources.** Scenarios come from the ticket and Xray manual case AM-2731 — *conditional = false, challenge Required, user enrolled → "the MFA challenge page will display"* — which nothing automated covered. The nearest existing test, AM-2829, reaches a required challenge with enrolment switched **off**, a different branch.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-2842]: https://gravitee.atlassian.net/browse/AM-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ