### PR TITLE
fix: AM-7603 always restrict mongo IDPs to system cluster in cloud mode

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -429,7 +429,7 @@ repositories:
   #    every Management API start, so it keeps naming the right store when the configuration changes
   #  - the users collection is forced to idp_<identity provider id>, so it cannot collide with
   #    another identity provider or with a collection the platform creates later
-  # Defaults to true on a Gravitee-managed cloud installation and to false anywhere else. An
+  # Always true on a Gravitee-managed cloud installation and by default false anywhere else. An
   # identity provider already created keeps its settings whatever this becomes.
   #system-cluster-restricted: true
   # Management repository is used to store global configuration such as domains, clients, ...

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/idp/SystemClusterIdpSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/idp/SystemClusterIdpSettings.java
@@ -42,11 +42,10 @@ public class SystemClusterIdpSettings {
      * that a provider can never end up with a collection the platform named inside a database it
      * did not choose.
      *
-     * <p>A rule left out of the configuration follows the deployment: on in a Gravitee-managed
-     * cloud installation, off elsewhere.
+     * <p>Enabled in a Gravitee-managed cloud installation, otherwise by system configuration.
      */
     public boolean isRestricted() {
-        final Boolean value = environment.getProperty(SYSTEM_CLUSTER_RESTRICTED, Boolean.class);
-        return value != null ? value : CloudProperties.isManagedCloudEnabled(environment);
+        return CloudProperties.isManagedCloudEnabled(environment)
+                || environment.getProperty(SYSTEM_CLUSTER_RESTRICTED, Boolean.class, false);
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/idp/SystemClusterIdpPolicyTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/idp/SystemClusterIdpPolicyTest.java
@@ -186,15 +186,16 @@ class SystemClusterIdpPolicyTest {
     }
 
     @Test
-    void should_leave_the_configuration_alone_when_pinning_is_turned_off() {
+    void should_keep_pinning_in_managed_cloud_when_the_setting_is_turned_off() throws ParseException {
         environment.setProperty(SystemClusterIdpSettings.SYSTEM_CLUSTER_RESTRICTED, "false");
-        var original = configuration(true, "custom-db", "my-users", null);
-        var idp = mongoIdp(original);
+        var idp = mongoIdp(configuration(true, "custom-db", "my-users", null));
 
         policy.applyOnCreate(idp);
 
-        assertEquals(original, idp.getConfiguration());
-        assertFalse(idp.isSystemClusterRestricted());
+        var configuration = JSONObjectUtils.parse(idp.getConfiguration());
+        assertEquals(PLATFORM_DATABASE, configuration.get("database"));
+        assertEquals("idp_" + IDP_ID, configuration.get("usersCollection"));
+        assertTrue(idp.isSystemClusterRestricted());
     }
 
     @Test
@@ -264,6 +265,15 @@ class SystemClusterIdpPolicyTest {
 
     @Test
     void should_reject_an_update_that_turns_the_system_cluster_on() {
+        var stored = mongoIdp(configuration(false, "custom-db", "my-users", null));
+        var toUpdate = mongoIdp(configuration(true, "custom-db", "my-users", null));
+
+        assertThrows(InvalidParameterException.class, () -> policy.applyOnUpdate(stored, toUpdate));
+    }
+
+    @Test
+    void should_reject_an_update_that_turns_the_system_cluster_on_in_managed_cloud_when_the_setting_is_turned_off() {
+        environment.setProperty(SystemClusterIdpSettings.SYSTEM_CLUSTER_RESTRICTED, "false");
         var stored = mongoIdp(configuration(false, "custom-db", "my-users", null));
         var toUpdate = mongoIdp(configuration(true, "custom-db", "my-users", null));
 


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7603](https://gravitee.atlassian.net/browse/AM-7603)

## :pencil2: A description of the changes proposed in the pull request
Amend system cluster restriction determination so that new Mongo IDPs created in managed cloud mode are always restricted.

The effect is that: _new Mongo IDPs that have "use system cluster" enabled (and no datasource) become bound to the system cluster, meaning their database and collections become readonly_.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7603]: https://gravitee.atlassian.net/browse/AM-7603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ