### PR TITLE
fix: an application with no auth method set accepts a client assertion (AM-7591)

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/JwtBearerClientAssertionValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/JwtBearerClientAssertionValidator.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.assertion.impl;
 
+import com.google.common.base.Strings;
 import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -187,8 +188,7 @@ public class JwtBearerClientAssertionValidator implements ClientAssertionValidat
         return clientLookupService.findByClientId(clientId)
                 .switchIfEmpty(Maybe.error(new InvalidClientException("Missing or invalid client")))
                 .flatMap(client -> {
-                    if (client.getTokenEndpointAuthMethod() != null &&
-                            !ClientAuthenticationMethod.PRIVATE_KEY_JWT.equalsIgnoreCase(client.getTokenEndpointAuthMethod())) {
+                    if (isAuthMethodMismatch(client, ClientAuthenticationMethod.PRIVATE_KEY_JWT)) {
                         return Maybe.error(new InvalidClientException(
                                 "Invalid client: missing or unsupported authentication method"));
                     }
@@ -231,8 +231,7 @@ public class JwtBearerClientAssertionValidator implements ClientAssertionValidat
         return clientLookupService.findByClientId(clientId)
                 .switchIfEmpty(Maybe.error(new InvalidClientException("Missing or invalid client")))
                 .flatMap(client -> {
-                    if (client.getTokenEndpointAuthMethod() != null &&
-                            !ClientAuthenticationMethod.CLIENT_SECRET_JWT.equalsIgnoreCase(client.getTokenEndpointAuthMethod())) {
+                    if (isAuthMethodMismatch(client, ClientAuthenticationMethod.CLIENT_SECRET_JWT)) {
                         return Maybe.error(new InvalidClientException(
                                 "Invalid client: missing or unsupported authentication method"));
                     }
@@ -248,6 +247,11 @@ public class JwtBearerClientAssertionValidator implements ClientAssertionValidat
                                 "Error validating client JWT signature", josee));
                     }
                 });
+    }
+
+    private static boolean isAuthMethodMismatch(Client client, String expectedMethod) {
+        final String authMethod = client.getTokenEndpointAuthMethod();
+        return !Strings.isNullOrEmpty(authMethod) && !expectedMethod.equalsIgnoreCase(authMethod);
     }
 
     private static boolean verifyJws(Client client, SignedJWT signedJWT) throws JOSEException {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/ClientAssertionServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/ClientAssertionServiceTest.java
@@ -552,6 +552,63 @@ public class ClientAssertionServiceTest {
     }
 
     @Test
+    public void shouldAcceptHmacJwtWhenTokenEndpointAuthMethodIsEmpty() throws JOSEException {
+        SecureRandom random = new SecureRandom();
+        byte[] sharedSecret = new byte[32];
+        random.nextBytes(sharedSecret);
+
+        JWSSigner signer = new MACSigner(new String(sharedSecret, StandardCharsets.UTF_8));
+
+        Client client = new Client();
+        client.setClientId(CLIENT_ID);
+        client.setClientSecret(new String(sharedSecret));
+        client.setTokenEndpointAuthMethod("");
+        String assertion = generateJWT(signer);
+        OpenIDProviderMetadata openIDProviderMetadata = Mockito.mock(OpenIDProviderMetadata.class);
+        String basePath = "/";
+
+        when(clientLookupService.findByClientId(any())).thenReturn(Maybe.just(client));
+        when(openIDProviderMetadata.getTokenEndpoint()).thenReturn(AUDIENCE);
+        when(openIDDiscoveryService.getConfiguration(basePath)).thenReturn(openIDProviderMetadata);
+
+        clientAssertionService.assertClient(JWT_BEARER_TYPE, assertion, basePath).test()
+                .assertNoErrors()
+                .assertValue(client);
+    }
+
+    @Test
+    public void shouldAcceptRsaJwtWhenTokenEndpointAuthMethodIsEmpty() throws NoSuchAlgorithmException, JOSEException {
+        KeyPair rsaKey = generateRsaKeyPair();
+
+        RSAPublicKey publicKey = (RSAPublicKey) rsaKey.getPublic();
+        RSAPrivateKey privateKey = (RSAPrivateKey) rsaKey.getPrivate();
+
+        RSAKey key = new RSAKey();
+        key.setKty("RSA");
+        key.setKid(KID);
+        key.setE(Base64.getUrlEncoder().encodeToString(publicKey.getPublicExponent().toByteArray()));
+        key.setN(Base64.getUrlEncoder().encodeToString(publicKey.getModulus().toByteArray()));
+        JWKSet jwkSet = new JWKSet();
+        jwkSet.setKeys(List.of(key));
+
+        Client client = generateClient(key);
+        client.setTokenEndpointAuthMethod("");
+        String assertion = generateJWT(privateKey);
+        OpenIDProviderMetadata openIDProviderMetadata = Mockito.mock(OpenIDProviderMetadata.class);
+        String basePath = "/";
+
+        when(clientLookupService.findByClientId(any())).thenReturn(Maybe.just(client));
+        when(openIDProviderMetadata.getTokenEndpoint()).thenReturn(AUDIENCE);
+        when(openIDDiscoveryService.getConfiguration(basePath)).thenReturn(openIDProviderMetadata);
+        when(jwkService.getKey(any(), any())).thenReturn(Maybe.just(key));
+        when(jwsService.isValidSignature(any(), any())).thenReturn(true);
+
+        clientAssertionService.assertClient(JWT_BEARER_TYPE, assertion, basePath).test()
+                .assertNoErrors()
+                .assertValue(client);
+    }
+
+    @Test
     public void testHmacJwt_invalidAlgorithm() throws NoSuchAlgorithmException, JOSEException {
         KeyPair rsaKey = generateRsaKeyPair();
 
@@ -655,60 +712,6 @@ public class ClientAssertionServiceTest {
         String basePath = "/";
 
         when(clientLookupService.findByClientId(any())).thenReturn(Maybe.empty());
-        when(openIDProviderMetadata.getTokenEndpoint()).thenReturn(AUDIENCE);
-        when(openIDDiscoveryService.getConfiguration(basePath)).thenReturn(openIDProviderMetadata);
-
-        clientAssertionService.assertClient(JWT_BEARER_TYPE, assertion, basePath).test()
-                .assertError(InvalidClientException.class)
-                .assertNotComplete();
-    }
-
-    @Test
-    public void testRsaJwt_withEmptyTokenEndpointAuthMethod() throws NoSuchAlgorithmException, JOSEException {
-        // Empty string tokenEndpointAuthMethod is NOT treated as null — it's an unsupported auth method
-        KeyPair rsaKey = generateRsaKeyPair();
-        RSAPublicKey publicKey = (RSAPublicKey) rsaKey.getPublic();
-        RSAPrivateKey privateKey = (RSAPrivateKey) rsaKey.getPrivate();
-
-        RSAKey key = new RSAKey();
-        key.setKty("RSA");
-        key.setKid(KID);
-        key.setE(Base64.getUrlEncoder().encodeToString(publicKey.getPublicExponent().toByteArray()));
-        key.setN(Base64.getUrlEncoder().encodeToString(publicKey.getModulus().toByteArray()));
-
-        Client client = generateClient(key);
-        client.setTokenEndpointAuthMethod(""); // Empty string — unsupported auth method
-        String assertion = generateJWT(privateKey);
-        OpenIDProviderMetadata openIDProviderMetadata = Mockito.mock(OpenIDProviderMetadata.class);
-        String basePath = "/";
-
-        when(clientLookupService.findByClientId(any())).thenReturn(Maybe.just(client));
-        when(openIDProviderMetadata.getTokenEndpoint()).thenReturn(AUDIENCE);
-        when(openIDDiscoveryService.getConfiguration(basePath)).thenReturn(openIDProviderMetadata);
-
-        clientAssertionService.assertClient(JWT_BEARER_TYPE, assertion, basePath).test()
-                .assertError(InvalidClientException.class)
-                .assertNotComplete();
-    }
-
-    @Test
-    public void testHmacJwt_withEmptyTokenEndpointAuthMethod() throws JOSEException {
-        // Empty string tokenEndpointAuthMethod is NOT treated as null — it's an unsupported auth method
-        SecureRandom random = new SecureRandom();
-        byte[] sharedSecret = new byte[32];
-        random.nextBytes(sharedSecret);
-        String clientSecret = new String(sharedSecret, StandardCharsets.UTF_8);
-        JWSSigner signer = new MACSigner(clientSecret);
-
-        Client client = new Client();
-        client.setClientId(CLIENT_ID);
-        client.setClientSecret(new String(sharedSecret));
-        client.setTokenEndpointAuthMethod(""); // Empty string — unsupported auth method
-        String assertion = generateJWT(signer);
-        OpenIDProviderMetadata openIDProviderMetadata = Mockito.mock(OpenIDProviderMetadata.class);
-        String basePath = "/";
-
-        when(clientLookupService.findByClientId(any())).thenReturn(Maybe.just(client));
         when(openIDProviderMetadata.getTokenEndpoint()).thenReturn(AUDIENCE);
         when(openIDDiscoveryService.getConfiguration(basePath)).thenReturn(openIDProviderMetadata);
 

--- a/gravitee-am-test/specs/gateway/token-auth-methods/arbitrary-auth-method.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-auth-methods/arbitrary-auth-method.jest.spec.ts
@@ -20,6 +20,8 @@ import { performPost } from '@gateway-commands/oauth-oidc-commands';
 import { getBase64BasicAuth } from '@gateway-commands/utils';
 import { setup } from '../../test-fixture';
 import { ArbitraryAuthMethodFixture, AuthMethodApp, setupArbitraryAuthMethodFixture } from './fixtures/arbitrary-auth-method-fixture';
+import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
 
 setup(200000);
 
@@ -32,13 +34,6 @@ setup(200000);
  * empty and the matching credentials are present.
  *
  * The two applications live in one domain, so the comparison differs only in that setting.
- *
- * Assertion-based methods are deliberately not covered here. An unset application refuses
- * client_secret_jwt even though `ClientAssertionAuthProvider.canHandle` carries the same
- * empty-method branch as basic and post — the identical assertion is accepted once the method is
- * set explicitly. That looks like a defect rather than intended behaviour, so it is tracked as
- * AM-7591 instead of being written down here as expected. Add the assertion cases to this file
- * once that is resolved.
  */
 let fixture: ArbitraryAuthMethodFixture;
 
@@ -70,6 +65,34 @@ const withRequestBody = (app: AuthMethodApp) =>
     FORM,
   );
 
+const JWT_BEARER = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
+/** A signed assertion carrying the credentials — client_secret_jwt. */
+const withSignedAssertion = (app: AuthMethodApp) => {
+  const now = Math.floor(Date.now() / 1000);
+  const assertion = jwt.sign(
+    {
+      iss: app.clientId,
+      sub: app.clientId,
+      aud: fixture.oidc.token_endpoint,
+      jti: crypto.randomUUID(),
+      iat: now,
+      exp: now + 300,
+    },
+    app.clientSecret,
+    { algorithm: 'HS256' },
+  );
+
+  return performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=client_credentials&client_assertion_type=${encodeURIComponent(JWT_BEARER)}&client_assertion=${encodeURIComponent(
+      assertion,
+    )}`,
+    FORM,
+  );
+};
+
 describe('An application with no authentication method set', () => {
   it(jira`is stored with an empty method rather than a default ${'AM-2232'}`, async () => {
     // Anchors the rest of the file. Omitting the field on create is not the same thing: the
@@ -91,6 +114,13 @@ describe('An application with no authentication method set', () => {
     expect(response.status).toEqual(200);
     expect(response.body.access_token).toMatch(JWT_FORMAT);
   });
+
+  it(jira`also accepts a signed assertion ${'AM-7591'}`, async () => {
+    const response = await withSignedAssertion(fixture.unsetApp);
+
+    expect(response.status).toEqual(200);
+    expect(response.body.access_token).toMatch(JWT_FORMAT);
+  });
 });
 
 describe('An application fixed to one authentication method', () => {
@@ -106,6 +136,13 @@ describe('An application fixed to one authentication method', () => {
 
     // The same request the unset application accepts above. Same domain, same identity provider,
     // same credentials — only the setting differs, which is what makes the option meaningful.
+    expect(response.status).toEqual(401);
+    expect(response.body.error).toEqual('invalid_client');
+  });
+
+  it(jira`refuses a signed assertion ${'AM-7591'}`, async () => {
+    const response = await withSignedAssertion(fixture.fixedApp);
+
     expect(response.status).toEqual(401);
     expect(response.body.error).toEqual('invalid_client');
   });


### PR DESCRIPTION
1. Create aplication with empty Requested Client Authentication method 
2. sign the jwt with clinet secret (256-bit MAC key)
example:
```
CID='c5efbbf2-81db-4ad1-afbb-f281db9ad1e0'
  SECRET='Dj4JGfST4HMSVGIp9PCG85RzdAI6tkrZF5jvHpdNqVw'
  TE='http://localhost:8092/test/oauth/token'

  ASSERTION=$(CID="$CID" SECRET="$SECRET" AUD="$TE" python3 - <<'PY'
  import base64, hmac, hashlib, json, os, time, uuid
  b64 = lambda b: base64.urlsafe_b64encode(b).rstrip(b'=').decode()
  now = int(time.time())
  h = {"alg": "HS256", "typ": "JWT"}
  p = {"iss": os.environ["CID"], "sub": os.environ["CID"], "aud": os.environ["AUD"],
       "jti": str(uuid.uuid4()), "iat": now, "exp": now + 300}
  si = b64(json.dumps(h, separators=(',', ':')).encode()) + "." + b64(json.dumps(p, separators=(',', ':')).encode())
  print(si + "." + b64(hmac.new(os.environ["SECRET"].encode(), si.encode(), hashlib.sha256).digest()))
  PY
  )
```
3. 
```
  curl -s "$TE" -H 'Content-Type: application/x-www-form-urlencoded' \
    -d grant_type=client_credentials \
    -d client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer \
    --data-urlencode "client_assertion=$ASSERTION"
```