### PR TITLE
fix: skip mongo uri setting for default idp relying on system cluster

### DIFF
--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/env/CloudProperties.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/env/CloudProperties.java
@@ -25,6 +25,9 @@ import org.springframework.core.env.Environment;
 public final class CloudProperties {
     public static final String INSTALLATION_TYPE_STANDALONE = "standalone";
     public static final String INSTALLATION_TYPE_MANAGED = "managed";
+    public static final String SETTINGS_INSTALLATION_TYPE = "installation.type";
+    public static final String SETTINGS_CLOUD_ENABLED = "cloud.enabled";
+    public static final String SETTINGS_COCKPIT_ENABLED = "cockpit.enabled";
 
     private CloudProperties() {
     }
@@ -37,14 +40,14 @@ public final class CloudProperties {
     }
 
     private static boolean isCloudEnabled(Environment environment) {
-        final Boolean cloudEnabled = environment.getProperty("cloud.enabled", Boolean.class);
+        final Boolean cloudEnabled = environment.getProperty(SETTINGS_CLOUD_ENABLED, Boolean.class);
         if (cloudEnabled != null) {
             return cloudEnabled;
         }
-        return environment.getProperty("cockpit.enabled", Boolean.class, false);
+        return environment.getProperty(SETTINGS_COCKPIT_ENABLED, Boolean.class, false);
     }
 
     private static boolean isManagedInstallation(Environment environment) {
-        return INSTALLATION_TYPE_MANAGED.equalsIgnoreCase(environment.getProperty("installation.type", INSTALLATION_TYPE_STANDALONE));
+        return INSTALLATION_TYPE_MANAGED.equalsIgnoreCase(environment.getProperty(SETTINGS_INSTALLATION_TYPE, INSTALLATION_TYPE_STANDALONE));
     }
 }

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/env/RepositoriesEnvironment.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/env/RepositoriesEnvironment.java
@@ -88,4 +88,7 @@ public class RepositoriesEnvironment {
         return key;
     }
 
+    public Environment getDelegate() {
+        return environment;
+    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.am.management.service.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.common.env.RepositoriesEnvironment;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.management.service.DefaultIdentityProviderService;
@@ -43,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.gravitee.am.repository.BackendConfigurationUtils.DEFAULT_SYSTEM_CLUSTER;
 import static io.gravitee.am.repository.BackendConfigurationUtils.getMongoDatabaseName;
 import static io.gravitee.am.repository.BackendConfigurationUtils.SYSTEM_CLUSTER;
 
@@ -50,13 +52,15 @@ import static io.gravitee.am.repository.BackendConfigurationUtils.SYSTEM_CLUSTER
 @CustomLog
 public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProviderService {
 
+    public static final String SETTINGS_DEFAULT_IDP_USE_SYSTEM_CLUSTER = "domains.identities.default.useSystemCluster";
     public static final String DEFAULT_IDP_PREFIX = "default-idp-";
+    public static final String PASSWORD = "password";
+    public static final String USE_SYSTEM_CLUSTER = "useSystemCluster";
+
     private static final String DEFAULT_IDP_NAME = "Default Identity Provider";
     private static final String DEFAULT_MONGO_IDP_TYPE = "mongo-am-idp";
     private static final String DEFAULT_JDBC_IDP_TYPE = "jdbc-am-idp";
     private static final int TABLE_NAME_MAX_LENGTH = 50;
-    public static final String PASSWORD = "password";
-    public static final String USE_SYSTEM_CLUSTER = "useSystemCluster";
     private static final String PASSWORD_ENCODER = "passwordEncoder";
     private static final String PASSWORD_ENCODER_OPTIONS = "passwordEncoderOptions";
 
@@ -83,7 +87,11 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
     public Single<IdentityProvider> create(Domain domain) {
         NewIdentityProvider newIdentityProvider = new NewIdentityProvider();
         return populateDefault(domain, newIdentityProvider)
-                .flatMap(populated -> identityProviderService.create(domain, populated, null, true));
+                .flatMap(populated -> identityProviderService.create(domain, populated, null, evalBoundToSystemCluster()));
+    }
+
+    private boolean evalBoundToSystemCluster() {
+        return environment.getProperty(SETTINGS_DEFAULT_IDP_USE_SYSTEM_CLUSTER, Boolean.class, true) || CloudProperties.isManagedCloudEnabled(environment.getDelegate());
     }
 
     @Override
@@ -114,9 +122,7 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
 
     @Override
     public Map<String, Object> createProviderConfiguration(String referenceId, NewIdentityProvider identityProvider) {
-        // A new default identity provider always reuses the system cluster; the Mongo provider decides at
-        // runtime which scope serves it.
-        return buildProviderConfiguration(referenceId, identityProvider, true);
+        return buildProviderConfiguration(referenceId, identityProvider, evalBoundToSystemCluster());
     }
 
     @Override
@@ -172,9 +178,13 @@ public class DefaultIdentityProviderServiceImpl implements DefaultIdentityProvid
 
             String mongoUri = environment.getProperty(Scope.MANAGEMENT.getRepositoryPropertyKey() + ".mongodb.uri", defaultMongoUri);
 
-            configMap.put("uri", mongoUri);
-            configMap.put("host", (mongoHost != null) ? mongoHost : "");
-            configMap.put("port", (mongoPort != null) ? Integer.parseInt(mongoPort): null);
+            if (!boundToSystemCluster) {
+                configMap.put("uri", mongoUri);
+                configMap.put("host", (mongoHost != null) ? mongoHost : "");
+                configMap.put("port", (mongoPort != null) ? Integer.parseInt(mongoPort) : null);
+            } else {
+                configMap.put("uri", String.format("from-system-cluster:%s", environment.getProperty(SYSTEM_CLUSTER, DEFAULT_SYSTEM_CLUSTER)));
+            }
             configMap.put("enableCredentials", false);
             configMap.put("database", mongoDBName);
             configMap.put("usersCollection", "idp_users_" + lowerCaseId);

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DefaultIdentityProviderServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.am.common.env.CloudProperties;
 import io.gravitee.am.common.env.RepositoriesEnvironment;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.IdentityProvider;
@@ -130,6 +131,10 @@ public class DefaultIdentityProviderServiceTest {
 
     @Test
     public void default_idp_config_has_null_port_when_mongo_servers_are_defined() {
+        environment.setProperty(DefaultIdentityProviderServiceImpl.SETTINGS_DEFAULT_IDP_USE_SYSTEM_CLUSTER, false);
+        environment.setProperty(CloudProperties.SETTINGS_INSTALLATION_TYPE, CloudProperties.INSTALLATION_TYPE_STANDALONE);
+        environment.setProperty(CloudProperties.SETTINGS_CLOUD_ENABLED, false);
+
         environment.setProperty("repositories.management.mongodb.servers[0].host", "localhost");
         environment.setProperty("repositories.management.mongodb.servers[0].port", 27017);
         environment.setProperty("repositories.management.mongodb.port", 99999); // this value should be ignored
@@ -224,17 +229,50 @@ public class DefaultIdentityProviderServiceTest {
 
         Map<String, Object> config = cut.createProviderConfiguration("test", null);
 
-        // the connection settings stay a fallback: the Mongo provider replaces both the client and the
-        // database with the system cluster's when it honors this flag
-        assertEquals("mgmt-host", config.get("host"));
-        assertEquals(27018, config.get("port"));
+        assertNull(config.get("host"));
+        assertNull(config.get("port"));
         assertEquals("mgmt-db", config.get("database"));
-        assertEquals("mongodb://mgmt-host:27018/?connectTimeoutMS=5000&socketTimeoutMS=5000", config.get("uri"));
+        assertEquals("from-system-cluster:management", config.get("uri"));
         assertEquals(true, config.get("useSystemCluster"));
+        assertEquals("idp_users_test", config.get("usersCollection"));
+        assertEquals("{username: ?}", config.get("findUserByUsernameQuery"));
+        assertEquals("{email: ?}", config.get("findUserByEmailQuery"));
+        assertEquals("username", config.get("usernameField"));
+        assertEquals("password", config.get("passwordField"));
+        assertEquals("BCrypt", config.get("passwordEncoder"));
+    }
+
+    @Test
+    public void mongoBackend_force_bindTheProviderToTheSystemCluster_InCloudMode() {
+        environment.setProperty(DefaultIdentityProviderServiceImpl.SETTINGS_DEFAULT_IDP_USE_SYSTEM_CLUSTER, false);
+        environment.setProperty(CloudProperties.SETTINGS_INSTALLATION_TYPE, CloudProperties.INSTALLATION_TYPE_MANAGED);
+        environment.setProperty(CloudProperties.SETTINGS_CLOUD_ENABLED, true);
+
+        environment.setProperty("repositories.management.mongodb.host", "mgmt-host");
+        environment.setProperty("repositories.management.mongodb.port", "27018");
+        environment.setProperty("repositories.management.mongodb.dbname", "mgmt-db");
+
+        Map<String, Object> config = cut.createProviderConfiguration("test", null);
+
+        assertNull(config.get("host"));
+        assertNull(config.get("port"));
+        assertEquals("mgmt-db", config.get("database"));
+        assertEquals("from-system-cluster:management", config.get("uri"));
+        assertEquals(true, config.get("useSystemCluster"));
+        assertEquals("idp_users_test", config.get("usersCollection"));
+        assertEquals("{username: ?}", config.get("findUserByUsernameQuery"));
+        assertEquals("{email: ?}", config.get("findUserByEmailQuery"));
+        assertEquals("username", config.get("usernameField"));
+        assertEquals("password", config.get("passwordField"));
+        assertEquals("BCrypt", config.get("passwordEncoder"));
     }
 
     @Test
     public void mongoBackend_emitsTheFullProviderConfiguration() {
+        environment.setProperty(DefaultIdentityProviderServiceImpl.SETTINGS_DEFAULT_IDP_USE_SYSTEM_CLUSTER, false);
+        environment.setProperty(CloudProperties.SETTINGS_INSTALLATION_TYPE, CloudProperties.INSTALLATION_TYPE_STANDALONE);
+        environment.setProperty(CloudProperties.SETTINGS_CLOUD_ENABLED, false);
+
         Map<String, Object> config = cut.createProviderConfiguration("test", null);
 
         assertEquals("localhost", config.get("host"));


### PR DESCRIPTION
This commit remove the mongo connection settings from the default idp config.
Is introduce a new setting to disable this behaviour (domains.identities.default.useSystemCluster)
If disable the default config is initialized using the management scope settings.

In cloud mode (installation.type: managed), the system cluster usage is enforced.

Important Reminder: the setting "repositories.system-cluster" has to be configure in a consistent manner across Management API and Gateway services. Only two values are possible
* management: idp collections are in the same cluster/database as the configuration entities (domain, app, factor configuration...)
* gateway: idp are manage by the DataPlane storage. That means in the MAPI, the connection rely on the dataplane definition linked to the domain and on Gateway side, the connection rely on the gateway scope settings. It is required that the gateway repository scope settings on the GW gravitee.yaml match the same cluster and db as the dataplane definition on MAPI

Fix AM-7606
