### PR TITLE
fix: AM-7606 remove gateway scope restriction for system-cluster default IDP

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -393,9 +393,7 @@ handlers:
       enabled: false
 
 repositories:
-  # specify which scope is used as reference
-  # to initialize the IdentityProviders with the "use system cluster"
-  # option enabled (only management and gateway scopes are allowed as value)
+  # Cluster bound to Mongo IDPs that have "use system cluster" option enabled (management or gateway)
   system-cluster: management
   # Management repository is used to store global configuration such as domains, clients, ...
   # This is the default configuration using MongoDB (single server)

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/main/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProvider.java
@@ -100,14 +100,7 @@ public abstract class MongoAbstractProvider implements InitializingBean {
             final var provider = this.dataPlaneRegistry.getProviderById(this.identityProviderEntity.getDataPlaneId());
             // make sure the DataPlane plugin is a Mongo one
             if (provider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)) {
-                final ClientWrapper<MongoClient> clientWrapper = provider.getClientWrapper();
-                // Only a domain's default identity provider follows the data plane's database: it has no
-                // connection settings of its own to honor. A user-configured provider keeps the database
-                // from its own form to preserve historical behavior.
-                if (this.identityProviderEntity.isSystem()) {
-                    this.configuration.setDatabase(clientWrapper.getDatabaseName());
-                }
-                return clientWrapper;
+                return provider.getClientWrapper();
             }
         }
 
@@ -120,11 +113,17 @@ public abstract class MongoAbstractProvider implements InitializingBean {
                 : getClientWrapperBasedOnConfig(scope);
     }
 
+    // A domain's default identity provider has no connection settings of its own to honor, so its
+    // database follows the client. A user-configured provider only does so when it was created under
+    // the storage regime and the database is pinned.
     private boolean shouldTakeDatabaseFromSystemCluster() {
-        return this.identityProviderEntity != null
-                && this.identityProviderEntity.isSystemClusterRestricted()
-                && this.configuration.isUseSystemCluster()
-                && !shouldUseDatasource();
+        if (this.identityProviderEntity == null || !this.configuration.isUseSystemCluster() || shouldUseDatasource()) {
+            return false;
+        }
+        if (this.identityProviderEntity.isSystem()) {
+            return true;
+        }
+        return this.identityProviderEntity.isSystemClusterRestricted();
     }
 
     private boolean shouldUseDatasource() {

--- a/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProviderTest.java
+++ b/gravitee-am-identityprovider/gravitee-am-identityprovider-mongo/src/test/java/io/gravitee/am/identityprovider/mongo/MongoAbstractProviderTest.java
@@ -169,7 +169,7 @@ public class MongoAbstractProviderTest {
 
     @Test
     public void systemProviderOnTheManagementScope_usesTheManagementClient() {
-        // the flag alone is not enough: gravitee.yml still has to select the gateway scope
+        // the flag alone does not select the data plane: gravitee.yml still has to select the gateway scope
         configuration.setUseSystemCluster(true);
         when(commonConnectionProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
         when(commonConnectionProvider.getClientWrapper()).thenReturn(commonClientWrapper);
@@ -178,6 +178,20 @@ public class MongoAbstractProviderTest {
 
         Assert.assertSame(commonClientWrapper, ReflectionTestUtils.getField(provider, "clientWrapper"));
         verify(dataPlaneRegistry, never()).getProviderById(DATA_PLANE_ID);
+    }
+
+    @Test
+    public void systemProviderOnTheManagementScope_readsTheManagementDatabase() {
+        // whichever scope serves a default identity provider, its database follows the client it is given
+        configuration.setUseSystemCluster(true);
+        configuration.setDatabase("persisted-db");
+        when(commonConnectionProvider.canHandle(ConnectionProvider.BACKEND_TYPE_MONGO)).thenReturn(true);
+        when(commonConnectionProvider.getClientWrapper()).thenReturn(commonClientWrapper);
+        when(commonClientWrapper.getDatabaseName()).thenReturn("management-db");
+
+        provider.afterPropertiesSet();
+
+        Assert.assertEquals("management-db", configuration.getDatabase());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
@@ -114,7 +114,9 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
 
     @Override
     public Map<String, Object> createProviderConfiguration(String referenceId, NewIdentityProvider identityProvider) {
-        return buildProviderConfiguration(referenceId, identityProvider, boundToSystemClusterByConfiguration());
+        // A new default identity provider always reuses the system cluster; the Mongo provider decides at
+        // runtime which scope serves it.
+        return buildProviderConfiguration(referenceId, identityProvider, true);
     }
 
     @Override
@@ -137,24 +139,6 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Unable to read the default idp configuration for domain '" + identityProvider.getReferenceId() + "'", e);
         }
-    }
-
-    private boolean boundToSystemClusterByConfiguration() {
-        return useMongoRepositories() && systemClusterScope() == Scope.GATEWAY;
-    }
-
-    private Scope systemClusterScope() {
-        final String value = environment.getProperty(SYSTEM_CLUSTER, Scope.MANAGEMENT.getName());
-        final Scope scope;
-        try {
-            scope = Scope.fromName(value);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalStateException("Invalid '" + SYSTEM_CLUSTER + "' value '" + value + "', only 'management' or 'gateway' are accepted", e);
-        }
-        if (scope != Scope.MANAGEMENT && scope != Scope.GATEWAY) {
-            throw new IllegalStateException("Invalid '" + SYSTEM_CLUSTER + "' value '" + value + "', only 'management' or 'gateway' are accepted");
-        }
-        return scope;
     }
 
     private Map<String, Object> buildProviderConfiguration(String referenceId, NewIdentityProvider identityProvider, boolean boundToSystemCluster) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceTest.java
@@ -19,8 +19,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -219,18 +217,20 @@ public class DefaultIdentityProviderServiceTest {
     // --- repositories.system-cluster binding ---
 
     @Test
-    public void managementScope_isNotBoundToTheSystemCluster() {
+    public void mongoBackend_bindsTheProviderToTheSystemCluster() {
         environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
         environment.setProperty("repositories.management.mongodb.port", "27018");
         environment.setProperty("repositories.management.mongodb.dbname", "mgmt-db");
 
         Map<String, Object> config = cut.createProviderConfiguration("test", null);
 
+        // the connection settings stay a fallback: the Mongo provider replaces both the client and the
+        // database with the system cluster's when it honors this flag
         assertEquals("mgmt-host", config.get("host"));
         assertEquals(27018, config.get("port"));
         assertEquals("mgmt-db", config.get("database"));
         assertEquals("mongodb://mgmt-host:27018/?connectTimeoutMS=5000&socketTimeoutMS=5000", config.get("uri"));
-        assertEquals(false, config.get("useSystemCluster"));
+        assertEquals(true, config.get("useSystemCluster"));
     }
 
     @Test
@@ -250,34 +250,12 @@ public class DefaultIdentityProviderServiceTest {
     }
 
     @Test
-    public void gatewayScope_bindsTheProviderToTheSystemCluster() {
+    public void bindingDoesNotDependOnTheSystemClusterScope() {
         environment.setProperty("repositories.system-cluster", "gateway");
-        environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
-        environment.setProperty("repositories.management.mongodb.dbname", "mgmt-db");
 
         Map<String, Object> config = cut.createProviderConfiguration("test", null);
 
-        // the connection settings stay a fallback: the Mongo provider replaces both the client and the
-        // database with the data plane's when it honors this flag
-        assertEquals("mgmt-host", config.get("host"));
-        assertEquals("mgmt-db", config.get("database"));
         assertEquals(true, config.get("useSystemCluster"));
-    }
-
-    @Test
-    public void invalidSystemClusterScope_isRejected() {
-        environment.setProperty("repositories.system-cluster", "oauth2");
-
-        IllegalStateException error = assertThrows(IllegalStateException.class,
-                () -> cut.createProviderConfiguration("test", null));
-        assertTrue(error.getMessage().contains("oauth2"));
-    }
-
-    @Test
-    public void unknownSystemClusterScope_isRejected() {
-        environment.setProperty("repositories.system-cluster", "not-a-scope");
-
-        assertThrows(IllegalStateException.class, () -> cut.createProviderConfiguration("test", null));
     }
 
     @Test
@@ -304,7 +282,6 @@ public class DefaultIdentityProviderServiceTest {
     @Test
     public void jdbcBackend_isNeverBoundToTheSystemCluster() {
         environment.setProperty("repositories.management.type", "jdbc");
-        environment.setProperty("repositories.system-cluster", "gateway");
         environment.setProperty("repositories.management.jdbc.host", "mgmt-jdbc");
 
         Map<String, Object> config = cut.createProviderConfiguration("test", null);
@@ -316,8 +293,7 @@ public class DefaultIdentityProviderServiceTest {
     // --- refreshProviderConfiguration preserves the binding made at creation time ---
 
     @Test
-    public void refresh_keepsAnExistingProviderUnboundEvenWhenGatewayIsConfigured() {
-        environment.setProperty("repositories.system-cluster", "gateway");
+    public void refresh_keepsAProviderCreatedBeforeTheFlagUnbound() {
         environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
 
         Map<String, Object> config = cut.refreshProviderConfiguration(
@@ -329,8 +305,6 @@ public class DefaultIdentityProviderServiceTest {
 
     @Test
     public void refresh_keepsAnExplicitlyUnboundProviderUnbound() {
-        environment.setProperty("repositories.system-cluster", "gateway");
-
         Map<String, Object> config = cut.refreshProviderConfiguration(
                 existingProvider("{\"useSystemCluster\":false,\"passwordEncoder\":\"BCrypt\"}"));
 
@@ -339,22 +313,9 @@ public class DefaultIdentityProviderServiceTest {
 
     @Test
     public void refresh_keepsABoundProviderBound() {
-        environment.setProperty("repositories.system-cluster", "gateway");
-
         Map<String, Object> config = cut.refreshProviderConfiguration(
                 existingProvider("{\"useSystemCluster\":true,\"passwordEncoder\":\"BCrypt\"}"));
 
-        assertEquals(true, config.get("useSystemCluster"));
-    }
-
-    @Test
-    public void refresh_keepsTheBindingWhenTheScopeIsMovedBackToManagement() {
-        environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
-
-        Map<String, Object> config = cut.refreshProviderConfiguration(
-                existingProvider("{\"useSystemCluster\":true,\"passwordEncoder\":\"BCrypt\"}"));
-
-        assertEquals("mgmt-host", config.get("host"));
         assertEquals(true, config.get("useSystemCluster"));
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -418,9 +418,7 @@ user:
     maxRequestOperations: 1000
 
 repositories:
-  # specify which scope is used as reference
-  # to initialize the IdentityProviders with the "use system cluster"
-  # option enabled (only management and gateway scopes are allowed as value)
+  # Cluster bound to Mongo IDPs that have "use system cluster" option enabled (management or gateway)
   system-cluster: management
   # When true, the platform owns where a Mongo identity provider created with the "use system
   # cluster" option enabled stores its users:


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7606](https://gravitee.atlassian.net/browse/AM-7606)

## :pencil2: A description of the changes proposed in the pull request
Enable "use system cluster" mode for domains' default Mongo IDPs regardless of `repositories.system-cluster` system setting.

- At create/refresh time:
  - **New default mongo IDPs now always have `useSystemCluster=true`**
  - Existing mongo IDPs continue to preserve their existing `useSystemCluster=false`
  - Existing non-default mongo IDPs continue to preserve whatever they have set for `useSystemCluster`
- At runtime:
  - **New default mongo IDPs get their database (and client) from the system cluster, regardless of its scope, aligning it with non-default IDPs that have the `useSystemCluster` flag enabled**
  - Existing default mongo IDPs with `useSystemCluster=false` or missing data plane id or when `repositories.system-cluster` is "management" preserve legacy usage of management client wrapper
  - Any mongo IDPs with a data source continue to use their own client wrapper

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7606]: https://gravitee.atlassian.net/browse/AM-7606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ