### PR TITLE
fix: do not publish distribution ZIP bundles to Nexus and Artifactory (AM-7616)

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -438,8 +438,9 @@ jobs:
       - run:
           name: Maven Package & deploy on artifactory
           command: |
-            mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot,ee-bundle,addons-bundle clean deploy -pl \!gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip,\!gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip
-            mvn -s /tmp/.gravitee.settings.xml -P ee-bundle,addons-bundle package -DskipTests -pl gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip,gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip
+            # The distribution bundle modules (gateway/mgmt-api standalone zips, webui) set
+            # maven.deploy.skip in their pom, so they are packaged but never pushed to Artifactory.
+            mvn -s /tmp/.gravitee.settings.xml -P gio-artifactory-snapshot,ee-bundle,addons-bundle clean deploy
             cp ./gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/target/*.zip ~/
             cp ./gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/target/*.zip ~/
             cp ./gravitee-am-ui/target/*.zip ~/

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/pom.xml
@@ -30,6 +30,11 @@
 
     <artifactId>gravitee-am-gateway-standalone-distribution-zip</artifactId>
     <name>Gravitee IO - Access Management - Gateway - Standalone - Distribution - Zip</name>
+
+    <properties>
+        <!-- Distribution bundle: published on download.gravitee.io, never on Nexus/Artifactory/Maven -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/pom.xml
@@ -28,6 +28,11 @@
 
     <artifactId>gravitee-am-management-api-standalone-distribution-zip</artifactId>
     <name>Gravitee IO - Access Management - Management API - Standalone - Distribution - Zip</name>
+
+    <properties>
+        <!-- Distribution bundle: published on download.gravitee.io, never on Nexus/Artifactory/Maven -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/gravitee-am-ui/pom.xml
+++ b/gravitee-am-ui/pom.xml
@@ -24,6 +24,8 @@
     <frontend-maven-plugin.version>1.15.4</frontend-maven-plugin.version>
     <node.version>v20.11.1</node.version>
     <yarn.version>v1.22.22</yarn.version>
+    <!-- Distribution bundle: published on download.gravitee.io, never on Nexus/Artifactory/Maven -->
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>25.1.0</version>
+        <version>25.1.2</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Why

Nexus OSS rate limiting makes large artifact uploads costly, and we publish three distribution bundles that nobody consumes as Maven artifacts:

| Artifact | Size |
|---|---|
| `gravitee-am-gateway-standalone-*.zip` | 301 MB |
| `gravitee-am-management-api-standalone-*.zip` | 310 MB |
| `gravitee-am-webui-*.zip` | 6 MB |

That is ~617 MB pushed to Artifactory snapshots **and** the same again to Sonatype snapshots on every branch build, plus Artifactory releases and Maven Central on every release.

Everything that actually needs these bundles reads them from `target/` or from `download.gravitee.io` — `package_bundle` (`workflows.yml:252`), `docker/local-stack/local-stack.sh:313`, and the published Dockerfiles. None of them resolve from a Maven repository.

## What changed

The three modules now set a single property:

```xml
<maven.deploy.skip>true</maven.deploy.skip>
```

One switch is enough because **gravitee-parent is bumped 25.1.0 → 25.1.2**, which introduces `central.publishing.skip` mapped onto `maven.deploy.skip` and wires it into the publishing plugin:

```xml
<central.publishing.skip>${maven.deploy.skip}</central.publishing.skip>
...
<skipPublishing>${central.publishing.skip}</skipPublishing>
```

That mapping matters: `central-publishing-maven-plugin` runs with `<extensions>true</extensions>`, takes over the `deploy` phase, and therefore never sees `maven.deploy.skip` by itself. Without 25.1.2 each module would need two unrelated switches.

The `build` job's two Maven invocations collapse into one, since the `-pl !…` exclusions are now redundant. Incidental fix: the second invocation had dropped the `gio-artifactory-snapshot` profile, so it could only resolve Gravitee SNAPSHOT dependencies from a warm local repository.

## Verification

The load-bearing assumption — that a child's `maven.deploy.skip` propagates through the parent's `central.publishing.skip` indirection — was checked rather than assumed:

| Module | `maven.deploy.skip` | `central.publishing.skip` | effective `<skipPublishing>` |
|---|---|---|---|
| 3 bundle modules | `true` | `true` | `true` |
| `idp-github` (control) | `false` | `false` | `false` |

Both release paths are covered, confirmed against the effective POM:

- `-P gravitee-release` (Central) → `central-publishing-maven-plugin` **is** bound in `<build><plugins>` and receives `skipPublishing=true`
- `-P gio-artifactory-release,gio-release` (Artifactory) → central-publishing is **not** bound (pluginManagement only), so `maven-deploy-plugin` runs and honours `maven.deploy.skip`

And the deploy mojo behaves accordingly:

```
gravitee-am-ui:                                          Skipping artifact deployment  ✓
gravitee-am-gateway-standalone-distribution-zip:         Skipping artifact deployment  ✓
gravitee-am-management-api-standalone-distribution-zip:  Skipping artifact deployment  ✓
gravitee-am-identityprovider-github (control):           not skipped                   ✓
```

`circleci config validate` passes on both config files.

**Not run locally:** a full `mvn deploy` to a file repo and a real CI build — both need a complete reactor build including the node/yarn UI and the two ~300 MB assemblies. The CI run on this PR is the final signal; please confirm the bundle ZIPs still land in `target/` for `package_bundle` and the Docker jobs.

## Out of scope

The ~49 **plugin** ZIPs still deploy, deliberately. The distribution poms consume them as real `<type>zip</type>` Maven dependencies (e.g. `gravitee-am-gateway-standalone-distribution/pom.xml:1002`), so suppressing them would break the bundle assembly. Dropping those too would mean sourcing plugins from somewhere other than the Maven repo — a separate change.

## Note for reviewers

After the parent bump, a CLI `-DskipPublishing=true` is silently ignored: the parent now hardcodes `<skipPublishing>${central.publishing.skip}</skipPublishing>` into the plugin's `<configuration>`, and explicit plugin configuration wins over a mojo's user property. Use `-Dmaven.deploy.skip=true` instead.

fix AM-7616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
