### PR TITLE
fix: AM-7601 decouple entrypoint sync events from data planes

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/main/java/io/gravitee/am/gateway/services/sync/SyncManager.java
@@ -30,6 +30,7 @@ import io.gravitee.am.monitoring.DomainState;
 import io.gravitee.am.repository.management.api.DomainRepository;
 import io.gravitee.am.repository.management.api.EventRepository;
 import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.service.EntryPointManager;
 import io.gravitee.am.common.event.EventManager;
 import io.gravitee.node.api.Node;
 import io.reactivex.rxjava3.core.Completable;
@@ -117,6 +118,10 @@ public class SyncManager implements InitializingBean, DisposableBean {
 
     @Autowired
     private DomainReadinessService domainReadinessService;
+
+    @Lazy
+    @Autowired
+    private EntryPointManager entryPointManager;
 
     private Optional<List<String>> shardingTags;
 
@@ -266,7 +271,18 @@ public class SyncManager implements InitializingBean, DisposableBean {
     }
 
     private Completable deployOne(Domain domain) {
-        return securityDomainManager.deployReactive(domain);
+        return warmEntrypointCache(domain).andThen(securityDomainManager.deployReactive(domain));
+    }
+
+    private Completable warmEntrypointCache(Domain domain) {
+        Completable warm = entryPointManager.ensureEnvironmentLoaded(domain.getReferenceId());
+        if (eventsTimeOut > 0) {
+            warm = warm.timeout(eventsTimeOut, TimeUnit.MILLISECONDS);
+        }
+        return warm
+                .doOnError(error -> log.warn("Domain {} is deploying without the entrypoints of environment {}", domain.getId(), domain.getReferenceId(), error))
+                .onErrorComplete()
+                .observeOn(deploymentScheduler);
     }
 
     private Completable processEvents(long from, long to) {
@@ -347,7 +363,7 @@ public class SyncManager implements InitializingBean, DisposableBean {
                                     Completable updateReadiness = domain.isEnabled()
                                             ? Completable.fromRunnable(() -> domainReadinessService.updateDomainStatus(domain.getId(), DomainState.Status.DEPLOYED))
                                             : Completable.fromRunnable(() -> domainReadinessService.removeDomain(domain.getId()));
-                                    return deployOrUpdate.andThen(updateReadiness);
+                                    return warmEntrypointCache(domain).andThen(deployOrUpdate).andThen(updateReadiness);
                                 }));
             }
             case DELETE -> Completable.fromRunnable(() -> domainReadinessService.updateDomainStatus(domainId, DomainState.Status.REMOVING))

--- a/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/test/java/io/gravitee/am/gateway/services/sync/SyncManagerTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-services/gravitee-am-gateway-services-sync/src/test/java/io/gravitee/am/gateway/services/sync/SyncManagerTest.java
@@ -25,6 +25,7 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Event;
 import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.monitoring.DomainReadinessService;
+import io.gravitee.am.service.EntryPointManager;
 import io.gravitee.am.monitoring.DomainState;
 import io.gravitee.am.monitoring.provider.GatewayMetricProvider;
 import io.gravitee.am.repository.Scope;
@@ -46,7 +47,9 @@ import org.springframework.core.env.Environment;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -56,6 +59,7 @@ import static io.gravitee.node.api.Node.META_ORGANIZATIONS;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -105,12 +109,16 @@ public class SyncManagerTest {
     @Mock
     private DomainReadinessService domainReadinessService;
 
+    @Mock
+    private EntryPointManager entryPointManager;
+
     @Before
     public void before() throws Exception {
         lenient().when(node.metadata()).thenReturn(Map.of(META_ORGANIZATIONS, new HashSet<>(), META_ENVIRONMENTS, new HashSet<>()));
         lenient().when(environment.getProperty(Scope.GATEWAY.getRepositoryPropertyKey()+".dataPlane.id", String.class, DEFAULT_DATA_PLANE_ID)).thenReturn(DEFAULT_DATA_PLANE_ID);
         syncManager.afterPropertiesSet();
         syncManager.setDeploymentScheduler(Schedulers.trampoline());
+        lenient().when(entryPointManager.ensureEnvironmentLoaded(any())).thenReturn(Completable.complete());
         lenient().when(securityDomainManager.deployReactive(any())).thenReturn(Completable.complete());
         lenient().when(securityDomainManager.updateReactive(any())).thenReturn(Completable.complete());
         lenient().when(securityDomainManager.undeployReactive(anyString())).thenReturn(Completable.complete());
@@ -292,6 +300,76 @@ public class SyncManagerTest {
         verify(securityDomainManager, never()).undeployReactive(domain.getId());
         verify(domainReadinessService).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.INITIALIZING));
         verify(domainReadinessService, times(2)).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.DEPLOYED));
+    }
+
+    @Test
+    public void init_declares_the_environment_of_every_deployed_domain() {
+        final Domain domain = new Domain();
+        domain.setId("domain-1");
+        domain.setReferenceId("env-1");
+        domain.setEnabled(true);
+        domain.setDataPlaneId(DEFAULT_DATA_PLANE_ID);
+        when(domainRepository.findAll()).thenReturn(Flowable.just(domain));
+
+        syncManager.refresh();
+
+        verify(entryPointManager).ensureEnvironmentLoaded("env-1");
+    }
+
+    @Test
+    public void init_loadsTheEnvironmentEntrypoints_beforeDeployingTheDomain() {
+        final Domain domain = new Domain();
+        domain.setId("domain-1");
+        domain.setReferenceId("env-1");
+        domain.setEnabled(true);
+        domain.setDataPlaneId(DEFAULT_DATA_PLANE_ID);
+        when(domainRepository.findAll()).thenReturn(Flowable.just(domain));
+
+        List<String> subscribed = new ArrayList<>();
+        when(entryPointManager.ensureEnvironmentLoaded("env-1")).thenReturn(Completable.fromRunnable(() -> subscribed.add("entrypoints")));
+        when(securityDomainManager.deployReactive(domain)).thenReturn(Completable.fromRunnable(() -> subscribed.add("domain")));
+
+        syncManager.refresh();
+
+        assertEquals(List.of("entrypoints", "domain"), subscribed);
+    }
+
+    @Test
+    public void init_entrypointLoadFailure_stillDeploysTheDomain() {
+        final Domain domain = new Domain();
+        domain.setId("domain-1");
+        domain.setReferenceId("env-1");
+        domain.setEnabled(true);
+        domain.setDataPlaneId(DEFAULT_DATA_PLANE_ID);
+        when(domainRepository.findAll()).thenReturn(Flowable.just(domain));
+        when(entryPointManager.ensureEnvironmentLoaded("env-1")).thenReturn(Completable.error(new RuntimeException("database unavailable")));
+
+        syncManager.refresh();
+
+        verify(securityDomainManager, times(1)).deployReactive(domain);
+        verify(domainReadinessService).updateDomainStatus(eq("domain-1"), eq(DomainState.Status.DEPLOYED));
+    }
+
+    @Test
+    public void test_declares_the_environment_of_a_domain_deployed_from_an_event() {
+        when(domainRepository.findAll()).thenReturn(Flowable.empty());
+        syncManager.refresh();
+
+        Event event = new Event();
+        event.setType(Type.DOMAIN);
+        event.setPayload(new Payload("domain-1", ReferenceType.DOMAIN, "domain-1", Action.CREATE));
+
+        final Domain domain = new Domain();
+        domain.setId("domain-1");
+        domain.setReferenceId("env-1");
+        domain.setEnabled(true);
+        domain.setDataPlaneId(DEFAULT_DATA_PLANE_ID);
+        when(eventRepository.findByTimeFrameAndDataPlaneId(any(Long.class), any(Long.class), anyString())).thenReturn(Flowable.just(event));
+        when(domainRepository.findById("domain-1")).thenReturn(Maybe.just(domain));
+
+        syncManager.refresh();
+
+        verify(entryPointManager).ensureEnvironmentLoaded("env-1");
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandler.java
@@ -18,7 +18,7 @@ package io.gravitee.am.management.service.impl.commands;
 import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.service.EntrypointService;
 import io.gravitee.am.service.EnvironmentService;
-import io.gravitee.am.service.model.NewEntrypoint;
+import io.gravitee.am.service.model.DesiredEntrypoint;
 import io.gravitee.am.service.model.NewEnvironment;
 import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
@@ -115,21 +115,26 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
         if (!CloudProperties.isManagedCloudEnabled(environment)) {
             return Completable.complete();
         }
+        return entrypointService.syncForEnvironment(
+                environmentPayload.organizationId(),
+                environmentPayload.id(),
+                toDesiredEntrypoints(environmentPayload),
+                null);
+    }
 
-        String organizationId = environmentPayload.organizationId();
-        String environmentId = environmentPayload.id();
-
-        List<AccessPoint> gatewayAccessPoints = environmentPayload.accessPoints() == null
-                ? List.of()
-                : environmentPayload.accessPoints().stream()
-                        .filter(this::isGatewayAccessPoint)
-                        .collect(Collectors.toList());
-
-        return entrypointService.findByEnvironment(organizationId, environmentId)
-                .flatMapCompletable(entrypoint -> entrypointService.delete(entrypoint.getId(), organizationId, null))
-                .andThen(Completable.defer(() -> Completable.merge(gatewayAccessPoints.stream()
-                        .map(accessPoint -> createEntrypoint(organizationId, environmentId, accessPoint))
-                        .collect(Collectors.toList()))));
+    /**
+     * Maps the access point Cockpit generates itself to the environment's <em>default</em> entrypoint and
+     * the customer's overriding one to a non-default, which is how
+     * {@code EntryPointManager#findByEnvironmentId} lets an override win.
+     */
+    private List<DesiredEntrypoint> toDesiredEntrypoints(EnvironmentCommandPayload environmentPayload) {
+        if (environmentPayload.accessPoints() == null) {
+            return List.of();
+        }
+        return environmentPayload.accessPoints().stream()
+                .filter(this::isGatewayAccessPoint)
+                .map(accessPoint -> new DesiredEntrypoint("https://" + accessPoint.getHost(), accessPoint.getHost(), !accessPoint.isOverriding()))
+                .collect(Collectors.toList());
     }
 
     private Optional<String> validateGatewayAccessPoints(EnvironmentCommandPayload environmentPayload) {
@@ -162,17 +167,5 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
 
     private boolean hasHost(AccessPoint accessPoint) {
         return accessPoint.getHost() != null && !accessPoint.getHost().isBlank();
-    }
-
-    private Completable createEntrypoint(String organizationId, String environmentId, AccessPoint accessPoint) {
-        NewEntrypoint newEntrypoint = new NewEntrypoint();
-        newEntrypoint.setUrl("https://" + accessPoint.getHost());
-        newEntrypoint.setName(accessPoint.getHost());
-        newEntrypoint.setEnvironmentId(environmentId);
-
-        // Counter-intuitive but avoids introducing a field: the access point Cockpit generates itself is
-        // the environment's *default* entrypoint, and the customer's overriding one is not. Resolution
-        // then drops the default whenever an override exists, see EntryPointManager#findByEnvironmentId.
-        return entrypointService.create(organizationId, newEntrypoint, !accessPoint.isOverriding(), null).ignoreElement();
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/commands/EnvironmentCommandHandlerTest.java
@@ -16,12 +16,11 @@
 package io.gravitee.am.management.service.impl.commands;
 
 import io.gravitee.am.common.env.CloudProperties;
-import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.repository.exceptions.TechnicalException;
 import io.gravitee.am.service.EntrypointService;
 import io.gravitee.am.service.EnvironmentService;
-import io.gravitee.am.service.model.NewEntrypoint;
+import io.gravitee.am.service.model.DesiredEntrypoint;
 import io.gravitee.am.service.model.NewEnvironment;
 import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
@@ -30,7 +29,6 @@ import io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommandPayload;
 import io.gravitee.cockpit.api.command.v1.environment.EnvironmentReply;
 import io.gravitee.exchange.api.command.CommandStatus;
 import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,12 +45,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -181,83 +177,19 @@ class EnvironmentCommandHandlerTest {
         verifyNoInteractions(environmentService, entrypointService);
     }
 
-    private void enableCloudMode() {
-        springEnvironment.setProperty("cloud.enabled", "true");
-        springEnvironment.setProperty("installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED);
-    }
-
     @Test
-    void handleCloudMode_syncsEntrypoints_deleteThenRecreate() {
+    void handleCloudMode_statesTheGatewayAccessPointsAsTheEnvironmentEntrypoints() {
         enableCloudMode();
 
-        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
-                .id("env#1")
-                .hrids(Collections.singletonList("env-1"))
-                .organizationId("orga#1")
-                .description("Environment description")
-                .name("Environment name")
-                .accessPoints(List.of(
-                        AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build(),
-                        AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction2.io").build(),
-                        AccessPoint.builder().target(AccessPoint.Target.CONSOLE).host("console.io").build()))
-                .build();
-        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+        handleSuccessfully(environmentCommand(List.of(
+                AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build(),
+                AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction2.io").build(),
+                // a CONSOLE access point must not become an entrypoint
+                AccessPoint.builder().target(AccessPoint.Target.CONSOLE).host("console.io").build())));
 
-        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
-
-        Entrypoint existing1 = new Entrypoint();
-        existing1.setId("entrypoint#1");
-        Entrypoint existing2 = new Entrypoint();
-        existing2.setId("entrypoint#2");
-        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.just(existing1, existing2));
-        when(entrypointService.delete(eq("entrypoint#1"), eq("orga#1"), isNull())).thenReturn(Completable.complete());
-        when(entrypointService.delete(eq("entrypoint#2"), eq("orga#1"), isNull())).thenReturn(Completable.complete());
-        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
-
-        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
-
-        obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
-
-        verify(entrypointService, times(1)).delete("entrypoint#1", "orga#1", null);
-        verify(entrypointService, times(1)).delete("entrypoint#2", "orga#1", null);
-        verify(entrypointService, times(1)).create(eq("orga#1"), argThat(newEntrypoint ->
-                newEntrypoint.getUrl().equals("https://domain.restriction1.io")
-                        && newEntrypoint.getName().equals("domain.restriction1.io")
-                        && "env#1".equals(newEntrypoint.getEnvironmentId())), eq(true), isNull());
-        verify(entrypointService, times(1)).create(eq("orga#1"), argThat(newEntrypoint ->
-                newEntrypoint.getUrl().equals("https://domain.restriction2.io")
-                        && newEntrypoint.getName().equals("domain.restriction2.io")
-                        && "env#1".equals(newEntrypoint.getEnvironmentId())), eq(true), isNull());
-        // CONSOLE access point must not generate an entrypoint
-        verify(entrypointService, times(2)).create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull());
-    }
-
-    @Test
-    void handleCloudMode_noPriorEntrypoints_createsNewOnes() {
-        enableCloudMode();
-
-        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
-                .id("env#1")
-                .hrids(Collections.singletonList("env-1"))
-                .organizationId("orga#1")
-                .description("Environment description")
-                .name("Environment name")
-                .accessPoints(List.of(AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("domain.restriction1.io").build()))
-                .build();
-        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
-
-        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
-        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.empty());
-        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
-
-        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
-
-        obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
-
-        verify(entrypointService, never()).delete(any(), any(), any());
-        verify(entrypointService, times(1)).create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull());
+        verify(entrypointService).syncForEnvironment("orga#1", "env#1", List.of(
+                new DesiredEntrypoint("https://domain.restriction1.io", "domain.restriction1.io", true),
+                new DesiredEntrypoint("https://domain.restriction2.io", "domain.restriction2.io", true)), null);
     }
 
     @Test
@@ -283,38 +215,12 @@ class EnvironmentCommandHandlerTest {
         verifyNoInteractions(entrypointService);
     }
 
-    /**
-     * The access point Cockpit generates itself becomes the environment's default entrypoint; the
-     * customer's overriding one does not. Resolution later drops the default whenever an override
-     * exists, so getting this inversion right is what makes the override win.
-     */
-    private void assertPersistedDefaultFlag(List<AccessPoint> accessPoints, String host, boolean expectedDefaultFlag) {
-        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
-                .id("env#1")
-                .hrids(Collections.singletonList("env-1"))
-                .organizationId("orga#1")
-                .name("Environment name")
-                .accessPoints(accessPoints)
-                .build();
-
-        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
-        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.empty());
-        when(entrypointService.create(eq("orga#1"), any(NewEntrypoint.class), anyBoolean(), isNull())).thenAnswer(i -> Single.just(new Entrypoint()));
-
-        TestObserver<EnvironmentReply> obs = cut.handle(new EnvironmentCommand(environmentPayload)).test();
-
-        obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        obs.assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
-        verify(entrypointService, times(1)).create(eq("orga#1"),
-                argThat(newEntrypoint -> newEntrypoint.getName().equals(host)), eq(expectedDefaultFlag), isNull());
-    }
-
     @Test
     void handleCloudMode_overridingAccessPoint_isNotTheDefaultEntrypoint() {
         enableCloudMode();
 
         // The non-overriding companion is what keeps the payload valid.
-        assertPersistedDefaultFlag(List.of(
+        assertStatedDefaultFlag(List.of(
                 AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("auth.acme.com").overriding(true).build(),
                 AccessPoint.builder().target(AccessPoint.Target.GATEWAY).host("env-acme.gravitee.io").build()),
                 "auth.acme.com", false);
@@ -324,7 +230,7 @@ class EnvironmentCommandHandlerTest {
     void handleCloudMode_nonOverridingAccessPoint_becomesTheDefaultEntrypoint() {
         enableCloudMode();
 
-        assertPersistedDefaultFlag(List.of(AccessPoint.builder()
+        assertStatedDefaultFlag(List.of(AccessPoint.builder()
                 .target(AccessPoint.Target.GATEWAY)
                 .host("env-acme.gravitee.io")
                 .overriding(false)
@@ -337,31 +243,10 @@ class EnvironmentCommandHandlerTest {
 
         // `overriding` is a primitive boolean, so a payload omitting it deserializes to false and every
         // entrypoint ends up flagged default. Resolution copes by returning them all rather than none.
-        assertPersistedDefaultFlag(List.of(AccessPoint.builder()
+        assertStatedDefaultFlag(List.of(AccessPoint.builder()
                 .target(AccessPoint.Target.GATEWAY)
                 .host("env-acme.gravitee.io")
                 .build()), "env-acme.gravitee.io", true);
-    }
-
-    private EnvironmentCommand commandWithAccessPoints(AccessPoint... accessPoints) {
-        return new EnvironmentCommand(EnvironmentCommandPayload.builder()
-                .id("env#1")
-                .hrids(Collections.singletonList("env-1"))
-                .organizationId("orga#1")
-                .description("Environment description")
-                .name("Environment name")
-                // Arrays.asList, not List.of: one case deliberately passes a null entry.
-                .accessPoints(Arrays.asList(accessPoints))
-                .build());
-    }
-
-    private void assertRejectedForMissingHost(EnvironmentCommand command) {
-        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
-
-        obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        obs.assertNoErrors();
-        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
-        verifyNoInteractions(environmentService, entrypointService);
     }
 
     /**
@@ -408,15 +293,6 @@ class EnvironmentCommandHandlerTest {
         // The guard runs before the reactive chain is built, so a null entry would escape handle() as a
         // synchronous throw rather than reaching onErrorReturn.
         assertRejectedInCloudMode(commandWithAccessPoints(new AccessPoint[]{null}));
-    }
-
-    private void assertRejectedInCloudMode(EnvironmentCommand command) {
-        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
-
-        obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        obs.assertNoErrors();
-        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
-        verifyNoInteractions(environmentService, entrypointService);
     }
 
     @Test
@@ -519,12 +395,74 @@ class EnvironmentCommandHandlerTest {
         EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
 
         when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
-        when(entrypointService.findByEnvironment("orga#1", "env#1")).thenReturn(Flowable.error(new TechnicalException("boom")));
+        when(entrypointService.syncForEnvironment(any(), any(), anyList(), any())).thenReturn(Completable.error(new TechnicalException("boom")));
 
         TestObserver<EnvironmentReply> obs = cut.handle(command).test();
 
         obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         obs.assertNoErrors();
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+    }
+
+    private void enableCloudMode() {
+        springEnvironment.setProperty("cloud.enabled", "true");
+        springEnvironment.setProperty("installation.type", CloudProperties.INSTALLATION_TYPE_MANAGED);
+    }
+
+    private void handleSuccessfully(EnvironmentCommand command) {
+        when(environmentService.createOrUpdate(eq("orga#1"), eq("env#1"), any(NewEnvironment.class), isNull())).thenReturn(Single.just(new Environment()));
+        when(entrypointService.syncForEnvironment(any(), any(), anyList(), any())).thenReturn(Completable.complete());
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        obs.assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+    }
+
+    private EnvironmentCommand environmentCommand(List<AccessPoint> accessPoints) {
+        return new EnvironmentCommand(EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
+                .organizationId("orga#1")
+                .name("Environment name")
+                .accessPoints(accessPoints)
+                .build());
+    }
+
+    private EnvironmentCommand commandWithAccessPoints(AccessPoint... accessPoints) {
+        return new EnvironmentCommand(EnvironmentCommandPayload.builder()
+                .id("env#1")
+                .hrids(Collections.singletonList("env-1"))
+                .organizationId("orga#1")
+                .description("Environment description")
+                .name("Environment name")
+                // Arrays.asList, not List.of: one case deliberately passes a null entry.
+                .accessPoints(Arrays.asList(accessPoints))
+                .build());
+    }
+
+    private void assertStatedDefaultFlag(List<AccessPoint> accessPoints, String host, boolean expectedDefaultFlag) {
+        handleSuccessfully(environmentCommand(accessPoints));
+
+        verify(entrypointService).syncForEnvironment(eq("orga#1"), eq("env#1"),
+                argThat(desired -> desired.contains(new DesiredEntrypoint("https://" + host, host, expectedDefaultFlag))), isNull());
+    }
+
+    private void assertRejectedForMissingHost(EnvironmentCommand command) {
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(environmentService, entrypointService);
+    }
+
+    private void assertRejectedInCloudMode(EnvironmentCommand command) {
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.awaitDone(HANDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        obs.assertNoErrors();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.ERROR));
+        verifyNoInteractions(environmentService, entrypointService);
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntryPointManager.java
@@ -17,6 +17,7 @@ package io.gravitee.am.service;
 
 import io.gravitee.am.common.web.UriBuilder;
 import io.gravitee.am.model.Entrypoint;
+import io.reactivex.rxjava3.core.Completable;
 import io.gravitee.common.service.Service;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import jakarta.annotation.Nullable;
@@ -56,6 +57,12 @@ public interface EntryPointManager extends Service<EntryPointManager> {
         List<Entrypoint> overriding = all.stream().filter(entrypoint -> !entrypoint.isDefaultEntrypoint()).toList();
         return overriding.isEmpty() ? all : overriding;
     }
+
+    /**
+     * Loads an environment's entrypoints when the cache holds none for it, completing once they are
+     * cached. Read once per environment, and concurrent callers share the one read.
+     */
+    Completable ensureEnvironmentLoaded(String environmentId);
 
     /**
      * The single entrypoint a user-facing URL should be built from for the given environment.

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/EntrypointService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/EntrypointService.java
@@ -18,11 +18,14 @@ package io.gravitee.am.service;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.Organization;
+import io.gravitee.am.service.model.DesiredEntrypoint;
 import io.gravitee.am.service.model.NewEntrypoint;
 import io.gravitee.am.service.model.UpdateEntrypoint;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+
+import java.util.List;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -43,6 +46,12 @@ public interface EntrypointService {
     Single<Entrypoint> create(String organizationId, NewEntrypoint entrypoint, boolean defaultEntrypoint, User principal);
 
     Flowable<Entrypoint> createDefaults(Organization organization);
+
+    /**
+     * Reconciles the environment's entrypoints against {@code desired}, deleting the stored ones it no
+     * longer lists. Idempotent: re-stating the same set leaves every row, and its id, untouched.
+     */
+    Completable syncForEnvironment(String organizationId, String environmentId, List<DesiredEntrypoint> desired, User principal);
 
     Single<Entrypoint> update(String entrypointId, String organizationId, UpdateEntrypoint entrypoint, User principal);
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractEntryPointManager.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/AbstractEntryPointManager.java
@@ -56,6 +56,7 @@ public abstract class AbstractEntryPointManager extends AbstractService<EntryPoi
 
 
     private final ConcurrentMap<String, Entrypoint> entrypoints = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Completable> environmentLoads = new ConcurrentHashMap<>();
 
     private final EventManager eventManager;
     private final Node node;
@@ -110,6 +111,23 @@ public abstract class AbstractEntryPointManager extends AbstractService<EntryPoi
         return entrypoints.values().stream()
                 .filter(entrypoint -> environmentId != null && environmentId.equals(entrypoint.getEnvironmentId()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Completable ensureEnvironmentLoaded(String environmentId) {
+        if (environmentId == null) {
+            return Completable.complete();
+        }
+        return Completable.defer(() -> findAllByEnvironmentId(environmentId).isEmpty()
+                ? environmentLoads.computeIfAbsent(environmentId, id -> loadEnvironment(id).cache())
+                : Completable.complete());
+    }
+
+    private Completable loadEnvironment(String environmentId) {
+        return cache(loadEnvironmentEntrypoints(environmentId))
+                .doOnComplete(() -> log.debug("Entrypoints of environment {} loaded on demand - cache now holds {} entrypoint(s)", environmentId, entrypoints.size()))
+                .doOnError(error -> log.error("Unable to load the entrypoints of environment {}", environmentId, error))
+                .doFinally(() -> environmentLoads.remove(environmentId));
     }
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/EntrypointServiceImpl.java
@@ -19,7 +19,6 @@ import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.common.event.Action;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.common.env.CloudProperties;
-import io.gravitee.am.dataplane.api.DataPlaneDescription;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Entrypoint;
 import io.gravitee.am.model.Organization;
@@ -30,10 +29,9 @@ import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.repository.management.api.EntrypointRepository;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.EntrypointService;
-import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.OrganizationService;
-import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
+import io.gravitee.am.service.model.DesiredEntrypoint;
 import io.gravitee.am.service.exception.EntrypointNotFoundException;
 import io.gravitee.am.service.exception.InvalidEntrypointException;
 import io.gravitee.am.service.exception.LastDefaultEntrypointException;
@@ -60,6 +58,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Set;
 
 /**
@@ -75,7 +75,6 @@ public class EntrypointServiceImpl implements EntrypointService {
     private final AuditService auditService;
     private final VirtualHostValidator virtualHostValidator;
     private final EventService eventService;
-    private final DataPlaneDefinitionService dataPlaneDefinitionService;
     private final String gatewayUrl;
     private final boolean managedCloudEnabled;
 
@@ -84,7 +83,6 @@ public class EntrypointServiceImpl implements EntrypointService {
                                  AuditService auditService,
                                  VirtualHostValidator virtualHostValidator,
                                  EventService eventService,
-                                 @Lazy DataPlaneDefinitionService dataPlaneDefinitionService,
                                  @Value("${gateway.url:http://localhost:8092}") String gatewayUrl,
                                  Environment environment) {
         this.entrypointRepository = entrypointRepository;
@@ -92,7 +90,6 @@ public class EntrypointServiceImpl implements EntrypointService {
         this.auditService = auditService;
         this.virtualHostValidator = virtualHostValidator;
         this.eventService = eventService;
-        this.dataPlaneDefinitionService = dataPlaneDefinitionService;
         this.gatewayUrl = gatewayUrl;
         this.managedCloudEnabled = CloudProperties.isManagedCloudEnabled(environment);
     }
@@ -177,6 +174,53 @@ public class EntrypointServiceImpl implements EntrypointService {
     }
 
     @Override
+    public Completable syncForEnvironment(String organizationId, String environmentId, List<DesiredEntrypoint> desired, User principal) {
+
+        log.debug("Sync {} entrypoint(s) for organization {} and environment {}", desired.size(), organizationId, environmentId);
+
+        Map<String, DesiredEntrypoint> wanted = indexByUrl(desired);
+
+        return findByEnvironment(organizationId, environmentId)
+                .toList()
+                .flatMapCompletable(stored -> {
+                    Set<String> kept = new LinkedHashSet<>();
+                    List<Entrypoint> obsolete = new ArrayList<>();
+                    for (Entrypoint entrypoint : stored) {
+                        if (matches(entrypoint, wanted.get(entrypoint.getUrl())) && kept.add(entrypoint.getUrl())) {
+                            continue;
+                        }
+                        // kept.add is false for a second row holding the same url
+                        obsolete.add(entrypoint);
+                    }
+                    Completable deletions = Flowable.fromIterable(obsolete)
+                            .flatMapCompletable(entrypoint -> delete(entrypoint.getId(), organizationId, principal));
+                    // sequenced: a replaced url is deleted before it is created again
+                    return deletions.andThen(Completable.defer(() -> Completable.merge(wanted.values().stream()
+                            .filter(candidate -> !kept.contains(candidate.url()))
+                            .map(candidate -> createDesired(organizationId, environmentId, candidate, principal))
+                            .toList())));
+                });
+    }
+
+    private boolean matches(Entrypoint entrypoint, DesiredEntrypoint desired) {
+        return desired != null && entrypoint.isDefaultEntrypoint() == desired.defaultEntrypoint();
+    }
+
+    private Map<String, DesiredEntrypoint> indexByUrl(List<DesiredEntrypoint> desired) {
+        Map<String, DesiredEntrypoint> byUrl = new LinkedHashMap<>();
+        desired.forEach(entrypoint -> byUrl.putIfAbsent(entrypoint.url(), entrypoint));
+        return byUrl;
+    }
+
+    private Completable createDesired(String organizationId, String environmentId, DesiredEntrypoint desired, User principal) {
+        NewEntrypoint newEntrypoint = new NewEntrypoint();
+        newEntrypoint.setUrl(desired.url());
+        newEntrypoint.setName(desired.name());
+        newEntrypoint.setEnvironmentId(environmentId);
+        return create(organizationId, newEntrypoint, desired.defaultEntrypoint(), principal).ignoreElement();
+    }
+
+    @Override
     public Single<Entrypoint> update(String entrypointId, String organizationId, UpdateEntrypoint updateEntrypoint, User principal) {
 
         log.debug("Update an existing entrypoint {}", updateEntrypoint);
@@ -213,7 +257,7 @@ public class EntrypointServiceImpl implements EntrypointService {
     }
 
     private Single<Entrypoint> deleteEntrypoint(Entrypoint e) {
-        // Skipped in cloud, where EnvironmentCommandHandler deletes every environment entrypoint to recreate them.
+        // Skipped in cloud, where an environment entrypoint goes whenever its access point does.
         if (e.isDefaultEntrypoint() && !managedCloudEnabled) {
             return isNotTheLastDefaultEntryPoint(e)
                     .flatMap(notLast -> notLast ? Single.just(e) : Single.error(new LastDefaultEntrypointException("You cannot remove the last default entrypoint")));
@@ -247,40 +291,9 @@ public class EntrypointServiceImpl implements EntrypointService {
         ReferenceType referenceType = entrypoint.getEnvironmentId() != null ? ReferenceType.ENVIRONMENT : ReferenceType.ORGANIZATION;
         String referenceId = entrypoint.getEnvironmentId() != null ? entrypoint.getEnvironmentId() : entrypoint.getOrganizationId();
         Payload payload = new Payload(entrypoint.getId(), referenceType, referenceId, action);
-        return resolveDataPlaneIds(entrypoint)
-                .flatMapCompletable(dataPlaneIds -> Flowable.fromIterable(dataPlaneIds)
-                        .flatMapCompletable(dataPlaneId -> eventService
-                                .create(new Event(Type.ENTRYPOINT, payload, dataPlaneId, entrypoint.getEnvironmentId()))
-                                .ignoreElement()));
-    }
-
-    /**
-     * Route an entrypoint event to every data plane that can serve a domain in this environment, so
-     * whichever gateway holds one picks it up (SyncManager polls events by data-plane id). One event
-     * per plane rather than one for the first row: an environment may hold several linked planes, and
-     * a gateway pinned to any other one would never see the change. Org-scoped entrypoints go to
-     * {@code default}.
-     */
-    private Single<Set<String>> resolveDataPlaneIds(Entrypoint entrypoint) {
-        if (entrypoint.getEnvironmentId() == null) {
-            return Single.just(Set.of(DataPlaneDescription.DEFAULT_DATA_PLANE_ID));
-        }
-        return dataPlaneDefinitionService.findByEnvironmentId(entrypoint.getEnvironmentId())
-                .map(DataPlaneDefinitionSummary::id)
-                .toList()
-                .map(this::targetPlanes);
-    }
-
-    private Set<String> targetPlanes(List<String> linkedForEnv) {
-        Set<String> targets = new LinkedHashSet<>(linkedForEnv);
-        // Cloud binds every domain to one of the environment's linked planes, so those are the only
-        // gateways that can be serving it. Outside managed cloud a domain may also sit on a plane the
-        // node's configuration declares while the environment has another provisioned against it, and
-        // dropping `default` there strands the entrypoints of every domain bound to it.
-        if (!managedCloudEnabled || targets.isEmpty()) {
-            targets.add(DataPlaneDescription.DEFAULT_DATA_PLANE_ID);
-        }
-        return targets;
+        // no data plane id: every gateway polls for it, whichever plane serves the environment
+        return eventService.create(new Event(Type.ENTRYPOINT, payload, null, entrypoint.getEnvironmentId()))
+                .ignoreElement();
     }
 
     private Completable validate(Entrypoint entrypoint) {

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/DesiredEntrypoint.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/DesiredEntrypoint.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.model;
+
+/**
+ * @author GraviteeSource Team
+ */
+public record DesiredEntrypoint(String url, String name, boolean defaultEntrypoint) {
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/EntrypointServiceTest.java
@@ -32,8 +32,7 @@ import io.gravitee.am.service.exception.EntrypointNotFoundException;
 import io.gravitee.am.service.exception.InvalidEntrypointException;
 import io.gravitee.am.service.exception.LastDefaultEntrypointException;
 import io.gravitee.am.service.impl.EntrypointServiceImpl;
-import io.gravitee.am.dataplane.api.DataPlaneDescription;
-import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
+import io.gravitee.am.service.model.DesiredEntrypoint;
 import io.gravitee.am.service.model.NewEntrypoint;
 import io.gravitee.am.service.model.UpdateEntrypoint;
 import io.gravitee.am.service.validators.virtualhost.VirtualHostValidator;
@@ -58,6 +57,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
@@ -93,9 +93,6 @@ public class EntrypointServiceTest {
     @Mock
     private EventService eventService;
 
-    @Mock
-    private DataPlaneDefinitionService dataPlaneDefinitionService;
-
     private EntrypointService cut;
 
     @Before
@@ -103,11 +100,10 @@ public class EntrypointServiceTest {
 
         cut = newEntrypointService(new MockEnvironment());
         lenient().when(eventService.create(any())).thenAnswer(i -> Single.just(i.getArgument(0)));
-        lenient().when(dataPlaneDefinitionService.findByEnvironmentId(any())).thenReturn(Flowable.empty());
     }
 
     private EntrypointService newEntrypointService(Environment environment) {
-        return new EntrypointServiceImpl(entrypointRepository, organizationService, auditService, virtualHostValidator, eventService, dataPlaneDefinitionService, "https://gravitee.io", environment);
+        return new EntrypointServiceImpl(entrypointRepository, organizationService, auditService, virtualHostValidator, eventService, "https://gravitee.io", environment);
     }
 
     private EntrypointService cloudModeEntrypointService() {
@@ -242,9 +238,6 @@ public class EntrypointServiceTest {
 
     @Test
     public void shouldDeleteDefaultFlaggedEnvironmentEntrypoint() {
-        // Cockpit's generated access point is now stored as a default entrypoint, and every ENVIRONMENT
-        // command deletes the environment's entrypoints before recreating them. That delete goes through
-        // the last-default guard, which passes because the organization keeps its own default entrypoint.
         Entrypoint environmentEntrypoint = new Entrypoint();
         environmentEntrypoint.setId(ENTRYPOINT_ID);
         environmentEntrypoint.setOrganizationId(ORGANIZATION_ID);
@@ -697,7 +690,7 @@ public class EntrypointServiceTest {
                         && event.getPayload().getAction() == Action.CREATE
                         && event.getPayload().getReferenceType() == ReferenceType.ORGANIZATION
                         && ORGANIZATION_ID.equals(event.getPayload().getReferenceId())
-                        && event.getDataPlaneId() != null));
+                        && event.getDataPlaneId() == null));
     }
 
     @Test
@@ -727,7 +720,7 @@ public class EntrypointServiceTest {
                         && event.getPayload().getReferenceType() == ReferenceType.ENVIRONMENT
                         && "env#1".equals(event.getPayload().getReferenceId())
                         && "env#1".equals(event.getEnvironmentId())
-                        && event.getDataPlaneId() != null));
+                        && event.getDataPlaneId() == null));
     }
 
     @Test
@@ -757,7 +750,7 @@ public class EntrypointServiceTest {
                         && event.getPayload().getAction() == Action.UPDATE
                         && event.getPayload().getReferenceType() == ReferenceType.ORGANIZATION
                         && ORGANIZATION_ID.equals(event.getPayload().getReferenceId())
-                        && event.getDataPlaneId() != null));
+                        && event.getDataPlaneId() == null));
     }
 
     @Test
@@ -781,11 +774,114 @@ public class EntrypointServiceTest {
                         && event.getPayload().getReferenceType() == ReferenceType.ENVIRONMENT
                         && "env#1".equals(event.getPayload().getReferenceId())
                         && "env#1".equals(event.getEnvironmentId())
-                        && event.getDataPlaneId() != null));
+                        && event.getDataPlaneId() == null));
+    }
+
+    private static Entrypoint storedEntrypoint(String id, String url, boolean defaultEntrypoint) {
+        Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setId(id);
+        entrypoint.setOrganizationId(ORGANIZATION_ID);
+        entrypoint.setEnvironmentId("env#1");
+        entrypoint.setUrl(url);
+        entrypoint.setDefaultEntrypoint(defaultEntrypoint);
+        return entrypoint;
+    }
+
+    private static DesiredEntrypoint desiredEntrypoint(String host, boolean defaultEntrypoint) {
+        return new DesiredEntrypoint("https://" + host, host, defaultEntrypoint);
+    }
+
+    private void syncForEnvironment(Entrypoint[] stored, DesiredEntrypoint... desired) {
+        when(entrypointRepository.findByEnvironment(ORGANIZATION_ID, "env#1")).thenReturn(Flowable.fromArray(stored));
+        lenient().when(organizationService.findById(ORGANIZATION_ID)).thenReturn(Single.just(new Organization()));
+        lenient().when(entrypointRepository.create(any(Entrypoint.class))).thenAnswer(i -> Single.just(i.getArgument(0)));
+        lenient().when(entrypointRepository.delete(anyString())).thenReturn(Completable.complete());
+        lenient().doReturn(true).when(virtualHostValidator).isValidDomainOrSubDomain(anyString(), any());
+        for (Entrypoint entrypoint : stored) {
+            lenient().when(entrypointRepository.findById(entrypoint.getId(), ORGANIZATION_ID)).thenReturn(Maybe.just(entrypoint));
+        }
+        // the delete path reads the organization's entrypoints for its last-default guard
+        Entrypoint organizationDefault = new Entrypoint();
+        organizationDefault.setId("entrypoint#organization-default");
+        organizationDefault.setOrganizationId(ORGANIZATION_ID);
+        organizationDefault.setDefaultEntrypoint(true);
+        lenient().when(entrypointRepository.findAll(ORGANIZATION_ID)).thenReturn(Flowable.just(organizationDefault));
+
+        cut.syncForEnvironment(ORGANIZATION_ID, "env#1", List.of(desired), null).test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
     }
 
     @Test
-    public void shouldPublishOneEntrypointEventPerLinkedDataPlane() {
+    public void syncForEnvironment_unchangedSet_touchesNothing() {
+        syncForEnvironment(
+                new Entrypoint[]{
+                        storedEntrypoint("entrypoint#1", "https://one.gravitee.io", true),
+                        storedEntrypoint("entrypoint#2", "https://custom.acme.com", false)},
+                desiredEntrypoint("one.gravitee.io", true),
+                desiredEntrypoint("custom.acme.com", false));
+
+        verify(entrypointRepository, never()).delete(anyString());
+        verify(entrypointRepository, never()).create(any(Entrypoint.class));
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    public void syncForEnvironment_addedAndRemoved_onlyTouchesWhatMoved() {
+        syncForEnvironment(
+                new Entrypoint[]{
+                        storedEntrypoint("entrypoint#kept", "https://kept.gravitee.io", true),
+                        storedEntrypoint("entrypoint#gone", "https://gone.gravitee.io", true)},
+                desiredEntrypoint("kept.gravitee.io", true),
+                desiredEntrypoint("added.gravitee.io", true));
+
+        verify(entrypointRepository, times(1)).delete("entrypoint#gone");
+        verify(entrypointRepository, times(1)).delete(anyString());
+        verify(entrypointRepository, times(1)).create(argThat(entrypoint ->
+                "https://added.gravitee.io".equals(entrypoint.getUrl())
+                        && "added.gravitee.io".equals(entrypoint.getName())
+                        && "env#1".equals(entrypoint.getEnvironmentId())
+                        && entrypoint.isDefaultEntrypoint()));
+        verify(entrypointRepository, times(1)).create(any(Entrypoint.class));
+    }
+
+    @Test
+    public void syncForEnvironment_defaultFlagChanged_replacesTheEntrypoint() {
+        syncForEnvironment(
+                new Entrypoint[]{storedEntrypoint("entrypoint#1", "https://custom.acme.com", true)},
+                desiredEntrypoint("custom.acme.com", false));
+
+        verify(entrypointRepository, times(1)).delete("entrypoint#1");
+        verify(entrypointRepository, times(1)).create(argThat(entrypoint ->
+                "https://custom.acme.com".equals(entrypoint.getUrl()) && !entrypoint.isDefaultEntrypoint()));
+        verify(entrypointRepository, never()).update(any(Entrypoint.class));
+    }
+
+    @Test
+    public void syncForEnvironment_duplicateStoredRows_keepsOnlyOne() {
+        syncForEnvironment(
+                new Entrypoint[]{
+                        storedEntrypoint("entrypoint#1", "https://one.gravitee.io", true),
+                        storedEntrypoint("entrypoint#2", "https://one.gravitee.io", true)},
+                desiredEntrypoint("one.gravitee.io", true));
+
+        verify(entrypointRepository, times(1)).delete("entrypoint#2");
+        verify(entrypointRepository, times(1)).delete(anyString());
+        verify(entrypointRepository, never()).create(any(Entrypoint.class));
+    }
+
+    @Test
+    public void syncForEnvironment_urlStatedTwice_createsOneEntrypoint() {
+        syncForEnvironment(
+                new Entrypoint[]{},
+                desiredEntrypoint("one.gravitee.io", true),
+                desiredEntrypoint("one.gravitee.io", true));
+
+        verify(entrypointRepository, times(1)).create(any(Entrypoint.class));
+    }
+
+    @Test
+    public void cloudMode_shouldPublishOneUntargetedEntrypointEvent() {
 
         Entrypoint existingEntrypoint = new Entrypoint();
         existingEntrypoint.setId(ENTRYPOINT_ID);
@@ -794,43 +890,15 @@ public class EntrypointServiceTest {
 
         when(entrypointRepository.findById(ENTRYPOINT_ID, ORGANIZATION_ID)).thenReturn(Maybe.just(existingEntrypoint));
         when(entrypointRepository.delete(ENTRYPOINT_ID)).thenReturn(Completable.complete());
-        when(dataPlaneDefinitionService.findByEnvironmentId("env#1"))
-                .thenReturn(Flowable.just(dpSummary("dp-a"), dpSummary("dp-b")));
 
-        cut.delete(ENTRYPOINT_ID, ORGANIZATION_ID, null).test()
+        cloudModeEntrypointService().delete(ENTRYPOINT_ID, ORGANIZATION_ID, null).test()
                 .awaitDone(10, TimeUnit.SECONDS)
                 .assertComplete();
 
         verify(eventService, times(1)).create(argThat(event ->
-                event.getType() == Type.ENTRYPOINT && "dp-a".equals(event.getDataPlaneId())));
-        verify(eventService, times(1)).create(argThat(event ->
-                event.getType() == Type.ENTRYPOINT && "dp-b".equals(event.getDataPlaneId())));
-        // outside managed cloud a domain can sit on a plane the node declares itself, so default is a target as well
-        verify(eventService, times(1)).create(argThat(event ->
-                DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(event.getDataPlaneId())));
-    }
-
-    @Test
-    public void shouldPublishEntrypointEventToDefaultWhenEnvironmentHasNoLinkedDataPlane() {
-
-        Entrypoint existingEntrypoint = new Entrypoint();
-        existingEntrypoint.setId(ENTRYPOINT_ID);
-        existingEntrypoint.setOrganizationId(ORGANIZATION_ID);
-        existingEntrypoint.setEnvironmentId("env#1");
-
-        when(entrypointRepository.findById(ENTRYPOINT_ID, ORGANIZATION_ID)).thenReturn(Maybe.just(existingEntrypoint));
-        when(entrypointRepository.delete(ENTRYPOINT_ID)).thenReturn(Completable.complete());
-
-        cut.delete(ENTRYPOINT_ID, ORGANIZATION_ID, null).test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete();
-
-        verify(eventService, times(1)).create(argThat(event ->
-                DataPlaneDescription.DEFAULT_DATA_PLANE_ID.equals(event.getDataPlaneId())));
-    }
-
-    private DataPlaneDefinitionSummary dpSummary(String id) {
-        return new DataPlaneDefinitionSummary(id, id, "mongodb", null, ORGANIZATION_ID, "env#1", null, List.of(), null, null);
+                event.getType() == Type.ENTRYPOINT
+                        && "env#1".equals(event.getEnvironmentId())
+                        && event.getDataPlaneId() == null));
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/AbstractEntryPointManagerTest.java
@@ -28,8 +28,11 @@ import io.gravitee.am.repository.management.api.OrganizationRepository;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.event.impl.SimpleEvent;
 import io.gravitee.node.api.Node;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.processors.PublishProcessor;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,12 +40,16 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -240,6 +247,99 @@ public class AbstractEntryPointManagerTest {
         cut.onEvent(event(EntrypointEvent.DEPLOY, "e1"));
         cut.onEvent(event(EntrypointEvent.UPDATE, "e1"));
 
+        assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
+    }
+
+    @Test
+    public void shouldLoadEnvironmentEntrypointsOnDemand() {
+        Environment environment = new Environment();
+        environment.setId("env#1");
+        environment.setOrganizationId("org#1");
+        when(environmentRepository.findById("env#1")).thenReturn(Maybe.just(environment));
+        Entrypoint entrypoint = entrypoint("e1", "org#1", "env#1");
+        when(entrypointRepository.findByEnvironment("org#1", "env#1")).thenReturn(Flowable.just(entrypoint));
+
+        cut.ensureEnvironmentLoaded("env#1").blockingAwait();
+
+        assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
+    }
+
+    @Test
+    public void shouldNotReadTheStoreAgainOnceAnEnvironmentIsLoaded() {
+        Environment environment = new Environment();
+        environment.setId("env#1");
+        environment.setOrganizationId("org#1");
+        when(environmentRepository.findById("env#1")).thenReturn(Maybe.just(environment));
+        when(entrypointRepository.findByEnvironment("org#1", "env#1")).thenReturn(Flowable.just(entrypoint("e1", "org#1", "env#1")));
+
+        cut.ensureEnvironmentLoaded("env#1").blockingAwait();
+        cut.ensureEnvironmentLoaded("env#1").blockingAwait();
+
+        verify(entrypointRepository, times(1)).findByEnvironment("org#1", "env#1");
+    }
+
+    @Test
+    public void shouldReadTheStoreAgainWhenTheOnDemandLoadFailed() {
+        Environment environment = new Environment();
+        environment.setId("env#1");
+        environment.setOrganizationId("org#1");
+        when(environmentRepository.findById("env#1")).thenReturn(Maybe.just(environment));
+        Entrypoint entrypoint = entrypoint("e1", "org#1", "env#1");
+        when(entrypointRepository.findByEnvironment("org#1", "env#1"))
+                .thenReturn(Flowable.error(new RuntimeException("database unavailable")), Flowable.just(entrypoint));
+
+        cut.ensureEnvironmentLoaded("env#1").test().awaitDone(10, TimeUnit.SECONDS).assertError(RuntimeException.class);
+        assertTrue(cut.findAllByEnvironmentId("env#1").isEmpty());
+
+        cut.ensureEnvironmentLoaded("env#1").blockingAwait();
+        assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
+    }
+
+    @Test
+    public void shouldNotLoadOnDemandWhenTheEnvironmentIsAlreadyCached() throws Exception {
+        Entrypoint entrypoint = entrypoint("e1", "org#1", "env#1");
+        cache(entrypoint);
+
+        cut.ensureEnvironmentLoaded("env#1").blockingAwait();
+
+        verifyNoInteractions(environmentRepository);
+        assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
+    }
+
+    @Test
+    public void shouldShareOneReadBetweenConcurrentCallers() {
+        Environment environment = new Environment();
+        environment.setId("env#1");
+        environment.setOrganizationId("org#1");
+        when(environmentRepository.findById("env#1")).thenReturn(Maybe.just(environment));
+        PublishProcessor<Entrypoint> stored = PublishProcessor.create();
+        when(entrypointRepository.findByEnvironment("org#1", "env#1")).thenReturn(stored);
+
+        TestObserver<Void> first = cut.ensureEnvironmentLoaded("env#1").test();
+        TestObserver<Void> second = cut.ensureEnvironmentLoaded("env#1").test();
+        assertTrue(stored.hasSubscribers());
+
+        stored.onNext(entrypoint("e1", "org#1", "env#1"));
+        stored.onComplete();
+        first.awaitDone(10, TimeUnit.SECONDS).assertComplete();
+        second.awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        verify(entrypointRepository, times(1)).findByEnvironment("org#1", "env#1");
+    }
+
+    @Test
+    public void shouldReadAgainForAnEnvironmentThatHadNothingToLoad() {
+        Environment environment = new Environment();
+        environment.setId("env#1");
+        environment.setOrganizationId("org#1");
+        when(environmentRepository.findById("env#1")).thenReturn(Maybe.just(environment));
+        Entrypoint entrypoint = entrypoint("e1", "org#1", "env#1");
+        when(entrypointRepository.findByEnvironment("org#1", "env#1")).thenReturn(Flowable.empty(), Flowable.just(entrypoint));
+
+        cut.ensureEnvironmentLoaded("env#1").blockingAwait();
+        assertTrue(cut.findAllByEnvironmentId("env#1").isEmpty());
+
+        cut.ensureEnvironmentLoaded("env#1").blockingAwait();
         assertEquals(List.of(entrypoint), cut.findAllByEnvironmentId("env#1"));
     }
 

--- a/gravitee-am-test/specs/cloud/entrypoint-cache.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/entrypoint-cache.jest.spec.ts
@@ -38,9 +38,7 @@ afterAll(async () => {
 });
 
 // These specs share one environment/domain and run in order (jest --runInBand): the initial access
-// points are asserted first, then re-synced to a new set. Each ENVIRONMENT command deletes-and-recreates
-// the environment's entrypoints, and the gateway cache refreshes off the sync event without redeploying
-// the domain.
+// points are asserted first, then re-synced to a new set.
 describe('Cloud entrypoint cache (Cockpit access points -> gateway)', () => {
   it("surfaces the environment's Cockpit access points as cached entrypoints on the domain state", async () => {
     const state = await retryUntil(
@@ -73,5 +71,12 @@ describe('Cloud entrypoint cache (Cockpit access points -> gateway)', () => {
 
     expect(cached).toEqual([...expectedUrls].sort());
     expect(cached).not.toContain(droppedUrl);
+  });
+
+  it('holds exactly what the management API stores for the environment', async () => {
+    const stored = await fixture.storedEntrypointUrls();
+
+    expect(stored.length).toBeGreaterThan(0);
+    expect(await fixture.cachedEntrypointUrls()).toEqual(stored);
   });
 });

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-entrypoint-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-entrypoint-fixture.ts
@@ -50,14 +50,15 @@ export interface CloudEntrypointFixture {
   resyncAccessPoints: (accessPoints: AccessPointSpec[]) => Promise<string[]>;
   /** The entrypoint URLs the gateway currently has cached for this domain's environment, sorted. */
   cachedEntrypointUrls: () => Promise<string[]>;
+  /** The entrypoint URLs the management API stores for this environment, sorted. */
+  storedEntrypointUrls: () => Promise<string[]>;
   cleanup: () => Promise<void>;
 }
 
 /**
  * Deploys an enabled domain in the shared cloud environment so its cached entrypoints can be
  * observed through the domain state endpoint. `resyncAccessPoints` re-issues the ENVIRONMENT
- * command to exercise the live update/eviction path (the handler deletes-and-recreates the
- * environment's entrypoints each time).
+ * command to exercise the live update/eviction path.
  *
  * Managed-cloud stack only (local-stack.sh --cloud).
  */
@@ -66,12 +67,8 @@ export const setupCloudEntrypointFixture = async (): Promise<CloudEntrypointFixt
   const { organizationId, environmentId, accessToken, dataPlaneId } = shared;
   const uniqueHost = () => `${uniqueName('gw', true)}.example.com`;
 
-  // Track every host we ever provision so cleanup removes all of them, not just the current set
-  // (each ENVIRONMENT command deletes-and-recreates the environment's entrypoints).
-  const provisionedHosts = new Set<string>();
   const resyncAccessPoints = async (accessPoints: AccessPointSpec[]): Promise<string[]> => {
     const hosts = accessPoints.map(hostOf);
-    hosts.forEach((host) => provisionedHosts.add(host));
     await sendCockpitCommand({
       type: 'ENVIRONMENT',
       payload: {
@@ -111,26 +108,23 @@ export const setupCloudEntrypointFixture = async (): Promise<CloudEntrypointFixt
     return (state.entrypoints ?? []).map((e) => e.url).sort();
   };
 
+  const storedEntrypointUrls = async (): Promise<string[]> => {
+    const entrypoints = await getEntrypointsApi(accessToken).listEntrypoints({ organizationId });
+    return entrypoints
+      .filter((e: any) => e.environmentId === environmentId)
+      .map((e: any) => e.url)
+      .sort();
+  };
+
   const deleteDomain = bindSafeDeleteCloudDomain({ accessToken, organizationId, environmentId });
 
   const cleanup = async () => {
     await deleteDomain(domain.id);
-    const provisionedUrls = [...provisionedHosts].map(urlFor);
-    const entrypoints = await getEntrypointsApi(accessToken)
-      .listEntrypoints({ organizationId })
-      .catch((e) => {
-        console.warn(`cleanup: failed to list entrypoints: ${e.message}`);
-        return [] as any[];
-      });
-    await Promise.all(
-      entrypoints
-        .filter((e: any) => provisionedUrls.includes(e.url))
-        .map((e: any) =>
-          getEntrypointsApi(accessToken)
-            .deleteEntrypoint({ organizationId, entrypointId: e.id })
-            .catch((err) => console.warn(`cleanup: failed to delete entrypoint ${e.id}: ${err.message}`)),
-        ),
-    );
+    try {
+      await shared.restoreAccessPoints();
+    } catch (err: any) {
+      console.warn(`cleanup: failed to restore the shared environment's access points: ${err.message}`);
+    }
   };
 
   return {
@@ -142,6 +136,7 @@ export const setupCloudEntrypointFixture = async (): Promise<CloudEntrypointFixt
     uniqueHost,
     resyncAccessPoints,
     cachedEntrypointUrls,
+    storedEntrypointUrls,
     cleanup,
   };
 };

--- a/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
+++ b/gravitee-am-test/specs/cloud/fixtures/cloud-shared-fixture.ts
@@ -68,6 +68,11 @@ const dataPlaneStore = () =>
 export interface CloudSharedFixture extends CloudOrganizationFixture {
   /** Id of the data plane linked to the shared environment, and the one the gateway is pinned to. */
   dataPlaneId: string;
+  /**
+   * Puts the shared environment back on the access point this fixture provisioned.
+   * The cloud way to clean up.
+   */
+  restoreAccessPoints: () => Promise<void>;
 }
 
 let cached: Promise<CloudSharedFixture> | null = null;
@@ -130,6 +135,8 @@ const provision = async (): Promise<CloudSharedFixture> => {
       accessPoints: [{ target: 'GATEWAY', host: `${ENVIRONMENT_ID}.example.com` }],
     });
 
+  // Issued before the data plane below exists, and not replayed after it: the entrypoints created here
+  // have to reach the gateway on their own.
   await syncEnvironment();
   const grantEnvironmentOwnership = (environmentId: string): Promise<CockpitQueueEntry> =>
     awaitCommand('MEMBERSHIP', {
@@ -165,10 +172,6 @@ const provision = async (): Promise<CloudSharedFixture> => {
     throw new Error(`Failed to provision shared data plane: status=${dpResponse.status} body=${dpResponse.raw}`);
   }
 
-  // The ENVIRONMENT command above created the entrypoints while the environment had no linked plane,
-  // so those events went to `default`. Replay it now the link exists and they route to DATA_PLANE_ID.
-  await syncEnvironment();
-
   const accessToken = await cockpitSignIn({ sub: USER_ID, organizationId: ORGANIZATION_ID, environmentId: ENVIRONMENT_ID });
 
   return {
@@ -177,6 +180,7 @@ const provision = async (): Promise<CloudSharedFixture> => {
     userId: USER_ID,
     accessToken,
     dataPlaneId: DATA_PLANE_ID,
+    restoreAccessPoints: () => syncEnvironment().then(() => undefined),
     resync,
     grantEnvironmentOwnership,
     // Nothing to reset: every spec sharing this organization owns its own state and clears it itself.


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7601](https://gravitee.atlassian.net/browse/AM-7601)

## :pencil2: A description of the changes proposed in the pull request
- Fan entrypoint events out to all gateways to avoid the category error of filtering by data plane.
- Warm entrypoints cache per ennvironment on gateway startup to self-heal domain startup.
- Reconcile entrypoints on cloud ENVIRONMENT commands to avoid deletion/recreation churn.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7601]: https://gravitee.atlassian.net/browse/AM-7601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ