### PR TITLE
fix: do not publish distribution ZIP bundles to Nexus and Artifactory (AM-7616)

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/gravitee-am-gateway-standalone-distribution-zip/pom.xml
@@ -30,6 +30,14 @@
 
     <artifactId>gravitee-am-gateway-standalone-distribution-zip</artifactId>
     <name>Gravitee IO - Access Management - Gateway - Standalone - Distribution - Zip</name>
+
+    <properties>
+        <!-- Distribution bundle: published on download.gravitee.io, never on Nexus/Artifactory/Maven Central.
+             maven.deploy.skip covers maven-deploy-plugin; central-publishing-maven-plugin takes over the
+             deploy phase and never sees it, so it needs skipPublishing of its own. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipPublishing>true</skipPublishing>
+    </properties>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/pom.xml
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-distribution/gravitee-am-management-api-standalone-distribution-zip/pom.xml
@@ -28,6 +28,14 @@
 
     <artifactId>gravitee-am-management-api-standalone-distribution-zip</artifactId>
     <name>Gravitee IO - Access Management - Management API - Standalone - Distribution - Zip</name>
+
+    <properties>
+        <!-- Distribution bundle: published on download.gravitee.io, never on Nexus/Artifactory/Maven Central.
+             maven.deploy.skip covers maven-deploy-plugin; central-publishing-maven-plugin takes over the
+             deploy phase and never sees it, so it needs skipPublishing of its own. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipPublishing>true</skipPublishing>
+    </properties>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/gravitee-am-ui/pom.xml
+++ b/gravitee-am-ui/pom.xml
@@ -24,6 +24,11 @@
     <frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
     <node.version>v20.11.1</node.version>
     <yarn.version>v1.22.22</yarn.version>
+    <!-- Distribution bundle: published on download.gravitee.io, never on Nexus/Artifactory/Maven Central.
+         maven.deploy.skip covers maven-deploy-plugin; central-publishing-maven-plugin takes over the
+         deploy phase and never sees it, so it needs skipPublishing of its own. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <skipPublishing>true</skipPublishing>
   </properties>
 
   <parent>


### PR DESCRIPTION
4.9.x backport of #8513.

## Why

Nexus OSS rate limiting makes large artifact uploads costly, and we publish three distribution bundles that nobody consumes as Maven artifacts:

- `gravitee-am-gateway-standalone-*.zip`
- `gravitee-am-management-api-standalone-*.zip`
- `gravitee-am-webui-*.zip`

On 4.9.x these go to Artifactory snapshots **and** Sonatype snapshots on every branch build, plus Artifactory releases and Maven Central on every release.

Everything that actually needs the bundles reads them from `target/` or from `download.gravitee.io` — `package_bundle`, `docker/local-stack/local-stack.sh`, and the published Dockerfiles. None resolve from a Maven repository.

## What changed

The three modules are marked skipped:

```xml
<maven.deploy.skip>true</maven.deploy.skip>
<skipPublishing>true</skipPublishing>
```

**Both properties are required on this branch**, which is the one thing that differs from #8513. `central-publishing-maven-plugin` runs with `<extensions>true</extensions>`, takes over the `deploy` phase, and therefore never sees `maven.deploy.skip`. On master that is handled by gravitee-parent 25.1.2, which maps `central.publishing.skip` onto `maven.deploy.skip` and injects it into the plugin config, letting one property do the job. gravitee-parent **23.4.1 has no such mapping** — its `pluginManagement` for the plugin declares only `publishingServerId`, `autoPublish` and `deploymentName` — so the mojo falls back to its `${skipPublishing}` user property, which the second line sets.

**The parent is deliberately not upgraded here**, to keep the maintenance branch's dependency surface unchanged.

## No CI change needed

Unlike master, the 4.9.x `build` job is already a single `mvn -P gio-artifactory-snapshot clean deploy` (`workflows.yml:423`) with no `-pl` exclusions to collapse, and it copies the bundles from `target/`, which the deploy skip does not affect. All four deploy paths are covered by the poms alone.

## Verification

| Module | `maven.deploy.skip` | `skipPublishing` | `maven-deploy-plugin:deploy` |
|---|---|---|---|
| `gravitee-am-ui` | `true` | `true` | Skipping artifact deployment |
| `gateway-standalone-distribution-zip` | `true` | `true` | Skipping artifact deployment |
| `management-api-standalone-distribution-zip` | `true` | `true` | Skipping artifact deployment |
| `idp-github` (control) | `false` | `false` | **not** skipped |

Re-run after rebasing onto the current `4.9.x`. Also re-checked on this branch rather than carried over from master: the distribution pom still consumes 126 `<type>zip</type>` plugin dependencies, the three bundle artifacts are leaves nothing depends on, and `performRelease` is unused.

**Not run locally:** a full `mvn deploy` to a file repo and a real CI build — both need a complete reactor build including the node/yarn UI and the two ~300 MB assemblies. The CI run on this PR is the final signal; please confirm the bundle ZIPs still land in `target/` for `package_bundle` and the Docker jobs.

## Out of scope

The plugin ZIPs still deploy, deliberately — the distribution poms consume them as real `<type>zip</type>` Maven dependencies, so suppressing them would break the bundle assembly.

fix AM-7616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
