### PR TITLE
fix: AM-7612 enabling system mode is irreversible

### DIFF
--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/idp/SystemClusterIdpPolicy.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/idp/SystemClusterIdpPolicy.java
@@ -32,6 +32,9 @@ import java.util.Optional;
  * provider id. Only providers created under this regime are affected, so an existing provider keeps
  * working whatever the setting becomes later.
  *
+ * <p>Under that regime a provider's use of the system cluster is settled at creation, whether or not
+ * the platform pinned it.
+ *
  * @author GraviteeSource Team
  */
 @Component
@@ -45,6 +48,9 @@ public class SystemClusterIdpPolicy {
     public static final String MONGO_IDP_TYPE = "mongo-am-idp";
 
     static final String COLLECTION_PREFIX = "idp_";
+
+    static final String SYSTEM_CLUSTER_CANNOT_BE_CHANGED =
+            "useSystemCluster cannot be changed after the identity provider has been created.";
 
     private static final String USE_SYSTEM_CLUSTER = "useSystemCluster";
     private static final String DATASOURCE_ID = "datasourceId";
@@ -65,24 +71,8 @@ public class SystemClusterIdpPolicy {
             checkStorageUnchanged(stored, identityToUpdate.getConfiguration());
             return;
         }
-        final Map<String, Object> current = parse(stored.getConfiguration());
-        // An identity provider that already reuses the system cluster keeps the settings it has
-        // today, whatever the mode says now.
-        if (current == null || isUseSystemCluster(current)) {
-            return;
-        }
-        rejectSystemClusterSwitch(identityToUpdate);
-    }
-
-    // The collection comes from the id, and users already stored elsewhere do not move, so joining
-    // the regime later would hide them.
-    private void rejectSystemClusterSwitch(IdentityProvider identityToUpdate) {
-        if (!ownsStorageLocation() || !isEligible(identityToUpdate)) {
-            return;
-        }
-        final Map<String, Object> updated = parse(identityToUpdate.getConfiguration());
-        if (updated != null && isUseSystemCluster(updated) && !hasDatasourceId(updated)) {
-            throw new InvalidParameterException("The system cluster can only be selected when the identity provider is created");
+        if (ownsStorageLocation() && isEligible(identityToUpdate)) {
+            checkSystemClusterUnchanged(stored, identityToUpdate);
         }
     }
 
@@ -192,6 +182,17 @@ public class SystemClusterIdpPolicy {
                 || !Objects.equals(current.get(DATABASE), updated.get(DATABASE))
                 || !Objects.equals(current.get(DATASOURCE_ID), updated.get(DATASOURCE_ID))) {
             throw new InvalidParameterException("Identity provider storage settings cannot be changed");
+        }
+    }
+
+    private void checkSystemClusterUnchanged(IdentityProvider stored, IdentityProvider identityToUpdate) {
+        final Map<String, Object> current = parse(stored.getConfiguration());
+        final Map<String, Object> updated = parse(identityToUpdate.getConfiguration());
+        if (current == null || updated == null) {
+            return;
+        }
+        if (isUseSystemCluster(current) != isUseSystemCluster(updated)) {
+            throw new InvalidParameterException(SYSTEM_CLUSTER_CANNOT_BE_CHANGED);
         }
     }
 

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/idp/SystemClusterIdpPolicyTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/idp/SystemClusterIdpPolicyTest.java
@@ -264,6 +264,116 @@ class SystemClusterIdpPolicyTest {
     }
 
     @Test
+    void should_reject_an_update_that_turns_the_system_cluster_off() {
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", null));
+        var toUpdate = mongoIdp(configuration(false, "custom-db", "my-users", null));
+
+        var thrown = assertThrows(InvalidParameterException.class, () -> policy.applyOnUpdate(stored, toUpdate));
+
+        assertEquals(SystemClusterIdpPolicy.SYSTEM_CLUSTER_CANNOT_BE_CHANGED, thrown.getMessage());
+    }
+
+    @Test
+    void should_allow_an_update_that_turns_the_system_cluster_off_outside_managed_cloud() {
+        var standalone = policyWith(new MockEnvironment());
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", null));
+        var original = configuration(false, "custom-db", "my-users", null);
+        var toUpdate = mongoIdp(original);
+
+        standalone.applyOnUpdate(stored, toUpdate);
+
+        assertEquals(original, toUpdate.getConfiguration());
+    }
+
+    @Test
+    void should_reject_an_update_that_turns_the_system_cluster_off_outside_managed_cloud_when_pinning_is_turned_on() {
+        var environment = new MockEnvironment();
+        environment.setProperty(SystemClusterIdpSettings.SYSTEM_CLUSTER_RESTRICTED, "true");
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", null));
+        var toUpdate = mongoIdp(configuration(false, "custom-db", "my-users", null));
+
+        assertThrows(InvalidParameterException.class, () -> policyWith(environment).applyOnUpdate(stored, toUpdate));
+    }
+
+    @Test
+    void should_allow_a_datasource_added_to_a_system_cluster_provider() {
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", null));
+        var original = configuration(true, "custom-db", "my-users", "ds-1");
+        var toUpdate = mongoIdp(original);
+
+        policy.applyOnUpdate(stored, toUpdate);
+
+        assertEquals(original, toUpdate.getConfiguration());
+    }
+
+    @Test
+    void should_reject_an_update_that_turns_the_system_cluster_off_alongside_a_datasource() {
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", "ds-1"));
+        var toUpdate = mongoIdp(configuration(false, "custom-db", "my-users", "ds-1"));
+
+        assertThrows(InvalidParameterException.class, () -> policy.applyOnUpdate(stored, toUpdate));
+    }
+
+    @Test
+    void should_allow_a_datasource_removed_from_a_system_cluster_provider() {
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", "ds-1"));
+        var original = configuration(true, "custom-db", "my-users", null);
+        var toUpdate = mongoIdp(original);
+
+        policy.applyOnUpdate(stored, toUpdate);
+
+        assertEquals(original, toUpdate.getConfiguration());
+    }
+
+    @Test
+    void should_allow_a_datasource_removed_outside_managed_cloud() {
+        var standalone = policyWith(new MockEnvironment());
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", "ds-1"));
+        var original = configuration(true, "custom-db", "my-users", null);
+        var toUpdate = mongoIdp(original);
+
+        standalone.applyOnUpdate(stored, toUpdate);
+
+        assertEquals(original, toUpdate.getConfiguration());
+    }
+
+    @Test
+    void should_allow_a_system_identity_provider_to_leave_the_system_cluster() {
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", null));
+        stored.setSystem(true);
+        var toUpdate = mongoIdp(configuration(false, "custom-db", "my-users", null));
+        toUpdate.setSystem(true);
+
+        policy.applyOnUpdate(stored, toUpdate);
+    }
+
+    @Test
+    void should_allow_a_non_mongo_identity_provider_to_leave_the_system_cluster() {
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", null));
+        stored.setType("inline-am-idp");
+        var toUpdate = mongoIdp(configuration(false, "custom-db", "my-users", null));
+        toUpdate.setType("inline-am-idp");
+
+        policy.applyOnUpdate(stored, toUpdate);
+    }
+
+    @Test
+    void should_allow_an_update_when_the_stored_configuration_cannot_be_read() {
+        var stored = mongoIdp("not json");
+        var toUpdate = mongoIdp(configuration(false, "custom-db", "my-users", null));
+
+        policy.applyOnUpdate(stored, toUpdate);
+    }
+
+    @Test
+    void should_allow_an_update_when_the_new_configuration_cannot_be_read() {
+        var stored = mongoIdp(configuration(true, "custom-db", "my-users", null));
+        var toUpdate = mongoIdp("not json");
+
+        policy.applyOnUpdate(stored, toUpdate);
+    }
+
+    @Test
     void should_reject_an_update_that_turns_the_system_cluster_on() {
         var stored = mongoIdp(configuration(false, "custom-db", "my-users", null));
         var toUpdate = mongoIdp(configuration(true, "custom-db", "my-users", null));
@@ -272,7 +382,7 @@ class SystemClusterIdpPolicyTest {
     }
 
     @Test
-    void should_reject_an_update_that_turns_the_system_cluster_on_in_managed_cloud_when_the_setting_is_turned_off() {
+    void should_keep_rejecting_an_update_that_turns_the_system_cluster_on_in_managed_cloud_when_the_setting_is_turned_off() {
         environment.setProperty(SystemClusterIdpSettings.SYSTEM_CLUSTER_RESTRICTED, "false");
         var stored = mongoIdp(configuration(false, "custom-db", "my-users", null));
         var toUpdate = mongoIdp(configuration(true, "custom-db", "my-users", null));
@@ -304,15 +414,11 @@ class SystemClusterIdpPolicyTest {
     }
 
     @Test
-    void should_allow_an_update_that_turns_the_system_cluster_on_for_a_datasource_provider() {
+    void should_reject_an_update_that_turns_the_system_cluster_on_for_a_datasource_provider() {
         var stored = mongoIdp(configuration(false, "custom-db", "my-users", "ds-1"));
-        var original = configuration(true, "custom-db", "my-users", "ds-1");
-        var toUpdate = mongoIdp(original);
+        var toUpdate = mongoIdp(configuration(true, "custom-db", "my-users", "ds-1"));
 
-        policy.applyOnUpdate(stored, toUpdate);
-
-        assertEquals(original, toUpdate.getConfiguration());
-        assertFalse(toUpdate.isSystemClusterRestricted());
+        assertThrows(InvalidParameterException.class, () -> policy.applyOnUpdate(stored, toUpdate));
     }
 
     @Test

--- a/gravitee-am-test/playwright/pages/identity-provider-settings.page.ts
+++ b/gravitee-am-test/playwright/pages/identity-provider-settings.page.ts
@@ -44,6 +44,10 @@ export class IdentityProviderSettingsPage extends BasePage {
     return this.page.locator('mat-checkbox').filter({ hasText: 'Use System Cluster' }).locator('input[type=checkbox]');
   }
 
+  get descriptionPanel(): Locator {
+    return this.page.locator('.gv-page-description-content');
+  }
+
   get saveButton(): Locator {
     return this.page.locator('button:has-text("SAVE")');
   }

--- a/gravitee-am-test/playwright/tests/domain/identity-provider-storage.spec.ts
+++ b/gravitee-am-test/playwright/tests/domain/identity-provider-storage.spec.ts
@@ -20,7 +20,7 @@ import { createIdp, deleteIdp } from '@management-commands/idp-management-comman
 
 const MONGO_IDP_TYPE = 'mongo-am-idp';
 
-const mongoIdpBody = (name: string) => ({
+const mongoIdpBody = (name: string, useSystemCluster = true) => ({
   external: false,
   type: MONGO_IDP_TYPE,
   domainWhitelist: [],
@@ -30,7 +30,7 @@ const mongoIdpBody = (name: string) => ({
     host: 'localhost',
     port: 27017,
     enableCredentials: false,
-    useSystemCluster: true,
+    useSystemCluster,
     database: 'my-own-database',
     usersCollection: 'my-own-users',
     findUserByUsernameQuery: '{username: ?}',
@@ -41,6 +41,10 @@ const mongoIdpBody = (name: string) => ({
   }),
 });
 
+const DATASOURCE_ADVICE = 'Prefer a data source';
+
+const IMMUTABLE_HINT = 'Once saved, this option cannot be changed.';
+
 const readsPinStorage = async (request, adminToken: string): Promise<boolean> => {
   const response = await request.get(`${process.env.AM_MANAGEMENT_URL}/management/platform/configuration/installation`, {
     headers: { Authorization: `Bearer ${adminToken}` },
@@ -48,7 +52,7 @@ const readsPinStorage = async (request, adminToken: string): Promise<boolean> =>
   return (await response.json())?.systemClusterRestricted === true;
 };
 
-/** Skipped unless the installation pins storage: a standalone stack has nothing to lock. */
+/** Two regimes share this file: each test skips on the installation the other one covers. */
 test.describe('Identity provider storage', () => {
   test('AM-7581: creation screen tells the administrator which fields the platform will set', async ({
     page,
@@ -87,6 +91,47 @@ test.describe('Identity provider storage', () => {
       // The widget drops the form binding for a boolean marked readonly, leaving it disabled.
       await expect(providerPage.systemClusterToggle).toBeChecked();
       await expect(providerPage.systemClusterToggle).toBeDisabled();
+    } finally {
+      await deleteIdp(testDomain.id, adminToken, idp.id);
+    }
+  });
+
+  test('edit screen leaves the toggle open when the platform does not own the storage', async ({
+    page,
+    adminToken,
+    testDomain,
+    request,
+  }) => {
+    test.skip(await readsPinStorage(request, adminToken), 'The installation pins storage, which locks the toggle');
+
+    const idp = await createIdp(testDomain.id, adminToken, mongoIdpBody('system-cluster-provider'));
+    try {
+      const providerPage = new IdentityProviderSettingsPage(page);
+      await providerPage.navigateToSettings(testDomain.id, idp.id);
+
+      await expect(providerPage.systemClusterToggle).toBeChecked();
+      await expect(providerPage.systemClusterToggle).toBeEnabled();
+      await expect(page.getByText(IMMUTABLE_HINT)).toHaveCount(0);
+    } finally {
+      await deleteIdp(testDomain.id, adminToken, idp.id);
+    }
+  });
+
+  test('the creation wizard recommends a data source', async ({ page, testDomain }) => {
+    const providerPage = new IdentityProviderSettingsPage(page);
+    await providerPage.navigateToCreation(testDomain.id);
+    await providerPage.chooseType('Mongo DB');
+
+    await expect(providerPage.descriptionPanel).toContainText(DATASOURCE_ADVICE);
+  });
+
+  test('the edit screen repeats the storage guidance beside the form', async ({ page, adminToken, testDomain }) => {
+    const idp = await createIdp(testDomain.id, adminToken, mongoIdpBody('guidance-provider'));
+    try {
+      const providerPage = new IdentityProviderSettingsPage(page);
+      await providerPage.navigateToSettings(testDomain.id, idp.id);
+
+      await expect(providerPage.descriptionPanel).toContainText(DATASOURCE_ADVICE);
     } finally {
       await deleteIdp(testDomain.id, adminToken, idp.id);
     }

--- a/gravitee-am-test/specs/cloud/identity-provider-system-cluster.jest.spec.ts
+++ b/gravitee-am-test/specs/cloud/identity-provider-system-cluster.jest.spec.ts
@@ -132,6 +132,17 @@ describe('Identity provider reusing the system cluster', () => {
     expect(unchanged.systemClusterRestricted).toBeFalsy();
   });
 
+  itMongoOnly(jira`should reject an update that turns the system cluster off ${'AM-7585'}`, async () => {
+    const idp = await newMongoIdp(true);
+
+    await expect(updateCloudIdp(scope, idp.id, buildMongoIdpUpdateBody(idp, { useSystemCluster: false }))).rejects.toMatchObject({
+      response: { status: 400 },
+    });
+
+    const unchanged = await getCloudIdp(scope, idp.id);
+    expect(JSON.parse(unchanged.configuration).useSystemCluster).toEqual(true);
+  });
+
   it(jira`should accept the same automation manifest applied twice ${'AM-7586'}`, async () => {
     const manifest = buildMongoAutomationIdpDef(uniqueName('am7264-auto', true).toLowerCase());
 

--- a/gravitee-am-test/specs/management/identity-provider/fixtures/system-cluster-fixture.ts
+++ b/gravitee-am-test/specs/management/identity-provider/fixtures/system-cluster-fixture.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { setupDomainForTest, safeDeleteDomain } from '@management-commands/domain-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { Domain } from '@management-models/Domain';
+import { Fixture } from '../../../test-fixture';
+
+export interface SystemClusterFixture extends Fixture {
+  domain: Domain;
+  accessToken: string;
+}
+
+export const setupSystemClusterFixture = async (): Promise<SystemClusterFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  const { domain } = await setupDomainForTest(uniqueName('idp-system-cluster', true), { accessToken, waitForStart: false });
+
+  return {
+    accessToken,
+    domain,
+    cleanUp: async () => {
+      if (domain?.id && accessToken) {
+        await safeDeleteDomain(domain.id, accessToken);
+      }
+    },
+  };
+};
+
+export const OWN_DATABASE = 'my-own-database';
+
+export const OWN_USERS_COLLECTION = 'my-own-users';
+
+export const isMongoStack = process.env.REPOSITORY_TYPE !== 'jdbc';
+
+const mongoStore = () => {
+  const url = new URL(process.env.AM_INTERNAL_MONGODB_URI ?? process.env.AM_MONGODB_URI);
+  return { uri: url.toString(), host: url.hostname, port: Number(url.port || 27017) };
+};
+
+export const buildMongoIdpBody = (overrides: { useSystemCluster: boolean; database?: string; usersCollection?: string }) => ({
+  external: false,
+  type: 'mongo-am-idp',
+  domainWhitelist: [],
+  name: uniqueName('mongo-idp', true),
+  configuration: JSON.stringify({
+    ...mongoStore(),
+    enableCredentials: false,
+    useSystemCluster: overrides.useSystemCluster,
+    database: overrides.database ?? OWN_DATABASE,
+    usersCollection: overrides.usersCollection ?? OWN_USERS_COLLECTION,
+    findUserByUsernameQuery: '{username: ?}',
+    findUserByEmailQuery: '{email: ?}',
+    usernameField: 'username',
+    passwordField: 'password',
+    passwordEncoder: 'BCrypt',
+  }),
+});
+
+export const buildMongoIdpUpdateBody = (idp, configurationOverrides: object) => ({
+  name: idp.name,
+  type: idp.type,
+  domainWhitelist: [],
+  configuration: JSON.stringify({ ...JSON.parse(idp.configuration), ...configurationOverrides }),
+});

--- a/gravitee-am-test/specs/management/identity-provider/identity-provider-system-cluster.jest.spec.ts
+++ b/gravitee-am-test/specs/management/identity-provider/identity-provider-system-cluster.jest.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { createIdp, getIdp, updateIdp } from '@management-commands/idp-management-commands';
+import { setup } from '../../test-fixture';
+import {
+  buildMongoIdpBody,
+  buildMongoIdpUpdateBody,
+  isMongoStack,
+  OWN_DATABASE,
+  OWN_USERS_COLLECTION,
+  setupSystemClusterFixture,
+  SystemClusterFixture,
+} from './fixtures/system-cluster-fixture';
+
+setup();
+
+let fixture: SystemClusterFixture;
+
+beforeAll(async () => {
+  fixture = await setupSystemClusterFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+const itMongoOnly = isMongoStack ? it : it.skip;
+
+const newMongoIdp = (useSystemCluster: boolean) =>
+  createIdp(fixture.domain.id, fixture.accessToken, buildMongoIdpBody({ useSystemCluster }));
+
+const update = (idp, configurationOverrides: object) =>
+  updateIdp(fixture.domain.id, fixture.accessToken, buildMongoIdpUpdateBody(idp, configurationOverrides), idp.id);
+
+describe('Identity provider reusing the system cluster outside the storage rule', () => {
+  itMongoOnly('should leave the storage of a new provider to the administrator', async () => {
+    const idp = await newMongoIdp(true);
+
+    const configuration = JSON.parse(idp.configuration);
+    expect(configuration.database).toEqual(OWN_DATABASE);
+    expect(configuration.usersCollection).toEqual(OWN_USERS_COLLECTION);
+    expect(idp.systemClusterRestricted).toBeFalsy();
+  });
+
+  itMongoOnly('should accept an update that turns the system cluster off', async () => {
+    const idp = await newMongoIdp(true);
+
+    const updated = await update(idp, { useSystemCluster: false });
+
+    expect(JSON.parse(updated.configuration).useSystemCluster).toEqual(false);
+  });
+
+  itMongoOnly('should accept an update that turns the system cluster on', async () => {
+    const idp = await newMongoIdp(false);
+
+    const updated = await update(idp, { useSystemCluster: true });
+
+    expect(JSON.parse(updated.configuration).useSystemCluster).toEqual(true);
+    expect(updated.systemClusterRestricted).toBeFalsy();
+  });
+
+  itMongoOnly('should accept the system cluster turned on and off again', async () => {
+    const idp = await newMongoIdp(false);
+    const joined = await update(idp, { useSystemCluster: true });
+
+    const left = await update(joined, { useSystemCluster: false });
+
+    expect(JSON.parse(left.configuration).useSystemCluster).toEqual(false);
+  });
+
+  itMongoOnly('should leave the database and the collection editable', async () => {
+    const idp = await newMongoIdp(true);
+
+    const updated = await update(idp, { database: 'another-database', usersCollection: 'another-collection' });
+
+    const configuration = JSON.parse(updated.configuration);
+    expect(configuration.database).toEqual('another-database');
+    expect(configuration.usersCollection).toEqual('another-collection');
+  });
+});

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.html
@@ -54,6 +54,13 @@
       <h3>Identity Provider</h3>
       <div class="gv-page-description-content">
         <p>Identity providers offer user authentication as a service.</p>
+        <ng-container *ngIf="showMongoStorageGuidance && stepper.selectedIndex === 1">
+          <h5>User storage</h5>
+          <small>
+            Prefer a data source. It is the connection the provider actually uses (ahead of the system cluster and any URI on this form) and
+            credentials stay in the platform configuration.
+          </small>
+        </ng-container>
       </div>
     </div>
   </div>

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.ts
@@ -19,6 +19,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { ProviderService } from '../../../../services/provider.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
+import { MONGO_IDP_TYPE } from '../provider/provider.form.enricher';
 
 @Component({
   selector: 'app-idp-creation',
@@ -45,6 +46,10 @@ export class ProviderCreationComponent implements OnInit {
     if (this.router.routerState.snapshot.url.startsWith('/settings')) {
       this.organizationContext = true;
     }
+  }
+
+  get showMongoStorageGuidance(): boolean {
+    return this.provider?.type === MONGO_IDP_TYPE;
   }
 
   create() {

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step2/step2.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step2/step2.component.ts
@@ -19,7 +19,11 @@ import { map, switchMap } from 'rxjs/operators';
 
 import { OrganizationService } from '../../../../../../services/organization.service';
 import { SnackbarService } from '../../../../../../services/snackbar.service';
-import { enrichFormWithCerts, enrichFormWithSystemClusterCreationHints } from '../../../provider/provider.form.enricher';
+import {
+  enrichFormWithCerts,
+  enrichFormWithSystemClusterCreationHints,
+  enrichFormWithSystemClusterDisclaimer,
+} from '../../../provider/provider.form.enricher';
 import { DataSourcesService } from '../../../../../../services/datasources.service';
 import { CloudModeService } from '../../../../../../services/cloud-mode.service';
 
@@ -62,6 +66,7 @@ export class ProviderCreationStep2Component implements OnInit, OnChanges {
             this.organizationService.identitySchema(providerType).pipe(
               map((schema) => enrichFormWithCerts(schema, this.certificates)),
               map((schema) => enrichFormWithSystemClusterCreationHints(schema, providerType, restricted)),
+              map((schema) => enrichFormWithSystemClusterDisclaimer(schema, providerType, restricted)),
             ),
           ),
         )

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/mappers/mappers.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/mappers/mappers.component.ts
@@ -99,7 +99,7 @@ export class ProviderMappersComponent implements OnInit {
     const dialogRef = this.dialog.open(CreateMapperComponent, { width: '700px' });
     dialogRef.afterClosed().subscribe((mapper) => {
       if (mapper) {
-        if (!this.attributeExits(mapper.key)) {
+        if (!this.attributeExists(mapper.key)) {
           this.mappers.push(mapper);
           this.mappers = [...this.mappers];
           this.update('Attribute added');
@@ -124,7 +124,7 @@ export class ProviderMappersComponent implements OnInit {
   updateMapper(event, cell, rowIndex) {
     const mapper = event.target.value;
     if (mapper) {
-      if (cell === 'key' && this.attributeExits(mapper)) {
+      if (cell === 'key' && this.attributeExists(mapper)) {
         this.snackbarService.open(`Error : mapper ${mapper} already exists`);
         return;
       }
@@ -148,7 +148,7 @@ export class ProviderMappersComponent implements OnInit {
     });
   }
 
-  attributeExits(attribute): boolean {
+  attributeExists(attribute): boolean {
     return (
       this.mappers
         .map(function (m) {

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/provider.form.enricher.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/provider.form.enricher.spec.ts
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { enrichFormWithSystemClusterCreationHints, enrichFormWithSystemClusterRestrictions } from './provider.form.enricher';
+import {
+  enrichFormWithSystemClusterCreationHints,
+  enrichFormWithSystemClusterDisclaimer,
+  enrichFormWithSystemClusterLock,
+  enrichFormWithSystemClusterRestrictions,
+} from './provider.form.enricher';
 
 describe('enrichFormWithSystemClusterRestrictions', () => {
   const mongoSchema = () =>
@@ -133,5 +138,128 @@ describe('enrichFormWithSystemClusterCreationHints', () => {
     enrichFormWithSystemClusterCreationHints(original, 'mongo-am-idp', pinned);
 
     expect(original.properties.usersCollection.description).toBeUndefined();
+  });
+});
+
+describe('enrichFormWithSystemClusterLock', () => {
+  const mongoSchema = () =>
+    ({
+      id: 'urn:jsonschema:io:gravitee:am:identityprovider:mongo:MongoIdentityProviderConfiguration',
+      version: '1',
+      properties: {
+        useSystemCluster: { type: 'boolean' },
+        database: { type: 'string' },
+        usersCollection: { type: 'string' },
+        datasourceId: { type: 'string' },
+      },
+    }) as any;
+
+  it('locks the toggle of a provider that already reuses the system cluster', () => {
+    const enriched = enrichFormWithSystemClusterLock(mongoSchema(), 'mongo-am-idp', true);
+
+    expect(enriched.properties.useSystemCluster.readonly).toBe(true);
+  });
+
+  it('leaves the storage fields and the datasource editable', () => {
+    const enriched = enrichFormWithSystemClusterLock(mongoSchema(), 'mongo-am-idp', true);
+
+    expect(enriched.properties.database.readonly).toBeUndefined();
+    expect(enriched.properties.usersCollection.readonly).toBeUndefined();
+    expect(enriched.properties.datasourceId.readonly).toBeUndefined();
+  });
+
+  it('leaves the schema alone for a provider of another type', () => {
+    const enriched = enrichFormWithSystemClusterLock(mongoSchema(), 'inline-am-idp', true);
+
+    expect(enriched.properties.useSystemCluster.readonly).toBeUndefined();
+  });
+
+  it('leaves a schema without the toggle alone', () => {
+    const schema = { id: 'other', version: '1', properties: { usernameField: { type: 'string' } } } as any;
+
+    expect(enrichFormWithSystemClusterLock(schema, 'mongo-am-idp', true)).toBe(schema);
+  });
+
+  it('does not mutate the schema it was given', () => {
+    const original = mongoSchema();
+
+    enrichFormWithSystemClusterLock(original, 'mongo-am-idp', true);
+
+    expect(original.properties.useSystemCluster.readonly).toBeUndefined();
+  });
+});
+
+describe('enrichFormWithSystemClusterDisclaimer', () => {
+  const mongoSchema = (title?: string) =>
+    ({
+      id: 'urn:jsonschema:io:gravitee:am:identityprovider:mongo:MongoIdentityProviderConfiguration',
+      version: '1',
+      properties: {
+        useSystemCluster: title ? { type: 'boolean', title } : { type: 'boolean' },
+        usernameField: { type: 'string' },
+      },
+    }) as any;
+
+  // The widget drawing a boolean reads the title and never the description, so the sentence has to
+  // ride on the label the administrator already sees.
+  it('appends the disclaimer to the toggle label', () => {
+    const enriched = enrichFormWithSystemClusterDisclaimer(mongoSchema('Use System Cluster'), 'mongo-am-idp', true);
+
+    expect(enriched.properties.useSystemCluster.title).toEqual(
+      'Use System Cluster<br><small>Once saved, this option cannot be changed.</small>',
+    );
+  });
+
+  it('leaves the description alone', () => {
+    const enriched = enrichFormWithSystemClusterDisclaimer(mongoSchema('Use System Cluster'), 'mongo-am-idp', true);
+
+    expect(enriched.properties.useSystemCluster.description).toBeUndefined();
+  });
+
+  it('sets the disclaimer when the toggle has no label', () => {
+    const enriched = enrichFormWithSystemClusterDisclaimer(mongoSchema(), 'mongo-am-idp', true);
+
+    expect(enriched.properties.useSystemCluster.title).toEqual('Once saved, this option cannot be changed.');
+  });
+
+  it('leaves the toggle editable', () => {
+    const enriched = enrichFormWithSystemClusterDisclaimer(mongoSchema(), 'mongo-am-idp', true);
+
+    expect(enriched.properties.useSystemCluster.readonly).toBeUndefined();
+  });
+
+  it('leaves the schema alone for a provider of another type', () => {
+    const enriched = enrichFormWithSystemClusterDisclaimer(mongoSchema('Use System Cluster'), 'inline-am-idp', true);
+
+    expect(enriched.properties.useSystemCluster.title).toEqual('Use System Cluster');
+  });
+
+  it('does not mutate the schema it was given', () => {
+    const original = mongoSchema('Use System Cluster');
+
+    enrichFormWithSystemClusterDisclaimer(original, 'mongo-am-idp', true);
+
+    expect(original.properties.useSystemCluster.title).toEqual('Use System Cluster');
+  });
+});
+
+describe('system cluster enrichers outside the storage rule', () => {
+  const mongoSchema = () =>
+    ({
+      id: 'urn:jsonschema:io:gravitee:am:identityprovider:mongo:MongoIdentityProviderConfiguration',
+      version: '1',
+      properties: { useSystemCluster: { type: 'boolean', title: 'Use System Cluster' } },
+    }) as any;
+
+  it('leaves the toggle open, because the setting is not held outside the storage rule', () => {
+    const enriched = enrichFormWithSystemClusterLock(mongoSchema(), 'mongo-am-idp', false);
+
+    expect(enriched.properties.useSystemCluster.readonly).toBeUndefined();
+  });
+
+  it('leaves the label alone, because there is nothing irreversible to warn about', () => {
+    const enriched = enrichFormWithSystemClusterDisclaimer(mongoSchema(), 'mongo-am-idp', false);
+
+    expect(enriched.properties.useSystemCluster.title).toEqual('Use System Cluster');
   });
 });

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/provider.form.enricher.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/provider.form.enricher.ts
@@ -18,7 +18,7 @@ const OIDC_JSON_FORM = {
   version: '05-2024',
 };
 
-const MONGO_IDP_TYPE = 'mongo-am-idp';
+export const MONGO_IDP_TYPE = 'mongo-am-idp';
 
 export const PINNED_STORAGE_FIELDS = ['database', 'usersCollection'];
 
@@ -26,6 +26,8 @@ export const PINNED_STORAGE_FIELDS = ['database', 'usersCollection'];
 export const PINNED_STORAGE_TOGGLE = 'useSystemCluster';
 
 const CREATION_HINT = 'The platform sets this value when "use system cluster" is selected.';
+
+const IMMUTABLE_HINT = 'Once saved, this option cannot be changed.';
 
 const LDAP_JSON_FORM = {
   id: 'urn:jsonschema:com:graviteesource:am:identityprovider:ldap:LdapIdentityProviderConfiguration',
@@ -57,6 +59,32 @@ export function enrichFormWithSystemClusterRestrictions(schema: FormSchema, prov
     .forEach((field) => {
       updatedSchema.properties[field] = { ...updatedSchema.properties[field], readonly: true };
     });
+  return updatedSchema;
+}
+
+/** Edit screen only: the toggle is closed under the storage rule, whichever way it is set. */
+export function enrichFormWithSystemClusterLock(schema: FormSchema, providerType: string, restricted: boolean): FormSchema {
+  if (!restricted || providerType !== MONGO_IDP_TYPE || !schema?.properties?.[PINNED_STORAGE_TOGGLE]) {
+    return schema;
+  }
+
+  const updatedSchema = { ...schema, properties: { ...schema.properties } };
+  updatedSchema.properties[PINNED_STORAGE_TOGGLE] = { ...updatedSchema.properties[PINNED_STORAGE_TOGGLE], readonly: true };
+  return updatedSchema;
+}
+
+/** The widget drawing a boolean reads only `title`, never `description`, so the sentence rides on the label. */
+export function enrichFormWithSystemClusterDisclaimer(schema: FormSchema, providerType: string, restricted: boolean): FormSchema {
+  if (!restricted || providerType !== MONGO_IDP_TYPE || !schema?.properties?.[PINNED_STORAGE_TOGGLE]) {
+    return schema;
+  }
+
+  const updatedSchema = { ...schema, properties: { ...schema.properties } };
+  const property = updatedSchema.properties[PINNED_STORAGE_TOGGLE];
+  updatedSchema.properties[PINNED_STORAGE_TOGGLE] = {
+    ...property,
+    title: property.title ? `${property.title}<br><small>${IMMUTABLE_HINT}</small>` : IMMUTABLE_HINT,
+  };
   return updatedSchema;
 }
 
@@ -96,6 +124,7 @@ interface FormProperty {
   enum?: string[];
   enumNames?: string[];
   description?: string;
+  title?: string;
   readonly?: boolean;
 }
 

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
@@ -102,6 +102,13 @@
       <h3>Manage identity provider</h3>
       <div class="gv-page-description-content">
         <p>Register your users to interact with the Access Management {{ organizationContext ? 'Portal' : 'Server' }}.</p>
+        <ng-container *ngIf="showMongoStorageGuidance">
+          <h5>User storage</h5>
+          <small>
+            Prefer a data source. It is the connection the provider actually uses (ahead of the system cluster and any URI on this form) and
+            credentials stay in the platform configuration.
+          </small>
+        </ng-container>
       </div>
       <div *ngIf="provider.external" class="social-provider-settings-description">
         <h5>Social/Enterprise Identity Provider</h5>

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.ts
@@ -30,11 +30,15 @@ import { EntrypointService } from '../../../../../services/entrypoint.service';
 import { AppConfig } from '../../../../../../config/app.config';
 import {
   enrichFormWithCerts,
+  enrichFormWithSystemClusterDisclaimer,
+  enrichFormWithSystemClusterLock,
   enrichFormWithSystemClusterRestrictions,
+  MONGO_IDP_TYPE,
   PINNED_STORAGE_FIELDS,
   PINNED_STORAGE_TOGGLE,
 } from '../provider.form.enricher';
 import { DataSourcesService } from '../../../../../services/datasources.service';
+import { CloudModeService } from '../../../../../services/cloud-mode.service';
 
 @Component({
   selector: 'provider-settings',
@@ -60,6 +64,7 @@ export class ProviderSettingsComponent implements OnInit {
   certificates: any[];
   licenseOptions: LicenseOptions = {};
   isMissingFeature$: Observable<boolean>;
+  private systemClusterRestricted = false;
   private datasources: any[];
 
   constructor(
@@ -73,6 +78,7 @@ export class ProviderSettingsComponent implements OnInit {
     private entrypointService: EntrypointService,
     private dataSourcesService: DataSourcesService,
     private pluginFeatureService: PluginFeatureService,
+    private cloudModeService: CloudModeService,
   ) {}
 
   ngOnInit() {
@@ -108,11 +114,18 @@ export class ProviderSettingsComponent implements OnInit {
     }
     this.providerConfiguration = JSON.parse(this.provider.configuration);
     this.updateProviderConfiguration = this.providerConfiguration;
-    this.organizationService
-      .identitySchema(this.provider.type)
+    this.cloudModeService
+      .isSystemClusterRestricted()
       .pipe(
-        map((schema) => enrichFormWithCerts(schema, this.certificates)),
-        map((schema) => enrichFormWithSystemClusterRestrictions(schema, this.provider.type, this.provider.systemClusterRestricted)),
+        switchMap((restricted) =>
+          this.organizationService.identitySchema(this.provider.type).pipe(
+            map((schema) => enrichFormWithCerts(schema, this.certificates)),
+            map((schema) => enrichFormWithSystemClusterRestrictions(schema, this.provider.type, this.provider.systemClusterRestricted)),
+            map((schema) => enrichFormWithSystemClusterLock(schema, this.provider.type, restricted)),
+            map((schema) => enrichFormWithSystemClusterDisclaimer(schema, this.provider.type, restricted)),
+            tap(() => (this.systemClusterRestricted = restricted)),
+          ),
+        ),
       )
       .subscribe((data) => {
         this.providerSchema = data;
@@ -133,6 +146,10 @@ export class ProviderSettingsComponent implements OnInit {
           this.providerSchema = this.dataSourcesService.applyDataSourceSelection(this.providerSchema, this.datasources);
         }
       });
+  }
+
+  get showMongoStorageGuidance(): boolean {
+    return this.provider?.type === MONGO_IDP_TYPE;
   }
 
   update(event: Event): void {
@@ -199,16 +216,24 @@ export class ProviderSettingsComponent implements OnInit {
   }
 
   /**
-   * Angular leaves a disabled control out of the form value, so the system cluster flag of a pinned
-   * provider would reach the server as undefined and read as a change. Send back what is stored.
+   * Angular leaves a readonly control out of the form value, so a field the form shows closed would
+   * reach the server as undefined and read as a change. Send back what is stored.
    */
   private withPinnedStorage(configuration: any): any {
-    if (!this.provider.systemClusterRestricted || typeof this.provider.configuration !== 'string') {
+    if (typeof this.provider.configuration !== 'string') {
+      return configuration;
+    }
+    const closed = this.provider.systemClusterRestricted
+      ? [PINNED_STORAGE_TOGGLE, ...PINNED_STORAGE_FIELDS]
+      : this.systemClusterRestricted
+        ? [PINNED_STORAGE_TOGGLE]
+        : [];
+    if (closed.length === 0) {
       return configuration;
     }
     const stored = JSON.parse(this.provider.configuration);
     const pinned = {};
-    [PINNED_STORAGE_TOGGLE, ...PINNED_STORAGE_FIELDS].forEach((field) => {
+    closed.forEach((field) => {
       pinned[field] = stored[field];
     });
     return { ...configuration, ...pinned };


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7612](https://gravitee.atlassian.net/browse/AM-7612)

## :pencil2: A description of the changes proposed in the pull request
Under `repositories.system-cluster-resticted` mode, prevent disabling of Mongo IDP "use system cluster" option once enabled. Previously this was only guarded for an IDP that was _created_ under restricted mode, leaving a gap for existing IDPs where inadvertent disabling of the mode could never be undone.

Bring attention to this fact by adding disclaimers to the console UI:
- A hint during IDP creation that "use system cluster" cannot be updated once set (restricted mode only)
- A recommendation onscreen to use datasource instead

Additionally, to draw more attention to the guidance, this markup is now shown onscreen during IDP creation.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
#### Mongo IDP data plane guidance
<img width="1424" height="578" alt="image" src="https://github.com/user-attachments/assets/664ab61b-0e6e-4edb-bd85-31c8693bf893" />

#### Augmented "use system cluster" warning hint
<img width="327" height="115" alt="image" src="https://github.com/user-attachments/assets/66dfb910-774d-49c5-8ee9-a3c656636fc6" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7612]: https://gravitee.atlassian.net/browse/AM-7612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ